### PR TITLE
refactor: expose slot props for reference base component

### DIFF
--- a/.changeset/tough-lobsters-obey.md
+++ b/.changeset/tough-lobsters-obey.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+refactor: expose slot props for reference base component

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -43,10 +43,10 @@ const otherProps = computed(() => {
       #header>
       <MobileHeader />
     </template>
-    <template
-      v-if="!isMobile"
-      #sidebar-start>
-      <SearchButton :searchHotKey="props.configuration?.searchHotKey" />
+    <template #sidebar-start="{ spec }">
+      <SearchButton
+        :searchHotKey="props.configuration?.searchHotKey"
+        :spec="spec" />
     </template>
     <template #sidebar-end>
       <DarkModeToggle />

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -2,7 +2,6 @@
 import { useMediaQuery } from '@vueuse/core'
 import { computed, ref } from 'vue'
 
-import { useTemplateStore } from '../stores/template'
 import { type ReferenceProps, type SpecConfiguration } from '../types'
 import ApiReferenceBase from './ApiReferenceBase.vue'
 import DarkModeToggle from './DarkModeToggle.vue'
@@ -11,7 +10,7 @@ import SearchButton from './SearchButton.vue'
 
 const props = defineProps<ReferenceProps>()
 
-const { state } = useTemplateStore()
+const showMobileDrawer = ref(false)
 
 const isMobile = useMediaQuery('(max-width: 1000px)')
 
@@ -20,7 +19,7 @@ const content = ref('')
 // Override the sidebar value for mobile to open and close the drawer
 const config = computed(() => {
   const showSidebar = isMobile.value
-    ? state.showMobileDrawer
+    ? showMobileDrawer.value
     : props.configuration?.showSidebar
   const spec: SpecConfiguration = props.configuration?.spec || {
     content: content.value,
@@ -41,7 +40,7 @@ const otherProps = computed(() => {
     <template
       v-if="isMobile"
       #header>
-      <MobileHeader />
+      <MobileHeader v-model:open="showMobileDrawer" />
     </template>
     <template #sidebar-start="{ spec }">
       <SearchButton

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -102,16 +102,36 @@ const swaggerEditorRef = ref<typeof SwaggerEditor | undefined>()
     :swaggerEditorRef="swaggerEditorRef"
     @changeTheme="$emit('changeTheme', $event)"
     @updateContent="(newContent: string) => setRawSpecRef(newContent)">
-    <template #header="attribs">
+    <template #header="scope">
       <slot
-        v-bind="attribs"
+        v-bind="scope"
         name="header" />
     </template>
-    <template #sidebar-start><slot name="sidebar-start" /></template>
-    <template #sidebar-end><slot name="sidebar-end" /></template>
-    <template #content-start><slot name="content-start" /></template>
-    <template #content-end><slot name="content-end" /></template>
-    <template #footer><slot name="footer" /></template>
+    <template #sidebar-start="scope">
+      <slot
+        name="sidebar-start"
+        v-bind="scope" />
+    </template>
+    <template #sidebar-end="scope">
+      <slot
+        name="sidebar-end"
+        v-bind="scope" />
+    </template>
+    <template #content-start="scope">
+      <slot
+        name="content-start"
+        v-bind="scope" />
+    </template>
+    <template #content-end="scope">
+      <slot
+        name="content-end"
+        v-bind="scope" />
+    </template>
+    <template #footer="scope">
+      <slot
+        name="footer"
+        v-bind="scope" />
+    </template>
     <template
       v-if="LazyLoadedSwaggerEditor"
       #editor>

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -10,7 +10,9 @@ import { useParser, useSpec } from '../hooks'
 import {
   DEFAULT_CONFIG,
   type ReferenceConfiguration,
+  type ReferenceLayoutSlot,
   type ReferenceProps,
+  type ReferenceSlotProps,
   type Spec,
 } from '../types'
 import ApiReferenceLayout from './ApiReferenceLayout.vue'
@@ -26,6 +28,12 @@ const emit = defineEmits<{
     swaggerData: string,
     swaggerType: 'json' | 'yaml',
   ): void
+}>()
+
+type ReferenceSlot = Exclude<ReferenceLayoutSlot, 'editor'>
+
+const slots = defineSlots<{
+  [x in ReferenceSlot]: (props: ReferenceSlotProps) => any
 }>()
 
 /**
@@ -102,34 +110,12 @@ const swaggerEditorRef = ref<typeof SwaggerEditor | undefined>()
     :swaggerEditorRef="swaggerEditorRef"
     @changeTheme="$emit('changeTheme', $event)"
     @updateContent="(newContent: string) => setRawSpecRef(newContent)">
-    <template #header="scope">
+    <!-- Passes up all the slots except `editor` with typed slot props -->
+    <template
+      v-for="(_, name) in slots"
+      #[name]="scope">
       <slot
-        v-bind="scope"
-        name="header" />
-    </template>
-    <template #sidebar-start="scope">
-      <slot
-        name="sidebar-start"
-        v-bind="scope" />
-    </template>
-    <template #sidebar-end="scope">
-      <slot
-        name="sidebar-end"
-        v-bind="scope" />
-    </template>
-    <template #content-start="scope">
-      <slot
-        name="content-start"
-        v-bind="scope" />
-    </template>
-    <template #content-end="scope">
-      <slot
-        name="content-end"
-        v-bind="scope" />
-    </template>
-    <template #footer="scope">
-      <slot
-        name="footer"
+        :name="name"
         v-bind="scope" />
     </template>
     <template

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -8,7 +8,12 @@ import { useMediaQuery, useResizeObserver } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 
 import { useTemplateStore } from '../stores/template'
-import type { ReferenceConfiguration, ReferenceSlotProps, Spec } from '../types'
+import type {
+  ReferenceConfiguration,
+  ReferenceLayoutSlot,
+  ReferenceSlotProps,
+  Spec,
+} from '../types'
 import {
   default as ApiClientModal,
   useApiClientStore,
@@ -27,6 +32,10 @@ defineEmits<{
   (e: 'changeTheme', value: ThemeId): void
   (e: 'updateContent', value: string): void
   (e: 'toggleDarkMode'): void
+}>()
+
+defineSlots<{
+  [x in ReferenceLayoutSlot]: (props: ReferenceSlotProps) => any
 }>()
 
 const isLargeScreen = useMediaQuery('(min-width: 1150px)')

--- a/packages/api-reference/src/components/MobileHeader.vue
+++ b/packages/api-reference/src/components/MobileHeader.vue
@@ -6,11 +6,8 @@ import FlowIconButton from './FlowIconButton.vue'
 
 const { state } = useApiClientStore()
 
-const {
-  state: templateState,
-  setItem: setTemplateItem,
-  toggleItem: toggleTemplateItem,
-} = useTemplateStore()
+const { state: templateState, toggleItem: toggleTemplateItem } =
+  useTemplateStore()
 </script>
 <template>
   <div class="references-mobile-header t-doc__header">
@@ -22,14 +19,7 @@ const {
     <span class="references-mobile-breadcrumbs">{{
       state.activeBreadcrumb
     }}</span>
-    <div class="sidebar-mobile-actions">
-      <FlowIconButton
-        icon="Search"
-        label="Search"
-        variant="clear"
-        width="24px"
-        @click="setTemplateItem('showSearch', true)" />
-    </div>
+    <div class="sidebar-mobile-actions"></div>
   </div>
 </template>
 <style scoped>

--- a/packages/api-reference/src/components/MobileHeader.vue
+++ b/packages/api-reference/src/components/MobileHeader.vue
@@ -1,21 +1,25 @@
 <script setup lang="ts">
 import { useApiClientStore } from '@scalar/api-client'
 
-import { useTemplateStore } from '../stores/template'
 import FlowIconButton from './FlowIconButton.vue'
 
-const { state } = useApiClientStore()
+defineProps<{
+  open?: boolean
+}>()
 
-const { state: templateState, toggleItem: toggleTemplateItem } =
-  useTemplateStore()
+defineEmits<{
+  (event: 'update:open', open: boolean): void
+}>()
+
+const { state } = useApiClientStore()
 </script>
 <template>
   <div class="references-mobile-header t-doc__header">
     <FlowIconButton
-      :icon="templateState.showMobileDrawer ? 'Close' : 'Menu'"
-      :label="templateState.showMobileDrawer ? 'Close Menu' : 'Open Menu'"
+      :icon="open ? 'Close' : 'Menu'"
+      :label="open ? 'Close Menu' : 'Open Menu'"
       width="20px"
-      @click="() => toggleTemplateItem('showMobileDrawer')" />
+      @click="$emit('update:open', !open)" />
     <span class="references-mobile-breadcrumbs">{{
       state.activeBreadcrumb
     }}</span>

--- a/packages/api-reference/src/components/SearchButton.vue
+++ b/packages/api-reference/src/components/SearchButton.vue
@@ -1,20 +1,35 @@
 <script setup lang="ts">
+import { useKeyboardEvent } from '@scalar/use-keyboard-event'
+import { useModal } from '@scalar/use-modal'
 import { isMacOS } from '@scalar/use-tooltip'
+import { type Spec } from 'src/types'
 
-import { useTemplateStore } from '../stores/template'
 import FlowIcon from './Icon/FlowIcon.vue'
+import SearchModal from './SearchModal.vue'
 
-withDefaults(defineProps<{ searchHotKey?: string }>(), {
-  searchHotKey: 'k',
+const props = withDefaults(
+  defineProps<{
+    spec: Spec
+    searchHotKey?: string
+  }>(),
+  {
+    searchHotKey: 'k',
+  },
+)
+
+const modalState = useModal()
+
+useKeyboardEvent({
+  keyList: [props.searchHotKey],
+  withCtrlCmd: true,
+  handler: () => (modalState.open ? modalState.hide() : modalState.show()),
 })
-
-const { setItem } = useTemplateStore()
 </script>
 <template>
   <button
     class="sidebar-search"
     type="button"
-    @click="setItem('showSearch', true)">
+    @click="modalState.show">
     <FlowIcon
       class="search-icon"
       icon="Search" />
@@ -31,6 +46,9 @@ const { setItem } = useTemplateStore()
       </span>
     </div>
   </button>
+  <SearchModal
+    :modalState="modalState"
+    :parsedSpec="spec" />
 </template>
 <style scoped>
 .sidebar-search {

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -9,5 +9,6 @@ export { default as Sidebar } from './components/Sidebar.vue'
 export { default as RenderedReference } from './components/Content/Content.vue'
 export { default as DarkModeToggle } from './components/DarkModeToggle.vue'
 export { default as SearchModal } from './components/SearchModal.vue'
+export { default as SearchButton } from './components/SearchButton.vue'
 
 export * from './types'

--- a/packages/api-reference/src/stores/template.ts
+++ b/packages/api-reference/src/stores/template.ts
@@ -16,7 +16,6 @@ export type SelectedClient = { targetKey: TargetId; clientKey: string }
 
 type TemplateState = {
   isDark: boolean
-  showMobileDrawer: boolean
   activeNavState: NavState
   collapsedSidebarItems: Partial<Record<string, boolean>>
   selectedClient: SelectedClient
@@ -24,7 +23,6 @@ type TemplateState = {
 
 const defaultTemplateState = (): TemplateState => ({
   isDark: false,
-  showMobileDrawer: false,
   activeNavState: NavState.Guide,
   collapsedSidebarItems: {},
   selectedClient: {

--- a/packages/api-reference/src/stores/template.ts
+++ b/packages/api-reference/src/stores/template.ts
@@ -17,7 +17,6 @@ export type SelectedClient = { targetKey: TargetId; clientKey: string }
 type TemplateState = {
   isDark: boolean
   showMobileDrawer: boolean
-  showSearch: boolean
   activeNavState: NavState
   collapsedSidebarItems: Partial<Record<string, boolean>>
   selectedClient: SelectedClient
@@ -25,7 +24,6 @@ type TemplateState = {
 
 const defaultTemplateState = (): TemplateState => ({
   isDark: false,
-  showSearch: false,
   showMobileDrawer: false,
   activeNavState: NavState.Guide,
   collapsedSidebarItems: {},

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -303,6 +303,15 @@ export type HarRequestWithPath = HarRequest & {
   path: string
 }
 
+export type ReferenceLayoutSlot =
+  | 'header'
+  | 'footer'
+  | 'editor'
+  | 'content-start'
+  | 'content-end'
+  | 'sidebar-start'
+  | 'sidebar-end'
+
 export type ReferenceSlotProps = {
   spec: Spec
   breadcrumb: string

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -302,3 +302,8 @@ export type Cookie = {
 export type HarRequestWithPath = HarRequest & {
   path: string
 }
+
+export type ReferenceSlotProps = {
+  spec: Spec
+  breadcrumb: string
+}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -20,5 +20,5 @@ pnpm concurrently \
             --workspace-concurrency=100 \
             --filter @scalar/api-reference \
             --filter @scalar/components \
-            storybook \
+            storybook --no-open \
     "


### PR DESCRIPTION
This exposes `referenceSlotProps` on all the slots on the `ApiReferenceBase` allowing us to externalize and control the search modal.