### PR TITLE
hotfix: import spec from url

### DIFF
--- a/.changeset/young-eels-dress.md
+++ b/.changeset/young-eels-dress.md
@@ -1,0 +1,6 @@
+---
+'@scalar/swagger-editor': patch
+'@scalar/api-reference': patch
+---
+
+hotfix: import spec from url

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -150,7 +150,7 @@ useResizeObserver(documentEl, (entries) => {
   elementHeight.value = entries[0].contentRect.height
 })
 
-const { toggleCollapsedSidebarItem } = useTemplateStore()
+const { setCollapsedSidebarItem } = useTemplateStore()
 const { state } = useApiClientStore()
 
 const showMobileDrawer = computed(() => {
@@ -197,7 +197,7 @@ const handleParsedSpecUpdate = (newSpec: any) => {
   const firstTag = parsedSpec.tags[0]
 
   if (firstTag) {
-    toggleCollapsedSidebarItem(getTagSectionId(firstTag))
+    setCollapsedSidebarItem(getTagSectionId(firstTag), true)
   }
 }
 
@@ -304,7 +304,7 @@ function handleAIWriter(
         :initialTabState="currentConfiguration?.tabs?.initialContent"
         :proxyUrl="currentConfiguration?.proxy"
         :theme="currentConfiguration?.theme"
-        :value="parsedSpecRef"
+        :value="rawSpecRef"
         @changeTheme="$emit('changeTheme', $event)"
         @contentUpdate="handleContentUpdate"
         @parsedSpecUpdate="handleParsedSpecUpdate"

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -3,7 +3,7 @@ import { type StatesArray } from '@hocuspocus/provider'
 import { type SwaggerSpec, parse } from '@scalar/swagger-parser'
 import { type ThemeId, ThemeStyles } from '@scalar/themes'
 import { useDebounceFn } from '@vueuse/core'
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 
 import coinmarketcap from '../../coinmarketcapv3.json'
 import petstore from '../../petstorev3.json'
@@ -64,6 +64,10 @@ const handleSpecUpdate = useDebounceFn((value) => {
 const rawContent = ref('')
 
 const handleContentUpdate = (value: string) => {
+  if (value === rawContent.value) {
+    return
+  }
+
   rawContent.value = value
   emit('contentUpdate', value)
   handleSpecUpdate(value)
@@ -125,7 +129,6 @@ watch(
   () => props.value,
   async () => {
     if (props.value) {
-      await nextTick()
       handleContentUpdate(props.value)
     }
   },


### PR DESCRIPTION
Wow, another regression from #362. The spec URL was fetched and stored in a ref, but the wrong ref was passed to the editor. This is the fix:

```diff
-:value="parsedSpecRef"
+:value="rawSpecRef"
```

Everything else cleans up the messy data flow just a little bit. Hopefully I didn’t introduce a new regression. Looks like it’s time to refactor the reference <> swagger editor <> parser data flow. 😵‍💫