### PR TITLE
fix: re-add missing menu icon

### DIFF
--- a/packages/api-reference/src/components/Icon/icons/Menu.svg
+++ b/packages/api-reference/src/components/Icon/icons/Menu.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 14 14">
+    <path fill="none" stroke="currentColor" d="M14 3.4H0m14 7.2H0" />
+</svg>


### PR DESCRIPTION
This PR adds the `Menu.svg` icon that was removed in #369 as it is still used: https://github.com/scalar/scalar/blob/9b1e2653f0c46f053681bc126dec5a631e281658/packages/api-reference/src/components/MobileHeader.vue#L15