### PR TITLE
refactor: test send request with proxy

### DIFF
--- a/.changeset/hungry-dolls-wash.md
+++ b/.changeset/hungry-dolls-wash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+refactor: sendRequest with and without proxy

--- a/packages/api-client-proxy/package.json
+++ b/packages/api-client-proxy/package.json
@@ -24,7 +24,7 @@
     "node": ">=18"
   },
   "exports": {
-    "import": "./dist/index.js"
+    "import": "./dist/src/index.js"
   },
   "files": [
     "dist",
@@ -37,8 +37,8 @@
     "proxy"
   ],
   "license": "MIT",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/src/index.js",
+  "module": "./dist/src/index.js",
   "peerDependencies": {
     "@types/cors": "2.8.13",
     "@types/express": "4.17.17"
@@ -57,5 +57,5 @@
     "types:check": "tsc --noEmit --skipLibCheck"
   },
   "type": "module",
-  "types": "dist/index.d.ts"
+  "types": "dist/src/index.d.ts"
 }

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -20,6 +20,7 @@
     "tippy.js": "6.3.7"
   },
   "devDependencies": {
+    "@scalar/api-client-proxy": "workspace:*",
     "@scalar/echo-server": "workspace:*",
     "@vitejs/plugin-vue": "4.3.4",
     "@vitest/coverage-v8": "0.34.4",

--- a/packages/api-client/src/helpers/sendRequest.test.ts
+++ b/packages/api-client/src/helpers/sendRequest.test.ts
@@ -1,3 +1,4 @@
+import { createApiClientProxy } from '@scalar/api-client-proxy'
 import { createEchoServer } from '@scalar/echo-server'
 import { type AddressInfo } from 'node:net'
 import { describe, expect, it } from 'vitest'
@@ -6,6 +7,13 @@ import { sendRequest } from './sendRequest'
 
 const createEchoServerOnAnyPort = (): number => {
   const { listen } = createEchoServer()
+  const instance = listen(0)
+
+  return Number((instance.address() as AddressInfo).port)
+}
+
+const createApiClientProxyOnAnyPort = (): number => {
+  const { listen } = createApiClientProxy()
   const instance = listen(0)
 
   return Number((instance.address() as AddressInfo).port)
@@ -21,7 +29,7 @@ describe('sendRequest', () => {
 
     const result = await sendRequest(request)
 
-    expect(result?.response.data).toContain({
+    expect(JSON.parse(result?.response.data ?? '')).toMatchObject({
       method: 'GET',
       path: '/',
     })
@@ -43,7 +51,7 @@ describe('sendRequest', () => {
 
     const result = await sendRequest(request)
 
-    expect(result?.response.data).toContain({
+    expect(JSON.parse(result?.response.data ?? '')).toMatchObject({
       method: 'GET',
       path: '/example',
     })
@@ -64,7 +72,9 @@ describe('sendRequest', () => {
 
     const result = await sendRequest(request)
 
-    expect((result?.response.data as Record<string, any>).query).toContain({
+    expect(
+      (JSON.parse(result?.response.data ?? '') as Record<string, any>).query,
+    ).toMatchObject({
       foo: 'bar',
     })
   })
@@ -84,7 +94,7 @@ describe('sendRequest', () => {
 
     const result = await sendRequest(request)
 
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data ?? '')).toMatchObject({
       query: {
         example: 'parameter',
         foo: 'bar',
@@ -107,7 +117,7 @@ describe('sendRequest', () => {
 
     const result = await sendRequest(request)
 
-    expect(result?.response?.data).toMatchObject({
+    expect(JSON.parse(result?.response.data ?? '')).toMatchObject({
       cookies: {
         foo: 'bar',
       },
@@ -133,11 +143,26 @@ describe('sendRequest', () => {
 
     const result = await sendRequest(request)
 
-    expect(result?.response?.data).toMatchObject({
+    expect(JSON.parse(result?.response.data ?? '')).toMatchObject({
       cookies: {
         foo: 'bar',
         another: 'cookie',
       },
     })
+
+  it('sends requests through a proxy', async () => {
+    const proxyPort = createApiClientProxyOnAnyPort()
+    const echoPort = createEchoServerOnAnyPort()
+
+    const request = {
+      url: `http://127.0.0.1:${echoPort}`,
+    }
+
+    const result = await sendRequest(request, `http://127.0.0.1:${proxyPort}`)
+
+    expect(JSON.parse(result?.response.data ?? '')).toMatchObject({
+      method: 'GET',
+      path: '/',
+    })
   })
-})
+  })

--- a/packages/api-client/src/helpers/sendRequest.test.ts
+++ b/packages/api-client/src/helpers/sendRequest.test.ts
@@ -149,6 +149,7 @@ describe('sendRequest', () => {
         another: 'cookie',
       },
     })
+  })
 
   it('sends requests through a proxy', async () => {
     const proxyPort = createApiClientProxyOnAnyPort()
@@ -165,4 +166,4 @@ describe('sendRequest', () => {
       path: '/',
     })
   })
-  })
+})

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -90,7 +90,7 @@ export type ClientResponse = {
   headers: Record<string, string>
   statusCode: number
   statusText: string
-  data: string | Record<string, any>
+  data: string
   query: Record<string, any>
   duration: number
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
         specifier: 3.3.4
         version: 3.3.4
     devDependencies:
+      '@scalar/api-client-proxy':
+        specifier: workspace:*
+        version: link:../api-client-proxy
       '@scalar/echo-server':
         specifier: workspace:*
         version: link:../echo-server
@@ -4850,7 +4853,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.4
-      vue-component-type-helpers: 1.8.21
+      vue-component-type-helpers: 1.8.22
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13787,8 +13790,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /vue-component-type-helpers@1.8.21:
-    resolution: {integrity: sha512-XL37QbmiqqbKrAFHPxqryMXpNgO0KMKd5bIo7LO9QABPMNEysd8xmYRIjwZhh0t2abveXjAJ//ZcAzwdxp/S3Q==}
+  /vue-component-type-helpers@1.8.22:
+    resolution: {integrity: sha512-LK3wJHs3vJxHG292C8cnsRusgyC5SEZDCzDCD01mdE/AoREFMl2tzLRuzwyuEsOIz13tqgBcnvysN3Lxsa14Fw==}
     dev: true
 
   /vue-demi@0.14.6(vue@3.3.4):


### PR DESCRIPTION
This PR improves sendRequest, the heart of the API client.

* I’ve added a test using it with a proxy and made the responses with/without a proxy look similar.
* I’ve also decided to keep the response body as a string. We shouldn’t care whether the response is JSON or not, except when rendering a preview.