### PR TITLE
fix: expose search modal events

### DIFF
--- a/.changeset/smart-bulldogs-enjoy.md
+++ b/.changeset/smart-bulldogs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: expose searchmodal events and showSearchModal config option

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -20,6 +20,7 @@ const props = defineProps<ReferenceProps>()
 const emit = defineEmits<{
   (e: 'changeTheme', value: ThemeId): void
   (e: 'updateContent', value: string): void
+  (e: 'closedSearchModal'): void
   (
     e: 'startAIWriter',
     value: string[],
@@ -101,6 +102,7 @@ const swaggerEditorRef = ref<typeof SwaggerEditor | undefined>()
     :rawSpec="rawSpecRef"
     :swaggerEditorRef="swaggerEditorRef"
     @changeTheme="$emit('changeTheme', $event)"
+    @closedSearchModal="$emit('closedSearchModal')"
     @updateContent="(newContent: string) => setRawSpecRef(newContent)">
     <template #header="attribs">
       <slot

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -29,6 +29,7 @@ defineEmits<{
   (e: 'changeTheme', value: ThemeId): void
   (e: 'updateContent', value: string): void
   (e: 'toggleDarkMode'): void
+  (e: 'closedSearchModal'): void
 }>()
 
 const isLargeScreen = useMediaQuery('(min-width: 1150px)')
@@ -96,6 +97,15 @@ const showSwaggerEditor = computed(() => {
 })
 
 const { state } = useApiClientStore()
+
+watch(
+  () => props.configuration.showSearchModal,
+  (val) => {
+    if (val !== undefined) {
+      setTemplateItem('showSearch', val)
+    }
+  },
+)
 </script>
 <template>
   <div
@@ -167,7 +177,8 @@ const { state } = useApiClientStore()
     <!-- Search Overlay -->
     <SearchModal
       :parsedSpec="parsedSpec"
-      variant="search" />
+      variant="search"
+      @closedSearchModal="$emit('closedSearchModal')" />
     <!-- REST API Client Overlay -->
     <ApiClientModal
       :parsedSpec="parsedSpec"

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -11,6 +11,9 @@ import { useTemplateStore } from '../stores/template'
 import type { Spec, Tag, TransformedOperation } from '../types'
 
 const props = defineProps<{ parsedSpec: Spec }>()
+const emit = defineEmits<{
+  (e: 'closedSearchModal'): void
+}>()
 const reactiveSpec = toRef(props, 'parsedSpec')
 const modalState = useModal()
 
@@ -61,6 +64,7 @@ watch(
   () => {
     if (!modalState.open) {
       setItem('showSearch', false)
+      emit('closedSearchModal')
     }
   },
 )

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -43,6 +43,8 @@ export type ReferenceConfiguration = {
   hocuspocusConfiguration?: HocuspocusConfigurationProp
   /** Key used with CNTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k) */
   searchHotKey?: string
+  /** Control the search modal, good use case is you want to use your own search */
+  showSearchModal?: boolean
   /** ??? */
   aiWriterMarkdown?: string
 }
@@ -61,6 +63,7 @@ export const DEFAULT_CONFIG: DeepReadonly<ReferenceConfiguration> = {
   },
   showSidebar: true,
   isEditable: false,
+  showSearchModal: undefined,
   hocuspocusConfiguration: undefined,
 }
 


### PR DESCRIPTION
okay, we want to use the searchModal from the OSS repo in the closed source repo but we also want to let users hook into the searchModal to show or hide, us passing in a config let's us do that and also exposes the closed event to handle closing outside :) 