### PR TITLE
feat: set `customCss` in the configuration

### DIFF
--- a/.changeset/ten-points-fix.md
+++ b/.changeset/ten-points-fix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add a customCss property to the configuration object

--- a/examples/web/src/pages/StandaloneApiReferencePage.vue
+++ b/examples/web/src/pages/StandaloneApiReferencePage.vue
@@ -11,7 +11,6 @@ const configuration = reactive<ReferenceConfiguration>({
   theme: 'default',
   proxy: 'http://localhost:5051',
   isEditable: true,
-
   tabs: {
     initialContent: 'Swagger Editor',
   },

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -107,6 +107,22 @@ Whether the sidebar should be shown.
 <ApiReference :configuration="{ showSidebar: true} />
 ```
 
+### customCss?: string
+
+You can pass custom CSS directly to the component. This is helpful for the integrations for Fastify, Express, Hono and others where you it’s easier to add CSS to the configuration.
+
+In Vue or React you’d probably use other ways to add custom CSS.
+
+```vue
+<script setup>
+const customCss = `* { font-family: "Comic Sans MS", cursive, sans-serif; }`
+</script>
+
+<template>
+  <ApiReference :configuration="{ customCss }" />
+</template>
+```
+
 #### searchHotKey?: string
 
 Key used with CNTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k)

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -101,6 +101,11 @@ function handleAIWriter(
 const swaggerEditorRef = ref<typeof SwaggerEditor | undefined>()
 </script>
 <template>
+  <component
+    :is="'style'"
+    v-if="currentConfiguration.customCss">
+    {{ currentConfiguration.customCss }}
+  </component>
   <ThemeStyles :id="currentConfiguration?.theme" />
   <FlowToastContainer />
   <ApiReferenceLayout

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -49,6 +49,8 @@ export type ReferenceConfiguration = {
   aiWriterMarkdown?: string
   /** If used, passed data will be added to the HTML header. Read more: https://unhead.unjs.io/usage/composables/use-seo-meta */
   metaData?: MetaFlatInput
+  /** Custom CSS to be added to the page */
+  customCss?: string
 }
 
 /** Default reference configuration */


### PR DESCRIPTION
Currently, we’re adding custom CSS for all our integrations to have a branded default theme for Fastify, Platformatic, Express, Hono … and need to build the functionality for every integration. @marclave had this amazing idea to add a custom CSS attribute to the configuration object. 🤯 

This PR adds `customCss` to the configuration object, so we can add custom CSS to all the integrations easily from now on. :)