### PR TITLE
fix: fastify plugin does not show content

### DIFF
--- a/.changeset/sharp-kangaroos-jam.md
+++ b/.changeset/sharp-kangaroos-jam.md
@@ -1,0 +1,7 @@
+---
+'@scalar/swagger-editor': patch
+'@scalar/api-reference': patch
+'@scalar/fastify-api-reference': patch
+---
+
+fix: initial swagger editor content is parsed

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -6,6 +6,11 @@
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        margin: 0;
+      }
+    </style>
   </head>
   <body>
     <!-- <script id="api-reference" data-url="/scalar.json"></script> -->

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -1,4 +1,5 @@
 import vue from '@vitejs/plugin-vue'
+import path from 'path'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import { defineConfig } from 'vitest/config'
@@ -49,5 +50,18 @@ export default defineConfig({
       enabled: true,
       reporter: 'text',
     },
+  },
+  resolve: {
+    alias: [
+      // Resolve the uncompiled source code for all @scalar packages
+      // It’s working with the alias, too. It’s just required to enable HMR.
+      {
+        // Resolve the uncompiled source code for all @scalar packages
+        // @scalar/* -> packages/*/
+        // (not @scalar/*/style.css)
+        find: /^@scalar\/([^/]+)$/,
+        replacement: path.resolve(__dirname, '../$1/src/index.ts'),
+      },
+    ],
   },
 })

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -112,7 +112,7 @@ watch(
   async () => {
     if (props.value) {
       await nextTick()
-      importHandler(props.value)
+      handleContentUpdate(props.value)
     }
   },
   { immediate: true },
@@ -137,7 +137,7 @@ const activeTab = ref<EditorHeaderTabs>(
       v-if="activeTab === 'Swagger Editor'"
       ref="codeMirrorReference"
       :hocuspocusConfiguration="hocuspocusConfiguration"
-      :value="currentExample ?? undefined"
+      :value="currentExample ?? props.value ?? ''"
       @awarenessUpdate="handleAwarenessUpdate"
       @contentUpdate="handleContentUpdate" />
     <SwaggerEditorStatusBar

--- a/projects/web/src/pages/StartPage.vue
+++ b/projects/web/src/pages/StartPage.vue
@@ -2,25 +2,19 @@
   <div
     class="flex flex-row gap-4 p-6 h-screen bg-gray-50 text-gray-600 items-center">
     <router-link
-      class="basis-1/4 text-center border border-solid border-gray-300 hover:border-gray-400 flex flex-col justify-center rounded text-xl px-4 py-10"
+      class="basis-1/3 text-center border border-solid border-gray-300 hover:border-gray-400 flex flex-col justify-center rounded text-xl px-4 py-10"
       :to="{ name: 'api-reference' }">
       <h2 class="mb-4 font-bold">API Reference</h2>
       <div>Interactive API documentations</div>
     </router-link>
     <router-link
-      class="basis-1/4 text-center border border-solid border-gray-300 hover:border-gray-400 flex flex-col justify-center rounded text-xl px-4 py-10"
-      :to="{ name: 'standalone-api-reference' }">
-      <h2 class="mb-4 font-bold">API Reference (Standalone)</h2>
-      <div>Interactive API documentations</div>
-    </router-link>
-    <router-link
-      class="basis-1/4 text-center border border-solid border-gray-300 hover:border-gray-400 flex flex-col justify-center rounded text-xl px-4 py-10"
+      class="basis-1/3 text-center border border-solid border-gray-300 hover:border-gray-400 flex flex-col justify-center rounded text-xl px-4 py-10"
       :to="{ name: 'api-client' }">
       <h2 class="mb-4 font-bold">API Client</h2>
       <div class="">Your drop-in API Client</div>
     </router-link>
     <router-link
-      class="basis-1/4 text-center border border-solid border-gray-300 hover:border-gray-400 flex flex-col justify-center rounded text-xl px-4 py-10"
+      class="basis-1/3 text-center border border-solid border-gray-300 hover:border-gray-400 flex flex-col justify-center rounded text-xl px-4 py-10"
       :to="{ name: 'swagger-editor' }">
       <h2 class="mb-4 font-bold">Swagger Editor</h2>
       <div>An editor for Swagger files</div>


### PR DESCRIPTION
With #166 we introduced a regression which made the ApiReference not show the initial content. This PR fixes it by passing the initial content to the parser, not just to the SwaggerEditor CodeMirror instance.