### PR TITLE
chore: make fastify an external dependency

### DIFF
--- a/.changeset/tall-points-run.md
+++ b/.changeset/tall-points-run.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: make fastify an external dependency

--- a/packages/fastify-api-reference/vite.config.ts
+++ b/packages/fastify-api-reference/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
       fileName: 'index',
       formats: ['es', 'umd'],
     },
+    rollupOptions: {
+      external: ['fastify'],
+    },
   },
   resolve: {
     alias: [


### PR DESCRIPTION
This PR makes sure fastify isn’t bundled with the fastify plugin.