### PR TITLE
fix: examples in collaborative editing mode

### DIFF
--- a/.changeset/red-pugs-impress.md
+++ b/.changeset/red-pugs-impress.md
@@ -1,0 +1,6 @@
+---
+'@scalar/swagger-editor': patch
+'@scalar/api-reference': patch
+---
+
+refactor: move getting started example to GettingStarted component

--- a/.changeset/thirty-terms-thank.md
+++ b/.changeset/thirty-terms-thank.md
@@ -1,0 +1,6 @@
+---
+'@scalar/swagger-editor': patch
+'@scalar/api-reference': patch
+---
+
+fix: don’t overwrite the CodeMirror content when collaborative editing is enabled

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -134,7 +134,8 @@ const { toggleDarkMode, isDark } = useDarkModeState()
     :rawSpec="rawSpecRef"
     :swaggerEditorRef="swaggerEditorRef"
     @changeTheme="$emit('changeTheme', $event)"
-    @toggleDarkMode="toggleDarkMode">
+    @toggleDarkMode="toggleDarkMode"
+    @updateContent="(newContent: string) => setRawSpecRef(newContent)">
     <template #header>
       <slot name="header" />
     </template>

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -140,6 +140,7 @@ const showSwaggerEditor = computed(() => {
             #empty-state>
             <SwaggerEditorGettingStarted
               :theme="currentConfiguration?.theme || 'default'"
+              :value="rawSpec"
               @changeTheme="$emit('changeTheme', $event)"
               @openSwaggerEditor="swaggerEditorRef?.handleOpenSwaggerEditor"
               @updateContent="$emit('updateContent', $event)" />

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -26,6 +26,7 @@ const props = defineProps<{
 
 defineEmits<{
   (e: 'changeTheme', value: ThemeId): void
+  (e: 'updateContent', value: string): void
   (e: 'toggleDarkMode'): void
 }>()
 
@@ -139,9 +140,9 @@ const showSwaggerEditor = computed(() => {
             #empty-state>
             <SwaggerEditorGettingStarted
               :theme="currentConfiguration?.theme || 'default'"
-              @changeExample="swaggerEditorRef?.handleChangeExample"
               @changeTheme="$emit('changeTheme', $event)"
-              @openSwaggerEditor="swaggerEditorRef?.handleOpenSwaggerEditor" />
+              @openSwaggerEditor="swaggerEditorRef?.handleOpenSwaggerEditor"
+              @updateContent="$emit('updateContent', $event)" />
           </template>
         </Content>
       </div>

--- a/packages/api-reference/src/hooks/useParser.ts
+++ b/packages/api-reference/src/hooks/useParser.ts
@@ -65,7 +65,9 @@ export function useParser({
       return
     }
 
-    parse(value)
+    const processedValue = value.trim()
+
+    parse(processedValue)
       .then((spec) => {
         errorRef.value = null
 

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -34,14 +34,7 @@ const swaggerEditorHeaderRef = ref<typeof SwaggerEditorHeader | null>(null)
 
 const awarenessStates = ref<StatesArray>([])
 
-const rawContent = ref('')
-
 const handleContentUpdate = (value: string) => {
-  if (value === rawContent.value) {
-    return
-  }
-
-  rawContent.value = value
   emit('contentUpdate', value)
 }
 
@@ -94,7 +87,7 @@ const handleOpenSwaggerEditor = (action?: OpenSwaggerEditorActions) => {
 }
 
 function handleAIWriter(queries: string[]) {
-  const content = rawContent.value ?? props.value ?? ''
+  const content = props.value ?? ''
   const specType = isJsonString(content) ? 'json' : 'yaml'
   emit('startAIWriter', queries, content, specType)
 }
@@ -120,7 +113,7 @@ defineExpose({
       v-if="activeTab === 'Swagger Editor'"
       ref="codeMirrorReference"
       :hocuspocusConfiguration="hocuspocusConfiguration"
-      :value="props.value ?? ''"
+      :value="value"
       @awarenessUpdate="handleAwarenessUpdate"
       @contentUpdate="handleContentUpdate" />
     <SwaggerEditorAIWriter
@@ -137,7 +130,7 @@ defineExpose({
     <SwaggerEditorGettingStarted
       v-show="activeTab === 'Getting Started'"
       :theme="!theme || theme === 'none' ? 'default' : theme"
-      :value="rawContent"
+      :value="value"
       @changeTheme="emit('changeTheme', $event)"
       @openSwaggerEditor="handleOpenSwaggerEditor"
       @updateContent="handleContentUpdate" />

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -137,6 +137,7 @@ defineExpose({
     <SwaggerEditorGettingStarted
       v-show="activeTab === 'Getting Started'"
       :theme="!theme || theme === 'none' ? 'default' : theme"
+      :value="rawContent"
       @changeTheme="emit('changeTheme', $event)"
       @openSwaggerEditor="handleOpenSwaggerEditor"
       @updateContent="handleContentUpdate" />

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -1,15 +1,11 @@
 <script lang="ts" setup>
 import { type StatesArray } from '@hocuspocus/provider'
 import { type ThemeId, ThemeStyles } from '@scalar/themes'
-import { computed, isRef, nextTick, ref, watch } from 'vue'
+import { computed, isRef, ref, watch } from 'vue'
 
-import coinmarketcap from '../../coinmarketcapv3.json'
 import { isJsonString } from '../../helpers'
-import petstore from '../../petstorev3.json'
-import tableau from '../../tableauv3.json'
 import {
   type EditorHeaderTabs,
-  type GettingStartedExamples,
   type OpenSwaggerEditorActions,
   type SwaggerEditorProps,
 } from '../../types'
@@ -73,24 +69,6 @@ const formattedError = computed(() => {
   return error
 })
 
-async function handleChangeExample(example: GettingStartedExamples) {
-  let spec = ''
-
-  if (example === 'Petstore') {
-    spec = JSON.stringify(petstore, null, 2)
-  } else if (example === 'CoinMarketCap') {
-    spec = JSON.stringify(coinmarketcap, null, 2)
-  } else if (example === 'Tableau') {
-    spec = JSON.stringify(tableau, null, 2)
-  } else {
-    return
-  }
-
-  activeTab.value = 'Swagger Editor'
-  await nextTick()
-  handleContentUpdate(spec)
-}
-
 watch(
   () => props.value,
   async () => {
@@ -123,7 +101,6 @@ function handleAIWriter(queries: string[]) {
 
 defineExpose({
   handleOpenSwaggerEditor,
-  handleChangeExample,
 })
 </script>
 <template>
@@ -160,9 +137,9 @@ defineExpose({
     <SwaggerEditorGettingStarted
       v-show="activeTab === 'Getting Started'"
       :theme="!theme || theme === 'none' ? 'default' : theme"
-      @changeExample="handleChangeExample"
       @changeTheme="emit('changeTheme', $event)"
-      @openSwaggerEditor="handleOpenSwaggerEditor" />
+      @openSwaggerEditor="handleOpenSwaggerEditor"
+      @updateContent="handleContentUpdate" />
   </div>
 </template>
 

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -110,7 +110,7 @@ defineExpose({
       {{ formattedError }}
     </SwaggerEditorNotification>
     <SwaggerEditorInput
-      v-if="activeTab === 'Swagger Editor'"
+      v-show="activeTab === 'Swagger Editor'"
       ref="codeMirrorReference"
       :hocuspocusConfiguration="hocuspocusConfiguration"
       :value="value"

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorGettingStarted.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorGettingStarted.vue
@@ -2,6 +2,9 @@
 import { type ThemeId } from '@scalar/themes'
 import { ref, watch } from 'vue'
 
+import coinmarketcap from '../../coinmarketcapv3.json'
+import petstore from '../../petstorev3.json'
+import tableau from '../../tableauv3.json'
 import { type GettingStartedExamples } from '../../types'
 import FlowButton from '../FlowButton.vue'
 
@@ -12,7 +15,7 @@ defineProps<{
 const emits = defineEmits<{
   (e: 'changeTheme', value: ThemeId): void
   (e: 'openSwaggerEditor', action?: 'importUrl' | 'uploadFile'): void
-  (e: 'changeExample', value: GettingStartedExamples): void
+  (e: 'updateContent', value: string): void
 }>()
 
 const themeIds: ThemeId[] = [
@@ -23,12 +26,26 @@ const themeIds: ThemeId[] = [
   'solarized',
 ]
 
-const activeExample = ref<GettingStartedExamples | null>(null)
+const example = ref<GettingStartedExamples | null>(null)
 
-watch(activeExample, () => {
-  if (activeExample.value) {
-    emits('changeExample', activeExample.value)
+watch(example, () => {
+  if (!example.value) {
+    return
   }
+
+  let content = ''
+
+  if (example.value === 'Petstore') {
+    content = JSON.stringify(petstore, null, 2)
+  } else if (example.value === 'CoinMarketCap') {
+    content = JSON.stringify(coinmarketcap, null, 2)
+  } else if (example.value === 'Tableau') {
+    content = JSON.stringify(tableau, null, 2)
+  } else {
+    return
+  }
+
+  emits('updateContent', content)
 })
 </script>
 <template>
@@ -42,7 +59,7 @@ watch(activeExample, () => {
     <div class="start-cta flex flex-row gap-1">
       <FlowButton
         label="Test Petstore"
-        @click="activeExample = 'Petstore'" />
+        @click="example = 'Petstore'" />
       <FlowButton
         label="Upload File"
         variant="outlined"
@@ -53,8 +70,8 @@ watch(activeExample, () => {
         <div class="start-h2">EXAMPLES</div>
         <div
           class="start-item"
-          :class="{ 'start-item-active': activeExample === 'Petstore' }"
-          @click="activeExample = 'Petstore'">
+          :class="{ 'start-item-active': example === 'Petstore' }"
+          @click="example = 'Petstore'">
           <svg
             baseProfile="tiny"
             fill="currentColor"
@@ -71,8 +88,8 @@ watch(activeExample, () => {
         </div>
         <div
           class="start-item"
-          :class="{ 'start-item-active': activeExample === 'Tableau' }"
-          @click="activeExample = 'Tableau'">
+          :class="{ 'start-item-active': example === 'Tableau' }"
+          @click="example = 'Tableau'">
           <svg
             height="2478.8"
             viewBox="0 0 2500 2478.8"
@@ -110,8 +127,8 @@ watch(activeExample, () => {
         </div>
         <div
           class="start-item"
-          :class="{ 'start-item-active': activeExample === 'CoinMarketCap' }"
-          @click="activeExample = 'CoinMarketCap'">
+          :class="{ 'start-item-active': example === 'CoinMarketCap' }"
+          @click="example = 'CoinMarketCap'">
           <svg
             height="586"
             viewBox="0 0 577.5 586"

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorGettingStarted.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorGettingStarted.vue
@@ -8,8 +8,9 @@ import tableau from '../../tableauv3.json'
 import { type GettingStartedExamples } from '../../types'
 import FlowButton from '../FlowButton.vue'
 
-defineProps<{
+const props = defineProps<{
   theme: ThemeId
+  value?: string
 }>()
 
 const emits = defineEmits<{
@@ -28,25 +29,32 @@ const themeIds: ThemeId[] = [
 
 const example = ref<GettingStartedExamples | null>(null)
 
+// When the example id changes, update the content.
 watch(example, () => {
   if (!example.value) {
     return
   }
 
-  let content = ''
+  emits('updateContent', getContentForExample(example.value))
+})
 
-  if (example.value === 'Petstore') {
-    content = JSON.stringify(petstore, null, 2)
-  } else if (example.value === 'CoinMarketCap') {
-    content = JSON.stringify(coinmarketcap, null, 2)
-  } else if (example.value === 'Tableau') {
-    content = JSON.stringify(tableau, null, 2)
-  } else {
-    return
+// Compares the content with the content for the given example id
+function isActiveExample(exampleId: string) {
+  return getContentForExample(exampleId) === props.value
+}
+
+// Petstore -> { … }
+function getContentForExample(exampleId: string) {
+  if (exampleId === 'Petstore') {
+    return JSON.stringify(petstore, null, 2)
+  } else if (exampleId === 'CoinMarketCap') {
+    return JSON.stringify(coinmarketcap, null, 2)
+  } else if (exampleId === 'Tableau') {
+    return JSON.stringify(tableau, null, 2)
   }
 
-  emits('updateContent', content)
-})
+  return ''
+}
 </script>
 <template>
   <div class="start custom-scroll">
@@ -70,7 +78,7 @@ watch(example, () => {
         <div class="start-h2">EXAMPLES</div>
         <div
           class="start-item"
-          :class="{ 'start-item-active': example === 'Petstore' }"
+          :class="{ 'start-item-active': isActiveExample('Petstore') }"
           @click="example = 'Petstore'">
           <svg
             baseProfile="tiny"
@@ -88,7 +96,7 @@ watch(example, () => {
         </div>
         <div
           class="start-item"
-          :class="{ 'start-item-active': example === 'Tableau' }"
+          :class="{ 'start-item-active': isActiveExample('Tableau') }"
           @click="example = 'Tableau'">
           <svg
             height="2478.8"
@@ -127,7 +135,7 @@ watch(example, () => {
         </div>
         <div
           class="start-item"
-          :class="{ 'start-item-active': example === 'CoinMarketCap' }"
+          :class="{ 'start-item-active': isActiveExample('CoinMarketCap') }"
           @click="example = 'CoinMarketCap'">
           <svg
             height="586"

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorGettingStarted.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorGettingStarted.vue
@@ -39,7 +39,11 @@ watch(example, () => {
 })
 
 // Compares the content with the content for the given example id
-function isActiveExample(exampleId: string) {
+function isActiveExample(exampleId: string | null) {
+  if (exampleId === null) {
+    return false
+  }
+
   return getContentForExample(exampleId) === props.value
 }
 
@@ -55,6 +59,17 @@ function getContentForExample(exampleId: string) {
 
   return ''
 }
+
+watch(
+  () => props.value,
+  () => {
+    if (isActiveExample(example.value)) {
+      return
+    }
+
+    example.value = null
+  },
+)
 </script>
 <template>
   <div class="start custom-scroll">

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
@@ -119,7 +119,7 @@ function getSyntaxHighlighting(content?: string): CodeMirrorLanguage[] {
   <div class="swagger-editor-input">
     <CodeMirror
       ref="codeMirrorRef"
-      :content="value"
+      :content="!props.hocuspocusConfiguration ? value : undefined"
       :extensions="yCodeMirrorExtension ? [yCodeMirrorExtension] : []"
       :languages="getSyntaxHighlighting(value)"
       lineNumbers

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
@@ -51,9 +51,11 @@ watch(
         )
       },
       onConnect() {
-        console.log(
-          `[SwaggerEditor] 🟢 onConnect (${HocuspocusProviderConfiguration?.name})`,
-        )
+        if (!HocuspocusProviderConfiguration.token) {
+          console.log(
+            `[SwaggerEditor] 🟢 onConnect (${HocuspocusProviderConfiguration?.name})`,
+          )
+        }
       },
       onAuthenticationFailed() {
         console.log(

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
@@ -36,6 +36,9 @@ watch(
       yCodeMirrorExtension.value = null
     }
 
+    // Reset the content, before loading a new Y.js document
+    emit('contentUpdate', '')
+
     if (!props.hocuspocusConfiguration) {
       return
     }

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorInput.vue
@@ -62,6 +62,11 @@ watch(
           `[SwaggerEditor] ❌ onAuthenticationFailed (${HocuspocusProviderConfiguration?.name})`,
         )
       },
+      onSynced() {
+        console.log(
+          `[SwaggerEditor] 🔄 onSynced (${HocuspocusProviderConfiguration?.name})`,
+        )
+      },
       onDisconnect() {
         console.log(
           `[SwaggerEditor] ⚪️ onDisconnect (${HocuspocusProviderConfiguration?.name})`,
@@ -119,7 +124,7 @@ function getSyntaxHighlighting(content?: string): CodeMirrorLanguage[] {
   <div class="swagger-editor-input">
     <CodeMirror
       ref="codeMirrorRef"
-      :content="!props.hocuspocusConfiguration ? value : undefined"
+      :content="value"
       :extensions="yCodeMirrorExtension ? [yCodeMirrorExtension] : []"
       :languages="getSyntaxHighlighting(value)"
       lineNumbers

--- a/projects/web/src/components/DevToolbar.vue
+++ b/projects/web/src/components/DevToolbar.vue
@@ -72,26 +72,32 @@ watch(
     <div class="references-dev-options">
       <div>
         <input
+          :checked="configuration.isEditable"
           type="checkbox"
-          :value="configuration.isEditable"
           @input="
             (event) =>
               emit(
                 'update:modelValue',
-                getCompleteConfiguration((event.target as HTMLSelectElement).value),
+                getCompleteConfiguration({
+                  ...configuration,
+                  isEditable: (event.target as HTMLInputElement).checked
+                }),
               )
           " />
         isEditable
       </div>
       <div>
         <input
+          :checked="configuration.footerBelowSidebar"
           type="checkbox"
-          :value="configuration.footerBelowSidebar"
           @input="
             (event) =>
               emit(
                 'update:modelValue',
-                getCompleteConfiguration((event.target as HTMLSelectElement).value),
+                getCompleteConfiguration({
+                  ...configuration,
+                  footerBelowSidebar: (event.target as HTMLInputElement).checked
+                }),
               )
           " />
         footerBelowSidebar
@@ -104,7 +110,10 @@ watch(
             (event) =>
               emit(
                 'update:modelValue',
-                getCompleteConfiguration((event.target as HTMLSelectElement).value),
+                getCompleteConfiguration({
+                  ...configuration,
+                  theme: (event.target as HTMLInputElement).value
+                }),
               )
           ">
           <option

--- a/projects/web/src/components/DevToolbar.vue
+++ b/projects/web/src/components/DevToolbar.vue
@@ -11,19 +11,50 @@ const emit = defineEmits<{
   (e: 'update:modelValue', v: ReferenceConfiguration): void
 }>()
 
-const configuration = computed({
-  get: () => props.modelValue,
-  set: (v: ReferenceConfiguration) => emit('update:modelValue', v),
+// Alias
+const configuration = computed(() => props.modelValue)
+
+// The collaborative editing configuration is an object and not just true/false, that’s
+// why we’re keeping track of it separately.
+const enableCollaborativeEditingRef = ref<boolean>(false)
+const collaborativeEditingDocumentRef = ref<string>('document-1')
+
+// This adds the collaborative editing configuration to the configuration object.
+function getCompleteConfiguration(v: any) {
+  if (enableCollaborativeEditingRef.value) {
+    return {
+      ...v,
+      hocuspocusConfiguration: {
+        name: collaborativeEditingDocumentRef.value,
+        token: 'secret',
+        url: 'ws://localhost:1234',
+      },
+    }
+  }
+
+  return {
+    ...v,
+    hocuspocusConfiguration: undefined,
+  }
+}
+
+// If one of the separate refs update, emit the new configuration
+watch([enableCollaborativeEditingRef, collaborativeEditingDocumentRef], () => {
+  emit('update:modelValue', getCompleteConfiguration(configuration.value))
 })
-const showToolbar = ref(true)
 
 const docStyle = document.documentElement.style
 
+// Toggle the toolbar visibility
+const showToolbar = ref(true)
 watch(
   showToolbar,
   (show) => {
-    if (show) docStyle.setProperty('--theme-header-height', '40px')
-    else docStyle.removeProperty('--theme-header-height')
+    if (show) {
+      docStyle.setProperty('--theme-header-height', '40px')
+    } else {
+      docStyle.removeProperty('--theme-header-height')
+    }
   },
   { immediate: true },
 )
@@ -41,25 +72,60 @@ watch(
     <div class="references-dev-options">
       <div>
         <input
-          v-model="configuration.isEditable"
-          type="checkbox" />
+          type="checkbox"
+          :value="configuration.isEditable"
+          @input="
+            (event) =>
+              emit(
+                'update:modelValue',
+                getCompleteConfiguration((event.target as HTMLSelectElement).value),
+              )
+          " />
         isEditable
       </div>
       <div>
         <input
-          v-model="configuration.footerBelowSidebar"
-          type="checkbox" />
+          type="checkbox"
+          :value="configuration.footerBelowSidebar"
+          @input="
+            (event) =>
+              emit(
+                'update:modelValue',
+                getCompleteConfiguration((event.target as HTMLSelectElement).value),
+              )
+          " />
         footerBelowSidebar
       </div>
       <div>
         Theme:
-        <select v-model="configuration.theme">
+        <select
+          :value="configuration.theme"
+          @input="
+            (event) =>
+              emit(
+                'update:modelValue',
+                getCompleteConfiguration((event.target as HTMLSelectElement).value),
+              )
+          ">
           <option
             v-for="theme in availableThemes"
             :key="theme"
             :value="theme">
             {{ theme }}
           </option>
+        </select>
+      </div>
+      <div>
+        <input
+          v-model="enableCollaborativeEditingRef"
+          type="checkbox" />
+        Collaborative Editing{{ enableCollaborativeEditingRef ? ':' : '' }}
+        <select
+          v-if="enableCollaborativeEditingRef"
+          v-model="collaborativeEditingDocumentRef">
+          <option value="document-1">Document #1</option>
+          <option value="document-2">Document #2</option>
+          <option value="document-3">Document #3</option>
         </select>
       </div>
       <button

--- a/projects/web/src/pages/ApiReferencePage.vue
+++ b/projects/web/src/pages/ApiReferencePage.vue
@@ -32,11 +32,6 @@ const configuration = reactive<ReferenceConfiguration>({
   tabs: {
     initialContent: 'Swagger Editor',
   },
-  // hocuspocusConfiguration: {
-  //   name: 'document-1',
-  //   token: 'secret',
-  //   url: 'ws://localhost:1234',
-  // },
 })
 </script>
 
@@ -45,14 +40,6 @@ const configuration = reactive<ReferenceConfiguration>({
     v-model="spec"
     cols="30"
     rows="10" /> -->
-  <!-- <select
-    @input="(event) => configuration.hocuspocusConfiguration ? configuration.hocuspocusConfiguration.name = (event.target as HTMLSelectElement).value : null"
-    @value="configuration.hocuspocusConfiguration?.name">
-    <option value="document-1">Document #1</option>
-    <option value="document-2">Document #2</option>
-    <option value="document-3">Document #3</option>
-  </select> -->
-
   <ApiReference
     :configuration="configuration"
     @changeTheme="(theme: ThemeId) => (configuration.theme = theme)"


### PR DESCRIPTION
WIP

We introduced a regression where loading examples created duplicate content. This PR has the following changes to fix this and related bugs.

* Fix: The editor is mounted even when another tab than 'Swagger Editor' is active (otherwise content can’t be synced in collaborative editing mode)
* Fix: Whitespace is trimmed from the content before it’s parsed.
* Refactor: The SwaggerEditor doesn’t “know” about the examples anymore, it just deals with strings. All examples have been moved to the GettingStarted component.
* Bonus: Collaborative editing can be configured in the dev toolbar now
<img width="326" alt="Screenshot 2023-11-07 at 12 20 44" src="https://github.com/scalar/scalar/assets/1577992/d78a1b53-b5a8-4662-800b-3d2e24540a56">