### PR TITLE
fix: check if the endpoint has example responses

### DIFF
--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/Copy.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/Copy.vue
@@ -26,12 +26,14 @@ const responseArray = computed(() => {
 
   const res: { name: string; description: string }[] = []
 
-  Object.keys(responses).forEach((statusCode: string) => {
-    res.push({
-      name: statusCode,
-      description: responses[statusCode].description,
+  if (responses) {
+    Object.keys(responses).forEach((statusCode: string) => {
+      res.push({
+        name: statusCode,
+        description: responses[statusCode].description,
+      })
     })
-  })
+  }
 
   return res
 })


### PR DESCRIPTION
Before rendering example responses, check whether the operation has example responses. :)