### PR TITLE
feat: show headings with lower depth in the sidebar

### DIFF
--- a/.changeset/beige-chairs-march.md
+++ b/.changeset/beige-chairs-march.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: show headings with a higher depth in the sidebar

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -71,11 +71,17 @@ watch(
       return []
     }
 
-    headings.value = (await getHeadingsFromMarkdown(description)).filter(
-      (heading) => heading.depth === 1,
-    )
+    headings.value = await updateHeadings(description)
   },
 )
+
+const updateHeadings = async (description: string) => {
+  const newHeadings = await getHeadingsFromMarkdown(description)
+
+  const lowestDepth = Math.min(...newHeadings.map((heading) => heading.depth))
+
+  return newHeadings.filter((heading) => heading.depth === lowestDepth)
+}
 </script>
 <template>
   <div class="sidebar">


### PR DESCRIPTION
Let’s say there are only h2 or h3 in the description, let’s find out and just use the highest level that was used and put all headings of that level in the sidebar.

Example: https://github.com/aolabsai/archs/blob/main/core_api.yaml

