### PR TITLE
feat: expose footer slot on standalone component

### DIFF
--- a/.changeset/fluffy-elephants-care.md
+++ b/.changeset/fluffy-elephants-care.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat: expose footer slot on standalone component

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -11,7 +11,7 @@ body:
     id: expected-behaviour
     attributes:
       label: Expected Behavior
-      description: what did you expect to happen?
+      description: What did you expect to happen?
       placeholder: Tell us what you expected!
     validations:
       required: true
@@ -19,7 +19,7 @@ body:
     id: actual-behaviour
     attributes:
       label: Actual Behavior
-      description: what did you actually happened?
+      description: What did you actually happened?
       placeholder: Tell us what you see!
     validations:
       required: true
@@ -36,6 +36,14 @@ body:
       render: bash
     validations:
       required: true
+  - type: input
+    id: env-link
+    attributes:
+      label: Link to site / OpenAPI Spec
+      description: What is the site or OpenAPI spec that is having the issue? (Optional)
+      placeholder: Please link to a public URL
+    validations:
+      required: false
   - type: input
     id: version
     attributes:

--- a/examples/web/src/pages/StandaloneApiReferencePage.vue
+++ b/examples/web/src/pages/StandaloneApiReferencePage.vue
@@ -5,6 +5,8 @@ import {
 } from '@scalar/api-reference'
 import { reactive } from 'vue'
 
+import SlotPlaceholder from '../components/SlotPlaceholder.vue'
+
 const configuration = reactive<ReferenceConfiguration>({
   theme: 'default',
   proxy: 'http://localhost:5051',
@@ -15,7 +17,8 @@ const configuration = reactive<ReferenceConfiguration>({
   },
 })
 </script>
-
 <template>
-  <ApiReference :configuration="configuration" />
+  <ApiReference :configuration="configuration">
+    <template #footer><SlotPlaceholder>footer</SlotPlaceholder></template>
+  </ApiReference>
 </template>

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -107,14 +107,6 @@ Whether the sidebar should be shown.
 <ApiReference :configuration="{ showSidebar: true} />
 ```
 
-#### footerBelowSidebar?: boolean
-
-Whether the footer should be below the content or below both the content _and_ the sidebar.
-
-```vue
-<ApiReference :configuration="{ footerBelowSidebar: true} />
-```
-
 #### searchHotKey?: string
 
 Key used with CNTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k)

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -57,6 +57,8 @@ if (config.value?.metaData) {
     <template #sidebar-end>
       <DarkModeToggle />
     </template>
+    <!-- Expose the content end slot as a slot for the footer -->
+    <template #content-end><slot name="footer" /></template>
   </ApiReferenceBase>
 </template>
 <style>


### PR DESCRIPTION
Exposes a slot for a footer in the standalone references component

Fixes #568

![Google Chrome-2023-11-27-13-52-57@2x](https://github.com/scalar/scalar/assets/6374090/d14b3316-66d2-48a0-9687-ffd44ef7f1ac)
