### PR TITLE
fix: hanging parser

### DIFF
--- a/.changeset/great-lamps-switch.md
+++ b/.changeset/great-lamps-switch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/swagger-parser': patch
+---
+
+fix: avoid timeouts with large files, downgrade @apidevtools/json-schema-ref-parser

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "pnpm": {
     "patchedDependencies": {
       "@jsdevtools/ono@7.1.3": "patches/@jsdevtools__ono@7.1.3.patch"
+    },
+    "overrides": {
+      "@apidevtools/json-schema-ref-parser": "9.0.7"
     }
   },
   "private": true,

--- a/packages/swagger-parser/src/helpers/parse.test.ts
+++ b/packages/swagger-parser/src/helpers/parse.test.ts
@@ -95,11 +95,9 @@ info`
    */
   it('doesn’t hang with large files', () =>
     new Promise((resolve) => {
-      return parseSwaggerFile(JSON.stringify(ShopwareExampleJson)).then(
-        (result) => {
-          expect(result.info.title).toBe('Shopware Admin API')
-          resolve(null)
-        },
-      )
+      return parse(JSON.stringify(ShopwareExampleJson)).then((result) => {
+        expect(result.info.title).toBe('Shopware Admin API')
+        resolve(null)
+      })
     }))
 })

--- a/packages/swagger-parser/src/helpers/parse.test.ts
+++ b/packages/swagger-parser/src/helpers/parse.test.ts
@@ -1,6 +1,7 @@
 import { globSync } from 'glob'
 import { describe, expect, it } from 'vitest'
 
+import ShopwareExampleJson from '../../tests/fixtures/shopware.json'
 import SwaggerExampleJson from '../../tests/fixtures/swagger.json'
 import { getFile } from '../../tests/utils'
 import { parse } from './parse'
@@ -86,4 +87,19 @@ info`
       })
     })
   })
+
+  /**
+   * This file used to hang with @apidevtools/json-schema-ref-parser above 9.0.7
+   *
+   * https://github.com/APIDevTools/swagger-parser/issues/221
+   */
+  it('doesn’t hang with large files', () =>
+    new Promise((resolve) => {
+      return parseSwaggerFile(JSON.stringify(ShopwareExampleJson)).then(
+        (result) => {
+          expect(result.info.title).toBe('Shopware Admin API')
+          resolve(null)
+        },
+      )
+    }))
 })

--- a/packages/swagger-parser/tests/fixtures/shopware.json
+++ b/packages/swagger-parser/tests/fixtures/shopware.json
@@ -1,0 +1,13824 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Shopware Admin API",
+    "description": "This endpoint reference contains an overview of all endpoints comprising the Shopware Admin API.\n\nFor a better overview, all CRUD-endpoints are hidden by default. If you want to show also CRUD-endpoints\nadd the query parameter `type=jsonapi`.",
+    "version": "6.5.5.2"
+  },
+  "servers": [
+    {
+      "url": "http://demopalast.ecow.dev/api"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "success": {
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          },
+          "links": {
+            "description": "Link members related to the primary data.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/links"
+              },
+              {
+                "$ref": "#/components/schemas/pagination"
+              }
+            ]
+          },
+          "data": {
+            "$ref": "#/components/schemas/data"
+          },
+          "included": {
+            "description": "To reduce the number of HTTP requests, servers **MAY** allow responses that include related resources along with the requested primary resources. Such responses are called \"compound documents\".",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/resource"
+            },
+            "uniqueItems": true
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "failure": {
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          },
+          "links": {
+            "$ref": "#/components/schemas/links"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/error"
+            },
+            "uniqueItems": true
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "info": {
+        "required": [
+          "meta"
+        ],
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          },
+          "links": {
+            "$ref": "#/components/schemas/links"
+          },
+          "jsonapi": {
+            "$ref": "#/components/schemas/jsonapi"
+          }
+        },
+        "type": "object"
+      },
+      "meta": {
+        "description": "Non-standard meta-information that can not be represented as an attribute or relationship.",
+        "type": "object",
+        "additionalProperties": true
+      },
+      "data": {
+        "description": "The document's \"primary data\" is a representation of the resource or collection of resources targeted by a request.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/resource"
+          },
+          {
+            "description": "An array of resource objects, an array of resource identifier objects, or an empty array ([]), for requests that target resource collections.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/resource"
+            },
+            "uniqueItems": true
+          }
+        ]
+      },
+      "resource": {
+        "description": "\"Resource objects\" appear in a JSON API document to represent resources.",
+        "required": [
+          "type",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/attributes"
+          },
+          "relationships": {
+            "$ref": "#/components/schemas/relationships"
+          },
+          "links": {
+            "$ref": "#/components/schemas/links"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          }
+        },
+        "type": "object"
+      },
+      "relationshipLinks": {
+        "description": "A resource object **MAY** contain references to other resource objects (\"relationships\"). Relationships may be to-one or to-many. Relationships can be specified by including a member in a resource's links object.",
+        "properties": {
+          "self": {
+            "allOf": [
+              {
+                "description": "A `self` member, whose value is a URL for the relationship itself (a \"relationship URL\"). This URL allows the client to directly manipulate the relationship. For example, it would allow a client to remove an `author` from an `article` without deleting the people resource itself.",
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              {
+                "$ref": "#/components/schemas/link"
+              }
+            ]
+          },
+          "related": {
+            "$ref": "#/components/schemas/link"
+          }
+        },
+        "type": "object",
+        "additionalProperties": true
+      },
+      "links": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/link"
+        }
+      },
+      "link": {
+        "description": "A link **MUST** be represented as either: a string containing the link's URL or a link object.",
+        "oneOf": [
+          {
+            "description": "A string containing the link's URL.",
+            "type": "string",
+            "format": "uri-reference"
+          },
+          {
+            "type": "object",
+            "required": [
+              "href"
+            ],
+            "properties": {
+              "href": {
+                "description": "A string containing the link's URL.",
+                "type": "string",
+                "format": "uri-reference"
+              },
+              "meta": {
+                "$ref": "#/components/schemas/meta"
+              }
+            }
+          }
+        ]
+      },
+      "attributes": {
+        "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.",
+        "type": "object",
+        "additionalProperties": true
+      },
+      "relationships": {
+        "description": "Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.",
+        "type": "object",
+        "anyOf": [
+          {
+            "required": [
+              "data"
+            ]
+          },
+          {
+            "required": [
+              "meta"
+            ]
+          },
+          {
+            "required": [
+              "links"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "links": {
+                "$ref": "#/components/schemas/relationshipLinks"
+              },
+              "data": {
+                "description": "Member, whose value represents \"resource linkage\".",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/relationshipToOne"
+                  },
+                  {
+                    "$ref": "#/components/schemas/relationshipToMany"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "additionalProperties": false
+      },
+      "relationshipToOne": {
+        "allOf": [
+          {
+            "description": "References to other resource objects in a to-one (\"relationship\"). Relationships can be specified by including a member in a resource's links object."
+          },
+          {
+            "$ref": "#/components/schemas/linkage"
+          }
+        ]
+      },
+      "relationshipToMany": {
+        "description": "An array of objects each containing \\\"type\\\" and \\\"id\\\" members for to-many relationships.",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/linkage"
+        },
+        "uniqueItems": true
+      },
+      "linkage": {
+        "description": "The \"type\" and \"id\" to non-empty members.",
+        "required": [
+          "type",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "pagination": {
+        "properties": {
+          "first": {
+            "description": "The first page of data",
+            "type": "string",
+            "format": "uri-reference"
+          },
+          "last": {
+            "description": "The last page of data",
+            "type": "string",
+            "format": "uri-reference"
+          },
+          "prev": {
+            "description": "The previous page of data",
+            "type": "string",
+            "format": "uri-reference"
+          },
+          "next": {
+            "description": "The next page of data",
+            "type": "string",
+            "format": "uri-reference"
+          }
+        },
+        "type": "object"
+      },
+      "jsonapi": {
+        "description": "An object describing the server's implementation",
+        "properties": {
+          "version": {
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "error": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "$ref": "#/components/schemas/links"
+          },
+          "status": {
+            "type": "string",
+            "description": "The HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "type": "string",
+            "description": "An application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "description": {
+            "type": "string",
+            "description": "A human-readable description of the problem."
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "pointer": {
+                "type": "string",
+                "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \"/data\" for a primary data object, or \"/data/attributes/title\" for a specific attribute]."
+              },
+              "parameter": {
+                "type": "string",
+                "description": "A string indicating which query parameter caused the error."
+              }
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/meta"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AclRole": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "name",
+          "privileges",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "privileges": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "deletedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "users": {
+            "$ref": "#/components/schemas/User"
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          },
+          "integrations": {
+            "$ref": "#/components/schemas/Integration"
+          }
+        },
+        "type": "object"
+      },
+      "AclUserRole": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "userId",
+          "aclRoleId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "userId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "aclRoleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "user": {
+            "$ref": "#/components/schemas/User"
+          },
+          "aclRole": {
+            "$ref": "#/components/schemas/AclRole"
+          }
+        },
+        "type": "object"
+      },
+      "App": {
+        "description": "Added since version: 6.3.1.0",
+        "required": [
+          "name",
+          "path",
+          "active",
+          "configurable",
+          "version",
+          "allowDisable",
+          "integrationId",
+          "aclRoleId",
+          "createdAt",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "copyright": {
+            "type": "string"
+          },
+          "license": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "configurable": {
+            "type": "boolean"
+          },
+          "privacy": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "icon": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "string",
+            "readOnly": true
+          },
+          "modules": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "mainModule": {
+            "type": "object"
+          },
+          "cookies": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "allowDisable": {
+            "type": "boolean"
+          },
+          "baseAppUrl": {
+            "type": "string"
+          },
+          "allowedHosts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "templateLoadPriority": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "privacyPolicyExtensions": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "integrationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "aclRoleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "integration": {
+            "$ref": "#/components/schemas/Integration"
+          },
+          "aclRole": {
+            "$ref": "#/components/schemas/AclRole"
+          },
+          "customFieldSets": {
+            "$ref": "#/components/schemas/CustomFieldSet"
+          },
+          "actionButtons": {
+            "$ref": "#/components/schemas/AppActionButton"
+          },
+          "templates": {
+            "$ref": "#/components/schemas/AppTemplate"
+          },
+          "webhooks": {
+            "$ref": "#/components/schemas/Webhook"
+          },
+          "paymentMethods": {
+            "$ref": "#/components/schemas/AppPaymentMethod"
+          },
+          "taxProviders": {
+            "$ref": "#/components/schemas/TaxProvider"
+          },
+          "cmsBlocks": {
+            "$ref": "#/components/schemas/AppCmsBlock"
+          },
+          "flowActions": {
+            "$ref": "#/components/schemas/AppFlowAction"
+          },
+          "flowEvents": {
+            "$ref": "#/components/schemas/AppFlowEvent"
+          }
+        },
+        "type": "object"
+      },
+      "AppActionButton": {
+        "description": "Added since version: 6.3.1.0",
+        "required": [
+          "entity",
+          "view",
+          "url",
+          "action",
+          "appId",
+          "createdAt",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "entity": {
+            "type": "string"
+          },
+          "view": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          }
+        },
+        "type": "object"
+      },
+      "AppAdministrationSnippet": {
+        "description": "Added since version: 6.4.15.0",
+        "required": [
+          "value",
+          "appId",
+          "localeId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "value": {
+            "type": "string"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "localeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        },
+        "type": "object"
+      },
+      "AppCmsBlock": {
+        "description": "Added since version: 6.4.2.0",
+        "required": [
+          "name",
+          "block",
+          "template",
+          "styles",
+          "appId",
+          "createdAt",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "block": {
+            "type": "object"
+          },
+          "template": {
+            "type": "string"
+          },
+          "styles": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          }
+        },
+        "type": "object"
+      },
+      "AppFlowAction": {
+        "description": "Added since version: 6.4.10.0",
+        "required": [
+          "appId",
+          "name",
+          "url",
+          "createdAt",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "badge": {
+            "type": "string"
+          },
+          "parameters": {
+            "type": "object"
+          },
+          "config": {
+            "type": "object"
+          },
+          "headers": {
+            "type": "object"
+          },
+          "requirements": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "iconRaw": {
+            "type": "string"
+          },
+          "icon": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "string",
+            "readOnly": true
+          },
+          "swIcon": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "delayable": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "headline": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          },
+          "flowSequences": {
+            "$ref": "#/components/schemas/FlowSequence"
+          }
+        },
+        "type": "object"
+      },
+      "AppFlowEvent": {
+        "description": "Added since version: 6.5.2.0",
+        "required": [
+          "appId",
+          "name",
+          "aware",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "aware": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          },
+          "flows": {
+            "$ref": "#/components/schemas/Flow"
+          }
+        },
+        "type": "object"
+      },
+      "AppPaymentMethod": {
+        "description": "Added since version: 6.4.1.0",
+        "required": [
+          "appName",
+          "identifier",
+          "paymentMethodId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "appName": {
+            "type": "string"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "payUrl": {
+            "type": "string"
+          },
+          "finalizeUrl": {
+            "type": "string"
+          },
+          "validateUrl": {
+            "type": "string"
+          },
+          "captureUrl": {
+            "type": "string"
+          },
+          "refundUrl": {
+            "type": "string"
+          },
+          "recurringUrl": {
+            "type": "string"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "originalMediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "paymentMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          },
+          "originalMedia": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "paymentMethod": {
+            "$ref": "#/components/schemas/PaymentMethod"
+          }
+        },
+        "type": "object"
+      },
+      "AppScriptCondition": {
+        "description": "Added since version: 6.4.10.3",
+        "required": [
+          "identifier",
+          "active",
+          "appId",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "group": {
+            "type": "string"
+          },
+          "script": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          },
+          "ruleConditions": {
+            "$ref": "#/components/schemas/RuleCondition"
+          }
+        },
+        "type": "object"
+      },
+      "AppTemplate": {
+        "description": "Added since version: 6.3.1.0",
+        "required": [
+          "template",
+          "path",
+          "active",
+          "appId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "template": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          }
+        },
+        "type": "object"
+      },
+      "Category": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "displayNestedProducts",
+          "type",
+          "productAssignmentType",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "afterCategoryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "afterCategoryVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "displayNestedProducts": {
+            "type": "boolean"
+          },
+          "autoIncrement": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "breadcrumb": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false
+            },
+            "readOnly": true
+          },
+          "level": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "path": {
+            "type": "string",
+            "readOnly": true
+          },
+          "childCount": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "productAssignmentType": {
+            "type": "string"
+          },
+          "visible": {
+            "type": "boolean"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "cmsPageIdSwitched": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean"
+          },
+          "visibleChildCount": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "slotConfig": {
+            "type": "object"
+          },
+          "linkType": {
+            "type": "string"
+          },
+          "internalLink": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "externalLink": {
+            "type": "string"
+          },
+          "linkNewTab": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "metaTitle": {
+            "type": "string"
+          },
+          "metaDescription": {
+            "type": "string"
+          },
+          "keywords": {
+            "type": "string"
+          },
+          "cmsPageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "cmsPageVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productStreamId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customEntityTypeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "children": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "products": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "nestedProducts": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "cmsPage": {
+            "$ref": "#/components/schemas/CmsPage"
+          },
+          "productStream": {
+            "$ref": "#/components/schemas/ProductStream"
+          },
+          "navigationSalesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "footerSalesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "serviceSalesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "mainCategories": {
+            "$ref": "#/components/schemas/MainCategory"
+          },
+          "seoUrls": {
+            "$ref": "#/components/schemas/SeoUrl"
+          }
+        },
+        "type": "object"
+      },
+      "CategoryTag": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "categoryId",
+          "tagId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "categoryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "categoryVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "tagId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "tag": {
+            "$ref": "#/components/schemas/Tag"
+          }
+        },
+        "type": "object"
+      },
+      "CmsBlock": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "position",
+          "type",
+          "sectionId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "type": {
+            "type": "string"
+          },
+          "locked": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sectionPosition": {
+            "type": "string"
+          },
+          "marginTop": {
+            "type": "string"
+          },
+          "marginBottom": {
+            "type": "string"
+          },
+          "marginLeft": {
+            "type": "string"
+          },
+          "marginRight": {
+            "type": "string"
+          },
+          "backgroundColor": {
+            "type": "string"
+          },
+          "backgroundMediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "backgroundMediaMode": {
+            "type": "string"
+          },
+          "cssClass": {
+            "type": "string"
+          },
+          "visibility": {
+            "properties": {
+              "mobile": {
+                "type": "boolean"
+              },
+              "desktop": {
+                "type": "boolean"
+              },
+              "tablet": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "sectionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "cmsSectionVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "section": {
+            "$ref": "#/components/schemas/CmsSection"
+          },
+          "backgroundMedia": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "slots": {
+            "$ref": "#/components/schemas/CmsSlot"
+          }
+        },
+        "type": "object"
+      },
+      "CmsPage": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "type",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "entity": {
+            "type": "string"
+          },
+          "cssClass": {
+            "type": "string"
+          },
+          "config": {
+            "properties": {
+              "backgroundColor": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "previewMediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "locked": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "sections": {
+            "$ref": "#/components/schemas/CmsSection"
+          },
+          "previewMedia": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "categories": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "landingPages": {
+            "$ref": "#/components/schemas/LandingPage"
+          },
+          "homeSalesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "products": {
+            "$ref": "#/components/schemas/Product"
+          }
+        },
+        "type": "object"
+      },
+      "CmsSection": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "position",
+          "type",
+          "pageId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "type": {
+            "type": "string"
+          },
+          "locked": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sizingMode": {
+            "type": "string"
+          },
+          "mobileBehavior": {
+            "type": "string"
+          },
+          "backgroundColor": {
+            "type": "string"
+          },
+          "backgroundMediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "backgroundMediaMode": {
+            "type": "string"
+          },
+          "cssClass": {
+            "type": "string"
+          },
+          "pageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "visibility": {
+            "properties": {
+              "mobile": {
+                "type": "boolean"
+              },
+              "desktop": {
+                "type": "boolean"
+              },
+              "tablet": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "cmsPageVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "page": {
+            "$ref": "#/components/schemas/CmsPage"
+          },
+          "backgroundMedia": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "blocks": {
+            "$ref": "#/components/schemas/CmsBlock"
+          }
+        },
+        "type": "object"
+      },
+      "CmsSlot": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "type",
+          "slot",
+          "blockId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "type": {
+            "type": "string"
+          },
+          "slot": {
+            "type": "string"
+          },
+          "locked": {
+            "type": "boolean"
+          },
+          "config": {
+            "type": "object"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "data": {
+            "type": "object",
+            "readOnly": true
+          },
+          "blockId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "fieldConfig": {
+            "type": "object"
+          },
+          "cmsBlockVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "block": {
+            "$ref": "#/components/schemas/CmsBlock"
+          }
+        },
+        "type": "object"
+      },
+      "Country": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt",
+          "name",
+          "addressFormat"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "iso": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "shippingAvailable": {
+            "type": "boolean"
+          },
+          "iso3": {
+            "type": "string"
+          },
+          "displayStateInRegistration": {
+            "type": "boolean"
+          },
+          "forceStateInRegistration": {
+            "type": "boolean"
+          },
+          "checkVatIdPattern": {
+            "type": "boolean"
+          },
+          "vatIdRequired": {
+            "type": "boolean"
+          },
+          "vatIdPattern": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "customerTax": {
+            "required": [
+              "enabled",
+              "currencyId",
+              "amount"
+            ],
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "currencyId": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "number",
+                "format": "float"
+              }
+            },
+            "type": "object"
+          },
+          "companyTax": {
+            "required": [
+              "enabled",
+              "currencyId",
+              "amount"
+            ],
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "currencyId": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "number",
+                "format": "float"
+              }
+            },
+            "type": "object"
+          },
+          "postalCodeRequired": {
+            "type": "boolean"
+          },
+          "checkPostalCodePattern": {
+            "type": "boolean"
+          },
+          "checkAdvancedPostalCodePattern": {
+            "type": "boolean"
+          },
+          "advancedPostalCodePattern": {
+            "type": "string"
+          },
+          "addressFormat": {
+            "type": "object"
+          },
+          "defaultPostalCodePattern": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "states": {
+            "$ref": "#/components/schemas/CountryState"
+          },
+          "customerAddresses": {
+            "$ref": "#/components/schemas/CustomerAddress"
+          },
+          "orderAddresses": {
+            "$ref": "#/components/schemas/OrderAddress"
+          },
+          "salesChannelDefaultAssignments": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "taxRules": {
+            "$ref": "#/components/schemas/TaxRule"
+          },
+          "currencyCountryRoundings": {
+            "$ref": "#/components/schemas/CurrencyCountryRounding"
+          }
+        },
+        "type": "object"
+      },
+      "CountryState": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "countryId",
+          "shortCode",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "countryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "shortCode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "country": {
+            "$ref": "#/components/schemas/Country"
+          },
+          "customerAddresses": {
+            "$ref": "#/components/schemas/CustomerAddress"
+          },
+          "orderAddresses": {
+            "$ref": "#/components/schemas/OrderAddress"
+          }
+        },
+        "type": "object"
+      },
+      "Currency": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "factor",
+          "symbol",
+          "isoCode",
+          "itemRounding",
+          "totalRounding",
+          "createdAt",
+          "shortName",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "factor": {
+            "type": "number",
+            "format": "float"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "isoCode": {
+            "type": "string"
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isSystemDefault": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean"
+          },
+          "taxFreeFrom": {
+            "type": "number",
+            "format": "float"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "itemRounding": {
+            "properties": {
+              "decimals": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "interval": {
+                "type": "number",
+                "format": "float"
+              },
+              "roundForNet": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "totalRounding": {
+            "properties": {
+              "decimals": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "interval": {
+                "type": "number",
+                "format": "float"
+              },
+              "roundForNet": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "salesChannelDefaultAssignments": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "orders": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "salesChannelDomains": {
+            "$ref": "#/components/schemas/SalesChannelDomain"
+          },
+          "promotionDiscountPrices": {
+            "$ref": "#/components/schemas/PromotionDiscountPrices"
+          },
+          "productExports": {
+            "$ref": "#/components/schemas/ProductExport"
+          },
+          "countryRoundings": {
+            "$ref": "#/components/schemas/CurrencyCountryRounding"
+          }
+        },
+        "type": "object"
+      },
+      "CurrencyCountryRounding": {
+        "description": "Added since version: 6.4.0.0",
+        "required": [
+          "currencyId",
+          "countryId",
+          "itemRounding",
+          "totalRounding",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "currencyId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "countryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "itemRounding": {
+            "properties": {
+              "decimals": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "interval": {
+                "type": "number",
+                "format": "float"
+              },
+              "roundForNet": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "totalRounding": {
+            "properties": {
+              "decimals": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "interval": {
+                "type": "number",
+                "format": "float"
+              },
+              "roundForNet": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          },
+          "country": {
+            "$ref": "#/components/schemas/Country"
+          }
+        },
+        "type": "object"
+      },
+      "CustomEntity": {
+        "description": "Added since version: 6.4.9.0",
+        "required": [
+          "name",
+          "fields",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "object"
+          },
+          "flags": {
+            "type": "object"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "pluginId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "cmsAware": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean"
+          },
+          "storeApiAware": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean"
+          },
+          "customFieldsAware": {
+            "type": "boolean"
+          },
+          "labelProperty": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        },
+        "type": "object"
+      },
+      "CustomField": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "name",
+          "type",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "customFieldSetId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "allowCustomerWrite": {
+            "type": "boolean"
+          },
+          "allowCartExpose": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "customFieldSet": {
+            "$ref": "#/components/schemas/CustomFieldSet"
+          },
+          "productSearchConfigFields": {
+            "$ref": "#/components/schemas/ProductSearchConfigField"
+          }
+        },
+        "type": "object"
+      },
+      "CustomFieldSet": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "name",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "global": {
+            "type": "boolean"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "customFields": {
+            "$ref": "#/components/schemas/CustomField"
+          },
+          "relations": {
+            "$ref": "#/components/schemas/CustomFieldSetRelation"
+          },
+          "products": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          }
+        },
+        "type": "object"
+      },
+      "CustomFieldSetRelation": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "customFieldSetId",
+          "entityName",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFieldSetId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "entityName": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "customFieldSet": {
+            "$ref": "#/components/schemas/CustomFieldSet"
+          }
+        },
+        "type": "object"
+      },
+      "Customer": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "groupId",
+          "defaultPaymentMethodId",
+          "salesChannelId",
+          "languageId",
+          "defaultBillingAddressId",
+          "defaultShippingAddressId",
+          "customerNumber",
+          "firstName",
+          "lastName",
+          "email",
+          "accountType",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "groupId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "defaultPaymentMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "lastPaymentMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "defaultBillingAddressId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "defaultShippingAddressId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "autoIncrement": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "customerNumber": {
+            "type": "string"
+          },
+          "salutationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "vatIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "affiliateCode": {
+            "type": "string"
+          },
+          "campaignCode": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "doubleOptInRegistration": {
+            "type": "boolean"
+          },
+          "doubleOptInEmailSentDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "doubleOptInConfirmDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "hash": {
+            "type": "string"
+          },
+          "guest": {
+            "type": "boolean"
+          },
+          "firstLogin": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastLogin": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "birthday": {
+            "type": "string"
+          },
+          "lastOrderDate": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "orderCount": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "orderTotalAmount": {
+            "type": "number",
+            "format": "float",
+            "readOnly": true
+          },
+          "reviewCount": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "remoteAddress": {
+            "type": "string"
+          },
+          "tagIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            },
+            "readOnly": true
+          },
+          "requestedGroupId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "boundSalesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "accountType": {
+            "type": "string"
+          },
+          "createdById": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "updatedById": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "group": {
+            "$ref": "#/components/schemas/CustomerGroup"
+          },
+          "defaultPaymentMethod": {
+            "$ref": "#/components/schemas/PaymentMethod"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "lastPaymentMethod": {
+            "$ref": "#/components/schemas/PaymentMethod"
+          },
+          "defaultBillingAddress": {
+            "$ref": "#/components/schemas/CustomerAddress"
+          },
+          "defaultShippingAddress": {
+            "$ref": "#/components/schemas/CustomerAddress"
+          },
+          "salutation": {
+            "$ref": "#/components/schemas/Salutation"
+          },
+          "addresses": {
+            "$ref": "#/components/schemas/CustomerAddress"
+          },
+          "orderCustomers": {
+            "$ref": "#/components/schemas/OrderCustomer"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "promotions": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "productReviews": {
+            "$ref": "#/components/schemas/ProductReview"
+          },
+          "recoveryCustomer": {
+            "$ref": "#/components/schemas/CustomerRecovery"
+          },
+          "requestedGroup": {
+            "$ref": "#/components/schemas/CustomerGroup"
+          },
+          "boundSalesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "wishlists": {
+            "$ref": "#/components/schemas/CustomerWishlist"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/User"
+          },
+          "updatedBy": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "type": "object"
+      },
+      "CustomerAddress": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "customerId",
+          "countryId",
+          "firstName",
+          "lastName",
+          "city",
+          "street",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customerId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "countryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "countryStateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salutationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "zipcode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          },
+          "street": {
+            "type": "string"
+          },
+          "department": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "phoneNumber": {
+            "type": "string"
+          },
+          "additionalAddressLine1": {
+            "type": "string"
+          },
+          "additionalAddressLine2": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "customer": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "country": {
+            "$ref": "#/components/schemas/Country"
+          },
+          "countryState": {
+            "$ref": "#/components/schemas/CountryState"
+          },
+          "salutation": {
+            "$ref": "#/components/schemas/Salutation"
+          }
+        },
+        "type": "object"
+      },
+      "CustomerGroup": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "displayGross": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "registrationActive": {
+            "type": "boolean"
+          },
+          "registrationTitle": {
+            "type": "string"
+          },
+          "registrationIntroduction": {
+            "type": "string"
+          },
+          "registrationOnlyCompanyRegistration": {
+            "type": "boolean"
+          },
+          "registrationSeoMetaDescription": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "customers": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "registrationSalesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "CustomerGroupRegistrationSalesChannels": {
+        "description": "Added since version: 6.3.1.0",
+        "required": [
+          "customerGroupId",
+          "salesChannelId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customerGroupId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "customerGroup": {
+            "$ref": "#/components/schemas/CustomerGroup"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "CustomerRecovery": {
+        "description": "Added since version: 6.1.0.0",
+        "required": [
+          "hash",
+          "customerId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "hash": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "customer": {
+            "$ref": "#/components/schemas/Customer"
+          }
+        },
+        "type": "object"
+      },
+      "CustomerTag": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "customerId",
+          "tagId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customerId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "tagId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "tag": {
+            "$ref": "#/components/schemas/Tag"
+          }
+        },
+        "type": "object"
+      },
+      "CustomerWishlist": {
+        "description": "Added since version: 6.3.4.0",
+        "required": [
+          "customerId",
+          "salesChannelId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customerId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "products": {
+            "$ref": "#/components/schemas/CustomerWishlistProduct"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "CustomerWishlistProduct": {
+        "description": "Added since version: 6.3.4.0",
+        "required": [
+          "productId",
+          "wishlistId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "wishlistId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "wishlist": {
+            "$ref": "#/components/schemas/CustomerWishlist"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          }
+        },
+        "type": "object"
+      },
+      "DeliveryTime": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "name",
+          "min",
+          "max",
+          "unit",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "min": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "max": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "shippingMethods": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          },
+          "products": {
+            "$ref": "#/components/schemas/Product"
+          }
+        },
+        "type": "object"
+      },
+      "Document": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "documentTypeId",
+          "fileType",
+          "orderId",
+          "config",
+          "deepLinkCode",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "documentTypeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "fileType": {
+            "type": "string"
+          },
+          "referencedDocumentId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "documentMediaFileId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "config": {
+            "type": "object"
+          },
+          "sent": {
+            "type": "boolean"
+          },
+          "static": {
+            "type": "boolean"
+          },
+          "deepLinkCode": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "documentType": {
+            "$ref": "#/components/schemas/DocumentType"
+          },
+          "order": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "referencedDocument": {
+            "$ref": "#/components/schemas/Document"
+          },
+          "dependentDocuments": {
+            "$ref": "#/components/schemas/Document"
+          },
+          "documentMediaFile": {
+            "$ref": "#/components/schemas/Media"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentBaseConfig": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "documentTypeId",
+          "name",
+          "global",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "documentTypeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "logoId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "filenamePrefix": {
+            "type": "string"
+          },
+          "filenameSuffix": {
+            "type": "string"
+          },
+          "global": {
+            "type": "boolean"
+          },
+          "documentNumber": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "documentType": {
+            "$ref": "#/components/schemas/DocumentType"
+          },
+          "logo": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/DocumentBaseConfigSalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentBaseConfigSalesChannel": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "documentBaseConfigId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "documentBaseConfigId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "documentTypeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "documentType": {
+            "$ref": "#/components/schemas/DocumentType"
+          },
+          "documentBaseConfig": {
+            "$ref": "#/components/schemas/DocumentBaseConfig"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "DocumentType": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "technicalName",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "technicalName": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "translated": {
+            "type": "object"
+          },
+          "documents": {
+            "$ref": "#/components/schemas/Document"
+          },
+          "documentBaseConfigs": {
+            "$ref": "#/components/schemas/DocumentBaseConfig"
+          },
+          "documentBaseConfigSalesChannels": {
+            "$ref": "#/components/schemas/DocumentBaseConfigSalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "Flow": {
+        "description": "Added since version: 6.4.6.0",
+        "required": [
+          "name",
+          "eventName",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "eventName": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "invalid": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "appFlowEventId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "sequences": {
+            "$ref": "#/components/schemas/FlowSequence"
+          },
+          "appFlowEvent": {
+            "$ref": "#/components/schemas/AppFlowEvent"
+          }
+        },
+        "type": "object"
+      },
+      "FlowSequence": {
+        "description": "Added since version: 6.4.6.0",
+        "required": [
+          "flowId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "flowId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "ruleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "actionName": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "displayGroup": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "trueCase": {
+            "type": "boolean"
+          },
+          "parentId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "appFlowActionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "flow": {
+            "$ref": "#/components/schemas/Flow"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/FlowSequence"
+          },
+          "children": {
+            "$ref": "#/components/schemas/FlowSequence"
+          },
+          "appFlowAction": {
+            "$ref": "#/components/schemas/AppFlowAction"
+          }
+        },
+        "type": "object"
+      },
+      "FlowTemplate": {
+        "description": "Added since version: 6.4.18.0",
+        "required": [
+          "name",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        },
+        "type": "object"
+      },
+      "ImportExportFile": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "originalName",
+          "path",
+          "expireDate",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "originalName": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "expireDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "accessToken": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "log": {
+            "$ref": "#/components/schemas/ImportExportLog"
+          }
+        },
+        "type": "object"
+      },
+      "ImportExportLog": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "activity",
+          "state",
+          "records",
+          "config",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "activity": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "records": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "userId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "profileId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "fileId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "invalidRecordsLogId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "username": {
+            "type": "string"
+          },
+          "profileName": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object"
+          },
+          "result": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "user": {
+            "$ref": "#/components/schemas/User"
+          },
+          "profile": {
+            "$ref": "#/components/schemas/ImportExportProfile"
+          },
+          "file": {
+            "$ref": "#/components/schemas/ImportExportFile"
+          },
+          "invalidRecordsLog": {
+            "$ref": "#/components/schemas/ImportExportLog"
+          },
+          "failedImportLog": {
+            "$ref": "#/components/schemas/ImportExportLog"
+          }
+        },
+        "type": "object"
+      },
+      "ImportExportProfile": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "label",
+          "sourceEntity",
+          "fileType",
+          "delimiter",
+          "enclosure",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "systemDefault": {
+            "type": "boolean"
+          },
+          "sourceEntity": {
+            "type": "string"
+          },
+          "fileType": {
+            "type": "string"
+          },
+          "delimiter": {
+            "type": "string"
+          },
+          "enclosure": {
+            "type": "string"
+          },
+          "mapping": {
+            "type": "object"
+          },
+          "updateBy": {
+            "type": "object"
+          },
+          "config": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "importExportLogs": {
+            "$ref": "#/components/schemas/ImportExportLog"
+          }
+        },
+        "type": "object"
+      },
+      "Integration": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "label",
+          "accessKey",
+          "secretAccessKey",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "label": {
+            "type": "string"
+          },
+          "accessKey": {
+            "type": "string"
+          },
+          "secretAccessKey": {
+            "type": "string"
+          },
+          "lastUsageAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "admin": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "deletedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "writeAccess": {
+            "type": "boolean",
+            "deprecated": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "extensions": {
+            "properties": {
+              "createdNotifications": {
+                "properties": {
+                  "links": {
+                    "type": "object",
+                    "properties": {
+                      "related": {
+                        "type": "string",
+                        "format": "uri-reference",
+                        "example": "/integration/018b38133f4472c28cc464c5110c99b6/createdNotifications"
+                      }
+                    }
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "example": "notification"
+                        },
+                        "id": {
+                          "type": "string",
+                          "example": "018b38133f4472c28cc464c512bdfd11"
+                        }
+                      }
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          },
+          "aclRoles": {
+            "$ref": "#/components/schemas/AclRole"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationRole": {
+        "description": "Added since version: 6.3.3.0",
+        "required": [
+          "integrationId",
+          "aclRoleId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "integrationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "aclRoleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "integration": {
+            "$ref": "#/components/schemas/Integration"
+          },
+          "role": {
+            "$ref": "#/components/schemas/AclRole"
+          }
+        },
+        "type": "object"
+      },
+      "LandingPage": {
+        "description": "Added since version: 6.4.0.0",
+        "required": [
+          "createdAt",
+          "name",
+          "url"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "slotConfig": {
+            "type": "object"
+          },
+          "metaTitle": {
+            "type": "string"
+          },
+          "metaDescription": {
+            "type": "string"
+          },
+          "keywords": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "cmsPageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "cmsPageVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "cmsPage": {
+            "$ref": "#/components/schemas/CmsPage"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "seoUrls": {
+            "$ref": "#/components/schemas/SeoUrl"
+          }
+        },
+        "type": "object"
+      },
+      "LandingPageSalesChannel": {
+        "description": "Added since version: 6.4.0.0",
+        "required": [
+          "landingPageId",
+          "salesChannelId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "landingPageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "landingPageVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "landingPage": {
+            "$ref": "#/components/schemas/LandingPage"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "LandingPageTag": {
+        "description": "Added since version: 6.4.0.0",
+        "required": [
+          "landingPageId",
+          "tagId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "landingPageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "landingPageVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "tagId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "landingPage": {
+            "$ref": "#/components/schemas/LandingPage"
+          },
+          "tag": {
+            "$ref": "#/components/schemas/Tag"
+          }
+        },
+        "type": "object"
+      },
+      "Language": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "localeId",
+          "name",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "localeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "translationCodeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "extensions": {
+            "properties": {
+              "swagLanguagePackLanguage": {
+                "properties": {
+                  "links": {
+                    "type": "object",
+                    "properties": {
+                      "related": {
+                        "type": "string",
+                        "format": "uri-reference",
+                        "example": "/language/018b38133f45703eacd2538846f50a4d/swagLanguagePackLanguage"
+                      }
+                    }
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "example": "swag_language_pack_language"
+                      },
+                      "id": {
+                        "type": "string",
+                        "pattern": "^[0-9a-f]{32}$",
+                        "example": "018b38133f4672df92f469de91e7b929"
+                      }
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "locale": {
+            "$ref": "#/components/schemas/Locale"
+          },
+          "translationCode": {
+            "$ref": "#/components/schemas/Locale"
+          },
+          "children": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "salesChannelDefaultAssignments": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "salesChannelDomains": {
+            "$ref": "#/components/schemas/SalesChannelDomain"
+          },
+          "customers": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "newsletterRecipients": {
+            "$ref": "#/components/schemas/NewsletterRecipient"
+          },
+          "orders": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "productSearchKeywords": {
+            "$ref": "#/components/schemas/ProductSearchKeyword"
+          },
+          "productKeywordDictionaries": {
+            "$ref": "#/components/schemas/ProductKeywordDictionary"
+          },
+          "productReviews": {
+            "$ref": "#/components/schemas/ProductReview"
+          },
+          "productSearchConfig": {
+            "$ref": "#/components/schemas/ProductSearchConfig"
+          }
+        },
+        "type": "object"
+      },
+      "Locale": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "code",
+          "createdAt",
+          "name",
+          "territory"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "territory": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "languages": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "users": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "type": "object"
+      },
+      "LogEntry": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "message": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "context": {
+            "type": "object"
+          },
+          "extra": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        },
+        "type": "object"
+      },
+      "MailHeaderFooter": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "systemDefault": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "headerHtml": {
+            "type": "string"
+          },
+          "headerPlain": {
+            "type": "string"
+          },
+          "footerHtml": {
+            "type": "string"
+          },
+          "footerPlain": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "MailTemplate": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "mailTemplateTypeId",
+          "createdAt",
+          "subject",
+          "contentHtml",
+          "contentPlain"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mailTemplateTypeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "systemDefault": {
+            "type": "boolean"
+          },
+          "senderName": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "contentHtml": {
+            "type": "string"
+          },
+          "contentPlain": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "mailTemplateType": {
+            "$ref": "#/components/schemas/MailTemplateType"
+          },
+          "media": {
+            "$ref": "#/components/schemas/MailTemplateMedia"
+          }
+        },
+        "type": "object"
+      },
+      "MailTemplateMedia": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "mailTemplateId",
+          "languageId",
+          "mediaId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mailTemplateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "mailTemplate": {
+            "$ref": "#/components/schemas/MailTemplate"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          }
+        },
+        "type": "object"
+      },
+      "MailTemplateType": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "technicalName",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "technicalName": {
+            "type": "string"
+          },
+          "availableEntities": {
+            "type": "object"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "templateData": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "mailTemplates": {
+            "$ref": "#/components/schemas/MailTemplate"
+          }
+        },
+        "type": "object"
+      },
+      "MainCategory": {
+        "description": "Added since version: 6.1.0.0",
+        "required": [
+          "productId",
+          "categoryId",
+          "salesChannelId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "categoryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "categoryVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "Media": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "userId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaFolderId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mimeType": {
+            "type": "string",
+            "readOnly": true
+          },
+          "fileExtension": {
+            "type": "string",
+            "readOnly": true
+          },
+          "uploadedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "fileName": {
+            "type": "string",
+            "readOnly": true
+          },
+          "fileSize": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "metaData": {
+            "type": "object",
+            "readOnly": true
+          },
+          "mediaType": {
+            "type": "object",
+            "readOnly": true
+          },
+          "alt": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "string"
+          },
+          "hasFile": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean"
+          },
+          "private": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "extensions": {
+            "properties": {
+              "themes": {
+                "properties": {
+                  "links": {
+                    "type": "object",
+                    "properties": {
+                      "related": {
+                        "type": "string",
+                        "format": "uri-reference",
+                        "example": "/media/018b38133f4773a2a46093848f36552a/themes"
+                      }
+                    }
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "example": "theme"
+                        },
+                        "id": {
+                          "type": "string",
+                          "example": "018b38133f4773a2a46093849a61fa88"
+                        }
+                      }
+                    }
+                  }
+                },
+                "type": "object"
+              },
+              "themeMedia": {
+                "properties": {
+                  "links": {
+                    "type": "object",
+                    "properties": {
+                      "related": {
+                        "type": "string",
+                        "format": "uri-reference",
+                        "example": "/media/018b38133f4773a2a46093848f36552a/themeMedia"
+                      }
+                    }
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "example": "theme"
+                        },
+                        "id": {
+                          "type": "string",
+                          "example": "018b38133f4773a2a46093849af425b3"
+                        }
+                      }
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "thumbnails": {
+            "$ref": "#/components/schemas/MediaThumbnail"
+          },
+          "user": {
+            "$ref": "#/components/schemas/User"
+          },
+          "categories": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "productManufacturers": {
+            "$ref": "#/components/schemas/ProductManufacturer"
+          },
+          "productMedia": {
+            "$ref": "#/components/schemas/ProductMedia"
+          },
+          "productDownloads": {
+            "$ref": "#/components/schemas/ProductDownload"
+          },
+          "orderLineItemDownloads": {
+            "$ref": "#/components/schemas/OrderLineItemDownload"
+          },
+          "avatarUsers": {
+            "$ref": "#/components/schemas/User"
+          },
+          "mediaFolder": {
+            "$ref": "#/components/schemas/MediaFolder"
+          },
+          "propertyGroupOptions": {
+            "$ref": "#/components/schemas/PropertyGroupOption"
+          },
+          "mailTemplateMedia": {
+            "$ref": "#/components/schemas/MailTemplateMedia"
+          },
+          "documentBaseConfigs": {
+            "$ref": "#/components/schemas/DocumentBaseConfig"
+          },
+          "shippingMethods": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          },
+          "paymentMethods": {
+            "$ref": "#/components/schemas/PaymentMethod"
+          },
+          "productConfiguratorSettings": {
+            "$ref": "#/components/schemas/ProductConfiguratorSetting"
+          },
+          "orderLineItems": {
+            "$ref": "#/components/schemas/OrderLineItem"
+          },
+          "cmsBlocks": {
+            "$ref": "#/components/schemas/CmsBlock"
+          },
+          "cmsSections": {
+            "$ref": "#/components/schemas/CmsSection"
+          },
+          "cmsPages": {
+            "$ref": "#/components/schemas/CmsPage"
+          },
+          "documents": {
+            "$ref": "#/components/schemas/Document"
+          },
+          "appPaymentMethods": {
+            "$ref": "#/components/schemas/AppPaymentMethod"
+          }
+        },
+        "type": "object"
+      },
+      "MediaDefaultFolder": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "entity",
+          "associationFields",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "entity": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "associationFields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "folder": {
+            "$ref": "#/components/schemas/MediaFolder"
+          }
+        },
+        "type": "object"
+      },
+      "MediaFolder": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "configurationId",
+          "name",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "useParentConfiguration": {
+            "type": "boolean"
+          },
+          "configurationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "defaultFolderId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "childCount": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "path": {
+            "type": "string",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "parent": {
+            "$ref": "#/components/schemas/MediaFolder"
+          },
+          "children": {
+            "$ref": "#/components/schemas/MediaFolder"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "defaultFolder": {
+            "$ref": "#/components/schemas/MediaDefaultFolder"
+          },
+          "configuration": {
+            "$ref": "#/components/schemas/MediaFolderConfiguration"
+          }
+        },
+        "type": "object"
+      },
+      "MediaFolderConfiguration": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createThumbnails": {
+            "type": "boolean"
+          },
+          "keepAspectRatio": {
+            "type": "boolean"
+          },
+          "thumbnailQuality": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "private": {
+            "type": "boolean"
+          },
+          "noAssociation": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "mediaFolders": {
+            "$ref": "#/components/schemas/MediaFolder"
+          },
+          "mediaThumbnailSizes": {
+            "$ref": "#/components/schemas/MediaThumbnailSize"
+          }
+        },
+        "type": "object"
+      },
+      "MediaFolderConfigurationMediaThumbnailSize": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "mediaFolderConfigurationId",
+          "mediaThumbnailSizeId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaFolderConfigurationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaThumbnailSizeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaFolderConfiguration": {
+            "$ref": "#/components/schemas/MediaFolderConfiguration"
+          },
+          "mediaThumbnailSize": {
+            "$ref": "#/components/schemas/MediaThumbnailSize"
+          }
+        },
+        "type": "object"
+      },
+      "MediaTag": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "mediaId",
+          "tagId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "tagId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "tag": {
+            "$ref": "#/components/schemas/Tag"
+          }
+        },
+        "type": "object"
+      },
+      "MediaThumbnail": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "mediaId",
+          "width",
+          "height",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "width": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "height": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "url": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          }
+        },
+        "type": "object"
+      },
+      "MediaThumbnailSize": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "width",
+          "height",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "width": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "height": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "mediaFolderConfigurations": {
+            "$ref": "#/components/schemas/MediaFolderConfiguration"
+          }
+        },
+        "type": "object"
+      },
+      "NewsletterRecipient": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "email",
+          "status",
+          "hash",
+          "languageId",
+          "salesChannelId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "email": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "zipCode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "street": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "hash": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "confirmedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "salutationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "salutation": {
+            "$ref": "#/components/schemas/Salutation"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "NewsletterRecipientTag": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "newsletterRecipientId",
+          "tagId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "newsletterRecipientId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "tagId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "newsletterRecipient": {
+            "$ref": "#/components/schemas/NewsletterRecipient"
+          },
+          "tag": {
+            "$ref": "#/components/schemas/Tag"
+          }
+        },
+        "type": "object"
+      },
+      "Notification": {
+        "description": "Added since version: 6.4.7.0",
+        "required": [
+          "status",
+          "message",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "status": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "adminOnly": {
+            "type": "boolean"
+          },
+          "requiredPrivileges": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "createdByIntegrationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdByUserId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "createdByIntegration": {
+            "$ref": "#/components/schemas/Integration"
+          },
+          "createdByUser": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "type": "object"
+      },
+      "NumberRange": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "typeId",
+          "global",
+          "pattern",
+          "start",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "typeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "global": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "start": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "type": {
+            "$ref": "#/components/schemas/NumberRangeType"
+          },
+          "numberRangeSalesChannels": {
+            "$ref": "#/components/schemas/NumberRangeSalesChannel"
+          },
+          "state": {
+            "$ref": "#/components/schemas/NumberRangeState"
+          }
+        },
+        "type": "object"
+      },
+      "NumberRangeSalesChannel": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "numberRangeId",
+          "salesChannelId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "numberRangeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "numberRangeTypeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "numberRange": {
+            "$ref": "#/components/schemas/NumberRange"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "numberRangeType": {
+            "$ref": "#/components/schemas/NumberRangeType"
+          }
+        },
+        "type": "object"
+      },
+      "NumberRangeState": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "numberRangeId",
+          "lastValue",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "numberRangeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "lastValue": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "numberRange": {
+            "$ref": "#/components/schemas/NumberRange"
+          }
+        },
+        "type": "object"
+      },
+      "NumberRangeType": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "global",
+          "createdAt",
+          "typeName"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "technicalName": {
+            "type": "string"
+          },
+          "typeName": {
+            "type": "string"
+          },
+          "global": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "numberRanges": {
+            "$ref": "#/components/schemas/NumberRange"
+          },
+          "numberRangeSalesChannels": {
+            "$ref": "#/components/schemas/NumberRangeSalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "Order": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "billingAddressId",
+          "currencyId",
+          "languageId",
+          "salesChannelId",
+          "orderDateTime",
+          "currencyFactor",
+          "stateId",
+          "itemRounding",
+          "totalRounding",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "autoIncrement": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "orderNumber": {
+            "type": "string"
+          },
+          "billingAddressId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "billingAddressVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "currencyId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "orderDate": {
+            "type": "string",
+            "readOnly": true
+          },
+          "price": {
+            "required": [
+              "netPrice",
+              "totalPrice",
+              "positionPrice",
+              "rawTotal",
+              "taxStatus"
+            ],
+            "properties": {
+              "netPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "totalPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "calculatedTaxes": {
+                "type": "object"
+              },
+              "taxRules": {
+                "type": "object"
+              },
+              "positionPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "rawTotal": {
+                "type": "number",
+                "format": "float"
+              },
+              "taxStatus": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "amountTotal": {
+            "type": "number",
+            "format": "float",
+            "readOnly": true
+          },
+          "amountNet": {
+            "type": "number",
+            "format": "float",
+            "readOnly": true
+          },
+          "positionPrice": {
+            "type": "number",
+            "format": "float",
+            "readOnly": true
+          },
+          "taxStatus": {
+            "type": "string",
+            "readOnly": true
+          },
+          "shippingCosts": {
+            "required": [
+              "unitPrice",
+              "totalPrice",
+              "quantity"
+            ],
+            "properties": {
+              "unitPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "totalPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "calculatedTaxes": {
+                "type": "object"
+              },
+              "taxRules": {
+                "type": "object"
+              },
+              "referencePrice": {
+                "type": "object"
+              },
+              "listPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "discount": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "percentage": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              },
+              "regulationPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "shippingTotal": {
+            "type": "number",
+            "format": "float",
+            "readOnly": true
+          },
+          "currencyFactor": {
+            "type": "number",
+            "format": "float"
+          },
+          "deepLinkCode": {
+            "type": "string"
+          },
+          "affiliateCode": {
+            "type": "string"
+          },
+          "campaignCode": {
+            "type": "string"
+          },
+          "customerComment": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "stateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "ruleIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdById": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "updatedById": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "itemRounding": {
+            "properties": {
+              "decimals": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "interval": {
+                "type": "number",
+                "format": "float"
+              },
+              "roundForNet": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "totalRounding": {
+            "properties": {
+              "decimals": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "interval": {
+                "type": "number",
+                "format": "float"
+              },
+              "roundForNet": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "stateMachineState": {
+            "$ref": "#/components/schemas/StateMachineState"
+          },
+          "orderCustomer": {
+            "$ref": "#/components/schemas/OrderCustomer"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "addresses": {
+            "$ref": "#/components/schemas/OrderAddress"
+          },
+          "billingAddress": {
+            "$ref": "#/components/schemas/OrderAddress"
+          },
+          "deliveries": {
+            "$ref": "#/components/schemas/OrderDelivery"
+          },
+          "lineItems": {
+            "$ref": "#/components/schemas/OrderLineItem"
+          },
+          "transactions": {
+            "$ref": "#/components/schemas/OrderTransaction"
+          },
+          "documents": {
+            "$ref": "#/components/schemas/Document"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/User"
+          },
+          "updatedBy": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "type": "object"
+      },
+      "OrderAddress": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "countryId",
+          "orderId",
+          "firstName",
+          "lastName",
+          "street",
+          "city",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "countryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "countryStateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salutationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "street": {
+            "type": "string"
+          },
+          "zipcode": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          },
+          "department": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "vatId": {
+            "type": "string"
+          },
+          "phoneNumber": {
+            "type": "string"
+          },
+          "additionalAddressLine1": {
+            "type": "string"
+          },
+          "additionalAddressLine2": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "country": {
+            "$ref": "#/components/schemas/Country"
+          },
+          "countryState": {
+            "$ref": "#/components/schemas/CountryState"
+          },
+          "order": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "orderDeliveries": {
+            "$ref": "#/components/schemas/OrderDelivery"
+          },
+          "salutation": {
+            "$ref": "#/components/schemas/Salutation"
+          }
+        },
+        "type": "object"
+      },
+      "OrderCustomer": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "orderId",
+          "email",
+          "firstName",
+          "lastName",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customerId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "email": {
+            "type": "string"
+          },
+          "salutationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "vatIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "customerNumber": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "remoteAddress": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "order": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "salutation": {
+            "$ref": "#/components/schemas/Salutation"
+          }
+        },
+        "type": "object"
+      },
+      "OrderDelivery": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "orderId",
+          "shippingOrderAddressId",
+          "shippingMethodId",
+          "stateId",
+          "trackingCodes",
+          "shippingDateEarliest",
+          "shippingDateLatest",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "shippingOrderAddressId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "shippingOrderAddressVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "shippingMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "stateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "trackingCodes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shippingDateEarliest": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "shippingDateLatest": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "shippingCosts": {
+            "required": [
+              "unitPrice",
+              "totalPrice",
+              "quantity"
+            ],
+            "properties": {
+              "unitPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "totalPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "calculatedTaxes": {
+                "type": "object"
+              },
+              "taxRules": {
+                "type": "object"
+              },
+              "referencePrice": {
+                "type": "object"
+              },
+              "listPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "discount": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "percentage": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              },
+              "regulationPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "stateMachineState": {
+            "$ref": "#/components/schemas/StateMachineState"
+          },
+          "order": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "shippingOrderAddress": {
+            "$ref": "#/components/schemas/OrderAddress"
+          },
+          "shippingMethod": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          },
+          "positions": {
+            "$ref": "#/components/schemas/OrderDeliveryPosition"
+          }
+        },
+        "type": "object"
+      },
+      "OrderDeliveryPosition": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "orderDeliveryId",
+          "orderLineItemId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderDeliveryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderDeliveryVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderLineItemId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderLineItemVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "price": {
+            "required": [
+              "unitPrice",
+              "totalPrice",
+              "quantity"
+            ],
+            "properties": {
+              "unitPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "totalPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "calculatedTaxes": {
+                "type": "object"
+              },
+              "taxRules": {
+                "type": "object"
+              },
+              "referencePrice": {
+                "type": "object"
+              },
+              "listPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "discount": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "percentage": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              },
+              "regulationPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "unitPrice": {
+            "type": "number",
+            "format": "float"
+          },
+          "totalPrice": {
+            "type": "number",
+            "format": "float"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "orderDelivery": {
+            "$ref": "#/components/schemas/OrderDelivery"
+          },
+          "orderLineItem": {
+            "$ref": "#/components/schemas/OrderLineItem"
+          }
+        },
+        "type": "object"
+      },
+      "OrderLineItem": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "orderId",
+          "identifier",
+          "quantity",
+          "label",
+          "position",
+          "states",
+          "price",
+          "children",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$",
+            "readOnly": true
+          },
+          "parentId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "coverId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "referencedId": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "label": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          },
+          "good": {
+            "type": "boolean"
+          },
+          "removable": {
+            "type": "boolean"
+          },
+          "stackable": {
+            "type": "boolean"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "price": {
+            "required": [
+              "unitPrice",
+              "totalPrice",
+              "quantity"
+            ],
+            "properties": {
+              "unitPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "totalPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "calculatedTaxes": {
+                "type": "object"
+              },
+              "taxRules": {
+                "type": "object"
+              },
+              "referencePrice": {
+                "type": "object"
+              },
+              "listPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "discount": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "percentage": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              },
+              "regulationPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "priceDefinition": {
+            "type": "object"
+          },
+          "unitPrice": {
+            "type": "number",
+            "format": "float"
+          },
+          "totalPrice": {
+            "type": "number",
+            "format": "float"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "cover": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "order": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "promotion": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "orderDeliveryPositions": {
+            "$ref": "#/components/schemas/OrderDeliveryPosition"
+          },
+          "orderTransactionCaptureRefundPositions": {
+            "$ref": "#/components/schemas/OrderTransactionCaptureRefundPosition"
+          },
+          "downloads": {
+            "$ref": "#/components/schemas/OrderLineItemDownload"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/OrderLineItem"
+          },
+          "children": {
+            "$ref": "#/components/schemas/OrderLineItem"
+          }
+        },
+        "type": "object"
+      },
+      "OrderLineItemDownload": {
+        "description": "Added since version: 6.4.19.0",
+        "required": [
+          "orderLineItemId",
+          "mediaId",
+          "position",
+          "accessGranted",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderLineItemId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderLineItemVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "accessGranted": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "orderLineItem": {
+            "$ref": "#/components/schemas/OrderLineItem"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          }
+        },
+        "type": "object"
+      },
+      "OrderTag": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "orderId",
+          "tagId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "tagId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "order": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "tag": {
+            "$ref": "#/components/schemas/Tag"
+          }
+        },
+        "type": "object"
+      },
+      "OrderTransaction": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "orderId",
+          "paymentMethodId",
+          "amount",
+          "stateId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "paymentMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "amount": {
+            "required": [
+              "unitPrice",
+              "totalPrice",
+              "quantity"
+            ],
+            "properties": {
+              "unitPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "totalPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "calculatedTaxes": {
+                "type": "object"
+              },
+              "taxRules": {
+                "type": "object"
+              },
+              "referencePrice": {
+                "type": "object"
+              },
+              "listPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "discount": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "percentage": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              },
+              "regulationPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "stateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "stateMachineState": {
+            "$ref": "#/components/schemas/StateMachineState"
+          },
+          "order": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "paymentMethod": {
+            "$ref": "#/components/schemas/PaymentMethod"
+          },
+          "captures": {
+            "$ref": "#/components/schemas/OrderTransactionCapture"
+          }
+        },
+        "type": "object"
+      },
+      "OrderTransactionCapture": {
+        "description": "Added since version: 6.4.12.0",
+        "required": [
+          "orderTransactionId",
+          "stateId",
+          "amount",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderTransactionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderTransactionVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "stateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "externalReference": {
+            "type": "string"
+          },
+          "amount": {
+            "required": [
+              "unitPrice",
+              "totalPrice",
+              "quantity"
+            ],
+            "properties": {
+              "unitPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "totalPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "calculatedTaxes": {
+                "type": "object"
+              },
+              "taxRules": {
+                "type": "object"
+              },
+              "referencePrice": {
+                "type": "object"
+              },
+              "listPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "discount": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "percentage": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              },
+              "regulationPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "stateMachineState": {
+            "$ref": "#/components/schemas/StateMachineState"
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/OrderTransaction"
+          },
+          "refunds": {
+            "$ref": "#/components/schemas/OrderTransactionCaptureRefund"
+          }
+        },
+        "type": "object"
+      },
+      "OrderTransactionCaptureRefund": {
+        "description": "Added since version: 6.4.12.0",
+        "required": [
+          "captureId",
+          "stateId",
+          "amount",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "captureId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "captureVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "stateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "externalReference": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "amount": {
+            "required": [
+              "unitPrice",
+              "totalPrice",
+              "quantity"
+            ],
+            "properties": {
+              "unitPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "totalPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "calculatedTaxes": {
+                "type": "object"
+              },
+              "taxRules": {
+                "type": "object"
+              },
+              "referencePrice": {
+                "type": "object"
+              },
+              "listPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "discount": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "percentage": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              },
+              "regulationPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "stateMachineState": {
+            "$ref": "#/components/schemas/StateMachineState"
+          },
+          "transactionCapture": {
+            "$ref": "#/components/schemas/OrderTransactionCapture"
+          },
+          "positions": {
+            "$ref": "#/components/schemas/OrderTransactionCaptureRefundPosition"
+          }
+        },
+        "type": "object"
+      },
+      "OrderTransactionCaptureRefundPosition": {
+        "description": "Added since version: 6.4.12.0",
+        "required": [
+          "refundId",
+          "orderLineItemId",
+          "amount",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "refundId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "refundVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderLineItemId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "orderLineItemVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "externalReference": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "amount": {
+            "required": [
+              "unitPrice",
+              "totalPrice",
+              "quantity"
+            ],
+            "properties": {
+              "unitPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "totalPrice": {
+                "type": "number",
+                "format": "float"
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "calculatedTaxes": {
+                "type": "object"
+              },
+              "taxRules": {
+                "type": "object"
+              },
+              "referencePrice": {
+                "type": "object"
+              },
+              "listPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "discount": {
+                    "type": "number",
+                    "format": "float"
+                  },
+                  "percentage": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              },
+              "regulationPrice": {
+                "properties": {
+                  "price": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "orderLineItem": {
+            "$ref": "#/components/schemas/OrderLineItem"
+          },
+          "orderTransactionCaptureRefund": {
+            "$ref": "#/components/schemas/OrderTransactionCaptureRefund"
+          }
+        },
+        "type": "object"
+      },
+      "PaymentMethod": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "pluginId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "handlerIdentifier": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "distinguishableName": {
+            "type": "string",
+            "readOnly": true
+          },
+          "description": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "afterOrderEnabled": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "availabilityRuleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "formattedHandlerIdentifier": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "string",
+            "readOnly": true
+          },
+          "synchronous": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "asynchronous": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "prepared": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "refundable": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "recurring": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean",
+            "readOnly": true
+          },
+          "shortName": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "availabilityRule": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "salesChannelDefaultAssignments": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "plugin": {
+            "$ref": "#/components/schemas/Plugin"
+          },
+          "customers": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "orderTransactions": {
+            "$ref": "#/components/schemas/OrderTransaction"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "appPaymentMethod": {
+            "$ref": "#/components/schemas/AppPaymentMethod"
+          }
+        },
+        "type": "object"
+      },
+      "Plugin": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "baseClass",
+          "name",
+          "autoload",
+          "version",
+          "createdAt",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "baseClass": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "composerName": {
+            "type": "string"
+          },
+          "autoload": {
+            "type": "object"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "managedByComposer": {
+            "type": "boolean"
+          },
+          "path": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "copyright": {
+            "type": "string"
+          },
+          "license": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "upgradeVersion": {
+            "type": "string"
+          },
+          "installedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "upgradedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "icon": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "string",
+            "readOnly": true
+          },
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "manufacturerLink": {
+            "type": "string"
+          },
+          "supportLink": {
+            "type": "string"
+          },
+          "changelog": {
+            "type": "object"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "paymentMethods": {
+            "$ref": "#/components/schemas/PaymentMethod"
+          }
+        },
+        "type": "object"
+      },
+      "Product": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "taxId",
+          "price",
+          "productNumber",
+          "stock",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "manufacturerId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productManufacturerVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "unitId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "taxId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "coverId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productMediaVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "deliveryTimeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "featureSetId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "canonicalProductId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "cmsPageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "cmsPageVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "price": {
+            "type": "object"
+          },
+          "productNumber": {
+            "type": "string"
+          },
+          "restockTime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "autoIncrement": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "available": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isCloseout": {
+            "type": "boolean"
+          },
+          "variation": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "displayGroup": {
+            "type": "string",
+            "readOnly": true
+          },
+          "variantListingConfig": {
+            "type": "object"
+          },
+          "variantRestrictions": {
+            "type": "object"
+          },
+          "manufacturerNumber": {
+            "type": "string"
+          },
+          "ean": {
+            "type": "string"
+          },
+          "purchaseSteps": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "maxPurchase": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "minPurchase": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "purchaseUnit": {
+            "type": "number",
+            "format": "float"
+          },
+          "referenceUnit": {
+            "type": "number",
+            "format": "float"
+          },
+          "shippingFree": {
+            "type": "boolean"
+          },
+          "purchasePrices": {
+            "type": "object"
+          },
+          "markAsTopseller": {
+            "type": "boolean"
+          },
+          "weight": {
+            "type": "number",
+            "format": "float"
+          },
+          "width": {
+            "type": "number",
+            "format": "float"
+          },
+          "height": {
+            "type": "number",
+            "format": "float"
+          },
+          "length": {
+            "type": "number",
+            "format": "float"
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ratingAverage": {
+            "type": "number",
+            "format": "float",
+            "readOnly": true
+          },
+          "categoryTree": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            },
+            "readOnly": true
+          },
+          "propertyIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            },
+            "readOnly": true
+          },
+          "optionIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            },
+            "readOnly": true
+          },
+          "streamIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            },
+            "readOnly": true
+          },
+          "tagIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            },
+            "readOnly": true
+          },
+          "categoryIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            },
+            "readOnly": true
+          },
+          "childCount": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "customFieldSetSelectionActive": {
+            "type": "boolean"
+          },
+          "sales": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true
+          },
+          "metaDescription": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "keywords": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "metaTitle": {
+            "type": "string"
+          },
+          "packUnit": {
+            "type": "string"
+          },
+          "packUnitPlural": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "slotConfig": {
+            "type": "object"
+          },
+          "customSearchKeywords": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "availableStock": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "stock": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "downloads": {
+            "$ref": "#/components/schemas/ProductDownload"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "children": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "deliveryTime": {
+            "$ref": "#/components/schemas/DeliveryTime"
+          },
+          "tax": {
+            "$ref": "#/components/schemas/Tax"
+          },
+          "manufacturer": {
+            "$ref": "#/components/schemas/ProductManufacturer"
+          },
+          "unit": {
+            "$ref": "#/components/schemas/Unit"
+          },
+          "cover": {
+            "$ref": "#/components/schemas/ProductMedia"
+          },
+          "featureSet": {
+            "$ref": "#/components/schemas/ProductFeatureSet"
+          },
+          "cmsPage": {
+            "$ref": "#/components/schemas/CmsPage"
+          },
+          "canonicalProduct": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "prices": {
+            "$ref": "#/components/schemas/ProductPrice"
+          },
+          "media": {
+            "$ref": "#/components/schemas/ProductMedia"
+          },
+          "crossSellings": {
+            "$ref": "#/components/schemas/ProductCrossSelling"
+          },
+          "crossSellingAssignedProducts": {
+            "$ref": "#/components/schemas/ProductCrossSellingAssignedProducts"
+          },
+          "configuratorSettings": {
+            "$ref": "#/components/schemas/ProductConfiguratorSetting"
+          },
+          "visibilities": {
+            "$ref": "#/components/schemas/ProductVisibility"
+          },
+          "searchKeywords": {
+            "$ref": "#/components/schemas/ProductSearchKeyword"
+          },
+          "productReviews": {
+            "$ref": "#/components/schemas/ProductReview"
+          },
+          "mainCategories": {
+            "$ref": "#/components/schemas/MainCategory"
+          },
+          "seoUrls": {
+            "$ref": "#/components/schemas/SeoUrl"
+          },
+          "orderLineItems": {
+            "$ref": "#/components/schemas/OrderLineItem"
+          },
+          "wishlists": {
+            "$ref": "#/components/schemas/CustomerWishlistProduct"
+          },
+          "options": {
+            "$ref": "#/components/schemas/PropertyGroupOption"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/PropertyGroupOption"
+          },
+          "categories": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "streams": {
+            "$ref": "#/components/schemas/ProductStream"
+          },
+          "categoriesRo": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "customFieldSets": {
+            "$ref": "#/components/schemas/CustomFieldSet"
+          }
+        },
+        "type": "object"
+      },
+      "ProductCategory": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productId",
+          "categoryId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "categoryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "categoryVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          }
+        },
+        "type": "object"
+      },
+      "ProductCategoryTree": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productId",
+          "categoryId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "categoryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "categoryVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          }
+        },
+        "type": "object"
+      },
+      "ProductConfiguratorSetting": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productId",
+          "optionId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "optionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "price": {
+            "type": "object"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "option": {
+            "$ref": "#/components/schemas/PropertyGroupOption"
+          }
+        },
+        "type": "object"
+      },
+      "ProductCrossSelling": {
+        "description": "Added since version: 6.1.0.0",
+        "required": [
+          "name",
+          "position",
+          "type",
+          "productId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "sortBy": {
+            "type": "string"
+          },
+          "sortDirection": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productStreamId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "productStream": {
+            "$ref": "#/components/schemas/ProductStream"
+          },
+          "assignedProducts": {
+            "$ref": "#/components/schemas/ProductCrossSellingAssignedProducts"
+          }
+        },
+        "type": "object"
+      },
+      "ProductCrossSellingAssignedProducts": {
+        "description": "Added since version: 6.2.0.0",
+        "required": [
+          "crossSellingId",
+          "productId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "crossSellingId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "crossSelling": {
+            "$ref": "#/components/schemas/ProductCrossSelling"
+          }
+        },
+        "type": "object"
+      },
+      "ProductCustomFieldSet": {
+        "description": "Added since version: 6.3.0.0",
+        "required": [
+          "productId",
+          "customFieldSetId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFieldSetId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "customFieldSet": {
+            "$ref": "#/components/schemas/CustomFieldSet"
+          }
+        },
+        "type": "object"
+      },
+      "ProductDownload": {
+        "description": "Added since version: 6.4.19.0",
+        "required": [
+          "productId",
+          "mediaId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          }
+        },
+        "type": "object"
+      },
+      "ProductExport": {
+        "description": "Added since version: 6.1.0.0",
+        "required": [
+          "productStreamId",
+          "storefrontSalesChannelId",
+          "salesChannelId",
+          "salesChannelDomainId",
+          "currencyId",
+          "fileName",
+          "accessKey",
+          "encoding",
+          "fileFormat",
+          "generateByCronjob",
+          "interval",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productStreamId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "storefrontSalesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelDomainId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "currencyId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "accessKey": {
+            "type": "string"
+          },
+          "encoding": {
+            "type": "string"
+          },
+          "fileFormat": {
+            "type": "string"
+          },
+          "includeVariants": {
+            "type": "boolean"
+          },
+          "generateByCronjob": {
+            "type": "boolean"
+          },
+          "generatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "interval": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "headerTemplate": {
+            "type": "string"
+          },
+          "bodyTemplate": {
+            "type": "string"
+          },
+          "footerTemplate": {
+            "type": "string"
+          },
+          "pausedSchedule": {
+            "type": "boolean"
+          },
+          "isRunning": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "productStream": {
+            "$ref": "#/components/schemas/ProductStream"
+          },
+          "storefrontSalesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "salesChannelDomain": {
+            "$ref": "#/components/schemas/SalesChannelDomain"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          }
+        },
+        "type": "object"
+      },
+      "ProductFeatureSet": {
+        "description": "Added since version: 6.3.0.0",
+        "required": [
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "features": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "products": {
+            "$ref": "#/components/schemas/Product"
+          }
+        },
+        "type": "object"
+      },
+      "ProductKeywordDictionary": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "languageId",
+          "keyword"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "keyword": {
+            "type": "string"
+          },
+          "reversed": {
+            "type": "string"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          }
+        },
+        "type": "object"
+      },
+      "ProductManufacturer": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "link": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "products": {
+            "$ref": "#/components/schemas/Product"
+          }
+        },
+        "type": "object"
+      },
+      "ProductMedia": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productId",
+          "mediaId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "coverProducts": {
+            "$ref": "#/components/schemas/Product"
+          }
+        },
+        "type": "object"
+      },
+      "ProductOption": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productId",
+          "optionId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "optionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "option": {
+            "$ref": "#/components/schemas/PropertyGroupOption"
+          }
+        },
+        "type": "object"
+      },
+      "ProductPrice": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productId",
+          "ruleId",
+          "price",
+          "quantityStart",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "ruleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "price": {
+            "type": "object"
+          },
+          "quantityStart": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "quantityEnd": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rule"
+          }
+        },
+        "type": "object"
+      },
+      "ProductProperty": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productId",
+          "optionId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "optionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "option": {
+            "$ref": "#/components/schemas/PropertyGroupOption"
+          }
+        },
+        "type": "object"
+      },
+      "ProductReview": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productId",
+          "salesChannelId",
+          "languageId",
+          "title",
+          "content",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customerId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "externalUser": {
+            "type": "string"
+          },
+          "externalEmail": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "points": {
+            "type": "number",
+            "format": "float"
+          },
+          "status": {
+            "type": "boolean"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          }
+        },
+        "type": "object"
+      },
+      "ProductSearchConfig": {
+        "description": "Added since version: 6.3.5.0",
+        "required": [
+          "languageId",
+          "andLogic",
+          "minSearchLength",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "andLogic": {
+            "type": "boolean"
+          },
+          "minSearchLength": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "excludedTerms": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "configFields": {
+            "$ref": "#/components/schemas/ProductSearchConfigField"
+          }
+        },
+        "type": "object"
+      },
+      "ProductSearchConfigField": {
+        "description": "Added since version: 6.3.5.0",
+        "required": [
+          "searchConfigId",
+          "field",
+          "tokenize",
+          "searchable",
+          "ranking",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "searchConfigId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFieldId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "field": {
+            "type": "string"
+          },
+          "tokenize": {
+            "type": "boolean"
+          },
+          "searchable": {
+            "type": "boolean"
+          },
+          "ranking": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "searchConfig": {
+            "$ref": "#/components/schemas/ProductSearchConfig"
+          },
+          "customField": {
+            "$ref": "#/components/schemas/CustomField"
+          }
+        },
+        "type": "object"
+      },
+      "ProductSearchKeyword": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "languageId",
+          "productId",
+          "keyword",
+          "ranking",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "versionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "keyword": {
+            "type": "string"
+          },
+          "ranking": {
+            "type": "number",
+            "format": "float"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          }
+        },
+        "type": "object"
+      },
+      "ProductSorting": {
+        "description": "Added since version: 6.3.2.0",
+        "required": [
+          "key",
+          "priority",
+          "active",
+          "fields",
+          "createdAt",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "locked": {
+            "type": "boolean"
+          },
+          "key": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "fields": {
+            "type": "object"
+          },
+          "label": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ProductStream": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "apiFilter": {
+            "type": "object",
+            "readOnly": true
+          },
+          "invalid": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/ProductStreamFilter"
+          },
+          "productCrossSellings": {
+            "$ref": "#/components/schemas/ProductCrossSelling"
+          },
+          "productExports": {
+            "$ref": "#/components/schemas/ProductExport"
+          },
+          "categories": {
+            "$ref": "#/components/schemas/Category"
+          }
+        },
+        "type": "object"
+      },
+      "ProductStreamFilter": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productStreamId",
+          "type",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productStreamId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "type": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "parameters": {
+            "type": "object"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "productStream": {
+            "$ref": "#/components/schemas/ProductStream"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/ProductStreamFilter"
+          },
+          "queries": {
+            "$ref": "#/components/schemas/ProductStreamFilter"
+          }
+        },
+        "type": "object"
+      },
+      "ProductStreamMapping": {
+        "description": "Added since version: 6.4.0.0",
+        "required": [
+          "productId",
+          "productStreamId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productStreamId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "productStream": {
+            "$ref": "#/components/schemas/ProductStream"
+          }
+        },
+        "type": "object"
+      },
+      "ProductTag": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productId",
+          "tagId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "tagId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "tag": {
+            "$ref": "#/components/schemas/Tag"
+          }
+        },
+        "type": "object"
+      },
+      "ProductVisibility": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "productId",
+          "salesChannelId",
+          "visibility",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "productVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "visibility": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product"
+          }
+        },
+        "type": "object"
+      },
+      "Promotion": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "active",
+          "priority",
+          "exclusive",
+          "useCodes",
+          "useIndividualCodes",
+          "useSetGroups",
+          "preventCombination",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "validFrom": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "maxRedemptionsGlobal": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "maxRedemptionsPerCustomer": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "exclusive": {
+            "type": "boolean"
+          },
+          "code": {
+            "type": "string"
+          },
+          "useCodes": {
+            "type": "boolean"
+          },
+          "useIndividualCodes": {
+            "type": "boolean"
+          },
+          "individualCodePattern": {
+            "type": "string"
+          },
+          "useSetGroups": {
+            "type": "boolean"
+          },
+          "customerRestriction": {
+            "type": "boolean"
+          },
+          "preventCombination": {
+            "type": "boolean"
+          },
+          "orderCount": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "ordersPerCustomerCount": {
+            "type": "object",
+            "readOnly": true
+          },
+          "exclusionIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            }
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "setgroups": {
+            "$ref": "#/components/schemas/PromotionSetgroup"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/PromotionSalesChannel"
+          },
+          "discounts": {
+            "$ref": "#/components/schemas/PromotionDiscount"
+          },
+          "individualCodes": {
+            "$ref": "#/components/schemas/PromotionIndividualCode"
+          },
+          "personaRules": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "personaCustomers": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "orderRules": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "cartRules": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "orderLineItems": {
+            "$ref": "#/components/schemas/OrderLineItem"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionCartRule": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "promotionId",
+          "ruleId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "ruleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotion": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rule"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionDiscount": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "promotionId",
+          "scope",
+          "type",
+          "value",
+          "considerAdvancedRules",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number",
+            "format": "float"
+          },
+          "considerAdvancedRules": {
+            "type": "boolean"
+          },
+          "maxValue": {
+            "type": "number",
+            "format": "float"
+          },
+          "sorterKey": {
+            "type": "string"
+          },
+          "applierKey": {
+            "type": "string"
+          },
+          "usageKey": {
+            "type": "string"
+          },
+          "pickerKey": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "promotion": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "discountRules": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "promotionDiscountPrices": {
+            "$ref": "#/components/schemas/PromotionDiscountPrices"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionDiscountPrices": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "discountId",
+          "currencyId",
+          "price",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "discountId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "currencyId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "price": {
+            "type": "number",
+            "format": "float"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "promotionDiscount": {
+            "$ref": "#/components/schemas/PromotionDiscount"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionDiscountRule": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "discountId",
+          "ruleId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "discountId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "ruleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "discount": {
+            "$ref": "#/components/schemas/PromotionDiscount"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rule"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionIndividualCode": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "promotionId",
+          "code",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "code": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "promotion": {
+            "$ref": "#/components/schemas/Promotion"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionOrderRule": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "promotionId",
+          "ruleId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "ruleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotion": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rule"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionPersonaCustomer": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "promotionId",
+          "customerId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customerId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotion": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/Customer"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionPersonaRule": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "promotionId",
+          "ruleId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "ruleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotion": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rule"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionSalesChannel": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "promotionId",
+          "salesChannelId",
+          "priority",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "promotion": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionSetgroup": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "promotionId",
+          "packagerKey",
+          "sorterKey",
+          "value",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "promotionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "packagerKey": {
+            "type": "string"
+          },
+          "sorterKey": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number",
+            "format": "float"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "promotion": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "setGroupRules": {
+            "$ref": "#/components/schemas/Rule"
+          }
+        },
+        "type": "object"
+      },
+      "PromotionSetgroupRule": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "setgroupId",
+          "ruleId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "setgroupId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "ruleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "setgroup": {
+            "$ref": "#/components/schemas/PromotionSetgroup"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rule"
+          }
+        },
+        "type": "object"
+      },
+      "PropertyGroup": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "displayType",
+          "sortingType",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "displayType": {
+            "type": "string"
+          },
+          "sortingType": {
+            "type": "string"
+          },
+          "filterable": {
+            "type": "boolean"
+          },
+          "visibleOnProductDetailPage": {
+            "type": "boolean"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "options": {
+            "$ref": "#/components/schemas/PropertyGroupOption"
+          }
+        },
+        "type": "object"
+      },
+      "PropertyGroupOption": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "groupId",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "groupId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "colorHexCode": {
+            "type": "string"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "group": {
+            "$ref": "#/components/schemas/PropertyGroup"
+          },
+          "productConfiguratorSettings": {
+            "$ref": "#/components/schemas/ProductConfiguratorSetting"
+          },
+          "productProperties": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "productOptions": {
+            "$ref": "#/components/schemas/Product"
+          }
+        },
+        "type": "object"
+      },
+      "Rule": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "name",
+          "priority",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": {
+            "type": "string"
+          },
+          "invalid": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "areas": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false
+            },
+            "readOnly": true
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "moduleTypes": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "conditions": {
+            "$ref": "#/components/schemas/RuleCondition"
+          },
+          "productPrices": {
+            "$ref": "#/components/schemas/ProductPrice"
+          },
+          "shippingMethodPrices": {
+            "$ref": "#/components/schemas/ShippingMethodPrice"
+          },
+          "shippingMethodPriceCalculations": {
+            "$ref": "#/components/schemas/ShippingMethodPrice"
+          },
+          "shippingMethods": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          },
+          "paymentMethods": {
+            "$ref": "#/components/schemas/PaymentMethod"
+          },
+          "personaPromotions": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "flowSequences": {
+            "$ref": "#/components/schemas/FlowSequence"
+          },
+          "taxProviders": {
+            "$ref": "#/components/schemas/TaxProvider"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "orderPromotions": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "cartPromotions": {
+            "$ref": "#/components/schemas/Promotion"
+          },
+          "promotionDiscounts": {
+            "$ref": "#/components/schemas/PromotionDiscount"
+          },
+          "promotionSetGroups": {
+            "$ref": "#/components/schemas/PromotionSetgroup"
+          }
+        },
+        "type": "object"
+      },
+      "RuleCondition": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "type",
+          "ruleId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ruleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "scriptId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "value": {
+            "type": "object"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "appScriptCondition": {
+            "$ref": "#/components/schemas/AppScriptCondition"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/RuleCondition"
+          },
+          "children": {
+            "$ref": "#/components/schemas/RuleCondition"
+          }
+        },
+        "type": "object"
+      },
+      "RuleTag": {
+        "description": "Added since version: 6.5.0.0",
+        "required": [
+          "ruleId",
+          "tagId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "ruleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "tagId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "tag": {
+            "$ref": "#/components/schemas/Tag"
+          }
+        },
+        "type": "object"
+      },
+      "SalesChannel": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "typeId",
+          "languageId",
+          "customerGroupId",
+          "currencyId",
+          "paymentMethodId",
+          "shippingMethodId",
+          "countryId",
+          "navigationCategoryId",
+          "accessKey",
+          "createdAt",
+          "name",
+          "homeEnabled"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "typeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customerGroupId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "currencyId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "paymentMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "shippingMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "countryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "analyticsId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "navigationCategoryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "navigationCategoryVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "navigationCategoryDepth": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "footerCategoryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "footerCategoryVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "serviceCategoryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "serviceCategoryVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mailHeaderFooterId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "hreflangDefaultDomainId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "taxCalculationType": {
+            "type": "string"
+          },
+          "accessKey": {
+            "type": "string"
+          },
+          "configuration": {
+            "type": "object"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "hreflangActive": {
+            "type": "boolean"
+          },
+          "maintenance": {
+            "type": "boolean"
+          },
+          "maintenanceIpWhitelist": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "paymentMethodIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            },
+            "readOnly": true
+          },
+          "homeCmsPageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "homeCmsPageVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "homeSlotConfig": {
+            "type": "object"
+          },
+          "homeEnabled": {
+            "type": "boolean"
+          },
+          "homeName": {
+            "type": "string"
+          },
+          "homeMetaTitle": {
+            "type": "string"
+          },
+          "homeMetaDescription": {
+            "type": "string"
+          },
+          "homeKeywords": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "extensions": {
+            "properties": {
+              "themes": {
+                "properties": {
+                  "links": {
+                    "type": "object",
+                    "properties": {
+                      "related": {
+                        "type": "string",
+                        "format": "uri-reference",
+                        "example": "/sales-channel/018b38133f557175b8cc2d60dc1395fd/themes"
+                      }
+                    }
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "example": "theme"
+                        },
+                        "id": {
+                          "type": "string",
+                          "example": "018b38133f5672068ae3e010fdc446b8"
+                        }
+                      }
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "currencies": {
+            "$ref": "#/components/schemas/Currency"
+          },
+          "languages": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "countries": {
+            "$ref": "#/components/schemas/Country"
+          },
+          "paymentMethods": {
+            "$ref": "#/components/schemas/PaymentMethod"
+          },
+          "shippingMethods": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          },
+          "type": {
+            "$ref": "#/components/schemas/SalesChannelType"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "customerGroup": {
+            "$ref": "#/components/schemas/CustomerGroup"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          },
+          "paymentMethod": {
+            "$ref": "#/components/schemas/PaymentMethod"
+          },
+          "shippingMethod": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          },
+          "country": {
+            "$ref": "#/components/schemas/Country"
+          },
+          "orders": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "customers": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "homeCmsPage": {
+            "$ref": "#/components/schemas/CmsPage"
+          },
+          "domains": {
+            "$ref": "#/components/schemas/SalesChannelDomain"
+          },
+          "systemConfigs": {
+            "$ref": "#/components/schemas/SystemConfig"
+          },
+          "navigationCategory": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "footerCategory": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "serviceCategory": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "productVisibilities": {
+            "$ref": "#/components/schemas/ProductVisibility"
+          },
+          "hreflangDefaultDomain": {
+            "$ref": "#/components/schemas/SalesChannelDomain"
+          },
+          "mailHeaderFooter": {
+            "$ref": "#/components/schemas/MailHeaderFooter"
+          },
+          "newsletterRecipients": {
+            "$ref": "#/components/schemas/NewsletterRecipient"
+          },
+          "numberRangeSalesChannels": {
+            "$ref": "#/components/schemas/NumberRangeSalesChannel"
+          },
+          "promotionSalesChannels": {
+            "$ref": "#/components/schemas/PromotionSalesChannel"
+          },
+          "documentBaseConfigSalesChannels": {
+            "$ref": "#/components/schemas/DocumentBaseConfigSalesChannel"
+          },
+          "productReviews": {
+            "$ref": "#/components/schemas/ProductReview"
+          },
+          "seoUrls": {
+            "$ref": "#/components/schemas/SeoUrl"
+          },
+          "seoUrlTemplates": {
+            "$ref": "#/components/schemas/SeoUrlTemplate"
+          },
+          "mainCategories": {
+            "$ref": "#/components/schemas/MainCategory"
+          },
+          "productExports": {
+            "$ref": "#/components/schemas/ProductExport"
+          },
+          "analytics": {
+            "$ref": "#/components/schemas/SalesChannelAnalytics"
+          },
+          "customerGroupsRegistrations": {
+            "$ref": "#/components/schemas/CustomerGroup"
+          },
+          "landingPages": {
+            "$ref": "#/components/schemas/LandingPage"
+          },
+          "boundCustomers": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "wishlists": {
+            "$ref": "#/components/schemas/CustomerWishlist"
+          }
+        },
+        "type": "object"
+      },
+      "SalesChannelAnalytics": {
+        "description": "Added since version: 6.2.0.0",
+        "required": [
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "trackingId": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "trackOrders": {
+            "type": "boolean"
+          },
+          "anonymizeIp": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "SalesChannelCountry": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "salesChannelId",
+          "countryId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "countryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "country": {
+            "$ref": "#/components/schemas/Country"
+          }
+        },
+        "type": "object"
+      },
+      "SalesChannelCurrency": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "salesChannelId",
+          "currencyId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "currencyId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          }
+        },
+        "type": "object"
+      },
+      "SalesChannelDomain": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "url",
+          "salesChannelId",
+          "languageId",
+          "currencyId",
+          "snippetSetId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "url": {
+            "type": "string"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "currencyId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "snippetSetId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "hreflangUseOnlyLocale": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          },
+          "snippetSet": {
+            "$ref": "#/components/schemas/SnippetSet"
+          },
+          "salesChannelDefaultHreflang": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "productExports": {
+            "$ref": "#/components/schemas/ProductExport"
+          }
+        },
+        "type": "object"
+      },
+      "SalesChannelLanguage": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "salesChannelId",
+          "languageId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          }
+        },
+        "type": "object"
+      },
+      "SalesChannelPaymentMethod": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "salesChannelId",
+          "paymentMethodId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "paymentMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "paymentMethod": {
+            "$ref": "#/components/schemas/PaymentMethod"
+          }
+        },
+        "type": "object"
+      },
+      "SalesChannelShippingMethod": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "salesChannelId",
+          "shippingMethodId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "shippingMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "shippingMethod": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          }
+        },
+        "type": "object"
+      },
+      "SalesChannelType": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "coverUrl": {
+            "type": "string"
+          },
+          "iconName": {
+            "type": "string"
+          },
+          "screenshotUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "manufacturer": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "descriptionLong": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "Salutation": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "salutationKey",
+          "createdAt",
+          "displayName",
+          "letterName"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salutationKey": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "letterName": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "customers": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "customerAddresses": {
+            "$ref": "#/components/schemas/CustomerAddress"
+          },
+          "orderCustomers": {
+            "$ref": "#/components/schemas/OrderCustomer"
+          },
+          "orderAddresses": {
+            "$ref": "#/components/schemas/OrderAddress"
+          },
+          "newsletterRecipients": {
+            "$ref": "#/components/schemas/NewsletterRecipient"
+          }
+        },
+        "type": "object"
+      },
+      "ScheduledTask": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "name",
+          "scheduledTaskClass",
+          "runInterval",
+          "status",
+          "nextExecutionTime",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "scheduledTaskClass": {
+            "type": "string"
+          },
+          "runInterval": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "status": {
+            "type": "string"
+          },
+          "lastExecutionTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "nextExecutionTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "defaultRunInterval": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        },
+        "type": "object"
+      },
+      "Script": {
+        "description": "Added since version: 6.4.7.0",
+        "required": [
+          "script",
+          "hook",
+          "name",
+          "active",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "script": {
+            "type": "string"
+          },
+          "hook": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          }
+        },
+        "type": "object"
+      },
+      "SeoUrl": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "languageId",
+          "foreignKey",
+          "routeName",
+          "pathInfo",
+          "seoPathInfo",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "foreignKey": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "routeName": {
+            "type": "string"
+          },
+          "pathInfo": {
+            "type": "string"
+          },
+          "seoPathInfo": {
+            "type": "string"
+          },
+          "isCanonical": {
+            "type": "boolean"
+          },
+          "isModified": {
+            "type": "boolean"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "url": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "isValid": {
+            "description": "Runtime field, cannot be used as part of the criteria.",
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "SeoUrlTemplate": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "entityName",
+          "routeName",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "entityName": {
+            "type": "string"
+          },
+          "routeName": {
+            "type": "string"
+          },
+          "template": {
+            "type": "string"
+          },
+          "isValid": {
+            "type": "boolean"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "ShippingMethod": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "availabilityRuleId",
+          "deliveryTimeId",
+          "taxType",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "availabilityRuleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "deliveryTimeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "taxType": {
+            "type": "string"
+          },
+          "taxId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "description": {
+            "type": "string"
+          },
+          "trackingUrl": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "deliveryTime": {
+            "$ref": "#/components/schemas/DeliveryTime"
+          },
+          "availabilityRule": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "prices": {
+            "$ref": "#/components/schemas/ShippingMethodPrice"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "orderDeliveries": {
+            "$ref": "#/components/schemas/OrderDelivery"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "salesChannelDefaultAssignments": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "tax": {
+            "$ref": "#/components/schemas/Tax"
+          }
+        },
+        "type": "object"
+      },
+      "ShippingMethodPrice": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "shippingMethodId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "shippingMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "ruleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "calculation": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "calculationRuleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "quantityStart": {
+            "type": "number",
+            "format": "float"
+          },
+          "quantityEnd": {
+            "type": "number",
+            "format": "float"
+          },
+          "currencyPrice": {
+            "type": "object"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "shippingMethod": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          },
+          "rule": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "calculationRule": {
+            "$ref": "#/components/schemas/Rule"
+          }
+        },
+        "type": "object"
+      },
+      "ShippingMethodTag": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "shippingMethodId",
+          "tagId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "shippingMethodId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "tagId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "shippingMethod": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          },
+          "tag": {
+            "$ref": "#/components/schemas/Tag"
+          }
+        },
+        "type": "object"
+      },
+      "Snippet": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "setId",
+          "translationKey",
+          "value",
+          "author",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "setId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "translationKey": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "set": {
+            "$ref": "#/components/schemas/SnippetSet"
+          }
+        },
+        "type": "object"
+      },
+      "SnippetSet": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "name",
+          "baseFile",
+          "iso",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "baseFile": {
+            "type": "string"
+          },
+          "iso": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "snippets": {
+            "$ref": "#/components/schemas/Snippet"
+          },
+          "salesChannelDomains": {
+            "$ref": "#/components/schemas/SalesChannelDomain"
+          }
+        },
+        "type": "object"
+      },
+      "StateMachine": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "technicalName",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "technicalName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "initialStateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "states": {
+            "$ref": "#/components/schemas/StateMachineState"
+          },
+          "transitions": {
+            "$ref": "#/components/schemas/StateMachineTransition"
+          },
+          "historyEntries": {
+            "$ref": "#/components/schemas/StateMachineHistory"
+          }
+        },
+        "type": "object"
+      },
+      "StateMachineHistory": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "stateMachineId",
+          "entityName",
+          "fromStateId",
+          "toStateId",
+          "entityId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "stateMachineId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "entityName": {
+            "type": "string"
+          },
+          "fromStateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "toStateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "transitionActionName": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "entityId": {
+            "type": "object",
+            "deprecated": true
+          },
+          "referencedId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "referencedVersionId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "stateMachine": {
+            "$ref": "#/components/schemas/StateMachine"
+          },
+          "fromStateMachineState": {
+            "$ref": "#/components/schemas/StateMachineState"
+          },
+          "toStateMachineState": {
+            "$ref": "#/components/schemas/StateMachineState"
+          },
+          "user": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "type": "object"
+      },
+      "StateMachineState": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "technicalName",
+          "stateMachineId",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "technicalName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "stateMachineId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "stateMachine": {
+            "$ref": "#/components/schemas/StateMachine"
+          },
+          "fromStateMachineTransitions": {
+            "$ref": "#/components/schemas/StateMachineTransition"
+          },
+          "toStateMachineTransitions": {
+            "$ref": "#/components/schemas/StateMachineTransition"
+          },
+          "orderTransactions": {
+            "$ref": "#/components/schemas/OrderTransaction"
+          },
+          "orderDeliveries": {
+            "$ref": "#/components/schemas/OrderDelivery"
+          },
+          "orders": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "orderTransactionCaptures": {
+            "$ref": "#/components/schemas/OrderTransactionCapture"
+          },
+          "orderTransactionCaptureRefunds": {
+            "$ref": "#/components/schemas/OrderTransactionCaptureRefund"
+          },
+          "toStateMachineHistoryEntries": {
+            "$ref": "#/components/schemas/StateMachineHistory"
+          },
+          "fromStateMachineHistoryEntries": {
+            "$ref": "#/components/schemas/StateMachineHistory"
+          }
+        },
+        "type": "object"
+      },
+      "StateMachineTransition": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "actionName",
+          "stateMachineId",
+          "fromStateId",
+          "toStateId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "actionName": {
+            "type": "string"
+          },
+          "stateMachineId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "fromStateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "toStateId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "stateMachine": {
+            "$ref": "#/components/schemas/StateMachine"
+          },
+          "fromStateMachineState": {
+            "$ref": "#/components/schemas/StateMachineState"
+          },
+          "toStateMachineState": {
+            "$ref": "#/components/schemas/StateMachineState"
+          }
+        },
+        "type": "object"
+      },
+      "SwagLanguagePackLanguage": {
+        "description": "Added since version: ",
+        "required": [
+          "languageId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "administrationActive": {
+            "type": "boolean"
+          },
+          "salesChannelActive": {
+            "type": "boolean"
+          },
+          "languageId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          }
+        },
+        "type": "object"
+      },
+      "SystemConfig": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "configurationKey",
+          "configurationValue",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "configurationKey": {
+            "type": "string"
+          },
+          "configurationValue": {
+            "properties": {
+              "_value": {
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "Tag": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "name",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "products": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "categories": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "customers": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "orders": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "shippingMethods": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          },
+          "newsletterRecipients": {
+            "$ref": "#/components/schemas/NewsletterRecipient"
+          },
+          "landingPages": {
+            "$ref": "#/components/schemas/LandingPage"
+          },
+          "rules": {
+            "$ref": "#/components/schemas/Rule"
+          }
+        },
+        "type": "object"
+      },
+      "Tax": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "taxRate",
+          "name",
+          "position",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "taxRate": {
+            "type": "number",
+            "format": "float"
+          },
+          "name": {
+            "type": "string"
+          },
+          "position": {
+            "description": "Added since version: 6.4.0.0.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "products": {
+            "$ref": "#/components/schemas/Product"
+          },
+          "rules": {
+            "$ref": "#/components/schemas/TaxRule"
+          },
+          "shippingMethods": {
+            "$ref": "#/components/schemas/ShippingMethod"
+          }
+        },
+        "type": "object"
+      },
+      "TaxProvider": {
+        "description": "Added since version: 6.5.0.0",
+        "required": [
+          "identifier",
+          "priority",
+          "createdAt",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "processUrl": {
+            "type": "string"
+          },
+          "availabilityRuleId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "availabilityRule": {
+            "$ref": "#/components/schemas/Rule"
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          }
+        },
+        "type": "object"
+      },
+      "TaxRule": {
+        "description": "Added since version: 6.1.0.0",
+        "required": [
+          "taxRuleTypeId",
+          "countryId",
+          "taxRate",
+          "taxId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "taxRuleTypeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "countryId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "taxRate": {
+            "type": "number",
+            "format": "float"
+          },
+          "data": {
+            "properties": {
+              "states": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "zipCode": {
+                "type": "string"
+              },
+              "fromZipCode": {
+                "type": "string"
+              },
+              "toZipCode": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "taxId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "activeFrom": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/TaxRuleType"
+          },
+          "country": {
+            "$ref": "#/components/schemas/Country"
+          },
+          "tax": {
+            "$ref": "#/components/schemas/Tax"
+          }
+        },
+        "type": "object"
+      },
+      "TaxRuleType": {
+        "description": "Added since version: 6.1.0.0",
+        "required": [
+          "technicalName",
+          "position",
+          "createdAt",
+          "typeName"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "technicalName": {
+            "type": "string",
+            "readOnly": true
+          },
+          "position": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "typeName": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "rules": {
+            "$ref": "#/components/schemas/TaxRule"
+          }
+        },
+        "type": "object"
+      },
+      "Theme": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "name",
+          "author",
+          "active",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "technicalName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object"
+          },
+          "helpTexts": {
+            "type": "object"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "previewMediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentThemeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "themeJson": {
+            "type": "object"
+          },
+          "baseConfig": {
+            "type": "object"
+          },
+          "configValues": {
+            "type": "object"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "salesChannels": {
+            "$ref": "#/components/schemas/SalesChannel"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "previewMedia": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "dependentThemes": {
+            "$ref": "#/components/schemas/Theme"
+          }
+        },
+        "type": "object"
+      },
+      "ThemeChild": {
+        "description": "Added since version: 6.4.8.0",
+        "required": [
+          "parentId",
+          "childId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "childId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "parentTheme": {
+            "$ref": "#/components/schemas/Theme"
+          },
+          "childTheme": {
+            "$ref": "#/components/schemas/Theme"
+          }
+        },
+        "type": "object"
+      },
+      "ThemeMedia": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "themeId",
+          "mediaId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "themeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "mediaId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "theme": {
+            "$ref": "#/components/schemas/Theme"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          }
+        },
+        "type": "object"
+      },
+      "ThemeSalesChannel": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "salesChannelId",
+          "themeId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "salesChannelId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "themeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "theme": {
+            "$ref": "#/components/schemas/Theme"
+          },
+          "salesChannel": {
+            "$ref": "#/components/schemas/SalesChannel"
+          }
+        },
+        "type": "object"
+      },
+      "Unit": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "createdAt",
+          "shortCode",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "shortCode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "translated": {
+            "type": "object"
+          },
+          "products": {
+            "$ref": "#/components/schemas/Product"
+          }
+        },
+        "type": "object"
+      },
+      "User": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "localeId",
+          "username",
+          "firstName",
+          "lastName",
+          "email",
+          "timeZone",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "localeId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "username": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "admin": {
+            "type": "boolean"
+          },
+          "lastUpdatedPasswordAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeZone": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "avatarId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "extensions": {
+            "properties": {
+              "createdNotifications": {
+                "properties": {
+                  "links": {
+                    "type": "object",
+                    "properties": {
+                      "related": {
+                        "type": "string",
+                        "format": "uri-reference",
+                        "example": "/user/018b38133f5c7041a58a3f045645ae84/createdNotifications"
+                      }
+                    }
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "example": "notification"
+                        },
+                        "id": {
+                          "type": "string",
+                          "example": "018b38133f5c7041a58a3f045c68c844"
+                        }
+                      }
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "locale": {
+            "$ref": "#/components/schemas/Locale"
+          },
+          "avatarMedia": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "media": {
+            "$ref": "#/components/schemas/Media"
+          },
+          "accessKeys": {
+            "$ref": "#/components/schemas/UserAccessKey"
+          },
+          "configs": {
+            "$ref": "#/components/schemas/UserConfig"
+          },
+          "stateMachineHistoryEntries": {
+            "$ref": "#/components/schemas/StateMachineHistory"
+          },
+          "importExportLogEntries": {
+            "$ref": "#/components/schemas/ImportExportLog"
+          },
+          "aclRoles": {
+            "$ref": "#/components/schemas/AclRole"
+          },
+          "recoveryUser": {
+            "$ref": "#/components/schemas/UserRecovery"
+          },
+          "createdOrders": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "updatedOrders": {
+            "$ref": "#/components/schemas/Order"
+          },
+          "createdCustomers": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "updatedCustomers": {
+            "$ref": "#/components/schemas/Customer"
+          }
+        },
+        "type": "object"
+      },
+      "UserAccessKey": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "userId",
+          "accessKey",
+          "secretAccessKey",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "userId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "accessKey": {
+            "type": "string"
+          },
+          "secretAccessKey": {
+            "type": "string"
+          },
+          "lastUsageAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "user": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "type": "object"
+      },
+      "UserConfig": {
+        "description": "Added since version: 6.3.5.0",
+        "required": [
+          "userId",
+          "key",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "userId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "user": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "type": "object"
+      },
+      "UserRecovery": {
+        "description": "Added since version: 6.0.0.0",
+        "required": [
+          "hash",
+          "userId",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "hash": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "user": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "type": "object"
+      },
+      "Webhook": {
+        "description": "Added since version: 6.3.1.0",
+        "required": [
+          "name",
+          "eventName",
+          "url",
+          "errorCount",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "eventName": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "errorCount": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "appId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "app": {
+            "$ref": "#/components/schemas/App"
+          }
+        },
+        "type": "object"
+      },
+      "WebhookEventLog": {
+        "description": "Added since version: 6.4.1.0",
+        "required": [
+          "webhookName",
+          "eventName",
+          "deliveryStatus",
+          "url",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$"
+          },
+          "appName": {
+            "type": "string"
+          },
+          "webhookName": {
+            "type": "string"
+          },
+          "eventName": {
+            "type": "string"
+          },
+          "deliveryStatus": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "processingTime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "appVersion": {
+            "type": "string"
+          },
+          "requestContent": {
+            "type": "object"
+          },
+          "responseContent": {
+            "type": "object"
+          },
+          "responseStatusCode": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "responseReasonPhrase": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "customFields": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        },
+        "type": "object"
+      },
+      "Criteria": {
+        "type": "object",
+        "description": "Search parameters. For more information, see our documentation on [Search Queries](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#structure)",
+        "properties": {
+          "page": {
+            "description": "Search result page",
+            "type": "integer"
+          },
+          "limit": {
+            "description": "Number of items per result page",
+            "type": "integer"
+          },
+          "filter": {
+            "type": "array",
+            "description": "List of filters to restrict the search result. For more information, see [Search Queries > Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "field": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "field",
+                "value"
+              ]
+            }
+          },
+          "sort": {
+            "type": "array",
+            "description": "Sorting in the search result.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "string"
+                },
+                "naturalSorting": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "field"
+              ]
+            }
+          },
+          "post-filter": {
+            "type": "array",
+            "description": "Filters that applied without affecting aggregations. For more information, see [Search Queries > Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "field": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "field",
+                "value"
+              ]
+            }
+          },
+          "associations": {
+            "type": "object",
+            "description": "Used to fetch associations which are not fetched by default."
+          },
+          "aggregations": {
+            "type": "array",
+            "description": "Used to perform aggregations on the search result. For more information, see [Search Queries > Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Give your aggregation an identifier, so you can find it easier",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "The type of aggregation",
+                  "type": "string"
+                },
+                "field": {
+                  "description": "The field you want to aggregate over.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "type",
+                "field"
+              ]
+            }
+          },
+          "grouping": {
+            "type": "array",
+            "description": "Perform groupings over certain fields",
+            "items": {
+              "type": "string",
+              "description": "Name of a field"
+            }
+          },
+          "fields": {
+            "type": "array",
+            "description": "Fields which should be returned in the search result.",
+            "items": {
+              "type": "string",
+              "description": "Name of a field"
+            }
+          },
+          "total-count-mode": {
+            "description": "Whether the total for the total number of hits should be determined for the search query. none = disabled total count, exact = calculate exact total amount (slow), next-pages = calculate only for next page (fast)",
+            "type": "string",
+            "default": "none",
+            "enum": [
+              "none",
+              "exact",
+              "next-pages"
+            ]
+          }
+        }
+      },
+      "flowBulderActionsResponse": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the flow action"
+            },
+            "requirements": {
+              "type": "array",
+              "description": "When requirement fit with aware from `events.json` actions will be shown",
+              "items": {
+                "type": "string"
+              }
+            },
+            "extensions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Extensions data of event"
+            }
+          }
+        }
+      },
+      "businessEventsResponse": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the event"
+            },
+            "class": {
+              "type": "string",
+              "description": "Class name of the event"
+            },
+            "data": {
+              "type": "object",
+              "description": "Available data of event"
+            },
+            "aware": {
+              "type": "array",
+              "description": "Flow builder will base on awareness to show actions",
+              "items": {
+                "type": "string"
+              }
+            },
+            "extensions": {
+              "type": "array",
+              "description": "Extensions data of event",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "infoConfigResponse": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string",
+            "description": "The Shopware version."
+          },
+          "versionRevision": {
+            "type": "string",
+            "description": "The Shopware version revision."
+          },
+          "adminWorker": {
+            "type": "object",
+            "description": "Information about the admin worker.",
+            "properties": {
+              "enableAdminWorker": {
+                "type": "boolean",
+                "description": "State of the admin worker."
+              },
+              "transports": {
+                "type": "array",
+                "description": "Configured transports.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "bundles": {
+            "type": "object",
+            "description": "Asset files of active extensions",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "css": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "description": "Url to the css file."
+                  }
+                },
+                "js": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "description": "Url to the js file."
+                  }
+                }
+              }
+            }
+          },
+          "settings": {
+            "type": "object",
+            "properties": {
+              "enableUrlFeature": {
+                "type": "boolean",
+                "description": "State of the `urlFeature` setting."
+              }
+            }
+          }
+        }
+      },
+      "OAuthScopes": {
+        "description": "OAuth scopes that should be requested.",
+        "type": "string",
+        "enum": [
+          "write",
+          "user-verified",
+          "admin",
+          "write user-verified",
+          "write admin",
+          "user-verified admin",
+          "write user-verified admin"
+        ]
+      },
+      "OAuthGrant": {
+        "type": "object",
+        "properties": {
+          "grant_type": {
+            "description": "OAuth grant type that should be requested. See [OAuth 2.0 grant](https://oauth2.thephpleague.com/authorization-server/which-grant/) for more information.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "grant_type"
+        ],
+        "discriminator": {
+          "propertyName": "grant_type",
+          "mapping": {
+            "client_credentials": "#/components/schemas/OAuthClientCredentialsGrant",
+            "password": "#/components/schemas/OAuthPasswordGrant",
+            "refresh_token": "#/components/schemas/OAuthRefreshTokenGrant"
+          }
+        }
+      },
+      "OAuthClientCredentialsGrant": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OAuthGrant"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "client_id": {
+                "description": "OAuth client id.",
+                "type": "string"
+              },
+              "client_secret": {
+                "description": "Password of the client that should be authenticated.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "client_id",
+              "client_secret"
+            ]
+          }
+        ]
+      },
+      "OAuthPasswordGrant": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OAuthGrant"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "client_id": {
+                "description": "OAuth client id.",
+                "type": "string",
+                "enum": [
+                  "administration"
+                ]
+              },
+              "scopes": {
+                "$ref": "#/components/schemas/OAuthScopes"
+              },
+              "username": {
+                "description": "Username of the user that should be authenticated.",
+                "type": "string"
+              },
+              "password": {
+                "description": "Password of the user that should be authenticated.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "client_id",
+              "scopes",
+              "username",
+              "password"
+            ]
+          }
+        ]
+      },
+      "OAuthRefreshTokenGrant": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OAuthGrant"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "client_id": {
+                "description": "OAuth client id.",
+                "type": "string",
+                "enum": [
+                  "administration"
+                ]
+              },
+              "scopes": {
+                "$ref": "#/components/schemas/OAuthScopes"
+              },
+              "refresh_token": {
+                "description": "The refresh token that should be used to refresh the access token.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "client_id",
+              "scopes",
+              "refresh_token"
+            ]
+          }
+        ]
+      }
+    },
+    "responses": {
+      "204": {
+        "description": "No Content"
+      },
+      "400": {
+        "description": "Bad Request",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            },
+            "example": {
+              "errors": [
+                {
+                  "status": "400",
+                  "title": "Bad Request",
+                  "description": "Bad parameters for this endpoint. See documentation for the correct ones."
+                }
+              ]
+            }
+          },
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            },
+            "example": {
+              "errors": [
+                {
+                  "status": "400",
+                  "title": "Bad Request",
+                  "description": "Bad parameters for this endpoint. See documentation for the correct ones."
+                }
+              ]
+            }
+          }
+        }
+      },
+      "401": {
+        "description": "Unauthorized",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            },
+            "example": {
+              "errors": [
+                {
+                  "status": "401",
+                  "title": "Unauthorized",
+                  "description": "Authorization information is missing or invalid."
+                }
+              ]
+            }
+          },
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            },
+            "example": {
+              "errors": [
+                {
+                  "status": "401",
+                  "title": "Unauthorized",
+                  "description": "Authorization information is missing or invalid."
+                }
+              ]
+            }
+          }
+        }
+      },
+      "403": {
+        "description": "Forbidden",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            },
+            "example": {
+              "errors": [
+                {
+                  "status": "403",
+                  "title": "Forbidden",
+                  "description": "This operation is restricted to logged in users."
+                }
+              ]
+            }
+          },
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            },
+            "example": {
+              "errors": [
+                {
+                  "status": "403",
+                  "title": "Forbidden",
+                  "description": "This operation is restricted to logged in users."
+                }
+              ]
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "Not Found",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            },
+            "example": {
+              "errors": [
+                {
+                  "status": "404",
+                  "title": "Not Found",
+                  "description": "Resource with given parameter was not found."
+                }
+              ]
+            }
+          },
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/failure"
+            },
+            "example": {
+              "errors": [
+                {
+                  "status": "404",
+                  "title": "Not Found",
+                  "description": "Resource with given parameter was not found."
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "oAuth": {
+        "type": "oauth2",
+        "description": "Authentication API",
+        "flows": {
+          "password": {
+            "tokenUrl": "http://demopalast.ecow.dev/api/oauth/token",
+            "scopes": {
+              "write": "Full write access"
+            }
+          },
+          "clientCredentials": {
+            "tokenUrl": "http://demopalast.ecow.dev/api/oauth/token",
+            "scopes": {
+              "write": "Full write access"
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "oAuth": [
+        "write"
+      ]
+    }
+  ],
+  "paths": {
+    "/_action/indexing": {
+      "post": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Run indexer",
+        "description": "Runs all registered indexer in the shop asynchronously.",
+        "operationId": "indexing",
+        "responses": {
+          "200": {
+            "description": "Returns an empty response indicating that the indexing process started."
+          }
+        }
+      }
+    },
+    "/_action/indexing/{indexer}": {
+      "post": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Iterate an indexer",
+        "description": "Starts a defined indexer with an offset.\n\nfor the next request. `finish: true` in the response indicates that the indexer is finished",
+        "operationId": "iterate",
+        "parameters": [
+          {
+            "name": "indexer",
+            "in": "path",
+            "description": "Name of the indexer to iterate.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "offset": {
+                    "description": "The offset for the iteration.",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns information about the iteration.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "finish": {
+                      "description": "Indicates if the indexing process finished.",
+                      "type": "boolean"
+                    },
+                    "offset": {
+                      "description": "Offset to be used for the next iteration.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/cache_info": {
+      "get": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Get cache information",
+        "description": "Get information about the cache configuration",
+        "operationId": "info",
+        "responses": {
+          "200": {
+            "description": "Information about the cache state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "environment": {
+                      "description": "The active environment.",
+                      "type": "string"
+                    },
+                    "httpCache": {
+                      "description": "State of the HTTP cache.",
+                      "type": "boolean"
+                    },
+                    "cacheAdapter": {
+                      "description": "The active cache adapter.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/order/document/download": {
+      "post": {
+        "tags": [
+          "Document Management"
+        ],
+        "summary": "Download a documents",
+        "description": "Download a multiple documents in one pdf file.",
+        "operationId": "downloadDocuments",
+        "requestBody": {
+          "description": "documentIds",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{32}$"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The documents.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/order/document/{documentTypeName}/create": {
+      "post": {
+        "tags": [
+          "Document Management"
+        ],
+        "summary": "Create documents for orders",
+        "description": "Creates documents for orders. Documents can for example be an invoice or a delivery note.",
+        "operationId": "createDocuments",
+        "parameters": [
+          {
+            "name": "documentTypeName",
+            "in": "path",
+            "description": "The type of document to create",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "test",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "orderId",
+                    "type"
+                  ],
+                  "properties": {
+                    "orderId": {
+                      "description": "Identifier of the order.",
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{32}$"
+                    },
+                    "type": {
+                      "description": "Type of the document to be generated.",
+                      "type": "string"
+                    },
+                    "fileType": {
+                      "description": "Type of document file to be generated.",
+                      "type": "string",
+                      "default": "pdf"
+                    },
+                    "static": {
+                      "description": "Indicate if the document should be static or not.",
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "referencedDocumentId": {
+                      "description": "Identifier of the reverenced document.",
+                      "type": "string",
+                      "default": "null",
+                      "pattern": "^[0-9a-f]{32}$"
+                    },
+                    "config": {
+                      "description": "Document specific configuration, like documentNumber, documentDate, documentComment.",
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Documents created successfully. The `api/_action/order/document/create` route can be used to download the document."
+          }
+        }
+      }
+    },
+    "/_action/order/{orderId}/state/{transition}": {
+      "post": {
+        "tags": [
+          "Order Management"
+        ],
+        "summary": "Transition an order to a new state",
+        "description": "Changes the order state and informs the customer via email if configured.",
+        "operationId": "orderStateTransition",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "Identifier of the order.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            }
+          },
+          {
+            "name": "transition",
+            "in": "path",
+            "description": "The `action_name` of the `state_machine_transition`. For example `process` if the order state should change from open to in progress.\n\nNote: If you choose a transition that is not available, you will get an error that lists possible transitions for the current state.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "sendMail": {
+                    "description": "Controls if a mail should be sent to the customer."
+                  },
+                  "documentIds": {
+                    "description": "A list of document identifiers that should be attached",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{32}$"
+                    }
+                  },
+                  "mediaIds": {
+                    "description": "A list of media identifiers that should be attached",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{32}$"
+                    }
+                  },
+                  "stateFieldName": {
+                    "description": "This is the state column within the order database table. There should be no need to change it from the default.",
+                    "type": "string",
+                    "default": "stateId"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Todo: Use ref of `state_machine_transition` here"
+          }
+        }
+      }
+    },
+    "/_action/sync": {
+      "post": {
+        "tags": [
+          "Bulk Operations"
+        ],
+        "summary": "Bulk edit entities",
+        "description": "Starts a sync process for the list of provided actions. This can be upserts and deletes on different entities to an asynchronous process in the background. You can control the behaviour with the `indexing-behavior` header.",
+        "operationId": "sync",
+        "parameters": [
+          {
+            "name": "fail-on-error",
+            "in": "header",
+            "description": "To continue upcoming actions on errors, set the `fail-on-error` header to `false`.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "indexing-behavior",
+            "in": "header",
+            "description": "Controls the indexing behavior.\n    - `disable-indexing`: Data indexing is completely disabled",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "use-queue-indexing",
+                "disable-indexing"
+              ]
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "required": [
+                    "action",
+                    "entity",
+                    "payload"
+                  ],
+                  "properties": {
+                    "action": {
+                      "description": "The action indicates what should happen with the provided payload.\n    * `upsert`: The Sync API does not differ between create and update operations,\n    but always performs an upsert operation. During an upsert, the system checks whether the entity already exists in the\n    system and updates it if an identifier has been passed, otherwise a new entity is created with this identifier.\n    * `delete`: Deletes entites with the provided identifiers",
+                      "type": "string",
+                      "enum": [
+                        "upsert",
+                        "delete"
+                      ]
+                    },
+                    "entity": {
+                      "description": "The entity that should be processed with the payload.",
+                      "type": "string",
+                      "example": "product"
+                    },
+                    "payload": {
+                      "description": "Contains a list of changesets for an entity. If the action type is `delete`,\n    a list of identifiers can be provided.",
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns a sync result containing information about the updated entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "description": "Object with information about updated entites",
+                      "type": "object"
+                    },
+                    "notFound": {
+                      "description": "Object with information about not found entites",
+                      "type": "object"
+                    },
+                    "deleted": {
+                      "description": "Object with information about deleted entites",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/number-range/reserve/{type}/{saleschannel}": {
+      "get": {
+        "tags": [
+          "Document Management"
+        ],
+        "summary": "Reserve or preview a document number",
+        "description": "This endpoint provides functionality to reserve or preview a document number which can be used to create a new document using the `/_action/order/{orderId}/document/{documentTypeName}` endpoint.\n\nThe number generated by the endpoint will be reserved and the number pointer will be incremented with every call. For preview purposes, you can add the `?preview=1` parameter to the request. In that case, the number will not be incremented.",
+        "operationId": "numberRangeReserve",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "description": "`technicalName` of the document type (e.g. `document_invoice`). Available types can be fetched with the `/api/document-type endpoint`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "saleschannel",
+            "in": "path",
+            "description": "Sales channel for the number range. Number ranges can be defined per sales channel, so you can pass a sales channel ID here.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "preview",
+            "in": "query",
+            "description": "If this parameter has a true value, the number will not actually be incremented, but only previewed.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The generated number",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "number": {
+                      "description": "The generated (or previewed) document number.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Number range not found"
+          }
+        }
+      }
+    },
+    "/_info/version": {
+      "get": {
+        "tags": [
+          "System Info & Healthcheck"
+        ],
+        "summary": "Get the Shopware version",
+        "description": "Get the version of the Shopware instance",
+        "operationId": "infoShopwareVersion",
+        "responses": {
+          "200": {
+            "description": "Returns the version of the Shopware instance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "version": {
+                      "description": "The Shopware version.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/scheduled-task/run": {
+      "post": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Run scheduled tasks.",
+        "description": "Starts the scheduled task worker to handle the next scheduled tasks.",
+        "operationId": "runScheduledTasks",
+        "responses": {
+          "200": {
+            "description": "Returns a success message indicating a successful run.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "description": "Success message",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/scheduled-task/min-run-interval": {
+      "get": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Get the minimum schedules task interval",
+        "description": "Fetches the smallest interval that a scheduled task uses.",
+        "operationId": "getMinRunInterval",
+        "responses": {
+          "200": {
+            "description": "Returns the minimum interval.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "minRunInterval": {
+                      "description": "Minimal interval in seconds.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/cache_warmup": {
+      "delete": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Clear and warm up caches",
+        "description": "After the cache has been cleared, new cache entries are generated asynchronously.",
+        "operationId": "clearCacheAndScheduleWarmUp",
+        "responses": {
+          "204": {
+            "description": "Returns a no content response indicating that the cache has been cleared and generation of new cache has started."
+          }
+        }
+      }
+    },
+    "/_action/order_transaction_capture_refund/{refundId}": {
+      "post": {
+        "tags": [
+          "Order Management"
+        ],
+        "summary": "Refund an order transaction capture",
+        "description": "Refunds an order transaction capture.",
+        "operationId": "orderTransactionCaptureRefund",
+        "parameters": [
+          {
+            "name": "refundId",
+            "in": "path",
+            "description": "Identifier of the order transaction capture refund.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Refund was successful"
+          },
+          "400": {
+            "description": "Something went wrong, while processing the refund"
+          },
+          "404": {
+            "description": "Refund with id not found"
+          }
+        }
+      }
+    },
+    "/_action/order_delivery/{orderDeliveryId}/state/{transition}": {
+      "post": {
+        "tags": [
+          "Order Management"
+        ],
+        "summary": "Transition an order delivery to a new state",
+        "description": "Changes the order delivery state and informs the customer via email if configured.",
+        "operationId": "orderDeliveryStateTransition",
+        "parameters": [
+          {
+            "name": "orderDeliveryId",
+            "in": "path",
+            "description": "Identifier of the order delivery.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            }
+          },
+          {
+            "name": "transition",
+            "in": "path",
+            "description": "The `action_name` of the `state_machine_transition`. For example `process` if the order state should change from open to in progress.\n\nNote: If you choose a transition which is not possible, you will get an error that lists possible transition for the actual state.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "sendMail": {
+                    "description": "Controls if a mail should be send to the customer."
+                  },
+                  "documentIds": {
+                    "description": "A list of document identifiers that should be attached",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{32}$"
+                    }
+                  },
+                  "mediaIds": {
+                    "description": "A list of media identifiers that should be attached",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{32}$"
+                    }
+                  },
+                  "stateFieldName": {
+                    "description": "This is the state column within the order delivery database table. There should be no need to change it from the default.",
+                    "type": "string",
+                    "default": "stateId"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Todo: Use ref of `state_machine_transition` here"
+          }
+        }
+      }
+    },
+    "/_action/cache": {
+      "delete": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Clear caches",
+        "description": "The cache is immediately cleared synchronously for all used adapters.",
+        "operationId": "clearCache",
+        "responses": {
+          "204": {
+            "description": "Returns a no content response indicating that the cache has been cleared."
+          }
+        }
+      }
+    },
+    "/metrics/needs-approval": {
+      "delete": {
+        "tags": [
+          "Metrics approval request"
+        ],
+        "summary": "Get information about the metrics approval request.",
+        "description": "Get whether the metrics approval request is necessary or not.",
+        "operationId": "getNeedsMetricsApprovalRequest",
+        "responses": {
+          "200": {
+            "description": "Returns true if it is needed, false if it is not."
+          }
+        }
+      }
+    },
+    "/_info/flow-actions.json": {
+      "get": {
+        "tags": [
+          "System Info & Healthcheck"
+        ],
+        "summary": "Get actions for flow builder",
+        "description": "Get a list of action for flow builder.",
+        "operationId": "flow-actions",
+        "responses": {
+          "200": {
+            "description": "Returns a list of action for flow builder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/flowBulderActionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oauth/token": {
+      "post": {
+        "tags": [
+          "Authorization & Authentication"
+        ],
+        "summary": "Fetch an access token",
+        "description": "Fetch a access token that can be used to perform authenticated requests. For more information take a look at the [Authentication documentation](https://shopware.stoplight.io/docs/admin-api/docs/concepts/authentication-authorisation.md).",
+        "operationId": "token",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/OAuthPasswordGrant"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OAuthRefreshTokenGrant"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OAuthClientCredentialsGrant"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Authorized successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "token_type",
+                    "expires_in",
+                    "access_token"
+                  ],
+                  "properties": {
+                    "token_type": {
+                      "description": "Type of the token.",
+                      "type": "string"
+                    },
+                    "expires_in": {
+                      "description": "Token lifetime in seconds.",
+                      "type": "integer"
+                    },
+                    "access_token": {
+                      "description": "The access token that can be used for subsequent requests",
+                      "type": "string"
+                    },
+                    "refresh_token": {
+                      "description": "The refresh token that can be used to refresh the access token. This field is not returned on grant type `refresh_token`.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          }
+        }
+      }
+    },
+    "/_info/health-check": {
+      "get": {
+        "tags": [
+          "System Info & Healthcheck"
+        ],
+        "summary": "Check that the Application is running",
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "Returns empty response"
+          },
+          "500": {
+            "description": "Application is not working properly"
+          }
+        }
+      }
+    },
+    "/_info/openapi3.json": {
+      "get": {
+        "tags": [
+          "System Info & Healthcheck"
+        ],
+        "summary": "Get OpenAPI Specification",
+        "description": "Get information about the API in OpenAPI format.",
+        "operationId": "api-info",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Type of the api",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "jsonapi",
+                "json"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns information about the API."
+          }
+        }
+      }
+    },
+    "/_action/index": {
+      "post": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Run indexer",
+        "description": "Runs all registered indexer in the shop asynchronously.",
+        "operationId": "index",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "skip": {
+                    "description": "Array of indexers/updaters to be skipped.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Returns a no content response indicating that the indexing progress startet."
+          }
+        }
+      }
+    },
+    "/_info/config": {
+      "get": {
+        "tags": [
+          "System Info & Healthcheck"
+        ],
+        "summary": "Get API information",
+        "description": "Get information about the API",
+        "operationId": "config",
+        "responses": {
+          "200": {
+            "description": "Returns information about the API.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/infoConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/cleanup": {
+      "delete": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Clear old cache folders",
+        "description": "Removes cache folders that are not needed anymore.",
+        "operationId": "clearOldCacheFolders",
+        "responses": {
+          "204": {
+            "description": "Returns a no content response indicating that the cleanup finished."
+          }
+        }
+      }
+    },
+    "/_info/events.json": {
+      "get": {
+        "tags": [
+          "System Info & Healthcheck"
+        ],
+        "summary": "Get Business events",
+        "description": "Get a list of about the business events.",
+        "operationId": "business-events",
+        "responses": {
+          "200": {
+            "description": "Returns a list of about the business events.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/businessEventsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/container_cache": {
+      "delete": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Clear container caches",
+        "description": "The container cache is immediately cleared synchronously.",
+        "operationId": "clearContainerCache",
+        "responses": {
+          "204": {
+            "description": "Returns a no content response indicating that the container cache is cleared."
+          }
+        }
+      }
+    },
+    "/_action/document/{documentId}/{deepLinkCode}": {
+      "get": {
+        "tags": [
+          "Document Management"
+        ],
+        "summary": "Download a document",
+        "description": "Download a document by its identifier and deep link code.",
+        "operationId": "downloadDocument",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "Identifier of the document to be downloaded.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            }
+          },
+          {
+            "name": "deepLinkCode",
+            "in": "path",
+            "description": "A unique hash code which was generated when the document was created.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "download",
+            "in": "query",
+            "description": "This parameter controls the `Content-Disposition` header. If set to `true` the header will be set to `attachment` else `inline`.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The document.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/document/{documentId}/upload": {
+      "post": {
+        "tags": [
+          "Document Management"
+        ],
+        "summary": "Upload a file for a document",
+        "description": "Uploads a file for a document. This prevents the document from being dynamically generated and delivers the uploaded file instead, when the document is downloaded.\n\nNote:\n* The document is required to be `static`\n* A document can only have one media file\n\nThe are two methods of providing a file to this route:\n * Use a typical file upload and provide the file in the request\n * Fetch the file from an url. This only works if the `shopware.media.enable_url_upload_feature` variable is set to true in the shop environment.\nTo use file upload via url, the content type has to be `application/json` and the parameter `url` has to be provided.",
+        "operationId": "uploadToDocument",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "Identifier of the document the new file should be added to.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            }
+          },
+          {
+            "name": "fileName",
+            "in": "query",
+            "description": "Name of the uploaded file.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "extension",
+            "in": "query",
+            "description": "Extension of the uploaded file. For example `pdf`",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "description": "The url of the document that will be downloaded.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Document uploaded successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "documentId": {
+                      "description": "Identifier of the document.",
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{32}$"
+                    },
+                    "documentDeepLink": {
+                      "description": "A unique hash code which is required to open the document.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/media/{mediaId}/upload": {
+      "post": {
+        "tags": [
+          "Asset Management"
+        ],
+        "summary": "Upload a file to a media entity",
+        "description": "Adds a new file to a media entity. If the entity has an existing file, it will be replaced.\n\nThe are two methods of providing a file to this route:\n * Use a typical file upload and provide the file in the request\n * Fetch the file from an url. This only works if the `shopware.media.enable_url_upload_feature` variable is set to true in the shop environment.\nTo use file upload via url, the content type has to be `application/json` and the parameter `url` has to be provided.",
+        "operationId": "upload",
+        "parameters": [
+          {
+            "name": "mediaId",
+            "in": "path",
+            "description": "Identifier of the media entity.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            }
+          },
+          {
+            "name": "fileName",
+            "in": "query",
+            "description": "Name of the uploaded file. If not provided the media identifier will be used as name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "extension",
+            "in": "query",
+            "description": "Extension of the uploaded file. For example `png`",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "description": "The url of the media file that will be downloaded.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Media file uploaded successful",
+            "headers": {
+              "Location": {
+                "description": "Contains the url to the uploaded media for a redirect.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/message-queue/consume": {
+      "post": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Consume messages from the message queue.",
+        "description": "This route can be used to consume messenges from the message queue. It is intended to be used if\nno cronjob is configured to consume messages regulary.",
+        "operationId": "consumeMessages",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "receiver"
+                ],
+                "properties": {
+                  "receiver": {
+                    "description": "The name of the transport in the messenger that should be processed.\nSee the [Symfony Messenger documentation](https://symfony.com/doc/current/messenger.html) for more information",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns information about handled messages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "handledMessages": {
+                      "description": "The number of messages processed.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/mail-template/send": {
+      "post": {
+        "tags": [
+          "Mail Operations"
+        ],
+        "summary": "Send a mail",
+        "description": "Generates a mail from a mail template and sends it to the customer.\n\nTake a look at the `salesChannel` entity for possible values. For example `{{ salesChannel.name }}` can be used.",
+        "operationId": "send",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "recipients",
+                  "salesChannelId",
+                  "contentHtml",
+                  "contentPlain",
+                  "subject",
+                  "senderName"
+                ],
+                "properties": {
+                  "recipients": {
+                    "description": "A list of recipients with name and mail address.",
+                    "type": "object",
+                    "example": {
+                      "test1@example.com": "Test user 1",
+                      "test2@example.com": "Test user 2"
+                    },
+                    "additionalProperties": {
+                      "description": "Name of the recipient.",
+                      "type": "string"
+                    }
+                  },
+                  "salesChannelId": {
+                    "description": "Identifier of the sales channel from which the mail should be send.",
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{32}$"
+                  },
+                  "contentHtml": {
+                    "description": "The content of the mail in HTML format.",
+                    "type": "string"
+                  },
+                  "contentPlain": {
+                    "description": "The content of the mail as plain text.",
+                    "type": "string"
+                  },
+                  "subject": {
+                    "description": "Subject of the mail.",
+                    "type": "string"
+                  },
+                  "senderName": {
+                    "description": "Name of the sender.",
+                    "type": "string"
+                  },
+                  "senderEmail": {
+                    "description": "Mail address of the sender. If not set, `core.basicInformation.email` or `core.mailerSettings.senderAddress` will be used from the shop configuration.",
+                    "type": "string"
+                  },
+                  "mediaIds": {
+                    "description": "List of media identifiers which should be attached to the mail.",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{32}$"
+                    }
+                  },
+                  "binAttachments": {
+                    "description": "A list of binary attachments which should be added to the mail.",
+                    "required": [
+                      "content",
+                      "fileName",
+                      "mimeType"
+                    ],
+                    "type": "array",
+                    "items": {
+                      "properties": {
+                        "content": {
+                          "description": "Binary content of the attachment.",
+                          "type": "string"
+                        },
+                        "fileName": {
+                          "description": "File name of the attachment.",
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "description": "Mime type of the attachment.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "recipientsBcc": {
+                    "description": "A list of recipients with name and mail address to be set in BCC.",
+                    "type": "object",
+                    "example": {
+                      "test1@example.com": "Test user 1",
+                      "test2@example.com": "Test user 2"
+                    },
+                    "additionalProperties": {
+                      "description": "Name of the recipient.",
+                      "type": "string"
+                    }
+                  },
+                  "recipientsCc": {
+                    "description": "A list of recipients with name and mail address to be set in CC.",
+                    "type": "object",
+                    "example": {
+                      "test1@example.com": "Test user 1",
+                      "test2@example.com": "Test user 2"
+                    },
+                    "additionalProperties": {
+                      "description": "Name of the recipient.",
+                      "type": "string"
+                    }
+                  },
+                  "replyTo": {
+                    "description": "A list of mail addresses with name and mail address to be set in reply to.",
+                    "type": "object",
+                    "example": {
+                      "test1@example.com": "Test user 1",
+                      "test2@example.com": "Test user 2"
+                    },
+                    "additionalProperties": {
+                      "description": "Name of the recipient.",
+                      "type": "string"
+                    }
+                  },
+                  "returnPath": {
+                    "description": "A list of mail addresses with name and mail address to be set in return path.",
+                    "type": "object",
+                    "example": {
+                      "test1@example.com": "Test user 1",
+                      "test2@example.com": "Test user 2"
+                    },
+                    "additionalProperties": {
+                      "description": "Name of the recipient.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The mail was sent successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "size": {
+                      "description": "Length of the email message",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/mail-template/validate": {
+      "post": {
+        "tags": [
+          "Mail Operations"
+        ],
+        "summary": "Validate a mail content",
+        "description": "Validates if content for a mail can be rendered without sending an email.",
+        "operationId": "validate",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "contentHtml",
+                  "contentPlain"
+                ],
+                "properties": {
+                  "contentHtml": {
+                    "description": "The content of the mail in HTML format.",
+                    "type": "string"
+                  },
+                  "contentPlain": {
+                    "description": "The content of the mail as plain text.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Returns a no content response indicating the mail content was rendered successfully."
+          }
+        }
+      }
+    },
+    "/_action/mail-template/build": {
+      "post": {
+        "tags": [
+          "Mail Operations"
+        ],
+        "summary": "Preview a mail template",
+        "description": "Generates a preview of a mail template.",
+        "operationId": "build",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "mailTemplateType",
+                  "mailTemplate"
+                ],
+                "properties": {
+                  "mailTemplateType": {
+                    "description": "Only the property `templateData` is used. It provides additional variables to the templating engine.",
+                    "properties": {
+                      "templateData": {
+                        "description": "An associative array that is handed over to the templating engine and can be used as variables in the mail content.",
+                        "type": "object",
+                        "example": {
+                          "order": {
+                            "orderNumber": 5000,
+                            "customerName": "Example Customer"
+                          },
+                          "messageOfTheDay": "An apple a day keeps the doctor away!"
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "mailTemplate": {
+                    "description": "The content of the mail as plain text.",
+                    "properties": {
+                      "contentHtml": {
+                        "description": "The content of mail mail template in html format.",
+                        "type": "string",
+                        "example": "Hello {{ order.customerName }}, this is example mail content, the current date is {{ 'now'|date('d/m/Y') }}"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The rendered preview of the mail template.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_action/index-products": {
+      "post": {
+        "tags": [
+          "System Operations"
+        ],
+        "summary": "Send product indexing message",
+        "description": "Dispachtes an product indexing message to the message bus, with the provided ids",
+        "operationId": "productIndexing",
+        "responses": {
+          "204": {
+            "description": "Returns an empty response indicating that the message dispatched."
+          }
+        }
+      }
+    },
+    "/_action/order_transaction/{orderTransactionId}/state/{transition}": {
+      "post": {
+        "tags": [
+          "Order Management"
+        ],
+        "summary": "Transition an order transaction to a new state",
+        "description": "Changes the order transaction state and informs the customer via email if configured.",
+        "operationId": "orderTransactionStateTransition",
+        "parameters": [
+          {
+            "name": "orderTransactionId",
+            "in": "path",
+            "description": "Identifier of the order transaction.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{32}$"
+            }
+          },
+          {
+            "name": "transition",
+            "in": "path",
+            "description": "The `action_name` of the `state_machine_transition`. For example `process` if the order state should change from open to in progress.\n\nNote: If you choose a transition that is not available, you will get an error that lists possible transitions for the current state.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "sendMail": {
+                    "description": "Controls if a mail should be sent to the customer."
+                  },
+                  "documentIds": {
+                    "description": "A list of document identifiers that should be attached",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{32}$"
+                    }
+                  },
+                  "mediaIds": {
+                    "description": "A list of media identifiers that should be attached",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{32}$"
+                    }
+                  },
+                  "stateFieldName": {
+                    "description": "This is the state column within the order transaction database table. There should be no need to change it from the default.",
+                    "type": "string",
+                    "default": "stateId"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Returns information about the transition that was made. `#/components/schemas/StateMachineTransition`"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Experimental",
+      "description": "Experimental API, not part of our backwards compatibility promise, thus this API can introduce breaking changes at any time.",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "https://github.com/shopware/platform/blob/trunk/adr/2023-05-10-experimental-features.md"
+      }
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-<<<<<<< HEAD
-=======
 overrides:
   '@apidevtools/json-schema-ref-parser': 9.0.7
 
->>>>>>> a38e7f3f (fix: use @apidevtools/json-schema-ref-parser 9.0.7 to timeouts with the parser)
 patchedDependencies:
   '@jsdevtools/ono@7.1.3':
     hash: gqumdw6qlspa2xjg2gstxyzvca

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+<<<<<<< HEAD
+=======
+overrides:
+  '@apidevtools/json-schema-ref-parser': 9.0.7
+
+>>>>>>> a38e7f3f (fix: use @apidevtools/json-schema-ref-parser 9.0.7 to timeouts with the parser)
 patchedDependencies:
   '@jsdevtools/ono@7.1.3':
     hash: gqumdw6qlspa2xjg2gstxyzvca
@@ -1037,8 +1043,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.19
     dev: true
 
-  /@apidevtools/json-schema-ref-parser@9.0.6:
-    resolution: {integrity: sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==}
+  /@apidevtools/json-schema-ref-parser@9.0.7:
+    resolution: {integrity: sha512-QdwOGF1+eeyFh+17v2Tz626WX0nucd1iKOm6JUTUvCZdbolblCOOQCxGrQPY0f7jEhn36PiAWqZnsC2r5vmUWg==}
     dependencies:
       '@jsdevtools/ono': 7.1.3(patch_hash=gqumdw6qlspa2xjg2gstxyzvca)
       call-me-maybe: 1.0.2
@@ -1059,7 +1065,7 @@ packages:
     peerDependencies:
       openapi-types: '>=7'
     dependencies:
-      '@apidevtools/json-schema-ref-parser': 9.0.6
+      '@apidevtools/json-schema-ref-parser': 9.0.7
       '@apidevtools/openapi-schemas': 2.1.0
       '@apidevtools/swagger-methods': 3.0.2
       '@jsdevtools/ono': 7.1.3(patch_hash=gqumdw6qlspa2xjg2gstxyzvca)


### PR DESCRIPTION
The recent version of @apidevtools/swagger-parser runs into a timeout with some (not all) large files. As described here:

https://github.com/APIDevTools/swagger-parser/issues/221

The mentioned workaround (pinning @apidevtools/json-schema-ref-parser to 9.0.7) seems to work just fine. I’ve added a test to make sure we don’t reintroduce the regression.