### PR TITLE
chore: don’t pass optional parameters to the client

### DIFF
--- a/.changeset/tasty-lemons-dance.md
+++ b/.changeset/tasty-lemons-dance.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: don’t add optional parameters to the client

--- a/packages/api-reference/src/helpers/getParametersFromOperation.test.ts
+++ b/packages/api-reference/src/helpers/getParametersFromOperation.test.ts
@@ -14,6 +14,7 @@ describe('getParametersFromOperation', () => {
             {
               in: 'query',
               name: 'api_key',
+              required: true,
             },
           ],
         },
@@ -38,6 +39,7 @@ describe('getParametersFromOperation', () => {
           {
             in: 'query',
             name: 'api_key',
+            required: true,
           },
         ],
       },
@@ -64,6 +66,7 @@ describe('getParametersFromOperation', () => {
           {
             in: 'query',
             name: 'foo',
+            required: true,
           },
         ],
         information: {
@@ -71,6 +74,7 @@ describe('getParametersFromOperation', () => {
             {
               in: 'query',
               name: 'bar',
+              required: true,
             },
           ],
         },
@@ -123,12 +127,6 @@ describe('getParametersFromOperation', () => {
         description: 'Your API token',
         required: true,
       },
-      {
-        name: 'id',
-        value: '',
-        description: 'A Query Parameter',
-        required: false,
-      },
     ])
   })
 
@@ -143,6 +141,7 @@ describe('getParametersFromOperation', () => {
               name: 'id',
               in: 'query',
               example: 123,
+              required: true,
             },
           ],
         },
@@ -155,7 +154,7 @@ describe('getParametersFromOperation', () => {
         name: 'id',
         description: null,
         value: 123,
-        required: false,
+        required: true,
       },
     ])
   })

--- a/packages/api-reference/src/helpers/getParametersFromOperation.ts
+++ b/packages/api-reference/src/helpers/getParametersFromOperation.ts
@@ -15,16 +15,22 @@ export function getParametersFromOperation(
     ...(operation.information?.parameters || []),
   ]
 
-  return parameters
-    .filter((parameter) => parameter.in === where)
-    .map((parameter) => ({
-      name: parameter.name,
-      description: parameter.description ?? null,
-      value: parameter.example
-        ? parameter.example
-        : parameter.schema
-        ? getExampleFromSchema(parameter.schema)
-        : '',
-      required: parameter.required ?? false,
-    }))
+  return (
+    parameters
+      // query, path, header, cookie?
+      .filter((parameter) => parameter.in === where)
+      // don’t add optional parameters
+      .filter((parameter) => parameter.required)
+      // transform them
+      .map((parameter) => ({
+        name: parameter.name,
+        description: parameter.description ?? null,
+        value: parameter.example
+          ? parameter.example
+          : parameter.schema
+          ? getExampleFromSchema(parameter.schema)
+          : '',
+        required: parameter.required ?? false,
+      }))
+  )
 }


### PR DESCRIPTION
**Problem**
Currently, the list of parameters becomes really long and combines parameters that are not possible to use together.

**Explanation**
This happens because we pass all known parameters to the API client.

**Solution**
With this PR optional parameters aren’t passed to the API client. The UI only shows required parameters now.
