### PR TITLE
feat: add request body to example request

### DIFF
--- a/.changeset/khaki-keys-rush.md
+++ b/.changeset/khaki-keys-rush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add example request body to example request generator


### PR DESCRIPTION
With this PR the example request body is added to the example request generator:

<img width="675" alt="Screenshot 2023-10-17 at 16 45 18" src="https://github.com/scalar/scalar/assets/1577992/91832218-3da0-4e08-832a-8927265c2c6c">
