### PR TITLE
feat: add requestbody to api client if json schema available

### DIFF
--- a/.changeset/sharp-icons-decide.md
+++ b/.changeset/sharp-icons-decide.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+feat: add requestbody to api client if json schema available

--- a/packages/api-client/src/helpers/generateRequest.ts
+++ b/packages/api-client/src/helpers/generateRequest.ts
@@ -1,6 +1,7 @@
 import { type ParamMap } from '../hooks/useOperation'
 import type { ClientRequestConfig, Operation, Server } from '../types'
 import { generateParameters } from './generateParameters'
+import { getRequestBody } from './generateRequestBody'
 
 /**
  * Generate parameters for the request
@@ -19,7 +20,7 @@ export function generateRequest(
     query: generateParameters(parameterMap.query),
     headers: generateParameters(parameterMap.header),
     url: server.url,
-    body: '',
+    body: getRequestBody(operation.information.requestBody),
   }
 
   return item

--- a/packages/api-client/src/helpers/generateRequest.ts
+++ b/packages/api-client/src/helpers/generateRequest.ts
@@ -20,7 +20,7 @@ export function generateRequest(
     query: generateParameters(parameterMap.query),
     headers: generateParameters(parameterMap.header),
     url: server.url,
-    body: getRequestBody(operation.information.requestBody),
+    body: getRequestBody(operation?.information?.requestBody),
   }
 
   return item

--- a/packages/api-client/src/helpers/generateRequestBody.test.ts
+++ b/packages/api-client/src/helpers/generateRequestBody.test.ts
@@ -1,0 +1,254 @@
+import { generateRequestBody } from 'src/helpers/generateRequestBody'
+import { describe, expect, it } from 'vitest'
+
+describe('generateResponseContent', () => {
+  it('sets example values', () => {
+    expect(
+      generateRequestBody({
+        properties: {
+          id: {
+            example: 10,
+          },
+        },
+      }),
+    ).toMatchObject({
+      id: 10,
+    })
+  })
+
+  it('takes the first enum as example', () => {
+    expect(
+      generateRequestBody({
+        properties: {
+          status: {
+            enum: ['available', 'pending', 'sold'],
+          },
+        },
+      }),
+    ).toMatchObject({
+      status: 'available',
+    })
+  })
+
+  it('goes through properties recursively with objects', () => {
+    expect(
+      generateRequestBody({
+        properties: {
+          category: {
+            type: 'object',
+            properties: {
+              id: {
+                example: 1,
+              },
+              name: {
+                example: 'Dogs',
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      category: {
+        id: 1,
+        name: 'Dogs',
+      },
+    })
+  })
+
+  it('goes through properties recursively with arrays', () => {
+    expect(
+      generateRequestBody({
+        properties: {
+          tags: {
+            type: 'array',
+            items: {
+              properties: {
+                id: {
+                  example: 1,
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      tags: [
+        {
+          id: 1,
+        },
+      ],
+    })
+  })
+
+  it('uses empty quotes as a fallback for arrays', () => {
+    expect(
+      generateRequestBody({
+        properties: {
+          title: {
+            type: 'array',
+          },
+        },
+      }),
+    ).toMatchObject({
+      title: [],
+    })
+  })
+
+  it('uses empty quotes as a fallback for strings', () => {
+    expect(
+      generateRequestBody({
+        properties: {
+          title: {
+            type: 'string',
+          },
+        },
+      }),
+    ).toMatchObject({
+      title: '',
+    })
+  })
+
+  it('uses true as a fallback for booleans', () => {
+    expect(
+      generateRequestBody({
+        properties: {
+          public: {
+            type: 'boolean',
+          },
+        },
+      }),
+    ).toMatchObject({
+      public: true,
+    })
+  })
+
+  it('uses 1 as a fallback for integers', () => {
+    expect(
+      generateRequestBody({
+        properties: {
+          id: {
+            type: 'integer',
+          },
+        },
+      }),
+    ).toMatchObject({
+      id: 1,
+    })
+  })
+
+  it('returns an array if the schema type is array', () => {
+    expect(
+      generateRequestBody({
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+      }),
+    ).toMatchObject([])
+  })
+
+  it('uses array example values', () => {
+    expect(
+      generateRequestBody({
+        type: 'array',
+        example: ['foobar'],
+        items: {
+          type: 'string',
+        },
+      }),
+    ).toMatchObject(['foobar'])
+  })
+
+  it('converts a whole schema to an example response', () => {
+    const schema = {
+      required: ['name', 'photoUrls'],
+      type: 'object',
+      properties: {
+        id: {
+          type: 'integer',
+          format: 'int64',
+          example: 10,
+        },
+        name: {
+          type: 'string',
+          example: 'doggie',
+        },
+        category: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'integer',
+              format: 'int64',
+              example: 1,
+            },
+            name: {
+              type: 'string',
+              example: 'Dogs',
+            },
+          },
+          xml: {
+            name: 'category',
+          },
+        },
+        photoUrls: {
+          type: 'array',
+          xml: {
+            wrapped: true,
+          },
+          items: {
+            type: 'string',
+            xml: {
+              name: 'photoUrl',
+            },
+          },
+        },
+        tags: {
+          type: 'array',
+          xml: {
+            wrapped: true,
+          },
+          items: {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'integer',
+                format: 'int64',
+              },
+              name: {
+                type: 'string',
+              },
+            },
+            xml: {
+              name: 'tag',
+            },
+          },
+        },
+        status: {
+          type: 'string',
+          description: 'pet status in the store',
+          enum: ['available', 'pending', 'sold'],
+        },
+      },
+      xml: {
+        name: 'pet',
+      },
+    }
+
+    expect(generateRequestBody(schema)).toMatchObject({
+      id: 10,
+      name: 'doggie',
+      category: {
+        id: 1,
+        name: 'Dogs',
+      },
+      photoUrls: [],
+      tags: [
+        {
+          id: 1,
+          name: '',
+        },
+      ],
+      status: 'available',
+    })
+  })
+})

--- a/packages/api-client/src/helpers/generateRequestBody.test.ts
+++ b/packages/api-client/src/helpers/generateRequestBody.test.ts
@@ -80,7 +80,7 @@ describe('generateResponseContent', () => {
     })
   })
 
-  it('uses empty quotes as a fallback for arrays', () => {
+  it('uses an array as a fallback for arrays', () => {
     expect(
       generateRequestBody({
         properties: {

--- a/packages/api-client/src/helpers/generateRequestBody.ts
+++ b/packages/api-client/src/helpers/generateRequestBody.ts
@@ -3,7 +3,7 @@ import type { RequestBody } from '../types'
 /**
  * This function takes a properties object and generates an example requestBody.
  */
-export function getRequestBody(requestBody: RequestBody) {
+export function getRequestBody(requestBody?: RequestBody) {
   if (!requestBody?.content['application/json']?.schema) return '{}'
 
   const body = generateRequestBody(

--- a/packages/api-client/src/helpers/generateRequestBody.ts
+++ b/packages/api-client/src/helpers/generateRequestBody.ts
@@ -1,0 +1,111 @@
+import type { RequestBody } from '../types'
+
+/**
+ * This function takes a properties object and generates an example requestBody.
+ */
+export function getRequestBody(requestBody: RequestBody) {
+  if (!requestBody?.content['application/json']?.schema) return '{}'
+
+  const body = generateRequestBody(
+    requestBody.content['application/json']?.schema,
+    0,
+    false,
+  )
+
+  return JSON.stringify(body || {}, null, 2)
+}
+
+/**
+ * This function takes a properties object and generates an example requestBody.
+ */
+export const generateRequestBody = (
+  schema: Record<string, any>,
+  level: number = 0,
+  includeExample: boolean = true,
+) => {
+  // Break an infinite loop
+  if (level > 10) {
+    return null
+  }
+
+  if (schema.type === 'array') {
+    if (schema.example !== undefined && includeExample) {
+      return schema.example
+    }
+
+    return []
+  }
+
+  const response: Record<string, any> | any[] = {}
+
+  if (typeof schema.properties !== 'object') {
+    return response
+  }
+
+  Object.keys(schema.properties).forEach((name: string) => {
+    const property = schema.properties[name]
+
+    // example: 'Dogs'
+    if (property.example !== undefined && includeExample) {
+      response[name] = property.example
+      return
+    }
+
+    // enum: [ 'available', 'pending', 'sold' ]
+    if (property.enum !== undefined && includeExample) {
+      response[name] = property.enum[0]
+      return
+    }
+
+    // properties: { … }
+    if (property.properties !== undefined) {
+      response[name] = generateRequestBody(property, level + 1, includeExample)
+
+      return
+    }
+
+    // items: { properties: { … } }
+    if (property.items?.properties !== undefined) {
+      const children = generateRequestBody(
+        property.items,
+        level + 1,
+        includeExample,
+      )
+
+      if (property?.type === 'array') {
+        response[name] = [children]
+      } else {
+        response[name] = null
+      }
+
+      return
+    }
+
+    // Set an example value based on the type
+    const exampleValues: Record<string, any> = {
+      // TODO: Need to check the schema and add a default value
+      array: [],
+      string: '',
+      boolean: true,
+      integer: 1,
+      number: 0,
+      // TODO: Need to check the schema and add a default value
+      object: {},
+    }
+
+    if (exampleValues[property.type] !== undefined) {
+      response[name] = exampleValues[property.type]
+      return
+    }
+
+    // Warn if the type is unknown …
+    console.warn(
+      `[generateResponseContent] Unknown property type "${property.type}" for property "${name}".`,
+    )
+
+    // … and just return null for now.
+    response[name] = null
+  })
+
+  return response
+}

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -130,12 +130,14 @@ export type ContentProperties = {
   }
 }
 
+export type ContentSchemaSchema = {
+  type: string
+  required: string[]
+  properties: ContentProperties
+}
+
 export type ContentSchema = {
-  schema: {
-    type: string
-    required: string[]
-    properties: ContentProperties
-  }
+  schema: ContentSchemaSchema
 }
 
 export type ContentType =


### PR DESCRIPTION
If a user has JSON schema for a request body, we populate it in the api client.

If they dont we set an empty object

<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6176314/b645d5fb-4c8a-4f65-b0a2-7be732394483">

<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6176314/c1ff1c64-32b5-4219-8387-9563d720d807">
