### PR TITLE
chore: better fallbacks for the name

### DIFF
--- a/.changeset/eighty-windows-develop.md
+++ b/.changeset/eighty-windows-develop.md
@@ -1,0 +1,6 @@
+---
+'@scalar/swagger-parser': patch
+'@scalar/api-reference': patch
+---
+
+chore: better fallbacks for the operation.name

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
@@ -20,12 +20,12 @@ defineProps<{
 <template>
   <Section
     :id="getOperationSectionId(operation, tag)"
-    :label="operation.name || operation.path">
+    :label="operation.name">
     <SectionContent>
       <SectionColumns>
         <SectionColumn>
           <SectionHeader :level="3">
-            {{ operation.name || operation.path }}
+            {{ operation.name }}
           </SectionHeader>
           <Copy :operation="operation" />
         </SectionColumn>

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -228,13 +228,16 @@ const searchResultsWithPlaceholderResults = computed(
           {{ entry.item.httpVerb }}
         </div>
         <div
-          v-if="entry.item.title || entry.item.operationId"
+          v-if="entry.item.title"
           class="item-entry-title">
-          {{ entry.item.title || entry.item.operationId }}
+          {{ entry.item.title }}
         </div>
 
         <div
-          v-if="entry.item.httpVerb || entry.item.path"
+          v-if="
+            (entry.item.httpVerb || entry.item.path) &&
+            entry.item.path !== entry.item.title
+          "
           class="item-entry-path">
           {{ entry.item.path }}
         </div>

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -147,7 +147,7 @@ const items = computed((): SidebarEntry[] => {
             children: tag.operations?.map((operation) => {
               return {
                 id: getOperationSectionId(operation, tag),
-                title: operation.name || operation.path,
+                title: operation.name,
                 type: 'Page',
                 httpVerb: operation.httpVerb,
                 select: () => {
@@ -162,7 +162,7 @@ const items = computed((): SidebarEntry[] => {
       : firstTag?.operations?.map((operation) => {
           return {
             id: getOperationSectionId(operation, firstTag),
-            title: operation.name || operation.path,
+            title: operation.name,
             type: 'Page',
             httpVerb: operation.httpVerb,
             select: () => {

--- a/packages/swagger-parser/src/helpers/parse.ts
+++ b/packages/swagger-parser/src/helpers/parse.ts
@@ -52,12 +52,13 @@ const transformResult = (result: OpenAPI.Document<object>): SwaggerSpec => {
     requestMethods.forEach((requestMethod) => {
       // @ts-ignore
       const operation = result.paths[path][requestMethod]
+
       // Transform the operation
       const newOperation = {
         httpVerb: requestMethod,
         path,
         operationId: operation.operationId || path || '',
-        name: operation.summary || '',
+        name: operation.operationId || operation.summary || path || '',
         description: operation.description || '',
         information: {
           ...operation,


### PR DESCRIPTION
It’s somehow confusing how the fallback for the operation.name is chosen. With this PR it’s done in a single place, and the order is:

1. `operationId` or…
2. `summary` or …
3. `path`

In the SearchModal, the `path` is only added if it’s not used for the name fallback already.

![Screenshot 2023-11-09 at 16 50 51](https://github.com/scalar/scalar/assets/1577992/72f1e9b4-9594-4846-954e-bf924c4696ac)