### PR TITLE
fix: fastify plugin doesn’t serve the JS

### DIFF
--- a/.changeset/little-suns-pump.md
+++ b/.changeset/little-suns-pump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: JS is missing

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -220,11 +220,6 @@ const fastifyApiReference: FastifyPluginAsync<
     async handler(_, reply) {
       reply.header('Content-Type', 'application/javascript; charset=utf-8')
 
-      // const content = fs.readFileSync(
-      //   path.resolve(`${__dirname}/../dist/templates/fastify-api-reference.js`),
-      //   'utf8',
-      // )
-
       const packageName = '@scalar/api-reference'
       const jsFilePath = 'dist/browser/standalone.js'
       const filePath = path.join(

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -1,8 +1,8 @@
 import { type ReferenceConfiguration } from '@scalar/api-reference'
 import type { FastifyPluginAsync } from 'fastify'
 import fp from 'fastify-plugin'
-import fs from 'fs'
-import path from 'path'
+
+import { getJavaScriptFile } from './utils'
 
 export type FastifyApiReferenceOptions = {
   /**
@@ -170,6 +170,9 @@ const fastifyApiReference: FastifyPluginAsync<
     return
   }
 
+  // Read the JavaScript file once.
+  const fileContent = getJavaScriptFile()
+
   // If no theme is passed, use the default theme.
   fastify.route({
     method: 'GET',
@@ -219,18 +222,6 @@ const fastifyApiReference: FastifyPluginAsync<
     schema: schemaToHideRoute,
     async handler(_, reply) {
       reply.header('Content-Type', 'application/javascript; charset=utf-8')
-
-      const packageName = '@scalar/api-reference'
-      const jsFilePath = 'dist/browser/standalone.js'
-      const filePath = path.join(
-        __dirname,
-        '../',
-        'node_modules',
-        packageName,
-        jsFilePath,
-      )
-      const fileContent = fs.readFileSync(filePath, 'utf8')
-
       reply.send(fileContent)
     },
   })

--- a/packages/fastify-api-reference/src/utils/getJavaScriptFile.ts
+++ b/packages/fastify-api-reference/src/utils/getJavaScriptFile.ts
@@ -5,8 +5,18 @@ import path from 'path'
  * Read the JavaScript file.
  */
 export function getJavaScriptFile() {
-  return fs.readFileSync(
+  const filePath = [
+    path.resolve(`${__dirname}/js/standalone.js`),
     path.resolve(`${__dirname}/../../dist/js/standalone.js`),
-    'utf8',
-  )
+  ].find((file: string) => fs.existsSync(file))
+
+  if (filePath === undefined) {
+    throw new Error(
+      `JavaScript file not found: ${path.resolve(
+        `${__dirname}/js/standalone.js`,
+      )}`,
+    )
+  }
+
+  return fs.readFileSync(filePath, 'utf8')
 }

--- a/packages/fastify-api-reference/src/utils/getJavaScriptFile.ts
+++ b/packages/fastify-api-reference/src/utils/getJavaScriptFile.ts
@@ -5,17 +5,8 @@ import path from 'path'
  * Read the JavaScript file.
  */
 export function getJavaScriptFile() {
-  const packageName = '@scalar/api-reference'
-
-  const jsFilePath = 'dist/browser/standalone.js'
-
-  const filePath = path.join(
-    __dirname,
-    '../../',
-    'node_modules',
-    packageName,
-    jsFilePath,
+  return fs.readFileSync(
+    path.resolve(`${__dirname}/../../dist/js/standalone.js`),
+    'utf8',
   )
-
-  return fs.readFileSync(filePath, 'utf8')
 }

--- a/packages/fastify-api-reference/src/utils/getJavaScriptFile.ts
+++ b/packages/fastify-api-reference/src/utils/getJavaScriptFile.ts
@@ -1,0 +1,21 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Read the JavaScript file.
+ */
+export function getJavaScriptFile() {
+  const packageName = '@scalar/api-reference'
+
+  const jsFilePath = 'dist/browser/standalone.js'
+
+  const filePath = path.join(
+    __dirname,
+    '../../',
+    'node_modules',
+    packageName,
+    jsFilePath,
+  )
+
+  return fs.readFileSync(filePath, 'utf8')
+}

--- a/packages/fastify-api-reference/src/utils/index.ts
+++ b/packages/fastify-api-reference/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './getJavaScriptFile'

--- a/packages/fastify-api-reference/vite.config.ts
+++ b/packages/fastify-api-reference/vite.config.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
 import { defineConfig } from 'vitest/config'
 
 import pkg from './package.json'
@@ -6,7 +7,18 @@ import { nodeExternals } from './src/vite-plugins'
 import { nodeShims } from './src/vite-plugins'
 
 export default defineConfig({
-  plugins: [nodeShims(), nodeExternals()],
+  plugins: [
+    nodeShims(),
+    nodeExternals(),
+    viteStaticCopy({
+      targets: [
+        {
+          src: '../api-reference/dist/browser/standalone.js',
+          dest: './js',
+        },
+      ],
+    }),
+  ],
   build: {
     // If minify is enabled, the nodeShims extension doesn’t work.
     minify: 'terser',


### PR DESCRIPTION
**Problem**
Currently, the fastify plugin isn’t serving the JS.

**Explanation**
This happens because the JS is read from the node_modules folder, expecting @scalar/api-reference to be there. That’s probably an unreliable way to get the JavaScript.

**Solution**
With this PR the JavaScript is bundled with the fastify plugin again. It’s copied to the ./dist folder on build.

Still better than what we had before the refactor. No extra build step, no code duplication, no EJS template. 🎉 
