### PR TITLE
chore: fix relative imports

### DIFF
--- a/.changeset/real-tips-walk.md
+++ b/.changeset/real-tips-walk.md
@@ -1,0 +1,6 @@
+---
+'@scalar/swagger-parser': patch
+'@scalar/api-reference': patch
+---
+
+chore: replace imports pointing to src with relative paths

--- a/packages/api-reference/src/components/SearchButton.vue
+++ b/packages/api-reference/src/components/SearchButton.vue
@@ -2,9 +2,9 @@
 import { useKeyboardEvent } from '@scalar/use-keyboard-event'
 import { useModal } from '@scalar/use-modal'
 import { isMacOS } from '@scalar/use-tooltip'
-import { type Spec } from 'src/types'
 
 import { useActive } from '../hooks/useActive'
+import { type Spec } from '../types'
 import FlowIcon from './Icon/FlowIcon.vue'
 import SearchModal from './SearchModal.vue'
 

--- a/packages/swagger-parser/src/helpers/preflight.test.ts
+++ b/packages/swagger-parser/src/helpers/preflight.test.ts
@@ -1,6 +1,6 @@
-import { parse } from 'src/helpers/parse'
 import { describe, expect, it } from 'vitest'
 
+import { parse } from '../helpers/parse'
 import { preflight } from './preflight'
 
 describe('preflight', () => {


### PR DESCRIPTION
This PR replaces imports pointing to `src` with relative paths. I think this is bringing trouble, e.g. when cross-using the packages in the monorepo.