### PR TITLE
chore: do not externalize @scalar deps

### DIFF
--- a/.changeset/olive-buckets-whisper.md
+++ b/.changeset/olive-buckets-whisper.md
@@ -1,0 +1,17 @@
+---
+'@scalar/use-keyboard-event': patch
+'@scalar/api-client-proxy': patch
+'@scalar/swagger-editor': patch
+'@scalar/swagger-parser': patch
+'@scalar/use-codemirror': patch
+'@scalar/api-reference': patch
+'@scalar/use-clipboard': patch
+'@scalar/echo-server': patch
+'@scalar/use-tooltip': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+'@scalar/use-toasts': patch
+'@scalar/use-modal': patch
+---
+
+chore: include @scalar dependencies in the bundle

--- a/packages/api-client-proxy/vite.config.ts
+++ b/packages/api-client-proxy/vite.config.ts
@@ -13,7 +13,12 @@ export default defineConfig({
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
     },
   },
   resolve: {

--- a/packages/api-client/vite.config.ts
+++ b/packages/api-client/vite.config.ts
@@ -16,7 +16,12 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
     },
   },
   resolve: {

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -37,7 +37,12 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
     },
   },
   resolve: {

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -26,7 +26,12 @@ export default defineConfig({
       },
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps

--- a/packages/echo-server/vite.config.ts
+++ b/packages/echo-server/vite.config.ts
@@ -12,7 +12,12 @@ export default defineConfig({
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
     },
   },
   resolve: {

--- a/packages/swagger-editor/vite.config.ts
+++ b/packages/swagger-editor/vite.config.ts
@@ -17,7 +17,12 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
       output: {
         assetFileNames: (assetInfo) => {
           if (assetInfo.name === 'index.css') {

--- a/packages/swagger-parser/vite.config.ts
+++ b/packages/swagger-parser/vite.config.ts
@@ -15,7 +15,12 @@ export default defineConfig({
       /**
        * Make sure to also externalize any dependencies that you do not want to bundle into your library
        */
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
     },
   },
   resolve: {

--- a/packages/use-clipboard/vite.config.ts
+++ b/packages/use-clipboard/vite.config.ts
@@ -16,7 +16,12 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
       output: {
         assetFileNames: (assetInfo) => {
           if (assetInfo.name === 'index.css') {

--- a/packages/use-codemirror/vite.config.ts
+++ b/packages/use-codemirror/vite.config.ts
@@ -16,7 +16,12 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
     },
   },
 

--- a/packages/use-keyboard-event/vite.config.ts
+++ b/packages/use-keyboard-event/vite.config.ts
@@ -16,7 +16,12 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
       output: {
         assetFileNames: (assetInfo) => {
           if (assetInfo.name === 'index.css') {

--- a/packages/use-modal/vite.config.ts
+++ b/packages/use-modal/vite.config.ts
@@ -16,7 +16,12 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
       output: {
         assetFileNames: (assetInfo) => {
           if (assetInfo.name === 'index.css') {

--- a/packages/use-toasts/vite.config.ts
+++ b/packages/use-toasts/vite.config.ts
@@ -16,7 +16,12 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
     },
   },
   test: {

--- a/packages/use-tooltip/vite.config.ts
+++ b/packages/use-tooltip/vite.config.ts
@@ -16,7 +16,12 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['vue', ...Object.keys(pkg.dependencies || {})],
+      external: [
+        'vue',
+        ...Object.keys(pkg.dependencies || {}).filter(
+          (item) => !item.startsWith('@scalar'),
+        ),
+      ],
       output: {
         assetFileNames: (assetInfo) => {
           if (assetInfo.name === 'index.css') {


### PR DESCRIPTION
I saw this funny issue, where the CSS for modals is missing when using the components. 🤔 Bundling the @scalar deps fixes it. Not sure if that’s the approach, but I consider this a quickfix.

https://github.com/scalar/scalar/assets/1577992/2b04b964-92ae-498f-ab43-288d677eb3d0

