### PR TITLE
Amrit/doc 1328 deep linking anchor tags doesnt work in references

### DIFF
--- a/.changeset/blue-moons-play.md
+++ b/.changeset/blue-moons-play.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: deep linking in api references

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -63,7 +63,6 @@ watch(props.parsedSpec, async (val) => {
   // The original scroll to top from mounted
   const hashId = document.location.hash
   if (!hashId) {
-    console.log('original scroll')
     document.querySelector('#tippy')?.scrollTo({
       top: 0,
       left: 0,


### PR DESCRIPTION
Basically we need to pop open the sections before we can scroll to the element. Tested on OSS side, needs testing on org.

Also could not for the life of me avoid that setTimeout short of using a ref and watching it (making it worse imo). Open to a better way of doing this. If you switch to nextTick, the page scrolls down so the section is partially showing only. 