### PR TITLE
feat: anchors, fixes #295 

### DIFF
--- a/.changeset/olive-forks-end.md
+++ b/.changeset/olive-forks-end.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add anchors to headings

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { useClipboard } from '@scalar/use-clipboard'
+
+defineProps<{
+  id: string
+}>()
+
+const { copyToClipboard } = useClipboard()
+
+const getUrlWithId = (id: string) => {
+  const url = new URL(window.location.href)
+
+  url.hash = id
+
+  return url.toString()
+}
+</script>
+
+<template>
+  <div class="anchor">
+    <div class="anchor-content">
+      <slot />
+    </div>
+    <button
+      class="anchor-action"
+      type="button"
+      @click="copyToClipboard(getUrlWithId(id))">
+      🔗
+    </button>
+  </div>
+</template>
+
+<style>
+.anchor {
+  display: flex;
+  gap: 8px;
+}
+</style>

--- a/packages/api-reference/src/components/Anchor/index.ts
+++ b/packages/api-reference/src/components/Anchor/index.ts
@@ -1,0 +1,1 @@
+export { default as Anchor } from './Anchor.vue'

--- a/packages/api-reference/src/components/Content/EndpointsOverview.vue
+++ b/packages/api-reference/src/components/Content/EndpointsOverview.vue
@@ -8,6 +8,7 @@ import {
 } from '../../helpers'
 import { useTemplateStore } from '../../stores/template'
 import type { Tag, TransformedOperation } from '../../types'
+import { Anchor } from '../Anchor'
 import { Card, CardContent, CardHeader } from '../Card'
 import {
   Section,
@@ -38,9 +39,11 @@ async function scrollHandler(operation: TransformedOperation) {
     <SectionContent>
       <SectionColumns>
         <SectionColumn>
-          <SectionHeader :level="2">
-            {{ tag.name }}
-          </SectionHeader>
+          <Anchor :id="getTagSectionId(tag)">
+            <SectionHeader :level="2">
+              {{ tag.name }}
+            </SectionHeader>
+          </Anchor>
           <MarkdownRenderer :value="tag.description" />
         </SectionColumn>
         <SectionColumn>

--- a/packages/api-reference/src/components/Content/Models.vue
+++ b/packages/api-reference/src/components/Content/Models.vue
@@ -4,6 +4,7 @@ import { computed } from 'vue'
 import { getModelSectionId } from '../../helpers'
 import { useTemplateStore } from '../../stores/template'
 import { type Components } from '../../types'
+import { Anchor } from '../Anchor'
 import {
   Section,
   SectionContainer,
@@ -45,9 +46,11 @@ const models = computed(() => {
       :label="name">
       <template v-if="components?.schemas?.[name]">
         <SectionContent>
-          <SectionHeader :level="2">
-            {{ name }}
-          </SectionHeader>
+          <Anchor :id="getModelSectionId(name)">
+            <SectionHeader :level="2">
+              {{ name }}
+            </SectionHeader>
+          </Anchor>
           <!-- Schema -->
           <Schema
             :name="name"

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { getOperationSectionId } from '../../../helpers'
 import type { Tag, TransformedOperation } from '../../../types'
+import { Anchor } from '../../Anchor'
 import {
   Section,
   SectionColumn,
@@ -24,9 +25,11 @@ defineProps<{
     <SectionContent>
       <SectionColumns>
         <SectionColumn>
-          <SectionHeader :level="3">
-            {{ operation.name }}
-          </SectionHeader>
+          <Anchor :id="getOperationSectionId(operation, tag)">
+            <SectionHeader :level="3">
+              {{ operation.name }}
+            </SectionHeader>
+          </Anchor>
           <Copy :operation="operation" />
         </SectionColumn>
         <SectionColumn>


### PR DESCRIPTION
This PR adds a new `Anchor` component, which can wrap headings to add an anchor. Clicking the anchor copies a sharable link to the section.

Added to tags, operations and models. Not yet to headings in the description.

I didn’t even try to make it look good and just used an emoji. @cameronrohani can you help here? 🙏 

<img width="425" alt="Screenshot 2023-11-21 at 15 33 58" src="https://github.com/scalar/scalar/assets/1577992/4175f2d8-7a91-4a27-bd85-d4a286f36a54">
