### PR TITLE
feat: use ‘default’ for example responses

### DIFF
--- a/.changeset/young-cycles-laugh.md
+++ b/.changeset/young-cycles-laugh.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: use default value in schemas for example responses

--- a/packages/api-reference/src/helpers/generateResponseContent.test.ts
+++ b/packages/api-reference/src/helpers/generateResponseContent.test.ts
@@ -159,7 +159,7 @@ describe('generateResponseContent', () => {
     ).toMatchObject(['foobar'])
   })
 
-  it.only('uses the default value', () => {
+  it('uses the default value', () => {
     const schema = {
       type: 'object',
       properties: {

--- a/packages/api-reference/src/helpers/generateResponseContent.test.ts
+++ b/packages/api-reference/src/helpers/generateResponseContent.test.ts
@@ -159,6 +159,27 @@ describe('generateResponseContent', () => {
     ).toMatchObject(['foobar'])
   })
 
+  it.only('uses the default value', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        statusCode: {
+          type: 'number',
+          default: 400,
+        },
+        errorCode: {
+          type: 'string',
+          default: 'BAD_REQUEST_EXCEPTION',
+        },
+      },
+    }
+
+    expect(generateResponseContent(schema)).toMatchObject({
+      statusCode: 400,
+      errorCode: 'BAD_REQUEST_EXCEPTION',
+    })
+  })
+
   it('converts a whole schema to an example response', () => {
     const schema = {
       required: ['name', 'photoUrls'],

--- a/packages/api-reference/src/helpers/generateResponseContent.ts
+++ b/packages/api-reference/src/helpers/generateResponseContent.ts
@@ -33,6 +33,12 @@ export const generateResponseContent = (
       return
     }
 
+    // default: 400
+    if (property.default !== undefined) {
+      response[name] = property.default
+      return
+    }
+
     // enum: [ 'available', 'pending', 'sold' ]
     if (property.enum !== undefined) {
       response[name] = property.enum[0]


### PR DESCRIPTION
Some schemas provide a `default` value. With this PR it’s used for the example responses, if it’s available:

<img width="663" alt="Screenshot 2023-10-17 at 15 32 01" src="https://github.com/scalar/scalar/assets/1577992/6c5b433b-aefe-4151-afa0-b2909d661662">
