### PR TITLE
chore: upgrade to Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/api-client-proxy/package.json
+++ b/packages/api-client-proxy/package.json
@@ -20,7 +20,7 @@
     "vitest": "0.34.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -30,7 +30,7 @@
     "vue-tsc": "1.8.19"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js"

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -64,7 +64,7 @@
     "vue-tsc": "1.8.19"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js"

--- a/packages/api-reference/src/hooks/useParser.test.ts
+++ b/packages/api-reference/src/hooks/useParser.test.ts
@@ -96,7 +96,7 @@ describe('useParser', () => {
     // Sleep for 10ms to wait for the parser to finish
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(errorRef.value).toContain('Unexpected end of JSON')
+    expect(errorRef.value).toContain('SyntaxError')
   })
 
   it('overwrites the ref', async () => {

--- a/packages/echo-server/package.json
+++ b/packages/echo-server/package.json
@@ -19,7 +19,7 @@
     "vitest": "0.34.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js",

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -24,7 +24,7 @@
     "vitest": "0.34.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js",

--- a/packages/swagger-editor/package.json
+++ b/packages/swagger-editor/package.json
@@ -35,7 +35,7 @@
     "vue-tsc": "1.8.19"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js"

--- a/packages/swagger-parser/package.json
+++ b/packages/swagger-parser/package.json
@@ -21,7 +21,7 @@
     "vitest": "0.34.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js"

--- a/packages/use-clipboard/package.json
+++ b/packages/use-clipboard/package.json
@@ -17,7 +17,7 @@
     "vue-tsc": "1.8.19"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js"

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -29,7 +29,7 @@
     "vue-tsc": "1.8.19"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js"

--- a/packages/use-keyboard-event/package.json
+++ b/packages/use-keyboard-event/package.json
@@ -13,7 +13,7 @@
     "vue-tsc": "1.8.19"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js"

--- a/packages/use-modal/package.json
+++ b/packages/use-modal/package.json
@@ -16,7 +16,7 @@
     "vue-tsc": "1.8.19"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js"

--- a/packages/use-toasts/package.json
+++ b/packages/use-toasts/package.json
@@ -17,7 +17,7 @@
     "vue-tsc": "1.8.19"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist",

--- a/packages/use-tooltip/package.json
+++ b/packages/use-tooltip/package.json
@@ -16,7 +16,7 @@
     "vue-tsc": "1.8.19"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "exports": {
     "import": "./dist/index.js"

--- a/projects/api-client-proxy/package.json
+++ b/projects/api-client-proxy/package.json
@@ -11,7 +11,7 @@
     "vite-node": "0.34.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "private": true,
   "scripts": {

--- a/projects/backend/package.json
+++ b/projects/backend/package.json
@@ -13,7 +13,7 @@
     "vite-node": "0.34.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "private": true,
   "scripts": {

--- a/projects/echo-server/package.json
+++ b/projects/echo-server/package.json
@@ -11,7 +11,7 @@
     "vite-node": "0.34.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "private": true,
   "scripts": {

--- a/projects/fastify-api-reference/package.json
+++ b/projects/fastify-api-reference/package.json
@@ -13,7 +13,7 @@
     "vite-node": "0.34.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
Node 18 isn’t in active support anymore. Let’s upgrade to Node 20 (LTS). 🏄 

<img width="758" alt="Screenshot 2023-11-24 at 10 56 03" src="https://github.com/scalar/scalar/assets/1577992/70bcee88-8494-4072-bed9-82cbd425c4d6">
