### PR TITLE
feat: CommonJS builds for `@scalar/api-client-proxy` and `@scalar/echo-server`

### DIFF
--- a/.changeset/fair-avocados-speak.md
+++ b/.changeset/fair-avocados-speak.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client-proxy': patch
+---
+
+fix: entry points

--- a/packages/api-client-proxy/package.json
+++ b/packages/api-client-proxy/package.json
@@ -23,7 +23,8 @@
     "node": ">=18"
   },
   "exports": {
-    "import": "./dist/index.js"
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
   },
   "files": [
     "dist",

--- a/packages/api-client-proxy/package.json
+++ b/packages/api-client-proxy/package.json
@@ -23,7 +23,7 @@
     "node": ">=18"
   },
   "exports": {
-    "import": "./dist/src/index.js"
+    "import": "./dist/index.js"
   },
   "files": [
     "dist",
@@ -36,8 +36,8 @@
     "proxy"
   ],
   "license": "MIT",
-  "main": "./dist/src/index.js",
-  "module": "./dist/src/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "peerDependencies": {
     "@types/cors": "2.8.13",
     "@types/express": "4.17.17"

--- a/packages/api-client-proxy/vite.config.ts
+++ b/packages/api-client-proxy/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       entry: 'src/index.ts',
       name: '@scalar/api-client-proxy',
       fileName: 'index',
-      formats: ['es'],
+      formats: ['es', 'cjs'],
     },
     rollupOptions: {
       external: ['express', 'cors', 'dotenv'],

--- a/packages/echo-server/package.json
+++ b/packages/echo-server/package.json
@@ -22,7 +22,8 @@
     "node": ">=18"
   },
   "exports": {
-    "import": "./dist/index.js"
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
   },
   "files": [
     "dist",

--- a/packages/echo-server/vite.config.ts
+++ b/packages/echo-server/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
       entry: 'src/index.ts',
       name: '@scalar/echo-server',
       fileName: 'index',
-      formats: ['es'],
+      formats: ['es', 'cjs'],
     },
     rollupOptions: {
       external: ['cookie-parser', 'cors', 'express'],


### PR DESCRIPTION
This PR fixes wrong paths for the api-client-proxy introduced in #426 and adds CommonJS builds for `@scalar/api-client-proxy` and `@scalar/echo-server`.

I’m a fan of ESM-only packages, but I needed them in another environment and using ESM-only there was just too big of a hurdle. And there are probably other people preferring CommonJS builds, too.