### PR TITLE
DOC-1162 fix: active state for operations with multiple tags

### DIFF
--- a/.changeset/few-boxes-swim.md
+++ b/.changeset/few-boxes-swim.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: active state for operations with multiple tags

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -98,7 +98,8 @@ const moreThanOneDefaultTag = (tag: Tag) =>
               :key="`${operation.httpVerb}-${operation.operationId}`"
               :operation="operation"
               :server="localServers[0]"
-              :spec="spec" />
+              :spec="spec"
+              :tag="tag" />
           </template>
         </SectionContainer>
       </template>

--- a/packages/api-reference/src/components/Content/EndpointsOverview.vue
+++ b/packages/api-reference/src/components/Content/EndpointsOverview.vue
@@ -28,7 +28,7 @@ const { setCollapsedSidebarItem } = useTemplateStore()
 async function scrollHandler(operation: TransformedOperation) {
   setCollapsedSidebarItem(getTagSectionId(props.tag), true)
   await nextTick()
-  scrollToId(getOperationSectionId(operation))
+  scrollToId(getOperationSectionId(operation, props.tag))
 }
 </script>
 <template>
@@ -51,7 +51,7 @@ async function scrollHandler(operation: TransformedOperation) {
                 <div class="endpoints custom-scroll">
                   <a
                     v-for="operation in tag.operations"
-                    :key="getOperationSectionId(operation)"
+                    :key="getOperationSectionId(operation, tag)"
                     class="endpoint"
                     @click="scrollHandler(operation)">
                     <span :class="operation.httpVerb">{{

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { getOperationSectionId } from '../../../helpers'
-import type { Server, Spec, TransformedOperation } from '../../../types'
+import type { Server, Spec, Tag, TransformedOperation } from '../../../types'
 import {
   Section,
   SectionColumn,
@@ -16,11 +16,12 @@ defineProps<{
   operation: TransformedOperation
   server: Server
   spec: Spec
+  tag: Tag
 }>()
 </script>
 <template>
   <Section
-    :id="getOperationSectionId(operation)"
+    :id="getOperationSectionId(operation, tag)"
     :label="operation.name || operation.path">
     <SectionContent>
       <SectionColumns>

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -4,11 +4,11 @@ import { FlowModal, useModal } from '@scalar/use-modal'
 import Fuse from 'fuse.js'
 import { computed, nextTick, ref, toRef, watch } from 'vue'
 
-import { getOperationSectionId, getTagSectionId, scrollToId } from '../helpers'
+import { getTagSectionId, scrollToId } from '../helpers'
 import { extractRequestBody } from '../helpers/specHelpers'
 import { type ParamMap, useOperation } from '../hooks'
 import { useTemplateStore } from '../stores/template'
-import type { Spec, Tag, TransformedOperation } from '../types'
+import type { Spec, Tag } from '../types'
 
 const props = defineProps<{ spec: Spec }>()
 const reactiveSpec = toRef(props, 'spec')

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -119,7 +119,7 @@ const items = computed((): SidebarEntry[] => {
             type: 'Folder',
             children: tag.operations?.map((operation) => {
               return {
-                id: getOperationSectionId(operation),
+                id: getOperationSectionId(operation, tag),
                 title: operation.name || operation.path,
                 type: 'Page',
                 select: () => {
@@ -133,7 +133,7 @@ const items = computed((): SidebarEntry[] => {
         })
       : firstTag?.operations?.map((operation) => {
           return {
-            id: getOperationSectionId(operation),
+            id: getOperationSectionId(operation, firstTag),
             title: operation.name || operation.path,
             type: 'Page',
             select: () => {

--- a/packages/api-reference/src/helpers/getModelSectionId.ts
+++ b/packages/api-reference/src/helpers/getModelSectionId.ts
@@ -8,5 +8,5 @@ export const getModelSectionId = (name?: string) => {
   const slugger = new GithubSlugger()
   const slug = slugger.slug(name)
 
-  return `model//${slug}`
+  return `model/${slug}`
 }

--- a/packages/api-reference/src/helpers/getOperationSectionId.ts
+++ b/packages/api-reference/src/helpers/getOperationSectionId.ts
@@ -1,5 +1,11 @@
-import { type TransformedOperation } from 'src/types'
+import type { Tag, TransformedOperation } from '../types'
+import { getTagSectionId } from './getTagSectionId'
 
-export const getOperationSectionId = (operation: TransformedOperation) => {
-  return `operation//[${operation.httpVerb}]${operation.path}`
+export const getOperationSectionId = (
+  operation: TransformedOperation,
+  parentTag: Tag,
+) => {
+  return `${getTagSectionId(parentTag)}/[${operation.httpVerb}]${
+    operation.path
+  }`
 }

--- a/packages/api-reference/src/helpers/getTagSectionId.ts
+++ b/packages/api-reference/src/helpers/getTagSectionId.ts
@@ -6,5 +6,5 @@ export const getTagSectionId = (tag: Tag) => {
   const slugger = new GithubSlugger()
   const slug = slugger.slug(tag.name)
 
-  return `tag//${slug}`
+  return `tag/${slug}`
 }


### PR DESCRIPTION
This PR prefixes all operation section ids with their parent tag. This makes it possible to distinguish which operation should be active, if the operation has multiple tags and is listed in multiple places.