### PR TITLE
style: hide empty table headers

### DIFF
--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -216,6 +216,9 @@ watch(
 .markdown :deep(th > *) {
   margin-bottom: 0;
 }
+.markdown :deep(th:empty) {
+  display: none;
+}
 .markdown.parameter-description :deep(p) {
   margin-top: 4px;
   font-size: var(--theme-small, var(--default-theme-small));


### PR DESCRIPTION
I saw some empty table headers in a spec. This PR adds CSS to hide empty table headers:

**Before**
<img width="596" alt="Screenshot 2023-10-27 at 14 24 55" src="https://github.com/scalar/scalar/assets/1577992/f6ca5794-ab80-42d9-a3d4-5a6c035e7f9a">

**After**
<img width="595" alt="Screenshot 2023-10-27 at 14 26 00" src="https://github.com/scalar/scalar/assets/1577992/53c02534-0f01-4b9b-97ca-d8c00e4d9759">

In theory, you could have some table headers empty and some not, but this looks still okay-ish and is probably less likely than having all table headers empty.