### PR TITLE
feat: fallback for http auth

### DIFF
--- a/.changeset/afraid-carpets-watch.md
+++ b/.changeset/afraid-carpets-watch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: use bearer auth as the fallback for http auth

--- a/packages/api-reference/src/components/Content/Authentication/Authentication.vue
+++ b/packages/api-reference/src/components/Content/Authentication/Authentication.vue
@@ -22,8 +22,7 @@ const showSecurityScheme = computed(() => {
       authentication.securitySchemeKey
     ]
 
-  // @ts-ignore
-  return !!scheme?.type
+  return typeof scheme !== 'undefined'
 })
 
 // Keep a copy of the security schemes in the global authentication state


### PR DESCRIPTION
With this PR bearer auth is taken as the default http auth method (that’s what Swagger UI does, too). E.g. this is enough:

```
  "security": [
    {
      "http": []
    }
  ],
```

Source: https://raw.githubusercontent.com/outline/openapi/main/spec3.json

**Before**
![Screenshot 2023-11-16 at 12 27 54](https://github.com/scalar/scalar/assets/1577992/b278affc-9312-4e43-a205-6976788e368d)

**After**
![Screenshot 2023-11-16 at 12 25 58](https://github.com/scalar/scalar/assets/1577992/77e68483-a733-415e-b5a4-3b0a2f0d81b8)
