### PR TITLE
chore: changeset for all packages

### DIFF
--- a/.changeset/heavy-ants-stare.md
+++ b/.changeset/heavy-ants-stare.md
@@ -1,0 +1,20 @@
+---
+'@scalar/api-client': minor
+'@scalar/api-client-proxy': minor
+'@scalar/api-reference': minor
+'@scalar/echo-server': minor
+'@scalar/fastify-api-reference': minor
+'@scalar/swagger-editor': minor
+'@scalar/swagger-parser': minor
+'@scalar/use-clipboard': minor
+'@scalar/use-codemirror': minor
+'@scalar/use-keyboard-event': minor
+'@scalar/use-toasts': minor
+'@scalar/use-tooltip': minor
+'@scalar-org/api-client-proxy': minor
+'@scalar-org/echo-server': minor
+'@scalar-org/fastify-api-reference': minor
+'@scalar-org/web': minor
+---
+
+manually releasing all packages to make sure the lastest version is on npm


### PR DESCRIPTION
This PR adds a changeset for all packages, which will lead to re-publishing all packages. I wasn’t very disciplined with releases recently and want to make sure all changes are on npm.

With the new automated release process, I’m optimistic releases will happen more often from now on.