### PR TITLE
hotfix: load swagger editor in readonly mode

### DIFF
--- a/.changeset/fast-wolves-mate.md
+++ b/.changeset/fast-wolves-mate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+hotfix: load the swagger editor even if it’s not used

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -296,7 +296,7 @@ function handleAIWriter(
     </aside>
     <!-- Swagger file editing -->
     <div
-      v-if="showSwaggerEditor"
+      v-show="showSwaggerEditor"
       class="references-editor">
       <LazyLoadedSwaggerEditor
         :aiWriterMarkdown="aiWriterMarkdown"


### PR DESCRIPTION
I’ve added a regression in #362. I didn’t want to load the swagger editor if it’s not used, but that also means the spec isn’t parsed … because currently the swagger editor is responsible for the parsing.