### PR TITLE
fix: keep swagger editor state

### DIFF
--- a/.changeset/few-candles-perform.md
+++ b/.changeset/few-candles-perform.md
@@ -1,0 +1,5 @@
+---
+'@scalar/swagger-editor': patch
+---
+
+fix: restore content from local storage

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -66,8 +66,7 @@ onMounted(async () => {
     return
   }
 
-  await nextTick()
-  importHandler(previousContent)
+  currentExample.value = previousContent
 })
 
 const handleAwarenessUpdate = (states: StatesArray) => {


### PR DESCRIPTION
Previously, the state was kept in storage but only restored onMount. This caused bugs, e.g. resetting the content  when changing tabs.

This PR stores the content from local storage in the the `currentExample` ref which we already introduced anyway. This seems to work better.