### PR TITLE
chore: change download spec button text

### DIFF
--- a/.changeset/unlucky-planets-unite.md
+++ b/.changeset/unlucky-planets-unite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: change Download OpenAPI Spec button text

--- a/packages/api-reference/src/components/Content/Introduction/DownloadSpec.vue
+++ b/packages/api-reference/src/components/Content/Introduction/DownloadSpec.vue
@@ -1,7 +1,9 @@
 <script lang="ts" setup>
 import { isJsonString } from '../../../helpers'
 
-defineProps<{ value: string }>()
+defineProps<{
+  value: string
+}>()
 
 /* Generate a download URL for the parsedSpec */
 function inlineDownloadUrl(content: string) {
@@ -20,11 +22,6 @@ function inlineDownloadUrl(content: string) {
 function getFilename(content: string) {
   return isJsonString(content) ? 'spec.json' : 'spec.yaml'
 }
-
-/* Prefix the filename with the current URL */
-function getFilePath(content: string) {
-  return `${window.location.origin}/${getFilename(content)}`
-}
 </script>
 <template>
   <div
@@ -34,7 +31,7 @@ function getFilePath(content: string) {
       <a
         :download="getFilename(value)"
         :href="inlineDownloadUrl(value)">
-        {{ getFilePath(value) }}
+        Download OpenAPI Spec
       </a>
     </div>
   </div>


### PR DESCRIPTION
**Problem**
Currently, people are confused by the made-up spec URL.

**Explanation**
This happens because you can’t open this in a new tab, copy the URL and it’s something else than what you configured.

**Solution**
This PR removes the made-up URL and replaces it with just a “Download OpenAPI Spec“ text.

<img width="602" alt="Screenshot 2023-12-05 at 11 30 28" src="https://github.com/scalar/scalar/assets/1577992/4e066701-b4b7-4909-b239-1fef8daeef28">
