### PR TITLE
fix: add fallback if no summary or key is provided for examples

### DIFF
--- a/.changeset/slimy-cougars-give.md
+++ b/.changeset/slimy-cougars-give.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: add fallback if no summary or key is provided for examples

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/SelectExample.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/SelectExample.vue
@@ -13,6 +13,8 @@ import { Icon } from '../../../Icon'
 
 const props = defineProps<{ examples: Record<string, any> }>()
 
+// we never set the key properly, but i figured people might also have a key field
+// so i added a scalar exclusive field to fallback to that uses the key of the object
 const examples = mapFromObject(props.examples, 'scalarExampleName')
 const selectedExample = ref(examples[0])
 </script>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/SelectExample.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/SelectExample.vue
@@ -13,7 +13,7 @@ import { Icon } from '../../../Icon'
 
 const props = defineProps<{ examples: Record<string, any> }>()
 
-const examples = mapFromObject(props.examples)
+const examples = mapFromObject(props.examples, 'scalarExampleName')
 const selectedExample = ref(examples[0])
 </script>
 <template>
@@ -29,7 +29,11 @@ const selectedExample = ref(examples[0])
         class="listbox-button">
         <div class="listbox-button-content">
           <div class="listbox-button-label">
-            {{ selectedExample.value.summary ?? selectedExample.key }}
+            {{
+              selectedExample.value.summary ??
+              selectedExample.key ??
+              selectedExample.scalarExampleName
+            }}
           </div>
           <div>
             <Icon
@@ -45,7 +49,9 @@ const selectedExample = ref(examples[0])
           :key="example.key"
           class="listbox-option"
           :value="example">
-          {{ example.value.summary ?? example.key }}
+          {{
+            example.value.summary ?? example.key ?? example.scalarExampleName
+          }}
         </ListboxOption>
       </ListboxOptions>
     </Listbox>


### PR DESCRIPTION
before if you had no key or summary it would be an empty list, now we provide a `scalarExampleName` generated to the object with the key of the example