### PR TITLE
feat: add CHANGELOG.md to packages

### DIFF
--- a/.changeset/plenty-flies-warn.md
+++ b/.changeset/plenty-flies-warn.md
@@ -1,0 +1,18 @@
+---
+'@scalar/fastify-api-reference': patch
+'@scalar/use-keyboard-event': patch
+'@scalar/api-client-proxy': patch
+'@scalar/swagger-editor': patch
+'@scalar/swagger-parser': patch
+'@scalar/use-codemirror': patch
+'@scalar/api-reference': patch
+'@scalar/use-clipboard': patch
+'@scalar/echo-server': patch
+'@scalar/use-tooltip': patch
+'@scalar/api-client': patch
+'@scalar/use-toasts': patch
+'@scalar/use-modal': patch
+'@scalar/themes': patch
+---
+
+feat: add CHANGELOG.md to the package

--- a/packages/api-client-proxy/package.json
+++ b/packages/api-client-proxy/package.json
@@ -26,7 +26,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -36,7 +36,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -66,7 +66,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/echo-server/package.json
+++ b/packages/echo-server/package.json
@@ -25,7 +25,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -32,7 +32,8 @@
     "require": "./dist/index.cjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/swagger-editor/package.json
+++ b/packages/swagger-editor/package.json
@@ -33,7 +33,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/swagger-parser/package.json
+++ b/packages/swagger-parser/package.json
@@ -28,7 +28,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -25,7 +25,8 @@
     "./presets/solarized.css": "./dist/presets/solarized.css"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/use-clipboard/package.json
+++ b/packages/use-clipboard/package.json
@@ -23,7 +23,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -44,7 +44,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/use-keyboard-event/package.json
+++ b/packages/use-keyboard-event/package.json
@@ -19,7 +19,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/use-modal/package.json
+++ b/packages/use-modal/package.json
@@ -22,7 +22,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/use-toasts/package.json
+++ b/packages/use-toasts/package.json
@@ -20,7 +20,8 @@
     "node": ">=18"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [

--- a/packages/use-tooltip/package.json
+++ b/packages/use-tooltip/package.json
@@ -22,7 +22,8 @@
     "import": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "homepage": "https://github.com/scalar/scalar",
   "keywords": [


### PR DESCRIPTION
This PR adds the CHANGELOG.md to the package. I’m not sure, but I think dependabot will then pick up the file and include it in the update PRs.