### PR TITLE
fix: handle root path in request generation

### DIFF
--- a/.changeset/tidy-suits-battle.md
+++ b/.changeset/tidy-suits-battle.md
@@ -1,0 +1,13 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/swagger-editor': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/use-toasts': patch
+'@scalar/use-modal': patch
+'@scalar/themes': patch
+---
+
+fix: handle root path in request generation

--- a/.changeset/tidy-suits-battle.md
+++ b/.changeset/tidy-suits-battle.md
@@ -2,12 +2,7 @@
 '@scalar/express-api-reference': patch
 '@scalar/fastify-api-reference': patch
 '@scalar/hono-api-reference': patch
-'@scalar/swagger-editor': patch
 '@scalar/api-reference': patch
-'@scalar/api-client': patch
-'@scalar/use-toasts': patch
-'@scalar/use-modal': patch
-'@scalar/themes': patch
 ---
 
 fix: handle root path in request generation

--- a/packages/api-reference/src/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.ts
@@ -7,10 +7,8 @@ export function getUrlFromServerState(state: ServerState) {
       ? state?.servers?.[0]?.url ?? undefined
       : state?.servers?.[state.selectedServer]?.url
 
-  if (url === '/') {
-    url = window.location.origin
-  } else if (url === '//') {
-    url = window.location.origin
+  if (url.startsWith('/')) {
+    url = `${window.location.origin}${url}`
   }
 
   return url ? replaceVariables(url, state?.variables) : undefined

--- a/packages/api-reference/src/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.ts
@@ -7,7 +7,7 @@ export function getUrlFromServerState(state: ServerState) {
       ? state?.servers?.[0]?.url ?? undefined
       : state?.servers?.[state.selectedServer]?.url
 
-  if (url.startsWith('/')) {
+  if (url?.startsWith('/')) {
     url = `${window.location.origin}${url}`
   }
 

--- a/packages/api-reference/src/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.ts
@@ -2,10 +2,16 @@ import type { ServerState } from '../types'
 import { replaceVariables } from './replaceVariables'
 
 export function getUrlFromServerState(state: ServerState) {
-  const url =
+  let url =
     state.selectedServer === null
       ? state?.servers?.[0]?.url ?? undefined
       : state?.servers?.[state.selectedServer]?.url
+
+  if (url === '/') {
+    url = window.location.origin
+  } else if (url === '//') {
+    url = window.location.origin
+  }
 
   return url ? replaceVariables(url, state?.variables) : undefined
 }


### PR DESCRIPTION
currently if a server is / or // we don't handle it being the location of the docs, throwing an error https://github.com/litestar-org/litestar/pull/2847#issuecomment-1842048832

this fixes that :) 