### PR TITLE
feat: add support for models with allOf, anyOf, oneOf …

### DIFF
--- a/.changeset/red-poets-lie.md
+++ b/.changeset/red-poets-lie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add support for models with top level anyOf, allOf, oneOf …

--- a/packages/api-reference/src/components/Content/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema.vue
@@ -47,7 +47,7 @@ withDefaults(
         :value="value.properties[property]" />
     </div>
     <div
-      v-else-if="value?.type"
+      v-else
       class="properties">
       <SchemaProperty
         :level="level"


### PR DESCRIPTION
I noticed some Models were empty and found out we’re not dealing with schemas that define anyOf, allOf, oneOf … on the top level. This PR fixes it.

**Before**
<img width="610" alt="Screenshot 2023-11-17 at 11 40 55" src="https://github.com/scalar/scalar/assets/1577992/fc677634-beb7-4eb1-b871-9242c80f0422">

**After**
<img width="594" alt="Screenshot 2023-11-17 at 11 38 19" src="https://github.com/scalar/scalar/assets/1577992/b4042bd8-2e9d-4e13-a429-281bcf380acf">
 