### PR TITLE
reduced negative margin on narrow refs

### DIFF
--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -143,6 +143,10 @@ const localServers = computed(() => {
   box-shadow: 0 0 0 1px
     var(--theme-border-color, var(--default-theme-border-color));
 }
+.references-narrow .show-more {
+  margin-top: -24px;
+  margin-bottom: 24px;
+}
 @media (max-width: 1165px) {
   .show-more {
     margin-top: -24px;


### PR DESCRIPTION
Before:
<img width="630" alt="image" src="https://github.com/scalar/scalar/assets/6201407/21baf8ca-2e74-4a72-8233-2f0ef73850a2">

After:
<img width="612" alt="image" src="https://github.com/scalar/scalar/assets/6201407/15d8893e-1ba1-4e2a-9c96-2680b8e0d28e">
