### PR TITLE
feat: [DOC-1357] allow test button + api client to be disabled, fix #519

### DIFF
--- a/.changeset/breezy-jars-buy.md
+++ b/.changeset/breezy-jars-buy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add `withApiClient` flag to the configuration

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -115,3 +115,11 @@ Key used with CNTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k)
 ```vue
 <ApiReference :configuration="{ searchHotKey: 'l'} />
 ```
+
+#### withApiClient?: boolean
+
+I mean, our API client is really something special. It lets you play with the API inside your reference. But in some cases it’s just not a good fit. For those rare cases, you can disable the API client:
+
+```vue
+<ApiReference :configuration="{ withApiClient: false } />
+```

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -23,16 +23,10 @@ const emit = defineEmits<{
   ): void
 }>()
 
-const { configuration: currentConfiguration, setConfiguration } =
-  useGlobalStore()
-
-watch(
-  () => props.configuration,
-  (value) => {
-    setConfiguration(value)
-  },
-  { immediate: true, deep: true },
-)
+// Put the configuration in the global store
+const { configuration: currentConfiguration } = useGlobalStore({
+  configuration: props.configuration,
+})
 
 /**
  * The editor component has heavy dependencies (process), let's lazy load it.

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -5,14 +5,9 @@ import { FlowToastContainer } from '@scalar/use-toasts'
 import { useResizeObserver } from '@vueuse/core'
 import { computed, defineAsyncComponent, ref, watch } from 'vue'
 
-import { deepMerge } from '../helpers'
 import { useParser, useSpec } from '../hooks'
-import {
-  DEFAULT_CONFIG,
-  type ReferenceConfiguration,
-  type ReferenceProps,
-  type Spec,
-} from '../types'
+import { useGlobalStore } from '../stores/globalStore'
+import { type ReferenceProps, type Spec } from '../types'
 import ApiReferenceLayout from './ApiReferenceLayout.vue'
 
 const props = defineProps<ReferenceProps>()
@@ -28,17 +23,22 @@ const emit = defineEmits<{
   ): void
 }>()
 
+const { configuration: currentConfiguration, setConfiguration } =
+  useGlobalStore()
+
+watch(
+  () => props.configuration,
+  (value) => {
+    setConfiguration(value)
+  },
+  { immediate: true, deep: true },
+)
+
 /**
  * The editor component has heavy dependencies (process), let's lazy load it.
  */
 const LazyLoadedSwaggerEditor = defineAsyncComponent(() =>
   import('@scalar/swagger-editor').then((module) => module.SwaggerEditor),
-)
-
-/** Merge the default configuration with the given configuration. */
-const currentConfiguration = computed(
-  (): ReferenceConfiguration =>
-    deepMerge(props.configuration ?? {}, { ...DEFAULT_CONFIG }),
 )
 
 // Make it a ComputedRef

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -21,11 +21,13 @@ import { Icon } from '../../Icon'
 const props = defineProps<{
   operation: TransformedOperation
 }>()
+
 const CodeMirrorValue = ref<string>('')
 const { copyToClipboard } = useClipboard()
 const { setActiveRequest } = useRequestStore()
 const { toggleApiClient } = useApiClientStore()
 const { state, setItem, getClientTitle, getTargetTitle } = useTemplateStore()
+const { configuration } = useGlobalStore()
 
 const { server: serverState, authentication: authenticationState } =
   useGlobalStore()
@@ -169,6 +171,7 @@ const formattedPath = computed(() => {
         readOnly />
     </CardContent>
     <CardFooter
+      v-if="configuration.withApiClient"
       class="scalar-card-footer"
       contrast>
       <button

--- a/packages/api-reference/src/stores/globalStore.ts
+++ b/packages/api-reference/src/stores/globalStore.ts
@@ -1,4 +1,4 @@
-import { computed, reactive } from 'vue'
+import { computed, reactive, watch } from 'vue'
 
 import { deepMerge } from '../helpers'
 import {
@@ -11,7 +11,11 @@ import {
 /** Configuration */
 const currentConfiguration: ReferenceConfiguration = reactive({})
 
-const setConfiguration = (newConfiguration: ReferenceConfiguration) => {
+const setConfiguration = (newConfiguration?: ReferenceConfiguration) => {
+  if (!newConfiguration) {
+    return
+  }
+
   Object.assign(currentConfiguration, newConfiguration)
 }
 
@@ -65,11 +69,25 @@ const setServer = (newState: Partial<ServerState>) => {
   })
 }
 
-export const useGlobalStore = () => ({
-  setConfiguration,
-  configuration,
-  authentication,
-  setAuthentication,
-  server,
-  setServer,
-})
+export const useGlobalStore = (params?: {
+  configuration?: ReferenceConfiguration
+}) => {
+  if (params?.configuration) {
+    watch(
+      () => params.configuration,
+      (value) => {
+        setConfiguration(value)
+      },
+      { immediate: true, deep: true },
+    )
+  }
+
+  return {
+    setConfiguration,
+    configuration,
+    authentication,
+    setAuthentication,
+    server,
+    setServer,
+  }
+}

--- a/packages/api-reference/src/stores/globalStore.ts
+++ b/packages/api-reference/src/stores/globalStore.ts
@@ -1,7 +1,27 @@
-import { reactive } from 'vue'
+import { computed, reactive } from 'vue'
 
-import type { AuthenticationState, ServerState } from '../types'
+import { deepMerge } from '../helpers'
+import {
+  type AuthenticationState,
+  DEFAULT_CONFIG,
+  type ReferenceConfiguration,
+  type ServerState,
+} from '../types'
 
+/** Configuration */
+const currentConfiguration: ReferenceConfiguration = reactive({})
+
+const setConfiguration = (newConfiguration: ReferenceConfiguration) => {
+  Object.assign(currentConfiguration, newConfiguration)
+}
+
+// Merge the default configuration with the given configuration.
+const configuration = computed(
+  (): ReferenceConfiguration =>
+    deepMerge(currentConfiguration ?? {}, { ...DEFAULT_CONFIG }),
+)
+
+/** Authentcation */
 export const createEmptyAuthenticationState = (): AuthenticationState => ({
   securitySchemeKey: null,
   http: {
@@ -29,6 +49,7 @@ const setAuthentication = (newState: Partial<AuthenticationState>) => {
   })
 }
 
+/** Server */
 export const createEmptyServerState = (): ServerState => ({
   selectedServer: null,
   servers: [],
@@ -45,6 +66,8 @@ const setServer = (newState: Partial<ServerState>) => {
 }
 
 export const useGlobalStore = () => ({
+  setConfiguration,
+  configuration,
   authentication,
   setAuthentication,
   server,

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -45,6 +45,12 @@ export type ReferenceConfiguration = {
   searchHotKey?: string
   /** ??? */
   aiWriterMarkdown?: string
+  /**
+   * Whether to include the interactive API client
+   *
+   * @default true
+   */
+  withApiClient?: boolean
 }
 
 /** Default reference configuration */
@@ -62,6 +68,7 @@ export const DEFAULT_CONFIG: DeepReadonly<ReferenceConfiguration> = {
   showSidebar: true,
   isEditable: false,
   hocuspocusConfiguration: undefined,
+  withApiClient: true,
 }
 
 export type Schema = {

--- a/projects/web/src/components/DevToolbar.vue
+++ b/projects/web/src/components/DevToolbar.vue
@@ -92,6 +92,12 @@ watch(
         showSidebar
       </div>
       <div>
+        <input
+          v-model="configuration.withApiClient"
+          type="checkbox" />
+        withApiClient
+      </div>
+      <div>
         Theme:
         <select v-model="configuration.theme">
           <option

--- a/projects/web/src/pages/ApiReferencePage.vue
+++ b/projects/web/src/pages/ApiReferencePage.vue
@@ -19,6 +19,7 @@ const configuration = reactive<ReferenceConfiguration>({
   tabs: {
     initialContent: 'Swagger Editor',
   },
+  withApiClient: true,
 })
 
 onMounted(() => {


### PR DESCRIPTION
This PR does two things:

1. The configuration is put into a global store now. So we don't need to do prop drilling all the time.
2. This feature is used to add a `withApiClient` flag to the configuration and show/hide the `Test Request` button.

https://github.com/scalar/scalar/assets/1577992/07e3239d-155f-4fd5-8439-f040c9d5dd52

