### PR TITLE
chore: rename @scalar-org to @scalar-examples

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@scalar-org/*"]
+  "ignore": ["@scalar-examples/*"]
 }

--- a/examples/api-client-proxy/package.json
+++ b/examples/api-client-proxy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar-org/api-client-proxy",
+  "name": "@scalar-examples/api-client-proxy",
   "version": "0.5.0",
   "dependencies": {
     "@scalar/api-client-proxy": "workspace:*",

--- a/examples/backend/package.json
+++ b/examples/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar-org/backend",
+  "name": "@scalar-examples/backend",
   "version": "0.5.2",
   "dependencies": {
     "@hocuspocus/extension-logger": "^2.6.1",

--- a/examples/echo-server/package.json
+++ b/examples/echo-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar-org/echo-server",
+  "name": "@scalar-examples/echo-server",
   "version": "0.5.0",
   "dependencies": {
     "@scalar/echo-server": "workspace:*",

--- a/examples/express-api-reference/package.json
+++ b/examples/express-api-reference/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar-org/express-api-reference",
+  "name": "@scalar-examples/express-api-reference",
   "dependencies": {
     "@scalar/express-api-reference": "workspace:^",
     "express": "^4.18.2",

--- a/examples/fastify-api-reference/package.json
+++ b/examples/fastify-api-reference/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar-org/fastify-api-reference",
+  "name": "@scalar-examples/fastify-api-reference",
   "version": "0.5.2",
   "dependencies": {
     "@fastify/swagger": "^8.10.1",

--- a/examples/hono-api-reference/package.json
+++ b/examples/hono-api-reference/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar-org/hono-api-reference",
+  "name": "@scalar-examples/hono-api-reference",
   "dependencies": {
     "@hono/node-server": "^1.2.0",
     "@hono/zod-openapi": "^0.8.3",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar-org/react",
+  "name": "@scalar-examples/react",
   "version": "0.0.0",
   "dependencies": {
     "react": "^18.2.0",

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar-org/ssg",
+  "name": "@scalar-examples/ssg",
   "version": "0.1.0",
   "dependencies": {
     "@scalar/api-reference": "workspace:*",

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar-org/web",
+  "name": "@scalar-examples/web",
   "version": "0.4.2",
   "dependencies": {
     "@scalar/api-client": "workspace:*",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,14 +5,14 @@ pnpm concurrently \
     " \
         pnpm \
             --workspace-concurrency=100 \
-            --filter @scalar-org/web \
-            --filter @scalar-org/react \
-            --filter @scalar-org/api-client-proxy \
-            --filter @scalar-org/echo-server \
-            --filter @scalar-org/fastify-api-reference \
-            --filter @scalar-org/hono-api-reference \
-            --filter @scalar-org/express-api-reference \
-            --filter @scalar-org/backend \
+            --filter @scalar-examples/web \
+            --filter @scalar-examples/react \
+            --filter @scalar-examples/api-client-proxy \
+            --filter @scalar-examples/echo-server \
+            --filter @scalar-examples/fastify-api-reference \
+            --filter @scalar-examples/hono-api-reference \
+            --filter @scalar-examples/express-api-reference \
+            --filter @scalar-examples/backend \
             dev \
     " \
     " \

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -50,14 +50,14 @@ const sortKeys = ['dependencies', 'devDependencies', 'scripts']
 const overrides: Record<string, unknown> = {
   license: 'MIT',
   author: 'Scalar (https://github.com/scalar)',
-  bugs: 'https://github.com/scalar/scalar/issues/new',
+  bugs: 'https://github.com/scalar/scalar/issues/new/choose',
   homepage: 'https://github.com/scalar/scalar',
 }
 
 /** Provide default values for some fields */
 const fallbacks: Record<string, unknown> = {
   engines: {
-    node: '>=18',
+    node: '>=20',
   },
 }
 


### PR DESCRIPTION
Follow up for #548, renaming @scalar-org to @scalar-examples.