### PR TITLE
chore: remove debug output

### DIFF
--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -225,7 +225,6 @@ const showCodeEditor = computed(() => {
 })
 </script>
 <template>
-  {{ currentConfiguration }}
   <ThemeStyles :id="currentConfiguration?.theme" />
   <FlowToastContainer />
   <div


### PR DESCRIPTION
Oops, my debug output slipped through. Let’s remove it quickly.