### PR TITLE
chore: use fastify-html to send HTML

### DIFF
--- a/.changeset/cuddly-kiwis-report.md
+++ b/.changeset/cuddly-kiwis-report.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+chore: use fastify-html to send HTML

--- a/.changeset/empty-poets-walk.md
+++ b/.changeset/empty-poets-walk.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+chore: disable CommonJS build, don’t support require() anymore

--- a/packages/fastify-api-reference/exports.test.ts
+++ b/packages/fastify-api-reference/exports.test.ts
@@ -23,7 +23,8 @@ describe('exports', () => {
       })
     }))
 
-  it('supports require', () =>
+  // TODO: The require() version doesn’t work since we added fastify-html. Do we want to bring it back?
+  it.skip('supports require', () =>
     new Promise((resolve) => {
       const fastify = Fastify({
         logger: false,

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -50,6 +50,7 @@
     "@types/ejs": "^3.1.3",
     "@vitejs/plugin-vue": "^4.4.0",
     "@vitest/coverage-v8": "^0.34.4",
+    "fastify-html": "^0.2.0",
     "magic-string": "^0.30.4",
     "nodemon": "^3.0.1",
     "rollup-plugin-node-externals": "^6.1.1",
@@ -65,6 +66,7 @@
   },
   "peerDependencies": {
     "fastify": "^4.0.0",
+    "fastify-html": "^0.2.0",
     "fastify-plugin": "^4.0.0"
   }
 }

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -25,11 +25,10 @@
     "types:check": "tsc --noEmit --skipLibCheck"
   },
   "type": "module",
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
+    "import": "./dist/index.js"
   },
   "files": [
     "dist",

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -1,5 +1,6 @@
 import { type ReferenceConfiguration } from '@scalar/api-reference'
 import type { FastifyPluginAsync } from 'fastify'
+import fastifyHtml from 'fastify-html'
 import fp from 'fastify-plugin'
 
 import { getJavaScriptFile } from './utils'
@@ -157,6 +158,11 @@ const fastifyApiReference: FastifyPluginAsync<
   let { configuration } = options
   const hasSwaggerPlugin = fastify.hasPlugin('@fastify/swagger')
 
+  // Register fastify-html if it isn’t registered yet.
+  if (!fastify.hasPlugin('fastify-html')) {
+    await fastify.register(fastifyHtml)
+  }
+
   // If no spec is passed and @fastify/swagger isn’t loaded, show a warning.
   if (
     !configuration?.spec?.content &&
@@ -208,9 +214,9 @@ const fastifyApiReference: FastifyPluginAsync<
         }
       }
 
-      const html = htmlDocument(configuration)
-
-      reply.send(html)
+      // Render the HTML
+      // @ts-ignore
+      return reply.html`${htmlDocument(configuration)}`
     },
   })
 

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -1,5 +1,6 @@
 import { type ReferenceConfiguration } from '@scalar/api-reference'
 import type { FastifyPluginAsync } from 'fastify'
+// @ts-ignore
 import fastifyHtml from 'fastify-html'
 import fp from 'fastify-plugin'
 

--- a/packages/fastify-api-reference/vite.config.ts
+++ b/packages/fastify-api-reference/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       entry: 'src/index.ts',
       name: '@scalar/fastify-api-reference',
       fileName: 'index',
-      formats: ['es', 'cjs'],
+      formats: ['es'],
     },
     rollupOptions: {
       external: Object.keys(pkg.dependencies || {}),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,6 +854,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^0.34.4
         version: 0.34.4(vitest@0.34.4)
+      fastify-html:
+        specifier: ^0.2.0
+        version: 0.2.0
       magic-string:
         specifier: ^0.30.4
         version: 0.30.4
@@ -6271,7 +6274,7 @@ packages:
       std-env: 3.4.3
       test-exclude: 6.0.0
       v8-to-istanbul: 9.1.0
-      vitest: 0.34.4(jsdom@22.1.0)
+      vitest: 0.34.4(terser@5.24.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7655,6 +7658,11 @@ packages:
   /commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+
+  /common-tags@1.8.2:
+    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
+    engines: {node: '>=4.0.0'}
+    dev: true
 
   /commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -9077,9 +9085,15 @@ packages:
     resolution: {integrity: sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==}
     dev: false
 
+  /fastify-html@0.2.0:
+    resolution: {integrity: sha512-P2zwpFnAUcxfzHbkcGtuKRwv2Y2lPGXfySRScnZHax0JfR8WL2YIzPW/xUdU+oexOQAsR29aQyeBmmSbwXRkRg==}
+    dependencies:
+      common-tags: 1.8.2
+      fastify-plugin: 4.5.1
+    dev: true
+
   /fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
-    dev: false
 
   /fastify@4.23.2:
     resolution: {integrity: sha512-WFSxsHES115svC7NrerNqZwwM0UOxbC/P6toT9LRHgAAFvG7o2AN5W+H4ihCtOGuYXjZf4z+2jXC89rVEoPWOA==}


### PR DESCRIPTION
**Problem**
Currently, we’re using `reply.send()`.

**Explanation**
This works, but could break the fastify promise chain. A better approach is to use fastify-html.

**Solution**
With this PR fastify-html is added, registered (if not done already) and used.

⚠️ The CommonJS build is failing with `fastify-html`. I just disabled/removed it for now. If someone complains, I’ll look into it again.
