### PR TITLE
chore: make the linting git hook only fix staged files

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,4 +20,5 @@ pre-commit:
       glob: '*.{js,ts,jsx,tsx,vue,md,json,css,scss,html,yml,yaml}'
       run: 'pnpm prettier --write {staged_files} && git add {staged_files}'
     eslint:
-      run: 'pnpm lint:fix && git add {staged_files}'
+      glob: '*.{js,ts,jsx,tsx,vue}'
+      run: 'pnpm eslint {staged_files} --fix && git add {staged_files}'


### PR DESCRIPTION
The linting Git hook took like 50s or so. 🤡 I’ve changed the hook to only lint staged files, which just takes a few ms (depending on how many files are staged).