### PR TITLE
fix: remove duplicate slash in previews for slash based servers

### DIFF
--- a/.changeset/breezy-bats-brake.md
+++ b/.changeset/breezy-bats-brake.md
@@ -1,0 +1,8 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+---
+
+fix: remove duplicate slash in example and client

--- a/packages/api-reference/src/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.ts
@@ -8,7 +8,7 @@ export function getUrlFromServerState(state: ServerState) {
       : state?.servers?.[state.selectedServer]?.url
 
   if (url?.startsWith('/')) {
-    url = `${window.location.origin}${url}`
+    url = `${window.location.origin}${url.slice(1)}`
   }
 
   return url ? replaceVariables(url, state?.variables) : undefined


### PR DESCRIPTION
**Problem**
currently double slashes if server URL is `/`
![image](https://github.com/scalar/scalar/assets/6176314/e68a81fc-d817-4b8d-a04f-a0190917c08a)


**Solution**
Now this edge case is handled properly ✨
<img width="911" alt="image" src="https://github.com/scalar/scalar/assets/6176314/9ddc9563-8b04-4509-9a50-000d2b79c12e">
<img width="621" alt="image" src="https://github.com/scalar/scalar/assets/6176314/dde8ffe2-4a4a-4b9e-8a40-f1aebb73a575">


