### PR TITLE
feat: swagger 2.0 host and schemes

### DIFF
--- a/.changeset/swift-peaches-hear.md
+++ b/.changeset/swift-peaches-hear.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add support for Swagger 2.0 host and schemes configuration

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -46,7 +46,11 @@ const fallBackServer = useRefOnMount(() => {
 const localServers = computed(() => {
   if (props.parsedSpec.servers && props.parsedSpec.servers.length > 0) {
     return props.parsedSpec.servers
-  } else if (props.parsedSpec.host && props.parsedSpec.schemes.length) {
+  } else if (
+    props.parsedSpec.host &&
+    props.parsedSpec.schemes &&
+    props.parsedSpec.schemes.length > 0
+  ) {
     return [
       { url: `${props.parsedSpec.schemes[0]}://${props.parsedSpec.host}` },
     ]

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -46,6 +46,10 @@ const fallBackServer = useRefOnMount(() => {
 const localServers = computed(() => {
   if (props.parsedSpec.servers && props.parsedSpec.servers.length > 0) {
     return props.parsedSpec.servers
+  } else if (props.parsedSpec.host && props.parsedSpec.schemes.length) {
+    return [
+      { url: `${props.parsedSpec.schemes[0]}://${props.parsedSpec.host}` },
+    ]
   } else if (fallBackServer.value) {
     return [fallBackServer.value]
   } else {

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -233,6 +233,8 @@ export type Definitions = OpenAPIV2.DefinitionsObject
 export type Spec = {
   tags: Tag[]
   info: Info
+  host?: string
+  schemes?: string[]
   externalDocs: ExternalDocs
   servers: Server[]
   components?: Components


### PR DESCRIPTION
In Swagger 2.0 files servers are configured like this:

```json
{
  "host": "api.example.com",
  "schemes": [
    "https"
  ]
}
```

This PR adds support for this syntax.