### PR TITLE
style: do not show empty example requests

### DIFF
--- a/.changeset/wild-taxis-call.md
+++ b/.changeset/wild-taxis-call.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: don’t show the example request card if it’s empty

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -109,7 +109,9 @@ const formattedPath = computed(() => {
 })
 </script>
 <template>
-  <Card class="dark-mode">
+  <Card
+    v-if="CodeMirrorValue"
+    class="dark-mode">
     <CardHeader muted>
       <div class="request">
         <span :class="`request-method request-method--${operation.httpVerb}`">


### PR DESCRIPTION
We can’t generate example requests e. g. if an invalid URL is given. In those (rare) cases, we can hide the example request card, because it’s empty anyway.

**Before**
![Screenshot 2023-11-16 at 11 44 40](https://github.com/scalar/scalar/assets/1577992/78fdf5b3-c945-4671-ace8-ff5cfa91073d)

**After**
![Screenshot 2023-11-16 at 11 47 43](https://github.com/scalar/scalar/assets/1577992/e780cdec-74d3-44bb-8692-62ce85b1853e)

