### PR TITLE
fix: make the base urls reactive

### DIFF
--- a/.changeset/fuzzy-rivers-jump.md
+++ b/.changeset/fuzzy-rivers-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: make the base urls reactive

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -106,9 +106,14 @@ const transformedSpec = reactive<Spec>({
   tags: [],
 })
 
-// @ts-ignore
-const handleSpecUpdate = (newSpec) => {
-  Object.assign(transformedSpec, newSpec)
+// TODO: proper types
+const handleSpecUpdate = (newSpec: any) => {
+  Object.assign(transformedSpec, {
+    // Some specs don’t have servers or tags, make sure they are defined
+    servers: [],
+    tags: [],
+    ...newSpec,
+  })
 
   if (!state.activeSidebar) {
     toggleCollapsedSidebarItem(transformedSpec.tags[0].name)

--- a/packages/api-reference/src/components/Content/Introduction/BaseUrl.vue
+++ b/packages/api-reference/src/components/Content/Introduction/BaseUrl.vue
@@ -2,11 +2,10 @@
 import { useClipboard } from '@scalar/use-clipboard'
 import { computed } from 'vue'
 
+import { type Server } from '../../../types'
+
 const props = defineProps<{
-  server?: {
-    url: string
-    description?: string
-  }
+  server?: Server
 }>()
 
 const { copyToClipboard } = useClipboard()

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -154,6 +154,7 @@ export type ExternalDocs = {
 
 export type Server = {
   url: string
+  description?: string
 }
 
 export type Spec = {


### PR DESCRIPTION
Reactivity is hard. The servers are in an array inside a reactive object. We need to make sure the array is always present, otherwise the Swagger editor would keep the url of the previously added spec when the new spec doesn’t have servers.