### PR TITLE
fix: don't trim the slash when it’s the only character in the URL (fix #567)

### DIFF
--- a/.changeset/witty-masks-wave.md
+++ b/.changeset/witty-masks-wave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: don’t trim / from the path, if it’s the only character

--- a/packages/api-client-proxy/src/createApiClientProxy.test.ts
+++ b/packages/api-client-proxy/src/createApiClientProxy.test.ts
@@ -147,4 +147,25 @@ describe('createApiClientProxy', () => {
         resolve(null)
       })
     }))
+
+  it('keeps a trailing slash', () =>
+    new Promise((resolve) => {
+      const echoServerPort = createEchoServerOnAnyPort()
+      const apiClientProxyPort = createApiClientProxyOnAnyPort()
+
+      fetch(`http://localhost:${apiClientProxyPort}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          method: 'POST',
+          url: `http://localhost:${echoServerPort}/v1/`,
+        }),
+      }).then(async (response) => {
+        expect(JSON.parse((await response.json()).data).path).toBe('/v1/')
+
+        resolve(null)
+      })
+    }))
 })

--- a/packages/api-client/src/helpers/normalizePath.test.ts
+++ b/packages/api-client/src/helpers/normalizePath.test.ts
@@ -14,4 +14,8 @@ describe('normalizePath', () => {
   it('trims whitespace', async () => {
     expect(normalizePath('foobar ')).toBe('foobar')
   })
+
+  it('keeps a slash if its the single character', async () => {
+    expect(normalizePath('/')).toBe('/')
+  })
 })

--- a/packages/api-client/src/helpers/normalizePath.ts
+++ b/packages/api-client/src/helpers/normalizePath.ts
@@ -8,7 +8,7 @@ export const normalizePath = (path?: string) => {
 
   let normalizedPath = path.trim()
 
-  if (normalizedPath.startsWith('/')) {
+  if (normalizedPath.length > 1 && normalizedPath.startsWith('/')) {
     normalizedPath = normalizedPath.slice(1)
   }
 

--- a/packages/api-client/src/helpers/sendRequest.test.ts
+++ b/packages/api-client/src/helpers/sendRequest.test.ts
@@ -166,4 +166,19 @@ describe('sendRequest', () => {
       path: '/',
     })
   })
+
+  it('keeps the trailing slash', async () => {
+    const port = createEchoServerOnAnyPort()
+
+    const request = {
+      url: `http://127.0.0.1:${port}/v1/`,
+    }
+
+    const result = await sendRequest(request)
+
+    expect(JSON.parse(result?.response.data ?? '')).toMatchObject({
+      method: 'GET',
+      path: '/v1/',
+    })
+  })
 })


### PR DESCRIPTION
We normalize/format URLs and paths before sending the request and we want to trim the first trailing slash from the path when  concatenating the URL, but we don’t want that, if the path is literally just the slash. This PR fixes it.

`https://example.com/v1/` + `/posts` = `https://example.com/v1/posts`
🆕 `https://example.com/v1/` + `/` = `https://example.com/v1/`