### PR TITLE
chore: increase pnpm workspace concurrency

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -4,6 +4,7 @@ pnpm concurrently \
     --prefix none \
     " \
         pnpm \
+            --workspace-concurrency=100 \
             --filter @scalar-org/web \
             --filter @scalar-org/react \
             --filter @scalar-org/api-client-proxy \


### PR DESCRIPTION
This PR increases the pnpm workspace concurrency. By default pnpm runs max 4 processes concurrently, that’s not enough if you want to start 5 processes concurrently. :) 