### PR TITLE
refactor: extract layout type into component

### DIFF
--- a/.changeset/eighty-pillows-mate.md
+++ b/.changeset/eighty-pillows-mate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+refactor: extract layout type into component

--- a/packages/api-reference/src/components/Layouts/BaseLayout.vue
+++ b/packages/api-reference/src/components/Layouts/BaseLayout.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+/**
+ * This definition provides type safety for the other layouts by requiring the
+ * use of ReferenceProps & ReferenceSlots
+ */
+import { onMounted } from 'vue'
+
+import type { ReferenceProps, ReferenceSlots } from '../../types'
+
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<ReferenceProps>()
+defineSlots<ReferenceSlots>()
+
+onMounted(() => {
+  throw new Error('DO NOT RENDER THE BASE LAYOUT')
+})
+</script>
+<template>
+  <slot name="footer" />
+</template>

--- a/packages/api-reference/src/components/Layouts/index.ts
+++ b/packages/api-reference/src/components/Layouts/index.ts
@@ -1,11 +1,12 @@
-import { type ReferenceLayoutType, type ReferenceProps } from 'src/types'
-import { type Component, type DeepReadonly } from 'vue'
+import { type ReferenceLayoutType } from 'src/types'
+import { type DeepReadonly } from 'vue'
 
+import type BaseLayout from './BaseLayout.vue'
 import ClassicLayout from './ClassicLayout.vue'
 import ModernLayout from './ModernLayout.vue'
 
 const layouts: DeepReadonly<{
-  [x in ReferenceLayoutType]: Component<ReferenceProps>
+  [x in ReferenceLayoutType]: typeof BaseLayout
 }> = {
   modern: ModernLayout,
   classic: ClassicLayout,


### PR DESCRIPTION
Types the layout props and slots using a base component so you get type errors if you don't use the right props / slots.

Example if `ClassicLayout.vue` included an extraneous prop.

<img width="1473" alt="Code-2023-12-01-12-47-14@2x" src="https://github.com/scalar/scalar/assets/6374090/eb577503-60d8-406a-b2b9-3f8514aeac51">
<img width="1473" alt="Code-2023-12-01-12-47-06@2x" src="https://github.com/scalar/scalar/assets/6374090/2fa89b1e-9c43-4a86-bd80-a3a023582ecf">
