### PR TITLE
fix: add SearchModal to exports

### DIFF
--- a/.changeset/beige-ears-bake.md
+++ b/.changeset/beige-ears-bake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+export searchmodal component

--- a/.changeset/beige-ears-bake.md
+++ b/.changeset/beige-ears-bake.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-export searchmodal component
+feat: export SearchModal component

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -6,6 +6,7 @@ export { default as ApiReference } from './components/ApiReference.vue'
 export { default as Sidebar } from './components/Sidebar.vue'
 export { default as RenderedReference } from './components/Content/Content.vue'
 export { default as DarkModeToggle } from './components/DarkModeToggle.vue'
+export { default as SearchModal } from './components/SearchModal.vue'
 
 export { useDarkModeState } from './hooks'
 export * from './types'


### PR DESCRIPTION
Now we can use our wonderful SearchModal outside the APIReferences :)