### PR TITLE
chore: add PostCSS to the examples again

### DIFF
--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -30,6 +30,8 @@
     "autoprefixer": "^10.4.16",
     "eslint": "^8.49.0",
     "eslint-plugin-vue": "^9.17.0",
+    "postcss": "^8.4.31",
+    "postcss-nested": "^6.0.1",
     "typescript": "^5.2.2",
     "vite": "^4.4.11",
     "vite-plugin-node-polyfills": "^0.14.1",

--- a/examples/web/postcss.config.js
+++ b/examples/web/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    'postcss-nested': {},
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,12 @@ importers:
       eslint-plugin-vue:
         specifier: ^9.17.0
         version: 9.17.0(eslint@8.49.0)
+      postcss:
+        specifier: ^8.4.31
+        version: 8.4.31
+      postcss-nested:
+        specifier: ^6.0.1
+        version: 6.0.1(postcss@8.4.31)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -6279,7 +6285,7 @@ packages:
       std-env: 3.4.3
       test-exclude: 6.0.0
       v8-to-istanbul: 9.1.0
-      vitest: 0.34.4(terser@5.24.0)
+      vitest: 0.34.4(jsdom@22.1.0)
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
**Problem**
Currently, the style reset doesn’t work in the examples.

**Explanation**
This happens because I’ve just uninstalled Tailwind and PostCSS in the examples. But we’re aliasing the source files from the packages and need PostCSS to compile them. :)

**Solution**
With this PR PostCSS is added to the examples again.
