### PR TITLE
fix: catch axios errors and show them in the response

### DIFF
--- a/.changeset/khaki-papayas-add.md
+++ b/.changeset/khaki-papayas-add.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client-proxy': patch
+'@scalar/api-client': patch
+---
+
+fix: surface proxy internal service errors

--- a/.changeset/light-olives-hug.md
+++ b/.changeset/light-olives-hug.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: catch axios errors and show them in the response

--- a/packages/api-client-proxy/src/createApiClientProxy.ts
+++ b/packages/api-client-proxy/src/createApiClientProxy.ts
@@ -100,6 +100,11 @@ export const createApiClientProxy = () => {
         })
       } catch (error) {
         console.error('ERROR', error)
+        const data = 'Scalar API Client Proxy Error'
+        res.status(500)
+        res.json({
+          data,
+        })
       }
 
       return

--- a/packages/api-client/src/helpers/sendRequest.ts
+++ b/packages/api-client/src/helpers/sendRequest.ts
@@ -130,10 +130,15 @@ export async function sendRequest(
     .catch((error) => {
       const { response: errorResponse } = error
 
+      // We add fallbacks where we set the code, status and header type so we can
+      // float all errors now to the user
       return {
+        headers: {
+          'content-type': 'application/json',
+        },
         ...errorResponse,
-        statusCode: errorResponse.status,
-        data: JSON.stringify(errorResponse.data),
+        statusCode: errorResponse?.status ?? 0,
+        data: JSON.stringify(errorResponse?.data ?? { error: error.code }),
       }
     })
 


### PR DESCRIPTION
now if there's any errors at the axios level we show it in the client :)

<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6176314/645916f8-efb6-49fa-88b5-f7df22ca4832">

<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6176314/a7c65dff-b7bd-4724-bddb-6f2714cb8b0f">

while still keeping old functionality 😎 

<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6176314/6c045ffd-7679-4765-a45f-46a0c6e95970">

