### PR TITLE
fix: types of @scalar/api-client-proxy

### DIFF
--- a/.changeset/great-panthers-help.md
+++ b/.changeset/great-panthers-help.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client-proxy': patch
+---
+
+fix: export types again


### PR DESCRIPTION
This PR only includes a changeset to force a new release of @scalar/api-client-proxy. At some point the build didn’t include the types anymore, but we fixed this already. With a force released, the package should include the types again.