### PR TITLE
feat: add api-reference-standalone package

### DIFF
--- a/packages/api-reference-standalone/package.json
+++ b/packages/api-reference-standalone/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@scalar/api-reference-standalone",
+  "description": "generate beautiful API references from OpenAPI specs",
+  "keywords": [
+    "vue",
+    "vue3",
+    "swagger",
+    "openapi",
+    "spec",
+    "reference",
+    "documentation",
+    "component"
+  ],
+  "version": "0.1.0",
+  "author": "Scalar (https://github.com/scalar)",
+  "homepage": "https://github.com/scalar/scalar",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/api-reference-standalone"
+  },
+  "bugs": {
+    "url": "https://github.com/scalar/scalar/issues/new"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "vite build && pnpm types:build && tsc-alias -p tsconfig.build.json",
+    "dev": "vite",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
+    "preview": "vite preview",
+    "test": "vitest",
+    "types:build": "vue-tsc -p tsconfig.build.json",
+    "types:check": "vue-tsc --noEmit --skipLibCheck"
+  },
+  "type": "module",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "exports": {
+    "development": "./src/index.ts",
+    "require": "./dist/index.umd.cjs",
+    "import": "./dist/index.js"
+  },
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@scalar/api-reference": "workspace:*"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "4.2.3",
+    "vite": "4.4.8",
+    "vite-plugin-css-injected-by-js": "^3.3.0",
+    "vite-plugin-node-polyfills": "^0.11.2",
+    "vitest": "0.34.1",
+    "vue-tsc": "1.8.8"
+  },
+  "peerDependencies": {
+    "vue": "3.3.4"
+  }
+}

--- a/packages/api-reference-standalone/src/index.ts
+++ b/packages/api-reference-standalone/src/index.ts
@@ -1,0 +1,26 @@
+import { ApiReference } from '@scalar/api-reference'
+import { createApp } from 'vue'
+
+const specElement = document.querySelector('[data-spec]')
+const specUrlElement = document.querySelector('[data-spec-url]')
+
+if (!specUrlElement && !specElement) {
+  console.error(
+    'Couldn’t find a [data-spec] or [data-spec-url] element. Try adding it like this: %c<div data-spec-url="https://petstore.swagger.io/v2/swagger.json" />',
+    'font-family: monospace;',
+  )
+} else {
+  const properties = specElement
+    ? {
+        spec: specElement.getAttribute('data-spec'),
+      }
+    : {
+        specUrl: specUrlElement?.getAttribute('data-spec-url') ?? '',
+      }
+
+  document.querySelector('body')?.classList.add('light-mode')
+
+  const container = specElement ? '[data-spec]' : '[data-spec-url]'
+
+  createApp(ApiReference, properties).mount(container)
+}

--- a/packages/api-reference-standalone/tsconfig.build.json
+++ b/packages/api-reference-standalone/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "test", "vite.config.ts", "**/*.test.ts"],
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/"
+  }
+}

--- a/packages/api-reference-standalone/tsconfig.json
+++ b/packages/api-reference-standalone/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ES2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "module": "ESNext" /* Specify what module code is generated. */,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "strict": true /* Enable all strict type-checking options. */,
+    "strictNullChecks": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "src/declarations"],
+  "exclude": ["dist", "vite.config.ts", "node_modules"],
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  }
+}

--- a/packages/api-reference-standalone/vite.config.ts
+++ b/packages/api-reference-standalone/vite.config.ts
@@ -1,0 +1,45 @@
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
+
+export default defineConfig({
+  optimizeDeps: {
+    include: ['@scalar/swagger-parser'],
+  },
+  plugins: [
+    vue(),
+    cssInjectedByJsPlugin(),
+    nodePolyfills({
+      // To exclude specific polyfills, add them to this list.
+      exclude: [
+        'fs', // Excludes the polyfill for `fs` and `node:fs`.
+      ],
+      // Whether to polyfill specific globals.
+      globals: {
+        Buffer: true, // can also be 'build', 'dev', or false
+        global: true,
+        process: true,
+      },
+      // Whether to polyfill `node:` protocol imports.
+      protocolImports: true,
+    }),
+  ],
+  build: {
+    commonjsOptions: {
+      include: [/@scalar\/swagger-editor/, /node_modules/],
+    },
+    cssCodeSplit: false,
+    minify: false,
+    lib: {
+      entry: ['src/index.ts'],
+      name: '@scalar/api-reference-standalone',
+      formats: ['es', 'umd'],
+    },
+    // rollupOptions: {
+    //   output: {
+    //     entryFileNames: 'api-reference.[name].js',
+    //   },
+    // },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,34 @@ importers:
         specifier: 1.8.8
         version: 1.8.8(typescript@5.2.2)
 
+  packages/api-reference-standalone:
+    dependencies:
+      '@scalar/api-reference':
+        specifier: workspace:*
+        version: link:../api-reference
+      vue:
+        specifier: 3.3.4
+        version: 3.3.4
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: 4.2.3
+        version: 4.2.3(vite@4.4.8)(vue@3.3.4)
+      vite:
+        specifier: 4.4.8
+        version: 4.4.8(@types/node@20.3.1)
+      vite-plugin-css-injected-by-js:
+        specifier: ^3.3.0
+        version: 3.3.0(vite@4.4.8)
+      vite-plugin-node-polyfills:
+        specifier: ^0.11.2
+        version: 0.11.2(vite@4.4.8)
+      vitest:
+        specifier: 0.34.1
+        version: 0.34.1
+      vue-tsc:
+        specifier: 1.8.8
+        version: 1.8.8(typescript@5.2.2)
+
   packages/default-theme:
     devDependencies:
       vite:


### PR DESCRIPTION
⚠️ Don’t merge, WIP ⚠️ 

UPDATE: We should try to add a second (browser-only) build to the @scalar/api-reference package.

This PR adds a separate `@scalar/api-reference-standalone` package. This package only holds a different entrypoint (src/index.ts) and a different build configuration for the CDN version.

Having it as a separate package would allow us to use any npm CDN (Skypack, unpkg, jsDelivr). This would allow us to get rid of the custom Netlify setup with a complex release setup (just published versions, not pushes to main).

**Tasks**
- [ ] I don’t think we need the `type="module"` for unpkg and jsDelivr. Need to check.
- [ ] I’d love to combine that with the existing `@scalar/api-reference` package, but I'm not sure how.
- [ ] Maybe `@scalar/api-reference-browser` would be a better name? Idk.

```diff
<!DOCTYPE html>
<html>
  <head>
    <title>API Reference</title>
    <meta charset="utf-8" />
    <meta
      name="viewport"
      content="width=device-width, initial-scale=1" />
  </head>
  <body>
    <div data-spec-url="/scalar.json" />
+    <script type="module" src="https://cdn.skypack.dev/@scalar/api-reference-standalone"></script>
  </body>
</html>
```