### PR TITLE
feat: improve layout for specs with one tag

### DIFF
--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -4,7 +4,7 @@ import { computed, onMounted, ref } from 'vue'
 
 import { useRefOnMount } from '../../hooks/useRefOnMount'
 import { useTemplateStore } from '../../stores/template'
-import type { Spec } from '../../types'
+import type { Spec, Tag } from '../../types'
 import { FlowIcon } from '../Icon'
 import EndpointsOverview from './EndpointsOverview.vue'
 import Introduction from './Introduction'
@@ -45,6 +45,11 @@ const localServers = computed(() => {
     return [{ url: '' }]
   }
 })
+
+const moreThanOneDefaultTag = (tag: Tag) =>
+  props.spec?.tags?.length !== 1 ||
+  tag?.name !== 'default' ||
+  tag?.description !== ''
 </script>
 <template>
   <div
@@ -63,6 +68,7 @@ const localServers = computed(() => {
           v-if="tag.operations && tag.operations.length > 0"
           class="reference">
           <EndpointsOverview
+            v-if="moreThanOneDefaultTag(tag)"
             :index="index"
             :tag="tag" />
           <button

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -58,6 +58,11 @@ useKeyboardEvent({
   withCtrlCmd: true,
   handler: () => setTemplateItem('showSearch', !templateState.showSearch),
 })
+
+const moreThanOneDefaultTag = (tag: Tag) =>
+  props.spec?.tags?.length !== 1 ||
+  tag?.name !== 'default' ||
+  tag?.description !== ''
 </script>
 <template>
   <div class="sidebar">
@@ -68,7 +73,7 @@ useKeyboardEvent({
       <SidebarGroup :level="0">
         <template v-for="tag in spec.tags">
           <SidebarElement
-            v-if="tag.operations?.length > 0"
+            v-if="moreThanOneDefaultTag(tag) && tag.operations?.length > 0"
             :key="tag.name"
             :hasChildren="true"
             :isActive="false"
@@ -101,6 +106,26 @@ useKeyboardEvent({
                 " />
             </SidebarGroup>
           </SidebarElement>
+          <template v-else>
+            <SidebarElement
+              v-for="operation in tag.operations"
+              :key="`${operation.httpVerb}-${operation.operationId}`"
+              :isActive="
+                state.activeSidebar ===
+                `${operation.httpVerb}-${operation.operationId}`
+              "
+              :item="{
+                uid: '',
+                title: operation.name || operation.path,
+                type: 'Page',
+              }"
+              @select="
+                () => {
+                  setCollapsedSidebarItem(tag.name, true)
+                  scrollToEndpoint(operation)
+                }
+              " />
+          </template>
         </template>
       </SidebarGroup>
     </div>

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -10,7 +10,7 @@ import { useMediaQuery } from '@vueuse/core'
 import { nextTick } from 'vue'
 
 import { useTemplateStore } from '../stores/template'
-import type { Operation, Spec } from '../types'
+import type { Operation, Spec, Tag } from '../types'
 import DarkModeToggle from './DarkModeToggle.vue'
 import FindAnythingButton from './FindAnythingButton.vue'
 import SidebarElement from './SidebarElement.vue'

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -110,6 +110,7 @@ const moreThanOneDefaultTag = (tag: Tag) =>
             <SidebarElement
               v-for="operation in tag.operations"
               :key="`${operation.httpVerb}-${operation.operationId}`"
+              class="sidebar-group-item--without-parent"
               :isActive="
                 state.activeSidebar ===
                 `${operation.httpVerb}-${operation.operationId}`
@@ -261,6 +262,12 @@ const moreThanOneDefaultTag = (tag: Tag) =>
 }
 .sidebar-group-item {
   position: relative;
+}
+
+.sidebar-group-item--without-parent .sidebar-heading {
+  margin-left: 12px;
+  padding-left: 12px !important;
+  border-radius: var(--theme-radius, var(--default-theme-radius));
 }
 
 /* Change font colors and weights for nested items */


### PR DESCRIPTION
This PR optimizes the layout for specs with just one default tag:

* No folder item in the sidebar
* No endpoints overview

<img width="1489" alt="Screenshot 2023-10-10 at 13 23 25" src="https://github.com/scalar/scalar/assets/1577992/c852bc81-697a-4238-a9e2-19553cf40f3f">
