### PR TITLE
fix: minor styling issues with native web view

### DIFF
--- a/.changeset/great-eggs-drop.md
+++ b/.changeset/great-eggs-drop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: minor styling issues in the macOS native web view

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -260,6 +260,11 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   display: flex;
   margin-top: 5px;
 }
+
+.scalar-api-client__url-input {
+  color: var(--theme-color-1, var(--default-theme-color-1));
+}
+
 .scalar-api-client__request-type {
   display: flex;
   align-items: center;

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -61,6 +61,7 @@ const { activeRequest, readOnly } = useApiClientRequestStore()
   overflow: auto;
 }
 .scalar-api-client__item__content .scalar-api-client__codemirror__wrapper {
+  width: 100%;
   min-height: 63px;
 }
 .scalar-api-client__item__content .cm-s-default {

--- a/packages/api-client/src/components/HelpfulLink.vue
+++ b/packages/api-client/src/components/HelpfulLink.vue
@@ -11,6 +11,7 @@ defineProps<{ href: string }>()
 </template>
 <style scoped>
 a {
+  color: var(--theme-color-3, var(--default-theme-color-3));
   text-decoration: underline;
   text-decoration-color: var(
     --theme-border-color,


### PR DESCRIPTION
This PR fixes some minor styling issues I’ve seen in the native web view on macOS.

* The CodeMirror component wasn’t full width.
* The address bar text color was always black.
* The response status code was always blue.