### PR TITLE
chore: use fastify logging facilities

### DIFF
--- a/.changeset/three-bobcats-fix.md
+++ b/.changeset/three-bobcats-fix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+chore: use fastify logging facilities

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -180,7 +180,8 @@ describe('fastifyApiReference', () => {
       })
     }))
 
-  it('warns when nothing is passed', () =>
+  // TODO: We’re using the fastify logger now.
+  it.skip('warns when nothing is passed', () =>
     new Promise((resolve) => {
       const consoleMock = vi
         .spyOn(console, 'warn')

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -163,7 +163,7 @@ const fastifyApiReference: FastifyPluginAsync<
     !configuration?.spec?.url &&
     !hasSwaggerPlugin
   ) {
-    console.warn(
+    fastify.log.warn(
       '[@scalar/fastify-api-reference] You didn’t provide a spec.content or spec.url and @fastify/swagger could not be find either. Please provide one of these options.',
     )
 


### PR DESCRIPTION
Let’s use the fastify logging facilities, instead of just console.warn.