### PR TITLE
feat: show references sidebar slot content in api client sidebar

### DIFF
--- a/.changeset/old-cameras-smash.md
+++ b/.changeset/old-cameras-smash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat: show references sidebar slot content in api client sidebar

--- a/.changeset/small-sloths-shake.md
+++ b/.changeset/small-sloths-shake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/swagger-editor': patch
+---
+
+fix: move swagger editor title down to cover border

--- a/packages/api-client/src/components/ApiClient/ApiClient.vue
+++ b/packages/api-client/src/components/ApiClient/ApiClient.vue
@@ -6,7 +6,7 @@ import { useMediaQuery } from '@vueuse/core'
 import { ref, watch } from 'vue'
 
 import { useRequestStore } from '../../stores'
-import AdressBar from './AddressBar.vue'
+import AddressBar from './AddressBar.vue'
 import { Request } from './Request'
 import { Response } from './Response'
 
@@ -60,7 +60,7 @@ useKeyboardEvent({
     class="scalar-api-client"
     :class="`scalar-api-client--${activeRequest.type.toLowerCase() || 'get'}`"
     @keydown.esc="emit('escapeKeyPress')">
-    <AdressBar
+    <AddressBar
       :proxyUrl="proxyUrl"
       @onSend="changeTab(Tabs.Response)" />
     <div class="scalar-api-client__main">

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -56,7 +56,15 @@ export { useApiClientStore } from '@scalar/api-client'
             <div class="t-doc__sidebar">
               <Sidebar
                 v-show="!isMobile"
-                :parsedSpec="parsedSpec" />
+                :parsedSpec="parsedSpec">
+                <!-- Pass up the sidebar slots -->
+                <template #sidebar-start>
+                  <slot name="sidebar-start" />
+                </template>
+                <template #sidebar-end>
+                  <slot name="sidebar-end" />
+                </template>
+              </Sidebar>
             </div>
           </template>
           <ApiClient

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -185,7 +185,18 @@ const { state } = useApiClientStore()
     <!-- REST API Client Overlay -->
     <ApiClientModal
       :parsedSpec="parsedSpec"
-      :proxyUrl="configuration?.proxy" />
+      :proxyUrl="configuration?.proxy">
+      <template #sidebar-start>
+        <slot
+          v-bind="referenceSlotProps"
+          name="sidebar-start" />
+      </template>
+      <template #sidebar-end>
+        <slot
+          v-bind="referenceSlotProps"
+          name="sidebar-end" />
+      </template>
+    </ApiClientModal>
   </div>
 </template>
 <style scoped>

--- a/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/SwaggerEditorHeader.vue
@@ -114,6 +114,8 @@ watch(files, () => {
   position: relative;
 
   padding: 9px;
+  /* Move down to cover the border below */
+  margin-bottom: -1px;
 
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
   color: var(--theme-color-1, var(--default-theme-color-1));


### PR DESCRIPTION
Puts whatever is in the references sidebar into the api client sidebar as well

<img width="600" alt="Google Chrome-2023-12-04-13-17-30@2x" src="https://github.com/scalar/scalar/assets/6374090/54f0c86f-5bfb-4d5f-bb25-65159a6a0686">
<img width="600" alt="Google Chrome-2023-12-04-13-17-07@2x" src="https://github.com/scalar/scalar/assets/6374090/d6743aab-0f52-439d-aed4-b594c84b563b">

Also fixes a subpixel rendering issue with the swagger editor tabs


<img width="300" src="https://github.com/scalar/scalar/assets/6374090/42f1db9a-0da7-4fd9-a8a9-5c0e9362be3a">
<img width="300" src="https://github.com/scalar/scalar/assets/6374090/ec003409-0f46-4e54-bcd0-537bb5c8926d">


