### PR TITLE
chore: enable vitest coverage summary

### DIFF
--- a/packages/api-client-proxy/package.json
+++ b/packages/api-client-proxy/package.json
@@ -52,6 +52,7 @@
     "vite": "4.4.8",
     "vite-node": "^0.34.3",
     "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4",
     "tsc-alias": "1.8.6",
     "typescript": "^5.2.2"
   },

--- a/packages/api-client-proxy/vite.config.ts
+++ b/packages/api-client-proxy/vite.config.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -26,5 +26,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -60,13 +60,14 @@
     "tippy.js": "6.3.7"
   },
   "devDependencies": {
+    "@scalar/echo-server": "workspace:*",
     "@vitejs/plugin-vue": "4.2.3",
+    "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4",
     "tsc-alias": "1.8.6",
     "vite": "4.4.8",
     "vite-plugin-css-injected-by-js": "^3.3.0",
-    "vitest": "0.34.1",
-    "vue-tsc": "1.8.8",
-    "@scalar/echo-server": "workspace:*"
+    "vue-tsc": "1.8.8"
   },
   "peerDependencies": {
     "vue": "3.3.4"

--- a/packages/api-client/vite.config.ts
+++ b/packages/api-client/vite.config.ts
@@ -1,7 +1,7 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
-import { defineConfig } from 'vite'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [vue(), cssInjectedByJsPlugin()],
@@ -29,5 +29,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -90,6 +90,7 @@
     "vite-plugin-css-injected-by-js": "^3.3.0",
     "vite-plugin-node-polyfills": "^0.11.2",
     "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4",
     "vue-tsc": "1.8.8"
   },
   "peerDependencies": {

--- a/packages/api-reference/vite.cdn.config.ts
+++ b/packages/api-reference/vite.cdn.config.ts
@@ -1,7 +1,7 @@
 import vue from '@vitejs/plugin-vue'
-import { defineConfig } from 'vite'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   optimizeDeps: {
@@ -42,6 +42,12 @@ export default defineConfig({
       output: {
         entryFileNames: 'api-reference.[name].js',
       },
+    },
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
     },
   },
 })

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -1,8 +1,8 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
-import { defineConfig } from 'vite'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   define: {
@@ -63,5 +63,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -29,6 +29,7 @@
   "dependencies": {},
   "devDependencies": {
     "vite": "4.4.8",
-    "vitest": "0.34.1"
+    "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4"
   }
 }

--- a/packages/echo-server/package.json
+++ b/packages/echo-server/package.json
@@ -51,6 +51,7 @@
     "vite": "4.4.8",
     "vite-node": "^0.34.3",
     "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4",
     "tsc-alias": "1.8.6",
     "typescript": "^5.2.2"
   },

--- a/packages/echo-server/vite.config.ts
+++ b/packages/echo-server/vite.config.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   build: {
@@ -25,5 +25,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -53,6 +53,7 @@
     "typescript": "^5.2.2",
     "vite": "4.4.8",
     "vite-node": "^0.34.3",
-    "vitest": "0.34.1"
+    "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4"
   }
 }

--- a/packages/fastify-api-reference/vite.config.ts
+++ b/packages/fastify-api-reference/vite.config.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   build: {
@@ -25,5 +25,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/packages/swagger-editor/package.json
+++ b/packages/swagger-editor/package.json
@@ -62,6 +62,7 @@
     "vite": "4.4.8",
     "vite-plugin-css-injected-by-js": "^3.3.0",
     "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4",
     "vue-tsc": "1.8.8"
   },
   "peerDependencies": {

--- a/packages/swagger-editor/vite.config.ts
+++ b/packages/swagger-editor/vite.config.ts
@@ -1,7 +1,7 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
-import { defineConfig } from 'vite'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [vue(), cssInjectedByJsPlugin()],
@@ -39,5 +39,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/packages/swagger-parser/package.json
+++ b/packages/swagger-parser/package.json
@@ -55,6 +55,7 @@
     "tslib": "^2.6.1",
     "typescript": "*",
     "vite": "4.4.8",
-    "vitest": "0.34.1"
+    "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4"
   }
 }

--- a/packages/swagger-parser/vite.config.ts
+++ b/packages/swagger-parser/vite.config.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   build: {
@@ -28,5 +28,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/packages/use-clipboard/package.json
+++ b/packages/use-clipboard/package.json
@@ -53,6 +53,7 @@
     "tsc-alias": "1.8.6",
     "vite": "4.4.8",
     "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4",
     "vue-tsc": "1.8.8"
   },
   "peerDependencies": {

--- a/packages/use-clipboard/vite.config.ts
+++ b/packages/use-clipboard/vite.config.ts
@@ -1,6 +1,6 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [vue()],
@@ -38,5 +38,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -72,6 +72,7 @@
     "tsc-alias": "1.8.6",
     "vite": "4.4.8",
     "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4",
     "vue-tsc": "1.8.8"
   },
   "peerDependencies": {

--- a/packages/use-codemirror/vite.config.ts
+++ b/packages/use-codemirror/vite.config.ts
@@ -1,6 +1,6 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [vue()],
@@ -42,5 +42,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/packages/use-keyboard-event/package.json
+++ b/packages/use-keyboard-event/package.json
@@ -48,6 +48,7 @@
     "tsc-alias": "1.8.6",
     "vite": "4.4.8",
     "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4",
     "vue-tsc": "1.8.8"
   },
   "peerDependencies": {

--- a/packages/use-keyboard-event/vite.config.ts
+++ b/packages/use-keyboard-event/vite.config.ts
@@ -1,6 +1,6 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [vue()],
@@ -38,5 +38,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/packages/use-toasts/package.json
+++ b/packages/use-toasts/package.json
@@ -46,6 +46,7 @@
     "tsc-alias": "1.8.6",
     "vite": "4.4.8",
     "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4",
     "vue-tsc": "1.8.8",
     "vite-plugin-css-injected-by-js": "^3.3.0"
   },

--- a/packages/use-toasts/vite.config.ts
+++ b/packages/use-toasts/vite.config.ts
@@ -1,6 +1,6 @@
 import vue from '@vitejs/plugin-vue'
-import { defineConfig } from 'vite'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [vue(), cssInjectedByJsPlugin()],
@@ -15,6 +15,12 @@ export default defineConfig({
     },
     rollupOptions: {
       external: ['vue'],
+    },
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
     },
   },
 })

--- a/packages/use-tooltip/package.json
+++ b/packages/use-tooltip/package.json
@@ -51,6 +51,7 @@
     "tsc-alias": "1.8.6",
     "vite": "4.4.8",
     "vitest": "0.34.1",
+    "@vitest/coverage-v8": "^0.34.4",
     "vue-tsc": "1.8.8"
   },
   "peerDependencies": {

--- a/packages/use-tooltip/vite.config.ts
+++ b/packages/use-tooltip/vite.config.ts
@@ -1,6 +1,6 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [vue()],
@@ -38,5 +38,11 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../$1/src/index.ts'),
       },
     ],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.4.8)(vue@3.3.4)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       tsc-alias:
         specifier: 1.8.6
         version: 1.8.6
@@ -141,6 +144,9 @@ importers:
       '@scalar/echo-server':
         specifier: workspace:*
         version: link:../echo-server
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       nodemon:
         specifier: ^3.0.1
         version: 3.0.1
@@ -262,6 +268,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.4.8)(vue@3.3.4)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
@@ -289,6 +298,9 @@ importers:
 
   packages/default-theme:
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       vite:
         specifier: 4.4.8
         version: 4.4.8(@types/node@20.3.1)
@@ -317,6 +329,9 @@ importers:
         specifier: ^4.18.2
         version: 4.18.2
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       nodemon:
         specifier: ^3.0.1
         version: 3.0.1
@@ -342,6 +357,9 @@ importers:
         specifier: ^4.22.1
         version: 4.22.1
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       nodemon:
         specifier: ^3.0.1
         version: 3.0.1
@@ -394,6 +412,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.4.8)(vue@3.3.4)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       tsc-alias:
         specifier: 1.8.6
         version: 1.8.6
@@ -428,6 +449,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.4.8)(vue@3.3.4)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       glob:
         specifier: 10.3.3
         version: 10.3.3
@@ -465,6 +489,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.4.8)(vue@3.3.4)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       tsc-alias:
         specifier: 1.8.6
         version: 1.8.6
@@ -553,6 +580,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.4.8)(vue@3.3.4)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       tsc-alias:
         specifier: 1.8.6
         version: 1.8.6
@@ -575,6 +605,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.4.8)(vue@3.3.4)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       tsc-alias:
         specifier: 1.8.6
         version: 1.8.6
@@ -600,6 +633,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.4.8)(vue@3.3.4)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       tsc-alias:
         specifier: 1.8.6
         version: 1.8.6
@@ -628,6 +664,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: 4.2.3
         version: 4.2.3(vite@4.4.8)(vue@3.3.4)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.1)
       tsc-alias:
         specifier: 1.8.6
         version: 1.8.6
@@ -760,6 +799,14 @@ packages:
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+    dev: true
+
+  /@ampproject/remapping@2.2.1:
+    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.19
     dev: true
 
   /@apidevtools/json-schema-ref-parser@9.0.6:
@@ -911,6 +958,10 @@ packages:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
+
+  /@bcoe/v8-coverage@0.2.3:
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
 
   /@changesets/apply-release-plan@6.1.4:
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
@@ -1517,6 +1568,11 @@ packages:
       wrap-ansi-cjs: /wrap-ansi@7.0.0
     dev: true
 
+  /@istanbuljs/schema@0.1.3:
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+    dev: true
+
   /@jest/schemas@29.6.0:
     resolution: {integrity: sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1787,6 +1843,10 @@ packages:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
     dependencies:
       ci-info: 3.8.0
+    dev: true
+
+  /@types/istanbul-lib-coverage@2.0.4:
+    resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
     dev: true
 
   /@types/js-yaml@4.0.5:
@@ -2210,6 +2270,27 @@ packages:
     dependencies:
       vite: 4.4.8(@types/node@20.3.1)
       vue: 3.3.4
+    dev: true
+
+  /@vitest/coverage-v8@0.34.4(vitest@0.34.1):
+    resolution: {integrity: sha512-TZ5ghzhmg3COQqfBShL+zRQEInHmV9TSwghTdfkHpCTyTOr+rxo6x41vCNcVfWysWULtqtBVpY6YFNovxnESfA==}
+    peerDependencies:
+      vitest: '>=0.32.0 <1'
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@bcoe/v8-coverage': 0.2.3
+      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.6
+      magic-string: 0.30.2
+      picocolors: 1.0.0
+      std-env: 3.3.3
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.1.0
+      vitest: 0.34.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@vitest/expect@0.34.1:
@@ -3186,6 +3267,10 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
     dev: false
+
+  /convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+    dev: true
 
   /cookie-parser@1.4.6:
     resolution: {integrity: sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==}
@@ -4694,6 +4779,10 @@ packages:
       whatwg-encoding: 2.0.0
     dev: true
 
+  /html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
   /html-void-elements@2.0.1:
     resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
     dev: false
@@ -5046,6 +5135,39 @@ packages:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
     dev: false
 
+  /istanbul-lib-coverage@3.2.0:
+    resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.0
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.0
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-reports@3.1.6:
+    resolution: {integrity: sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+    dev: true
+
   /jackspeak@2.3.0:
     resolution: {integrity: sha512-uKmsITSsF4rUWQHzqaRUuyAir3fZfW3f202Ee34lz/gZCi970CPZwyQXLGNgWJvvZbvFyzeyGq0+4fcG/mBKZg==}
     engines: {node: '>=14'}
@@ -5339,6 +5461,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  /make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.5.4
+    dev: true
 
   /map-obj@1.0.1:
     resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
@@ -7119,6 +7248,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
     dev: false
@@ -7382,6 +7516,15 @@ packages:
   /term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+    dev: true
+
+  /test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
     dev: true
 
   /text-table@0.2.0:
@@ -7872,6 +8015,15 @@ packages:
       kleur: 4.1.5
       sade: 1.8.1
     dev: false
+
+  /v8-to-istanbul@9.1.0:
+    resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.19
+      '@types/istanbul-lib-coverage': 2.0.4
+      convert-source-map: 1.9.0
+    dev: true
 
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}


### PR DESCRIPTION
This PR enables the Vitest coverage summary. I’m not aiming for 100% coverage, but it’s a great motivation to see numbers go up with every test.

**Example output**
```
----------------------------|---------|----------|---------|---------|-------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------------|---------|----------|---------|---------|-------------------
All files                   |   93.07 |     87.3 |     100 |   93.07 |
 generateResponseContent.ts |   84.41 |       85 |     100 |   84.41 | 7-8,48-49,66-73
 getExampleResponses.ts     |     100 |      100 |     100 |     100 |
 parseSwaggerFile.ts        |   95.23 |    83.33 |     100 |   95.23 | 47-48,51-54,72-73
----------------------------|---------|----------|---------|---------|-------------------
```