### PR TITLE
fix: render valid request methods only

### DIFF
--- a/packages/api-client/src/components/ApiClient/RequestMethodSelect.vue
+++ b/packages/api-client/src/components/ApiClient/RequestMethodSelect.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import { validRequestMethods } from '../../helpers'
-
 withDefaults(defineProps<{ requestMethod: string; readOnly?: boolean }>(), {
   readOnly: true,
 })
@@ -8,6 +6,19 @@ withDefaults(defineProps<{ requestMethod: string; readOnly?: boolean }>(), {
 defineEmits<{
   (e: 'change', value: string): void
 }>()
+
+// TODO: Support all request methods
+const supportedRequestMethods = [
+  'GET',
+  'POST',
+  'PUT',
+  // 'HEAD',
+  'DELETE',
+  'PATCH',
+  // 'OPTIONS',
+  // 'CONNECT',
+  // 'TRACE',
+]
 </script>
 <template>
   <div class="request-method-select">
@@ -22,7 +33,7 @@ defineEmits<{
       :value="requestMethod.toLowerCase()"
       @input="(event) => $emit('change', (event.target as HTMLSelectElement).value)">
       <option
-        v-for="validRequestMethod in validRequestMethods"
+        v-for="validRequestMethod in supportedRequestMethods"
         :key="validRequestMethod"
         :value="validRequestMethod.toLocaleLowerCase()">
         {{ validRequestMethod }}

--- a/packages/api-client/src/fixtures/httpRequestMethods.ts
+++ b/packages/api-client/src/fixtures/httpRequestMethods.ts
@@ -1,0 +1,11 @@
+export const validRequestMethods = [
+    'GET',
+    'POST',
+    'PUT',
+    'HEAD',
+    'DELETE',
+    'PATCH',
+    'OPTIONS',
+    'CONNECT',
+    'TRACE',
+]

--- a/packages/api-client/src/fixtures/index.ts
+++ b/packages/api-client/src/fixtures/index.ts
@@ -1,6 +1,3 @@
-export { httpHeaders, type HttpHeader } from './httpHeaders'
-export {
-  default as httpStatusCodes,
-  type HttpStatusCode,
-  type HttpStatusCodes,
-} from './httpStatusCodes'
+export * from './httpHeaders'
+export * from './httpRequestMethods'
+export * from './httpStatusCodes'

--- a/packages/api-client/src/helpers/normalizeRequestMethod.ts
+++ b/packages/api-client/src/helpers/normalizeRequestMethod.ts
@@ -1,17 +1,6 @@
-const defaultRequestMethod = 'GET'
+import { validRequestMethods } from '../fixtures'
 
-// TODO: Support all request methods
-export const validRequestMethods = [
-  'GET',
-  'POST',
-  'PUT',
-  // 'HEAD',
-  'DELETE',
-  'PATCH',
-  // 'OPTIONS',
-  // 'CONNECT',
-  // 'TRACE',
-]
+const defaultRequestMethod = 'GET'
 
 /**
  * Get a normalized request method (e.g. GET, POST, etc.)

--- a/packages/swagger-parser/src/fixtures/httpRequestMethods.ts
+++ b/packages/swagger-parser/src/fixtures/httpRequestMethods.ts
@@ -1,0 +1,11 @@
+export const validRequestMethods = [
+  'GET',
+  'POST',
+  'PUT',
+  'HEAD',
+  'DELETE',
+  'PATCH',
+  'OPTIONS',
+  'CONNECT',
+  'TRACE',
+]

--- a/packages/swagger-parser/src/fixtures/index.ts
+++ b/packages/swagger-parser/src/fixtures/index.ts
@@ -1,0 +1,1 @@
+export * from './httpRequestMethods'

--- a/packages/swagger-parser/src/helpers/parse.ts
+++ b/packages/swagger-parser/src/helpers/parse.ts
@@ -2,6 +2,7 @@ import SwaggerParser from '@apidevtools/swagger-parser'
 import yaml from 'js-yaml'
 import { type OpenAPI, type OpenAPIV2, type OpenAPIV3 } from 'openapi-types'
 
+import { validRequestMethods } from '../fixtures'
 import type { AnyObject, AnyStringOrObject, SwaggerSpec } from '../types'
 
 export const parse = (value: AnyStringOrObject): Promise<SwaggerSpec> => {
@@ -44,20 +45,9 @@ const transformResult = (result: OpenAPI.Document<object>): SwaggerSpec => {
    */
   Object.keys(result.paths).forEach((path: string) => {
     // @ts-ignore
-    const requestMethods = Object.keys(result.paths[path]).filter((key) => {
-      // TODO: Replace with a global constant
-      return [
-        'GET',
-        'POST',
-        'PUT',
-        'HEAD',
-        'DELETE',
-        'PATCH',
-        'OPTIONS',
-        'CONNECT',
-        'TRACE',
-      ].includes(key.toUpperCase())
-    })
+    const requestMethods = Object.keys(result.paths[path]).filter((key) =>
+      validRequestMethods.includes(key.toUpperCase()),
+    )
 
     requestMethods.forEach((requestMethod) => {
       // @ts-ignore

--- a/packages/swagger-parser/src/helpers/parse.ts
+++ b/packages/swagger-parser/src/helpers/parse.ts
@@ -44,7 +44,22 @@ const transformResult = (result: OpenAPI.Document<object>): SwaggerSpec => {
    */
   Object.keys(result.paths).forEach((path: string) => {
     // @ts-ignore
-    Object.keys(result.paths[path]).forEach((requestMethod) => {
+    const requestMethods = Object.keys(result.paths[path]).filter((key) => {
+      // TODO: Replace with a global constant
+      return [
+        'GET',
+        'POST',
+        'PUT',
+        'HEAD',
+        'DELETE',
+        'PATCH',
+        'OPTIONS',
+        'CONNECT',
+        'TRACE',
+      ].includes(key.toUpperCase())
+    })
+
+    requestMethods.forEach((requestMethod) => {
       // @ts-ignore
       const operation = result.paths[path][requestMethod]
       // Transform the operation


### PR DESCRIPTION
The path object item has more keys than just request methods:
https://spec.openapis.org/oas/v3.1.0#pathItemObject

Let’s not iterate over the other keys.