### PR TITLE
chore: don’t overwrite the configuration constant

### DIFF
--- a/projects/web/src/pages/ApiReferencePage.vue
+++ b/projects/web/src/pages/ApiReferencePage.vue
@@ -52,7 +52,11 @@ const configuration = reactive<ReferenceConfiguration>({
     :configuration="configuration"
     @changeTheme="(theme: ThemeId) => (configuration.theme = theme)">
     <template #header>
-      <DevToolbar v-model="configuration" />
+      <DevToolbar
+        :modelValue="configuration"
+        @update:modelValue="
+          (newConfiguration) => Object.assign(configuration, newConfiguration)
+        " />
     </template>
     <template #footer>
       <MockFooter />


### PR DESCRIPTION
This PR fixes a warning in the reference demo. Let’s not overwrite the configuration constant, but assign the new configuration. 👍 

```
[plugin:vite:esbuild] This assignment will throw because "configuration" is a constant
50 |        _createVNode(DevToolbar, {
51 |          modelValue: configuration,
52 |          "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((configuration) = $event))
   |                                                                              ^
53 |        }, null, 8, ["modelValue"])
54 |      ]),
```