### PR TITLE
fix: temp cap on schema level due to stack overflow

### DIFF
--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -180,8 +180,9 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
           :value="schema" />
       </div>
       <!-- Arrays -->
+      <!-- TODO: remove level 3 temp fix when we get a real one for recursion -->
       <div
-        v-if="value?.items?.[rule]"
+        v-if="value?.items?.[rule] && level < 3"
         class="rule">
         <Schema
           v-for="(schema, index) in value.items[rule]"


### PR DESCRIPTION
**Problem**
Currently we stack overflow on a recursive schema property

**Explanation**
This happens because our parser just loops on it (I think)

**Solution**
With this PR we just put a temp cap on recursion level while we sort out a proper fix

To test, throw startons spec into the editor and open the models section
https://docs.starton.com/api-reference


The proper fix would be to test for recursion in the parser and just set the schema name as the type when referencing itself. I will throw up a ticket for this