### PR TITLE
Fix references not respecting height on mobile Safari

### DIFF
--- a/.changeset/short-doors-laugh.md
+++ b/.changeset/short-doors-laugh.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix references not respecting height on mobile Safari

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -324,7 +324,6 @@ const breadCrumbs = computed(() => {
   --default-scalar-api-reference-col-width-1: 250px;
   --default-scalar-api-reference-col-width-2: calc(50% - 125px);
   --default-scalar-api-reference-col-width-3: calc(50% - 125px);
-  --default-scalar-api-reference-document-height: 100vh;
   --default-scalar-api-reference-full-height: 100%;
 }
 
@@ -981,10 +980,8 @@ const breadCrumbs = computed(() => {
 
     /* Offset by 2px to fill screen and compensate for gap */
     height: calc(
-      var(
-          --scalar-api-reference-document-height,
-          var(--default-scalar-api-reference-document-height)
-        ) - var(--scalar-api-reference-theme-header-height) + 2px
+      var(--full-height, 100vh) -
+        var(--scalar-api-reference-theme-header-height) + 2px
     );
 
     border-top: 1px solid


### PR DESCRIPTION
Classic Safari bug

<img width="400px" src="https://github.com/scalar/scalar/assets/6374090/029c2231-1181-421a-94e9-de0e2edf0f84" />
