### PR TITLE
fix: select menu on chrome

### DIFF
--- a/.changeset/quiet-spiders-leave.md
+++ b/.changeset/quiet-spiders-leave.md
@@ -1,0 +1,9 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: windows select menu not updating on prefers color scheme

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -251,10 +251,11 @@ const { activeRequest, readOnly } = useRequestStore()
   background: transparent;
   outline: none;
   border: none;
+  -moz-appearance: none;
   -webkit-appearance: none;
+  appearance: none;
   font-size: var(--theme-micro, var(--default-theme-micro));
   color: var(--theme-color-1, var(--default-theme-color-1));
-  appearance: none;
   width: 100%;
   padding: 14px 9px 4px 9px;
   top: 0;

--- a/packages/api-client/src/components/ApiClient/RequestMethodSelect.vue
+++ b/packages/api-client/src/components/ApiClient/RequestMethodSelect.vue
@@ -63,6 +63,8 @@ const supportedRequestMethods = [
   width: 100%;
   height: 100%;
   opacity: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
   appearance: none;
 }
 

--- a/packages/api-client/src/components/CollapsibleSection/CollapsibleSection.vue
+++ b/packages/api-client/src/components/CollapsibleSection/CollapsibleSection.vue
@@ -154,6 +154,9 @@ defineProps<{
   height: 100%;
   opacity: 0;
   cursor: pointer;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
 }
 .scalar-api-client__item__content .scalar-api-client__codemirror__wrapper {
   padding-top: 0;

--- a/packages/api-client/src/components/Grid/Grid.vue
+++ b/packages/api-client/src/components/Grid/Grid.vue
@@ -535,6 +535,8 @@ const showDescription = ref(false)
   outline: none;
   border: none;
   font-size: var(--theme-micro, var(--default-theme-micro));
+  -moz-appearance: none;
+  -webkit-appearance: none;
   appearance: none;
   width: 100%;
   padding: 12px 6px;

--- a/packages/api-reference/src/components/Content/Authentication/SecuritySchemeSelector.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecuritySchemeSelector.vue
@@ -126,6 +126,9 @@ const keys = computed(() => Object.keys(props.value))
   left: 0;
   right: 0;
   cursor: pointer;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .security-scheme-selector svg {

--- a/packages/api-reference/src/components/Content/Introduction/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/Introduction/ClientSelector.vue
@@ -378,6 +378,9 @@ function checkIfClientIsFeatured(client: SelectedClient) {
   left: 0;
   cursor: pointer;
   z-index: 1;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
 }
 .code-languages__select span {
   position: relative;

--- a/packages/api-reference/src/components/Content/Introduction/ServerList.vue
+++ b/packages/api-reference/src/components/Content/Introduction/ServerList.vue
@@ -155,6 +155,9 @@ watch(
   right: 0;
   opacity: 0;
   top: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .server-selector svg {

--- a/packages/api-reference/src/components/Content/Introduction/ServerVariables.vue
+++ b/packages/api-reference/src/components/Content/Introduction/ServerVariables.vue
@@ -72,6 +72,9 @@ const getValue = (name: string) => {
   right: 0;
   bottom: 0;
   opacity: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .input-value {

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -209,6 +209,8 @@ computed(() => {
   width: 100%;
   height: 100%;
   opacity: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
   appearance: none;
 }
 .language-select span {


### PR DESCRIPTION
**Problem**
Some select menu's currently don't have `appearance:none` which create a conflict when your systems preferred colour scheme doesn't match the prefers-color-scheme attribute on .dark-mode / .light-mode. 

Results in this:
<img width="206" alt="image (1)" src="https://github.com/scalar/scalar/assets/6201407/10c72d8f-0a50-4663-a4ea-e4bb6a06b457">


**Solution**
Add appearance: none; to all select menu's 
