### PR TITLE
feat: add analyse helper to return stats about specs

### DIFF
--- a/.changeset/five-crews-mix.md
+++ b/.changeset/five-crews-mix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/swagger-parser': patch
+---
+
+feat: add analyze helper to get stats for Swagger/OpenAPI specs

--- a/.changeset/healthy-moons-refuse.md
+++ b/.changeset/healthy-moons-refuse.md
@@ -1,0 +1,5 @@
+---
+'@scalar/swagger-parser': patch
+---
+
+feat: add preflight helper function to quickly analyze specs without parsing them

--- a/.changeset/pink-ravens-live.md
+++ b/.changeset/pink-ravens-live.md
@@ -1,0 +1,5 @@
+---
+'@scalar/swagger-parser': patch
+---
+
+refactor: rename parseSwaggerFile to just parse

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { type StatesArray } from '@hocuspocus/provider'
-import { type SwaggerSpec, parseSwaggerFile } from '@scalar/swagger-parser'
+import { type SwaggerSpec, parse } from '@scalar/swagger-parser'
 import { type ThemeId, ThemeStyles } from '@scalar/themes'
 import { useDebounceFn } from '@vueuse/core'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
@@ -43,7 +43,7 @@ const handleSpecUpdate = useDebounceFn((value) => {
     localStorage.setItem('swagger-editor-content', value)
   }
 
-  parseSwaggerFile(value)
+  parse(value)
     .then((spec: SwaggerSpec) => {
       parserError.value = ''
 

--- a/packages/swagger-parser/README.md
+++ b/packages/swagger-parser/README.md
@@ -14,9 +14,9 @@ npm install @scalar/swagger-parser
 ## Usage
 
 ```js
-import { parseSwaggerFile } from '@scalar/swagger-parser'
+import { parse } from '@scalar/swagger-parser'
 
-parseSwaggerFile(value)
+parse(value)
   .then((spec) => {
     console.log(spec)
   })

--- a/packages/swagger-parser/src/helpers/analyze.test.ts
+++ b/packages/swagger-parser/src/helpers/analyze.test.ts
@@ -1,0 +1,143 @@
+import { parseSwaggerFile } from 'src/helpers/parse'
+import { describe, expect, it } from 'vitest'
+
+import { analyze } from './analyze'
+
+describe('analyze', () => {
+  it('detects the title', async () => {
+    const spec = { openapi: '3.1.0', info: { title: 'Example' }, paths: {} }
+
+    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+      hasTitle: true,
+    })
+  })
+
+  it('detects a missing title', async () => {
+    const spec = { openapi: '3.1.0', info: {}, paths: {} }
+
+    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+      hasTitle: false,
+    })
+  })
+
+  it('detects the description', async () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: { description: 'Example' },
+      paths: {},
+    }
+
+    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+      hasDescription: true,
+    })
+  })
+
+  it('detects a missing title', async () => {
+    const spec = { openapi: '3.1.0', info: {}, paths: {} }
+
+    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+      hasDescription: false,
+    })
+  })
+
+  it('counts tags', async () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: {},
+      paths: {},
+      tags: [
+        {
+          name: 'foo',
+        },
+        {
+          name: 'bar',
+        },
+      ],
+    }
+
+    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+      numberOfTags: 2,
+    })
+  })
+
+  it('counts tags in operations', async () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: {},
+      paths: {
+        '/example': {
+          get: {
+            tags: ['foobar'],
+          },
+        },
+      },
+    }
+
+    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+      numberOfTags: 1,
+    })
+  })
+
+  it('counts tags and tags in operations', async () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: {},
+      tags: [
+        {
+          name: 'foo',
+        },
+      ],
+      paths: {
+        '/example': {
+          get: {
+            tags: ['bar'],
+          },
+        },
+      },
+    }
+
+    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+      numberOfTags: 2,
+    })
+  })
+
+  it('merges tags and tags in operations', async () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: {},
+      tags: [
+        {
+          name: 'foobar',
+        },
+      ],
+      paths: {
+        '/example': {
+          get: {
+            tags: ['foobar'],
+          },
+        },
+      },
+    }
+
+    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+      numberOfTags: 1,
+    })
+  })
+
+  it('counts operations', async () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: {},
+      paths: {
+        '/example': {
+          get: {},
+          post: {},
+        },
+      },
+    }
+
+    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+      numberOfOperations: 2,
+    })
+  })
+})

--- a/packages/swagger-parser/src/helpers/analyze.test.ts
+++ b/packages/swagger-parser/src/helpers/analyze.test.ts
@@ -1,4 +1,4 @@
-import { parseSwaggerFile } from 'src/helpers/parse'
+import { parse } from 'src/helpers/parse'
 import { describe, expect, it } from 'vitest'
 
 import { analyze } from './analyze'
@@ -7,7 +7,7 @@ describe('analyze', () => {
   it('detects the title', async () => {
     const spec = { openapi: '3.1.0', info: { title: 'Example' }, paths: {} }
 
-    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+    expect(analyze(await parse(spec))).toMatchObject({
       hasTitle: true,
     })
   })
@@ -15,7 +15,7 @@ describe('analyze', () => {
   it('detects a missing title', async () => {
     const spec = { openapi: '3.1.0', info: {}, paths: {} }
 
-    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+    expect(analyze(await parse(spec))).toMatchObject({
       hasTitle: false,
     })
   })
@@ -27,7 +27,7 @@ describe('analyze', () => {
       paths: {},
     }
 
-    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+    expect(analyze(await parse(spec))).toMatchObject({
       hasDescription: true,
     })
   })
@@ -35,7 +35,7 @@ describe('analyze', () => {
   it('detects a missing title', async () => {
     const spec = { openapi: '3.1.0', info: {}, paths: {} }
 
-    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+    expect(analyze(await parse(spec))).toMatchObject({
       hasDescription: false,
     })
   })
@@ -55,7 +55,7 @@ describe('analyze', () => {
       ],
     }
 
-    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+    expect(analyze(await parse(spec))).toMatchObject({
       numberOfTags: 2,
     })
   })
@@ -73,7 +73,7 @@ describe('analyze', () => {
       },
     }
 
-    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+    expect(analyze(await parse(spec))).toMatchObject({
       numberOfTags: 1,
     })
   })
@@ -96,7 +96,7 @@ describe('analyze', () => {
       },
     }
 
-    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+    expect(analyze(await parse(spec))).toMatchObject({
       numberOfTags: 2,
     })
   })
@@ -119,7 +119,7 @@ describe('analyze', () => {
       },
     }
 
-    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+    expect(analyze(await parse(spec))).toMatchObject({
       numberOfTags: 1,
     })
   })
@@ -136,7 +136,7 @@ describe('analyze', () => {
       },
     }
 
-    expect(analyze(await parseSwaggerFile(spec))).toMatchObject({
+    expect(analyze(await parse(spec))).toMatchObject({
       numberOfOperations: 2,
     })
   })

--- a/packages/swagger-parser/src/helpers/analyze.test.ts
+++ b/packages/swagger-parser/src/helpers/analyze.test.ts
@@ -140,4 +140,35 @@ describe('analyze', () => {
       numberOfOperations: 2,
     })
   })
+
+  it('counts models', async () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: {},
+      paths: {},
+      components: {
+        schemas: {
+          success: {
+            required: ['data'],
+            properties: {
+              links: {
+                description: 'Link members related to the primary data.',
+              },
+              included: {
+                description:
+                  'To reduce the number of HTTP requests, servers **MAY** allow responses that include related resources along with the requested primary resources. Such responses are called "compound documents".',
+                type: 'array',
+              },
+            },
+            type: 'object',
+            additionalProperties: false,
+          },
+        },
+      },
+    }
+
+    expect(analyze(await parse(spec))).toMatchObject({
+      numberOfModels: 1,
+    })
+  })
 })

--- a/packages/swagger-parser/src/helpers/analyze.ts
+++ b/packages/swagger-parser/src/helpers/analyze.ts
@@ -3,7 +3,7 @@ import type { SwaggerSpec } from '../types'
 /**
  * This function analyzes a spec and returns a report of the analysis.
  */
-export const analyze = async (spec: SwaggerSpec) => {
+export const analyze = (spec: SwaggerSpec) => {
   const hasTitle = spec.info?.title !== undefined
 
   const hasDescription = spec.info?.description !== undefined

--- a/packages/swagger-parser/src/helpers/analyze.ts
+++ b/packages/swagger-parser/src/helpers/analyze.ts
@@ -1,4 +1,9 @@
-export const analyze = (spec: any) => {
+import type { SwaggerSpec } from '../types'
+
+/**
+ * This function analyzes a spec and returns a report of the analysis.
+ */
+export const analyze = async (spec: SwaggerSpec) => {
   const hasTitle = spec.info?.title !== undefined
 
   const hasDescription = spec.info?.description !== undefined

--- a/packages/swagger-parser/src/helpers/analyze.ts
+++ b/packages/swagger-parser/src/helpers/analyze.ts
@@ -1,0 +1,19 @@
+export const analyze = (spec: any) => {
+  const hasTitle = spec.info?.title !== undefined
+
+  const hasDescription = spec.info?.description !== undefined
+
+  const numberOfTags = spec.tags?.length ?? 0
+
+  const numberOfOperations = spec.tags.reduce(
+    (acc: number, tag: any) => acc + (tag.operations?.length ?? 0),
+    0,
+  )
+
+  return {
+    hasTitle,
+    hasDescription,
+    numberOfTags,
+    numberOfOperations,
+  }
+}

--- a/packages/swagger-parser/src/helpers/analyze.ts
+++ b/packages/swagger-parser/src/helpers/analyze.ts
@@ -15,10 +15,14 @@ export const analyze = (spec: SwaggerSpec) => {
     0,
   )
 
+  const numberOfModels =
+    Object.keys(spec?.components?.schemas ?? {}).length ?? 0
+
   return {
     hasTitle,
     hasDescription,
     numberOfTags,
     numberOfOperations,
+    numberOfModels,
   }
 }

--- a/packages/swagger-parser/src/helpers/index.ts
+++ b/packages/swagger-parser/src/helpers/index.ts
@@ -1,4 +1,5 @@
 import './polyfills'
 
-export * from './parse'
 export * from './analyze'
+export * from './parse'
+export * from './preflight'

--- a/packages/swagger-parser/src/helpers/index.ts
+++ b/packages/swagger-parser/src/helpers/index.ts
@@ -1,3 +1,4 @@
 import './polyfills'
 
-export * from './parseSwaggerFile'
+export * from './parse'
+export * from './analyze'

--- a/packages/swagger-parser/src/helpers/parse.test.ts
+++ b/packages/swagger-parser/src/helpers/parse.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, it } from 'vitest'
 
 import SwaggerExampleJson from '../../tests/fixtures/swagger.json'
 import { getFile } from '../../tests/utils'
-import { parseSwaggerFile } from './parseSwaggerFile'
+import { parse } from './parse'
 
-describe('parseSwaggerFile', () => {
+describe('parse', () => {
   it('complains if the JSON isn’t valid', () =>
     new Promise((resolve) => {
       const invalidJson = '{"foo": "bar}'
 
-      parseSwaggerFile(invalidJson).catch((error) => {
+      parse(invalidJson).catch((error) => {
         expect(error.message).toContain('JSON')
         resolve(null)
       })
@@ -18,7 +18,7 @@ describe('parseSwaggerFile', () => {
 
   it('successfully parses the Swagger petstore example as JSON', () =>
     new Promise((resolve) => {
-      parseSwaggerFile(JSON.stringify(SwaggerExampleJson)).then((result) => {
+      parse(JSON.stringify(SwaggerExampleJson)).then((result) => {
         expect(result.info.title).toBe('Swagger Petstore - OpenAPI 3.0')
         expect(result.info.version).toBe('1.0.11')
         expect(result.info.description).toBeDefined()
@@ -33,7 +33,7 @@ describe('parseSwaggerFile', () => {
 
   it('successfully parses the Swagger petstore example as object', () =>
     new Promise((resolve) => {
-      parseSwaggerFile(SwaggerExampleJson).then((result) => {
+      parse(SwaggerExampleJson).then((result) => {
         expect(result.info.title).toBe('Swagger Petstore - OpenAPI 3.0')
 
         resolve(null)
@@ -42,7 +42,7 @@ describe('parseSwaggerFile', () => {
 
   it('finds all tags', () =>
     new Promise((resolve) => {
-      parseSwaggerFile(SwaggerExampleJson).then((result) => {
+      parse(SwaggerExampleJson).then((result) => {
         expect(result.tags.length).toBe(3)
         expect(result.tags[0].name).toBe('pet')
         expect(result.tags[1].name).toBe('store')
@@ -56,7 +56,7 @@ describe('parseSwaggerFile', () => {
     new Promise((resolve) => {
       const swaggerYaml = getFile('./tests/fixtures/swagger.yaml')
 
-      parseSwaggerFile(swaggerYaml).then((result) => {
+      parse(swaggerYaml).then((result) => {
         expect(result.info.title).toBe('Sample API')
         expect(result.info.version).toBe('0.1.9')
 
@@ -69,7 +69,7 @@ describe('parseSwaggerFile', () => {
       const invalidSwaggerYaml = `openapi: 3.0.0
 info`
 
-      parseSwaggerFile(invalidSwaggerYaml).catch((error) => {
+      parse(invalidSwaggerYaml).catch((error) => {
         expect(error.toString()).toMatch('YAMLException')
         resolve(null)
       })
@@ -78,7 +78,7 @@ info`
   globSync('./tests/fixtures/examples/*.yaml').forEach((file) => {
     it(`parses: ${file}`, () => {
       return new Promise((resolve) => {
-        return parseSwaggerFile(getFile(file)).then((result) => {
+        return parse(getFile(file)).then((result) => {
           expect(result.info.title).toBeDefined()
 
           resolve(null)

--- a/packages/swagger-parser/src/helpers/parse.ts
+++ b/packages/swagger-parser/src/helpers/parse.ts
@@ -2,40 +2,9 @@ import SwaggerParser from '@apidevtools/swagger-parser'
 import yaml from 'js-yaml'
 import { type OpenAPI, type OpenAPIV2, type OpenAPIV3 } from 'openapi-types'
 
-export type SwaggerSpec = {
-  info: {
-    title: string
-    description?: string
-    version: string
-    termsOfService: string
-    contact: {
-      email: string
-    }
-    license: {
-      name: string
-      url: string
-    }
-  }
-  tags: SwaggerTag[]
-}
+import type { AnyObject, AnyStringOrObject, SwaggerSpec } from '../types'
 
-export type SwaggerTag = {
-  name: string
-  description?: string
-  operations: SwaggerOperation[]
-}
-
-// TODO: types
-export type SwaggerOperation = any
-
-type AnyObject = Record<string, any>
-
-export const parse = (
-  /**
-   * A JSON string or an object containg a Swagger spec.
-   */
-  value: string | AnyObject,
-): Promise<SwaggerSpec> => {
+export const parse = (value: AnyStringOrObject): Promise<SwaggerSpec> => {
   return new Promise((resolve, reject) => {
     try {
       const data = parseJsonOrYaml(value) as OpenAPI.Document<object>

--- a/packages/swagger-parser/src/helpers/parse.ts
+++ b/packages/swagger-parser/src/helpers/parse.ts
@@ -30,7 +30,7 @@ export type SwaggerOperation = any
 
 type AnyObject = Record<string, any>
 
-export const parseSwaggerFile = (
+export const parse = (
   /**
    * A JSON string or an object containg a Swagger spec.
    */
@@ -180,3 +180,6 @@ export const parseJsonOrYaml = (value: string | AnyObject): AnyObject => {
 
   return value as AnyObject
 }
+
+/** @deprecated */
+export const parseSwaggerFile = parse

--- a/packages/swagger-parser/src/helpers/preflight.test.ts
+++ b/packages/swagger-parser/src/helpers/preflight.test.ts
@@ -1,0 +1,14 @@
+import { parse } from 'src/helpers/parse'
+import { describe, expect, it } from 'vitest'
+
+import { preflight } from './preflight'
+
+describe('preflight', () => {
+  it('detects the title', async () => {
+    const spec = { openapi: '3.1.0', info: { title: 'Example' }, paths: {} }
+
+    expect(preflight(await parse(spec))).toMatchObject({
+      hasTitle: true,
+    })
+  })
+})

--- a/packages/swagger-parser/src/helpers/preflight.ts
+++ b/packages/swagger-parser/src/helpers/preflight.ts
@@ -3,7 +3,7 @@ import type { AnyObject } from '../types'
 /**
  * This function analyzes a spec without parsing it. The values are inaccurate, but it’s much faster.
  */
-export const preflight = async (value: AnyObject) => {
+export const preflight = (value: AnyObject) => {
   const hasTitle = value.info?.title !== undefined
 
   const hasDescription = value.info?.description !== undefined

--- a/packages/swagger-parser/src/helpers/preflight.ts
+++ b/packages/swagger-parser/src/helpers/preflight.ts
@@ -10,8 +10,8 @@ export const preflight = (value: AnyObject) => {
 
   const numberOfTags = value.tags?.length ?? 0
 
-  const numberOfOperations = value.tags.reduce(
-    (acc: number, tag: any) => acc + (tag.operations?.length ?? 0),
+  const numberOfOperations = Object.keys(value.paths).reduce(
+    (sum, path) => sum + Object.keys(value.paths[path]).length,
     0,
   )
 

--- a/packages/swagger-parser/src/helpers/preflight.ts
+++ b/packages/swagger-parser/src/helpers/preflight.ts
@@ -1,0 +1,24 @@
+import type { AnyObject } from '../types'
+
+/**
+ * This function analyzes a spec without parsing it. The values are inaccurate, but it’s much faster.
+ */
+export const preflight = async (value: AnyObject) => {
+  const hasTitle = value.info?.title !== undefined
+
+  const hasDescription = value.info?.description !== undefined
+
+  const numberOfTags = value.tags?.length ?? 0
+
+  const numberOfOperations = value.tags.reduce(
+    (acc: number, tag: any) => acc + (tag.operations?.length ?? 0),
+    0,
+  )
+
+  return {
+    hasTitle,
+    hasDescription,
+    numberOfTags,
+    numberOfOperations,
+  }
+}

--- a/packages/swagger-parser/src/helpers/preflight.ts
+++ b/packages/swagger-parser/src/helpers/preflight.ts
@@ -15,10 +15,14 @@ export const preflight = (value: AnyObject) => {
     0,
   )
 
+  const numberOfModels =
+    Object.keys(value?.components?.schemas ?? {}).length ?? 0
+
   return {
     hasTitle,
     hasDescription,
     numberOfTags,
     numberOfOperations,
+    numberOfModels,
   }
 }

--- a/packages/swagger-parser/src/index.ts
+++ b/packages/swagger-parser/src/index.ts
@@ -1,1 +1,2 @@
 export * from './helpers'
+export * from './types'

--- a/packages/swagger-parser/src/types.ts
+++ b/packages/swagger-parser/src/types.ts
@@ -12,6 +12,9 @@ export type SwaggerSpec = {
       url: string
     }
   }
+  components?: {
+    schemas?: Record<string, any>
+  }
   tags: SwaggerTag[]
 }
 

--- a/packages/swagger-parser/src/types.ts
+++ b/packages/swagger-parser/src/types.ts
@@ -1,0 +1,29 @@
+export type SwaggerSpec = {
+  info: {
+    title: string
+    description?: string
+    version: string
+    termsOfService: string
+    contact: {
+      email: string
+    }
+    license: {
+      name: string
+      url: string
+    }
+  }
+  tags: SwaggerTag[]
+}
+
+export type SwaggerTag = {
+  name: string
+  description?: string
+  operations: SwaggerOperation[]
+}
+
+// TODO: types
+export type SwaggerOperation = any
+
+export type AnyObject = Record<string, any>
+
+export type AnyStringOrObject = string | Record<string, any>


### PR DESCRIPTION
**analyze()**
This PR introduces a tiny `analyze` helper function which returns a few basic stats about the given spec. The current aim is to make testing of specs easier. I think we’ll extend the anaylze function to return more stats soon.

**preflight()**
This PR adds a `preflight` helper function which analyzes an unparsed spec. It’s faster, but inaccurate. 

**parse instead of parseSwaggerFile**
It also renames `parseSwaggerFile` to just `parse`. It felt wrong to name other helper files `somethingSwaggerFile()`. And it‘s not even expecting a file, just the content.