### PR TITLE
fix: use undefined as the default for deprecated props

### DIFF
--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -21,7 +21,10 @@ import MobileHeader from './MobileHeader.vue'
 import SearchModal from './SearchModal.vue'
 import Sidebar from './Sidebar.vue'
 
-const props = defineProps<ReferenceProps>()
+const props = withDefaults(defineProps<ReferenceProps>(), {
+  showSidebar: undefined,
+  isEditable: undefined,
+})
 
 defineEmits<{
   (e: 'changeTheme', value: ThemeId): void


### PR DESCRIPTION
In #236 I’ve added the deprecated props, which by default fallback to false and are then considered to be set. Eventually `showSidebar` was `false`.

With this PR the default for those deprecated boolean props is `undefined`. This should fix the bug and the sidebar should appear again. 🥵