### PR TITLE
height of example request example responses can overflows viewport

### DIFF
--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -523,6 +523,10 @@ const breadCrumbs = computed(() => {
   top: 12px;
   height: fit-content;
   position: sticky;
+  max-height: calc(100vh - 48px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .copy .tag-description a {

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -523,7 +523,7 @@ const breadCrumbs = computed(() => {
   top: 12px;
   height: fit-content;
   position: sticky;
-  max-height: calc(100vh - 48px);
+  max-height: calc(100vh - 96px);
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/packages/api-reference/src/components/Card/Card.vue
+++ b/packages/api-reference/src/components/Card/Card.vue
@@ -10,5 +10,8 @@
   overflow: hidden;
   border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
   background: var(--theme-background-2, var(--default-theme-background-2));
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 220px);
 }
 </style>

--- a/packages/api-reference/src/components/Card/Card.vue
+++ b/packages/api-reference/src/components/Card/Card.vue
@@ -12,6 +12,6 @@
   background: var(--theme-background-2, var(--default-theme-background-2));
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 220px);
+  max-height: calc(100vh - 310px);
 }
 </style>

--- a/packages/api-reference/src/components/Card/CardFooter.vue
+++ b/packages/api-reference/src/components/Card/CardFooter.vue
@@ -8,7 +8,6 @@ import CardContent from './CardContent.vue'
 </template>
 <style scoped>
 .card-footer {
-  border-top: 1px solid
-    var(--theme-border-color, var(--default-theme-border-color));
+  flex-shrink: 0;
 }
 </style>

--- a/packages/api-reference/src/components/Card/CardHeader.vue
+++ b/packages/api-reference/src/components/Card/CardHeader.vue
@@ -18,8 +18,8 @@ import CardContent from './CardContent.vue'
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
   font-size: var(--theme-mini, var(--default-theme-mini));
   color: var(--theme-color-3, var(--default-theme-color-3));
+  flex-shrink: 0;
 }
-
 .card-header-slots {
   display: flex;
   justify-content: space-between;

--- a/packages/api-reference/src/components/Content/EndpointsOverview.vue
+++ b/packages/api-reference/src/components/Content/EndpointsOverview.vue
@@ -91,7 +91,6 @@ onMounted(() => {
   overflow: auto;
   background: var(--theme-background-2, var(--default-theme-background-2));
   padding: 10px 12px;
-  max-height: calc(100vh - 300px);
 }
 @media (max-width: 580px) {
   .endpoints {

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -59,7 +59,7 @@ const { state, getClientTitle, getTargetTitle } = useTemplateStore()
             <ClientSelector />
           </CardContent>
           <CardFooter
-            class="font-mono"
+            class="font-mono card-footer"
             muted>
             {{ getTargetTitle(state.selectedClient) }}
             {{ getClientTitle(state.selectedClient) }}

--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -146,6 +146,7 @@ watch(
   border-left: 3px solid
     var(--theme-border-color, var(--default-theme-border-color));
   padding-left: 12px;
+  margin: 0;
 }
 
 .markdown :deep(table) {

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -168,6 +168,7 @@ const formattedPath = computed(() => {
     </CardHeader>
     <CardContent
       borderless
+      class="custom-scroll"
       frameless>
       <!-- @vue-ignore -->
       <CodeMirror
@@ -177,7 +178,9 @@ const formattedPath = computed(() => {
         lineNumbers
         readOnly />
     </CardContent>
-    <CardFooter contrast>
+    <CardFooter
+      class="card-footer"
+      contrast>
       <button
         class="show-api-client-button"
         :class="`show-api-client-button--${operation.httpVerb}`"
@@ -290,6 +293,14 @@ const formattedPath = computed(() => {
   align-items: center;
   height: fit-content;
 }
+/* Can't use flex align center on parent (card-header-actions) so have to match sibling font size vertically align*/
+.copy-button:after {
+  content: '.';
+  color: transparent;
+  font-size: var(--theme-mini, var(--default-theme-mini));
+  line-height: 1.35;
+  width: 0px;
+}
 .copy-button:hover {
   color: var(--theme-color-1, var(--default-theme-color-1));
 }
@@ -373,6 +384,5 @@ const formattedPath = computed(() => {
 }
 .card-header-actions {
   display: flex;
-  align-items: center;
 }
 </style>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
@@ -132,6 +132,7 @@ const changeTab = (index: number) => {
     </div>
     <CardFooter
       v-if="currentResponse?.description"
+      class="card-footer"
       muted>
       <div class="description">
         {{ currentResponse.description }}
@@ -143,6 +144,8 @@ const changeTab = (index: number) => {
 <style scoped>
 .code-copy {
   display: flex;
+  align-items: center;
+  justify-content: center;
   appearance: none;
   -webkit-appearance: none;
   outline: none;
@@ -205,7 +208,6 @@ const changeTab = (index: number) => {
   margin: 6px;
 }
 .card-container {
-  max-height: calc(100vh - 300px);
   background: var(--theme-background-2, var(--default-theme-background-2));
 }
 .card-container :deep(.cm-scroller) {

--- a/packages/use-toasts/src/FlowToast.vue
+++ b/packages/use-toasts/src/FlowToast.vue
@@ -63,7 +63,7 @@ const isCustom = (t: Toast): t is CustomToast => {
   background: var(--theme-background-1, var(--default-theme-background-1));
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
   box-shadow: var(--theme-shadow-2, var(--default-theme-shadow-2));
-
+  font-family: var(--theme-font, var(--default-theme-font));
   width: 380px;
 }
 </style>


### PR DESCRIPTION
before: 
<img width="1511" alt="image" src="https://github.com/scalar/scalar/assets/6201407/4e2be62f-89f5-4abf-a5bb-92038bdad989">

after:
<img width="1245" alt="image" src="https://github.com/scalar/scalar/assets/6201407/64a32488-c251-4459-9c6e-2f902b96481f">
