### PR TITLE
feat: make swagger editor tabs configurable

### DIFF
--- a/.changeset/unlucky-sheep-compare.md
+++ b/.changeset/unlucky-sheep-compare.md
@@ -1,0 +1,6 @@
+---
+'@scalar/swagger-editor': patch
+'@scalar/api-reference': patch
+---
+
+feat: make the available tabs configurable

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -88,8 +88,15 @@ You can decide which tab should be active by default:
 ```vue
 <ApiReference
   :initialTabState="{ tabs: { initialContent: 'Getting Started' } }" />
-<!-- or -->
-<ApiReference :configuration="{ tabs: { initialContent: 'Swagger Editor' } }" />
+```
+
+And you can define which tabs should be visible:
+
+```vue
+<ApiReference
+  :configuration="{
+    tabs: { available: ['Getting Started', 'Swagger Editor'] },
+  }" />
 ```
 
 #### showSidebar?: boolean

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -118,6 +118,7 @@ const swaggerEditorRef = ref<typeof SwaggerEditor | undefined>()
       <LazyLoadedSwaggerEditor
         ref="swaggerEditorRef"
         :aiWriterMarkdown="currentConfiguration.aiWriterMarkdown"
+        :availableTabs="currentConfiguration.tabs?.available"
         :error="errorRef"
         :hocuspocusConfiguration="currentConfiguration.hocuspocusConfiguration"
         :initialTabState="currentConfiguration.tabs?.initialContent"

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -35,6 +35,7 @@ export type ReferenceConfiguration = {
     // enabled?: boolean
     /** The initial tab to show */
     initialContent?: EditorHeaderTabs
+    available?: EditorHeaderTabs[]
   }
   /** Whether to show the sidebar */
   showSidebar?: boolean

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditor.vue
@@ -102,6 +102,7 @@ defineExpose({
     <SwaggerEditorHeader
       ref="swaggerEditorHeaderRef"
       :activeTab="activeTab"
+      :availableTabs="availableTabs"
       :proxyUrl="proxyUrl"
       @import="handleContentUpdate"
       @updateActiveTab="activeTab = $event" />

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -199,8 +199,6 @@ watch(files, () => {
   position: relative;
   z-index: 1;
 }
-.swagger-editor-type:first-of-type:last-of-type {
-}
 .swagger-editor-buttons {
   display: flex;
   justify-content: space-between;
@@ -268,8 +266,8 @@ watch(files, () => {
   margin-left: auto;
 }
 .single-tab .swagger-editor-active .swagger-editor-type {
-  box-shadow: 0 1px 0 0px
-      var(--theme-background-2, var(--default-theme-background-2)),
+  box-shadow:
+    0 1px 0 0px var(--theme-background-2, var(--default-theme-background-2)),
     0px 0 0 1px var(--theme-border-color, var(--default-theme-border-color)),
     0 0 0 1px var(--theme-background-2, var(--default-theme-background-2));
   background: var(--theme-background-2, var(--default-theme-background-2));

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -63,7 +63,11 @@ watch(files, () => {
 })
 </script>
 <template>
-  <div :class="{ 'single-tab': availableTabs?.length === 1 && availableTabs.includes('Swagger Editor') }">
+  <div
+    :class="{
+      'single-tab':
+        availableTabs?.length === 1 && availableTabs.includes('Swagger Editor'),
+    }">
     <div class="swagger-editor-header">
       <div
         v-if="!availableTabs || availableTabs.includes('Swagger Editor')"
@@ -196,7 +200,6 @@ watch(files, () => {
   z-index: 1;
 }
 .swagger-editor-type:first-of-type:last-of-type {
-  
 }
 .swagger-editor-buttons {
   display: flex;

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -63,60 +63,69 @@ watch(files, () => {
 })
 </script>
 <template>
-  <div class="swagger-editor-header">
-    <!-- <div
-      class="swagger-editor-title"
-      :class="{
-        'swagger-editor-active': activeTab === 'Getting Started',
-      }"
-      @click="emit('updateActiveTab', 'Getting Started')">
-      <div class="swagger-editor-type">Getting Started</div>
-    </div> -->
-    <div
-      v-if="!availableTabs || availableTabs.includes('Swagger Editor')"
-      class="swagger-editor-title"
-      :class="{
-        'swagger-editor-active': activeTab === 'Swagger Editor',
-      }"
-      @click="emit('updateActiveTab', 'Swagger Editor')">
-      <div class="swagger-editor-type">Swagger Editor</div>
+  <div :class="{ 'single-tab': availableTabs?.length === 1 && availableTabs.includes('Swagger Editor') }">
+    <div class="swagger-editor-header">
+      <div
+        v-if="!availableTabs || availableTabs.includes('Swagger Editor')"
+        class="swagger-editor-title"
+        :class="{
+          'swagger-editor-active': activeTab === 'Swagger Editor',
+        }"
+        @click="emit('updateActiveTab', 'Swagger Editor')">
+        <div class="swagger-editor-type">Swagger Editor</div>
+      </div>
+      <div
+        v-if="!availableTabs || availableTabs.includes('Getting Started')"
+        class="swagger-editor-title"
+        :class="{
+          'swagger-editor-active': activeTab === 'Getting Started',
+        }"
+        @click="emit('updateActiveTab', 'Getting Started')">
+        <div class="swagger-editor-type">Getting Started</div>
+      </div>
+      <div
+        v-if="!availableTabs || availableTabs.includes('AI Writer')"
+        class="swagger-editor-title"
+        :class="{
+          'swagger-editor-active': activeTab === 'AI Writer',
+        }"
+        @click="emit('updateActiveTab', 'AI Writer')">
+        <div class="swagger-editor-type">✨ AI Writer</div>
+      </div>
+      <div class="single-tab-items">
+        <button
+          class="swagger-editor-title"
+          type="button"
+          @click="() => open()">
+          <div class="swagger-editor-type">Upload File</div>
+        </button>
+        <button
+          class="swagger-editor-title"
+          type="button"
+          @click="importUrlModal.show">
+          <div class="swagger-editor-type">Import URL</div>
+        </button>
+      </div>
     </div>
     <div
-      v-if="!availableTabs || availableTabs.includes('Getting Started')"
-      class="swagger-editor-title"
-      :class="{
-        'swagger-editor-active': activeTab === 'Getting Started',
-      }"
-      @click="emit('updateActiveTab', 'Getting Started')">
-      <div class="swagger-editor-type">Getting Started</div>
-    </div>
-    <div
-      v-if="!availableTabs || availableTabs.includes('AI Writer')"
-      class="swagger-editor-title"
-      :class="{
-        'swagger-editor-active': activeTab === 'AI Writer',
-      }"
-      @click="emit('updateActiveTab', 'AI Writer')">
-      <div class="swagger-editor-type">✨ AI Writer</div>
+      v-show="activeTab === 'Swagger Editor'"
+      class="swagger-editor-buttons">
+      <div class="swagger-editor-heading">Swagger File</div>
+      <div>
+        <button
+          type="button"
+          @click="() => open()">
+          Upload File
+        </button>
+        <button
+          type="button"
+          @click="importUrlModal.show">
+          Import URL
+        </button>
+      </div>
     </div>
   </div>
-  <div
-    v-show="activeTab === 'Swagger Editor'"
-    class="swagger-editor-buttons">
-    <div class="swagger-editor-heading">Swagger File</div>
-    <div>
-      <button
-        type="button"
-        @click="() => open()">
-        Upload File
-      </button>
-      <button
-        type="button"
-        @click="importUrlModal.show">
-        Import URL
-      </button>
-    </div>
-  </div>
+
   <FlowModal
     :state="importUrlModal"
     title="Import Swagger from URL">
@@ -186,6 +195,9 @@ watch(files, () => {
   position: relative;
   z-index: 1;
 }
+.swagger-editor-type:first-of-type:last-of-type {
+  
+}
 .swagger-editor-buttons {
   display: flex;
   justify-content: space-between;
@@ -243,5 +255,25 @@ watch(files, () => {
   font-size: var(--theme-mini, var(--default-theme-mini));
   color: var(--theme-color-3, var(--default-theme-color-3));
   text-transform: uppercase;
+}
+.single-tab .swagger-editor-buttons,
+.single-tab-items {
+  display: none;
+}
+.single-tab .single-tab-items {
+  display: flex;
+  margin-left: auto;
+}
+.single-tab .swagger-editor-active .swagger-editor-type {
+  box-shadow: 0 1px 0 0px
+      var(--theme-background-2, var(--default-theme-background-2)),
+    0px 0 0 1px var(--theme-border-color, var(--default-theme-border-color)),
+    0 0 0 1px var(--theme-background-2, var(--default-theme-background-2));
+  background: var(--theme-background-2, var(--default-theme-background-2));
+  border-radius: var(--theme-radius, var(--default-theme-radius))
+    var(--theme-radius, var(--default-theme-radius)) 0 0;
+}
+.single-tab .swagger-editor-header {
+  padding-right: 6px;
 }
 </style>

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -73,6 +73,7 @@ watch(files, () => {
       <div class="swagger-editor-type">Getting Started</div>
     </div> -->
     <div
+      v-if="!availableTabs || availableTabs.includes('Swagger Editor')"
       class="swagger-editor-title"
       :class="{
         'swagger-editor-active': activeTab === 'Swagger Editor',
@@ -81,6 +82,7 @@ watch(files, () => {
       <div class="swagger-editor-type">Swagger Editor</div>
     </div>
     <div
+      v-if="!availableTabs || availableTabs.includes('Getting Started')"
       class="swagger-editor-title"
       :class="{
         'swagger-editor-active': activeTab === 'Getting Started',
@@ -89,6 +91,7 @@ watch(files, () => {
       <div class="swagger-editor-type">Getting Started</div>
     </div>
     <div
+      v-if="!availableTabs || availableTabs.includes('AI Writer')"
       class="swagger-editor-title"
       :class="{
         'swagger-editor-active': activeTab === 'AI Writer',

--- a/packages/swagger-editor/src/types.ts
+++ b/packages/swagger-editor/src/types.ts
@@ -7,12 +7,14 @@ export type SwaggerEditorProps = {
   hocuspocusConfiguration?: HocuspocusConfigurationProp
   theme?: ThemeId
   initialTabState?: EditorHeaderTabs
+  availableTabs?: EditorHeaderTabs[]
   proxyUrl?: string
   error?: string | Ref<string> | ComputedRef<string> | null
 }
 
 export type SwaggerEditorHeaderProps = {
   activeTab: EditorHeaderTabs
+  availableTabs?: EditorHeaderTabs[]
   proxyUrl?: string
 }
 


### PR DESCRIPTION
needs @cameronrohani to polish it ✨ 

but now you can pass in:

```
  tabs: {
    initialContent: 'Swagger Editor',
    available: ['Swagger Editor'],
  },
  ```

to configure this
<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6176314/c36a8777-e3d7-4cde-98e8-04c15a9c5d72">
