### PR TITLE
feat: classic introduction layout

### DIFF
--- a/.changeset/dry-days-lick.md
+++ b/.changeset/dry-days-lick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: classic introduction layout

--- a/examples/web/src/components/DevToolbar.vue
+++ b/examples/web/src/components/DevToolbar.vue
@@ -103,6 +103,17 @@ watch(
         </select>
       </div>
       <div>
+        Layout:
+        <select v-model="configuration.layout">
+          <option
+            v-for="layout in ['modern', 'classic']"
+            :key="layout"
+            :value="layout">
+            {{ layout }}
+          </option>
+        </select>
+      </div>
+      <div>
         <input
           v-model="enableCollaborativeEditingRef"
           type="checkbox" />

--- a/examples/web/src/main.ts
+++ b/examples/web/src/main.ts
@@ -5,6 +5,7 @@ import App from './App.vue'
 import ApiClientPage from './pages/ApiClientPage.vue'
 import ApiReferencePage from './pages/ApiReferencePage.vue'
 import ClassicApiReferencePage from './pages/ClassicApiReferencePage.vue'
+import EditableApiReferencePage from './pages/EditableApiReferencePage.vue'
 import StandaloneApiReferencePage from './pages/StandaloneApiReferencePage.vue'
 import StartPage from './pages/StartPage.vue'
 import SwaggerEditorPage from './pages/SwaggerEditorPage.vue'
@@ -27,6 +28,11 @@ const routes = [
     path: '/classic-api-reference',
     name: 'classic-api-reference',
     component: ClassicApiReferencePage,
+  },
+  {
+    path: '/editable-api-reference',
+    name: 'editable-api-reference',
+    component: EditableApiReferencePage,
   },
   {
     path: '/swagger-editor',

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -15,6 +15,7 @@ const configuration = reactive<ReferenceConfiguration>({
   proxy: 'http://localhost:5051',
   isEditable: true,
   showSidebar: true,
+  layout: 'modern',
   spec: { content },
 })
 

--- a/examples/web/src/pages/EditableApiReferencePage.vue
+++ b/examples/web/src/pages/EditableApiReferencePage.vue
@@ -6,13 +6,11 @@ import {
 import { reactive } from 'vue'
 
 import SlotPlaceholder from '../components/SlotPlaceholder.vue'
-import content from '../fixtures/petstorev3.json'
 
 const configuration = reactive<ReferenceConfiguration>({
   theme: 'default',
   proxy: 'http://localhost:5051',
-  isEditable: false,
-  spec: { content },
+  isEditable: true,
 })
 </script>
 <template>

--- a/examples/web/src/pages/StartPage.vue
+++ b/examples/web/src/pages/StartPage.vue
@@ -24,8 +24,8 @@ import PageLink from '../components/PageLink.vue'
       <PageLink to="standalone-api-reference">
         <template #title>Full API Reference</template>
         <template #description>
-          Interactive API documentation with pre-configured search and all the
-          bells and whistles.
+          Modern API documentation with pre-configured search and all the bells
+          and whistles.
         </template>
       </PageLink>
       <PageLink to="classic-api-reference">
@@ -33,6 +33,12 @@ import PageLink from '../components/PageLink.vue'
         <template #description>
           Classic API documentation with search. Looks like Swagger UI if it was
           born today.
+        </template>
+      </PageLink>
+      <PageLink to="editable-api-reference">
+        <template #title>Editable API Reference</template>
+        <template #description>
+          Interactive API documentation with real-time editing.
         </template>
       </PageLink>
     </div>

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -5,7 +5,10 @@ import { computed, onMounted, ref } from 'vue'
 import { hasModels } from '../../helpers'
 import { useNavigation, useRefOnMount } from '../../hooks'
 import type { Spec } from '../../types'
+import { Authentication } from './Authentication'
 import Introduction from './Introduction'
+import ClientList from './Introduction/ClientList.vue'
+import ServerList from './Introduction/ServerList.vue'
 import Models from './Models.vue'
 import ModelsAccordion from './ModelsAccordion.vue'
 import ReferenceEndpoint from './ReferenceEndpoint'
@@ -78,8 +81,13 @@ const endpointLayout = computed<typeof ReferenceEndpoint>(() =>
       v-if="parsedSpec.info.title || parsedSpec.info.description"
       :info="parsedSpec.info"
       :parsedSpec="parsedSpec"
-      :rawSpec="rawSpec"
-      :servers="localServers" />
+      :rawSpec="rawSpec">
+      <template #aside>
+        <ServerList :value="localServers" />
+        <ClientList />
+        <Authentication :parsedSpec="parsedSpec" />
+      </template>
+    </Introduction>
     <slot
       v-else
       name="empty-state" />

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -69,6 +69,9 @@ const tagLayout = computed<typeof ReferenceTag>(() =>
 const endpointLayout = computed<typeof ReferenceEndpoint>(() =>
   props.layout === 'accordion' ? ReferenceEndpointAccordion : ReferenceEndpoint,
 )
+const introCardsSlot = computed(() =>
+  props.layout === 'accordion' ? 'after' : 'aside',
+)
 </script>
 <template>
   <div
@@ -82,10 +85,14 @@ const endpointLayout = computed<typeof ReferenceEndpoint>(() =>
       :info="parsedSpec.info"
       :parsedSpec="parsedSpec"
       :rawSpec="rawSpec">
-      <template #aside>
-        <ServerList :value="localServers" />
-        <ClientList />
-        <Authentication :parsedSpec="parsedSpec" />
+      <template #[introCardsSlot]>
+        <div
+          class="introduction-cards"
+          :class="{ 'introduction-cards-row': layout === 'accordion' }">
+          <ServerList :value="localServers" />
+          <ClientList />
+          <Authentication :parsedSpec="parsedSpec" />
+        </div>
       </template>
     </Introduction>
     <slot
@@ -126,5 +133,21 @@ const endpointLayout = computed<typeof ReferenceEndpoint>(() =>
   display: flex;
   align-items: center;
   justify-content: center;
+}
+.introduction-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.introduction-cards-row {
+  flex-direction: row;
+  align-items: flex-start;
+}
+.introduction-cards-row > * {
+  flex: 1;
+}
+.references-narrow .introduction-cards-row {
+  flex-direction: column;
+  align-items: stretch;
 }
 </style>

--- a/packages/api-reference/src/components/Content/Introduction/ClientList.vue
+++ b/packages/api-reference/src/components/Content/Introduction/ClientList.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { useTemplateStore } from '../../../stores/template'
+import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
+import ClientSelector from './ClientSelector.vue'
+
+const { state, getClientTitle, getTargetTitle } = useTemplateStore()
+</script>
+<template>
+  <Card>
+    <CardHeader transparent>Client Libraries</CardHeader>
+    <CardContent
+      frameless
+      transparent>
+      <ClientSelector />
+    </CardContent>
+    <CardFooter
+      class="selected-client card-footer"
+      muted>
+      {{ getTargetTitle(state.selectedClient) }}
+      {{ getClientTitle(state.selectedClient) }}
+    </CardFooter>
+  </Card>
+</template>
+<style scoped>
+.selected-client {
+  color: var(--theme-color-1, var(--default-theme-color-1));
+  font-size: var(--theme-small, var(--default-theme-small));
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+  padding: 10px 12px;
+}
+</style>

--- a/packages/api-reference/src/components/Content/Introduction/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/Introduction/ClientSelector.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { useMediaQuery } from '@vueuse/core'
+import { useResizeObserver } from '@vueuse/core'
 import { type TargetId } from 'httpsnippet-lite'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import { getAvailableTargets } from '../../../helpers'
 import { type SelectedClient, useTemplateStore } from '../../../stores/template'
@@ -10,31 +10,17 @@ import { Icon } from '../../Icon'
 // Use the template store to keep it accessible globally
 const { state, setItem, getClientTitle, getTargetTitle } = useTemplateStore()
 
-const selectLanguage = (selectedClient: SelectedClient) => {
-  setItem('selectedClient', selectedClient)
+const isSmall = ref(false)
+const containerRef = ref<HTMLElement>()
 
-  // Check if selected client is featured already (icon + text)
-  const selectedClientIsIncluded = !!featuredClients.value.filter((item) => {
-    return isSelectedClient(item)
-  }).length
-
-  // Exit early if the client is already featured
-  if (selectedClientIsIncluded) {
-    return
-  }
-
-  // Remove first item and add the preferred client to the end of the list
-  featuredClients.value = [
-    ...featuredClients.value.slice(1),
-    state.selectedClient,
-  ]
-}
-
-const isMobile = useMediaQuery('(max-width: 1000px)')
+useResizeObserver(
+  containerRef,
+  (entries) => (isSmall.value = entries[0].contentRect.width < 400),
+)
 
 // Show popular clients with an icon, not just in a select.
-const featuredClients = ref<SelectedClient[]>(
-  isMobile.value
+const featuredClients = computed<SelectedClient[]>(() =>
+  isSmall.value
     ? // Mobile
       [
         {
@@ -113,7 +99,9 @@ function checkIfClientIsFeatured(client: SelectedClient) {
 }
 </script>
 <template>
-  <div class="client-libraries-content">
+  <div
+    ref="containerRef"
+    class="client-libraries-content">
     <div
       v-for="client in featuredClients"
       :key="client.clientKey"
@@ -121,7 +109,7 @@ function checkIfClientIsFeatured(client: SelectedClient) {
       :class="{
         'code-languages__active': isSelectedClient(client),
       }"
-      @click="() => selectLanguage(client)">
+      @click="() => setItem('selectedClient', client)">
       <div
         class="code-languages-background"
         :class="`code-languages-icon__${client.targetKey}`">

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -26,7 +26,7 @@ const specVersion = computed(() => {
 </script>
 <template>
   <SectionContainer>
-    <Section>
+    <Section class="introduction-section">
       <SectionContent :loading="!info.description && !info.title">
         <SectionColumns>
           <SectionColumn>
@@ -50,6 +50,7 @@ const specVersion = computed(() => {
           </SectionColumn>
         </SectionColumns>
       </SectionContent>
+      <slot name="after" />
     </Section>
   </SectionContainer>
 </template>
@@ -66,10 +67,12 @@ const specVersion = computed(() => {
 .heading.loading {
   width: 80%;
 }
+.introduction-section {
+  gap: 48px;
+}
 .sticky-cards {
   display: flex;
   flex-direction: column;
-  gap: 12px;
 
   position: sticky;
   top: calc(var(--refs-header-height) + 24px);

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-import { useTemplateStore } from '../../../stores/template'
-import type { Info, Server, Spec } from '../../../types'
+import type { Info, Spec } from '../../../types'
 import { Badge } from '../../Badge'
-import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
 import {
   Section,
   SectionColumn,
@@ -13,26 +11,19 @@ import {
   SectionContent,
   SectionHeader,
 } from '../../Section'
-import { Authentication } from '../Authentication'
-import ClientSelector from './ClientSelector.vue'
 import Description from './Description.vue'
 import DownloadSpec from './DownloadSpec.vue'
-import ServerList from './ServerList.vue'
 
 const props = defineProps<{
   info: Info
-  servers: Server[]
   parsedSpec: Spec
   rawSpec: string
 }>()
-
-const { state, getClientTitle, getTargetTitle } = useTemplateStore()
 
 const specVersion = computed(() => {
   return props.parsedSpec.openapi ?? props.parsedSpec.swagger ?? ''
 })
 </script>
-
 <template>
   <SectionContainer>
     <Section>
@@ -52,26 +43,9 @@ const specVersion = computed(() => {
             <DownloadSpec :value="rawSpec" />
             <Description :value="info.description" />
           </SectionColumn>
-          <SectionColumn>
+          <SectionColumn v-if="$slots.aside">
             <div class="sticky-cards">
-              <ServerList :value="servers" />
-
-              <Card>
-                <CardHeader transparent>Client Libraries</CardHeader>
-                <CardContent
-                  frameless
-                  transparent>
-                  <ClientSelector />
-                </CardContent>
-                <CardFooter
-                  class="font-mono card-footer"
-                  muted>
-                  {{ getTargetTitle(state.selectedClient) }}
-                  {{ getClientTitle(state.selectedClient) }}
-                </CardFooter>
-              </Card>
-
-              <Authentication :parsedSpec="parsedSpec" />
+              <slot name="aside" />
             </div>
           </SectionColumn>
         </SectionColumns>
@@ -92,19 +66,12 @@ const specVersion = computed(() => {
 .heading.loading {
   width: 80%;
 }
-
-.font-mono {
-  color: var(--theme-color-1, var(--default-theme-color-1));
-  font-size: var(--theme-small, var(--default-theme-small));
-  font-family: var(--theme-font-code, var(--default-theme-font-code));
-  padding: 10px 12px;
-}
 .sticky-cards {
   display: flex;
   flex-direction: column;
   gap: 12px;
 
   position: sticky;
-  top: 24px;
+  top: calc(var(--refs-header-height) + 24px);
 }
 </style>

--- a/packages/api-reference/src/components/Section/SectionContainerAccordion.vue
+++ b/packages/api-reference/src/components/Section/SectionContainerAccordion.vue
@@ -3,30 +3,34 @@ import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon } from '@scalar/components'
 </script>
 <template>
-  <Disclosure
-    v-slot="{ open }"
-    as="div"
-    class="section-accordion"
-    defaultOpen>
-    <DisclosureButton class="section-accordion-button">
-      <ScalarIcon
-        class="section-accordion-chevron"
-        :icon="open ? 'ChevronDown' : 'ChevronRight'" />
-      <div class="section-accordion-title">
-        <slot name="title" />
-      </div>
-    </DisclosureButton>
-    <DisclosurePanel class="section-accordion-content">
-      <slot />
-    </DisclosurePanel>
-  </Disclosure>
+  <div class="section-accordion-wrapper">
+    <Disclosure
+      v-slot="{ open }"
+      as="div"
+      class="section-accordion"
+      defaultOpen>
+      <DisclosureButton class="section-accordion-button">
+        <ScalarIcon
+          class="section-accordion-chevron"
+          :icon="open ? 'ChevronDown' : 'ChevronRight'" />
+        <div class="section-accordion-title">
+          <slot name="title" />
+        </div>
+      </DisclosureButton>
+      <DisclosurePanel class="section-accordion-content">
+        <slot />
+      </DisclosurePanel>
+    </Disclosure>
+  </div>
 </template>
 <style scoped>
+.section-accordion-wrapper {
+  padding: 0 60px;
+}
 .section-accordion {
   position: relative;
   width: 100%;
   max-width: var(--refs-content-max-width);
-  padding: 0 60px;
   margin: auto;
 }
 .section-accordion-content {
@@ -59,7 +63,7 @@ import { ScalarIcon } from '@scalar/components'
   align-items: start;
   flex: 1;
 }
-.references-narrow .section-accordion {
+.references-narrow .section-accordion-wrapper {
   padding: calc(48px + var(--refs-header-height)) 24px 48px 24px;
 }
 </style>


### PR DESCRIPTION
Switches out the introduction layout for the classic layout, going to work on the language picker in another ticket.

<img width="1389" alt="Google Chrome-2023-12-13-12-51-41@2x" src="https://github.com/scalar/scalar/assets/6374090/d41f83c8-66a9-4b16-af22-714aba7f72bd">
