### PR TITLE
Fix/add tagless operations to default

### DIFF
--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -116,9 +116,18 @@ const handleSpecUpdate = (newSpec: any) => {
   })
 
   if (!state.activeSidebar) {
-    toggleCollapsedSidebarItem(transformedSpec.tags[0].name)
-    const { httpVerb, operationId } = transformedSpec.tags[0].operations[0]
-    setActiveSidebar(`${httpVerb}-${operationId}`)
+    const firstTag = transformedSpec.tags[0]
+
+    if (firstTag) {
+      toggleCollapsedSidebarItem(firstTag.name)
+    }
+
+    const firstOperation = transformedSpec.tags[0]?.operations?.[0]
+
+    if (firstOperation) {
+      const { httpVerb, operationId } = firstOperation
+      setActiveSidebar(`${httpVerb}-${operationId}`)
+    }
   }
 }
 

--- a/packages/swagger-parser/src/helpers/generateResponseContent.ts
+++ b/packages/swagger-parser/src/helpers/generateResponseContent.ts
@@ -53,10 +53,14 @@ export const generateResponseContent = (schema: Record<string, any>) => {
 
     // Set an example value based on the type
     const exampleValues: Record<string, any> = {
+      // TODO: Need to check the schema and add a default value
       array: [],
       string: '',
       boolean: true,
       integer: 1,
+      number: 0,
+      // TODO: Need to check the schema and add a default value
+      object: {},
     }
 
     if (exampleValues[property.type] !== undefined) {

--- a/packages/swagger-parser/src/helpers/parseSwaggerFile.ts
+++ b/packages/swagger-parser/src/helpers/parseSwaggerFile.ts
@@ -116,7 +116,9 @@ const transformResult = (result: OpenAPI.Document<object>): SwaggerSpec => {
             tag.name === 'default',
         )
 
-        if (indexOfDefaultTag && indexOfDefaultTag >= 0) {
+        // Add the new operation to the default tag.
+        // @ts-ignore
+        if (indexOfDefaultTag >= 0) {
           // Add the new operation to the default tag.
           // @ts-ignore
           result.tags[indexOfDefaultTag]?.operations.push(newOperation)


### PR DESCRIPTION
There was a regression introduced in #193. It checked for the truthiness of the `indexOfDefaultTag`, which returned false for 0. That caused an issue where operations were not added to the default tag.

This PR fixes it.