### PR TITLE
Mobile improvements and layout fixes + consitency improvements

### DIFF
--- a/.changeset/clean-worms-beam.md
+++ b/.changeset/clean-worms-beam.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+Mobile improvements and layout fixes + consitency improvements

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -244,8 +244,6 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
 }
 .scalar-api-client__field {
-  box-shadow: 0 0 0 1px
-    var(--theme-border-color, var(--default-theme-border-color));
   border-right: 0;
   background: var(--theme-background-2, var(--default-theme-background-2));
   border-radius: var(--theme-radius, var(--default-theme-radius)) 0 0
@@ -319,7 +317,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   color: white;
   border: none;
   white-space: nowrap;
-  padding: 0 10px;
+  padding: 0 12px;
   text-transform: uppercase;
   cursor: pointer;
   outline: none;
@@ -330,20 +328,20 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
     --scalar-api-client-color,
     var(--default-scalar-api-client-color)
   );
-  box-shadow: 0 0 0 1px
-    var(--scalar-api-client-color, var(--default-scalar-api-client-color));
   position: relative;
   /**  #087f5b */
   display: flex;
   align-items: center;
+  overflow: hidden;
+  flex-shrink: 0;
 }
 .scalar-api-client__send-request-button:before {
   content: '';
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  top: -5%;
+  left: -5%;
+  width: 110%;
+  height: 110%;
   pointer-events: none;
   cursor: pointer;
   border-radius: var(--theme-radius, var(--default-theme-radius));
@@ -355,6 +353,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
 .scalar-api-client__send-request-button svg {
   width: 12px;
   height: 12px;
+  flex-shrink: 0;
   margin-right: 6px;
   position: relative;
 }
@@ -367,7 +366,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
 }
 
 .scalar-api-client__history-toggle {
-  padding: 0 9px;
+  padding: 0 12px;
   line-height: 30px;
   color: var(--theme-color-3, var(--default-theme-color-3));
   font-size: var(--theme-micro, var(--default-theme-micro));

--- a/packages/api-client/src/components/ApiClient/ApiClient.vue
+++ b/packages/api-client/src/components/ApiClient/ApiClient.vue
@@ -236,7 +236,7 @@ useKeyboardEvent({
 
 /** TODO: Consider to make a Column component */
 .scalar-api-client__main__content {
-  padding: 12px;
+  padding: 12px 6px;
   background: var(--theme-background-1, var(--default-theme-background-1));
   top: 0;
   position: sticky;
@@ -261,6 +261,7 @@ useKeyboardEvent({
 
 .meta {
   display: flex;
+  margin-top: 3px;
   font-size: var(--theme-font-size-2, var(--default-theme-font-size-2));
   font-weight: var(--theme-font-size-2, var(--default-theme-font-size-2));
   color: var(

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -41,17 +41,18 @@ const { activeRequest, readOnly } = useApiClientRequestStore()
   width: 50%;
   border-right: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
-  padding: 0 0 12px 12px;
+  padding: 0 6px 12px 18px;
 }
 @media screen and (max-width: 820px) {
   .scalar-api-client__main__left {
     width: 100%;
     border-right: none;
+    padding: 0 0 12px 12px;
   }
 }
 .scalar-api-client__item__content {
   flex-flow: wrap;
-  padding: 6px 12px 12px;
+  padding: 3px 6px 6px 6px;
   border-radius: 3px;
   color: var(--theme-color-3, var(--default-theme-color-3));
   font-size: var(--theme-micro, var(--default-theme-micro));
@@ -220,10 +221,13 @@ const { activeRequest, readOnly } = useApiClientRequestStore()
   font-size: var(--theme-micro, var(--default-theme-micro));
   border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
   border-radius: 3px;
-  padding: 11px 12px;
+  padding: 10px 12px;
   user-select: none;
   min-height: 38px;
   width: 100%;
+}
+.checkmark:hover {
+  background: var(--theme-background-3, var(--default-theme-background-3));
 }
 .check:focus-within {
   border-color: var(--theme-color-1, var(--default-theme-color-1));
@@ -241,9 +245,8 @@ const { activeRequest, readOnly } = useApiClientRequestStore()
 }
 
 .checkmark {
-  height: 15px;
-  width: 15px;
-  background: var(--theme-background-1, var(--default-theme-background-1));
+  height: 17px;
+  width: 17px;
   box-shadow: 0 0 0 1px
     var(--theme-border-color, var(--default-theme-border-color));
   margin-right: 10px;

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuth.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuth.vue
@@ -45,14 +45,14 @@ const authDropdownItems = [
         <span>
           {{ authTypeFriendlyString[authState.type] }}
           <svg
-            height="18"
-            viewBox="0 0 10 18"
-            width="10"
+            fill="none"
+            height="100%"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg">
             <path
-              d="M5 2.83L8.17 6l1.41-1.41L5 0 .41 4.59 1.83 6 5 2.83zm0 12.34L1.83 12 .42 13.41 5 18l4.59-4.59L8.17 12 5 15.17z"
-              fill="currentColor"
-              fill-rule="nonzero" />
+              d="m19.5 10-7.5 7.5-7.5-7.5"
+              xmlns="http://www.w3.org/2000/svg"></path>
           </svg>
         </span>
         <select

--- a/packages/api-client/src/components/ApiClient/Request/RequestHeaders.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestHeaders.vue
@@ -63,10 +63,6 @@ function addAnotherHandler() {
   border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
   margin: 0 6px;
   font-family: var(--theme-font);
-  background: var(
-    --theme-background-3,
-    var(--default-theme-background-3)
-  ) !important;
   appearance: none;
   display: flex;
   align-items: center;

--- a/packages/api-client/src/components/ApiClient/RequestHistory.vue
+++ b/packages/api-client/src/components/ApiClient/RequestHistory.vue
@@ -50,11 +50,13 @@ const { requestHistoryOrder } = useApiClientRequestStore()
   flex: 1;
   position: relative;
   z-index: 0;
+  border-top: 1px solid
+    var(--theme-border-color, var(--default-theme-border-color));
   background: repeating-linear-gradient(
     var(--default-theme-background-1),
-    var(--default-theme-background-1) 28.8px,
-    var(--default-theme-border-color) 28.8px,
-    var(--default-theme-border-color) 29.8px
+    var(--default-theme-background-1) 34.8px,
+    var(--default-theme-border-color) 34.8px,
+    var(--default-theme-border-color) 35.8px
   );
 }
 .navtable-mock .navtable-item {
@@ -90,11 +92,15 @@ const { requestHistoryOrder } = useApiClientRequestStore()
   height: 100%;
   cursor: pointer;
 }
-.navtable-item__active {
-  background: var(--theme-background-2, var(--default-theme-background-2));
-  border-radius: var(--theme-radius, var(--default-theme-radius));
-  box-shadow: 0 0 0 1px
-    var(--theme-border-color, var(--default-theme-border-color)) !important;
+.navtable-item__active:before {
+  content: '';
+  display: block;
+  box-shadow: 0 0 0 1px var(--theme-color-1, var(--default-theme-color-1)) !important;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
 }
 .navtable-item__active + .navtable-item {
   /* box-shadow: none; */

--- a/packages/api-client/src/components/ApiClient/Response/Response.vue
+++ b/packages/api-client/src/components/ApiClient/Response/Response.vue
@@ -99,12 +99,13 @@ const responseData = computed(() => {
 <style>
 .scalar-api-client__main__right {
   width: 50%;
-  padding: 0 0 12px 12px;
+  padding: 0 6px 12px 18px;
 }
 @media screen and (max-width: 820px) {
   .scalar-api-client__main__right {
     width: 100%;
     border-right: none;
+    padding: 0 0 12px 12px;
   }
 }
 .scalar-api-client__main__right :deep(.scalar-copilot__header-button) {

--- a/packages/api-client/src/components/CollapsibleSection/CollapsibleSection.vue
+++ b/packages/api-client/src/components/CollapsibleSection/CollapsibleSection.vue
@@ -47,7 +47,6 @@ defineProps<{
 .scalar-api-client__item {
   border-radius: var(--theme-radius, var(--default-theme-radius));
   margin-bottom: 6px;
-  background: var(--theme-background-2, var(--default-theme-background-2));
   position: relative;
 }
 
@@ -58,7 +57,18 @@ defineProps<{
 .scalar-api-client__item:hover {
   cursor: pointer;
 }
-
+.scalar-api-client__toggle:after {
+  content: '';
+  position: absolute;
+  bottom: -6.5px;
+  width: 100%;
+  height: 6px;
+  left: 0;
+}
+.scalar-api-client__item--open .scalar-api-client__toggle:after {
+  display: none;
+}
+.scalar-api-client__item:hover,
 .scalar-api-client__item--open {
   background: var(--theme-background-2, var(--default-theme-background-2));
 }
@@ -75,7 +85,7 @@ defineProps<{
   transform: rotate(90deg);
 }
 .scalar-api-client__toggle {
-  padding: 6px 12px;
+  padding: 6px;
   min-height: 37px;
   display: flex;
   align-items: center;
@@ -99,29 +109,15 @@ defineProps<{
   position: relative;
   z-index: 1;
 }
-
-.scalar-api-client__toggle:after {
-  content: '';
-  position: absolute;
-  top: 6px;
-  left: 6px;
-  width: calc(100% - 12px);
-  height: calc(100% - 12px);
-  display: block;
-  background: var(--theme-background-3, var(--default-theme-background-3));
-  z-index: 0;
-  opacity: 0;
-  border-radius: var(--default-theme-radius);
-}
-.scalar-api-client__toggle:hover:after {
-  opacity: 1;
-}
 .scalar-api-client__item .scalar-api-client__toggle__icon {
   width: 10px;
   margin-right: 6px;
   color: var(--theme-color-3, var(--default-theme-color-3));
   z-index: 1;
   position: relative;
+}
+.scalar-api-client__toggle:hover .scalar-api-client__toggle__icon {
+  color: var(--theme-color-1, var(--default-theme-color-1));
 }
 
 .scalar-api-client__item__options {
@@ -145,8 +141,8 @@ defineProps<{
   border-color: currentColor;
 }
 .scalar-api-client__item__options span svg {
-  width: 11px;
-  height: 11px;
+  width: 15px;
+  height: 15px;
   margin-left: 3px;
 }
 

--- a/packages/api-client/src/components/Grid/Grid.vue
+++ b/packages/api-client/src/components/Grid/Grid.vue
@@ -376,21 +376,26 @@ const showDescription = ref(false)
   position: relative;
   display: flex;
   flex-direction: column;
-  min-height: 381px;
-  border-top: 1px solid
-    var(--theme-border-color, var(--default-theme-border-color));
+  min-height: 389px;
+  border-radius: var(--theme-radius, var(--default-theme-radius));
+  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
 }
 .navtable-radios {
   z-index: 1;
+  border-top: 1px solid
+    var(--theme-border-color, var(--default-theme-border-color));
 }
 .navtable-item {
   display: flex;
   position: relative;
   color: var(--theme-color-1, var(--default-theme-color-1));
   font-size: var(--theme-micro, var(--default-theme-micro));
-  box-shadow: 0 1px 0
+  border-top: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
+}
+.navtable-item:first-of-type {
+  border-top: none;
 }
 .navtable-item > div {
   word-wrap: break-word;
@@ -482,13 +487,13 @@ const showDescription = ref(false)
   width: 40%;
   display: flex;
   align-items: center;
-  padding: 6px 9px;
+  padding: 9px;
 }
 .navtable-item-20 {
   width: 20%;
   display: flex;
   align-items: center;
-  padding: 6px 9px;
+  padding: 9px;
 }
 .navtable-item-50 {
   width: 50%;
@@ -611,6 +616,7 @@ const showDescription = ref(false)
   outline: none;
   border-radius: 50%;
   opacity: 0;
+  padding: 4px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/api-client/src/components/SimpleTable/SimpleCell.vue
+++ b/packages/api-client/src/components/SimpleTable/SimpleCell.vue
@@ -29,7 +29,7 @@ withDefaults(
   border-right: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
   position: relative;
-  padding: 6px 9px;
+  padding: 9px;
   color: var(--theme-color-1, var(--default-theme-color-1));
   white-space: nowrap;
 }

--- a/packages/api-client/src/components/SimpleTable/SimpleRow.vue
+++ b/packages/api-client/src/components/SimpleTable/SimpleRow.vue
@@ -8,9 +8,7 @@
   border-top: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
 }
-
-.simple-row:last-of-type {
-  border-bottom: 1px solid
-    var(--theme-border-color, var(--default-theme-border-color));
+.simple-row:first-of-type {
+  border-top: none;
 }
 </style>

--- a/packages/api-client/src/components/SimpleTable/SimpleTable.vue
+++ b/packages/api-client/src/components/SimpleTable/SimpleTable.vue
@@ -8,5 +8,8 @@
 .simple-table {
   display: table;
   width: 100%;
+  box-shadow: 0 0 0 1px
+    var(--theme-border-color, var(--default-theme-border-color));
+  border-radius: var(--theme-radius, var(--default-theme-radius));
 }
 </style>

--- a/packages/api-reference/src/components/Card/Card.vue
+++ b/packages/api-reference/src/components/Card/Card.vue
@@ -13,5 +13,6 @@
   display: flex;
   flex-direction: column;
   max-height: calc(100vh - 310px);
+  position: relative;
 }
 </style>

--- a/packages/api-reference/src/components/Card/CardHeader.vue
+++ b/packages/api-reference/src/components/Card/CardHeader.vue
@@ -23,7 +23,7 @@ import CardContent from './CardContent.vue'
 .card-header-slots {
   display: flex;
   justify-content: space-between;
-  margin: 9px 12px;
+  margin: 9px 0 9px 12px;
   line-height: 1.35;
 }
 

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -312,6 +312,7 @@ const formattedPath = computed(() => {
   cursor: pointer;
   color: var(--theme-color-3, var(--default-theme-color-3));
   margin-left: 6px;
+  margin-right: 12px;
   border: none;
   border-radius: 3px;
   padding: 0;
@@ -410,5 +411,13 @@ const formattedPath = computed(() => {
 }
 .card-header-actions {
   display: flex;
+}
+@media screen and (max-width: 400px) {
+  .language-select {
+    position: absolute;
+    bottom: 9px;
+    left: 0;
+    border-right: none;
+  }
 }
 </style>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
@@ -248,6 +248,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
   color: var(--theme-color-3, var(--default-theme-color-3));
   border: none;
   padding: 0;
+  margin-right: 12px;
 }
 .code-copy:hover {
   color: var(--theme-color-1, var(--default-theme-color-1));
@@ -268,9 +269,6 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
     var(--theme-border-color, var(--default-theme-border-color));
 }
 .scalar-api-reference__empty-state {
-  border: 1px dashed
-    var(--theme-border-color, var(--default-theme-border-color));
-  width: calc(100% - 24px);
   margin: 10px 0 10px 12px;
   text-align: center;
   font-size: var(--theme-micro, var(--default-theme-micro));

--- a/packages/api-reference/src/components/MobileHeader.vue
+++ b/packages/api-reference/src/components/MobileHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useTemplateStore } from '../stores/template'
+import DarkModeToggle from './DarkModeToggle.vue'
 import FlowIconButton from './FlowIconButton.vue'
 
 const {
@@ -16,13 +17,15 @@ const {
       width="20px"
       @click="() => toggleTemplateItem('showMobileDrawer')" />
     <span class="references-mobile-breadcrumbs"><slot /></span>
-
-    <FlowIconButton
-      icon="Search"
-      label="Search"
-      variant="clear"
-      width="24px"
-      @click="setTemplateItem('showSearch', true)" />
+    <div class="sidebar-mobile-actions">
+      <FlowIconButton
+        icon="Search"
+        label="Search"
+        variant="clear"
+        width="24px"
+        @click="setTemplateItem('showSearch', true)" />
+      <DarkModeToggle class="sidebar-mobile-darkmode-toggle" />
+    </div>
   </div>
 </template>
 <style scoped>
@@ -33,7 +36,9 @@ const {
   height: 100%;
   width: 100%;
   padding: 0 8px;
-  border-bottom: var(--theme-border);
+  background: var(--theme-background-1, var(--default-theme-background-1));
+  border-bottom: 1px solid
+    var(--theme-border-color, var(--default-theme-border-color));
 }
 
 .references-mobile-breadcrumbs {

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -281,6 +281,7 @@ const searchResultsWithPlaceholderResults = computed(
   min-height: 31px;
   display: flex;
   gap: 6px;
+  overflow: hidden;
 }
 .item-entry-http-verb:empty {
   display: none;

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -411,12 +411,33 @@ const activeSidebarItemId = computed(() => {
   gap: 4px;
   height: 24px;
   align-items: center;
-  padding: 0 4px;
+  padding-left: 4px;
 }
 
 .sidebar-mobile-actions .sidebar-mobile-darkmode-toggle {
-  height: 16px;
-  width: 16px;
+  height: 24px;
+  width: 24px;
+  margin-top: 0;
+}
+.sidebar-mobile-actions .sidebar-mobile-darkmode-toggle .darklight {
+  height: 24px;
+  width: 24px;
+  font-size: 0;
+  padding: 0;
+  margin-top: 0;
+  border-top: 0;
+  text-indent: 0;
+  color: var(--theme-color-3, var(--default-theme-color-3));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.sidebar-mobile-actions .sidebar-mobile-darkmode-toggle svg {
+  width: 15px;
+  height: 15px;
+}
+.sidebar-mobile-actions .darklight-reference-promo {
+  display: none;
 }
 .active_page.sidebar-heading:hover,
 .active_page.sidebar-heading {


### PR DESCRIPTION
so much polish done by the wonderful @cameronrohani 

<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6176314/f09f893b-2af9-4dfd-b995-ee4a70fb3a9b">

```
mobile header broken (missing background and border bottom) 

mobile header missing night mode toggle 

mobile tabs overflow doesn't scroll + word breaks 

inconsistent table styles across client 

remove dashed border for empty states where there's no table / code block going in to

more consistent buttons in client

Temp remove client topbar border (until we make it an actual input)

hide overflow from search

move language selector to bottom left of cards on mobile
```
