### PR TITLE
chore: add @scalar/fastify-api-reference CommonJS build again

### DIFF
--- a/.changeset/fast-crabs-flow.md
+++ b/.changeset/fast-crabs-flow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: common js build

--- a/packages/fastify-api-reference/exports.test.ts
+++ b/packages/fastify-api-reference/exports.test.ts
@@ -23,8 +23,7 @@ describe('exports', () => {
       })
     }))
 
-  // TODO: The require() version doesn’t work since we added fastify-html. Do we want to bring it back?
-  it.skip('supports require', () =>
+  it('supports require', () =>
     new Promise((resolve) => {
       const fastify = Fastify({
         logger: false,

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -25,10 +25,11 @@
     "types:check": "tsc --noEmit --skipLibCheck"
   },
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.js"
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
   },
   "files": [
     "dist",
@@ -41,21 +42,15 @@
     "directory": "packages/fastify-api-reference"
   },
   "devDependencies": {
-    "@rollup/plugin-terser": "^0.4.4",
     "@scalar/api-reference": "workspace:*",
-    "@types/ejs": "^3.1.3",
-    "@vitejs/plugin-vue": "^4.4.0",
     "@vitest/coverage-v8": "^0.34.4",
     "fastify-html": "^0.2.0",
     "magic-string": "^0.30.4",
-    "nodemon": "^3.0.1",
     "rollup-plugin-node-externals": "^6.1.1",
     "terser": "^5.24.0",
     "tsc-alias": "^1.8.8",
     "typescript": "^5.2.2",
     "vite": "^4.4.11",
-    "vite-node": "^0.34.4",
-    "vite-plugin-css-injected-by-js": "^3.3.0",
     "vite-plugin-node-polyfills": "^0.14.1",
     "vite-plugin-static-copy": "^0.17.0",
     "vitest": "^0.34.4",

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -1,7 +1,6 @@
 import type { ReferenceConfiguration } from '@scalar/api-reference'
 import type { FastifyPluginAsync } from 'fastify'
 // @ts-ignore
-import fastifyHtml from 'fastify-html'
 import fp from 'fastify-plugin'
 
 import { getJavaScriptFile } from './utils'

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -161,7 +161,8 @@ const fastifyApiReference: FastifyPluginAsync<
 
   // Register fastify-html if it isn’t registered yet.
   if (!fastify.hasPlugin('fastify-html')) {
-    await fastify.register(fastifyHtml)
+    // @ts-ignore
+    await fastify.register(import('fastify-html'))
   }
 
   // If no spec is passed and @fastify/swagger isn’t loaded, show a warning.

--- a/packages/fastify-api-reference/vite.config.ts
+++ b/packages/fastify-api-reference/vite.config.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import { defineConfig } from 'vitest/config'
 
-import pkg from './package.json'
+// import pkg from './package.json'
 import { nodeExternals } from './src/vite-plugins'
 import { nodeShims } from './src/vite-plugins'
 

--- a/packages/fastify-api-reference/vite.config.ts
+++ b/packages/fastify-api-reference/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       entry: 'src/index.ts',
       name: '@scalar/fastify-api-reference',
       fileName: 'index',
-      formats: ['es'],
+      formats: ['es', 'cjs'],
     },
     // We don’t have any production dependencies.
     // rollupOptions: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,18 +842,9 @@ importers:
         specifier: ^4.0.0
         version: 4.5.1
     devDependencies:
-      '@rollup/plugin-terser':
-        specifier: ^0.4.4
-        version: 0.4.4(rollup@3.29.2)
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../api-reference
-      '@types/ejs':
-        specifier: ^3.1.3
-        version: 3.1.3
-      '@vitejs/plugin-vue':
-        specifier: ^4.4.0
-        version: 4.4.0(vite@4.4.11)(vue@3.3.4)
       '@vitest/coverage-v8':
         specifier: ^0.34.4
         version: 0.34.4(vitest@0.34.4)
@@ -863,9 +854,6 @@ importers:
       magic-string:
         specifier: ^0.30.4
         version: 0.30.4
-      nodemon:
-        specifier: ^3.0.1
-        version: 3.0.1
       rollup-plugin-node-externals:
         specifier: ^6.1.1
         version: 6.1.1(rollup@3.29.2)
@@ -881,12 +869,6 @@ importers:
       vite:
         specifier: ^4.4.11
         version: 4.4.11(@types/node@20.6.3)(terser@5.24.0)
-      vite-node:
-        specifier: ^0.34.4
-        version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
-      vite-plugin-css-injected-by-js:
-        specifier: ^3.3.0
-        version: 3.3.0(vite@4.4.11)
       vite-plugin-node-polyfills:
         specifier: ^0.14.1
         version: 0.14.1(rollup@3.29.2)(vite@4.4.11)
@@ -4438,21 +4420,6 @@ packages:
       estree-walker: 2.0.2
       magic-string: 0.27.0
       rollup: 3.29.2
-    dev: true
-
-  /@rollup/plugin-terser@0.4.4(rollup@3.29.2):
-    resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      rollup: 3.29.2
-      serialize-javascript: 6.0.1
-      smob: 1.4.1
-      terser: 5.24.0
     dev: true
 
   /@rollup/pluginutils@5.0.5(rollup@3.29.2):
@@ -13870,12 +13837,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /serialize-javascript@6.0.1:
-    resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
-    dependencies:
-      randombytes: 2.1.0
-    dev: true
-
   /serve-static@1.15.0:
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
     engines: {node: '>= 0.8.0'}
@@ -14006,10 +13967,6 @@ packages:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
       yargs: 15.4.1
-    dev: true
-
-  /smob@1.4.1:
-    resolution: {integrity: sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==}
     dev: true
 
   /socks-proxy-agent@6.2.1:


### PR DESCRIPTION
**Problem**
Currently, there’s no CommonJS build anymore, I removed it in #621. 

**Explanation**
This happens because `fastify-html` was breaking the CommonJS build … and I thought we can just get away with removing the CommonJS build. Turns out, the fastify community still loves CommonJS and we need it. :)

**Solution**
With this PR the CommonJS build is fixed, with a dynamic `import()` instead of a regular import.

This PR also removes some unused dependencies and does some clean up.
