### PR TITLE
chore: optimize bundle size of `@scalar/swagger-editor`

### DIFF
--- a/.changeset/cyan-news-tell.md
+++ b/.changeset/cyan-news-tell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/swagger-editor': patch
+---
+
+chore: externalize dependencies, optimize bundle size

--- a/packages/swagger-editor/package.json
+++ b/packages/swagger-editor/package.json
@@ -71,7 +71,10 @@
     "remark-stringify": "^11.0.0",
     "unified": "^11.0.3",
     "vue": "^3.3.4",
-    "yjs": "^13.6.8"
+    "yjs": "^13.6.8",
+    "@scalar/themes": "0.0.0",
+    "@scalar/use-codemirror": "0.0.0",
+    "y-codemirror.next": "0.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/swagger-editor/vite.config.ts
+++ b/packages/swagger-editor/vite.config.ts
@@ -17,8 +17,15 @@ export default defineConfig({
     rollupOptions: {
       external: [
         '@codemirror/state',
+        '@codemirror/view',
         '@hocuspocus/provider',
+        '@lezer/common',
+        '@lezer/javascript',
+        '@lezer/lr',
+        '@lezer/python',
         '@scalar/swagger-editor',
+        '@scalar/themes',
+        '@scalar/use-codemirror',
         '@xmldom/xmldom',
         'rehype-external-links',
         'rehype-format',
@@ -32,6 +39,7 @@ export default defineConfig({
         'remark-stringify',
         'unified',
         'vue',
+        'y-codemirror.next',
         'yjs',
       ],
       output: {


### PR DESCRIPTION
This PR optimises the bundle size of `@scalar/swagger-editor` through externalizing dependencies.

**Before**
```
dist/index.js  2,109.06 kB │ gzip: 556.83 kB
```

**After**
```
dist/index.js  611.88 kB │ gzip: 61.61 kB
```

⚠️ This is not really helping with the bundle size you’d have in an app, because the peer dependencies will be installed separately. To be honest, this is more a theoretical optimisation than an actual benefit.

The examples make up most of the bundle size now:

<img width="1498" alt="Screenshot 2023-11-20 at 11 36 47" src="https://github.com/scalar/scalar/assets/1577992/91560d98-0b27-4605-b7d0-547f312a759c">
