### PR TITLE
fix: only activate hotkey if component is active

### DIFF
--- a/.changeset/modern-ears-push.md
+++ b/.changeset/modern-ears-push.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: don't handle search shortcut if component is deactivated

--- a/packages/api-reference/src/components/SearchButton.vue
+++ b/packages/api-reference/src/components/SearchButton.vue
@@ -4,6 +4,7 @@ import { useModal } from '@scalar/use-modal'
 import { isMacOS } from '@scalar/use-tooltip'
 import { type Spec } from 'src/types'
 
+import { useActive } from '../hooks/useActive'
 import FlowIcon from './Icon/FlowIcon.vue'
 import SearchModal from './SearchModal.vue'
 
@@ -17,12 +18,15 @@ const props = withDefaults(
   },
 )
 
+const { isActive } = useActive()
+
 const modalState = useModal()
 
 useKeyboardEvent({
   keyList: [props.searchHotKey],
   withCtrlCmd: true,
   handler: () => (modalState.open ? modalState.hide() : modalState.show()),
+  active: () => isActive.value,
 })
 </script>
 <template>

--- a/packages/api-reference/src/hooks/useActive.ts
+++ b/packages/api-reference/src/hooks/useActive.ts
@@ -1,0 +1,19 @@
+import { computed, onActivated, onDeactivated, onMounted, ref } from 'vue'
+
+/** This tells you if a component is active in a `<keepalive>` */
+export function useActive() {
+  const isActive = ref<boolean>(true)
+
+  // Component is active on mount
+  onMounted(() => (isActive.value = true))
+
+  // Component was activated
+  onActivated(() => (isActive.value = true))
+
+  // Component was deactivated
+  onDeactivated(() => (isActive.value = false))
+
+  return {
+    isActive: computed(() => isActive.value),
+  }
+}


### PR DESCRIPTION
Prevents search modal hotkey from being active if the component is in a `<keepalive>`  (like our references are) but deactivated.

Before:

https://github.com/scalar/scalar/assets/6374090/41a34bbb-05dc-4c20-8bb2-7a29e6e991b4

After:

https://github.com/scalar/scalar/assets/6374090/556bae47-71f8-4bca-bbf4-4529a8a7f688



