### PR TITLE
feat: show schema description in parameter item

### DIFF
--- a/.changeset/hip-baboons-play.md
+++ b/.changeset/hip-baboons-play.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: show schema description in parameter item

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ParameterItem.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ParameterItem.vue
@@ -19,8 +19,8 @@ defineProps<{ parameter: Parameters }>()
       {{ parameter.schema?.type }}
     </span>
     <MarkdownRenderer
-      v-if="parameter.description"
+      v-if="parameter.description || parameter.schema?.description"
       class="parameter-description"
-      :value="parameter.description" />
+      :value="parameter.description || parameter.schema?.description" />
   </li>
 </template>

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -64,6 +64,7 @@ export type Schema = {
   format: string
   type: string
   default?: any
+  description?: string
 }
 
 export type Parameters = {


### PR DESCRIPTION
**Problem**
Currently, if there’s a description in the schema we don’t show it in the ParameterItem component.

**Explanation**
This happens because the description can be on the parameter level, or in the schema and we forgot to add the one in the schema.

**Solution**
With this PR both fields can be used.

**In the schema**
```diff
{
  "schema": {
    "type": "string",
+    "description": "Page of transactions to load"
  },
  "name": "page",
  "in": "query"
},
```

**In the parameter**
```diff
{
+  "description": "Page of transactions to load",
  "schema": {
    "type": "string",
  },
  "name": "page",
  "in": "query"
},
```

<img width="439" alt="Screenshot 2023-12-13 at 11 16 07" src="https://github.com/scalar/scalar/assets/1577992/11895f16-22fc-450c-9e91-5b690835542e">
