### PR TITLE
fix: filter out tags with no operations

### DIFF
--- a/packages/swagger-parser/src/helpers/analyze.test.ts
+++ b/packages/swagger-parser/src/helpers/analyze.test.ts
@@ -44,7 +44,13 @@ describe('analyze', () => {
     const spec = {
       openapi: '3.1.0',
       info: {},
-      paths: {},
+      paths: {
+        '/example': {
+          get: {
+            tags: ['foo', 'bar'],
+          },
+        },
+      },
       tags: [
         {
           name: 'foo',
@@ -90,7 +96,7 @@ describe('analyze', () => {
       paths: {
         '/example': {
           get: {
-            tags: ['bar'],
+            tags: ['bar', 'foo'],
           },
         },
       },

--- a/packages/swagger-parser/src/helpers/parse.ts
+++ b/packages/swagger-parser/src/helpers/parse.ts
@@ -136,11 +136,14 @@ const transformResult = (result: OpenAPI.Document<object>): SwaggerSpec => {
 
   const returnedResult = result as unknown as SwaggerSpec
 
-  returnedResult.tags = returnedResult.tags.filter(
-    (tag) => tag.operations?.length > 0,
-  )
+  return removeTagsWithoutOperations(returnedResult)
+}
 
-  return returnedResult
+const removeTagsWithoutOperations = (spec: SwaggerSpec) => {
+  return {
+    ...spec,
+    tags: spec.tags?.filter((tag) => tag.operations?.length > 0),
+  }
 }
 
 export const parseJsonOrYaml = (value: string | AnyObject): AnyObject => {

--- a/packages/swagger-parser/src/helpers/parse.ts
+++ b/packages/swagger-parser/src/helpers/parse.ts
@@ -134,7 +134,13 @@ const transformResult = (result: OpenAPI.Document<object>): SwaggerSpec => {
     })
   })
 
-  return result as unknown as SwaggerSpec
+  const returnedResult = result as unknown as SwaggerSpec
+
+  returnedResult.tags = returnedResult.tags.filter(
+    (tag) => tag.operations?.length > 0,
+  )
+
+  return returnedResult
 }
 
 export const parseJsonOrYaml = (value: string | AnyObject): AnyObject => {


### PR DESCRIPTION
We can remove tags that have no operations, it's default for what most swagger/oas doc tools use and I think that makes sense.

I couldnt imagine the need for a tag with no endpoints, let me know if you disagree :) 