### PR TITLE
fix: don't override Content-Type header when present in the request

### DIFF
--- a/packages/api-client/src/helpers/prepareClientRequestConfig.test.ts
+++ b/packages/api-client/src/helpers/prepareClientRequestConfig.test.ts
@@ -163,4 +163,66 @@ describe('prepareClientRequestConfig', () => {
       },
     })
   })
+
+  it('sends body as JSON', async () => {
+    const clientRequestConfig = prepareClientRequestConfig({
+      request: {
+        type: 'GET',
+        url: 'https://example.com',
+        path: '/',
+        body: '{ "foo": "bar"}',
+      },
+      authState: { ...defaultAuthState },
+    })
+
+    expect(clientRequestConfig).toMatchObject({
+      body: {
+        foo: 'bar',
+      },
+    })
+  })
+
+  it('adds a json header', async () => {
+    const clientRequestConfig = prepareClientRequestConfig({
+      request: {
+        type: 'GET',
+        url: 'https://example.com',
+        path: '/',
+        body: '{ "foo": "bar"}',
+      },
+      authState: { ...defaultAuthState },
+    })
+
+    expect(clientRequestConfig.headers).toMatchObject([
+      {
+        name: 'Content-Type',
+        value: 'application/json; charset=utf-8',
+      },
+    ])
+  })
+
+  it('keeps content-type headers', async () => {
+    const clientRequestConfig = prepareClientRequestConfig({
+      request: {
+        type: 'GET',
+        url: 'https://example.com',
+        path: '/',
+        body: '{ "foo": "bar"}',
+        headers: [
+          {
+            name: 'Content-Type',
+            value: 'plain/text',
+          },
+        ],
+      },
+      authState: { ...defaultAuthState },
+    })
+
+    expect(clientRequestConfig.headers).toMatchObject([
+      {
+        name: 'Content-Type',
+        value: 'plain/text',
+      },
+    ])
+  })
 })

--- a/packages/api-client/src/helpers/prepareClientRequestConfig.ts
+++ b/packages/api-client/src/helpers/prepareClientRequestConfig.ts
@@ -1,6 +1,14 @@
 import type { AuthState, ClientRequestConfig } from '../types'
 import { isJsonString } from './isJsonString'
 
+/**
+ * Before a request is sent to the server, we’ll do some final preparation.
+ *
+ * - Add authentication headers
+ * - Add Content-Type header if request.body is JSON
+ * - Parse request.body if it’s JSON
+ * - Remove duplicate headers
+ */
 export const prepareClientRequestConfig = (configuration: {
   request: ClientRequestConfig
   authState: AuthState
@@ -29,12 +37,20 @@ export const prepareClientRequestConfig = (configuration: {
 
   // Check if request.body contains JSON
   if (request.body && isJsonString(request.body)) {
-    if (!request.headers?.some((header) => header.name === 'Content-Type')) {
-      // Add Content-Type header
-      request.headers?.push({
-        name: 'Content-Type',
-        value: `application/json; charset=utf-8`,
-      })
+    // Check whether the request already has a Content-Type header
+    const hasContentTypeHeader = request.headers?.some(
+      (header) => header.name.toLowerCase() === 'content-type',
+    )
+
+    // If not, add one.
+    if (!hasContentTypeHeader) {
+      request.headers = [
+        ...(request.headers ?? []),
+        {
+          name: 'Content-Type',
+          value: `application/json; charset=utf-8`,
+        },
+      ]
     }
 
     request.body = JSON.parse(request.body)

--- a/packages/api-client/src/helpers/prepareClientRequestConfig.ts
+++ b/packages/api-client/src/helpers/prepareClientRequestConfig.ts
@@ -29,14 +29,13 @@ export const prepareClientRequestConfig = (configuration: {
 
   // Check if request.body contains JSON
   if (request.body && isJsonString(request.body)) {
-    // Add Content-Type header
-    request.headers = [
-      ...(request.headers ?? []),
-      {
+    if (!request.headers?.some((header) => header.name === 'Content-Type')) {
+      // Add Content-Type header
+      request.headers?.push({
         name: 'Content-Type',
         value: `application/json; charset=utf-8`,
-      },
-    ]
+      })
+    }
 
     request.body = JSON.parse(request.body)
   }


### PR DESCRIPTION
**Problem**
Currently, The `Content-Type` header is always getting overridden 

**Explanation**
This happens because of these lines of code here 
https://github.com/scalar/scalar/blob/00c01b56b37a278083ce1bc3b38714061d154703/packages/api-client/src/helpers/prepareClientRequestConfig.ts#L33-L39

**Solution**
With this PR we only override the `Content-Type` header if it's not present in the request
