### PR TITLE
users not using themed css fallbacks

### DIFF
--- a/.changeset/brown-buckets-repair.md
+++ b/.changeset/brown-buckets-repair.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/use-modal': patch
+---
+
+users not using themed css fallbacks

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -134,26 +134,6 @@ export { useApiClientStore } from '@scalar/api-client'
 .scalar-api-client__close:hover {
   cursor: pointer;
 }
-/*
-TODO: Markup is missing
-.scalar-api-client__close__icon {
-  width: 28px;
-  height: 28px;
-  border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
-  margin-right: 12px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: var(--theme-color-2, var(--default-theme-color-2));
-}
-.scalar-api-client__close__icon:hover {
-  background: var(--theme-background-2, var(--default-theme-background-2));
-}
-.scalar-api-client__close__icon svg {
-  width: 12px;
-  height: 12px;
-  transform: rotate(180deg);
-} */
 .api-client-drawer {
   background: var(--theme-background-1, var(--default-theme-background-1));
   height: calc(100% - 58px);
@@ -167,6 +147,20 @@ TODO: Markup is missing
   z-index: 1001;
   opacity: 0;
   animation: apiclientfadein 0.35s forwards;
+}
+.api-client-drawer:before {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  z-index: 0;
+}
+.dark-mode .api-client-drawer:before {
+  background: #1a1a1a;
+}
+.light-mode .api-client-drawer:before {
+  background: #fff;
 }
 @keyframes apiclientfadein {
   from {

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -485,9 +485,8 @@ const setRef = (el: SidebarElementType, id: string) => {
 }
 
 .sidebar-mobile-actions .sidebar-mobile-darkmode-toggle {
-  height: 24px;
-  width: 24px;
-  margin-top: 0;
+  width: auto;
+  margin: 0;
 }
 .sidebar-mobile-actions .sidebar-mobile-darkmode-toggle .darklight {
   height: 24px;

--- a/packages/use-modal/src/components/FlowModal.vue
+++ b/packages/use-modal/src/components/FlowModal.vue
@@ -69,6 +69,7 @@ withDefaults(
   background: var(--theme-background-1, var(--default-theme-background-1));
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
   font-family: var(--theme-font, var(--default-theme-font));
+  position: relative;
 }
 .modal {
   margin: 80px auto 0;
@@ -84,6 +85,21 @@ withDefaults(
   animation: modal-pop 0.15s 0.15s forwards;
   display: flex;
   flex-direction: column;
+}
+.modal:before {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  z-index: 0;
+  border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
+}
+.dark-mode .modal:before {
+  background: #1a1a1a;
+}
+.light-mode .modal:before {
+  background: #fff;
 }
 .modal-content-history {
   background: var(--theme-background-1, var(--default-theme-background-1));


### PR DESCRIPTION
quick fixes for two common things I've seen 

Making our --theme-background-1 transparent (which makes search + client unusable)

And making darklight display: none; 