### PR TITLE
fix: hide version if it’s not set

### DIFF
--- a/.changeset/lucky-turtles-play.md
+++ b/.changeset/lucky-turtles-play.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: don’t show a version badge if no version is defined

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -38,12 +38,16 @@ const specVersion = computed(() => {
       <SectionContent :loading="!info.description && !info.title">
         <SectionColumns>
           <SectionColumn>
-            <span class="section-version">{{ info.version }}</span>
+            <span
+              v-if="info.version"
+              class="section-version">
+              {{ info.version }}
+            </span>
             <span
               v-if="specVersion"
-              class="section-oas"
-              >OAS {{ specVersion }}</span
-            >
+              class="section-oas">
+              OAS {{ specVersion }}
+            </span>
             <SectionHeader
               :level="1"
               :loading="!info.title"


### PR DESCRIPTION
The version field is required according to the OpenAPI spec, but the parser won’t complain. So let’s ignore it, if there’s no version defined.

We don’t need this for the OpenAPI version. The parser requires this field.

**Before**
<img width="269" alt="Screenshot 2023-11-06 at 15 05 57" src="https://github.com/scalar/scalar/assets/1577992/d38d5b5d-b178-4f40-add8-278f6e5db035">

**After**
<img width="304" alt="Screenshot 2023-11-06 at 15 07 06" src="https://github.com/scalar/scalar/assets/1577992/c51a11b8-d700-4d76-9a50-5849c70d2211">
