### PR TITLE
feat: add support for oneOf and allOf in the response schema

### DIFF
--- a/.changeset/strange-baboons-marry.md
+++ b/.changeset/strange-baboons-marry.md
@@ -3,3 +3,4 @@
 ---
 
 feat: add support for oneOf in response schemas
+feat: add support for allOf in response schemas

--- a/.changeset/strange-baboons-marry.md
+++ b/.changeset/strange-baboons-marry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add support for oneOf in response schemas

--- a/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
@@ -435,4 +435,26 @@ describe('getExampleFromSchema', () => {
       photoUrls: ['https://example.com'],
     })
   })
+
+  it.only('doesn’t wrap items when not needed', () => {
+    expect(
+      getExampleFromSchema({
+        properties: {
+          firstname: {
+            oneOf: [
+              {
+                maxLength: 255,
+                type: 'string',
+              },
+              {
+                type: 'null',
+              },
+            ],
+          },
+        },
+      }),
+    ).toMatchObject({
+      firstname: '',
+    })
+  })
 })

--- a/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
@@ -436,7 +436,7 @@ describe('getExampleFromSchema', () => {
     })
   })
 
-  it.only('doesn’t wrap items when not needed', () => {
+  it('use the first item of oneOf', () => {
     expect(
       getExampleFromSchema({
         properties: {
@@ -455,6 +455,57 @@ describe('getExampleFromSchema', () => {
       }),
     ).toMatchObject({
       firstname: '',
+    })
+  })
+
+  it('works with allOf', () => {
+    expect(
+      getExampleFromSchema({
+        properties: {
+          firstname: {
+            allOf: [
+              {
+                maxLength: 255,
+                type: 'string',
+              },
+            ],
+          },
+        },
+      }),
+    ).toMatchObject({
+      firstname: '',
+    })
+  })
+
+  it('uses all schemas in allOf', () => {
+    expect(
+      getExampleFromSchema({
+        properties: {
+          post: {
+            allOf: [
+              {
+                properties: {
+                  id: {
+                    example: 10,
+                  },
+                },
+              },
+              {
+                properties: {
+                  title: {
+                    example: 'Foobar',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    ).toMatchObject({
+      post: {
+        id: 10,
+        title: 'Foobar',
+      },
     })
   })
 })

--- a/packages/api-reference/src/helpers/getExampleFromSchema.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.ts
@@ -130,9 +130,33 @@ export const getExampleFromSchema = (
 
       // Return an example for the first item
       if (exampleValues[firstOneOfItem.type] !== undefined) {
-        response[xmlTagName ?? name] = exampleValues[firstOneOfItem.type]
+        response[xmlTagName ?? name] = getExampleFromSchema(
+          firstOneOfItem,
+          options,
+          level + 1,
+        )
         return
       }
+    }
+
+    // Check if property has the `allOf` key
+    if (Array.isArray(property.allOf)) {
+      // Loop through all `allOf` schemas
+      property.allOf.forEach((allOfItem: Record<string, any>) => {
+        // Return an example from the schema
+        const newExample = getExampleFromSchema(allOfItem, options, level + 1)
+
+        // Merge or overwrite the example
+        response[xmlTagName ?? name] =
+          typeof newExample === 'object'
+            ? {
+                ...(response[xmlTagName ?? name] ?? {}),
+                ...newExample,
+              }
+            : newExample
+      })
+
+      return
     }
 
     // Warn if the type is unknown …

--- a/packages/api-reference/src/helpers/getExampleFromSchema.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.ts
@@ -123,6 +123,18 @@ export const getExampleFromSchema = (
       return
     }
 
+    // Check if property has the `oneOf` key
+    if (Array.isArray(property.oneOf)) {
+      // Get the first item from the `oneOf` array
+      const firstOneOfItem = property.oneOf[0]
+
+      // Return an example for the first item
+      if (exampleValues[firstOneOfItem.type] !== undefined) {
+        response[xmlTagName ?? name] = exampleValues[firstOneOfItem.type]
+        return
+      }
+    }
+
     // Warn if the type is unknown …
     console.warn(
       `[getExampleFromSchema] Unknown property type "${property.type}" for property "${name}".`,


### PR DESCRIPTION
This PR adds support for the use of `oneOf` and `allOf` in the schema for responses.

When generating example responses from the schema, the first entry in `oneOf` is used.

For `allOf` we generated example for all given schemas and try to merge them.