### PR TITLE
feat: disable enter key in address bar

### DIFF
--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -107,6 +107,7 @@ const onChange = () => {
           class="scalar-api-client__url-input"
           :content="formattedUrl"
           :readOnly="readOnly"
+          :disableEnter="true"
           :withVariables="true"
           :withoutTheme="true"
           @change="onChange" />

--- a/packages/api-client/src/components/CodeMirror/CodeMirror.vue
+++ b/packages/api-client/src/components/CodeMirror/CodeMirror.vue
@@ -21,6 +21,7 @@ import { ruby } from '@codemirror/legacy-modes/mode/ruby'
 import { shell } from '@codemirror/legacy-modes/mode/shell'
 import { swift } from '@codemirror/legacy-modes/mode/swift'
 import { type Extension } from '@codemirror/state'
+import { keymap } from '@codemirror/view'
 import {
   EditorView,
   type ViewUpdate,
@@ -78,14 +79,20 @@ type Language =
   | 'swift'
   | 'php'
 
-const props = defineProps<{
-  content?: string
-  readOnly?: boolean
-  languages?: Language[]
-  withVariables?: boolean
-  lineNumbers?: boolean
-  withoutTheme?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    content?: string
+    readOnly?: boolean
+    languages?: Language[]
+    withVariables?: boolean
+    lineNumbers?: boolean
+    withoutTheme?: boolean
+    disableEnter?: boolean
+  }>(),
+  {
+    disableEnter: false,
+  },
+)
 
 const emit = defineEmits<{
   (e: 'change', value: string): void
@@ -125,6 +132,32 @@ const getCodeMirrorExtensions = () => {
   // Highlight variables
   if (props.withVariables) {
     extensions.push(variables())
+  }
+
+  if (props.disableEnter) {
+    extensions.push(
+      keymap.of([
+        {
+          key: 'Enter',
+          run: () => {
+            return true
+          },
+        },
+        {
+          key: 'Ctrl-Enter',
+          mac: 'Cmd-Enter',
+          run: () => {
+            return true
+          },
+        },
+        {
+          key: 'Shift-Enter',
+          run: () => {
+            return true
+          },
+        },
+      ]),
+    )
   }
 
   // Listen to updates


### PR DESCRIPTION
This PR disables Enter, Shift-Enter, Command-Enter and Ctrl-Enter in the address bar.

```vue
<CodeMirror :disableEnter="true" />
```