### PR TITLE
feat: use min value as the default for numbers

### DIFF
--- a/.changeset/red-buses-call.md
+++ b/.changeset/red-buses-call.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: use min value as the default for generated example responses

--- a/packages/api-reference/src/helpers/generateResponseContent.test.ts
+++ b/packages/api-reference/src/helpers/generateResponseContent.test.ts
@@ -180,6 +180,37 @@ describe('generateResponseContent', () => {
     })
   })
 
+  it('uses 0 as the default for a number', () => {
+    expect(
+      generateResponseContent({
+        type: 'object',
+        properties: {
+          statusCode: {
+            type: 'number',
+          },
+        },
+      }),
+    ).toMatchObject({
+      statusCode: 0,
+    })
+  })
+
+  it('uses min as the default for a number', () => {
+    expect(
+      generateResponseContent({
+        type: 'object',
+        properties: {
+          statusCode: {
+            type: 'number',
+            min: 200,
+          },
+        },
+      }),
+    ).toMatchObject({
+      statusCode: 200,
+    })
+  })
+
   it('converts a whole schema to an example response', () => {
     const schema = {
       required: ['name', 'photoUrls'],

--- a/packages/api-reference/src/helpers/generateResponseContent.ts
+++ b/packages/api-reference/src/helpers/generateResponseContent.ts
@@ -72,7 +72,7 @@ export const generateResponseContent = (
       string: '',
       boolean: true,
       integer: 1,
-      number: 0,
+      number: property.min ?? 0,
       // TODO: Need to check the schema and add a default value
       object: {},
     }


### PR DESCRIPTION
With this PR the min value for numbers is used as the default when generating example responses. 🤓 