### PR TITLE
fix: empty example responses

### DIFF
--- a/.changeset/thin-dragons-sort.md
+++ b/.changeset/thin-dragons-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: don’t show generated example responses if there’s an example

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
@@ -130,7 +130,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
         <template v-else>
           <div v-if="currentJsonResponse?.example">
             <CodeMirror
-              :content="currentJsonResponse?.example"
+              :content="prettyPrintJson(currentJsonResponse?.example)"
               :languages="['json']"
               readOnly />
           </div>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
@@ -134,7 +134,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
               :languages="['json']"
               readOnly />
           </div>
-          <div v-if="currentJsonResponse?.schema">
+          <div v-else-if="currentJsonResponse?.schema">
             <!-- Single Schema -->
             <CodeMirror
               v-if="currentJsonResponse?.schema.type"


### PR DESCRIPTION
I saw some empty example responses. This PR includes two related fixes:

* When there’s an example, make sure to transform it to text before passing it to CodeMirror.
* If there’s an example, don’t show the generated example.

**Before**
<img width="586" alt="" src="https://github.com/scalar/scalar/assets/1577992/3658e21b-fa0b-4c12-86a7-6020244cc2d8">

**After**
<img width="586" alt="Screenshot 2023-10-27 at 14 29 27" src="https://github.com/scalar/scalar/assets/1577992/fa8f851f-86bc-4f28-9d79-44eb20f404c2">
