### PR TITLE
feat: reduce fastify scalar bundle size by 800kb

### DIFF
--- a/.changeset/swift-points-report.md
+++ b/.changeset/swift-points-report.md
@@ -1,0 +1,11 @@
+---
+'@scalar/fastify-api-reference': minor
+'@scalar/use-keyboard-event': minor
+'@scalar/use-codemirror': minor
+'@scalar/use-clipboard': minor
+'@scalar/use-tooltip': minor
+'@scalar/use-toasts': minor
+'@scalar/use-modal': minor
+---
+
+feat: add terser minification to fastify integration

--- a/.changeset/swift-points-report.md
+++ b/.changeset/swift-points-report.md
@@ -1,11 +1,5 @@
 ---
 '@scalar/fastify-api-reference': minor
-'@scalar/use-keyboard-event': minor
-'@scalar/use-codemirror': minor
-'@scalar/use-clipboard': minor
-'@scalar/use-tooltip': minor
-'@scalar/use-toasts': minor
-'@scalar/use-modal': minor
 ---
 
 feat: add terser minification to fastify integration

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -44,9 +44,11 @@
   },
   "dependencies": {
     "@scalar/api-reference": "workspace:*",
-    "ejs": "^3.1.9"
+    "ejs": "^3.1.9",
+    "terser": "^5.24.0"
   },
   "devDependencies": {
+    "@rollup/plugin-terser": "^0.4.4",
     "@types/ejs": "^3.1.3",
     "@vitejs/plugin-vue": "^4.4.0",
     "@vitest/coverage-v8": "^0.34.4",

--- a/packages/fastify-api-reference/vite.config.ts
+++ b/packages/fastify-api-reference/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   plugins: [nodeShims(), nodeExternals()],
   build: {
     // If minify is enabled, the nodeShims extension doesn’t work.
-    minify: false,
+    minify: 'terser',
     lib: {
       entry: 'src/index.ts',
       name: '@scalar/fastify-api-reference',

--- a/packages/fastify-api-reference/vite.template.config.ts
+++ b/packages/fastify-api-reference/vite.template.config.ts
@@ -1,3 +1,4 @@
+import terser from '@rollup/plugin-terser'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
@@ -41,6 +42,7 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
+      plugins: [terser()],
       output: {
         manualChunks: () => 'index',
       },

--- a/packages/use-clipboard/package.json
+++ b/packages/use-clipboard/package.json
@@ -41,16 +41,15 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/use-clipboard"
   },
-  "dependencies": {},
   "devDependencies": {
+    "@scalar/use-toasts": "workspace:*",
     "@vitejs/plugin-vue": "^4.4.0",
     "@vitest/coverage-v8": "^0.34.4",
+    "nanoid": "^5.0.1",
     "tsc-alias": "^1.8.8",
     "vite": "^4.4.11",
     "vitest": "^0.34.4",
-    "vue-tsc": "^1.8.19",
-    "@scalar/use-toasts": "workspace:*",
-    "nanoid": "^5.0.1"
+    "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {
     "@scalar/use-toasts": "workspace:*",

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -40,15 +40,14 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/use-codemirror"
   },
-  "dependencies": {},
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
     "@vitest/coverage-v8": "^0.34.4",
     "tsc-alias": "^1.8.8",
     "vite": "^4.4.11",
     "vitest": "^0.34.4",
-    "vue-tsc": "^1.8.19",
-    "vue": "^3.3.0"
+    "vue": "^3.3.0",
+    "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {
     "vue": "^3.3.0",

--- a/packages/use-keyboard-event/package.json
+++ b/packages/use-keyboard-event/package.json
@@ -40,15 +40,14 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/use-keyboard-event"
   },
-  "dependencies": {},
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
     "@vitest/coverage-v8": "^0.34.4",
     "tsc-alias": "^1.8.8",
     "vite": "^4.4.11",
     "vitest": "^0.34.4",
-    "vue-tsc": "^1.8.19",
-    "vue": "^3.3.0"
+    "vue": "^3.3.0",
+    "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {
     "vue": "^3.3.0"

--- a/packages/use-modal/package.json
+++ b/packages/use-modal/package.json
@@ -40,16 +40,15 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/use-modal"
   },
-  "dependencies": {},
   "devDependencies": {
+    "@headlessui/vue": "^1.7.16",
     "@vitejs/plugin-vue": "^4.4.0",
     "@vitest/coverage-v8": "^0.34.4",
     "tsc-alias": "^1.8.8",
     "vite": "^4.4.11",
     "vitest": "^0.34.4",
-    "vue-tsc": "^1.8.19",
-    "@headlessui/vue": "^1.7.16",
-    "vue": "^3.3.0"
+    "vue": "^3.3.0",
+    "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {
     "vue": "^3.3.0",

--- a/packages/use-toasts/package.json
+++ b/packages/use-toasts/package.json
@@ -37,17 +37,16 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/use-toasts"
   },
-  "dependencies": {},
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
     "@vitest/coverage-v8": "^0.34.4",
+    "nanoid": "^5.0.1",
     "tsc-alias": "^1.8.8",
     "vite": "^4.4.11",
     "vite-plugin-css-injected-by-js": "^3.3.0",
     "vitest": "^0.34.4",
-    "vue-tsc": "^1.8.19",
     "vue": "^3.3.0",
-    "nanoid": "^5.0.0"
+    "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {
     "nanoid": "4 - 5",

--- a/packages/use-tooltip/package.json
+++ b/packages/use-tooltip/package.json
@@ -40,16 +40,15 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/use-tooltip"
   },
-  "dependencies": {},
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
     "@vitest/coverage-v8": "^0.34.4",
+    "tippy.js": "^6.3.7",
     "tsc-alias": "^1.8.8",
     "vite": "^4.4.11",
     "vitest": "^0.34.4",
-    "vue-tsc": "^1.8.19",
-    "tippy.js": "^6.3.7",
-    "vue": "^3.3.0"
+    "vue": "^3.3.0",
+    "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {
     "vue": "^3.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 5.2.2
       vite-node:
         specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)
+        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
       vue-eslint-parser:
         specifier: ^9.3.1
         version: 9.3.1(eslint@8.49.0)
@@ -91,10 +91,10 @@ importers:
         version: 3.0.1
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-node:
         specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)
+        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
 
   examples/backend:
     dependencies:
@@ -116,10 +116,10 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-node:
         specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)
+        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
 
   examples/echo-server:
     dependencies:
@@ -135,10 +135,10 @@ importers:
         version: 3.0.1
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-node:
         specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)
+        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
 
   examples/express-api-reference:
     dependencies:
@@ -163,7 +163,7 @@ importers:
         version: 3.0.1
       vite-node:
         specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)
+        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
 
   examples/fastify-api-reference:
     dependencies:
@@ -185,10 +185,10 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-node:
         specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)
+        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
 
   examples/hono-api-reference:
     dependencies:
@@ -207,7 +207,7 @@ importers:
         version: 3.0.1
       vite-node:
         specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)
+        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
 
   examples/react:
     dependencies:
@@ -271,7 +271,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-plugin-node-polyfills:
         specifier: ^0.14.1
         version: 0.14.1(rollup@3.29.2)(vite@4.4.11)
@@ -293,7 +293,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-ssg:
         specifier: ^0.23.4
         version: 0.23.4(vite@4.4.11)(vue@3.3.4)
@@ -345,7 +345,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-plugin-node-polyfills:
         specifier: ^0.14.1
         version: 0.14.1(rollup@3.29.2)(vite@4.4.11)
@@ -415,7 +415,7 @@ importers:
         version: 1.8.8
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-plugin-css-injected-by-js:
         specifier: ^3.3.0
         version: 3.3.0(vite@4.4.11)
@@ -461,10 +461,10 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-node:
         specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)
+        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
       vitest:
         specifier: ^0.34.4
         version: 0.34.4(jsdom@22.1.0)
@@ -633,7 +633,7 @@ importers:
         version: 1.8.8
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-plugin-css-injected-by-js:
         specifier: ^3.3.0
         version: 3.3.0(vite@4.4.11)
@@ -754,7 +754,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-plugin-dts:
         specifier: ^3.6.3
         version: 3.6.3(@types/node@20.6.3)(typescript@5.2.2)(vite@4.4.11)
@@ -803,10 +803,10 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-node:
         specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)
+        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
       vitest:
         specifier: ^0.34.4
         version: 0.34.4(jsdom@22.1.0)
@@ -828,7 +828,7 @@ importers:
         version: 7.2.0(typescript@5.2.2)
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vitest:
         specifier: ^0.34.4
         version: 0.34.4(jsdom@22.1.0)
@@ -847,7 +847,13 @@ importers:
       fastify-plugin:
         specifier: ^4.0.0
         version: 4.5.1
+      terser:
+        specifier: ^5.24.0
+        version: 5.24.0
     devDependencies:
+      '@rollup/plugin-terser':
+        specifier: ^0.4.4
+        version: 0.4.4(rollup@3.29.2)
       '@types/ejs':
         specifier: ^3.1.3
         version: 3.1.3
@@ -874,10 +880,10 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-node:
         specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)
+        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
       vite-plugin-css-injected-by-js:
         specifier: ^3.3.0
         version: 3.3.0(vite@4.4.11)
@@ -889,7 +895,7 @@ importers:
         version: 0.17.0(vite@4.4.11)
       vitest:
         specifier: ^0.34.4
-        version: 0.34.4(jsdom@22.1.0)
+        version: 0.34.4(terser@5.24.0)
       vue:
         specifier: ^3.3.0
         version: 3.3.4
@@ -908,7 +914,7 @@ importers:
         version: 7.2.0(typescript@5.2.2)
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vitest:
         specifier: ^0.34.4
         version: 0.34.4(jsdom@22.1.0)
@@ -987,7 +993,7 @@ importers:
         version: 1.8.8
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-plugin-css-injected-by-js:
         specifier: ^3.3.0
         version: 3.3.0(vite@4.4.11)
@@ -1033,7 +1039,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vitest:
         specifier: ^0.34.4
         version: 0.34.4(jsdom@22.1.0)
@@ -1055,7 +1061,7 @@ importers:
         version: 1.8.8
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-plugin-css-injected-by-js:
         specifier: ^3.3.0
         version: 3.3.0(vite@4.4.11)
@@ -1088,7 +1094,7 @@ importers:
         version: 1.8.8
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vitest:
         specifier: ^0.34.4
         version: 0.34.4(jsdom@22.1.0)
@@ -1152,7 +1158,7 @@ importers:
         version: 1.8.8
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vitest:
         specifier: ^0.34.4
         version: 0.34.4(jsdom@22.1.0)
@@ -1176,7 +1182,7 @@ importers:
         version: 1.8.8
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vitest:
         specifier: ^0.34.4
         version: 0.34.4(jsdom@22.1.0)
@@ -1203,7 +1209,7 @@ importers:
         version: 1.8.8
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vitest:
         specifier: ^0.34.4
         version: 0.34.4(jsdom@22.1.0)
@@ -1223,14 +1229,14 @@ importers:
         specifier: ^0.34.4
         version: 0.34.4(vitest@0.34.4)
       nanoid:
-        specifier: ^5.0.0
+        specifier: ^5.0.1
         version: 5.0.1
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vite-plugin-css-injected-by-js:
         specifier: ^3.3.0
         version: 3.3.0(vite@4.4.11)
@@ -1260,7 +1266,7 @@ importers:
         version: 1.8.8
       vite:
         specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.6.3)
+        version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vitest:
         specifier: ^0.34.4
         version: 0.34.4(jsdom@22.1.0)
@@ -3625,17 +3631,20 @@ packages:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.19
-    dev: true
 
   /@jridgewell/resolve-uri@3.1.1:
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
-    dev: true
+
+  /@jridgewell/source-map@0.3.5:
+    resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.19
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
@@ -3645,7 +3654,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -4427,6 +4435,21 @@ packages:
       rollup: 3.29.2
     dev: true
 
+  /@rollup/plugin-terser@0.4.4(rollup@3.29.2):
+    resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      rollup: 3.29.2
+      serialize-javascript: 6.0.1
+      smob: 1.4.1
+      terser: 5.24.0
+    dev: true
+
   /@rollup/pluginutils@5.0.5(rollup@3.29.2):
     resolution: {integrity: sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==}
     engines: {node: '>=14.0.0'}
@@ -4929,7 +4952,7 @@ packages:
       magic-string: 0.30.4
       rollup: 3.29.2
       typescript: 5.2.2
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5487,7 +5510,7 @@ packages:
       magic-string: 0.30.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vue-docgen-api: 4.74.1(vue@3.3.4)
     transitivePeerDependencies:
       - '@preact/preset-vite'
@@ -6209,7 +6232,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.22.20)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.22.20)
       react-refresh: 0.14.0
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6224,7 +6247,7 @@ packages:
       '@babel/core': 7.22.20
       '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.22.20)
       '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.22.20)
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vue: 3.3.4
     transitivePeerDependencies:
       - supports-color
@@ -6237,7 +6260,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vue: 3.3.4
     dev: true
 
@@ -6594,7 +6617,6 @@ packages:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /address@1.2.2:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
@@ -7247,7 +7269,6 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: true
 
   /buffer-xor@1.0.3:
     resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
@@ -7618,7 +7639,6 @@ packages:
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -13820,6 +13840,12 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /serialize-javascript@6.0.1:
+    resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: true
+
   /serve-static@1.15.0:
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
     engines: {node: '>= 0.8.0'}
@@ -13952,6 +13978,10 @@ packages:
       yargs: 15.4.1
     dev: true
 
+  /smob@1.4.1:
+    resolution: {integrity: sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==}
+    dev: true
+
   /socks-proxy-agent@6.2.1:
     resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
     engines: {node: '>= 10'}
@@ -13990,7 +14020,6 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-    dev: true
 
   /source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
@@ -14000,7 +14029,6 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
@@ -14527,6 +14555,16 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
     dev: true
+
+  /terser@5.24.0:
+    resolution: {integrity: sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.5
+      acorn: 8.10.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
 
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -15442,7 +15480,7 @@ packages:
       vfile-message: 4.0.2
     dev: false
 
-  /vite-node@0.34.4(@types/node@20.6.3):
+  /vite-node@0.34.4(@types/node@20.6.3)(terser@5.24.0):
     resolution: {integrity: sha512-ho8HtiLc+nsmbwZMw8SlghESEE3KxJNp04F/jPUCLVvaURwt0d+r9LxEqCX5hvrrOQ0GSyxbYr5ZfRYhQ0yVKQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -15452,7 +15490,7 @@ packages:
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15469,7 +15507,7 @@ packages:
     peerDependencies:
       vite: '>2.0.0-0'
     dependencies:
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
     dev: true
 
   /vite-plugin-dts@3.6.3(@types/node@20.6.3)(typescript@5.2.2)(vite@4.4.11):
@@ -15488,7 +15526,7 @@ packages:
       debug: 4.3.4
       kolorist: 1.8.0
       typescript: 5.2.2
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vue-tsc: 1.8.22(typescript@5.2.2)
     transitivePeerDependencies:
       - '@types/node'
@@ -15505,7 +15543,7 @@ packages:
       buffer-polyfill: /buffer@6.0.3
       node-stdlib-browser: 1.2.0
       process: 0.11.10
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -15528,7 +15566,7 @@ packages:
       fast-glob: 3.3.1
       fs-extra: 11.1.1
       picocolors: 1.0.0
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
     dev: true
 
   /vite-ssg@0.23.4(vite@4.4.11)(vue@3.3.4):
@@ -15554,7 +15592,7 @@ packages:
       jsdom: 22.1.0
       kolorist: 1.8.0
       prettier: 3.0.3
-      vite: 4.4.11(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
       vue: 3.3.4
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -15564,7 +15602,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /vite@4.4.11(@types/node@20.6.3):
+  /vite@4.4.11(@types/node@20.6.3)(terser@5.24.0):
     resolution: {integrity: sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -15596,6 +15634,7 @@ packages:
       esbuild: 0.18.20
       postcss: 8.4.31
       rollup: 3.29.2
+      terser: 5.24.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -15653,8 +15692,73 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.7.0
-      vite: 4.4.11(@types/node@20.6.3)
-      vite-node: 0.34.4(@types/node@20.6.3)
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
+      vite-node: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@0.34.4(terser@5.24.0):
+    resolution: {integrity: sha512-SE/laOsB6995QlbSE6BtkpXDeVNLJc1u2LHRG/OpnN4RsRzM3GQm4nm3PQCK5OBtrsUqnhzLdnT7se3aeNGdlw==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.6
+      '@types/chai-subset': 1.3.3
+      '@types/node': 20.6.3
+      '@vitest/expect': 0.34.4
+      '@vitest/runner': 0.34.4
+      '@vitest/snapshot': 0.34.4
+      '@vitest/spy': 0.34.4
+      '@vitest/utils': 0.34.4
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.10
+      debug: 4.3.4
+      local-pkg: 0.4.3
+      magic-string: 0.30.4
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.4.3
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.7.0
+      vite: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
+      vite-node: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
alright, I would LOVE assistance here on vite + rollup. But it appears in library mode vite [can't minify es builds](https://github.com/vitejs/vite/pull/6314), but jsdelivr does this automatically for our cdn.

https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.2.5/+esm

When I added terser to our minification, we shaved off **800KB**!

before (**3.9MB**)[before gzip]:
<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6176314/0d843f90-2d53-4abd-86bf-e963f33d050f">


after (**3.1MB**) [before gzip]:
<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6176314/5eb67c47-5a21-41a5-a910-ec451a66da93">
