### PR TITLE
fix: show non 200 responses when not using the proxy

### DIFF
--- a/.changeset/two-carpets-watch.md
+++ b/.changeset/two-carpets-watch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: show non 200 responses when not using the proxy

--- a/packages/api-client/src/helpers/sendRequest.ts
+++ b/packages/api-client/src/helpers/sendRequest.ts
@@ -109,46 +109,46 @@ export async function sendRequest(
     console.info(`${requestConfig.method} ${requestConfig.url}`)
   }
 
-  const response: (ClientResponse & { error: false }) | { error: true } =
-    await axios(axiosRequestConfig)
-      .then((result) => {
-        // With proxy
-        if (proxyUrl) {
-          return {
-            ...result.data,
-            error: false,
-          }
-        }
-
-        // Without proxy
+  const response: ClientResponse = await axios(axiosRequestConfig)
+    .then((result) => {
+      // With proxy
+      if (proxyUrl) {
         return {
-          ...result,
-          statusCode: result.status,
-          data: JSON.stringify(result.data),
+          ...result.data,
           error: false,
         }
-      })
-      .catch((error) => {
-        return {
-          error: true,
-          ...error?.response,
-        }
-      })
-
-  return response.error
-    ? null
-    : {
-        sentTime: Date.now(),
-        request: {
-          ...request,
-          type: method,
-          url,
-          path,
-        },
-        response: {
-          ...response,
-          duration: Date.now() - startTime,
-        },
-        responseId: nanoid(),
       }
+
+      // Without proxy
+      return {
+        ...result,
+        statusCode: result.status,
+        data: JSON.stringify(result.data),
+        error: false,
+      }
+    })
+    .catch((error) => {
+      const { response: errorResponse } = error
+
+      return {
+        ...errorResponse,
+        statusCode: errorResponse.status,
+        data: JSON.stringify(errorResponse.data),
+      }
+    })
+
+  return {
+    sentTime: Date.now(),
+    request: {
+      ...request,
+      type: method,
+      url,
+      path,
+    },
+    response: {
+      ...response,
+      duration: Date.now() - startTime,
+    },
+    responseId: nanoid(),
+  }
 }

--- a/projects/web/src/pages/StandaloneApiReferencePage.vue
+++ b/projects/web/src/pages/StandaloneApiReferencePage.vue
@@ -6,5 +6,5 @@ import { ApiReference } from '@scalar/api-reference'
   <ApiReference
     :initialTabState="'Swagger Editor'"
     :isEditable="true"
-    specUrl="/scalar.json" />
+    proxyUrl="https://api.scalar.com/request-proxy" />
 </template>


### PR DESCRIPTION
this fixes https://github.com/scalar/scalar/issues/440

Now when not using the proxy, we catch the error and add it to the request history. 

before:
<img width="1511" alt="image" src="https://github.com/scalar/scalar/assets/6176314/a426377d-559c-4415-b871-d84bfe1e5645">

after:

<img width="1509" alt="image" src="https://github.com/scalar/scalar/assets/6176314/168deeb2-7261-451f-9308-04e1d142d147">

