### PR TITLE
feat: expose spec content updates

### DIFF
--- a/.changeset/big-bulldogs-double.md
+++ b/.changeset/big-bulldogs-double.md
@@ -1,0 +1,9 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+feat: expose spec content updates

--- a/examples/web/src/pages/StandaloneApiReferencePage.vue
+++ b/examples/web/src/pages/StandaloneApiReferencePage.vue
@@ -14,9 +14,6 @@ const configuration = reactive<ReferenceConfiguration>({
   tabs: {
     initialContent: 'Swagger Editor',
   },
-  onSpecUpdate: (value: string) => {
-    console.log('Content updated:', value)
-  },
 })
 </script>
 <template>

--- a/examples/web/src/pages/StandaloneApiReferencePage.vue
+++ b/examples/web/src/pages/StandaloneApiReferencePage.vue
@@ -14,6 +14,9 @@ const configuration = reactive<ReferenceConfiguration>({
   tabs: {
     initialContent: 'Swagger Editor',
   },
+  onSpecUpdate: (value: string) => {
+    console.log('Content updated:', value)
+  },
 })
 </script>
 <template>

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -148,3 +148,15 @@ You can pass information to the config object to configure meta information out 
       }
   } />
 ```
+
+#### onSpecUpdate?: (spec: string) => void
+
+You can listen to spec changes with onSpecUpdate that runs on spec/swagger content change
+
+```vue
+<ApiReference :configuration="{
+    onSpecUpdate: (value: string) => {
+      console.log('Content updated:', value)
+    }
+  } />
+```

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -7,6 +7,10 @@ import Layouts from './Layouts/'
 
 const props = defineProps<ReferenceProps>()
 
+const emit = defineEmits<{
+  (e: 'updateContent', value: string): void
+}>()
+
 const content = ref('')
 
 // Create a local spec for caching the content if no spec is set
@@ -22,12 +26,19 @@ if (config.value?.metaData) {
   createHead()
   useSeoMeta(config.value.metaData)
 }
+
+function handleUpdateContent(value: string) {
+  content.value = value
+  if (props.configuration?.onSpecUpdate) {
+    props.configuration.onSpecUpdate(value)
+  }
+}
 </script>
 <template>
   <Component
     :is="Layouts[config.layout || 'modern']"
     :configuration="config"
-    @updateContent="content = $event">
+    @updateContent="handleUpdateContent">
     <template #footer><slot name="footer" /></template>
   </Component>
 </template>

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -53,6 +53,8 @@ export type ReferenceConfiguration = {
   metaData?: MetaFlatInput
   /** Custom CSS to be added to the page */
   customCss?: string
+  /** onSpecUpdate is fired on spec/swagger content change */
+  onSpecUpdate?: (spec: string) => void
 }
 
 /** Default reference configuration */


### PR DESCRIPTION
**Problem**
Currently, we can't get the spec programatically

**Explanation**
This happens because we dont emit any events to listen to 

**Solution**
With this PR we can configure the references to emit up events. we dont want to always emit events cause that can be expensive to bubble up large payloads
