### PR TITLE
feat: import URL & upload file in getting started open the modal/dialog

### DIFF
--- a/.changeset/perfect-melons-hear.md
+++ b/.changeset/perfect-melons-hear.md
@@ -1,0 +1,6 @@
+---
+'@scalar/swagger-editor': patch
+'@scalar/api-reference': patch
+---
+
+feat: fix import URL, use proxy to fetch files

--- a/.changeset/rare-lobsters-sparkle.md
+++ b/.changeset/rare-lobsters-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/swagger-editor': patch
+---
+
+feat: click on import url or upload file in getting started opens the modal/dialog now

--- a/.changeset/slow-panthers-sit.md
+++ b/.changeset/slow-panthers-sit.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client-proxy': patch
+---
+
+feat: add errors for missing payload

--- a/packages/api-client-proxy/src/createApiClientProxy.ts
+++ b/packages/api-client-proxy/src/createApiClientProxy.ts
@@ -19,10 +19,32 @@ export const createApiClientProxy = () => {
   // Post request to / are proxied to the target url.
   app.post('/', async (req, res) => {
     if (req.method === 'POST') {
-      console.log(`${req.body.method} ${req.body.url}`)
+      if (req.body.method === undefined || req.body.method.trim() === '') {
+        res.status(400)
+        res.json({
+          error: 'MissingMethod',
+          message:
+            'Could not find a valid request method. Try adding a JSON object with a `method` to your request.',
+        })
+
+        return
+      }
+
+      if (req.body.url === undefined || req.body.url.trim() === '') {
+        res.status(400)
+        res.json({
+          error: 'MissingUrl',
+          message:
+            'Could not find an URL. Try adding a JSON object with an `url` to your request.',
+        })
+
+        return
+      }
+
+      console.log(`${req.body.method.trim()} ${req.body.url.trim()}`)
 
       const isGetOrHeadRequest = ['get', 'head'].includes(
-        req.body.method.toLowerCase(),
+        req.body.method.trim().toLowerCase(),
       )
       const body = isGetOrHeadRequest
         ? null
@@ -32,9 +54,9 @@ export const createApiClientProxy = () => {
 
       // Default options are marked with *
       try {
-        const response = await fetch(req.body.url, {
+        const response = await fetch(req.body.url.trim(), {
           // *GET, POST, PUT, DELETE, etc.
-          method: req.body.method,
+          method: req.body.method.trim(),
           // no-cors, *cors, same-origin
           mode: 'cors',
           // *default, no-cache, reload, force-cache, only-if-cached

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -236,6 +236,7 @@ const breadCrumbs = computed(() => {
       <LazyLoadedSwaggerEditor
         :hocuspocusConfiguration="hocuspocusConfiguration"
         :initialTabState="initialTabState"
+        :proxyUrl="proxyUrl"
         :theme="theme"
         :value="specRef"
         @changeTheme="$emit('changeTheme', $event)"

--- a/packages/swagger-editor/src/components/SwaggerEditor/GettingStarted.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/GettingStarted.vue
@@ -10,7 +10,7 @@ defineProps<{
 
 const emits = defineEmits<{
   (e: 'changeTheme', value: ThemeId): void
-  (e: 'openEditor'): void
+  (e: 'openSwaggerEditor', action?: 'importUrl' | 'uploadFile'): void
   (e: 'changeExample', value: GettingStartedExamples): void
 }>()
 
@@ -54,7 +54,7 @@ watch(activeExample, () => {
       <div class="start-h2">Quick Start</div>
       <div
         class="start-item"
-        @click="$emit('openEditor')">
+        @click="$emit('openSwaggerEditor', 'importUrl')">
         <svg
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg">
@@ -69,7 +69,7 @@ watch(activeExample, () => {
       </div>
       <div
         class="start-item"
-        @click="$emit('openEditor')">
+        @click="$emit('openSwaggerEditor', 'uploadFile')">
         <svg
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg">
@@ -89,7 +89,7 @@ watch(activeExample, () => {
       </div>
       <div
         class="start-item"
-        @click="$emit('openEditor')">
+        @click="$emit('openSwaggerEditor')">
         <svg
           viewBox="0 0 12 16"
           width="10"
@@ -103,7 +103,7 @@ watch(activeExample, () => {
       </div>
       <div
         class="start-item"
-        @click="$emit('openEditor')">
+        @click="$emit('openSwaggerEditor')">
         <svg
           viewBox="0 0 24 24"
           xmlns="http://www.w3.org/2000/svg">

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -11,6 +11,7 @@ import tableau from '../../tableauv3.json'
 import {
   type EditorHeaderTabs,
   type GettingStartedExamples,
+  type OpenSwaggerEditorActions,
   type SwaggerEditorProps,
 } from '../../types'
 import GettingStarted from './GettingStarted.vue'
@@ -27,6 +28,8 @@ const emit = defineEmits<{
   (e: 'import', value: string): void
   (e: 'changeTheme', value: ThemeId): void
 }>()
+
+const swaggerEditorHeaderRef = ref<typeof SwaggerEditorHeader | null>(null)
 
 const currentExample = ref<string | null>(null)
 
@@ -121,11 +124,22 @@ watch(
 const activeTab = ref<EditorHeaderTabs>(
   props.initialTabState ?? 'Getting Started',
 )
+
+const handleOpenSwaggerEditor = (action?: OpenSwaggerEditorActions) => {
+  activeTab.value = 'Swagger Editor'
+
+  if (action === 'importUrl') {
+    swaggerEditorHeaderRef?.value?.importUrlModal?.show()
+  } else if (action === 'uploadFile') {
+    swaggerEditorHeaderRef?.value?.openFileDialog()
+  }
+}
 </script>
 <template>
   <ThemeStyles :id="theme" />
   <div class="swagger-editor">
     <SwaggerEditorHeader
+      ref="swaggerEditorHeaderRef"
       :activeTab="activeTab"
       @import="importHandler"
       @updateActiveTab="activeTab = $event" />
@@ -152,7 +166,7 @@ const activeTab = ref<EditorHeaderTabs>(
       :theme="!theme || theme === 'none' ? 'default' : theme"
       @changeExample="handleChangeExample"
       @changeTheme="emit('changeTheme', $event)"
-      @openEditor="activeTab = 'Swagger Editor'" />
+      @openSwaggerEditor="handleOpenSwaggerEditor" />
   </div>
 </template>
 

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -141,6 +141,7 @@ const handleOpenSwaggerEditor = (action?: OpenSwaggerEditorActions) => {
     <SwaggerEditorHeader
       ref="swaggerEditorHeaderRef"
       :activeTab="activeTab"
+      :proxyUrl="proxyUrl"
       @import="importHandler"
       @updateActiveTab="activeTab = $event" />
     <SwaggerEditorNotification

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -22,14 +22,20 @@ const { files, open, reset } = useFileDialog({
   accept: '.json,.yaml,.yml',
 })
 
-const swaggerURLModalState = useModal()
+const importUrlModal = useModal()
+
+defineExpose({
+  importUrlModal,
+  openFileDialog: open,
+})
+
 const swaggerUrl = ref('')
 
 async function fetchURL() {
   const response = await fetch(swaggerUrl.value)
   const data = await response.json()
   emit('import', JSON.stringify(data, null, 4))
-  swaggerURLModalState.hide()
+  importUrlModal.hide()
 }
 
 watch(files, () => {
@@ -82,8 +88,8 @@ const useExample = () => {
       </button>
       <button
         type="button"
-        @click="swaggerURLModalState.show">
-        Paste URL
+        @click="importUrlModal.show">
+        Import URL
       </button>
       <button
         type="button"
@@ -93,7 +99,7 @@ const useExample = () => {
     </div>
   </div>
   <FlowModal
-    :state="swaggerURLModalState"
+    :state="importUrlModal"
     title="Import Swagger from URL">
     <div class="flex-col gap-1">
       <FlowTextField
@@ -105,7 +111,7 @@ const useExample = () => {
         <FlowButton
           label="Cancel"
           variant="outlined"
-          @click="swaggerURLModalState.hide()" />
+          @click="importUrlModal.hide()" />
         <FlowButton
           label="Import"
           @click="fetchURL" />

--- a/packages/swagger-editor/src/components/SwaggerEditor/fetchSpecFromUrl.ts
+++ b/packages/swagger-editor/src/components/SwaggerEditor/fetchSpecFromUrl.ts
@@ -37,7 +37,7 @@ export const fetchSpecFromUrl = async (
   // Without proxy
   else {
     console.warn(
-      '[fetchSpecFromUrl] Trying to fetch the spec file without a proxy. The CORS headers have to bet set properly, otherwise the request will fail.',
+      '[fetchSpecFromUrl] Trying to fetch the spec file without a proxy. The CORS headers have to be set properly, otherwise the request will fail.',
     )
     const response = await fetch(url)
     const json = await response.json()

--- a/packages/swagger-editor/src/components/SwaggerEditor/fetchSpecFromUrl.ts
+++ b/packages/swagger-editor/src/components/SwaggerEditor/fetchSpecFromUrl.ts
@@ -1,0 +1,46 @@
+export const fetchSpecFromUrl = async (
+  url: string,
+  { proxyUrl }: { proxyUrl?: string },
+) => {
+  // With Proxy
+  if (proxyUrl) {
+    const response = proxyUrl
+      ? await fetch(proxyUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            method: 'GET',
+            url,
+          }),
+        })
+      : await fetch(url)
+
+    const payload = await response.json()
+
+    if (payload.error) {
+      throw new Error(JSON.stringify(payload))
+    }
+
+    if (!payload.data) {
+      throw new Error(
+        'Didn’t receive a proper answer from the Proxy: ' +
+          JSON.stringify(payload),
+      )
+    }
+
+    const data = JSON.parse(payload.data)
+
+    return JSON.stringify(data, null, 2)
+  }
+  // Without proxy
+  else {
+    console.warn(
+      '[fetchSpecFromUrl] Trying to fetch the spec file without a proxy. The CORS headers have to bet set properly, otherwise the request will fail.',
+    )
+    const response = await fetch(url)
+    const json = await response.json()
+    return JSON.stringify(json, null, 2)
+  }
+}

--- a/packages/swagger-editor/src/types.ts
+++ b/packages/swagger-editor/src/types.ts
@@ -5,6 +5,12 @@ export type SwaggerEditorProps = {
   hocuspocusConfiguration?: HocuspocusConfigurationProp
   theme?: ThemeId
   initialTabState?: EditorHeaderTabs
+  proxyUrl?: string
+}
+
+export type SwaggerEditorHeaderProps = {
+  activeTab: EditorHeaderTabs
+  proxyUrl?: string
 }
 
 export type SwaggerEditorInputProps = {

--- a/packages/swagger-editor/src/types.ts
+++ b/packages/swagger-editor/src/types.ts
@@ -22,3 +22,5 @@ export type HocuspocusConfigurationProp = {
 export type EditorHeaderTabs = 'Getting Started' | 'Swagger Editor'
 
 export type GettingStartedExamples = 'Petstore' | 'Tableau' | 'CoinMarketCap'
+
+export type OpenSwaggerEditorActions = 'importUrl' | 'uploadFile'


### PR DESCRIPTION
People were confused when they clicked on import URL or upload file and they saw the empty editor. This PR opens the import url modal or the file dialog. 💅 

https://github.com/scalar/scalar/assets/1577992/6b25b2aa-6e80-434a-8713-489e1f7e697b

