### PR TITLE
docs: Fix some backlinks in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Generate interactive API documentations from Swagger files. [Try our Demo](https
 - [Advanced: Styling](#advanced-styling)
 - [Community](#community)
 - [Other packages](#other-packages)
-- [Contributing](#contributing)
+- [Contributing](#contributors)
 - [License](#license)
 
 ## Getting Started

--- a/packages/fastify-api-reference/README.md
+++ b/packages/fastify-api-reference/README.md
@@ -74,7 +74,7 @@ await fastify.register(require('@scalar/fastify-api-reference'), {
 })
 ```
 
-The fastify plugin takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/tree/main/packages/api-reference#props) in the core package README.
+The fastify plugin takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/tree/main/packages/api-reference#configuration) in the core package README.
 
 ## Themes
 


### PR DESCRIPTION
Thanks a lot for building this. 
I'm considering to contribute on another issue but I came across some broken links here so I thought I'd help !

**Problem**
Contributors link and fastify-api-reference links are wrong

**Solution**
Change the urls to fix them up !
