### PR TITLE
chore: add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
This PR configures dependabot to keep the GitHub Actions workflows up to date. 🤖 