### PR TITLE
fix: empty parameters break the api client

### DIFF
--- a/.changeset/clean-avocados-attend.md
+++ b/.changeset/clean-avocados-attend.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: pass global parameters and parameters to the api client

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
@@ -50,11 +50,11 @@ const currentResponse = computed(() => {
   const currentStatusCode =
     orderedStatusCodes.value[selectedResponseIndex.value]
 
-  return props.operation.information?.responses[currentStatusCode]
+  return props.operation.information?.responses?.[currentStatusCode]
 })
 
 const currentJsonResponse = computed(
-  () => currentResponse.value.content?.['application/json'],
+  () => currentResponse.value?.content?.['application/json'],
 )
 
 const changeTab = (index: number) => {

--- a/packages/api-reference/src/helpers/getApiClientRequest.test.ts
+++ b/packages/api-reference/src/helpers/getApiClientRequest.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { useGlobalStore } from '../stores'
+import { getApiClientRequest } from './getApiClientRequest'
+
+const { server, authentication } = useGlobalStore()
+
+describe('getApiClientRequest', () => {
+  it('returns a basic request', () => {
+    expect(
+      getApiClientRequest({
+        serverState: server,
+        authenticationState: authentication,
+        operation: {
+          operationId: 'foobar',
+          description: 'foobar',
+          name: 'foobar',
+          httpVerb: 'GET',
+          path: '/foobar',
+          information: {
+            operationId: 'foobar',
+          },
+        },
+      }),
+    ).toMatchObject({
+      id: 'foobar',
+      name: 'foobar',
+      path: '/foobar',
+      type: 'GET',
+      url: '',
+    })
+  })
+})

--- a/packages/api-reference/src/helpers/getApiClientRequest.ts
+++ b/packages/api-reference/src/helpers/getApiClientRequest.ts
@@ -34,8 +34,8 @@ export function getApiClientRequest({
 
   const requestFromOperation = getRequestFromOperation(operation)
   const parameters = [
-    ...operation.information.parameters,
-    ...operation.pathParameters,
+    ...(operation.information.parameters ?? []),
+    ...(operation.pathParameters ?? []),
   ]
 
   return {

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -85,14 +85,14 @@ export type Response = {
 }
 
 export type Information = {
-  description: string
-  operationId: string
-  parameters: Parameters[]
-  responses: Record<string, Response>
-  security: OpenAPIV3.SecurityRequirementObject[]
-  requestBody: RequestBody
-  summary: string
-  tags: string[]
+  description?: string
+  operationId?: string | number
+  parameters?: Parameters[]
+  responses?: Record<string, Response>
+  security?: OpenAPIV3.SecurityRequirementObject[]
+  requestBody?: RequestBody
+  summary?: string
+  tags?: string[]
 }
 
 export type Operation = {
@@ -125,7 +125,7 @@ export type RequestBodyMimeTypes =
   | 'text/plain'
 
 export type TransformedOperation = Operation & {
-  pathParameters: Parameters[]
+  pathParameters?: Parameters[]
   information: {
     requestBody?: {
       content?: Record<


### PR DESCRIPTION
We introduced a regression in #536: If a request didn’t have parameters it would fail and the API client wouldn’t open at all.

This PR adds a test for that regression and fixes the issue.

I’ve also made all operation properties optional. Even if that might not match the spec, our package should be flexible with the input.