### PR TITLE
chore: do not use the operationId as name

### DIFF
--- a/.changeset/tricky-birds-give.md
+++ b/.changeset/tricky-birds-give.md
@@ -1,0 +1,5 @@
+---
+'@scalar/swagger-parser': patch
+---
+
+chore: don’t use the operationId as a name fallback

--- a/packages/swagger-parser/src/helpers/parse.ts
+++ b/packages/swagger-parser/src/helpers/parse.ts
@@ -58,7 +58,7 @@ const transformResult = (result: OpenAPI.Document<object>): SwaggerSpec => {
         httpVerb: requestMethod,
         path,
         operationId: operation.operationId || path,
-        name: operation.summary || operation.operationId || path || '',
+        name: operation.summary || path || '',
         description: operation.description || '',
         information: {
           ...operation,


### PR DESCRIPTION
Okay … that’s kind of a long journey. I experimented with different fallbacks for the name, but based on the user feedback I don’t think we should use the operationId as a potential fallback for the operation name.

With this PR we’re looking for the `summary` and if it’s not available, we just use the path.

That change gives users still control, but avoids confusion and the use of (in most cases technical) operationIds.