### PR TITLE
feat: show models

### DIFF
--- a/.changeset/grumpy-plants-retire.md
+++ b/.changeset/grumpy-plants-retire.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: show models ("schemas") in the reference

--- a/packages/api-reference/src/components/Content/Models.vue
+++ b/packages/api-reference/src/components/Content/Models.vue
@@ -1,26 +1,47 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import { getModelSectionId } from '../../helpers'
+import { useTemplateStore } from '../../stores/template'
 import { type Components } from '../../types'
 import {
   Section,
-  SectionColumn,
-  SectionColumns,
   SectionContainer,
   SectionContent,
   SectionHeader,
 } from '../Section'
 import Schema from './Schema.vue'
+import ShowMoreButton from './ShowMoreButton.vue'
 
-defineProps<{
+const props = defineProps<{
   components?: Components
 }>()
+
+const { state: templateState } = useTemplateStore()
+
+const showAllModels = computed(
+  () =>
+    Object.keys(props.components?.schemas ?? {}).length <= 3 ||
+    templateState.collapsedSidebarItems[getModelSectionId()],
+)
+
+const models = computed(() => {
+  const allModels = Object.keys(props.components?.schemas ?? {})
+
+  if (showAllModels.value) {
+    return allModels
+  }
+
+  // return only first 3 models
+  return allModels.slice(0, 3)
+})
 </script>
 <template>
   <SectionContainer
     v-if="components"
-    id="models">
+    :id="getModelSectionId()">
     <Section
-      v-for="name in Object.keys(components?.schemas ?? {})"
+      v-for="(name, index) in models"
       :id="getModelSectionId(name)"
       :key="name">
       <template v-if="components?.schemas?.[name]">
@@ -28,7 +49,12 @@ defineProps<{
           {{ name }}
         </SectionHeader>
         <SectionContent>
+          <!-- Schema -->
           <Schema :value="components?.schemas?.[name]" />
+          <!-- Show More Button -->
+          <ShowMoreButton
+            v-if="!showAllModels && index === models.length - 1"
+            :id="getModelSectionId()" />
         </SectionContent>
       </template>
     </Section>

--- a/packages/api-reference/src/components/Content/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema.vue
@@ -69,7 +69,11 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         class="property">
         <div class="property-information">
           <div class="property-name">
-            {{ property }}
+            {{ property
+            }}<span
+              v-if="value?.required?.includes(property)"
+              class="required"
+              v-text="'*'" />
           </div>
           <div
             v-if="value?.required?.includes(property)"
@@ -135,7 +139,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
           {{ value.properties[property].description }}
         </div>
         <div
-          v-if="generatePropertyDescription(value.properties[property])"
+          v-else-if="generatePropertyDescription(value.properties[property])"
           class="property-description">
           {{ generatePropertyDescription(value.properties[property]) }}
         </div>

--- a/packages/api-reference/src/components/Content/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-// TODO: value.xml isn’t rendered yet
 import Schema from './Schema.vue'
 
 withDefaults(
@@ -11,6 +10,39 @@ withDefaults(
     level: 0,
   },
 )
+
+const descriptions: Record<string, Record<string, string>> = {
+  number: {
+    _default: 'Any numbers.',
+    float: 'Floating-point numbers.',
+    double: 'Floating-point numbers with double precision.',
+  },
+  integer: {
+    _default: 'Integer numbers.',
+    int32: 'Signed 32-bit integers (commonly used integer type).',
+    int64: 'Signed 64-bit integers (long type).',
+  },
+  string: {
+    'date':
+      'full-date notation as defined by RFC 3339, section 5.6, for example, 2017-07-21',
+    'date-time':
+      'the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z',
+    'password': 'a hint to UIs to mask the input',
+    'byte': 'base64-encoded characters, for example, U3dhZ2dlciByb2Nrcw==',
+    'binary': 'binary data, used to describe files',
+  },
+}
+
+const generatePropertyDescription = (property: {
+  type: string
+  format?: string
+}) => {
+  if (descriptions[property.type]) {
+    return descriptions[property.type][property.format || '_default']
+  }
+}
+
+const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 </script>
 <template>
   <div class="schema">
@@ -24,7 +56,7 @@ withDefaults(
           <template v-if="value.type === 'object'"> {} </template>
           <template v-if="value.type === 'array'"> [] </template>
         </span>
-        <template v-if="value?.xml?.name">
+        <template v-if="value?.xml?.name && value?.xml?.name !== '##default'">
           &lt;{{ value?.xml?.name }} /&gt;
         </template>
         <template v-else>
@@ -48,10 +80,35 @@ withDefaults(
             v-if="value.properties[property].type"
             class="property-type">
             <template v-if="value.properties[property].type !== 'object'">
-              {{ value.properties[property].type }}
+              <template
+                v-if="
+                  value.properties[property]?.items &&
+                  !['object'].includes(value.properties[property].items.type)
+                ">
+                {{ value.properties[property].type }}
+                {{ value.properties[property].items.type }}[]
+              </template>
+              <template v-else>
+                {{ value.properties[property].type }}
+              </template>
+              <template
+                v-if="
+                  value.properties[property].minItems ||
+                  value.properties[property].maxItems
+                ">
+                {{ value.properties[property].minItems }}..{{
+                  value.properties[property].maxItems
+                }}
+              </template>
+              <template v-if="value.properties[property].uniqueItems">
+                unique!
+              </template>
             </template>
             <template v-if="value.properties[property].format">
               &middot; {{ value.properties[property].format }}
+            </template>
+            <template v-if="value.properties[property].enum">
+              &middot; enum
             </template>
           </div>
           <div
@@ -61,12 +118,41 @@ withDefaults(
               example: {{ value.properties[property].example }}
             </code>
           </div>
+          <template
+            v-for="rule in rules"
+            :key="rule">
+            <div
+              v-if="value.properties[property][rule]"
+              class="property-rule">
+              {{ rule }}
+            </div>
+          </template>
         </div>
+        <!-- Description -->
         <div
           v-if="value.properties[property].description"
           class="property-description">
           {{ value.properties[property].description }}
         </div>
+        <div
+          v-if="generatePropertyDescription(value.properties[property])"
+          class="property-description">
+          {{ generatePropertyDescription(value.properties[property]) }}
+        </div>
+        <!-- Enum -->
+        <div
+          v-if="value.properties[property].enum"
+          class="property-enum">
+          <ul class="property-enum-values">
+            <li
+              v-for="enumValue in value.properties[property].enum"
+              :key="enumValue"
+              class="property-enum-value">
+              {{ enumValue }}
+            </li>
+          </ul>
+        </div>
+        <!-- Object -->
         <div
           v-if="value.properties[property].properties"
           class="children">
@@ -75,7 +161,31 @@ withDefaults(
             :level="level + 1"
             :value="value.properties[property]" />
         </div>
-        <!-- TODO: .items for array -->
+        <!-- Array of objects -->
+        <template v-if="value.properties[property].items">
+          <div
+            v-if="['object'].includes(value.properties[property].items.type)"
+            class="children">
+            <Schema
+              v-if="level < 3"
+              :level="level + 1"
+              :value="value.properties[property].items" />
+          </div>
+        </template>
+        <!-- oneOf -->
+        <template
+          v-for="rule in rules"
+          :key="rule">
+          <div
+            v-if="value.properties[property][rule]"
+            class="rule">
+            <Schema
+              v-for="(schema, index) in value.properties[property][rule]"
+              :key="index"
+              :level="level + 1"
+              :value="schema" />
+          </div>
+        </template>
       </div>
     </div>
   </div>
@@ -117,6 +227,12 @@ withDefaults(
 .property-description {
   margin-top: 12px;
   color: var(--theme-color-2, var(--default-theme-color-2));
+}
+
+.property-rule {
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+  background: var(--theme-color-orange, var(--default-theme-color-orange));
+  padding: 0 6px;
 }
 
 .property:not(:last-of-type) {
@@ -163,11 +279,31 @@ withDefaults(
   padding: 12px 12px;
   background: var(--theme-background-4, var(--default-theme-background-4));
   padding: 2px 5px;
-  border-radius: var(--theme-radius, var(--default-theme-radius));
   font-family: var(--theme-font-code, var(--default-theme-font-code));
   font-size: var(
     --default-theme-font-size-5,
     var(--default-default-theme-font-size-5)
   );
+}
+
+.rule {
+  margin-top: 12px;
+  padding: 0 12px 12px;
+  border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
+  background: var(--theme-background-4, var(--default-theme-background-4));
+  border: 2px dotted
+    var(--theme-border-color, var(--default-theme-border-color));
+}
+
+.property-enum-value {
+  padding: 3px 0;
+}
+.property-enum-value::before {
+  content: '▶';
+  margin-right: 6px;
+  color: var(--theme-color-3, var(--default-theme-color-3));
+}
+.property-enum-values {
+  margin-top: 12px;
 }
 </style>

--- a/packages/api-reference/src/components/Content/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema.vue
@@ -18,11 +18,18 @@ withDefaults(
       v-if="value?.properties"
       class="properties">
       <div class="type">
-        <span class="type-icon">
+        <span
+          class="type-icon"
+          :title="value.type">
           <template v-if="value.type === 'object'"> {} </template>
           <template v-if="value.type === 'array'"> [] </template>
         </span>
-        {{ value.type }}
+        <template v-if="value?.xml?.name">
+          &lt;{{ value?.xml?.name }} /&gt;
+        </template>
+        <template v-else>
+          {{ value.type }}
+        </template>
       </div>
       <div
         v-for="property in Object.keys(value.properties)"

--- a/packages/api-reference/src/components/Content/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema.vue
@@ -35,7 +35,11 @@ withDefaults(
         :key="property"
         :level="level"
         :name="property"
-        :required="value.required?.includes(property)"
+        :required="
+          value.required &&
+          value.required.length &&
+          value.required.includes(property)
+        "
         :value="value.properties[property]" />
     </div>
     <div

--- a/packages/api-reference/src/components/Content/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import Schema from './Schema.vue'
+import SchemaProperty from './SchemaProperty.vue'
 
 withDefaults(
   defineProps<{
@@ -10,39 +10,6 @@ withDefaults(
     level: 0,
   },
 )
-
-const descriptions: Record<string, Record<string, string>> = {
-  number: {
-    _default: 'Any numbers.',
-    float: 'Floating-point numbers.',
-    double: 'Floating-point numbers with double precision.',
-  },
-  integer: {
-    _default: 'Integer numbers.',
-    int32: 'Signed 32-bit integers (commonly used integer type).',
-    int64: 'Signed 64-bit integers (long type).',
-  },
-  string: {
-    'date':
-      'full-date notation as defined by RFC 3339, section 5.6, for example, 2017-07-21',
-    'date-time':
-      'the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z',
-    'password': 'a hint to UIs to mask the input',
-    'byte': 'base64-encoded characters, for example, U3dhZ2dlciByb2Nrcw==',
-    'binary': 'binary data, used to describe files',
-  },
-}
-
-const generatePropertyDescription = (property: {
-  type: string
-  format?: string
-}) => {
-  if (descriptions[property.type]) {
-    return descriptions[property.type][property.format || '_default']
-  }
-}
-
-const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 </script>
 <template>
   <div class="schema">
@@ -63,139 +30,28 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
           {{ value.type }}
         </template>
       </div>
-      <div
+      <SchemaProperty
         v-for="property in Object.keys(value.properties)"
         :key="property"
-        class="property">
-        <div class="property-information">
-          <div class="property-name">
-            {{ property
-            }}<span
-              v-if="value?.required?.includes(property)"
-              class="required"
-              v-text="'*'" />
-          </div>
-          <div
-            v-if="value?.required?.includes(property)"
-            class="required">
-            required
-          </div>
-          <div
-            v-if="value.properties[property].type"
-            class="property-type">
-            <template v-if="value.properties[property].type !== 'object'">
-              <template
-                v-if="
-                  value.properties[property]?.items &&
-                  !['object'].includes(value.properties[property].items.type)
-                ">
-                {{ value.properties[property].type }}
-                {{ value.properties[property].items.type }}[]
-              </template>
-              <template v-else>
-                {{ value.properties[property].type }}
-              </template>
-              <template
-                v-if="
-                  value.properties[property].minItems ||
-                  value.properties[property].maxItems
-                ">
-                {{ value.properties[property].minItems }}..{{
-                  value.properties[property].maxItems
-                }}
-              </template>
-              <template v-if="value.properties[property].uniqueItems">
-                unique!
-              </template>
-            </template>
-            <template v-if="value.properties[property].format">
-              &middot; {{ value.properties[property].format }}
-            </template>
-            <template v-if="value.properties[property].enum">
-              &middot; enum
-            </template>
-          </div>
-          <div
-            v-if="value.properties[property].example"
-            class="property-example">
-            <code class="property-example-value">
-              example: {{ value.properties[property].example }}
-            </code>
-          </div>
-          <template
-            v-for="rule in rules"
-            :key="rule">
-            <div
-              v-if="value.properties[property][rule]"
-              class="property-rule">
-              {{ rule }}
-            </div>
-          </template>
-        </div>
-        <!-- Description -->
-        <div
-          v-if="value.properties[property].description"
-          class="property-description">
-          {{ value.properties[property].description }}
-        </div>
-        <div
-          v-else-if="generatePropertyDescription(value.properties[property])"
-          class="property-description">
-          {{ generatePropertyDescription(value.properties[property]) }}
-        </div>
-        <!-- Enum -->
-        <div
-          v-if="value.properties[property].enum"
-          class="property-enum">
-          <ul class="property-enum-values">
-            <li
-              v-for="enumValue in value.properties[property].enum"
-              :key="enumValue"
-              class="property-enum-value">
-              {{ enumValue }}
-            </li>
-          </ul>
-        </div>
-        <!-- Object -->
-        <div
-          v-if="value.properties[property].properties"
-          class="children">
-          <Schema
-            v-if="level < 3"
-            :level="level + 1"
-            :value="value.properties[property]" />
-        </div>
-        <!-- Array of objects -->
-        <template v-if="value.properties[property].items">
-          <div
-            v-if="['object'].includes(value.properties[property].items.type)"
-            class="children">
-            <Schema
-              v-if="level < 3"
-              :level="level + 1"
-              :value="value.properties[property].items" />
-          </div>
-        </template>
-        <!-- oneOf -->
-        <template
-          v-for="rule in rules"
-          :key="rule">
-          <div
-            v-if="value.properties[property][rule]"
-            class="rule">
-            <Schema
-              v-for="(schema, index) in value.properties[property][rule]"
-              :key="index"
-              :level="level + 1"
-              :value="schema" />
-          </div>
-        </template>
-      </div>
+        :level="level"
+        :name="property"
+        :required="value.required?.includes(property)"
+        :value="value.properties[property]" />
+    </div>
+    <div
+      v-else-if="value?.type"
+      class="properties">
+      <SchemaProperty
+        :level="level"
+        :value="value" />
     </div>
   </div>
 </template>
 
 <style scoped>
+.error {
+  background-color: red;
+}
 .schema {
   max-width: 600px;
   width: 100%;
@@ -218,96 +74,10 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
   font-size: var(--default-theme-font-size-3, var(--default-theme-font-size-3));
 }
 
-.property {
-  padding: 12px 0;
-}
-
-.property-information {
-  display: flex;
-  align-items: end;
-  gap: 16px;
-}
-
-.property-description {
-  margin-top: 12px;
-  color: var(--theme-color-2, var(--default-theme-color-2));
-}
-
-.property-rule {
-  font-family: var(--theme-font-code, var(--default-theme-font-code));
-  background: var(--theme-color-orange, var(--default-theme-color-orange));
-  padding: 0 6px;
-}
-
-.property:not(:last-of-type) {
-  border-bottom: 1px solid
-    var(--theme-border-color, var(--default-theme-border-color));
-}
-.property-name {
-  font-family: var(--theme-font-code, var(--default-theme-font-code));
-}
-
-.required,
-.optional {
-  color: var(--theme-color-2, var(--default-theme-color-2));
-  font-size: var(
-    --default-theme-font-size-5,
-    var(--default-default-theme-font-size-5)
-  );
-}
-
-.required {
-  text-transform: uppercase;
-  color: var(--theme-color-orange, var(--default-theme-color-orange));
-}
-
-.property-type {
-  color: var(--theme-color-2, var(--default-theme-color-2));
-}
-
 .properties {
   border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
   margin: 16px 0 0;
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
   overflow: hidden;
-}
-
-.property {
-  padding: 12px 12px;
-}
-
-.property-example {
-  font-family: var(--theme-font-code, var(--default-theme-font-code));
-}
-.property-example-value {
-  padding: 12px 12px;
-  background: var(--theme-background-4, var(--default-theme-background-4));
-  padding: 2px 5px;
-  font-family: var(--theme-font-code, var(--default-theme-font-code));
-  font-size: var(
-    --default-theme-font-size-5,
-    var(--default-default-theme-font-size-5)
-  );
-}
-
-.rule {
-  margin-top: 12px;
-  padding: 0 12px 12px;
-  border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
-  background: var(--theme-background-4, var(--default-theme-background-4));
-  border: 2px dotted
-    var(--theme-border-color, var(--default-theme-border-color));
-}
-
-.property-enum-value {
-  padding: 3px 0;
-}
-.property-enum-value::before {
-  content: '▶';
-  margin-right: 6px;
-  color: var(--theme-color-3, var(--default-theme-color-3));
-}
-.property-enum-values {
-  margin-top: 12px;
 }
 </style>

--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -1,0 +1,285 @@
+<script lang="ts" setup>
+import Schema from './Schema.vue'
+
+withDefaults(
+  defineProps<{
+    value?: Record<string, any>
+    level?: number
+    name?: string
+    required?: boolean
+  }>(),
+  {
+    level: 0,
+    required: false,
+  },
+)
+
+const descriptions: Record<string, Record<string, string>> = {
+  number: {
+    _default: 'Any numbers.',
+    float: 'Floating-point numbers.',
+    double: 'Floating-point numbers with double precision.',
+  },
+  integer: {
+    _default: 'Integer numbers.',
+    int32: 'Signed 32-bit integers (commonly used integer type).',
+    int64: 'Signed 64-bit integers (long type).',
+  },
+  string: {
+    'date':
+      'full-date notation as defined by RFC 3339, section 5.6, for example, 2017-07-21',
+    'date-time':
+      'the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z',
+    'password': 'a hint to UIs to mask the input',
+    'byte': 'base64-encoded characters, for example, U3dhZ2dlciByb2Nrcw==',
+    'binary': 'binary data, used to describe files',
+  },
+}
+
+const generatePropertyDescription = function (property?: Record<string, any>) {
+  if (!property) {
+    return null
+  }
+
+  if (!descriptions[property.type]) {
+    return null
+  }
+
+  return descriptions[property.type][property.format || '_default']
+}
+
+const rules = ['oneOf', 'anyOf', 'allOf', 'not']
+</script>
+
+<template>
+  <div class="property">
+    <div class="property-information">
+      <div
+        v-if="name"
+        class="property-name">
+        {{ name
+        }}<span
+          v-if="required"
+          class="required"
+          v-text="'*'" />
+      </div>
+      <div
+        v-if="required"
+        class="required">
+        required
+      </div>
+      <div
+        v-if="value?.type"
+        class="property-type">
+        <template v-if="value.type !== 'object'">
+          <template
+            v-if="value?.items && !['object'].includes(value.items.type)">
+            {{ value.type }}
+            {{ value.items.type }}[]
+          </template>
+          <template v-else>
+            {{ value.type }}
+          </template>
+          <template v-if="value.minItems || value.maxItems">
+            {{ value.minItems }}..{{ value.maxItems }}
+          </template>
+          <template v-if="value.uniqueItems"> unique! </template>
+        </template>
+        <template v-if="value.format"> &middot; {{ value.format }} </template>
+        <template v-if="value.enum"> &middot; enum </template>
+      </div>
+      <div
+        v-if="value?.example !== undefined"
+        class="property-example">
+        <code class="property-example-value">
+          example: {{ value.example }}
+        </code>
+      </div>
+      <template
+        v-for="rule in rules"
+        :key="rule">
+        <div
+          v-if="value?.[rule]"
+          class="property-rule">
+          {{ rule }}
+        </div>
+      </template>
+      <div
+        v-if="value?.readOnly"
+        class="property-read-only">
+        read-only
+      </div>
+      <div
+        v-if="value?.readOnly"
+        class="property-nullable">
+        nullable
+      </div>
+    </div>
+    <!-- Description -->
+    <div
+      v-if="value?.description"
+      class="property-description">
+      {{ value.description }}
+    </div>
+    <div
+      v-else-if="generatePropertyDescription(value)"
+      class="property-description">
+      {{ generatePropertyDescription(value) }}
+    </div>
+    <!-- Enum -->
+    <div
+      v-if="value?.enum"
+      class="property-enum">
+      <ul class="property-enum-values">
+        <li
+          v-for="enumValue in value.enum"
+          :key="enumValue"
+          class="property-enum-value">
+          {{ enumValue }}
+        </li>
+      </ul>
+    </div>
+    <!-- Object -->
+    <div
+      v-if="value?.properties"
+      class="children">
+      <Schema
+        v-if="level < 3"
+        :level="level + 1"
+        :value="value" />
+      <div
+        v-else
+        class="too-deep">
+        …
+      </div>
+    </div>
+    <!-- Array of objects -->
+    <template v-if="value?.items">
+      <div
+        v-if="['object'].includes(value.items.type)"
+        class="children">
+        <Schema
+          v-if="level < 3"
+          :level="level + 1"
+          :value="value.items" />
+        <div
+          v-else
+          class="too-deep">
+          …
+        </div>
+      </div>
+    </template>
+    <!-- oneOf -->
+    <template
+      v-for="rule in rules"
+      :key="rule">
+      <div
+        v-if="value?.[rule]"
+        class="rule">
+        <Schema
+          v-for="(schema, index) in value[rule]"
+          :key="index"
+          :level="level + 1"
+          :value="schema" />
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.property {
+  padding: 12px 0;
+}
+
+.property-information {
+  display: flex;
+  align-items: end;
+  gap: 16px;
+}
+
+.property-description {
+  margin-top: 12px;
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  line-height: 1.6;
+}
+
+.property-rule {
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+  background: var(--theme-color-orange, var(--default-theme-color-orange));
+  padding: 0 6px;
+}
+
+.property:not(:last-of-type) {
+  border-bottom: 1px solid
+    var(--theme-border-color, var(--default-theme-border-color));
+}
+.property-name {
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+}
+
+.required,
+.optional {
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  font-size: var(
+    --default-theme-font-size-5,
+    var(--default-default-theme-font-size-5)
+  );
+}
+
+.required {
+  text-transform: uppercase;
+  color: var(--theme-color-orange, var(--default-theme-color-orange));
+}
+
+.property-type {
+  color: var(--theme-color-2, var(--default-theme-color-2));
+}
+
+.property {
+  padding: 12px 12px;
+}
+
+.property-example {
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+}
+.property-example-value {
+  padding: 12px 12px;
+  background: var(--theme-background-4, var(--default-theme-background-4));
+  padding: 2px 5px;
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+  font-size: var(
+    --default-theme-font-size-5,
+    var(--default-default-theme-font-size-5)
+  );
+}
+
+.rule {
+  margin-top: 12px;
+  padding: 0 12px 12px;
+  border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
+  background: var(--theme-background-4, var(--default-theme-background-4));
+  border: 2px dotted
+    var(--theme-border-color, var(--default-theme-border-color));
+}
+
+.property-enum-value {
+  padding: 3px 0;
+}
+.property-enum-value::before {
+  content: '◼';
+  margin-right: 6px;
+  color: var(--theme-color-3, var(--default-theme-color-3));
+}
+.property-enum-values {
+  margin-top: 12px;
+}
+
+.property-read-only {
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+}
+
+.property-nullable {
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+  color: var(--theme-color-2, var(--default-theme-color-2));
+}
+</style>

--- a/packages/api-reference/src/components/Content/ShowMoreButton.vue
+++ b/packages/api-reference/src/components/Content/ShowMoreButton.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { useTemplateStore } from '../../stores/template'
+import { FlowIcon } from '../Icon'
+
+defineProps<{
+  id: string
+}>()
+
+const { setCollapsedSidebarItem } = useTemplateStore()
+</script>
+
+<template>
+  <button
+    class="show-more"
+    type="button"
+    @click="setCollapsedSidebarItem(id, true)">
+    Show More
+    <FlowIcon
+      class="show-more-icon"
+      icon="ChevronDown" />
+  </button>
+</template>
+
+<style scoped>
+.show-more {
+  background: var(--theme-background-1, var(--default-theme-background-1));
+  appearance: none;
+  border: none;
+  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
+  padding: 8px 12px;
+  border-radius: 30px;
+  color: var(--theme-color-1, var(--default-theme-color-1));
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
+  font-size: var(--theme-small, var(--default-theme-small));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  margin: 48px auto;
+}
+.show-more:hover {
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  cursor: pointer;
+}
+.show-more-icon {
+  width: 14px;
+  height: 14px;
+  margin-left: 3px;
+}
+.show-more:active {
+  box-shadow: 0 0 0 1px
+    var(--theme-border-color, var(--default-theme-border-color));
+}
+
+@media (max-width: 1165px) {
+  .show-more {
+    margin: 24px auto;
+  }
+}
+</style>

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -150,7 +150,7 @@ const items = computed((): SidebarEntry[] => {
   const modelEntries: SidebarEntry[] = hasModels(props.spec)
     ? [
         {
-          id: 'models',
+          id: getModelSectionId(),
           title: 'MODELS',
           type: 'Folder',
           children: Object.keys(props.spec.components?.schemas ?? {}).map(

--- a/packages/api-reference/src/helpers/getModelSectionId.ts
+++ b/packages/api-reference/src/helpers/getModelSectionId.ts
@@ -1,6 +1,10 @@
 import GithubSlugger from 'github-slugger'
 
-export const getModelSectionId = (name: string) => {
+export const getModelSectionId = (name?: string) => {
+  if (!name) {
+    return 'models'
+  }
+
   const slugger = new GithubSlugger()
   const slug = slugger.slug(name)
 

--- a/packages/api-reference/src/helpers/hasModels.ts
+++ b/packages/api-reference/src/helpers/hasModels.ts
@@ -1,10 +1,9 @@
 import { type Spec } from 'src/types'
 
 export const hasModels = (spec: Spec) => {
-  // TODO: Let’s hide the models for now
-  // if (Object.keys(spec?.components?.schemas ?? {}).length) {
-  //   return true
-  // }
+  if (Object.keys(spec?.components?.schemas ?? {}).length) {
+    return true
+  }
 
   return false
 }


### PR DESCRIPTION
This PR adds models ("schemas") from the spec file as a separate section.

* Models are listed after all operations
* Max. 3 models are rendered
* When the sidebar folder is toggled or the "show more" button has been clicked, all models are rendered
* Models are listed in the sidebar

This PR comes with a new `Schema` component, which already has a great support for everything defined in the OpenAPI specification, including the `oneOf`, `anyOf` … rules.

**Examples**
<img width="637" alt="Screenshot 2023-10-17 at 13 41 26" src="https://github.com/scalar/scalar/assets/1577992/21b0d548-2be8-4634-a38a-4e152ed3ad62">

<img width="639" alt="Screenshot 2023-10-17 at 13 41 19" src="https://github.com/scalar/scalar/assets/1577992/d39adc2b-0059-4b6e-80fc-5708734eda54">

<img width="653" alt="Screenshot 2023-10-17 at 12 41 06" src="https://github.com/scalar/scalar/assets/1577992/cc8c3be5-4781-405c-9df5-e6200ecf9f00">

