### PR TITLE
fix: @scalar/hono-api-reference doesn’t use content & preparsedContent

### DIFF
--- a/.changeset/ninety-onions-carry.md
+++ b/.changeset/ninety-onions-carry.md
@@ -1,0 +1,6 @@
+---
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+---
+
+fix: hono middleware fails to read configuration.spec.content

--- a/examples/hono-api-reference/src/index.ts
+++ b/examples/hono-api-reference/src/index.ts
@@ -175,6 +175,11 @@ app.get(
   apiReference({
     spec: {
       url: '/swagger.json',
+      // content: {
+      //   openapi: '3.1.0',
+      //   info: { title: 'Example' },
+      //   paths: {},
+      // },
     },
     pageTitle: 'Hono API Reference Demo',
   }),

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -16,7 +16,7 @@ const getConfiguration = () => {
       configurationScriptElement.getAttribute('data-configuration')
 
     if (configurationFromElement) {
-      return JSON.parse(configurationFromElement)
+      return JSON.parse(configurationFromElement.split('&quot;').join('"'))
     }
   }
 
@@ -54,7 +54,7 @@ const getSpec = () => {
     const specFromScriptTag = specScriptTag.innerHTML
 
     if (specFromScriptTag) {
-      return specFromScriptTag.trim()
+      return JSON.parse(specFromScriptTag.trim())
     }
   }
 

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -9,7 +9,7 @@ const configurationScriptElement = document.querySelector(
   '#api-reference[data-configuration]',
 )
 
-const getConfiguration = () => {
+const getConfiguration = (): Record<string, any> => {
   // <script data-configuration="{ … }" />
   if (configurationScriptElement) {
     const configurationFromElement =
@@ -48,7 +48,7 @@ const getSpecUrl = () => {
   return undefined
 }
 
-const getSpec = () => {
+const getSpec = (): Record<string, any> | undefined => {
   // <script id="api-reference" type="application/json">{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}</script>
   if (specScriptTag) {
     const specFromScriptTag = specScriptTag.innerHTML
@@ -66,7 +66,7 @@ const getSpec = () => {
     const specFromSpecElement = specElement.getAttribute('data-spec')
 
     if (specFromSpecElement) {
-      return specFromSpecElement
+      return JSON.parse(specFromSpecElement.trim())
     }
   }
 

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -25,6 +25,11 @@ const getConfiguration = (): ReferenceConfiguration => {
 }
 
 const getSpecUrl = () => {
+  // Let’s first check if the user passed a spec URL in the configuration.
+  if (getConfiguration().spec?.url) {
+    return getConfiguration().spec?.url
+  }
+
   // <script id="api-reference" data-url="/scalar.json" />
   if (specScriptTag) {
     const urlFromScriptTag = specScriptTag.getAttribute('data-url')

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -32,7 +32,7 @@ const getSpecUrl = () => {
 
   // <script id="api-reference" data-url="/scalar.json" />
   if (specScriptTag) {
-    const urlFromScriptTag = specScriptTag.getAttribute('data-url')
+    const urlFromScriptTag = specScriptTag.getAttribute('data-url')?.trim()
 
     if (urlFromScriptTag) {
       return urlFromScriptTag
@@ -57,10 +57,10 @@ const getSpecUrl = () => {
 const getSpec = (): Record<string, any> | undefined => {
   // <script id="api-reference" type="application/json">{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}</script>
   if (specScriptTag) {
-    const specFromScriptTag = specScriptTag.innerHTML
+    const specFromScriptTag = specScriptTag.innerHTML?.trim()
 
     if (specFromScriptTag) {
-      return JSON.parse(specFromScriptTag.trim())
+      return JSON.parse(specFromScriptTag)
     }
   }
 
@@ -69,10 +69,10 @@ const getSpec = (): Record<string, any> | undefined => {
     console.warn(
       '[@scalar/api-reference] The [data-spec] HTML API is deprecated. Use the new <script id="api-reference" type="application/json">{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}</script> API instead.',
     )
-    const specFromSpecElement = specElement.getAttribute('data-spec')
+    const specFromSpecElement = specElement.getAttribute('data-spec')?.trim()
 
     if (specFromSpecElement) {
-      return JSON.parse(specFromSpecElement.trim())
+      return JSON.parse(specFromSpecElement)
     }
   }
 

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 
 import { default as ApiReference } from './components/ApiReference.vue'
+import { type ReferenceConfiguration } from './types'
 
 const specScriptTag = document.querySelector('#api-reference')
 const specElement = document.querySelector('[data-spec]')
@@ -9,7 +10,7 @@ const configurationScriptElement = document.querySelector(
   '#api-reference[data-configuration]',
 )
 
-const getConfiguration = (): Record<string, any> => {
+const getConfiguration = (): ReferenceConfiguration => {
   // <script data-configuration="{ … }" />
   if (configurationScriptElement) {
     const configurationFromElement =

--- a/packages/hono-api-reference/src/honoApiReference.test.ts
+++ b/packages/hono-api-reference/src/honoApiReference.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { ApiReference } from '../src'
+import { javascript } from './honoApiReference'
 
-describe('ApiReference', () => {
+describe('javascript', () => {
   const url = 'https://petstore3.swagger.io/api/v3/openapi.json'
 
   it('renders the given spec URL', () => {
-    expect(ApiReference({ spec: { url } }).toString()).toContain(
+    expect(javascript({ spec: { url } }).toString()).toContain(
       `https://petstore3.swagger.io/api/v3/openapi.json`,
     )
   })

--- a/packages/hono-api-reference/src/honoApiReference.ts
+++ b/packages/hono-api-reference/src/honoApiReference.ts
@@ -116,15 +116,23 @@ export const customThemeCSS = `
 `
 
 /**
- * The HTML to load the @scalar/api-reference package.
+ * The HTML to load the @scalar/api-reference JavaScript package.
  */
-export const ApiReference = (options: ApiReferenceOptions) => {
+export const javascript = (configuration: ReferenceConfiguration) => {
   return html`
     <script
       id="api-reference"
       type="application/json"
-      data-configuration="${JSON.stringify(options).split('"').join('&quot;')}">
-      ${options.spec?.content ? raw(JSON.stringify(options.spec?.content)) : ''}
+      data-configuration="${JSON.stringify(configuration)
+        .split('"')
+        .join('&quot;')}">
+      ${raw(
+        configuration.spec?.content
+          ? typeof configuration.spec?.content === 'function'
+            ? JSON.stringify(configuration.spec?.content())
+            : JSON.stringify(configuration.spec?.content)
+          : '',
+      )}
     </script>
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   `
@@ -154,7 +162,7 @@ export const apiReference =
           </style>
         </head>
         <body>
-          ${ApiReference(options)}
+          ${javascript(options)}
         </body>
       </html>
     `)

--- a/packages/hono-api-reference/src/honoApiReference.ts
+++ b/packages/hono-api-reference/src/honoApiReference.ts
@@ -123,7 +123,6 @@ export const ApiReference = (options: ApiReferenceOptions) => {
     <script
       id="api-reference"
       type="application/json"
-      data-url="${options.spec?.url}"
       data-configuration="${JSON.stringify(options).split('"').join('&quot;')}">
       ${options.spec?.content ? raw(JSON.stringify(options.spec?.content)) : ''}
     </script>

--- a/packages/hono-api-reference/src/honoApiReference.ts
+++ b/packages/hono-api-reference/src/honoApiReference.ts
@@ -122,10 +122,11 @@ export const ApiReference = (options: ApiReferenceOptions) => {
   return html`
     <script
       id="api-reference"
+      type="application/json"
       data-url="${options.spec?.url}"
-      data-configuration="${raw(
-        JSON.stringify(options).split('"').join('&quot;'),
-      )}"></script>
+      data-configuration="${JSON.stringify(options).split('"').join('&quot;')}">
+      ${options.spec?.content ? raw(JSON.stringify(options.spec?.content)) : ''}
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   `
 }


### PR DESCRIPTION
Fixes https://github.com/scalar/scalar/issues/585

Looks like there may be some issues parsing due to the escaped quotes not being unescaped. I also noticed there were different implementations from the `express` implementation, so this makes `hono` consistent with that by adding the swagger json as an embedded `application/json` script.

I also updated some typing to ensure that it's clear that the parsed json is in fact an object (rather than `any`) as it trickles down to deeper components.