### PR TITLE
fix: do not touch the content if nothing is configured

### DIFF
--- a/.changeset/short-bottles-push.md
+++ b/.changeset/short-bottles-push.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: don’t overwrite the content if there is nothing configured

--- a/packages/api-reference/src/hooks/useSpec.ts
+++ b/packages/api-reference/src/hooks/useSpec.ts
@@ -20,7 +20,7 @@ const rawSpecRef = ref('')
 const getSpecContent = async (
   { url, content }: SpecConfiguration,
   proxy?: string,
-): Promise<string> => {
+): Promise<string | undefined> => {
   if (url !== undefined && url.length > 0) {
     return await fetchSpecFromUrl(url, proxy)
   }

--- a/packages/api-reference/src/hooks/useSpec.ts
+++ b/packages/api-reference/src/hooks/useSpec.ts
@@ -42,7 +42,7 @@ const getSpecContent = async (
     )
   }
 
-  return ''
+  return undefined
 }
 
 /**
@@ -67,7 +67,9 @@ export function useSpec({
         async () => {
           if (configuration.value !== undefined) {
             getSpecContent(configuration.value, proxy).then((value) => {
-              setRawSpecRef(value)
+              if (value !== undefined) {
+                setRawSpecRef(value)
+              }
             })
           }
         },
@@ -80,7 +82,9 @@ export function useSpec({
     // Get the content once
     else {
       getSpecContent(configuration, proxy).then((value) => {
-        setRawSpecRef(value)
+        if (value !== undefined) {
+          setRawSpecRef(value)
+        }
       })
     }
   }


### PR DESCRIPTION
With #398 I introduced a regression: When a Swagger spec is added, and the config changes, the content is overwritten - even if there’s not configuration for it.

This PR adds a test and a fix.