### PR TITLE
fix: handle both direct and proxied responses

### DIFF
--- a/packages/api-client/src/components/ApiClient/Response/Response.vue
+++ b/packages/api-client/src/components/ApiClient/Response/Response.vue
@@ -59,6 +59,9 @@ const responseData = computed(() => {
   if (value && isJsonString(value)) {
     return JSON.stringify(JSON.parse(value), null, 2)
   }
+  if (value && !isJsonString(value)) {
+    return JSON.stringify(value, null, 2)
+  }
 
   return value
 })

--- a/packages/api-client/src/helpers/sendRequest.ts
+++ b/packages/api-client/src/helpers/sendRequest.ts
@@ -76,7 +76,8 @@ export async function sendRequest(
     await axios(config)
       .then((res) => {
         return {
-          ...res.data,
+          ...(proxyUrl ? res.data : res),
+          ...(!proxyUrl && { statusCode: res.status }),
           error: false,
         }
       })


### PR DESCRIPTION
Direct request responses look different than responses received via a
proxy. Transform direct responses to look more like proxied responses
after they are received.

Updates #312 
