### PR TITLE
property overflow fix

### DIFF
--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -185,12 +185,14 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 <style scoped>
 .property {
   padding: 12px 0;
+  overflow: auto;
 }
 
 .property-information {
   display: flex;
   align-items: flex-end;
   gap: 9px;
+  white-space: nowrap;
 }
 
 .property-description {


### PR DESCRIPTION
Before:
<img width="642" alt="image" src="https://github.com/scalar/scalar/assets/6201407/3bd277de-5209-4aec-8d7f-1b866f719385">

After: 
<img width="631" alt="image" src="https://github.com/scalar/scalar/assets/6201407/2d200cb1-b79a-4c22-8fb4-780bef3a6efb">
(scrollable ui)