### PR TITLE
fix: add fallback to name for models if no xml attribute passed

### DIFF
--- a/.changeset/twelve-knives-learn.md
+++ b/.changeset/twelve-knives-learn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: add fallback to name for models if no xml attribute passed

--- a/packages/api-reference/src/components/Content/Models.vue
+++ b/packages/api-reference/src/components/Content/Models.vue
@@ -49,7 +49,9 @@ const models = computed(() => {
             {{ name }}
           </SectionHeader>
           <!-- Schema -->
-          <Schema :value="components?.schemas?.[name]" />
+          <Schema
+            :name="name"
+            :value="components?.schemas?.[name]" />
           <!-- Show More Button -->
           <ShowMoreButton
             v-if="!showAllModels && index === models.length - 1"

--- a/packages/api-reference/src/components/Content/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema.vue
@@ -5,6 +5,7 @@ withDefaults(
   defineProps<{
     value?: Record<string, any>
     level?: number
+    name?: string
   }>(),
   {
     level: 0,
@@ -25,6 +26,9 @@ withDefaults(
         </span>
         <template v-if="value?.xml?.name && value?.xml?.name !== '##default'">
           &lt;{{ value?.xml?.name }} /&gt;
+        </template>
+        <template v-else-if="name">
+          {{ name }}
         </template>
         <template v-else>
           {{ value.type }}


### PR DESCRIPTION
this fixes 

https://github.com/scalar/scalar/issues/449

before:
<img width="1507" alt="image" src="https://github.com/scalar/scalar/assets/6176314/6dacf6b9-742c-4fce-851c-3103c7f059f2">


after:
<img width="1503" alt="image" src="https://github.com/scalar/scalar/assets/6176314/a2fda6ec-9667-47dc-b644-fa481b361daa">
