### PR TITLE
fix: default show endpoint when tags have one endpoint

### DIFF
--- a/.changeset/sixty-tips-warn.md
+++ b/.changeset/sixty-tips-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: default show endpoint when tags have one endpoint

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -88,7 +88,8 @@ const moreThanOneDefaultTag = (tag: Tag) =>
           <template
             v-if="
               index === 0 ||
-              templateState.collapsedSidebarItems[getTagSectionId(tag)]
+              templateState.collapsedSidebarItems[getTagSectionId(tag)] ||
+              tag.operations?.length === 1
             ">
             <ReferenceEndpoint
               v-for="operation in tag.operations"


### PR DESCRIPTION
before:
<img width="1511" alt="image" src="https://github.com/scalar/scalar/assets/6176314/615e6c9d-1001-4942-b25d-f7261892e633">


after:
![Uploading image.png…]()
