### PR TITLE
fix: externalize markdown plugin to not break SSG

### DIFF
--- a/.changeset/wise-radios-explode.md
+++ b/.changeset/wise-radios-explode.md
@@ -1,0 +1,7 @@
+---
+'@scalar/fastify-api-reference': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: externalize markdown plugins to not break SSG

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -7,7 +7,7 @@ import {
 } from '@scalar/api-client'
 import { useKeyboardEvent } from '@scalar/use-keyboard-event'
 import { useMediaQuery } from '@vueuse/core'
-import { nextTick, ref, watch } from 'vue'
+import { nextTick, onMounted, ref, watch } from 'vue'
 
 import { getHeadingsFromMarkdown } from '../helpers'
 import { useTemplateStore } from '../stores/template'
@@ -62,18 +62,20 @@ const moreThanOneDefaultTag = (tag: Tag) =>
 
 const headings = ref<any[]>([])
 
-watch(
-  () => props?.spec?.info?.description,
-  async () => {
-    const description = props?.spec?.info?.description
+onMounted(() => {
+  watch(
+    () => props?.spec?.info?.description,
+    async () => {
+      const description = props?.spec?.info?.description
 
-    if (!description) {
-      return []
-    }
+      if (!description) {
+        return []
+      }
 
-    headings.value = await updateHeadings(description)
-  },
-)
+      headings.value = await updateHeadings(description)
+    },
+  )
+})
 
 const updateHeadings = async (description: string) => {
   const newHeadings = await getHeadingsFromMarkdown(description)

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -62,20 +62,18 @@ const moreThanOneDefaultTag = (tag: Tag) =>
 
 const headings = ref<any[]>([])
 
-onMounted(() => {
-  watch(
-    () => props?.spec?.info?.description,
-    async () => {
-      const description = props?.spec?.info?.description
+watch(
+  () => props?.spec?.info?.description,
+  async () => {
+    const description = props?.spec?.info?.description
 
-      if (!description) {
-        return []
-      }
+    if (!description) {
+      return []
+    }
 
-      headings.value = await updateHeadings(description)
-    },
-  )
-})
+    headings.value = await updateHeadings(description)
+  },
+)
 
 const updateHeadings = async (description: string) => {
   const newHeadings = await getHeadingsFromMarkdown(description)

--- a/packages/api-reference/src/helpers/getHeadingsFromMarkdown.ts
+++ b/packages/api-reference/src/helpers/getHeadingsFromMarkdown.ts
@@ -4,18 +4,16 @@ import remarkParse from 'remark-parse'
 import remarkStringify from 'remark-stringify'
 import { unified } from 'unified'
 
-const slugger = new GithubSlugger()
-
-const processor = unified()
-  .use(remarkParse)
-  .use(remarkStringify)
-  .use(remarkHeadings)
-
 export type Headings = {
   depth: number
   value: string
   slug?: string
 }[]
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkStringify)
+  .use(remarkHeadings)
 
 export const getHeadingsFromMarkdown = async (
   input: string,
@@ -24,6 +22,8 @@ export const getHeadingsFromMarkdown = async (
 
   return withSlugs(headings as Headings)
 }
+
+const slugger = new GithubSlugger()
 
 const withSlugs = (headings: Headings): Headings =>
   headings.map((heading) => {

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
         'remark-parse',
         'remark-rehype',
         'remark-textr',
+        'remark-stringify',
         'typographic-base',
         'unified',
         '@scalar/swagger-editor',


### PR DESCRIPTION
In #233 I broke SSG. This PR externalizes the new Markdown plugin to not break SSG. :)