### PR TITLE
feat: use variable name as placeholder for the server url

### DIFF
--- a/packages/api-reference/src/components/Content/Introduction/ServerItem.vue
+++ b/packages/api-reference/src/components/Content/Introduction/ServerItem.vue
@@ -23,7 +23,9 @@ const formattedServerUrl = computed(() => {
       (currentVariable: Variable) => currentVariable.name === match,
     )
 
-    return `<span class="base-url-variable">${variable?.value ?? ''}</span>`
+    return `<span class="base-url-variable">${
+      (variable?.value ?? '') !== '' ? variable?.value : `{${match}}`
+    }</span>`
   })
 })
 </script>


### PR DESCRIPTION
When variables are empty, the server url looks wrong. Let’s use the variable name as the placeholder then.

https://github.com/scalar/scalar/assets/1577992/e3c9ff1d-8b46-4ca3-937a-2bd4bc834542

