### PR TITLE
fix: don’t always show the description loading placeholder

### DIFF
--- a/.changeset/thick-jobs-wonder.md
+++ b/.changeset/thick-jobs-wonder.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+amazing sprint fixes

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -31,10 +31,12 @@ const { state, getClientTitle, getTargetTitle } = useTemplateStore()
           </template>
           <!-- @vue-ignore -->
           <template
-            v-for="index in [...Array(8).keys()]"
-            v-else
-            :key="index">
-            <span class="loading" />
+            v-if="!info.title && !info.description && !info?.operations">
+            <template
+              v-for="index in [...Array(8).keys()]"
+              :key="index">
+              <span class="loading" />
+            </template>
           </template>
         </p>
       </div>


### PR DESCRIPTION
The description loading placeholder was even shown when a spec file without a description was loaded.

This PR makes sure the description place holder is only shown when there’s no spec file loaded.