### PR TITLE
fix: add CSS reset to headless portal, fix #103

### DIFF
--- a/packages/api-client/src/components/ApiClient/ApiClient.vue
+++ b/packages/api-client/src/components/ApiClient/ApiClient.vue
@@ -98,7 +98,8 @@ useKeyboardEvent({
 </template>
 
 <style>
-.scalar-api-client {
+.scalar-api-client,
+#headlessui-portal-root {
   background: var(--theme-background-1, var(--default-theme-background-1));
   position: relative;
   height: 100%;

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -210,7 +210,8 @@ const breadCrumbs = computed(() => {
 
 <style lang="postcss">
 /** CSS Reset */
-.scalar-api-reference {
+.scalar-api-reference,
+#headlessui-portal-root {
   p {
     margin: 0;
   }

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -93,7 +93,8 @@ watch(
 
 <style>
 /** CSS Reset */
-.swagger-editor {
+.swagger-editor,
+#headlessui-portal-root {
   p {
     margin: 0;
   }


### PR DESCRIPTION
This PR adds the minimal CSS reset to the headless UI portal and fixes some minor styling issues in modals.