### PR TITLE
fix markdown collisions + prefix the card name

### DIFF
--- a/.changeset/nervous-queens-attend.md
+++ b/.changeset/nervous-queens-attend.md
@@ -1,0 +1,7 @@
+---
+'@scalar/swagger-editor': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix markdown collisions + prefix the card name

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -58,6 +58,7 @@ const { activeRequest, readOnly } = useApiClientRequestStore()
   font-size: var(--theme-micro, var(--default-theme-micro));
   margin-top: -3px;
   justify-content: space-between;
+  overflow: auto;
 }
 .scalar-api-client__item__content .scalar-api-client__codemirror__wrapper {
   min-height: 63px;

--- a/packages/api-client/src/components/SimpleTable/SimpleCell.vue
+++ b/packages/api-client/src/components/SimpleTable/SimpleCell.vue
@@ -26,10 +26,12 @@ withDefaults(
 </template>
 <style scoped>
 .simple-cell {
+  all: unset;
+  display: table-cell;
   border-right: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
   position: relative;
-  padding: 9px;
+  padding: 9px !important;
   color: var(--theme-color-1, var(--default-theme-color-1));
   white-space: nowrap;
 }

--- a/packages/api-client/src/components/SimpleTable/SimpleRow.vue
+++ b/packages/api-client/src/components/SimpleTable/SimpleRow.vue
@@ -5,6 +5,8 @@
 </template>
 <style scoped>
 .simple-row {
+  all: unset;
+  display: table-row;
   box-shadow: 0 -1px var(--theme-border-color, var(--default-theme-border-color));
 }
 .simple-row:first-of-type {

--- a/packages/api-client/src/components/SimpleTable/SimpleTable.vue
+++ b/packages/api-client/src/components/SimpleTable/SimpleTable.vue
@@ -6,6 +6,7 @@
 
 <style scoped>
 .simple-table {
+  all: unset;
   display: table;
   width: 100%;
   border-spacing: 0;

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -330,7 +330,6 @@ function handleAIWriter(
   --refs-sidebar-width: var(--theme-sidebar-width, 250px);
   --refs-header-height: var(--theme-header-height, 0px);
 }
-
 @media (max-width: 1000px) {
   .scalar-api-reference {
     /* By default add a header on mobile for the navigation */

--- a/packages/api-reference/src/components/Card/Card.vue
+++ b/packages/api-reference/src/components/Card/Card.vue
@@ -1,10 +1,11 @@
 <template>
-  <div class="card">
+  <div class="scalar-card">
     <slot />
   </div>
 </template>
 <style scoped>
-.card {
+.scalar-card {
+  all: unset;
   font-family: var(--theme-font, var(--default-theme-font));
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
   overflow: hidden;

--- a/packages/api-reference/src/components/Card/CardContent.vue
+++ b/packages/api-reference/src/components/Card/CardContent.vue
@@ -19,40 +19,40 @@ withDefaults(
 <template>
   <div
     :class="{
-      'card-content': true,
-      'card--muted': muted,
-      'card--contrast': contrast,
-      'card--frameless': frameless,
-      'card--transparent': transparent,
-      'card--borderless': borderless,
+      'scalar-card-content': true,
+      'scalar-card--muted': muted,
+      'scalar-card--contrast': contrast,
+      'scalar-card--frameless': frameless,
+      'scalar-card--transparent': transparent,
+      'scalar-card--borderless': borderless,
     }">
     <slot />
   </div>
 </template>
 <style scoped>
-.card-content {
+.scalar-card-content {
   overflow: auto;
   border-bottom: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
 }
-.card-content :deep(.simple-table .simple-header) {
+.scalar-card-content :deep(.simple-table .simple-header) {
   display: none;
 }
-.card-content:last-of-type,
-.card-content.card--borderless {
+.scalar-card-content:last-of-type,
+.scalar-card-content.scalar-card--borderless {
   border-bottom: none;
 }
 
-.card--muted {
+.scalar-card--muted {
   background: var(--theme-background-2, var(--default-theme-background-2));
 }
-.card--contrast {
+.scalar-card--contrast {
   background: var(--theme-background-3, var(--default-theme-background-3));
 }
-.card--frameless {
+.scalar-card--frameless {
   padding: 0;
 }
-.card--transparent {
+.scalar-card--transparent {
   background: var(--theme-background-1, var(--default-theme-background-1));
 }
 </style>

--- a/packages/api-reference/src/components/Card/CardFooter.vue
+++ b/packages/api-reference/src/components/Card/CardFooter.vue
@@ -7,7 +7,7 @@ import CardContent from './CardContent.vue'
   </CardContent>
 </template>
 <style scoped>
-.card-footer {
+.scalar-card-footer {
   flex-shrink: 0;
 }
 </style>

--- a/packages/api-reference/src/components/Card/CardHeader.vue
+++ b/packages/api-reference/src/components/Card/CardHeader.vue
@@ -2,37 +2,37 @@
 import CardContent from './CardContent.vue'
 </script>
 <template>
-  <CardContent class="card-header">
-    <div class="card-header-slots">
-      <div class="card-header-slot card-header-title">
+  <CardContent class="scalar-card-header">
+    <div class="scalar-card-header-slots">
+      <div class="scalar-card-header-slot scalar-card-header-title">
         <slot />
       </div>
-      <div class="card-header-slot card-header-actions">
+      <div class="scalar-card-header-slot scalar-card-header-actions">
         <slot name="actions" />
       </div>
     </div>
   </CardContent>
 </template>
 <style scoped>
-.card-header {
+.scalar-card-header {
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
   font-size: var(--theme-mini, var(--default-theme-mini));
   color: var(--theme-color-3, var(--default-theme-color-3));
   flex-shrink: 0;
 }
-.card-header-slots {
+.scalar-card-header-slots {
   display: flex;
   justify-content: space-between;
   margin: 9px 0 9px 12px;
   line-height: 1.35;
 }
 
-.card-header-title {
+.scalar-card-header-title {
   text-transform: uppercase;
   word-break: break-all;
 }
 
-.card-header-actions {
+.scalar-card-header-actions {
   display: flex;
 }
 </style>

--- a/packages/api-reference/src/components/Card/CardTab.vue
+++ b/packages/api-reference/src/components/Card/CardTab.vue
@@ -23,6 +23,7 @@ import { Tab } from '@headlessui/vue'
   color: var(--theme-color-2, var(--default-theme-color-2));
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
   line-height: calc(var(--theme-mini, var(--default-theme-mini)) + 2px);
+  white-space: nowrap;
   cursor: pointer;
   padding: 0;
   margin-right: 3px;

--- a/packages/api-reference/src/components/Content/Introduction/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/Introduction/ClientSelector.vue
@@ -205,6 +205,7 @@ function checkIfClientIsFeatured(client: SelectedClient) {
   justify-content: center;
   gap: 6px;
   padding: 0 12px;
+  overflow: hidden;
 }
 .code-languages {
   display: flex;
@@ -235,6 +236,7 @@ function checkIfClientIsFeatured(client: SelectedClient) {
   align-items: center;
   justify-content: center;
   position: relative;
+  box-sizing: border-box;
   color: var(
     --theme-code-language-color-supersede,
     var(--default-theme-code-language-color-supersede, #fff)

--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -60,9 +60,13 @@ watch(
 .markdown {
   color: var(--theme-color-1, var(--default-theme-color-1));
   word-wrap: break-word;
+  all: unset;
 }
 .markdown :deep(*) {
+  all: unset;
   margin: 12px 0;
+  font-family: var(--theme-font, var(--default-theme-font));
+  color: var(--theme-color-1, var(--default-theme-color-1));
 }
 .markdown :deep(h1),
 .markdown :deep(h2),
@@ -73,8 +77,12 @@ watch(
   font-size: var(--font-size, var(--default-font-size));
   margin: 24px 0 6px;
   font-weight: var(--theme-bold, var(--default-theme-bold));
+  display: block;
 }
-
+.markdown :deep(b),
+.markdown :deep(strong) {
+  font-weight: var(--theme-bold, var(--default-theme-bold));
+}
 .markdown :deep(p) {
   font-size: var(
     --font-size,
@@ -90,6 +98,7 @@ watch(
   );
   line-height: 1.5;
   margin-bottom: 0;
+  display: block;
 }
 
 .markdown :deep(ul),
@@ -97,6 +106,7 @@ watch(
   padding-left: 24px;
   line-height: 1.5;
   margin: 12px 0;
+  display: block;
 }
 
 .markdown :deep(ul) {
@@ -114,6 +124,7 @@ watch(
 
 .markdown :deep(li) {
   margin: 6px 0;
+  display: list-item;
 }
 .markdown :deep(a) {
   color: var(
@@ -121,6 +132,7 @@ watch(
     var(--default-theme-color-accent)
   ) !important;
   text-decoration: none !important;
+  cursor: pointer;
 }
 .markdown :deep(a:hover) {
   text-decoration: underline !important;
@@ -155,9 +167,11 @@ watch(
     var(--theme-border-color, var(--default-theme-border-color));
   padding-left: 12px;
   margin: 0;
+  display: block;
 }
 
 .markdown :deep(table) {
+  display: table;
   position: relative;
   border-collapse: collapse;
   table-layout: fixed;
@@ -168,11 +182,26 @@ watch(
     var(--theme-border-color, var(--default-theme-border-color));
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
 }
+.markdown :deep(tbody) {
+  display: table-row-group;
+  vertical-align: middle;
+}
+.markdown :deep(thead) {
+  display: table-header-group;
+  vertical-align: middle;
+}
 
+.markdown :deep(tr) {
+  display: table-row;
+  border-color: inherit;
+  vertical-align: inherit;
+}
 .markdown :deep(td),
 .markdown :deep(th) {
+  display: table-cell;
+  vertical-align: inherit;
   min-width: 1em;
-  padding: 6px;
+  padding: 6px 9px;
   vertical-align: top;
   box-sizing: border-box;
   position: relative;
@@ -208,7 +237,7 @@ watch(
 }
 
 .markdown :deep(th) {
-  font-weight: bold !important;
+  font-weight: var(--theme-semibold, var(--default-theme-semibold)) !important;
   text-align: left;
   border-left-color: transparent;
   background: var(--theme-background-2, var(--default-theme-background-2));
@@ -221,6 +250,13 @@ watch(
     display: block;
     overflow-x: auto;
     padding: 1em;
+  }
+  pre * {
+    font-size: var(--theme-small, var(--default-theme-small)) !important;
+    font-family: var(
+      --theme-font-code,
+      var(--default-theme-font-code)
+    ) !important;
   }
   code.hljs {
     padding: 3px 5px;

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -211,7 +211,7 @@ const formattedPath = computed(() => {
         readOnly />
     </CardContent>
     <CardFooter
-      class="card-footer"
+      class="scalar-card-footer"
       contrast>
       <button
         class="show-api-client-button"
@@ -326,7 +326,7 @@ const formattedPath = computed(() => {
   align-items: center;
   height: fit-content;
 }
-/* Can't use flex align center on parent (card-header-actions) so have to match sibling font size vertically align*/
+/* Can't use flex align center on parent (scalar-card-header-actions) so have to match sibling font size vertically align*/
 .copy-button:after {
   content: '.';
   color: transparent;
@@ -364,6 +364,7 @@ const formattedPath = computed(() => {
   font-family: var(--theme-font, var(--default-theme-font));
   position: relative;
   cursor: pointer;
+  box-sizing: border-box;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 }
 .show-api-client-button span,
@@ -415,7 +416,7 @@ const formattedPath = computed(() => {
 .request-path {
   font-family: var(--theme-font-code, var(--default-theme-font-code));
 }
-.card-header-actions {
+.scalar-card-header-actions {
   display: flex;
 }
 @media screen and (max-width: 400px) {

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
@@ -101,7 +101,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
         </button>
       </template>
     </CardTabHeader>
-    <div class="card-container custom-scroll">
+    <div class="scalar-card-container custom-scroll">
       <!-- Commenting out until we re-organize cause of height issues -->
       <!-- <CardContent
         v-if="currentResponse.headers"
@@ -233,7 +233,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
     </div>
     <CardFooter
       v-if="currentResponse?.description"
-      class="card-footer"
+      class="scalar-card-footer"
       muted>
       <div class="description">
         <MarkdownRenderer
@@ -277,6 +277,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
   min-height: 35px;
   display: flex;
   align-items: center;
+  box-sizing: border-box;
   border-top: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
 }
@@ -310,10 +311,10 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
   display: block;
   margin: 6px;
 }
-.card-container {
+.scalar-card-container {
   background: var(--theme-background-2, var(--default-theme-background-2));
 }
-.card-container :deep(.cm-scroller) {
+.scalar-card-container :deep(.cm-scroller) {
   overflow: hidden;
 }
 

--- a/packages/api-reference/src/components/FlowButton.vue
+++ b/packages/api-reference/src/components/FlowButton.vue
@@ -55,8 +55,8 @@ export { useLoadButtonState }
   padding: 0px 24px;
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
   color: var(--theme-button-1-color, var(--default-theme-button-1-color));
-  font-size: var(--theme-small, var(--default-theme-small));
-  font-weight: 500;
+  font-size: var(--theme-font-size-4, var(--default--theme-font-size-4));
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
   cursor: pointer;
   background: var(--theme-button-1, var(--default-theme-button-1));
   border: none;

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -376,6 +376,7 @@ const setRef = (el: SidebarElementType, id: string) => {
   display: flex;
   flex: 1;
   justify-content: space-between;
+  align-items: flex-start !important;
 }
 
 /* Sidebar link icon */

--- a/packages/api-reference/src/components/SimpleTable/SimpleCell.vue
+++ b/packages/api-reference/src/components/SimpleTable/SimpleCell.vue
@@ -26,8 +26,10 @@ withDefaults(
 </template>
 <style scoped>
 .simple-cell {
+  all: unset;
+  display: table-cell;
   position: relative;
-  padding: 6px 9px;
+  padding: 9px !important;
   color: var(--theme-color-1, var(--default-theme-color-1));
   white-space: nowrap;
   vertical-align: top;

--- a/packages/api-reference/src/components/SimpleTable/SimpleTable.vue
+++ b/packages/api-reference/src/components/SimpleTable/SimpleTable.vue
@@ -6,6 +6,7 @@
 
 <style scoped>
 .simple-table {
+  all: unset;
   display: table;
   width: 100%;
   font-size: var(--theme-micro, var(--default-theme-micro));

--- a/packages/swagger-editor/src/components/SwaggerEditor/MarkdownRenderer.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/MarkdownRenderer.vue
@@ -96,14 +96,15 @@ watch(
   padding-left: 24px;
   line-height: 1.5;
   margin: 12px 0;
+  display: block;
 }
 
 .markdown :deep(ul) {
-  list-style: disc;
+  list-style-type: disc;
 }
 
 .markdown :deep(ol) {
-  list-style: decimal;
+  list-style-type: decimal;
 }
 
 .markdown :deep(ul.contains-task-list) {


### PR DESCRIPTION
We're seeing some collisions with markdown + cards on users websites so I unset all markdown and prefixed cards. 

We should come up with something more robust later but this should be good for now