### PR TITLE
fix(getApiClientRequest): added missing path parameter variable and default values.

### DIFF
--- a/packages/api-reference/src/helpers/getApiClientRequest.ts
+++ b/packages/api-reference/src/helpers/getApiClientRequest.ts
@@ -38,8 +38,6 @@ export function getApiClientRequest({
     ...operation.pathParameters,
   ]
 
-  console.log('o', operation)
-
   return {
     id: operation.operationId,
     name: operation.name,

--- a/packages/api-reference/src/helpers/getApiClientRequest.ts
+++ b/packages/api-reference/src/helpers/getApiClientRequest.ts
@@ -33,16 +33,22 @@ export function getApiClientRequest({
   )
 
   const requestFromOperation = getRequestFromOperation(operation)
+  const parameters = [
+    ...operation.information.parameters,
+    ...operation.pathParameters,
+  ]
+
+  console.log('o', operation)
 
   return {
     id: operation.operationId,
     name: operation.name,
     type: request.method,
     path: requestFromOperation.path ?? '',
-    parameters: (operation.information.parameters ?? []).map((parameter) => {
+    parameters: parameters.map((parameter) => {
       return {
         name: parameter.name,
-        value: '',
+        value: parameter.schema?.default ?? '',
       }
     }),
     cookies: request.cookies,

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -75,6 +75,7 @@ export const DEFAULT_CONFIG: DeepReadonly<ReferenceConfiguration> = {
 export type Schema = {
   format: string
   type: string
+  default?: any
 }
 
 export type Parameters = {


### PR DESCRIPTION
## Description

The API client should populate the variables with endpoint-level parameters just like it does for method-level parameters. Also, it should use the default values when provided in the spec.

Resolves #531 