### PR TITLE
feat: toggle parameters, fix #653

### DIFF
--- a/.changeset/dull-mugs-knock.md
+++ b/.changeset/dull-mugs-knock.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+feat: toggle parameters to include/exclude them in/from the request

--- a/packages/api-client/src/components/ApiClient/Request/RequestCookies.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestCookies.vue
@@ -12,7 +12,7 @@ function handleDeleteIndex(index: number) {
 }
 
 function addAnotherHandler() {
-  activeRequest.cookies?.push({ name: '', value: '' })
+  activeRequest.cookies?.push({ name: '', value: '', enabled: true })
 }
 </script>
 <template>

--- a/packages/api-client/src/components/ApiClient/Request/RequestHeaders.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestHeaders.vue
@@ -12,7 +12,7 @@ function handleDeleteIndex(index: number) {
 }
 
 function addAnotherHandler() {
-  activeRequest.headers?.push({ name: '', value: '' })
+  activeRequest.headers?.push({ name: '', value: '', enabled: true })
 }
 </script>
 <template>

--- a/packages/api-client/src/components/ApiClient/Request/RequestQuery.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestQuery.vue
@@ -13,7 +13,7 @@ function handleDeleteIndex(index: number) {
 }
 
 function addAnotherHandler() {
-  activeRequest.query?.push({ name: '', value: '' })
+  activeRequest.query?.push({ name: '', value: '', enabled: true })
 }
 </script>
 <template>

--- a/packages/api-client/src/components/ApiClient/Request/RequestVariables.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestVariables.vue
@@ -13,7 +13,7 @@ function handleDeleteIndex(index: number) {
 }
 
 function addAnotherHandler() {
-  activeRequest.variables?.push({ name: '', value: '' })
+  activeRequest.variables?.push({ name: '', value: '', enabled: true })
 }
 </script>
 <template>

--- a/packages/api-client/src/components/Grid/Grid.vue
+++ b/packages/api-client/src/components/Grid/Grid.vue
@@ -98,8 +98,8 @@ const showDescription = ref(false)
       </div>
       <div class="table-row-meta">
         <label class="meta-check">
-          <!-- v-model="item.enabled" -->
           <input
+            v-model="item.enabled"
             checked
             type="checkbox" />
           <span class="meta-checkmark" />

--- a/packages/api-client/src/helpers/prepareClientRequestConfig.test.ts
+++ b/packages/api-client/src/helpers/prepareClientRequestConfig.test.ts
@@ -212,6 +212,7 @@ describe('prepareClientRequestConfig', () => {
           {
             name: 'Content-Type',
             value: 'plain/text',
+            enabled: true,
           },
         ],
       },

--- a/packages/api-client/src/helpers/prepareClientRequestConfig.ts
+++ b/packages/api-client/src/helpers/prepareClientRequestConfig.ts
@@ -23,6 +23,7 @@ export const prepareClientRequestConfig = (configuration: {
         value: `Basic ${btoa(
           `${authState.basic.username}:${authState.basic.password}`,
         )}`,
+        enabled: true,
       },
     ]
   } else if (authState.type === 'bearer' && authState.bearer.active) {
@@ -31,6 +32,7 @@ export const prepareClientRequestConfig = (configuration: {
       {
         name: 'Authorization',
         value: `Bearer ${authState.bearer.token}`,
+        enabled: true,
       },
     ]
   }
@@ -49,6 +51,7 @@ export const prepareClientRequestConfig = (configuration: {
         {
           name: 'Content-Type',
           value: `application/json; charset=utf-8`,
+          enabled: true,
         },
       ]
     }

--- a/packages/api-client/src/helpers/sendRequest.test.ts
+++ b/packages/api-client/src/helpers/sendRequest.test.ts
@@ -45,6 +45,7 @@ describe('sendRequest', () => {
         {
           name: 'path',
           value: 'example',
+          enabled: true,
         },
       ],
     }
@@ -66,6 +67,7 @@ describe('sendRequest', () => {
         {
           name: 'foo',
           value: 'bar',
+          enabled: true,
         },
       ],
     }
@@ -88,6 +90,7 @@ describe('sendRequest', () => {
         {
           name: 'foo',
           value: 'bar',
+          enabled: true,
         },
       ],
     }
@@ -111,6 +114,7 @@ describe('sendRequest', () => {
         {
           name: 'foo',
           value: 'bar',
+          enabled: true,
         },
       ],
     }
@@ -133,10 +137,12 @@ describe('sendRequest', () => {
         {
           name: 'foo',
           value: 'bar',
+          enabled: true,
         },
         {
           name: 'another',
           value: 'cookie',
+          enabled: true,
         },
       ],
     }

--- a/packages/api-client/src/helpers/sendRequest.ts
+++ b/packages/api-client/src/helpers/sendRequest.ts
@@ -39,7 +39,11 @@ export async function sendRequest(
 
   const renderedUrl = replaceVariables(
     urlWithPath,
-    mapFromArray(request.variables ?? [], 'name', 'value'),
+    mapFromArray(
+      (request.variables ?? []).filter((variable) => variable.enabled),
+      'name',
+      'value',
+    ),
   )
 
   // Get query string from urlWithPath ("https://example.com?foo=bar")

--- a/packages/api-client/src/helpers/sendRequest.ts
+++ b/packages/api-client/src/helpers/sendRequest.ts
@@ -24,8 +24,9 @@ export async function sendRequest(
   proxyUrl?: string,
 ): Promise<RequestResult | null> {
   const method = normalizeRequestMethod(request.type)
+
   const headers: Record<string, string | number> = mapFromArray(
-    request.headers ?? [],
+    (request.headers ?? []).filter((header) => header.enabled),
     'name',
     'value',
   )
@@ -51,6 +52,7 @@ export async function sendRequest(
       queryStringsFromUrl.push({
         name,
         value,
+        enabled: true,
       })
     })
   })
@@ -58,7 +60,10 @@ export async function sendRequest(
   const queryString = new URLSearchParams(
     // TODO: No type-casting
     mapFromArray(
-      [...(request.query ?? []), ...queryStringsFromUrl],
+      [
+        ...(request.query ?? []).filter((query) => query.enabled),
+        ...queryStringsFromUrl,
+      ],
       'name',
       'value',
     ) as Record<string, string>,
@@ -75,7 +80,11 @@ export async function sendRequest(
 
   // Add cookies to the headers
   if (request.cookies) {
-    const cookies = mapFromArray(request.cookies, 'name', 'value')
+    const cookies = mapFromArray(
+      (request.cookies ?? []).filter((cookie) => cookie.enabled),
+      'name',
+      'value',
+    )
 
     headers.Cookie = Object.keys(cookies)
       .map((key) => `${key}=${cookies[key]}`)
@@ -134,7 +143,7 @@ export async function sendRequest(
       // float all errors now to the user
       return {
         headers: {
-          'content-type': 'application/json',
+          'content-type': 'application/json; charset=utf-8',
         },
         ...errorResponse,
         statusCode: errorResponse?.status ?? 0,

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -42,6 +42,7 @@ export type BaseParameter = {
   value: string | number
   customClass?: string
   required?: boolean
+  enabled: boolean
 }
 
 export type Header = BaseParameter

--- a/packages/api-reference/src/helpers/generateParameters.ts
+++ b/packages/api-reference/src/helpers/generateParameters.ts
@@ -12,6 +12,7 @@ export function generateParameters(parameters: Parameters[]) {
       name: parameter.name,
       value: '',
       customClass: parameter.required ? 'required-parameter' : '',
+      enabled: true,
     }
     param.value = ''
     params.push(param)

--- a/packages/api-reference/src/helpers/getApiClientRequest.ts
+++ b/packages/api-reference/src/helpers/getApiClientRequest.ts
@@ -42,9 +42,15 @@ export function getApiClientRequest({
     type: request.method,
     path: requestFromOperation.path ?? '',
     variables,
-    cookies: request.cookies,
-    query: request.queryString,
-    headers: request.headers,
+    cookies: request.cookies.map((cookie) => {
+      return { ...cookie, enabled: true }
+    }),
+    query: request.queryString.map((queryString) => {
+      return { ...queryString, enabled: true }
+    }),
+    headers: request.headers.map((header) => {
+      return { ...header, enabled: true }
+    }),
     url: getUrlFromServerState(serverState) ?? '',
     body: request.postData?.text,
   }

--- a/packages/api-reference/src/helpers/getParametersFromOperation.test.ts
+++ b/packages/api-reference/src/helpers/getParametersFromOperation.test.ts
@@ -126,6 +126,7 @@ describe('getParametersFromOperation', () => {
         value: '',
         description: 'Your API token',
         required: true,
+        enabled: true,
       },
     ])
   })
@@ -155,6 +156,7 @@ describe('getParametersFromOperation', () => {
         description: null,
         value: 123,
         required: true,
+        enabled: true,
       },
     ])
   })
@@ -188,6 +190,7 @@ describe('getParametersFromOperation', () => {
         description: 'Pet id to delete',
         value: 1,
         required: true,
+        enabled: true,
       },
     ])
   })

--- a/packages/api-reference/src/helpers/getParametersFromOperation.ts
+++ b/packages/api-reference/src/helpers/getParametersFromOperation.ts
@@ -1,3 +1,5 @@
+import type { BaseParameter } from '@scalar/api-client'
+
 import type { TransformedOperation } from '../types'
 import { getExampleFromSchema } from './getExampleFromSchema'
 
@@ -9,7 +11,7 @@ import { getExampleFromSchema } from './getExampleFromSchema'
 export function getParametersFromOperation(
   operation: TransformedOperation,
   where: 'query' | 'path' | 'header' | 'cookie',
-) {
+): BaseParameter[] {
   const parameters = [
     ...(operation.pathParameters || []),
     ...(operation.information?.parameters || []),
@@ -31,6 +33,7 @@ export function getParametersFromOperation(
           ? getExampleFromSchema(parameter.schema)
           : '',
         required: parameter.required ?? false,
+        enabled: true,
       }))
   )
 }

--- a/packages/api-reference/src/helpers/getRequestFromOperation.ts
+++ b/packages/api-reference/src/helpers/getRequestFromOperation.ts
@@ -1,5 +1,8 @@
 import type {
+  Cookie,
   HarRequestWithPath,
+  Header,
+  Query,
   RequestBodyMimeTypes,
   TransformedOperation,
 } from '../types'
@@ -34,10 +37,10 @@ export const getRequestFromOperation = (
     headers: [
       ...getParametersFromOperation(operation, 'header'),
       ...(requestBody?.headers ?? []),
-    ],
+    ] as Header[],
     postData: requestBody?.postData,
-    queryString: getParametersFromOperation(operation, 'query'),
-    cookies: getParametersFromOperation(operation, 'cookie'),
+    queryString: getParametersFromOperation(operation, 'query') as Query[],
+    cookies: getParametersFromOperation(operation, 'cookie') as Cookie[],
   }
 }
 


### PR DESCRIPTION
**Problem**
Currently, there’s a checkbox to enable/disable parameters, but they are sent anyway.

**Explanation**
This happens because we didn’t build the feature, just the UI. :)

**Solution**
With this PR the parameter type is extended to have `enabled: boolean`, by default `enabled` is set to `true` and the client will only sent what’s enabled.
