### PR TITLE
chore: remove git sync button for now

### DIFF
--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -17,7 +17,6 @@ const { files, open, reset } = useFileDialog({
 })
 
 const swaggerURLModalState = useModalState()
-const syncGitModal = useModalState()
 const swaggerUrl = ref('')
 
 async function fetchURL() {
@@ -67,23 +66,8 @@ const importExampleFile = () => {
         @click="swaggerURLModalState.show">
         <i>Import </i>URL
       </button>
-      <button
-        type="button"
-        @click="syncGitModal.show">
-        <i>Sync With </i>Git
-      </button>
     </div>
   </div>
-  <FlowModal
-    :state="syncGitModal"
-    title="Sync with Git">
-    <div class="flex-col gap-1">
-      <h1>coming soon!</h1>
-      <FlowButton
-        label="Close"
-        @click="syncGitModal.hide()" />
-    </div>
-  </FlowModal>
   <FlowModal
     :state="swaggerURLModalState"
     title="Import Swagger from URL">


### PR DESCRIPTION
Let’s remove the Git button for now. It’s too complex to build *now*.

<img width="642" alt="Screenshot 2023-08-29 at 12 03 40" src="https://github.com/scalar/api-reference/assets/1577992/5468b5ae-e04c-42bb-8242-61f9badf8b86">
