### PR TITLE
Marc/make search hotkey configurable

### DIFF
--- a/.changeset/khaki-colts-trade.md
+++ b/.changeset/khaki-colts-trade.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+make search modal hotkey configurable

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -106,3 +106,11 @@ Whether the footer should be below the content or below both the content _and_ t
 ```vue
 <ApiReference :configuration="{ footerBelowSidebar: true} />
 ```
+
+#### searchHotKey?: string
+
+Key used with CNTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k)
+
+```vue
+<ApiReference :configuration="{ footerBelowSidebar: true} />
+```

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -112,5 +112,5 @@ Whether the footer should be below the content or below both the content _and_ t
 Key used with CNTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k)
 
 ```vue
-<ApiReference :configuration="{ footerBelowSidebar: true} />
+<ApiReference :configuration="{ searchHotKey: 'l'} />
 ```

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -291,7 +291,9 @@ function handleAIWriter(
         <slot
           v-if="isMobile"
           name="header" />
-        <Sidebar :spec="parsedSpec" />
+        <Sidebar
+          :searchHotKey="currentConfiguration.searchHotKey"
+          :spec="parsedSpec" />
       </div>
     </aside>
     <!-- Swagger file editing -->

--- a/packages/api-reference/src/components/FindAnythingButton.vue
+++ b/packages/api-reference/src/components/FindAnythingButton.vue
@@ -2,6 +2,10 @@
 import { isMacOS } from '@scalar/use-tooltip'
 
 import FlowIcon from './Icon/FlowIcon.vue'
+
+withDefaults(defineProps<{ searchHotKey?: string }>(), {
+  searchHotKey: 'k',
+})
 </script>
 <template>
   <button
@@ -17,7 +21,9 @@ import FlowIcon from './Icon/FlowIcon.vue'
         Search
       </span>
       <span class="sidebar-search-shortcut">
-        <span class="sidebar-search-key">{{ isMacOS() ? '⌘' : '⌃' }}k</span>
+        <span class="sidebar-search-key">
+          {{ isMacOS() ? '⌘' : '⌃' }}{{ searchHotKey }}
+        </span>
       </span>
     </div>
   </button>

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -22,7 +22,12 @@ import FindAnythingButton from './FindAnythingButton.vue'
 import SidebarElement from './SidebarElement.vue'
 import SidebarGroup from './SidebarGroup.vue'
 
-const props = defineProps<{ spec: Spec }>()
+const props = withDefaults(
+  defineProps<{ spec: Spec; searchHotKey?: string }>(),
+  {
+    searchHotKey: 'k',
+  },
+)
 
 const { server: serverState, authentication: authenticationState } =
   useGlobalStore()
@@ -52,7 +57,7 @@ const {
 } = useTemplateStore()
 
 useKeyboardEvent({
-  keyList: ['k'],
+  keyList: [props.searchHotKey],
   withCtrlCmd: true,
   handler: () => setTemplateItem('showSearch', !templateState.showSearch),
 })
@@ -222,6 +227,7 @@ const setRef = (el: SidebarElementType, id: string) => {
   <div class="sidebar">
     <FindAnythingButton
       v-if="!isMobile"
+      :searchHotKey="searchHotKey"
       @click="setTemplateItem('showSearch', true)" />
     <div
       ref="scrollerEl"

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -62,6 +62,8 @@ export type ReferenceConfiguration = {
   /** Remove the Scalar branding :( */
   // doNotPromoteScalar?: boolean
   hocuspocusConfiguration?: HocuspocusConfigurationProp
+  /** Key used with CNTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k) */
+  searchHotKey?: string
 }
 
 export type Schema = {

--- a/projects/web/src/pages/ApiReferencePage.vue
+++ b/projects/web/src/pages/ApiReferencePage.vue
@@ -12,6 +12,7 @@ const configuration = reactive<ReferenceConfiguration>({
   theme: 'default',
   proxy: 'http://localhost:5051',
   isEditable: true,
+  searchHotKey: 'l',
   // spec: {
   //   preparsedContent,
   // },


### PR DESCRIPTION
now the search modal hotkey can be configured, a good use case is your adding scalar to an existing site but want two searchbars

<img width="311" alt="image" src="https://github.com/scalar/scalar/assets/6176314/572409e7-884d-4e71-ab4c-e8aa59592b14">
