### PR TITLE
fix: dont alias themes source files

### DIFF
--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -53,8 +53,8 @@ export default defineConfig({
       {
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
-        // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(components\/style\.css|components\b))(.+)/,
+        // (not @scalar/components/*/style.css)
+        find: /^@scalar\/(?!(components\/style\.css|components|themes\b))(.+)/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],


### PR DESCRIPTION
I'm not sure if this is the best way to fix this but it fixes an issue with importing theme css files