### PR TITLE
fix: deal with empty descriptions

### DIFF
--- a/.changeset/strong-glasses-collect.md
+++ b/.changeset/strong-glasses-collect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: better deal with empty descriptions

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -30,7 +30,7 @@ const { state, getClientTitle, getTargetTitle } = useTemplateStore()
         tight>
         {{ info.title }}
       </SectionHeader>
-      <SectionContent :loading="!info.description">
+      <SectionContent :loading="!info.description && !info.title">
         <SectionColumns>
           <SectionColumn>
             <MarkdownRenderer :value="info.description" />

--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -13,7 +13,7 @@ import typographicBase from 'typographic-base'
 import { unified } from 'unified'
 import { ref, watch } from 'vue'
 
-const props = defineProps<{ value: string }>()
+const props = defineProps<{ value?: string }>()
 
 const html = ref<string>('')
 


### PR DESCRIPTION
In #247 I introduced a tiny regression. Specs without a description showed the loading skeleton forever. This PR fixes it.