### PR TITLE
chore: custom package json formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "syncpack": "11.2.1",
     "turbo": "1.10.15",
     "typescript": "5.2.2",
+    "vite-node": "0.34.4",
     "vue-eslint-parser": "9.3.1"
   },
   "pnpm": {
@@ -41,6 +42,7 @@
     "lint": "pnpm -r lint:check",
     "lint:fix": "pnpm -r lint:fix",
     "preview:standalone": "pnpm --filter api-reference preview:standalone",
+    "script:package-files": "vite-node scripts/format-package.ts",
     "test": "pnpm -r test",
     "types:check": "pnpm -r types:check"
   }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -47,6 +47,8 @@
   },
   "scripts": {
     "build": "vite build && pnpm types:build && tsc-alias -p tsconfig.build.json",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "types:build": "vue-tsc -p tsconfig.build.json",
     "types:check": "vue-tsc --noEmit --skipLibCheck --composite false"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       typescript:
         specifier: 5.2.2
         version: 5.2.2
+      vite-node:
+        specifier: 0.34.4
+        version: 0.34.4(@types/node@20.6.3)
       vue-eslint-parser:
         specifier: 9.3.1
         version: 9.3.1(eslint@8.49.0)

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -1,0 +1,178 @@
+import fs from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { printColor } from './utility'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+type PackageType = 'examples' | 'packages'
+
+/**
+ * # Formatting script for package.json files
+ * Sorts, defaults and overrides keys as specified in the definitions below
+ */
+
+/** List of keys to sort and format */
+const restrictedKeys = [
+  'name',
+  'description',
+  'license',
+  'author',
+  'homepage',
+  'bugs',
+  'keywords',
+  'version',
+  'private',
+  'engines',
+  'packageManager',
+  'scripts',
+  'type',
+  'main',
+  'types',
+  'exports',
+  'files',
+  'UNSORTED',
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+]
+
+/** Sort nested keys in these fields */
+const sortKeys = ['dependencies', 'devDependencies', 'scripts']
+
+/** Provide hardcoded overrides for some fields */
+const overrides: Record<string, unknown> = {
+  license: 'MIT',
+  author: 'Scalar (https://github.com/scalar)',
+  bugs: 'https://github.com/scalar/scalar/issues/new',
+  homepage: 'https://github.com/scalar/scalar',
+}
+
+/** Provide default values for some fields */
+const fallbacks: Record<string, unknown> = {
+  engines: {
+    node: '>=18',
+  },
+}
+
+/** Format a package json file and validate scalar-org linting rules */
+async function formatPackage(filepath: string) {
+  const file = await fs.readFile(filepath, 'utf-8').catch(() => null)
+
+  if (!file) {
+    return
+  }
+
+  const data = JSON.parse(file)
+
+  if (
+    !data.name.startsWith('@scalar/') &&
+    !data.name.startsWith('@scalar-examples/')
+  ) {
+    printColor(
+      'yellow',
+      `Package ${data.name} is not in the @scalar/* or @scalar-examples/* scope.`,
+    )
+  }
+
+  const unsortedKeys = Object.keys(data).filter(
+    (key) => !restrictedKeys.includes(key),
+  )
+
+  const formattedData: Record<string, any> = {}
+
+  restrictedKeys.forEach((key) => {
+    if (key === 'UNSORTED') {
+      // Add in all unsorted keys at a designated sort point
+      unsortedKeys.forEach((uKey) => {
+        formattedData[uKey] = data[uKey]
+      })
+    } else {
+      // Either assign the override or the data in sorted order
+      const value = overrides[key] ?? data[key] ?? fallbacks[key]
+      if (value) {
+        formattedData[key] = value
+      }
+    }
+  })
+
+  // Validate before sorting
+  // Check that required scripts are entered
+  validatePackageScripts(formattedData['scripts'], formattedData.name)
+
+  // Sort nested keys alphanumerically
+  sortKeys.forEach((key) => {
+    if (formattedData[key]) {
+      formattedData[key] = sortObjectKeys(formattedData[key])
+    }
+  })
+
+  if (JSON.stringify(data) !== JSON.stringify(formattedData)) {
+    printColor('green', `Package file at ${filepath} was formatted`)
+  }
+
+  await fs
+    .writeFile(filepath, JSON.stringify(formattedData, null, 2) + '\n')
+    .catch((err) => console.error(err))
+}
+
+async function formatDirectoryPackageFiles(folder: PackageType) {
+  const packages = await fs.readdir(__dirname + `/../${folder}`)
+  await Promise.all(
+    packages.map((dir) =>
+      formatPackage(__dirname + `/../${folder}/${dir}/package.json`, folder),
+    ),
+  )
+}
+/**
+ * Lint all package.json files in the project. Sorts keys and checks critical fields like
+ * licenses and private.
+ */
+const run = async () => {
+  await formatDirectoryPackageFiles('packages')
+  await formatDirectoryPackageFiles('examples')
+}
+
+run()
+
+// ---------------------------------------------------------------------------
+// Helpers
+
+/** Sort object keys alphanumerically */
+function sortObjectKeys(obj: Record<string, any>) {
+  const sorted: Record<string, any> = {}
+  Object.keys(obj)
+    .sort()
+    .forEach((key) => {
+      sorted[key] = obj[key]
+    })
+
+  return sorted
+}
+
+/** Validate that required package scripts exists */
+function validatePackageScripts(
+  scripts: Record<string, string>,
+  packageName: string,
+) {
+  if (!scripts) {
+    printColor('yellow', `WARNING: No scripts detected for ${packageName}`)
+    return
+  }
+  const required = ['lint:fix', 'lint:check', 'types:check', 'format']
+
+  required.forEach((scriptName) => {
+    const command = scripts[scriptName]
+
+    // Require basic scripts for top level formatting
+    if (!command) {
+      printColor(
+        'yellow',
+        `Package file is missing the required script ${scriptName} in ${packageName}`,
+      )
+      return
+    }
+  })
+}

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -1,3 +1,7 @@
+/**
+ * This script formats package.json files in the project. It sorts keys and checks critical fields like
+ * licenses and private.
+ */
 import fs from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -161,7 +161,7 @@ function validatePackageScripts(
     printColor('yellow', `WARNING: No scripts detected for ${packageName}`)
     return
   }
-  const required = ['lint:fix', 'lint:check', 'types:check', 'format']
+  const required = ['lint:fix', 'lint:check', 'types:check']
 
   required.forEach((scriptName) => {
     const command = scripts[scriptName]
@@ -170,7 +170,7 @@ function validatePackageScripts(
     if (!command) {
       printColor(
         'yellow',
-        `Package file is missing the required script ${scriptName} in ${packageName}`,
+        `[${packageName}] package.json is missing a required script: ${scriptName}`,
       )
       return
     }

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -110,7 +110,7 @@ async function formatPackage(filepath: string) {
   })
 
   if (JSON.stringify(data) !== JSON.stringify(formattedData)) {
-    printColor('green', `Package file at ${filepath} was formatted`)
+    printColor('green', `[${formattedData.name}] package.json formatted`)
   }
 
   await fs
@@ -122,7 +122,7 @@ async function formatDirectoryPackageFiles(folder: PackageType) {
   const packages = await fs.readdir(__dirname + `/../${folder}`)
   await Promise.all(
     packages.map((dir) =>
-      formatPackage(__dirname + `/../${folder}/${dir}/package.json`, folder),
+      formatPackage(__dirname + `/../${folder}/${dir}/package.json`),
     ),
   )
 }

--- a/scripts/utility.ts
+++ b/scripts/utility.ts
@@ -1,0 +1,28 @@
+/** A list of colors that can be used in the console */
+export const ansiColors = {
+  black: 30,
+  red: 31,
+  green: 32,
+  yellow: 33,
+  blue: 34,
+  magenta: 35,
+  cyan: 36,
+  white: 37,
+  gray: 90,
+  brightRed: 91,
+  brightGreen: 92,
+  brightYellow: 93,
+  brightBlue: 94,
+  brightMagenta: 95,
+  brightCyan: 96,
+  brightWhite: 97,
+} as const
+
+/** Log to the console with a specific color */
+export function printColor(color: keyof typeof ansiColors, message: string) {
+  if (!ansiColors[color]) {
+    return console.log(message)
+  }
+
+  console.log(`\x1b[${ansiColors[color]}m${message}\x1b[0m`)
+}


### PR DESCRIPTION
Took the custom formatting script from #425 and added it to the repository. 🙌

Changed some minor details and used vite-node instead of bun. I don’t really care, but vite-node is already used 7 other packages in the repository.

This PR doesn’t actually apply the formatting, we’ll do this in a separate PR when the PR list is shorter.