### PR TITLE
style: visualize deprecated operations

### DIFF
--- a/.changeset/yellow-months-remember.md
+++ b/.changeset/yellow-months-remember.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+style: visualize deprecated operations

--- a/packages/api-reference/src/components/Badge/Badge.stories.ts
+++ b/packages/api-reference/src/components/Badge/Badge.stories.ts
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+import { Badge } from '.'
+
+const meta: Meta<typeof Badge> = {
+  title: 'Example/Badge',
+  component: Badge,
+  argTypes: {},
+}
+
+export default meta
+
+type Story = StoryObj<typeof Badge>
+
+export const Text: Story = {
+  render: () => ({
+    components: {
+      Badge,
+    },
+    template: `
+      <Badge>
+        Deprecated
+      </Badge>
+    `,
+  }),
+}
+
+export const TwoBadges: Story = {
+  render: () => ({
+    components: {
+      Badge,
+    },
+    template: `
+      <Badge>
+        1.0.11
+      </Badge>
+      <Badge>
+        OAS 3.0.2
+      </Badge>
+    `,
+  }),
+}

--- a/packages/api-reference/src/components/Badge/Badge.vue
+++ b/packages/api-reference/src/components/Badge/Badge.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="badge">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.badge {
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  font-size: var(--theme-micro, var(--default-theme-micro));
+  background: var(--theme-background-2, var(--default-theme-background-2));
+  padding: 2px 6px;
+  border-radius: 12px;
+  margin-right: 4px;
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
+  margin-bottom: 3px;
+  display: inline-block;
+  text-transform: uppercase;
+}
+</style>

--- a/packages/api-reference/src/components/Badge/index.ts
+++ b/packages/api-reference/src/components/Badge/index.ts
@@ -1,0 +1,1 @@
+export { default as Badge } from './Badge.vue'

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 
 import { useTemplateStore } from '../../../stores/template'
 import type { Info, Server, Spec } from '../../../types'
+import { Badge } from '../../Badge'
 import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
 import {
   Section,
@@ -38,16 +39,10 @@ const specVersion = computed(() => {
       <SectionContent :loading="!info.description && !info.title">
         <SectionColumns>
           <SectionColumn>
-            <span
-              v-if="info.version"
-              class="section-version">
+            <Badge v-if="info.version">
               {{ info.version }}
-            </span>
-            <span
-              v-if="specVersion"
-              class="section-oas">
-              OAS {{ specVersion }}
-            </span>
+            </Badge>
+            <Badge v-if="specVersion"> OAS {{ specVersion }} </Badge>
             <SectionHeader
               :level="1"
               :loading="!info.title"
@@ -107,17 +102,5 @@ const specVersion = computed(() => {
 .sticky-cards {
   position: sticky;
   top: 24px;
-}
-.section-version,
-.section-oas {
-  color: var(--theme-color-2, var(--default-theme-color-2));
-  font-size: var(--theme-micro, var(--default-theme-micro));
-  background: var(--theme-background-2, var(--default-theme-background-2));
-  padding: 2px 6px;
-  border-radius: 12px;
-  margin-right: 4px;
-  font-weight: var(--theme-semibold, var(--default-theme-semibold));
-  margin-bottom: 3px;
-  display: inline-block;
 }
 </style>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
@@ -2,6 +2,7 @@
 import { getOperationSectionId } from '../../../helpers'
 import type { Tag, TransformedOperation } from '../../../types'
 import { Anchor } from '../../Anchor'
+import { Badge } from '../../Badge'
 import {
   Section,
   SectionColumn,
@@ -25,11 +26,7 @@ defineProps<{
     <SectionContent>
       <SectionColumns>
         <SectionColumn>
-          <div
-            v-if="operation.information?.deprecated"
-            class="badge">
-            Deprecated
-          </div>
+          <Badge v-if="operation.information?.deprecated"> Deprecated </Badge>
           <div :class="operation.information?.deprecated ? 'deprecated' : ''">
             <SectionHeader :level="3">
               <Anchor :id="getOperationSectionId(operation, tag)">
@@ -58,20 +55,7 @@ defineProps<{
   top: calc(var(--refs-header-height) + 24px);
 }
 
-.badge {
-  display: inline-block;
-  padding: 2px 4px;
-  border-radius: var(--theme-radius, var(--default-theme-radius));
-  background: var(--theme-background-3, var(--default-theme-background-3));
-  color: var(--theme-color-3, var(--default-theme-color-3));
-  font-size: var(--theme-micro, var(--default-theme-micro));
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 1em;
-}
-
 .deprecated * {
   text-decoration: line-through;
-  color: var(--theme-color-2, var(--default-theme-color-2));
 }
 </style>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
@@ -25,11 +25,18 @@ defineProps<{
     <SectionContent>
       <SectionColumns>
         <SectionColumn>
-          <SectionHeader :level="3">
-            <Anchor :id="getOperationSectionId(operation, tag)">
-              {{ operation.name }}
-            </Anchor>
-          </SectionHeader>
+          <div
+            v-if="operation.information?.deprecated"
+            class="badge">
+            Deprecated
+          </div>
+          <div :class="operation.information?.deprecated ? 'deprecated' : ''">
+            <SectionHeader :level="3">
+              <Anchor :id="getOperationSectionId(operation, tag)">
+                {{ operation.name }}
+              </Anchor>
+            </SectionHeader>
+          </div>
           <Copy :operation="operation" />
         </SectionColumn>
         <SectionColumn>
@@ -49,5 +56,22 @@ defineProps<{
 .examples {
   position: sticky;
   top: calc(var(--refs-header-height) + 24px);
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 4px;
+  border-radius: var(--theme-radius, var(--default-theme-radius));
+  background: var(--theme-background-3, var(--default-theme-background-3));
+  color: var(--theme-color-3, var(--default-theme-color-3));
+  font-size: var(--theme-micro, var(--default-theme-micro));
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1em;
+}
+
+.deprecated * {
+  text-decoration: line-through;
+  color: var(--theme-color-2, var(--default-theme-color-2));
 }
 </style>

--- a/packages/api-reference/src/components/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar.vue
@@ -75,6 +75,7 @@ const setRef = (el: SidebarElementType, id: string) => {
               title: item.title,
               type: item.type,
               httpVerb: item.httpVerb,
+              deprecated: item.deprecated ?? false,
             }"
             :open="collapsedSidebarItems[item.id] ?? false"
             @select="
@@ -103,6 +104,7 @@ const setRef = (el: SidebarElementType, id: string) => {
                       title: child.title,
                       type: child.type,
                       httpVerb: child.httpVerb,
+                      deprecated: child.deprecated ?? false,
                     }"
                     @select="
                       () => {
@@ -182,6 +184,10 @@ const setRef = (el: SidebarElementType, id: string) => {
   flex: 1;
   padding-right: 12px;
   user-select: none;
+}
+
+.sidebar-heading.deprecated p {
+  text-decoration: line-through;
 }
 
 /* Folder/page collapse icon */

--- a/packages/api-reference/src/components/SidebarElement.vue
+++ b/packages/api-reference/src/components/SidebarElement.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
       src: string
     }
     httpVerb?: string
+    deprecated?: boolean
   }
   isActive?: boolean
   hasChildren?: boolean
@@ -76,6 +77,7 @@ defineExpose({ el })
         'sidebar-group-item__folder':
           hasChildren || item.type === ElementType.Folder,
         'active_page': isActive,
+        'deprecated': item.deprecated ?? false,
       }"
       @click="handleClick">
       <!-- If children are detected then show the nesting icon -->

--- a/packages/api-reference/src/hooks/useNavigation.ts
+++ b/packages/api-reference/src/hooks/useNavigation.ts
@@ -21,6 +21,7 @@ export type SidebarEntry = {
   select?: () => void
   httpVerb?: string
   show: boolean
+  deprecated?: boolean
 }
 
 // Track the parsed spec
@@ -100,6 +101,7 @@ const items = computed((): SidebarEntry[] => {
                 title: operation.name,
                 type: 'Page',
                 httpVerb: operation.httpVerb,
+                deprecated: operation.information?.deprecated ?? false,
                 show: true,
                 select: () => {
                   if (state.showApiClient) {
@@ -116,6 +118,7 @@ const items = computed((): SidebarEntry[] => {
             title: operation.name,
             type: 'Page',
             httpVerb: operation.httpVerb,
+            deprecated: operation.information?.deprecated ?? false,
             show: true,
             select: () => {
               if (state.showApiClient) {

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -88,6 +88,7 @@ export type Information = {
   requestBody?: RequestBody
   summary?: string
   tags?: string[]
+  deprecated?: boolean
 }
 
 export type Operation = {


### PR DESCRIPTION
**Problem**
OpenAPI allows to mark operations as deprecated, but we don’t visualize that.

**Solution**
This PR adds styling for deprecated operations.

If someone wants to improve the design, go for it! :) @hwkr @cameronrohani 

**Preview**

<img width="245" alt="Screenshot 2023-12-01 at 16 32 10" src="https://github.com/scalar/scalar/assets/1577992/8b0e2cbe-0ea6-402c-b99b-c3a15a1a2a19">

<img width="603" alt="Screenshot 2023-12-01 at 16 33 00" src="https://github.com/scalar/scalar/assets/1577992/dd4a18e3-4725-46aa-b334-a3f84167ab80">