### PR TITLE
fix: mobile sidebar doesnt close on change item

### DIFF
--- a/.changeset/plenty-bees-fly.md
+++ b/.changeset/plenty-bees-fly.md
@@ -1,0 +1,8 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+---
+
+fix: sidebar on mobile doesnt close once changing active item

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -26,8 +26,8 @@ const config = computed(() => {
 
 const { activeItemId } = useNavigation()
 
-watch(activeItemId, () => {
-  if (activeItemId) {
+watch(activeItemId, (n, o) => {
+  if (n && n !== o) {
     showMobileDrawer.value = false
   }
 })

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { useMediaQuery } from '@vueuse/core'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
+import { useNavigation } from '../../hooks'
 import { type ReferenceProps, type ReferenceSlots } from '../../types'
 import ApiReferenceBase from '../ApiReferenceBase.vue'
 import DarkModeToggle from '../DarkModeToggle.vue'
@@ -21,6 +22,14 @@ const config = computed(() => {
     ? showMobileDrawer.value
     : props.configuration?.showSidebar
   return { ...props.configuration, showSidebar }
+})
+
+const { activeItemId } = useNavigation()
+
+watch(activeItemId, () => {
+  if (activeItemId) {
+    showMobileDrawer.value = false
+  }
 })
 </script>
 <template>


### PR DESCRIPTION
**Problem**
When you click the sidebar on mobile, it doesnt close the sidebar

**Solution**
sidebar closes once activeitem changes 
