### PR TITLE
chore: make imports relative

### DIFF
--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useMediaQuery } from '@vueuse/core'
-import { type ReferenceProps, type SpecConfiguration } from 'src/types'
 import { computed, ref } from 'vue'
 
 import { useTemplateStore } from '../stores/template'
+import { type ReferenceProps, type SpecConfiguration } from '../types'
 import ApiReferenceBase from './ApiReferenceBase.vue'
 import DarkModeToggle from './DarkModeToggle.vue'
 import MobileHeader from './MobileHeader.vue'

--- a/packages/api-reference/src/helpers/hasModels.ts
+++ b/packages/api-reference/src/helpers/hasModels.ts
@@ -1,4 +1,4 @@
-import { type Spec } from 'src/types'
+import { type Spec } from '../types'
 
 export const hasModels = (spec: Spec) => {
   if (Object.keys(spec?.components?.schemas ?? {}).length) {

--- a/packages/api-reference/src/helpers/hasSecuritySchemes.ts
+++ b/packages/api-reference/src/helpers/hasSecuritySchemes.ts
@@ -1,4 +1,4 @@
-import { type Spec } from 'src/types'
+import { type Spec } from '../types'
 
 export const hasSecuritySchemes = (spec?: Spec) => {
   // TODO: Show security schemes

--- a/packages/api-reference/src/hooks/useSpec.test.ts
+++ b/packages/api-reference/src/hooks/useSpec.test.ts
@@ -1,7 +1,7 @@
-import { type SpecConfiguration } from 'src/types'
 import { describe, expect, it, vi } from 'vitest'
 import { computed, nextTick, reactive, watch } from 'vue'
 
+import { type SpecConfiguration } from '../types'
 import { useSpec } from './useSpec'
 
 describe('useSpec', () => {


### PR DESCRIPTION
This PR makes the imports relative paths and fixes the following error:

```
projects/web dev: Error: The following dependencies are imported but could not be resolved:
projects/web dev:   src/types (imported by scalar/packages/api-reference/src/components/ApiReference.vue?id=0)
```