### PR TITLE
chore: store content in local storage

### DIFF
--- a/.changeset/three-teachers-drum.md
+++ b/.changeset/three-teachers-drum.md
@@ -1,0 +1,6 @@
+---
+'@scalar/swagger-editor': patch
+'@scalar/api-reference': patch
+---
+
+feat: add updateContent event to the ApiReference component

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -17,8 +17,9 @@ const props = withDefaults(defineProps<ReferenceProps>(), {
   footerBelowSidebar: undefined,
 })
 
-const emits = defineEmits<{
+const emit = defineEmits<{
   (e: 'changeTheme', value: ThemeId): void
+  (e: 'updateContent', value: string): void
   (
     e: 'startAIWriter',
     value: string[],
@@ -87,6 +88,10 @@ const { parsedSpecRef, overwriteParsedSpecRef, errorRef } = useParser({
   input: rawSpecRef,
 })
 
+watch(rawSpecRef, () => {
+  emit('updateContent', rawSpecRef.value)
+})
+
 // Use preparsed content, if it’s passed
 watch(
   () => currentConfiguration.value.spec?.preparsedContent,
@@ -113,7 +118,7 @@ function handleAIWriter(
   swaggerData: string,
   swaggerType: 'json' | 'yaml',
 ) {
-  emits('startAIWriter', value, swaggerData, swaggerType)
+  emit('startAIWriter', value, swaggerData, swaggerType)
 }
 
 const swaggerEditorRef = ref<typeof SwaggerEditor | undefined>()

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { type StatesArray } from '@hocuspocus/provider'
 import { type ThemeId, ThemeStyles } from '@scalar/themes'
-import { computed, isRef, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, isRef, nextTick, ref, watch } from 'vue'
 
 import coinmarketcap from '../../coinmarketcapv3.json'
 import { isJsonString } from '../../helpers'
@@ -48,17 +48,6 @@ const handleContentUpdate = (value: string) => {
   rawContent.value = value
   emit('contentUpdate', value)
 }
-
-onMounted(async () => {
-  if (props.hocuspocusConfiguration || props.value) {
-    return
-  }
-
-  const previousContent = localStorage.getItem('swagger-editor-content')
-  if (!previousContent) {
-    return
-  }
-})
 
 const handleAwarenessUpdate = (states: StatesArray) => {
   awarenessStates.value = states

--- a/projects/web/src/pages/ApiReferencePage.vue
+++ b/projects/web/src/pages/ApiReferencePage.vue
@@ -11,11 +11,16 @@ import MockFooter from '../components/MockFooter.vue'
 
 // import preparsedContent from '../fixtures/specResult.json'
 
+const handleUpdateContent = (content: string) => {
+  window.localStorage.setItem('api-reference-content', content)
+}
+
 const configuration = reactive<ReferenceConfiguration>({
   theme: 'default',
   proxy: 'http://localhost:5051',
   isEditable: true,
   spec: {
+    content: window.localStorage.getItem('api-reference-content') ?? undefined,
     // content: { openapi: '3.1.0', info: { title: 'Example' }, paths: {} },
     // content: () => {
     //   return { openapi: '3.1.0', info: { title: 'Example' }, paths: {} }
@@ -50,7 +55,8 @@ const configuration = reactive<ReferenceConfiguration>({
 
   <ApiReference
     :configuration="configuration"
-    @changeTheme="(theme: ThemeId) => (configuration.theme = theme)">
+    @changeTheme="(theme: ThemeId) => (configuration.theme = theme)"
+    @updateContent="handleUpdateContent">
     <template #header>
       <DevToolbar
         :modelValue="configuration"


### PR DESCRIPTION
We used to store the Swagger editor content in local storage but broke that recently. But I miss it, it made the dev cycle so much faster.

I’ve added the code to cache the content to the example and removed it from the package.
And I’ve added a `updateContent` event to the `ApiReference` component.