### PR TITLE
remove grid from mobile reference as it breaks layout

### DIFF
--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -895,22 +895,7 @@ const breadCrumbs = computed(() => {
   .document,
   .document.layout-swagger-editor {
     /** Content area heights are restricted using just the template row defs */
-    grid-template-rows:
-      var(
-        --scalar-api-reference-theme-header-height,
-        var(--default-scalar-api-reference-theme-header-height)
-      )
-      auto
-      auto
-      auto;
-
-    grid-template-columns: 100%;
-
-    grid-template-areas:
-      'sidebar'
-      'content'
-      'aside'
-      'footer';
+    display: block;
   }
 
   .layout-aside-left,


### PR DESCRIPTION
Before
https://github.com/scalar/scalar/assets/6201407/f533b53b-b7f4-44b0-a1e7-05b7f866e629

After
<img width="752" alt="image" src="https://github.com/scalar/scalar/assets/6201407/3d7ab291-08ea-4bab-a0c1-457747508d14">
