### PR TITLE
fix word breaks in .markdown

### DIFF
--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -52,7 +52,7 @@ watch(
 .markdown {
   color: var(--theme-color-1, var(--default-theme-color-1));
   all: unset;
-  word-break: break-all;
+  word-break: break-word;
 }
 .markdown :deep(*) {
   all: unset;

--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -51,8 +51,8 @@ watch(
 <style scoped>
 .markdown {
   color: var(--theme-color-1, var(--default-theme-color-1));
-  word-wrap: break-word;
   all: unset;
+  word-break: break-all;
 }
 .markdown :deep(*) {
   all: unset;
@@ -70,6 +70,7 @@ watch(
   margin: 24px 0 6px;
   font-weight: var(--theme-bold, var(--default-theme-bold));
   display: block;
+  line-height: 1.45;
 }
 .markdown :deep(b),
 .markdown :deep(strong) {


### PR DESCRIPTION
before:
<img width="700" alt="image" src="https://github.com/scalar/scalar/assets/6201407/aa31200f-a255-4642-b791-52e2b3a4091e">

After:
<img width="684" alt="image" src="https://github.com/scalar/scalar/assets/6201407/aea3cb37-8a40-46d8-91a7-210a37a2f346">

+ fix line height for headings 