### PR TITLE
fix: searchModal shows underline for all links, fix #583

### DIFF
--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -252,6 +252,9 @@ const searchResultsWithPlaceholderResults = computed(
   </FlowModal>
 </template>
 <style scoped>
+a {
+  text-decoration: none;
+}
 /** Input */
 .ref-search-input {
   width: 100%;


### PR DESCRIPTION
**Before**
Currently, the search modal shows an underline under all links.

![image](https://github.com/scalar/scalar/assets/1577992/a630b7ff-f1a5-4c34-9cc0-44b46141216f)

**After**
This PR makes sure there’s no decoration for the anchors.