### PR TITLE
fix: add null check to tag operations in sidebar

### DIFF
--- a/.changeset/proud-dogs-tie.md
+++ b/.changeset/proud-dogs-tie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: add null check to tag operations in sidebar

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -119,7 +119,7 @@ const items = computed((): SidebarEntry[] => {
             id: getTagSectionId(tag),
             title: tag.name.toUpperCase(),
             type: 'Folder',
-            children: tag.operations.map((operation) => {
+            children: tag.operations?.map((operation) => {
               return {
                 id: getOperationSectionId(operation),
                 title: operation.name || operation.path,


### PR DESCRIPTION
handles the edge case where people have no operations for a tag