### PR TITLE
feat: get rid of the .umd.cjs extension

### DIFF
--- a/packages/api-reference/vite.cdn.config.ts
+++ b/packages/api-reference/vite.cdn.config.ts
@@ -34,8 +34,13 @@ export default defineConfig({
     lib: {
       entry: ['src/standalone.ts'],
       name: '@scalar/api-reference',
-      fileName: 'api-reference.standalone',
+      fileName: 'standalone',
       formats: ['umd'],
+    },
+    rollupOptions: {
+      output: {
+        entryFileNames: 'api-reference.[name].js',
+      },
     },
   },
 })


### PR DESCRIPTION
Shorter file name 🌟 

Old: dist/api-reference.standalone.umd.cjs
New: dist/api-reference.standalone.js