### PR TITLE
chore: add an interface to start an OpenAuth2 flow, see #604

### DIFF
--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -53,6 +53,7 @@
     "directory": "packages/api-reference"
   },
   "dependencies": {
+    "@floating-ui/vue": "^1.0.2",
     "@headlessui/vue": "^1.7.16",
     "@scalar/api-client": "workspace:*",
     "@scalar/components": "workspace:*",

--- a/packages/api-reference/src/components/Badge/Badge.vue
+++ b/packages/api-reference/src/components/Badge/Badge.vue
@@ -11,9 +11,7 @@
   background: var(--theme-background-2, var(--default-theme-background-2));
   padding: 2px 6px;
   border-radius: 12px;
-  margin-right: 4px;
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
-  margin-bottom: 3px;
   display: inline-block;
   text-transform: uppercase;
 }

--- a/packages/api-reference/src/components/Card/CardContent.vue
+++ b/packages/api-reference/src/components/Card/CardContent.vue
@@ -29,11 +29,6 @@ defineProps<CardContentProps>()
 .scalar-card-content.scalar-card--borderless {
   border-bottom: none;
 }
-
-.scalar-card-content.scalar-card--borderless {
-  padding-bottom: 0;
-}
-
 .scalar-card--muted {
   background: var(--theme-background-2, var(--default-theme-background-2));
 }

--- a/packages/api-reference/src/components/Card/CardHeader.vue
+++ b/packages/api-reference/src/components/Card/CardHeader.vue
@@ -27,6 +27,9 @@ const props = defineProps<CardContentProps>()
   padding: 9px 0 9px 12px;
   flex-shrink: 0;
 }
+.scalar-card-header.scalar-card--borderless + :deep(.scalar-card-content) {
+  margin-top: -9px;
+}
 .scalar-card-header-slots {
   display: flex;
   justify-content: space-between;

--- a/packages/api-reference/src/components/Content/Authentication/Authentication.stories.ts
+++ b/packages/api-reference/src/components/Content/Authentication/Authentication.stories.ts
@@ -142,14 +142,6 @@ export const OpenAuth2: Story = {
                   'read:pets': 'read your pets',
                 },
               },
-              authorizationCode: {
-                authorizationUrl: 'https://example.com/api/oauth/dialog',
-                tokenUrl: 'https://example.com/api/oauth/token',
-                scopes: {
-                  'write:pets': 'modify pets in your account',
-                  'read:pets': 'read your pets',
-                },
-              },
             },
           },
         },

--- a/packages/api-reference/src/components/Content/Authentication/Authentication.stories.ts
+++ b/packages/api-reference/src/components/Content/Authentication/Authentication.stories.ts
@@ -114,7 +114,7 @@ export const ApiKey: Story = {
   },
 }
 
-export const OpenAuth: Story = {
+export const OpenAuth2: Story = {
   ...Default,
   args: {
     parsedSpec: {
@@ -126,10 +126,31 @@ export const OpenAuth: Story = {
         securitySchemes: {
           oauth: {
             type: 'oauth2',
-            flow: 'accessCode',
-            authorizationUrl: '',
-            tokenUrl: '',
-            scopes: [],
+
+            // OpenAPI 2/3?
+            // flow: 'accessCode',
+            // authorizationUrl: '',
+            // tokenUrl: '',
+            // scopes: [],
+
+            // OpenAPI 3.1
+            flows: {
+              implicit: {
+                authorizationUrl: 'https://example.com/api/oauth/dialog',
+                scopes: {
+                  'write:pets': 'modify pets in your account',
+                  'read:pets': 'read your pets',
+                },
+              },
+              authorizationCode: {
+                authorizationUrl: 'https://example.com/api/oauth/dialog',
+                tokenUrl: 'https://example.com/api/oauth/token',
+                scopes: {
+                  'write:pets': 'modify pets in your account',
+                  'read:pets': 'read your pets',
+                },
+              },
+            },
           },
         },
       },

--- a/packages/api-reference/src/components/Content/Authentication/Authentication.vue
+++ b/packages/api-reference/src/components/Content/Authentication/Authentication.vue
@@ -41,6 +41,7 @@ watch(
   <Card v-if="hasSecuritySchemes(parsedSpec)">
     <CardHeader
       borderless
+      class="authentication-header"
       transparent>
       Authentication
       <template #actions>
@@ -54,6 +55,7 @@ watch(
     </CardHeader>
     <CardContent
       v-if="showSecurityScheme"
+      class="authentication-content"
       transparent>
       <SecurityScheme
         v-if="authentication.securitySchemeKey"
@@ -65,8 +67,10 @@ watch(
     </CardContent>
   </Card>
 </template>
-
 <style scoped>
+.authentication-content {
+  padding: 9px;
+}
 .selector {
   margin-right: 12px;
 }

--- a/packages/api-reference/src/components/Content/Authentication/Authentication.vue
+++ b/packages/api-reference/src/components/Content/Authentication/Authentication.vue
@@ -22,7 +22,6 @@ const showSecurityScheme = computed(() => {
       authentication.securitySchemeKey
     ]
 
-  // @ts-ignore
   return !!scheme?.type
 })
 
@@ -31,7 +30,6 @@ watch(
   () => props.parsedSpec?.components?.securitySchemes,
   () => {
     setAuthentication({
-      // @ts-ignore
       securitySchemes: props.parsedSpec?.components?.securitySchemes,
     })
   },

--- a/packages/api-reference/src/components/Content/Authentication/CardForm.vue
+++ b/packages/api-reference/src/components/Content/Authentication/CardForm.vue
@@ -5,8 +5,9 @@
 </template>
 <style scoped>
 .card-form {
-  color: var(--theme-color-1, var(--default-theme-color-1));
   --input-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
+  border-color: var(--theme-border-color, var(--default-theme-border-color));
+  color: var(--theme-color-1, var(--default-theme-color-1));
 }
 .card-form > :first-child {
   border-top-left-radius: var(--input-radius);
@@ -16,7 +17,7 @@
   border-bottom-left-radius: var(--input-radius);
   border-bottom-right-radius: var(--input-radius);
 }
-.card-form.card-form > :deep(* + *) {
+.card-form > :deep(* + *) {
   margin-top: -1px;
   border-top-color: transparent;
 }

--- a/packages/api-reference/src/components/Content/Authentication/CardForm.vue
+++ b/packages/api-reference/src/components/Content/Authentication/CardForm.vue
@@ -1,0 +1,23 @@
+<template>
+  <form class="card-form">
+    <slot />
+  </form>
+</template>
+<style scoped>
+.card-form {
+  color: var(--theme-color-1, var(--default-theme-color-1));
+  --input-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
+}
+.card-form > :first-child {
+  border-top-left-radius: var(--input-radius);
+  border-top-right-radius: var(--input-radius);
+}
+.card-form > :last-child {
+  border-bottom-left-radius: var(--input-radius);
+  border-bottom-right-radius: var(--input-radius);
+}
+.card-form.card-form > :deep(* + *) {
+  margin-top: -1px;
+  border-top-color: transparent;
+}
+</style>

--- a/packages/api-reference/src/components/Content/Authentication/CardForm.vue
+++ b/packages/api-reference/src/components/Content/Authentication/CardForm.vue
@@ -1,7 +1,7 @@
 <template>
-  <form class="card-form">
+  <div class="card-form">
     <slot />
-  </form>
+  </div>
 </template>
 <style scoped>
 .card-form {

--- a/packages/api-reference/src/components/Content/Authentication/CardFormButton.vue
+++ b/packages/api-reference/src/components/Content/Authentication/CardFormButton.vue
@@ -16,6 +16,7 @@ defineExpose({ el })
 <style scoped>
 :where(.card-form-button) {
   display: flex;
+  align-items: center;
   position: relative;
   background: transparent;
   cursor: pointer;

--- a/packages/api-reference/src/components/Content/Authentication/CardFormButton.vue
+++ b/packages/api-reference/src/components/Content/Authentication/CardFormButton.vue
@@ -1,6 +1,13 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const el = ref<HTMLButtonElement>()
+
+defineExpose({ el })
+</script>
 <template>
   <button
+    ref="el"
     class="card-form-button"
     type="button">
     <slot />

--- a/packages/api-reference/src/components/Content/Authentication/CardFormButton.vue
+++ b/packages/api-reference/src/components/Content/Authentication/CardFormButton.vue
@@ -24,8 +24,9 @@ defineExpose({ el })
   border-color: inherit;
   padding: 9px;
   outline: none;
+  white-space: nowrap;
   font-size: var(--theme-micro, var(--default-theme-micro));
-  font-weight: var(--theme-font-medium, var(--default-theme-font-medium));
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
   color: var(--theme-color-1, var(--default-theme-color-1));
 }
 .card-form-button:hover {

--- a/packages/api-reference/src/components/Content/Authentication/CardFormButton.vue
+++ b/packages/api-reference/src/components/Content/Authentication/CardFormButton.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts"></script>
+<template>
+  <button
+    class="card-form-button"
+    type="button">
+    <slot />
+  </button>
+</template>
+<style scoped>
+:where(.card-form-button) {
+  display: flex;
+  position: relative;
+  background: transparent;
+  cursor: pointer;
+  border-style: solid;
+  border-width: 1px;
+  border-color: inherit;
+  padding: 9px;
+  outline: none;
+  font-size: var(--theme-micro, var(--default-theme-micro));
+  font-weight: var(--theme-font-medium, var(--default-theme-font-medium));
+  color: var(--theme-color-1, var(--default-theme-color-1));
+}
+.card-form-button:hover {
+  background: var(--theme-background-2, var(--default-theme-background-2));
+  border-color: var(--theme-border-color, var(--default-theme-border-color));
+}
+</style>

--- a/packages/api-reference/src/components/Content/Authentication/CardFormGroup.vue
+++ b/packages/api-reference/src/components/Content/Authentication/CardFormGroup.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="card-form-group">
+    <slot />
+  </div>
+</template>
+<style scoped>
+:where(.card-form-group) {
+  display: flex;
+  border-color: inherit;
+}
+.card-form-group > * {
+  border-color: inherit;
+}
+.card-form-group > :first-child {
+  border-top-left-radius: inherit;
+  border-bottom-left-radius: inherit;
+}
+.card-form-group > :last-child {
+  border-top-right-radius: inherit;
+  border-bottom-right-radius: inherit;
+}
+.card-form-group > :deep(* + *) {
+  margin-left: -1px;
+  border-left-color: transparent;
+}
+</style>

--- a/packages/api-reference/src/components/Content/Authentication/CardFormTextInput.vue
+++ b/packages/api-reference/src/components/Content/Authentication/CardFormTextInput.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 defineProps<{
   id: string
+  type?: string
 }>()
 
 defineOptions({
@@ -17,18 +18,19 @@ defineOptions({
       :id="id"
       autocomplete="off"
       spellcheck="false"
-      type="text" />
+      :type="type ?? 'text'" />
   </div>
 </template>
 <style scoped>
-.card-form-input {
+:where(.card-form-input) {
   background: transparent;
   position: relative;
   width: 100%;
   text-align: left;
   display: flex;
-  box-sizing: content-box;
-  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
+  border-style: solid;
+  border-width: 1px;
+  border-color: inherit;
 }
 .card-form-input:focus-within {
   border-color: var(--theme-color-3, var(--default-theme-color-3));

--- a/packages/api-reference/src/components/Content/Authentication/CardFormTextInput.vue
+++ b/packages/api-reference/src/components/Content/Authentication/CardFormTextInput.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+defineProps<{
+  id: string
+}>()
+
+defineOptions({
+  inheritAttrs: false,
+})
+</script>
+<template>
+  <div class="card-form-input">
+    <label :for="id">
+      <slot />
+    </label>
+    <input
+      v-bind="$attrs"
+      :id="id"
+      autocomplete="off"
+      spellcheck="false"
+      type="text" />
+  </div>
+</template>
+<style scoped>
+.card-form-input {
+  background: transparent;
+  position: relative;
+  width: 100%;
+  text-align: left;
+  display: flex;
+  box-sizing: content-box;
+  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
+}
+.card-form-input:focus-within {
+  border-color: var(--theme-color-3, var(--default-theme-color-3));
+}
+
+.card-form-input label,
+.card-form-input input {
+  padding: 9px;
+  border: 0;
+  outline: none;
+  font-size: var(--theme-micro, var(--default-theme-micro));
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  width: 100%;
+  background: transparent;
+  appearance: none;
+  -webkit-appearance: none;
+  left: 0;
+}
+.card-form-input label {
+  color: var(--theme-color-1, var(--default-theme-color-1));
+  width: fit-content;
+  padding-right: 0;
+  white-space: nowrap;
+  cursor: text;
+}
+.card-form-input input {
+  position: relative;
+  z-index: 99;
+}
+.card-form-input input:not(:placeholder-shown) + label {
+  color: var(--theme-color-2, var(--default-theme-color-2));
+}
+</style>

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -6,6 +6,7 @@ import CardForm from './CardForm.vue'
 import CardFormButton from './CardFormButton.vue'
 import CardFormGroup from './CardFormGroup.vue'
 import CardFormTextInput from './CardFormTextInput.vue'
+import SecuritySchemeScopes from './SecuritySchemeScopes.vue'
 
 // import MarkdownRenderer from '../MarkdownRenderer.vue'
 
@@ -162,22 +163,11 @@ const startAuthentication = (url: string) => {
       <CardFormTextInput
         id="oAuth2.clientId"
         placeholder="Token"
-        :value="authentication.oAuth2.clientId">
+        :value="authentication.oAuth2.clientId"
+        @input="handleOpenAuth2ClientIdInput">
         Client ID
       </CardFormTextInput>
-      <CardFormButton>Scopes</CardFormButton>
-      <!-- <label
-          v-for="scope in Object.keys(value.flows.implicit.scopes)"
-          :key="scope"
-          class="check">
-          <input
-            :checked="authentication.oAuth2.scopes[scope] ?? false"
-            type="checkbox"
-            @input="() => handleScopeInput(scope)" />
-          <span class="checkmark" />
-          <code>{{ scope }}</code>
-        </label> -->
-
+      <SecuritySchemeScopes :scopes="value.flows.implicit.scopes" />
       <CardFormButton
         @click="
           () =>

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 
 import { useGlobalStore } from '../../../stores'
+import type { SecurityScheme } from '../../../types'
 import CardForm from './CardForm.vue'
 import CardFormButton from './CardFormButton.vue'
 import CardFormGroup from './CardFormGroup.vue'
@@ -11,7 +12,7 @@ import SecuritySchemeScopes from './SecuritySchemeScopes.vue'
 // import MarkdownRenderer from '../MarkdownRenderer.vue'
 
 defineProps<{
-  value?: any
+  value?: SecurityScheme
 }>()
 
 const { authentication, setAuthentication } = useGlobalStore()

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { computed } from 'vue'
+
 import { useGlobalStore } from '../../../stores'
 import CardForm from './CardForm.vue'
 import CardFormButton from './CardFormButton.vue'
@@ -68,18 +70,6 @@ const handleOpenAuth2ClientIdInput = (event: Event) => {
   })
 }
 
-const handleScopeInput = (scope: string) => {
-  setAuthentication({
-    oAuth2: {
-      ...authentication.oAuth2,
-      scopes: {
-        ...authentication.oAuth2.scopes,
-        [scope]: !authentication.oAuth2.scopes[scope],
-      },
-    },
-  })
-}
-
 const getOpenAuth2AuthorizationUrl = (flow: any) => {
   // https://example.com/oauth/authorize?
   //   response_type=token
@@ -88,9 +78,7 @@ const getOpenAuth2AuthorizationUrl = (flow: any) => {
   //   &scope=write%3Apets%20read%3Apets
   //   &state=something-random
 
-  const scopes = Object.keys(flow.scopes)
-    .filter((scope) => authentication.oAuth2.scopes[scope])
-    .join(' ')
+  const scopes = authentication.oAuth2.scopes.join(' ')
 
   const url = new URL(flow.authorizationUrl)
 
@@ -103,6 +91,12 @@ const getOpenAuth2AuthorizationUrl = (flow: any) => {
 
   return url.toString()
 }
+
+const oauth2SelectedScopes = computed<string[]>({
+  get: () => authentication.oAuth2.scopes,
+  set: (scopes) =>
+    setAuthentication({ oAuth2: { ...authentication.oAuth2, scopes } }),
+})
 
 const startAuthentication = (url: string) => {
   const windowFeatures = 'left=100,top=100,width=800,height=600'
@@ -165,7 +159,9 @@ const startAuthentication = (url: string) => {
         @input="handleOpenAuth2ClientIdInput">
         Client ID
       </CardFormTextInput>
-      <SecuritySchemeScopes :scopes="value.flows.implicit.scopes" />
+      <SecuritySchemeScopes
+        v-model:selected="oauth2SelectedScopes"
+        :scopes="value.flows.implicit.scopes" />
       <CardFormButton
         @click="
           () =>

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -1,5 +1,7 @@
 <script lang="ts" setup>
 import { useGlobalStore } from '../../../stores'
+import CardForm from './CardForm.vue'
+import CardFormTextInput from './CardFormTextInput.vue'
 
 // import MarkdownRenderer from '../MarkdownRenderer.vue'
 
@@ -111,201 +113,89 @@ const startAuthentication = (url: string) => {
 }
 </script>
 <template>
-  <div
-    v-if="value"
-    class="security-scheme">
-    <form>
-      <!-- <div
-      v-if="value.description"
-      class="description">
-      <MarkdownRenderer :value="value.description" />
-    </div> -->
-      <div v-if="!value.type"></div>
-      <div v-else-if="value.type === 'apiKey'">
-        <div class="input">
-          <label :for="`security-scheme-${value.name}`">
-            {{ value.in.charAt(0).toUpperCase() + value.in.slice(1) }} API Key
-          </label>
-          <input
-            :id="`security-scheme-${value.name}`"
-            autocomplete="off"
-            placeholder="Token"
-            spellcheck="false"
-            type="text"
-            :value="authentication.apiKey.token"
-            @input="handleApiKeyTokenInput" />
-        </div>
-      </div>
-      <div v-else-if="value.type === 'http' || value.type === 'basic'">
-        <div v-if="value.type === 'basic' || value.scheme === 'basic'">
+  <CardForm v-if="value && value?.type">
+    <CardFormTextInput
+      v-if="value.type === 'apiKey'"
+      :id="`security-scheme-${value.name}`"
+      placeholder="Token"
+      :value="authentication.apiKey.token"
+      @input="handleApiKeyTokenInput">
+      {{ value.in.charAt(0).toUpperCase() + value.in.slice(1) }} API Key
+    </CardFormTextInput>
+    <template v-else-if="value.type === 'http' || value.type === 'basic'">
+      <template v-if="value.type === 'basic' || value.scheme === 'basic'">
+        <CardFormTextInput
+          id="http.basic.username"
+          placeholder="Username"
+          :value="authentication.http.basic.username"
+          @input="handleHttpBasicUsernameInput">
+          Username
+        </CardFormTextInput>
+        <CardFormTextInput
+          id="http.basic.password"
+          placeholder="Password"
+          type="password"
+          :value="authentication.http.basic.password"
+          @input="handleHttpBasicPasswordInput">
+          Password
+        </CardFormTextInput>
+      </template>
+      <CardFormTextInput
+        v-else-if="value.scheme === 'bearer'"
+        id="http.bearer.token"
+        placeholder="Token"
+        :value="authentication.http.bearer.token"
+        @input="handleHttpBearerTokenInput">
+        Bearer Token
+      </CardFormTextInput>
+    </template>
+    <div v-else-if="value.type.toLowerCase() === 'oauth2'">
+      <template v-if="value.flows">
+        <div
+          v-for="flowKey in Object.keys(value.flows)"
+          :key="flowKey">
           <div class="input">
-            <label for="http.basic.username">Username</label>
+            <label for="oAuth2.clientId">Client ID</label>
             <input
-              id="http.basic.username"
+              id="oAuth2.clientId"
               autocomplete="off"
-              placeholder="Username"
+              placeholder="Client ID"
               spellcheck="false"
               type="text"
-              :value="authentication.http.basic.username"
-              @input="handleHttpBasicUsernameInput" />
+              :value="authentication.oAuth2.clientId"
+              @input="handleOpenAuth2ClientIdInput" />
           </div>
+
           <div class="input">
-            <label for="http.basic.password">Password</label>
-            <input
-              id="http.basic.password"
-              autocomplete="off"
-              placeholder="Password"
-              spellcheck="false"
-              type="password"
-              :value="authentication.http.basic.password"
-              @input="handleHttpBasicPasswordInput" />
-          </div>
-        </div>
-        <div v-else-if="value.scheme === 'bearer'">
-          <div class="input">
-            <label for="http.bearer.token">Token</label>
-            <input
-              id="http.bearer.token"
-              autocomplete="off"
-              placeholder="Token"
-              spellcheck="false"
-              type="text"
-              :value="authentication.http.bearer.token"
-              @input="handleHttpBearerTokenInput" />
-          </div>
-        </div>
-      </div>
-      <div v-else-if="value.type.toLowerCase() === 'oauth2'">
-        <template v-if="value.flows">
-          <div
-            v-for="flowKey in Object.keys(value.flows)"
-            :key="flowKey">
-            <div class="input">
-              <label for="oAuth2.clientId">Client ID</label>
+            <label>Scopes</label>
+            <label
+              v-for="scope in Object.keys(value.flows[flowKey].scopes)"
+              :key="scope"
+              class="check">
               <input
-                id="oAuth2.clientId"
-                autocomplete="off"
-                placeholder="Client ID"
-                spellcheck="false"
-                type="text"
-                :value="authentication.oAuth2.clientId"
-                @input="handleOpenAuth2ClientIdInput" />
-            </div>
-
-            <div class="input">
-              <label>Scopes</label>
-              <label
-                v-for="scope in Object.keys(value.flows[flowKey].scopes)"
-                :key="scope"
-                class="check">
-                <input
-                  :checked="authentication.oAuth2.scopes[scope] ?? false"
-                  type="checkbox"
-                  @input="() => handleScopeInput(scope)" />
-                <span class="checkmark" />
-                <code>{{ scope }}</code>
-              </label>
-            </div>
-
-            <button
-              type="button"
-              @click="
-                () =>
-                  startAuthentication(
-                    getOpenAuth2AuthorizationUrl(value.flows[flowKey]),
-                  )
-              ">
-              Authorize
-            </button>
+                :checked="authentication.oAuth2.scopes[scope] ?? false"
+                type="checkbox"
+                @input="() => handleScopeInput(scope)" />
+              <span class="checkmark" />
+              <code>{{ scope }}</code>
+            </label>
           </div>
-        </template>
 
-        <!-- {{ value }} -->
-      </div>
-      <div
-        v-else
-        class="work-in-progress">
-        <h3 class="work-in-progress-title">Work in Progress</h3>
-        <p>The given security scheme ({{ value.type }}) is not supported.</p>
-      </div>
-    </form>
-  </div>
+          <button
+            class="input"
+            type="button"
+            @click="
+              () =>
+                startAuthentication(
+                  getOpenAuth2AuthorizationUrl(value.flows[flowKey]),
+                )
+            ">
+            Authorize
+          </button>
+        </div>
+      </template>
+
+      <!-- {{ value }} -->
+    </div>
+  </CardForm>
 </template>
-
-<style scoped>
-.security-scheme {
-  margin: 9px;
-  color: var(--theme-color-1, var(--default-theme-color-1));
-  border-radius: var(--theme-radius, var(--default-theme-radius));
-  position: relative;
-  box-shadow: 0 0 0 1px
-    var(--theme-border-color, var(--default-theme-border-color));
-}
-.security-scheme :deep(.input:nth-of-type(3) ~ .input) {
-  height: 0px;
-  opacity: 0;
-}
-.security-scheme :deep(.input:nth-of-type(3):not(:last-child):before) {
-  content: 'Show More...';
-  white-space: nowrap;
-  font-size: var(--theme-micro, var(--default-theme-micro));
-  color: var(--theme-color-3, var(--default-theme-color-3));
-  font-weight: var(--theme-semibold, var(--default-theme-semibold));
-  pointer-events: none;
-  position: absolute;
-  padding: 9px;
-}
-.security-scheme :deep(.input:hover:before) {
-  color: var(--theme-color-1, var(--default-theme-color-1)) !important;
-}
-.security-scheme:focus-within
-  :deep(.input:nth-of-type(3):not(:last-child):before) {
-  display: none;
-}
-.security-scheme:not(:focus-within)
-  :deep(.input:nth-of-type(3):not(:last-child)) {
-  box-shadow: none !important;
-}
-.security-scheme :deep(.input:nth-of-type(3):not(:last-child) input),
-.security-scheme :deep(.input:nth-of-type(3):not(:last-child) label) {
-  opacity: 0;
-}
-.security-scheme:focus-within :deep(.input:nth-of-type(3) input),
-.security-scheme:focus-within :deep(.input:nth-of-type(3) label),
-.security-scheme:focus-within :deep(.input:nth-of-type(3) ~ .input) {
-  opacity: 1;
-  height: fit-content;
-  transition: opacity 0.3s ease-in-out;
-}
-.description {
-  margin-bottom: 12px;
-}
-
-.work-in-progress {
-  color: var(--theme-color-1, var(--default-theme-color-1));
-  padding: 9px;
-  border-radius: var(--theme-radius, var(--default-theme-radius));
-  font-size: var(--theme-micro, var(--default-theme-micro));
-  display: flex;
-  box-shadow: 0 0 0 1px
-    var(--theme-color-yellow, var(--default-theme-color-yellow));
-  position: relative;
-}
-.work-in-progress:before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  background: var(--theme-color-yellow, var(--default-theme-color-yellow));
-  opacity: 0.1;
-}
-.work-in-progress-title {
-  font-weight: var(--theme-semibold, var(--default-theme-semibold));
-  font-size: var(--theme-micro, var(--default-theme-micro));
-  margin-top: 0;
-  margin-bottom: 0;
-  margin-right: 6px;
-}
-</style>

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import { ScalarIcon } from '@scalar/components'
-
 import { useGlobalStore } from '../../../stores'
 import CardForm from './CardForm.vue'
 import CardFormButton from './CardFormButton.vue'

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import { a } from '@storybook/vue3/dist/render-ddbe18a8'
-
 import { useGlobalStore } from '../../../stores'
 
 // import MarkdownRenderer from '../MarkdownRenderer.vue'

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
+import { type OpenAPIV3 } from 'openapi-types'
 import { computed } from 'vue'
 
+import { Security } from '../../../../../api-client/dist'
 import { useGlobalStore } from '../../../stores'
 import type { SecurityScheme } from '../../../types'
 import CardForm from './CardForm.vue'
@@ -150,8 +152,8 @@ const startAuthentication = (url: string) => {
     <CardFormGroup
       v-else-if="
         value.type.toLowerCase() === 'oauth2' &&
-        value.flows &&
-        value.flows.implicit
+        (value as OpenAPIV3.OAuth2SecurityScheme).flows &&
+        (value as OpenAPIV3.OAuth2SecurityScheme).flows.implicit
       ">
       <CardFormTextInput
         id="oAuth2.clientId"
@@ -161,13 +163,20 @@ const startAuthentication = (url: string) => {
         Client ID
       </CardFormTextInput>
       <SecuritySchemeScopes
+        v-if="value !== undefined"
         v-model:selected="oauth2SelectedScopes"
-        :scopes="value.flows.implicit.scopes" />
+        :scopes="
+          //@ts-ignore
+          value.flows.implicit.scopes
+        " />
       <CardFormButton
         @click="
           () =>
             startAuthentication(
-              getOpenAuth2AuthorizationUrl(value.flows.implicit),
+              getOpenAuth2AuthorizationUrl(
+                //@ts-ignore
+                value?.flows.implicit,
+              ),
             )
         ">
         Authorize

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -1,6 +1,10 @@
 <script lang="ts" setup>
+import { ScalarIcon } from '@scalar/components'
+
 import { useGlobalStore } from '../../../stores'
 import CardForm from './CardForm.vue'
+import CardFormButton from './CardFormButton.vue'
+import CardFormGroup from './CardFormGroup.vue'
 import CardFormTextInput from './CardFormTextInput.vue'
 
 // import MarkdownRenderer from '../MarkdownRenderer.vue'
@@ -123,7 +127,7 @@ const startAuthentication = (url: string) => {
       {{ value.in.charAt(0).toUpperCase() + value.in.slice(1) }} API Key
     </CardFormTextInput>
     <template v-else-if="value.type === 'http' || value.type === 'basic'">
-      <template v-if="value.type === 'basic' || value.scheme === 'basic'">
+      <CardFormGroup v-if="value.type === 'basic' || value.scheme === 'basic'">
         <CardFormTextInput
           id="http.basic.username"
           placeholder="Username"
@@ -139,7 +143,7 @@ const startAuthentication = (url: string) => {
           @input="handleHttpBasicPasswordInput">
           Password
         </CardFormTextInput>
-      </template>
+      </CardFormGroup>
       <CardFormTextInput
         v-else-if="value.scheme === 'bearer'"
         id="http.bearer.token"
@@ -149,53 +153,40 @@ const startAuthentication = (url: string) => {
         Bearer Token
       </CardFormTextInput>
     </template>
-    <div v-else-if="value.type.toLowerCase() === 'oauth2'">
-      <template v-if="value.flows">
-        <div
-          v-for="flowKey in Object.keys(value.flows)"
-          :key="flowKey">
-          <div class="input">
-            <label for="oAuth2.clientId">Client ID</label>
-            <input
-              id="oAuth2.clientId"
-              autocomplete="off"
-              placeholder="Client ID"
-              spellcheck="false"
-              type="text"
-              :value="authentication.oAuth2.clientId"
-              @input="handleOpenAuth2ClientIdInput" />
-          </div>
+    <CardFormGroup
+      v-else-if="
+        value.type.toLowerCase() === 'oauth2' &&
+        value.flows &&
+        value.flows.implicit
+      ">
+      <CardFormTextInput
+        id="oAuth2.clientId"
+        placeholder="Token"
+        :value="authentication.oAuth2.clientId">
+        Client ID
+      </CardFormTextInput>
+      <CardFormButton>Scopes</CardFormButton>
+      <!-- <label
+          v-for="scope in Object.keys(value.flows.implicit.scopes)"
+          :key="scope"
+          class="check">
+          <input
+            :checked="authentication.oAuth2.scopes[scope] ?? false"
+            type="checkbox"
+            @input="() => handleScopeInput(scope)" />
+          <span class="checkmark" />
+          <code>{{ scope }}</code>
+        </label> -->
 
-          <div class="input">
-            <label>Scopes</label>
-            <label
-              v-for="scope in Object.keys(value.flows[flowKey].scopes)"
-              :key="scope"
-              class="check">
-              <input
-                :checked="authentication.oAuth2.scopes[scope] ?? false"
-                type="checkbox"
-                @input="() => handleScopeInput(scope)" />
-              <span class="checkmark" />
-              <code>{{ scope }}</code>
-            </label>
-          </div>
-
-          <button
-            class="input"
-            type="button"
-            @click="
-              () =>
-                startAuthentication(
-                  getOpenAuth2AuthorizationUrl(value.flows[flowKey]),
-                )
-            ">
-            Authorize
-          </button>
-        </div>
-      </template>
-
-      <!-- {{ value }} -->
-    </div>
+      <CardFormButton
+        @click="
+          () =>
+            startAuthentication(
+              getOpenAuth2AuthorizationUrl(value.flows.implicit),
+            )
+        ">
+        Authorize
+      </CardFormButton>
+    </CardFormGroup>
   </CardForm>
 </template>

--- a/packages/api-reference/src/components/Content/Authentication/SecuritySchemeScopes.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecuritySchemeScopes.vue
@@ -46,11 +46,17 @@ const { floatingStyles } = useFloating(trigger, dropdown, {
             <ListboxOption
               v-for="[key, description] in Object.entries(scopes)"
               :key="key"
+              v-slot="{ selected }"
               as="div"
               class="dropdown-item"
               :value="key">
-              <dt>{{ key }}</dt>
-              <dd>{{ description }}</dd>
+              <input
+                :checked="selected"
+                class="dropdown-item-check"
+                tabindex="-1"
+                type="checkbox" />
+              <dt class="dropdown-item-title">{{ key }}</dt>
+              <dd class="dropdown-item-description">{{ description }}</dd>
             </ListboxOption>
           </ListboxOptions>
         </div>
@@ -74,11 +80,75 @@ const { floatingStyles } = useFloating(trigger, dropdown, {
   );
   border-radius: var(--theme-radius, var(--default-theme-radius));
   box-shadow: var(--theme-shadow-2, var(--default-theme-shadow-2));
-  width: 160px;
-  padding: 3px;
+  padding: 4px;
   font-style: normal;
 
   display: flex;
   flex-direction: column;
+  gap: 10px;
+}
+.dropdown-item {
+  display: grid;
+  grid-template-areas:
+    'check title'
+    'check description';
+  grid-template-columns: auto 1fr;
+
+  padding: 6px 10px 8px 6px;
+
+  row-gap: 2px;
+  column-gap: 8px;
+
+  border-radius: var(--theme-radius, var(--default-theme-radius));
+
+  font-size: var(--theme-mini, var(--default-theme-mini));
+
+  cursor: pointer;
+}
+.dropdown-item[data-headlessui-state='active'],
+.dropdown-item[data-headlessui-state='active selected'] {
+  background: var(--theme-background-2, var(--default-theme-background-2));
+}
+.dropdown-item-title {
+  grid-area: title;
+
+  color: var(--theme-color-1, var(--default-theme-color-1));
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
+}
+.dropdown-item-description {
+  grid-area: description;
+
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  line-height: initial;
+}
+.dropdown-item-check {
+  all: unset;
+
+  position: relative;
+  grid-area: check;
+
+  width: 20px;
+  height: 20px;
+
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  background: var(--theme-background-1, var(--default-theme-background-1));
+  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
+  border-radius: var(--theme-radius, var(--default-theme-radius));
+}
+.dropdown-item-check:checked:after {
+  content: '';
+  position: absolute;
+  border-bottom: 1.5px solid currentColor;
+  border-right: 1.5px solid currentColor;
+  width: 6px;
+  height: 12px;
+  top: calc(50% - 1.5px);
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+.dropdown-item-check:checked {
+  background: var(--theme-color-accent, var(--default-theme-color-accent));
+  color: var(--theme-background-1, var(--default-theme-background-1));
+  border: 1px solid currentColor;
 }
 </style>

--- a/packages/api-reference/src/components/Content/Authentication/SecuritySchemeScopes.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecuritySchemeScopes.vue
@@ -6,9 +6,11 @@ import {
   ListboxOption,
   ListboxOptions,
 } from '@headlessui/vue'
+import { ScalarIcon } from '@scalar/components'
 import { ResetStyles } from '@scalar/swagger-editor'
 import { computed, ref } from 'vue'
 
+import { Badge } from '../../../components/Badge'
 import CardFormButton from './CardFormButton.vue'
 
 const props = defineProps<{
@@ -36,13 +38,23 @@ const model = computed({
 </script>
 <template>
   <Listbox
+    v-slot="{ open }"
     v-model="model"
     multiple>
     <div
       ref="trigger"
-      class="wrapper">
+      class="wrapper"
+      :class="{ 'wrapper-open': open }">
       <ListboxButton :as="CardFormButton">
-        Scopes ({{ model.length }})
+        <div class="scopes-label">
+          <ScalarIcon
+            :icon="open ? 'ChevronUp' : 'ChevronDown'"
+            size="sm" />
+          Scopes
+          <Badge class="scopes-label-badge">
+            {{ model.length }}<em>|</em>{{ Object.entries(scopes).length }}
+          </Badge>
+        </div>
       </ListboxButton>
     </div>
     <Teleport to="body">
@@ -80,6 +92,22 @@ const model = computed({
 :where(.wrapper) {
   display: grid;
   border-color: inherit;
+}
+.scopes-label {
+  display: inline-flex;
+  align-items: center;
+  height: 1em;
+  line-height: 1;
+  gap: 4px;
+}
+.scopes-label-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.scopes-label-badge em {
+  transform: rotate(10deg) translate(0, -0.9px);
+  color: var(--theme-color-3, var(--default-theme-color-3));
 }
 .floating {
   position: relative;

--- a/packages/api-reference/src/components/Content/Authentication/SecuritySchemeScopes.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecuritySchemeScopes.vue
@@ -1,29 +1,84 @@
 <script setup lang="ts">
+import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue'
 import {
   Listbox,
   ListboxButton,
   ListboxOption,
   ListboxOptions,
 } from '@headlessui/vue'
+import { onMounted, ref } from 'vue'
 
+import { ResetStyles } from '../../../../../swagger-editor/dist'
 import CardFormButton from './CardFormButton.vue'
 
 defineProps<{
   scopes: { [scope: string]: string }
 }>()
+
+const trigger = ref()
+const dropdown = ref()
+
+onMounted(() => console.log(trigger.value))
+
+const { floatingStyles } = useFloating(trigger, dropdown, {
+  placement: 'bottom-end',
+  whileElementsMounted: autoUpdate,
+  middleware: [offset(5), flip(), shift()],
+})
 </script>
 <template>
-  <Listbox>
-    <ListboxButton :as="CardFormButton">Scopes</ListboxButton>
-    <ListboxOptions class="dropdown">
-      <ListboxOption
-        v-for="[key, description] in Object.entries(scopes)"
-        :key="key"
-        :value="key">
-        {{ key }}
-        {{ description }}
-      </ListboxOption>
-    </ListboxOptions>
+  <Listbox multiple>
+    <div
+      ref="trigger"
+      class="wrapper">
+      <ListboxButton :as="CardFormButton"> Scopes </ListboxButton>
+    </div>
+    <Teleport to="#app">
+      <ResetStyles v-slot="{ styles: resetStyles }">
+        <div
+          ref="dropdown"
+          class="floating"
+          :class="resetStyles"
+          :style="floatingStyles">
+          <ListboxOptions
+            as="dl"
+            class="dropdown">
+            <ListboxOption
+              v-for="[key, description] in Object.entries(scopes)"
+              :key="key"
+              as="div"
+              class="dropdown-item"
+              :value="key">
+              <dt>{{ key }}</dt>
+              <dd>{{ description }}</dd>
+            </ListboxOption>
+          </ListboxOptions>
+        </div>
+      </ResetStyles>
+    </Teleport>
   </Listbox>
 </template>
-<style scoped></style>
+<style scoped>
+:where(.wrapper) {
+  display: grid;
+  border-color: inherit;
+}
+.floating {
+  position: relative;
+  z-index: 100;
+}
+.dropdown {
+  background: var(--theme-background-1, var(--default-theme-background-1));
+  filter: brightness(
+    var(--theme-lifted-brightness, var(--default-theme-lifted-brightness))
+  );
+  border-radius: var(--theme-radius, var(--default-theme-radius));
+  box-shadow: var(--theme-shadow-2, var(--default-theme-shadow-2));
+  width: 160px;
+  padding: 3px;
+  font-style: normal;
+
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/packages/api-reference/src/components/Content/Authentication/SecuritySchemeScopes.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecuritySchemeScopes.vue
@@ -6,34 +6,46 @@ import {
   ListboxOption,
   ListboxOptions,
 } from '@headlessui/vue'
-import { onMounted, ref } from 'vue'
+import { ResetStyles } from '@scalar/swagger-editor'
+import { computed, ref } from 'vue'
 
-import { ResetStyles } from '../../../../../swagger-editor/dist'
 import CardFormButton from './CardFormButton.vue'
 
-defineProps<{
+const props = defineProps<{
   scopes: { [scope: string]: string }
+  selected: string[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:selected', v: string[]): void
 }>()
 
 const trigger = ref()
 const dropdown = ref()
-
-onMounted(() => console.log(trigger.value))
 
 const { floatingStyles } = useFloating(trigger, dropdown, {
   placement: 'bottom-end',
   whileElementsMounted: autoUpdate,
   middleware: [offset(5), flip(), shift()],
 })
+
+const model = computed({
+  get: () => props.selected,
+  set: (v) => emit('update:selected', v),
+})
 </script>
 <template>
-  <Listbox multiple>
+  <Listbox
+    v-model="model"
+    multiple>
     <div
       ref="trigger"
       class="wrapper">
-      <ListboxButton :as="CardFormButton"> Scopes </ListboxButton>
+      <ListboxButton :as="CardFormButton">
+        Scopes ({{ model.length }})
+      </ListboxButton>
     </div>
-    <Teleport to="#app">
+    <Teleport to="body">
       <ResetStyles v-slot="{ styles: resetStyles }">
         <div
           ref="dropdown"
@@ -46,12 +58,12 @@ const { floatingStyles } = useFloating(trigger, dropdown, {
             <ListboxOption
               v-for="[key, description] in Object.entries(scopes)"
               :key="key"
-              v-slot="{ selected }"
+              v-slot="{ selected: s }"
               as="div"
               class="dropdown-item"
               :value="key">
               <input
-                :checked="selected"
+                :checked="s"
                 class="dropdown-item-check"
                 tabindex="-1"
                 type="checkbox" />

--- a/packages/api-reference/src/components/Content/Authentication/SecuritySchemeScopes.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecuritySchemeScopes.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from '@headlessui/vue'
+
+import CardFormButton from './CardFormButton.vue'
+
+defineProps<{
+  scopes: { [scope: string]: string }
+}>()
+</script>
+<template>
+  <Listbox>
+    <ListboxButton :as="CardFormButton">Scopes</ListboxButton>
+    <ListboxOptions class="dropdown">
+      <ListboxOption
+        v-for="[key, description] in Object.entries(scopes)"
+        :key="key"
+        :value="key">
+        {{ key }}
+        {{ description }}
+      </ListboxOption>
+    </ListboxOptions>
+  </Listbox>
+</template>
+<style scoped></style>

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -30,10 +30,12 @@ const specVersion = computed(() => {
       <SectionContent :loading="!info.description && !info.title">
         <SectionColumns>
           <SectionColumn>
-            <Badge v-if="info.version">
-              {{ info.version }}
-            </Badge>
-            <Badge v-if="specVersion"> OAS {{ specVersion }} </Badge>
+            <div class="badges">
+              <Badge v-if="info.version">
+                {{ info.version }}
+              </Badge>
+              <Badge v-if="specVersion"> OAS {{ specVersion }}</Badge>
+            </div>
             <SectionHeader
               :level="1"
               :loading="!info.title"
@@ -63,6 +65,12 @@ const specVersion = computed(() => {
   background: var(--theme-background-3, var(--default-theme-background-3));
   animation: loading-skeleton 1.5s infinite alternate;
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
+}
+.badges {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 3px;
 }
 .heading.loading {
   width: 80%;

--- a/packages/api-reference/src/stores/globalStore.ts
+++ b/packages/api-reference/src/stores/globalStore.ts
@@ -18,7 +18,7 @@ export const createEmptyAuthenticationState = (): AuthenticationState => ({
   },
   oAuth2: {
     clientId: '',
-    scopes: {},
+    scopes: [],
   },
 })
 

--- a/packages/api-reference/src/stores/globalStore.ts
+++ b/packages/api-reference/src/stores/globalStore.ts
@@ -16,6 +16,10 @@ export const createEmptyAuthenticationState = (): AuthenticationState => ({
   apiKey: {
     token: '',
   },
+  oAuth2: {
+    clientId: '',
+    scopes: {},
+  },
 })
 
 const authentication = reactive<AuthenticationState>(

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -277,7 +277,7 @@ export type AuthenticationState = {
   }
   oAuth2: {
     clientId: string
-    scopes: Record<string, boolean>
+    scopes: string[]
   }
 }
 

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -232,16 +232,17 @@ export type Server = {
   variables?: ServerVariables
 }
 
+type SecurityScheme =
+  | Record<string, never> // Empty objects
+  | OpenAPIV2.SecuritySchemeObject
+  | OpenAPIV3.SecuritySchemeObject
+  | OpenAPIV3_1.SecuritySchemeObject
+
 export type Components = Omit<
   OpenAPIV3.ComponentsObject | OpenAPIV3_1.ComponentsObject,
   'securitySchemes'
 > & {
-  securitySchemes?: Record<
-    string,
-    | Record<string, never>
-    | OpenAPIV3.SecuritySchemeObject
-    | OpenAPIV2.SecuritySchemeObject
-  >
+  securitySchemes?: Record<string, SecurityScheme>
 }
 
 export type Definitions = OpenAPIV2.DefinitionsObject
@@ -261,10 +262,7 @@ export type Spec = {
 
 export type AuthenticationState = {
   securitySchemeKey: string | null
-  securitySchemes?:
-    | Record<string, OpenAPIV2.SecuritySchemeObject>
-    | Record<string, OpenAPIV3.SecuritySchemeObject>
-    | Record<string, OpenAPIV3_1.SecuritySchemeObject>
+  securitySchemes?: Record<string, SecurityScheme>
   http: {
     basic: {
       username: string

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -277,6 +277,10 @@ export type AuthenticationState = {
   apiKey: {
     token: string
   }
+  oAuth2: {
+    clientId: string
+    scopes: Record<string, boolean>
+  }
 }
 
 export type Variable = {

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -232,7 +232,7 @@ export type Server = {
   variables?: ServerVariables
 }
 
-type SecurityScheme =
+export type SecurityScheme =
   | Record<string, never> // Empty objects
   | OpenAPIV2.SecuritySchemeObject
   | OpenAPIV3.SecuritySchemeObject

--- a/packages/components/src/components/ScalarIcon/ScalarIcon.vue
+++ b/packages/components/src/components/ScalarIcon/ScalarIcon.vue
@@ -25,7 +25,11 @@ const iconProps = cva({
       md: 'h-4 w-4',
       lg: 'h-5 w-5',
       xl: 'h-6 w-6',
+      full: 'h-full w-full',
     },
+  },
+  defaultVariants: {
+    size: 'full',
   },
 })
 
@@ -36,7 +40,5 @@ const data = computed(() => getIcon(props.icon))
   <SvgRenderer
     v-if="data"
     :class="cx('scalar-icon', iconProps({ size }))"
-    height="100%"
-    :raw="data"
-    width="100%" />
+    :raw="data" />
 </template>

--- a/packages/swagger-editor/src/components/ResetStyles.vue
+++ b/packages/swagger-editor/src/components/ResetStyles.vue
@@ -47,6 +47,9 @@ onMounted(() => {
   p,
   ol,
   ul,
+  dl,
+  dd,
+  dt,
   em,
   strong,
   button {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,6 +446,9 @@ importers:
 
   packages/api-reference:
     dependencies:
+      '@floating-ui/vue':
+        specifier: ^1.0.2
+        version: 1.0.2(vue@3.3.4)
       '@headlessui/vue':
         specifier: ^1.7.16
         version: 1.7.16(vue@3.3.4)
@@ -3649,14 +3652,12 @@ packages:
     resolution: {integrity: sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==}
     dependencies:
       '@floating-ui/utils': 0.1.4
-    dev: true
 
   /@floating-ui/dom@1.5.3:
     resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
     dependencies:
       '@floating-ui/core': 1.5.0
       '@floating-ui/utils': 0.1.4
-    dev: true
 
   /@floating-ui/react-dom@2.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==}
@@ -3671,7 +3672,16 @@ packages:
 
   /@floating-ui/utils@0.1.4:
     resolution: {integrity: sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA==}
-    dev: true
+
+  /@floating-ui/vue@1.0.2(vue@3.3.4):
+    resolution: {integrity: sha512-sImlAl9mAoCKZLNlwWz2P2ZMJIDlOEDXrRD6aD2sIHAka1LPC+nWtB+D3lPe7IE7FGWSbwBPTnlSdlABa3Fr0A==}
+    dependencies:
+      '@floating-ui/dom': 1.5.3
+      vue-demi: 0.14.6(vue@3.3.4)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: false
 
   /@headlessui/vue@1.7.16(vue@3.3.4):
     resolution: {integrity: sha512-nKT+nf/q6x198SsyK54mSszaQl/z+QxtASmgMEJtpxSX2Q0OPJX0upS/9daDyiECpeAsvjkoOrm2O/6PyBQ+Qg==}


### PR DESCRIPTION
**Problem**
Currently, there’s no support for OpenAuth 2 authentication.

**Explanation**
This flow is way more complex than the others, but let’s start at least with something.

**Solution**
With this PR an basic interface is added to start an Open Auth2 flow, which covers at least the config from the Petstore example.

**Preview**
<img width="591" alt="Screenshot 2023-12-01 at 15 23 34" src="https://github.com/scalar/scalar/assets/1577992/e571e8d9-7593-4f08-93d2-da1d834821c2">

**Swagger UI**

<img width="608" alt="Screenshot 2023-12-01 at 15 48 41" src="https://github.com/scalar/scalar/assets/1577992/5feb2660-0da2-4e21-8bee-9c8d50dca0be">
