### PR TITLE
refactor: swagger editor reactivity

### DIFF
--- a/.changeset/purple-books-impress.md
+++ b/.changeset/purple-books-impress.md
@@ -1,0 +1,8 @@
+---
+'@scalar/swagger-editor': patch
+'@scalar/use-codemirror': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+refactor: move all api reference refs and watchers to hooks

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -487,4 +487,3 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   padding: 0 9px;
 }
 </style>
-../../stores/requestStore

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -349,4 +349,3 @@ const { activeRequest, readOnly } = useRequestStore()
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
 }
 </style>
-../../../stores/requestStore

--- a/packages/api-client/src/components/ApiClient/RequestHistory.vue
+++ b/packages/api-client/src/components/ApiClient/RequestHistory.vue
@@ -144,4 +144,3 @@ const { requestHistoryOrder } = useRequestStore()
   color: var(--theme-color-3, var(--default-theme-color-3));
 }
 </style>
-../../stores/requestStore

--- a/packages/api-client/src/helpers/sendRequest.ts
+++ b/packages/api-client/src/helpers/sendRequest.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosProxyConfig, type AxiosRequestConfig } from 'axios'
+import axios, { type AxiosRequestConfig } from 'axios'
 import { nanoid } from 'nanoid'
 
 import type {

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -6,7 +6,7 @@ import { type Spec } from '../types'
 import { default as Sidebar } from './Sidebar.vue'
 
 defineProps<{
-  spec: Spec
+  parsedSpec: Spec
   overloadShow?: boolean
   tabMode?: boolean
   activeTab?: string
@@ -41,7 +41,7 @@ export { useApiClientStore } from '@scalar/api-client'
               <div class="t-doc__sidebar">
                 <Sidebar
                   v-show="!isMobile"
-                  :spec="spec" />
+                  :parsedSpec="parsedSpec" />
               </div>
             </template>
             <template v-else>
@@ -52,7 +52,7 @@ export { useApiClientStore } from '@scalar/api-client'
             <div class="t-doc__sidebar">
               <Sidebar
                 v-show="!isMobile"
-                :spec="spec" />
+                :parsedSpec="parsedSpec" />
             </div>
           </template>
           <ApiClient

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -83,6 +83,7 @@ const specConfiguration = computed(() => {
 // Get the raw content
 const { rawSpecRef, setRawSpecRef } = useSpec({
   configuration: specConfiguration,
+  proxy: currentConfiguration.value.proxy,
 })
 
 // Parse the content

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -17,6 +17,7 @@ import {
 } from 'vue'
 
 import { deepMerge, getTagSectionId } from '../helpers'
+import { useSpec } from '../hooks'
 import { useTemplateStore } from '../stores/template'
 import type { ReferenceConfiguration, ReferenceProps, Spec } from '../types'
 import { default as ApiClientModal } from './ApiClientModal.vue'
@@ -80,6 +81,14 @@ const currentConfiguration = computed((): ReferenceConfiguration => {
   })
 })
 
+const specConfiguration = computed(() => {
+  return currentConfiguration.value.spec
+})
+
+const { rawSpecRef: foobar } = useSpec({
+  configuration: specConfiguration,
+})
+
 /**
  * The editor component has heavy dependencies (process), let's lazy load it.
  */
@@ -106,14 +115,6 @@ const parsedSpecRef = ref<string>(
 const rawSpecRef = ref<string>(
   getSpecContent(currentConfiguration.value.spec?.content),
 )
-
-watch(rawSpecRef, () => {
-  console.log(rawSpecRef.value)
-})
-
-watch(parsedSpecRef, () => {
-  console.log(parsedSpecRef.value)
-})
 
 watch(
   currentConfiguration,
@@ -258,6 +259,7 @@ function handleAIWriter(
 }
 </script>
 <template>
+  foobar: {{ foobar }}
   <ThemeStyles :id="currentConfiguration?.theme" />
   <FlowToastContainer />
   <div

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -7,16 +7,9 @@ import {
 import { type ThemeId, ThemeStyles } from '@scalar/themes'
 import { FlowToastContainer } from '@scalar/use-toasts'
 import { useMediaQuery, useResizeObserver } from '@vueuse/core'
-import {
-  computed,
-  defineAsyncComponent,
-  onMounted,
-  reactive,
-  ref,
-  watch,
-} from 'vue'
+import { computed, defineAsyncComponent, onMounted, ref, watch } from 'vue'
 
-import { deepMerge, getTagSectionId } from '../helpers'
+import { deepMerge } from '../helpers'
 import { useParser, useSpec } from '../hooks'
 import { useTemplateStore } from '../stores/template'
 import type { ReferenceConfiguration, ReferenceProps, Spec } from '../types'
@@ -42,9 +35,10 @@ const emits = defineEmits<{
   ): void
 }>()
 
+// Keep a ref to the Swagger editor
 const swaggerEditorRef = ref<typeof SwaggerEditor | undefined>()
 
-/** Merge the default configuration with the given configuration. */
+// Merge the default configuration with the given configuration.
 const currentConfiguration = computed((): ReferenceConfiguration => {
   if (
     props.spec ||
@@ -126,34 +120,9 @@ useResizeObserver(documentEl, (entries) => {
   elementHeight.value = entries[0].contentRect.height
 })
 
-// const { setCollapsedSidebarItem } = useTemplateStore()
 const { state } = useApiClientStore()
 
-const showMobileDrawer = computed(() => {
-  const { state: s } = useTemplateStore()
-  return s.showMobileDrawer
-})
-
-// TODO: proper types for the parsed spec
-// const handleParsedSpecUpdate = (newSpec: any) => {
-//   Object.assign(parsedSpec, {
-//     // Some specs don’t have servers or tags, make sure they are defined
-//     servers: [],
-//     tags: [],
-//     ...newSpec,
-//   })
-
-//   const firstTag = parsedSpec.tags[0]
-
-//   if (firstTag) {
-//     setCollapsedSidebarItem(getTagSectionId(firstTag), true)
-//   }
-// }
-
-function handleContentUpdate(newContent: string) {
-  setRawSpecRef(newContent)
-}
-
+// Scroll to top
 onMounted(() => {
   document.querySelector('#tippy')?.scrollTo({
     top: 0,
@@ -161,15 +130,24 @@ onMounted(() => {
   })
 })
 
-const showRenderedContent = computed(
-  () => isLargeScreen.value || !currentConfiguration.value?.isEditable,
-)
-
+// Whether to show the spec input
 const showSwaggerEditor = computed(() => {
   return (
     !currentConfiguration.value.spec?.preparsedContent &&
     currentConfiguration.value?.isEditable
   )
+})
+
+// Whether to show the result
+const showRenderedContent = computed(
+  () => isLargeScreen.value || !currentConfiguration.value?.isEditable,
+)
+
+// Show the mobile drawer
+const showMobileDrawer = computed(() => {
+  const { state: templateState } = useTemplateStore()
+
+  return templateState.showMobileDrawer
 })
 
 function handleAIWriter(
@@ -246,7 +224,7 @@ function handleAIWriter(
         :theme="currentConfiguration?.theme"
         :value="rawSpecRef"
         @changeTheme="$emit('changeTheme', $event)"
-        @contentUpdate="handleContentUpdate"
+        @contentUpdate="(newContent) => setRawSpecRef(newContent)"
         @startAIWriter="handleAIWriter" />
     </div>
     <!-- Rendered reference -->

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -85,7 +85,7 @@ const specConfiguration = computed(() => {
   return currentConfiguration.value.spec
 })
 
-const { rawSpecRef: foobar } = useSpec({
+const { rawSpecRef: newRawSpecRef, setRawSpecRef } = useSpec({
   configuration: specConfiguration,
 })
 
@@ -217,7 +217,7 @@ const handleParsedSpecUpdate = (newSpec: any) => {
 }
 
 function handleContentUpdate(newContent: string) {
-  rawSpecRef.value = newContent
+  setRawSpecRef(newContent)
 }
 
 watch(
@@ -259,7 +259,7 @@ function handleAIWriter(
 }
 </script>
 <template>
-  foobar: {{ foobar }}
+  newRawSpecRef: {{ newRawSpecRef }}
   <ThemeStyles :id="currentConfiguration?.theme" />
   <FlowToastContainer />
   <div
@@ -323,7 +323,7 @@ function handleAIWriter(
         :initialTabState="currentConfiguration?.tabs?.initialContent"
         :proxyUrl="currentConfiguration?.proxy"
         :theme="currentConfiguration?.theme"
-        :value="rawSpecRef"
+        :value="newRawSpecRef"
         @changeTheme="$emit('changeTheme', $event)"
         @contentUpdate="handleContentUpdate"
         @parsedSpecUpdate="handleParsedSpecUpdate"

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -87,7 +87,7 @@ const { rawSpecRef, setRawSpecRef } = useSpec({
 })
 
 // Parse the content
-const { parsedSpecRef, overwriteParsedSpecRef } = useParser({
+const { parsedSpecRef, overwriteParsedSpecRef, errorRef } = useParser({
   input: rawSpecRef,
 })
 
@@ -219,6 +219,7 @@ function handleAIWriter(
       <LazyLoadedSwaggerEditor
         ref="swaggerEditorRef"
         :aiWriterMarkdown="aiWriterMarkdown"
+        :error="errorRef"
         :hocuspocusConfiguration="currentConfiguration?.hocuspocusConfiguration"
         :initialTabState="currentConfiguration?.tabs?.initialContent"
         :proxyUrl="currentConfiguration?.proxy"

--- a/packages/api-reference/src/components/Content/Authentication/Authentication.vue
+++ b/packages/api-reference/src/components/Content/Authentication/Authentication.vue
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader } from '../../Card'
 import SecurityScheme from './SecurityScheme.vue'
 import SecuritySchemeSelector from './SecuritySchemeSelector.vue'
 
-const props = defineProps<{ spec?: Spec }>()
+const props = defineProps<{ parsedSpec?: Spec }>()
 
 const { authentication, setAuthentication } = useGlobalStore()
 
@@ -18,7 +18,9 @@ const showSecurityScheme = computed(() => {
   }
 
   const scheme =
-    props.spec?.components?.securitySchemes?.[authentication.securitySchemeKey]
+    props.parsedSpec?.components?.securitySchemes?.[
+      authentication.securitySchemeKey
+    ]
 
   // @ts-ignore
   return !!scheme?.type
@@ -26,11 +28,11 @@ const showSecurityScheme = computed(() => {
 
 // Keep a copy of the security schemes in the global authentication state
 watch(
-  () => props.spec?.components?.securitySchemes,
+  () => props.parsedSpec?.components?.securitySchemes,
   () => {
     setAuthentication({
       // @ts-ignore
-      securitySchemes: props.spec?.components?.securitySchemes,
+      securitySchemes: props.parsedSpec?.components?.securitySchemes,
     })
   },
   { deep: true, immediate: true },
@@ -38,13 +40,15 @@ watch(
 </script>
 
 <template>
-  <Card v-if="hasSecuritySchemes(spec)">
+  <Card v-if="hasSecuritySchemes(parsedSpec)">
     <CardHeader transparent>
       Authentication
       <template #actions>
         <div class="selector">
           <SecuritySchemeSelector
-            :value="spec?.components?.securitySchemes"></SecuritySchemeSelector>
+            :value="
+              parsedSpec?.components?.securitySchemes
+            "></SecuritySchemeSelector>
         </div>
       </template>
     </CardHeader>
@@ -54,7 +58,9 @@ watch(
       <SecurityScheme
         v-if="authentication.securitySchemeKey"
         :value="
-          spec?.components?.securitySchemes?.[authentication.securitySchemeKey]
+          parsedSpec?.components?.securitySchemes?.[
+            authentication.securitySchemeKey
+          ]
         " />
     </CardContent>
   </Card>

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -66,7 +66,7 @@ const moreThanOneDefaultTag = (tag: Tag) =>
     }">
     <template v-if="ready">
       <Introduction
-        v-if="rawSpec.length > 0"
+        v-if="parsedSpec.info.title || parsedSpec.info.description"
         :info="parsedSpec.info"
         :parsedSpec="parsedSpec"
         :rawSpec="rawSpec"
@@ -106,7 +106,6 @@ const moreThanOneDefaultTag = (tag: Tag) =>
               :key="`${operation.httpVerb}-${operation.operationId}`"
               :operation="operation"
               :server="localServers[0]"
-              :spec="parsedSpec"
               :tag="tag" />
           </template>
         </SectionContainer>

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -60,7 +60,7 @@ const { state, getClientTitle, getTargetTitle } = useTemplateStore()
                 </CardFooter>
               </Card>
 
-              <Authentication :spec="parsedSpec" />
+              <Authentication :parsedSpec="parsedSpec" />
             </div>
           </SectionColumn>
         </SectionColumns>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -38,7 +38,7 @@ const generateSnippet = async (): Promise<string> => {
   // Generate a request object
   const request = getHarRequest(
     {
-      url: getUrlFromServerState(serverState),
+      url: getUrlFromServerState(serverState) ?? window.location.origin,
     },
     getRequestFromOperation(props.operation, {
       replaceVariables: true,
@@ -54,7 +54,7 @@ const generateSnippet = async (): Promise<string> => {
       state.selectedClient.targetKey,
       state.selectedClient.clientKey,
     )) as string
-  } catch {
+  } catch (e) {
     return ''
   }
 }

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
@@ -14,8 +14,6 @@ import { ExampleResponses } from './ExampleResponses'
 
 defineProps<{
   operation: TransformedOperation
-  server: Server
-  spec: Spec
   tag: Tag
 }>()
 </script>
@@ -33,10 +31,7 @@ defineProps<{
         </SectionColumn>
         <SectionColumn>
           <div class="examples">
-            <ExampleRequest
-              :operation="operation"
-              :server="server"
-              :spec="spec" />
+            <ExampleRequest :operation="operation" />
             <ExampleResponses
               :operation="operation"
               style="margin-top: 12px" />

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { getOperationSectionId } from '../../../helpers'
-import type { Server, Spec, Tag, TransformedOperation } from '../../../types'
+import type { Tag, TransformedOperation } from '../../../types'
 import {
   Section,
   SectionColumn,

--- a/packages/api-reference/src/components/DarkModeToggle.vue
+++ b/packages/api-reference/src/components/DarkModeToggle.vue
@@ -105,4 +105,3 @@ onMounted(() => {
   text-decoration: underline;
 }
 </style>
-../hooks/useDarkModeState

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -10,8 +10,8 @@ import { type ParamMap, useOperation } from '../hooks'
 import { useTemplateStore } from '../stores/template'
 import type { Spec, Tag, TransformedOperation } from '../types'
 
-const props = defineProps<{ spec: Spec }>()
-const reactiveSpec = toRef(props, 'spec')
+const props = defineProps<{ parsedSpec: Spec }>()
+const reactiveSpec = toRef(props, 'parsedSpec')
 const modalState = useModal()
 
 type FuseData = {
@@ -93,13 +93,13 @@ watch(
   () => {
     fuseDataArray = []
 
-    if (!props.spec.tags.length) {
+    if (!props.parsedSpec.tags.length) {
       fuse.setCollection([])
       return
     }
 
     // TODO: We need to go through the operations, not the tags. Spec files can have zero tags.
-    props.spec.tags.forEach((tag) => {
+    props.parsedSpec.tags.forEach((tag) => {
       const tagData = {
         title: tag.name,
         description: tag.description,

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -32,6 +32,26 @@ const props = withDefaults(
   },
 )
 
+const {
+  state: templateState,
+  setItem: setTemplateItem,
+  toggleCollapsedSidebarItem,
+  setCollapsedSidebarItem,
+} = useTemplateStore()
+
+// Open the first tag section by default
+watch(
+  props.parsedSpec,
+  () => {
+    const firstTag = props.parsedSpec.tags[0]
+
+    if (firstTag) {
+      setCollapsedSidebarItem(getTagSectionId(firstTag), true)
+    }
+  },
+  { immediate: true },
+)
+
 const { server: serverState, authentication: authenticationState } =
   useGlobalStore()
 
@@ -52,12 +72,6 @@ function showItemInClient(operation: TransformedOperation) {
 }
 
 const isMobile = useMediaQuery('(max-width: 1000px)')
-
-const {
-  state: templateState,
-  setItem: setTemplateItem,
-  toggleCollapsedSidebarItem,
-} = useTemplateStore()
 
 useKeyboardEvent({
   keyList: [props.searchHotKey],

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -23,7 +23,10 @@ import SidebarElement from './SidebarElement.vue'
 import SidebarGroup from './SidebarGroup.vue'
 
 const props = withDefaults(
-  defineProps<{ spec: Spec; searchHotKey?: string }>(),
+  defineProps<{
+    parsedSpec: Spec
+    searchHotKey?: string
+  }>(),
   {
     searchHotKey: 'k',
   },
@@ -63,16 +66,16 @@ useKeyboardEvent({
 })
 
 const moreThanOneDefaultTag = (tag: Tag) =>
-  props.spec?.tags?.length !== 1 ||
+  props.parsedSpec?.tags?.length !== 1 ||
   tag?.name !== 'default' ||
   tag?.description !== ''
 
 const headings = ref<any[]>([])
 
 watch(
-  () => props?.spec?.info?.description,
+  () => props?.parsedSpec?.info?.description,
   async () => {
-    const description = props?.spec?.info?.description
+    const description = props?.parsedSpec?.info?.description
 
     if (!description) {
       return []
@@ -112,13 +115,13 @@ const items = computed((): SidebarEntry[] => {
   })
 
   // Tags & Operations
-  const firstTag = props?.spec?.tags?.[0]
+  const firstTag = props?.parsedSpec?.tags?.[0]
 
   const operationEntries: SidebarEntry[] =
     firstTag &&
     moreThanOneDefaultTag(firstTag) &&
     firstTag.operations?.length > 0
-      ? props.spec.tags?.map((tag) => {
+      ? props.parsedSpec.tags?.map((tag) => {
           return {
             id: getTagSectionId(tag),
             title: tag.name.toUpperCase(),
@@ -153,13 +156,13 @@ const items = computed((): SidebarEntry[] => {
         })
 
   // Models
-  const modelEntries: SidebarEntry[] = hasModels(props.spec)
+  const modelEntries: SidebarEntry[] = hasModels(props.parsedSpec)
     ? [
         {
           id: getModelSectionId(),
           title: 'MODELS',
           type: 'Folder',
-          children: Object.keys(props.spec.components?.schemas ?? {}).map(
+          children: Object.keys(props.parsedSpec.components?.schemas ?? {}).map(
             (name) => {
               return {
                 id: getModelSectionId(name),

--- a/packages/api-reference/src/helpers/getApiClientRequest.ts
+++ b/packages/api-reference/src/helpers/getApiClientRequest.ts
@@ -48,7 +48,7 @@ export function getApiClientRequest({
     cookies: request.cookies,
     query: request.queryString,
     headers: request.headers,
-    url: getUrlFromServerState(serverState),
+    url: getUrlFromServerState(serverState) ?? '',
     body: request.postData?.text,
   }
 }

--- a/packages/api-reference/src/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.ts
@@ -4,8 +4,8 @@ import { replaceVariables } from './replaceVariables'
 export function getUrlFromServerState(state: ServerState) {
   const url =
     state.selectedServer === null
-      ? state?.servers?.[0]?.url ?? ''
+      ? state?.servers?.[0]?.url ?? undefined
       : state?.servers?.[state.selectedServer]?.url
 
-  return replaceVariables(url, state?.variables)
+  return url ? replaceVariables(url, state?.variables) : undefined
 }

--- a/packages/api-reference/src/hooks/index.ts
+++ b/packages/api-reference/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useDarkModeState'
 export * from './useOperation'
 export * from './useRefOnMount'
+export * from './useSpec'

--- a/packages/api-reference/src/hooks/index.ts
+++ b/packages/api-reference/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useDarkModeState'
 export * from './useOperation'
+export * from './useParser'
 export * from './useRefOnMount'
 export * from './useSpec'

--- a/packages/api-reference/src/hooks/useParser.test.ts
+++ b/packages/api-reference/src/hooks/useParser.test.ts
@@ -1,0 +1,113 @@
+import { type SpecConfiguration } from 'src/types'
+import { describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, reactive, ref, watch } from 'vue'
+
+import { useParser } from './useParser'
+
+describe('useParser', () => {
+  it('returns the content', async () => {
+    const { parsedSpecRef } = useParser({
+      input: JSON.stringify({
+        openapi: '3.1.0',
+        info: { title: 'Example' },
+        paths: {},
+      }),
+    })
+
+    // Sleep for 10ms to wait for the parser to finish
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(parsedSpecRef.info.title).toBe('Example')
+  })
+
+  it('works with refs', async () => {
+    const rawSpec = ref<string>(
+      JSON.stringify({
+        openapi: '3.1.0',
+        info: { title: 'Example' },
+        paths: {},
+      }),
+    )
+
+    const { parsedSpecRef } = useParser({
+      input: rawSpec,
+    })
+
+    // Sleep for 300ms to wait for the debouncer and the parser
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    expect(parsedSpecRef.info.title).toBe('Example')
+  })
+
+  it('watches the ref', async () => {
+    const rawSpec = ref<string>(
+      JSON.stringify({
+        openapi: '3.1.0',
+        info: { title: 'Example' },
+        paths: {},
+      }),
+    )
+
+    const { parsedSpecRef } = useParser({
+      input: rawSpec,
+    })
+
+    // Sleep for 300ms to wait for the debouncer and the parser
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    expect(parsedSpecRef.info.title).toBe('Example')
+
+    rawSpec.value = JSON.stringify({
+      openapi: '3.1.0',
+      info: { title: 'Foobar' },
+      paths: {},
+    })
+
+    // Sleep for 300ms to wait for the debouncer and the parser
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    expect(parsedSpecRef.info.title).toBe('Foobar')
+  })
+
+  it('deals with undefined input', async () => {
+    const { parsedSpecRef } = useParser({})
+
+    // Sleep for 10ms to wait for the parser to finish
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(parsedSpecRef.info.title).toBe('')
+  })
+
+  it('deals with empty input', async () => {
+    const { parsedSpecRef } = useParser({
+      input: '',
+    })
+
+    // Sleep for 10ms to wait for the parser to finish
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(parsedSpecRef.info.title).toBe('')
+  })
+
+  it('returns errors', async () => {
+    const { errorRef } = useParser({
+      input: '{"foo}',
+    })
+
+    // Sleep for 10ms to wait for the parser to finish
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(errorRef.value).toContain('Unexpected end of JSON')
+  })
+
+  it('overwrites the ref', async () => {
+    const { parsedSpecRef, overwriteParsedSpecRef } = useParser({})
+
+    overwriteParsedSpecRef({
+      // @ts-ignore
+      info: { title: 'Example' },
+    })
+
+    expect(parsedSpecRef.info.title).toBe('Example')
+  })
+})

--- a/packages/api-reference/src/hooks/useParser.ts
+++ b/packages/api-reference/src/hooks/useParser.ts
@@ -36,7 +36,7 @@ const emptySpec: Spec = {
 export function useParser({
   input,
 }: {
-  input: string | Ref<string> | ComputedRef<string>
+  input?: string | Ref<string> | ComputedRef<string>
 }) {
   const parsedSpecRef = reactive<Spec>({ ...emptySpec })
 
@@ -45,7 +45,9 @@ export function useParser({
   if (isRef(input)) {
     watch(
       input,
-      useDebounceFn((value) => parseInput(value)),
+      useDebounceFn((value) => {
+        parseInput(value)
+      }),
       { immediate: true },
     )
   } else {
@@ -63,23 +65,19 @@ export function useParser({
       return
     }
 
-    try {
-      parse(value)
-        .then((spec) => {
-          errorRef.value = null
+    parse(value)
+      .then((spec) => {
+        errorRef.value = null
 
-          Object.assign(parsedSpecRef, {
-            // Some specs don’t have servers or tags, make sure they are defined
-            servers: [],
-            ...spec,
-          })
+        Object.assign(parsedSpecRef, {
+          // Some specs don’t have servers or tags, make sure they are defined
+          servers: [],
+          ...spec,
         })
-        .catch((error) => {
-          errorRef.value = error.toString()
-        })
-    } catch (error) {
-      console.error(error)
-    }
+      })
+      .catch((error) => {
+        errorRef.value = error.toString()
+      })
   }
 
   function overwriteParsedSpecRef(value: Spec) {

--- a/packages/api-reference/src/hooks/useParser.ts
+++ b/packages/api-reference/src/hooks/useParser.ts
@@ -1,0 +1,83 @@
+import { parse } from '@scalar/swagger-parser'
+import { type ComputedRef, type Ref, isRef, reactive, ref, watch } from 'vue'
+
+import type { Spec } from '../types'
+
+const emptySpec: Spec = {
+  info: {
+    title: '',
+    description: '',
+    termsOfService: '',
+    version: '',
+    license: {
+      name: '',
+      url: '',
+    },
+    contact: {
+      email: '',
+    },
+  },
+  externalDocs: {
+    description: '',
+    url: '',
+  },
+  servers: [],
+  components: {
+    schemas: {},
+    securitySchemes: {},
+  },
+  tags: [],
+}
+
+/**
+ * Dereference OpenAPI/Swagger specs
+ */
+export function useParser({
+  input,
+}: {
+  input: string | Ref<string> | ComputedRef<string>
+}) {
+  const parsedSpecRef = reactive<Spec>(emptySpec)
+
+  const errorRef = ref<string | null>(null)
+
+  if (isRef(input)) {
+    watch(input, parseInput, { immediate: true })
+  } else {
+    parseInput(input)
+  }
+
+  async function parseInput(value?: string) {
+    if (value === undefined) {
+      return
+    }
+
+    try {
+      parse(value)
+        .then((spec) => {
+          errorRef.value = null
+
+          Object.assign(parsedSpecRef, {
+            // Some specs don’t have servers or tags, make sure they are defined
+            servers: [],
+            ...spec,
+          })
+        })
+        .catch((error) => {
+          errorRef.value = error.toString()
+        })
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  function overwriteParsedSpecRef(value: Spec) {
+    Object.assign(parsedSpecRef, value)
+  }
+
+  return {
+    parsedSpecRef,
+    overwriteParsedSpecRef,
+    errorRef,
+  }
+}

--- a/packages/api-reference/src/hooks/useParser.ts
+++ b/packages/api-reference/src/hooks/useParser.ts
@@ -1,4 +1,5 @@
 import { parse } from '@scalar/swagger-parser'
+import { useDebounceFn } from '@vueuse/core'
 import { type ComputedRef, type Ref, isRef, reactive, ref, watch } from 'vue'
 
 import type { Spec } from '../types'
@@ -42,7 +43,11 @@ export function useParser({
   const errorRef = ref<string | null>(null)
 
   if (isRef(input)) {
-    watch(input, parseInput, { immediate: true })
+    watch(
+      input,
+      useDebounceFn((value) => parseInput(value)),
+      { immediate: true },
+    )
   } else {
     parseInput(input)
   }

--- a/packages/api-reference/src/hooks/useParser.ts
+++ b/packages/api-reference/src/hooks/useParser.ts
@@ -38,7 +38,7 @@ export function useParser({
 }: {
   input: string | Ref<string> | ComputedRef<string>
 }) {
-  const parsedSpecRef = reactive<Spec>(emptySpec)
+  const parsedSpecRef = reactive<Spec>({ ...emptySpec })
 
   const errorRef = ref<string | null>(null)
 
@@ -54,6 +54,12 @@ export function useParser({
 
   async function parseInput(value?: string) {
     if (value === undefined) {
+      Object.assign(parsedSpecRef, { ...emptySpec })
+      return
+    }
+
+    if (value.length === 0) {
+      Object.assign(parsedSpecRef, { ...emptySpec })
       return
     }
 

--- a/packages/api-reference/src/hooks/useSpec.test.ts
+++ b/packages/api-reference/src/hooks/useSpec.test.ts
@@ -70,6 +70,7 @@ describe('useSpec', () => {
   }
 
   it('fetches JSON from an URL', async () => {
+    // @ts-ignore
     fetch.mockResolvedValue(
       createFetchResponse(
         '{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}',

--- a/packages/api-reference/src/hooks/useSpec.test.ts
+++ b/packages/api-reference/src/hooks/useSpec.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import { useSpec } from './useSpec'
+
+describe('useSpec', () => {
+  it('returns the content', async () => {
+    const { rawSpecRef } = useSpec({
+      configuration: {
+        content: { openapi: '3.1.0', info: { title: 'Example' }, paths: {} },
+      },
+    })
+
+    await nextTick()
+
+    expect(rawSpecRef.value).toMatch(
+      '{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}',
+    )
+  })
+
+  it('calls the content callback', async () => {
+    const { rawSpecRef } = useSpec({
+      configuration: {
+        content: () => {
+          return { openapi: '3.1.0', info: { title: 'Example' }, paths: {} }
+        },
+      },
+    })
+
+    await nextTick()
+
+    expect(rawSpecRef.value).toMatch(
+      '{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}',
+    )
+  })
+
+  it('works with strings', async () => {
+    const { rawSpecRef } = useSpec({
+      configuration: {
+        content: '{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}',
+      },
+    })
+
+    await nextTick()
+
+    expect(rawSpecRef.value).toMatch(
+      '{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}',
+    )
+  })
+
+  it('works with strings in callbacks', async () => {
+    const { rawSpecRef } = useSpec({
+      configuration: {
+        content: () =>
+          '{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}',
+      },
+    })
+
+    await nextTick()
+
+    expect(rawSpecRef.value).toMatch(
+      '{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}',
+    )
+  })
+
+  global.fetch = vi.fn()
+
+  function createFetchResponse(data: string) {
+    return { text: () => new Promise((resolve) => resolve(data)) }
+  }
+
+  it('fetches JSON from an URL', async () => {
+    fetch.mockResolvedValue(
+      createFetchResponse(
+        '{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}',
+      ),
+    )
+
+    const { rawSpecRef } = useSpec({
+      configuration: {
+        url: 'https://example.com/swagger.json',
+      },
+    })
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com/swagger.json')
+
+    // await nextTick()
+
+    // expect(rawSpecRef.value).toMatch(
+    //   '{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}',
+    // )
+  })
+})

--- a/packages/api-reference/src/hooks/useSpec.ts
+++ b/packages/api-reference/src/hooks/useSpec.ts
@@ -1,0 +1,100 @@
+import { type ComputedRef, type Ref, isRef, ref, watch } from 'vue'
+
+import type { SpecConfiguration } from '../types'
+
+// TODO: Trigger swagger parser
+// TODO: Deal with Preparsed content
+// TODO: Update CodeMirror when the config changed
+
+const rawSpecRef = ref('')
+
+const getSpecContent = async (
+  configuration: SpecConfiguration,
+): Promise<string> => {
+  if (configuration.url !== undefined && configuration.url.length > 0) {
+    return await fetchSpecFromUrl(configuration.url)
+  }
+
+  if (typeof configuration.content === 'string') {
+    return configuration.content
+  }
+
+  if (typeof configuration.content === 'object') {
+    return JSON.stringify(configuration.content)
+  }
+
+  if (typeof configuration.content === 'function') {
+    return await getSpecContent({
+      content: configuration.content(),
+    })
+  }
+
+  return ''
+}
+
+const fetchSpecFromUrl = async (url: string): Promise<string> => {
+  return await new Promise((resolve, reject) => {
+    fetch(url)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('The provided OpenAPI/Swagger spec URL is invalid.')
+        }
+
+        return response.text()
+      })
+      .then((data: string) => {
+        resolve(data)
+      })
+      .catch((error) => {
+        console.warn(
+          'Could not fetch the OpenAPI/Swagger Spec file:',
+          error.message,
+        )
+
+        reject('')
+      })
+  })
+}
+
+export function useSpec({
+  configuration,
+}: {
+  configuration?:
+    | SpecConfiguration
+    | Ref<SpecConfiguration>
+    | ComputedRef<SpecConfiguration>
+}) {
+  // Don’t do anything if the configuration is undefined
+  if (configuration !== undefined) {
+    // Watch for changes
+    if (isRef(configuration)) {
+      watch(
+        configuration,
+        async () => {
+          getSpecContent(configuration.value).then((value) => {
+            setRawSpecRef(value)
+          })
+        },
+        {
+          immediate: true,
+          deep: true,
+        },
+      )
+    }
+    // Get the content once
+    else {
+      getSpecContent(configuration).then((value) => {
+        setRawSpecRef(value)
+      })
+    }
+  }
+
+  function setRawSpecRef(value: string) {
+    rawSpecRef.value = value
+  }
+
+  return {
+    rawSpecRef,
+    setRawSpecRef,
+  }
+}

--- a/packages/api-reference/src/hooks/useSpec.ts
+++ b/packages/api-reference/src/hooks/useSpec.ts
@@ -2,12 +2,11 @@ import { type ComputedRef, type Ref, isRef, ref, watch } from 'vue'
 
 import type { SpecConfiguration } from '../types'
 
-// TODO: Trigger swagger parser
-// TODO: Deal with Preparsed content
-// TODO: Update CodeMirror when the config changed
-
 const rawSpecRef = ref('')
 
+/**
+ * Get the spec content from the provided configuration.
+ */
 const getSpecContent = async ({
   url,
   content,
@@ -33,6 +32,9 @@ const getSpecContent = async ({
   return ''
 }
 
+/**
+ * Fetch the spec from the provided URL.
+ */
 const fetchSpecFromUrl = async (url: string): Promise<string> => {
   return await new Promise((resolve, reject) => {
     fetch(url)
@@ -57,6 +59,9 @@ const fetchSpecFromUrl = async (url: string): Promise<string> => {
   })
 }
 
+/**
+ * Keep the raw spec content in a ref and update it when the configuration changes.
+ */
 export function useSpec({
   configuration,
 }: {

--- a/packages/api-reference/src/hooks/useSpec.ts
+++ b/packages/api-reference/src/hooks/useSpec.ts
@@ -2,10 +2,19 @@ import { type ComputedRef, type Ref, isRef, ref, watch } from 'vue'
 
 import type { SpecConfiguration } from '../types'
 
+/**
+ * The raw (= including references) spec content.
+ */
 const rawSpecRef = ref('')
 
 /**
- * Get the spec content from the provided configuration.
+ * Get the spec content from the provided configuration:
+ *
+ * 1. If the URL is provided, fetch the spec from the URL.
+ * 2. If the content is a string, return it.
+ * 3. If the content is an object, stringify it.
+ * 4. If the content is a function, call it and get the content.
+ * 5. Otherwise, return an empty string.
  */
 const getSpecContent = async ({
   url,
@@ -54,7 +63,7 @@ const fetchSpecFromUrl = async (url: string): Promise<string> => {
           error.message,
         )
 
-        reject('')
+        reject(error)
       })
   })
 }

--- a/packages/api-reference/src/hooks/useSpec.ts
+++ b/packages/api-reference/src/hooks/useSpec.ts
@@ -8,24 +8,25 @@ import type { SpecConfiguration } from '../types'
 
 const rawSpecRef = ref('')
 
-const getSpecContent = async (
-  configuration: SpecConfiguration,
-): Promise<string> => {
-  if (configuration.url !== undefined && configuration.url.length > 0) {
-    return await fetchSpecFromUrl(configuration.url)
+const getSpecContent = async ({
+  url,
+  content,
+}: SpecConfiguration): Promise<string> => {
+  if (url !== undefined && url.length > 0) {
+    return await fetchSpecFromUrl(url)
   }
 
-  if (typeof configuration.content === 'string') {
-    return configuration.content
+  if (typeof content === 'string') {
+    return content
   }
 
-  if (typeof configuration.content === 'object') {
-    return JSON.stringify(configuration.content)
+  if (typeof content === 'object') {
+    return JSON.stringify(content)
   }
 
-  if (typeof configuration.content === 'function') {
+  if (typeof content === 'function') {
     return await getSpecContent({
-      content: configuration.content(),
+      content: content(),
     })
   }
 
@@ -61,8 +62,8 @@ export function useSpec({
 }: {
   configuration?:
     | SpecConfiguration
-    | Ref<SpecConfiguration>
-    | ComputedRef<SpecConfiguration>
+    | Ref<SpecConfiguration | undefined>
+    | ComputedRef<SpecConfiguration | undefined>
 }) {
   // Don’t do anything if the configuration is undefined
   if (configuration !== undefined) {
@@ -71,9 +72,11 @@ export function useSpec({
       watch(
         configuration,
         async () => {
-          getSpecContent(configuration.value).then((value) => {
-            setRawSpecRef(value)
-          })
+          if (configuration.value !== undefined) {
+            getSpecContent(configuration.value).then((value) => {
+              setRawSpecRef(value)
+            })
+          }
         },
         {
           immediate: true,
@@ -90,6 +93,10 @@ export function useSpec({
   }
 
   function setRawSpecRef(value: string) {
+    if (value === rawSpecRef.value) {
+      return
+    }
+
     rawSpecRef.value = value
   }
 

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -32,18 +32,20 @@ export type ReferenceProps = {
   hocuspocusConfiguration?: HocuspocusConfigurationProp
 }
 
+export type SpecConfiguration = {
+  /** URL to a Swagger/OpenAPI file */
+  url?: string
+  /** Swagger/Open API spec */
+  content?: string | Record<string, any> | (() => Record<string, any>)
+  /** The result of @scalar/swagger-parser */
+  preparsedContent?: Record<any, any>
+}
+
 export type ReferenceConfiguration = {
   /** A string to use one of the color presets */
   theme?: ThemeId
   /** The Swagger/OpenAPI spec to render */
-  spec?: {
-    /** URL to a Swagger/OpenAPI file */
-    url?: string
-    /** Swagger/Open API spec */
-    content?: string | Record<string, any> | (() => Record<string, any>)
-    /** The result of @scalar/swagger-parser */
-    preparsedContent?: Record<any, any>
-  }
+  spec?: SpecConfiguration
   /** URL to a request proxy for the API client */
   proxy?: string
   /** Whether the spec input should show */

--- a/packages/swagger-editor/package.json
+++ b/packages/swagger-editor/package.json
@@ -8,7 +8,6 @@
     "@codemirror/state": "6.2.1",
     "@headlessui/vue": "1.7.16",
     "@hocuspocus/provider": "2.5.0",
-    "@scalar/swagger-parser": "workspace:*",
     "@scalar/themes": "workspace:*",
     "@scalar/use-codemirror": "workspace:*",
     "@scalar/use-modal": "workspace:*",

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -66,11 +66,14 @@ const handleAwarenessUpdate = (states: StatesArray) => {
 const codeMirrorReference = ref<typeof SwaggerEditorInput | null>(null)
 
 const formattedError = computed(() => {
-  if (!props.error) {
+  // Check whether there‘s an error
+  if (props.error === undefined || props.error === null || props.error === '') {
     return ''
   }
 
+  // Work with strings and refs
   const error = isRef(props.error) ? props.error.value : props.error
+
   // Handle YAMLExceptions
   if (error.startsWith('YAMLException:')) {
     // Trim everything but the first line

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -68,7 +68,6 @@ const handleContentUpdate = (value: string) => {
 
   rawContent.value = value
   emit('contentUpdate', value)
-  handleSpecUpdate(value)
 }
 
 onMounted(async () => {

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -1,8 +1,6 @@
 <script lang="ts" setup>
 import { type StatesArray } from '@hocuspocus/provider'
-// import { type SwaggerSpec, parse } from '@scalar/swagger-parser'
 import { type ThemeId, ThemeStyles } from '@scalar/themes'
-// import { useDebounceFn } from '@vueuse/core'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 
 import coinmarketcap from '../../coinmarketcapv3.json'
@@ -15,7 +13,6 @@ import {
   type SwaggerEditorProps,
 } from '../../types'
 import SwaggerEditorAIWriter from './SwaggerEditorAIWriter.vue'
-import SwaggerEditorGettingStarted from './SwaggerEditorGettingStarted.vue'
 import SwaggerEditorHeader from './SwaggerEditorHeader.vue'
 import SwaggerEditorInput from './SwaggerEditorInput.vue'
 import SwaggerEditorNotification from './SwaggerEditorNotification.vue'
@@ -25,7 +22,6 @@ const props = defineProps<SwaggerEditorProps>()
 
 const emit = defineEmits<{
   (e: 'contentUpdate', value: string): void
-  // (e: 'parsedSpecUpdate', spec: SwaggerSpec): void
   (e: 'import', value: string): void
   (e: 'changeTheme', value: ThemeId): void
   (
@@ -41,23 +37,6 @@ const swaggerEditorHeaderRef = ref<typeof SwaggerEditorHeader | null>(null)
 const awarenessStates = ref<StatesArray>([])
 
 const parserError = ref<string>('')
-
-// const handleSpecUpdate = useDebounceFn((value) => {
-//   // Store content in local storage
-//   if (!props.hocuspocusConfiguration) {
-//     localStorage.setItem('swagger-editor-content', value)
-//   }
-
-//   parse(value)
-//     .then((spec: SwaggerSpec) => {
-//       parserError.value = ''
-
-//       emit('parsedSpecUpdate', spec)
-//     })
-//     .catch((error) => {
-//       parserError.value = error.toString()
-//     })
-// })
 
 const rawContent = ref('')
 
@@ -84,11 +63,6 @@ onMounted(async () => {
 const handleAwarenessUpdate = (states: StatesArray) => {
   awarenessStates.value = states
 }
-
-// Import new content
-// const importHandler = (value: string) => {
-//   codeMirrorReference.value?.setCodeMirrorContent(value)
-// }
 
 const codeMirrorReference = ref<typeof SwaggerEditorInput | null>(null)
 

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -13,6 +13,7 @@ import {
   type SwaggerEditorProps,
 } from '../../types'
 import SwaggerEditorAIWriter from './SwaggerEditorAIWriter.vue'
+import SwaggerEditorGettingStarted from './SwaggerEditorGettingStarted.vue'
 import SwaggerEditorHeader from './SwaggerEditorHeader.vue'
 import SwaggerEditorInput from './SwaggerEditorInput.vue'
 import SwaggerEditorNotification from './SwaggerEditorNotification.vue'
@@ -174,12 +175,12 @@ defineExpose({
       }}
       online
     </SwaggerEditorStatusBar>
-    <!-- <SwaggerEditorGettingStarted
+    <SwaggerEditorGettingStarted
       v-show="activeTab === 'Getting Started'"
       :theme="!theme || theme === 'none' ? 'default' : theme"
       @changeExample="handleChangeExample"
       @changeTheme="emit('changeTheme', $event)"
-      @openSwaggerEditor="handleOpenSwaggerEditor" /> -->
+      @openSwaggerEditor="handleOpenSwaggerEditor" />
   </div>
 </template>
 

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { type StatesArray } from '@hocuspocus/provider'
-import { type SwaggerSpec, parse } from '@scalar/swagger-parser'
+// import { type SwaggerSpec, parse } from '@scalar/swagger-parser'
 import { type ThemeId, ThemeStyles } from '@scalar/themes'
-import { useDebounceFn } from '@vueuse/core'
+// import { useDebounceFn } from '@vueuse/core'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 
 import coinmarketcap from '../../coinmarketcapv3.json'
@@ -25,7 +25,7 @@ const props = defineProps<SwaggerEditorProps>()
 
 const emit = defineEmits<{
   (e: 'contentUpdate', value: string): void
-  (e: 'parsedSpecUpdate', spec: SwaggerSpec): void
+  // (e: 'parsedSpecUpdate', spec: SwaggerSpec): void
   (e: 'import', value: string): void
   (e: 'changeTheme', value: ThemeId): void
   (
@@ -42,22 +42,22 @@ const awarenessStates = ref<StatesArray>([])
 
 const parserError = ref<string>('')
 
-const handleSpecUpdate = useDebounceFn((value) => {
-  // Store content in local storage
-  if (!props.hocuspocusConfiguration) {
-    localStorage.setItem('swagger-editor-content', value)
-  }
+// const handleSpecUpdate = useDebounceFn((value) => {
+//   // Store content in local storage
+//   if (!props.hocuspocusConfiguration) {
+//     localStorage.setItem('swagger-editor-content', value)
+//   }
 
-  parse(value)
-    .then((spec: SwaggerSpec) => {
-      parserError.value = ''
+//   parse(value)
+//     .then((spec: SwaggerSpec) => {
+//       parserError.value = ''
 
-      emit('parsedSpecUpdate', spec)
-    })
-    .catch((error) => {
-      parserError.value = error.toString()
-    })
-})
+//       emit('parsedSpecUpdate', spec)
+//     })
+//     .catch((error) => {
+//       parserError.value = error.toString()
+//     })
+// })
 
 const rawContent = ref('')
 
@@ -86,9 +86,9 @@ const handleAwarenessUpdate = (states: StatesArray) => {
 }
 
 // Import new content
-const importHandler = (value: string) => {
-  codeMirrorReference.value?.setCodeMirrorContent(value)
-}
+// const importHandler = (value: string) => {
+//   codeMirrorReference.value?.setCodeMirrorContent(value)
+// }
 
 const codeMirrorReference = ref<typeof SwaggerEditorInput | null>(null)
 
@@ -117,7 +117,7 @@ async function handleChangeExample(example: GettingStartedExamples) {
 
   activeTab.value = 'Swagger Editor'
   await nextTick()
-  importHandler(spec)
+  handleContentUpdate(spec)
 }
 
 watch(
@@ -131,7 +131,7 @@ watch(
 )
 
 const activeTab = ref<EditorHeaderTabs>(
-  props.initialTabState ?? 'Getting Started',
+  props.initialTabState ?? 'Swagger Editor',
 )
 
 const handleOpenSwaggerEditor = (action?: OpenSwaggerEditorActions) => {
@@ -176,7 +176,7 @@ defineExpose({
       ref="swaggerEditorHeaderRef"
       :activeTab="activeTab"
       :proxyUrl="proxyUrl"
-      @import="importHandler"
+      @import="handleContentUpdate"
       @updateActiveTab="activeTab = $event" />
     <SwaggerEditorNotification
       v-if="activeTab === 'Swagger Editor' && formattedError">
@@ -200,12 +200,12 @@ defineExpose({
       }}
       online
     </SwaggerEditorStatusBar>
-    <SwaggerEditorGettingStarted
+    <!-- <SwaggerEditorGettingStarted
       v-show="activeTab === 'Getting Started'"
       :theme="!theme || theme === 'none' ? 'default' : theme"
       @changeExample="handleChangeExample"
       @changeTheme="emit('changeTheme', $event)"
-      @openSwaggerEditor="handleOpenSwaggerEditor" />
+      @openSwaggerEditor="handleOpenSwaggerEditor" /> -->
   </div>
 </template>
 

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { type StatesArray } from '@hocuspocus/provider'
 import { type ThemeId, ThemeStyles } from '@scalar/themes'
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, isRef, nextTick, onMounted, ref, watch } from 'vue'
 
 import coinmarketcap from '../../coinmarketcapv3.json'
 import petstore from '../../petstorev3.json'
@@ -37,8 +37,6 @@ const swaggerEditorHeaderRef = ref<typeof SwaggerEditorHeader | null>(null)
 
 const awarenessStates = ref<StatesArray>([])
 
-const parserError = ref<string>('')
-
 const rawContent = ref('')
 
 const handleContentUpdate = (value: string) => {
@@ -68,13 +66,18 @@ const handleAwarenessUpdate = (states: StatesArray) => {
 const codeMirrorReference = ref<typeof SwaggerEditorInput | null>(null)
 
 const formattedError = computed(() => {
-  // Handle YAMLExceptions
-  if (parserError.value?.startsWith('YAMLException:')) {
-    // Trim everything but the first line
-    return parserError.value.split('\n')[0]
+  if (!props.error) {
+    return ''
   }
 
-  return parserError.value
+  const error = isRef(props.error) ? props.error.value : props.error
+  // Handle YAMLExceptions
+  if (error.startsWith('YAMLException:')) {
+    // Trim everything but the first line
+    return error.split('\n')[0]
+  }
+
+  return error
 })
 
 async function handleChangeExample(example: GettingStartedExamples) {

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -4,7 +4,6 @@ import { useFileDialog } from '@vueuse/core'
 import { ref, watch } from 'vue'
 
 import { fetchSpecFromUrl } from '../../helpers'
-import spec from '../../petstorev3.json'
 import {
   type EditorHeaderTabs,
   type SwaggerEditorHeaderProps,
@@ -37,9 +36,7 @@ const specUrl = ref('')
 const handleImportUrl = () => {
   importUrlError.value = ''
 
-  fetchSpecFromUrl(specUrl.value, {
-    proxyUrl: props.proxyUrl,
-  })
+  fetchSpecFromUrl(specUrl.value, props.proxyUrl)
     .then(async (content) => {
       emit('import', content)
       importUrlModal.hide()
@@ -64,10 +61,6 @@ watch(files, () => {
     reader.readAsText(file)
   }
 })
-
-const useExample = () => {
-  emit('import', JSON.stringify(spec, null, 2))
-}
 </script>
 <template>
   <div class="swagger-editor-header">
@@ -119,11 +112,6 @@ const useExample = () => {
         @click="importUrlModal.show">
         Import URL
       </button>
-      <!-- <button
-        type="button"
-        @click="useExample">
-        Example
-      </button> -->
     </div>
   </div>
   <FlowModal

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -71,6 +71,14 @@ const useExample = () => {
 </script>
 <template>
   <div class="swagger-editor-header">
+    <!-- <div
+      class="swagger-editor-title"
+      :class="{
+        'swagger-editor-active': activeTab === 'Getting Started',
+      }"
+      @click="emit('updateActiveTab', 'Getting Started')">
+      <div class="swagger-editor-type">Getting Started</div>
+    </div> -->
     <div
       class="swagger-editor-title"
       :class="{

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -3,6 +3,7 @@ import { FlowModal, useModal } from '@scalar/use-modal'
 import { useFileDialog } from '@vueuse/core'
 import { ref, watch } from 'vue'
 
+import { fetchSpecFromUrl } from '../../helpers'
 import spec from '../../petstorev3.json'
 import {
   type EditorHeaderTabs,
@@ -10,7 +11,6 @@ import {
 } from '../../types'
 import FlowButton from '../FlowButton.vue'
 import FlowTextField from '../FlowTextField.vue'
-import { fetchSpecFromUrl } from './fetchSpecFromUrl'
 
 const props = defineProps<SwaggerEditorHeaderProps>()
 
@@ -254,3 +254,4 @@ const useExample = () => {
   text-transform: uppercase;
 }
 </style>
+../../../../api-reference/src/helpers/fetchSpecFromUrl../../helpers/fetchSpecFromUrl

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -254,4 +254,3 @@ const useExample = () => {
   text-transform: uppercase;
 }
 </style>
-../../../../api-reference/src/helpers/fetchSpecFromUrl../../helpers/fetchSpecFromUrl

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
@@ -23,7 +23,6 @@ const yCodeMirrorExtension = ref<any | null>(null)
 
 defineExpose({
   setCodeMirrorContent: (value: string) => {
-    console.log('setCodeMirrorContent')
     codeMirrorRef.value?.setCodeMirrorContent(value)
   },
 })
@@ -31,7 +30,6 @@ defineExpose({
 watch(
   () => props.hocuspocusConfiguration,
   () => {
-    console.log('hocuspocusConfiguration changed')
     if (provider) {
       provider.destroy()
       yCodeMirrorExtension.value = null

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { HocuspocusProvider, type StatesArray } from '@hocuspocus/provider'
 import { CodeMirror } from '@scalar/use-codemirror'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { yCollab as yjsCodeMirrorBinding } from 'y-codemirror.next'
 import * as Y from 'yjs'
 
@@ -23,13 +23,15 @@ const yCodeMirrorExtension = ref<any | null>(null)
 
 defineExpose({
   setCodeMirrorContent: (value: string) => {
+    console.log('setCodeMirrorContent')
     codeMirrorRef.value?.setCodeMirrorContent(value)
   },
 })
 
 watch(
-  props,
+  () => props.hocuspocusConfiguration,
   () => {
+    console.log('hocuspocusConfiguration changed')
     if (provider) {
       provider.destroy()
       yCodeMirrorExtension.value = null
@@ -90,10 +92,14 @@ watch(
       { undoManager },
     )
   },
-  { immediate: true },
+  { immediate: true, deep: true },
 )
 
 const codeMirrorRef = ref<typeof CodeMirror | null>(null)
+
+const codeMirrorExtensions = computed(() => {
+  return yCodeMirrorExtension.value ? [yCodeMirrorExtension] : []
+})
 </script>
 
 <template>
@@ -101,7 +107,7 @@ const codeMirrorRef = ref<typeof CodeMirror | null>(null)
     <CodeMirror
       ref="codeMirrorRef"
       :content="value"
-      :extensions="yCodeMirrorExtension ? [yCodeMirrorExtension] : []"
+      :extensions="codeMirrorExtensions"
       :languages="['json']"
       lineNumbers
       @change="(value: string) => $emit('contentUpdate', value)" />

--- a/packages/swagger-editor/src/helpers/fetchSpecFromUrl.ts
+++ b/packages/swagger-editor/src/helpers/fetchSpecFromUrl.ts
@@ -1,11 +1,11 @@
-export const fetchSpecFromUrl = async (
-  url: string,
-  { proxyUrl }: { proxyUrl?: string },
-) => {
+/**
+ * Fetches a spec file from a given URL.
+ */
+export const fetchSpecFromUrl = async (url: string, proxy: string) => {
   // With Proxy
-  if (proxyUrl) {
-    const response = proxyUrl
-      ? await fetch(proxyUrl, {
+  if (proxy) {
+    const response = proxy
+      ? await fetch(proxy, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -30,8 +30,8 @@ export const fetchSpecFromUrl = async (
       )
     }
 
+    // TODO: Deal with Yaml
     const data = JSON.parse(payload.data)
-
     return JSON.stringify(data, null, 2)
   }
   // Without proxy
@@ -40,6 +40,8 @@ export const fetchSpecFromUrl = async (
       '[fetchSpecFromUrl] Trying to fetch the spec file without a proxy. The CORS headers have to be set properly, otherwise the request will fail.',
     )
     const response = await fetch(url)
+
+    // TODO: Deal with Yaml
     const json = await response.json()
     return JSON.stringify(json, null, 2)
   }

--- a/packages/swagger-editor/src/helpers/fetchSpecFromUrl.ts
+++ b/packages/swagger-editor/src/helpers/fetchSpecFromUrl.ts
@@ -1,7 +1,7 @@
 /**
  * Fetches a spec file from a given URL.
  */
-export const fetchSpecFromUrl = async (url: string, proxy: string) => {
+export const fetchSpecFromUrl = async (url: string, proxy?: string) => {
   // With Proxy
   if (proxy) {
     const response = proxy

--- a/packages/swagger-editor/src/helpers/fetchSpecFromUrl.ts
+++ b/packages/swagger-editor/src/helpers/fetchSpecFromUrl.ts
@@ -30,9 +30,7 @@ export const fetchSpecFromUrl = async (url: string, proxy: string) => {
       )
     }
 
-    // TODO: Deal with Yaml
-    const data = JSON.parse(payload.data)
-    return JSON.stringify(data, null, 2)
+    return jsonOrYaml(payload.data)
   }
   // Without proxy
   else {
@@ -41,8 +39,17 @@ export const fetchSpecFromUrl = async (url: string, proxy: string) => {
     )
     const response = await fetch(url)
 
-    // TODO: Deal with Yaml
-    const json = await response.json()
-    return JSON.stringify(json, null, 2)
+    return jsonOrYaml(await response.text())
+  }
+}
+
+function jsonOrYaml(value: string) {
+  try {
+    // JSON
+    const data = JSON.parse(value)
+    return JSON.stringify(data, null, 2)
+  } catch {
+    // Yaml
+    return value
   }
 }

--- a/packages/swagger-editor/src/helpers/index.ts
+++ b/packages/swagger-editor/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './fetchSpecFromUrl'

--- a/packages/swagger-editor/src/index.ts
+++ b/packages/swagger-editor/src/index.ts
@@ -2,6 +2,7 @@ export {
   SwaggerEditor,
   SwaggerEditorGettingStarted,
 } from './components/SwaggerEditor'
+export * from './helpers'
 export * from './hooks'
 export * from './types'
 

--- a/packages/swagger-editor/src/types.ts
+++ b/packages/swagger-editor/src/types.ts
@@ -8,7 +8,7 @@ export type SwaggerEditorProps = {
   theme?: ThemeId
   initialTabState?: EditorHeaderTabs
   proxyUrl?: string
-  error?: string | Ref<string> | ComputedRef<string>
+  error?: string | Ref<string> | ComputedRef<string> | null
 }
 
 export type SwaggerEditorHeaderProps = {

--- a/packages/swagger-editor/src/types.ts
+++ b/packages/swagger-editor/src/types.ts
@@ -1,4 +1,5 @@
 import { type ThemeId } from '@scalar/themes'
+import { type ComputedRef, type Ref } from 'vue'
 
 export type SwaggerEditorProps = {
   aiWriterMarkdown?: string
@@ -7,6 +8,7 @@ export type SwaggerEditorProps = {
   theme?: ThemeId
   initialTabState?: EditorHeaderTabs
   proxyUrl?: string
+  error?: string | Ref<string> | ComputedRef<string>
 }
 
 export type SwaggerEditorHeaderProps = {

--- a/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
+++ b/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
@@ -55,7 +55,7 @@ const emit = defineEmits<{
   (e: 'change', value: string): void
 }>()
 
-// TODO: Add 'php' and 'laravel'
+// TODO: Add 'php'
 const syntaxHighlighting: Partial<
   Record<CodeMirrorLanguage, LanguageSupport | StreamLanguage<any>>
 > = {
@@ -176,16 +176,35 @@ const {
   forceDarkMode: props.forceDarkMode,
 })
 
-watch(props, () => {
-  setCodeMirrorContent(props.content ?? '')
-  reconfigureCodeMirror(getCodeMirrorExtensions())
-})
+// Content changed. Updating CodeMirror …
+watch(
+  () => props.content,
+  () => {
+    setCodeMirrorContent(props.content ?? '')
+  },
+)
 
-// If the passed extensions change, destroy and remount CodeMirror.
+// Extensions changed. Restarting CodeMirror …
 watch(
   () => props.extensions,
   () => {
     restartCodeMirror(getCodeMirrorExtensions())
+  },
+)
+
+// Settings changed. Reconfiguring CodeMirror …
+watch(
+  [
+    () => props.disableEnter,
+    () => props.forceDarkMode,
+    () => props.languages,
+    () => props.lineNumbers,
+    () => props.readOnly,
+    () => props.withoutTheme,
+    () => props.withVariables,
+  ],
+  () => {
+    reconfigureCodeMirror(getCodeMirrorExtensions())
   },
 )
 

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -145,11 +145,22 @@ export const useCodeMirror = (
   }
 
   const setCodeMirrorContent = (newValue: string) => {
+    // Check whether CodeMirror is mounted properly.
     if (!codeMirror.value) {
       return
     }
 
+    if (value.value === newValue) {
+      // No need to update the content ref
+      return
+    }
+
     value.value = newValue
+
+    if (codeMirror.value.state.doc.toString() === newValue) {
+      // No need to set the CodeMirror content
+      return
+    }
 
     codeMirror.value.dispatch({
       changes: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,9 +486,6 @@ importers:
       '@hocuspocus/provider':
         specifier: 2.5.0
         version: 2.5.0(y-protocols@1.0.6)(yjs@13.6.8)
-      '@scalar/swagger-parser':
-        specifier: workspace:*
-        version: link:../swagger-parser
       '@scalar/themes':
         specifier: workspace:*
         version: link:../themes

--- a/projects/web/src/pages/ApiReferencePage.vue
+++ b/projects/web/src/pages/ApiReferencePage.vue
@@ -12,45 +12,47 @@ const configuration = reactive<ReferenceConfiguration>({
   theme: 'default',
   proxy: 'http://localhost:5051',
   isEditable: true,
-<<<<<<< HEAD
   // spec: {
   //   preparsedContent,
   // },
-=======
-  searchHotKey: 'l',
   spec: {
-    content: { openapi: '3.1.0', info: { title: 'Example' }, paths: {} },
+    // content: { openapi: '3.1.0', info: { title: 'Example' }, paths: {} },
     // content: () => {
     //   return { openapi: '3.1.0', info: { title: 'Example' }, paths: {} }
     // },
     // preparsedContent,
     // url: 'https://raw.githubusercontent.com/testimio/public-openapi/TES-14404-mobile-applications/api.yaml',
   },
->>>>>>> fcc7127d (chore: keep CodeMirror in sync)
   tabs: {
     initialContent: 'Swagger Editor',
   },
 })
 
-const spec = ref<string>(
-  JSON.stringify({ openapi: '3.1.0', info: { title: 'Example' }, paths: {} }),
-)
+// const spec = ref<string>(
+//   JSON.stringify({ openapi: '3.1.0', info: { title: 'Example' }, paths: {} }),
+// )
 
-watch(spec, () => {
-  Object.assign(configuration, {
-    ...configuration,
-    spec: {
-      content: spec.value,
-    },
-  })
-})
+// watch(
+//   spec,
+//   () => {
+//     Object.assign(configuration, {
+//       ...configuration,
+//       spec: {
+//         content: spec.value,
+//       },
+//     })
+//   },
+//   // {
+//   //   immediate: true,
+//   // },
+// )
 </script>
 
 <template>
-  <textarea
+  <!-- <textarea
     v-model="spec"
     cols="30"
-    rows="10" />
+    rows="10" /> -->
   <!-- <div>
     <input
       v-model="configuration.isEditable"

--- a/projects/web/src/pages/ApiReferencePage.vue
+++ b/projects/web/src/pages/ApiReferencePage.vue
@@ -21,7 +21,7 @@ const configuration = reactive<ReferenceConfiguration>({
     //   return { openapi: '3.1.0', info: { title: 'Example' }, paths: {} }
     // },
     // preparsedContent,
-    url: 'https://raw.githubusercontent.com/outline/openapi/main/spec3.json',
+    // url: 'https://raw.githubusercontent.com/outline/openapi/main/spec3.json',
     // url: 'https://raw.githubusercontent.com/testimio/public-openapi/TES-14404-mobile-applications/api.yaml',
   },
   tabs: {

--- a/projects/web/src/pages/ApiReferencePage.vue
+++ b/projects/web/src/pages/ApiReferencePage.vue
@@ -4,7 +4,7 @@ import {
   type ReferenceConfiguration,
 } from '@scalar/api-reference'
 import { type ThemeId } from '@scalar/themes'
-import { reactive } from 'vue'
+import { reactive, ref, watch } from 'vue'
 
 // import preparsedContent from '../fixtures/specResult.json'
 
@@ -12,16 +12,45 @@ const configuration = reactive<ReferenceConfiguration>({
   theme: 'default',
   proxy: 'http://localhost:5051',
   isEditable: true,
+<<<<<<< HEAD
   // spec: {
   //   preparsedContent,
   // },
+=======
+  searchHotKey: 'l',
+  spec: {
+    content: { openapi: '3.1.0', info: { title: 'Example' }, paths: {} },
+    // content: () => {
+    //   return { openapi: '3.1.0', info: { title: 'Example' }, paths: {} }
+    // },
+    // preparsedContent,
+    // url: 'https://raw.githubusercontent.com/testimio/public-openapi/TES-14404-mobile-applications/api.yaml',
+  },
+>>>>>>> fcc7127d (chore: keep CodeMirror in sync)
   tabs: {
     initialContent: 'Swagger Editor',
   },
 })
+
+const spec = ref<string>(
+  JSON.stringify({ openapi: '3.1.0', info: { title: 'Example' }, paths: {} }),
+)
+
+watch(spec, () => {
+  Object.assign(configuration, {
+    ...configuration,
+    spec: {
+      content: spec.value,
+    },
+  })
+})
 </script>
 
 <template>
+  <textarea
+    v-model="spec"
+    cols="30"
+    rows="10" />
   <!-- <div>
     <input
       v-model="configuration.isEditable"

--- a/projects/web/src/pages/ApiReferencePage.vue
+++ b/projects/web/src/pages/ApiReferencePage.vue
@@ -21,6 +21,7 @@ const configuration = reactive<ReferenceConfiguration>({
     //   return { openapi: '3.1.0', info: { title: 'Example' }, paths: {} }
     // },
     // preparsedContent,
+    url: 'https://raw.githubusercontent.com/outline/openapi/main/spec3.json',
     // url: 'https://raw.githubusercontent.com/testimio/public-openapi/TES-14404-mobile-applications/api.yaml',
   },
   tabs: {

--- a/projects/web/src/pages/ApiReferencePage.vue
+++ b/projects/web/src/pages/ApiReferencePage.vue
@@ -4,7 +4,7 @@ import {
   type ReferenceConfiguration,
 } from '@scalar/api-reference'
 import { type ThemeId } from '@scalar/themes'
-import { reactive, ref, watch } from 'vue'
+import { reactive } from 'vue'
 
 // import preparsedContent from '../fixtures/specResult.json'
 


### PR DESCRIPTION
This PR refactors how the data flows between the reference and the editor.

**Before**
We’ve had a handful of props, refs, computed refs and watchers. Debugging what triggered what became so hard, we introduced regressions every time we touched it.

Example: Checkout `main`, scroll down in the swagger editor, start typing. The editor scrolls to the top. 👎  Instead of fixing just this, let’s refactor:

**After**
This PR moves all refs and watchers to `useSpec()` and `useParser()`. Probably still hard to reason what triggers what, but at least it’s mostly only one file that you need to look at.

And this PR adds tests for `useSpec` and `useParser`.