### PR TITLE
fix: show tag description only if available

### DIFF
--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -201,7 +201,7 @@ const searchResultsWithPlaceholderResults = computed(
             {{ entry.item.path }}
           </div>
         </div>
-        <div v-else>
+        <div v-else-if="entry.item.description">
           {{ entry.item.description }}
         </div>
       </button>


### PR DESCRIPTION
Tags without a description had some extra space before this PR. 💅 

**Before**
<img width="661" alt="Screenshot 2023-09-04 at 14 29 59" src="https://github.com/scalar/api-reference/assets/1577992/2205b304-42a1-430a-a004-f46480cec57f">

**After**
<img width="663" alt="Screenshot 2023-09-04 at 14 30 10" src="https://github.com/scalar/api-reference/assets/1577992/82fdcbb0-6ab9-4ccc-bce0-431f53abbf32">

