### PR TITLE
chore: don’t run ci on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
CI is running on push to main, but we don’t do anything with the output, so we could also not run it on push to main. :)

It’ll still running on all PRs.