### PR TITLE
chore: use summary instead of operationId

### DIFF
--- a/.changeset/calm-bats-flash.md
+++ b/.changeset/calm-bats-flash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/swagger-parser': patch
+---
+
+chore: use the summary as the title, fall back to operationId, and then the path

--- a/packages/swagger-parser/src/helpers/parse.ts
+++ b/packages/swagger-parser/src/helpers/parse.ts
@@ -57,8 +57,8 @@ const transformResult = (result: OpenAPI.Document<object>): SwaggerSpec => {
       const newOperation = {
         httpVerb: requestMethod,
         path,
-        operationId: operation.operationId || path || '',
-        name: operation.operationId || operation.summary || path || '',
+        operationId: operation.operationId || path,
+        name: operation.summary || operation.operationId || path || '',
         description: operation.description || '',
         information: {
           ...operation,


### PR DESCRIPTION
In #448 we changed the priority of what is used as the operation name for the sidebar, headings and so on. I think I made a mistake. In #448 the priority was:

1. operationId or…
2. summary or …
3. path

But the operationId is something more technical (more like a variable name) and the summary is more descriptive. Let’s change the priority to this:

1. summary or …
2. operationId or…
3. path

I tested it with a lot of specs and it improved every example I tested.