### PR TITLE
references themes and color bugs

### DIFF
--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -363,7 +363,8 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   align-items: center;
   cursor: pointer;
   white-space: nowrap;
-  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
+  box-shadow: 0 0 0 1px
+    var(--theme-border-color, var(--default-theme-border-color));
   margin-left: 12px;
   border-radius: var(--theme-radius, var(--default-theme-radius));
   user-select: none;

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -220,10 +220,13 @@ const { activeRequest, readOnly } = useApiClientRequestStore()
   font-size: var(--theme-micro, var(--default-theme-micro));
   border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
   border-radius: 3px;
-  padding: 10px 12px;
+  padding: 11px 12px;
   user-select: none;
   min-height: 38px;
   width: 100%;
+}
+.check:focus-within {
+  border-color: var(--theme-color-1, var(--default-theme-color-1));
 }
 .check p {
   color: var(--theme-color-2, var(--default-theme-color-2));

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -927,8 +927,6 @@ const breadCrumbs = computed(() => {
       --scalar-api-reference-theme-header-height,
       var(--default-scalar-api-reference-theme-header-height)
     );
-    border-bottom: 1px solid
-      var(--theme-border-color, var(--default-theme-border-color));
 
     width: 100%;
     z-index: 10;

--- a/packages/api-reference/src/components/Card/CardContent.vue
+++ b/packages/api-reference/src/components/Card/CardContent.vue
@@ -4,12 +4,14 @@ withDefaults(
     muted?: boolean
     contrast?: boolean
     frameless?: boolean
+    transparent?: boolean
     borderless?: boolean
   }>(),
   {
     muted: false,
     contrast: false,
     frameless: false,
+    transparent: false,
     borderless: false,
   },
 )
@@ -21,6 +23,7 @@ withDefaults(
       'card--muted': muted,
       'card--contrast': contrast,
       'card--frameless': frameless,
+      'card--transparent': transparent,
       'card--borderless': borderless,
     }">
     <slot />
@@ -48,5 +51,8 @@ withDefaults(
 }
 .card--frameless {
   padding: 0;
+}
+.card--transparent {
+  background: var(--theme-background-1, var(--default-theme-background-1));
 }
 </style>

--- a/packages/api-reference/src/components/Content/Introduction/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/Introduction/ClientSelector.vue
@@ -181,7 +181,7 @@ function checkIfClientIsFeatured(client: SelectedClient) {
         </template>
         <template v-else>
           <svg
-            class="code-languages-icon code-languages-icon__more"
+            class="code-languages-icon"
             height="50"
             viewBox="0 0 50 50"
             width="50"

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -52,8 +52,10 @@ const { state, getClientTitle, getTargetTitle } = useTemplateStore()
         </Card>
 
         <Card>
-          <CardHeader>Client Libraries</CardHeader>
-          <CardContent frameless>
+          <CardHeader transparent>Client Libraries</CardHeader>
+          <CardContent
+            frameless
+            transparent>
             <ClientSelector />
           </CardContent>
           <CardFooter

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -216,4 +216,10 @@ const activeTab = ref<EditorHeaderTabs>(
       var(--theme-border-color, var(--default-theme-border-color)),
     -1px 0 0 0 var(--theme-background-1, var(--default-theme-background-1));
 }
+@media screen and (max-width: 1000px) {
+  .swagger-editor {
+    border-right: none;
+    box-shadow: none;
+  }
+}
 </style>

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -163,7 +163,7 @@ const useExample = () => {
 .swagger-editor-buttons {
   display: flex;
   justify-content: space-between;
-  padding: 0 12px 0 18px;
+  padding: 0 12px 0 21px;
   height: 35px;
   min-height: 35px;
   align-items: center;

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -67,7 +67,7 @@ const useExample = () => {
         'swagger-editor-active': activeTab === 'Swagger Editor',
       }"
       @click="emit('updateActiveTab', 'Swagger Editor')">
-      <div class="swagger-editor-type"><i>Swagger </i>Editor</div>
+      <div class="swagger-editor-type">Swagger Editor</div>
     </div>
   </div>
   <div
@@ -211,16 +211,6 @@ const useExample = () => {
   cursor: pointer;
   border-color: currentColor;
   background: var(--theme-background-2, var(--default-theme-background-2));
-}
-@media (max-width: 580px) {
-  .swagger-editor-title i,
-  .swagger-editor-header button i {
-    display: none;
-  }
-  .swagger-editor-header button {
-    padding: 4px 8px;
-    margin-left: 6px;
-  }
 }
 .swagger-editor-heading {
   font-weight: var(--theme-semibold, var(--default-theme-semibold));

--- a/packages/themes/src/presets/alternate.css
+++ b/packages/themes/src/presets/alternate.css
@@ -73,6 +73,7 @@
 /* Sidebar */
 .light-mode .t-doc__sidebar {
   --default-sidebar-background-1: var(--default-theme-background-2);
+  --default-sidebar-item-hover-color: currentColor;
   --default-sidebar-item-hover-background: var(--default-theme-background-3);
   --default-sidebar-item-active-background: var(
     --default-theme-background-accent
@@ -88,6 +89,7 @@
 
 .dark-mode .sidebar {
   --default-sidebar-background-1: var(--default-theme-background-2);
+  --default-sidebar-item-hover-color: currentColor;
   --default-sidebar-item-hover-background: var(--default-theme-background-3);
   --default-sidebar-item-active-background: var(
     --default-theme-background-accent

--- a/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
+++ b/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
@@ -212,11 +212,6 @@ defineExpose({
   display: flex;
   align-items: stretch;
 }
-@media screen and (max-width: 720px) {
-  .scalar-api-client__codemirror__wrapper {
-    width: calc(100% - 50px);
-  }
-}
 .scalar-api-client__codemirror {
   flex-grow: 1;
   max-width: 100%;


### PR DESCRIPTION
A handful of small fixes

- client libraries background broke when added a mobile fix it needs to be transparent
- client libraries more icon is broken
- just now alignment
- checkbox active
- swagger file alignment
- remove unused mobile media query (scalar-api-client__codemirror__wrapper)
- remove unused border left and right on mobile