### PR TITLE
fix: oneOf rule in arrays is ignored, fix #599

### DIFF
--- a/.changeset/thin-items-matter.md
+++ b/.changeset/thin-items-matter.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: oneOf rules for arrays are ignored

--- a/packages/api-reference/src/components/Content/Schema.stories.ts
+++ b/packages/api-reference/src/components/Content/Schema.stories.ts
@@ -80,7 +80,15 @@ const schema = {
       description: 'pet status in the store',
       enum: ['available', 'pending', 'sold'],
     },
+
+    tensor_data: {
+      type: 'array',
+      items: {
+        oneOf: [{ type: 'number' }, { type: 'string' }, { type: 'boolean' }],
+      },
+    },
   },
+
   xml: {
     name: 'pet',
   },

--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -95,7 +95,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         v-for="rule in rules"
         :key="rule">
         <div
-          v-if="value?.[rule]"
+          v-if="value?.[rule] || value?.items?.[rule]"
           class="property-rule">
           {{ rule }}
         </div>
@@ -169,11 +169,22 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     <template
       v-for="rule in rules"
       :key="rule">
+      <!-- Property -->
       <div
         v-if="value?.[rule]"
         class="rule">
         <Schema
           v-for="(schema, index) in value[rule]"
+          :key="index"
+          :level="level + 1"
+          :value="schema" />
+      </div>
+      <!-- Arrays -->
+      <div
+        v-if="value?.items?.[rule]"
+        class="rule">
+        <Schema
+          v-for="(schema, index) in value.items[rule]"
           :key="index"
           :level="level + 1"
           :value="schema" />
@@ -203,6 +214,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 }
 
 .property-rule {
+  display: inline-block;
   font-family: var(--theme-font-code, var(--default-theme-font-code));
   background: var(--theme-color-orange, var(--default-theme-color-orange));
   padding: 0 6px;


### PR DESCRIPTION
**Problem**
Currently, if there’s a oneOf rule in an array (`items`), it’s just ignored. This happens because it’s checking the property for the rule, not inside `items`. #599

With this PR the oneOf rule is detected in arrays and visualized accordingly.

<img width="1042" alt="Screenshot 2023-12-01 at 15 44 21" src="https://github.com/scalar/scalar/assets/1577992/363ae0a6-f83b-4ace-acc5-706656b3a2db">


