### PR TITLE
fix: wrap watchEffect onMounted for dark light toggle until we use refs

### DIFF
--- a/.changeset/cuddly-insects-design.md
+++ b/.changeset/cuddly-insects-design.md
@@ -1,0 +1,17 @@
+---
+'@scalar/fastify-api-reference': patch
+'@scalar/use-keyboard-event': patch
+'@scalar/api-client-proxy': patch
+'@scalar/swagger-editor': patch
+'@scalar/swagger-parser': patch
+'@scalar/use-codemirror': patch
+'@scalar/api-reference': patch
+'@scalar/use-clipboard': patch
+'@scalar/use-tooltip': patch
+'@scalar/api-client': patch
+'@scalar/use-toasts': patch
+'@scalar/use-modal': patch
+'@scalar/themes': patch
+---
+
+lots of amazing fixes from when we missed last patch

--- a/packages/api-reference/src/components/DarkModeToggle.vue
+++ b/packages/api-reference/src/components/DarkModeToggle.vue
@@ -1,14 +1,17 @@
 <script lang="ts" setup>
-import { watchEffect } from 'vue'
+import { onMounted, watchEffect } from 'vue'
 
 import { useDarkModeState } from '../hooks/useDarkModeState'
 import { FlowIcon } from './Icon'
 
 const { toggleDarkMode, isDark } = useDarkModeState()
 
-watchEffect(() => {
-  document.body.classList.toggle('dark-mode', isDark.value)
-  document.body.classList.toggle('light-mode', !isDark.value)
+// todo move to refs so ssg doesnt break
+onMounted(() => {
+  watchEffect(() => {
+    document.body.classList.toggle('dark-mode', isDark.value)
+    document.body.classList.toggle('light-mode', !isDark.value)
+  })
 })
 </script>
 <template>


### PR DESCRIPTION
this breaks SSG before, we need to be using a ref.

We also should think about a way to ensure document deploys in internal repo are less fragile