### PR TITLE
fix: make layout self contained

### DIFF
--- a/.changeset/pretty-maps-sniff.md
+++ b/.changeset/pretty-maps-sniff.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/use-toasts": patch
+---
+
+fix: self contain app and toast containers + size changing fix

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -223,6 +223,9 @@ const { state } = useApiClientStore()
   max-width: 100%;
   flex: 1;
 
+  /* For aligning the mobile nav */
+  position: relative;
+
   /* Scroll vertically */
   overflow-y: auto;
   overflow-x: hidden;

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useMediaQuery } from '@vueuse/core'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import { type ReferenceProps, type ReferenceSlots } from '../../types'
 import ApiReferenceBase from '../ApiReferenceBase.vue'
@@ -14,6 +14,11 @@ defineSlots<ReferenceSlots>()
 const showMobileDrawer = ref(false)
 
 const isMobile = useMediaQuery('(max-width: 1000px)')
+
+watch(isMobile, (n, o) => {
+  // Close the drawer when we go from desktop to mobile
+  if (n && !o) showMobileDrawer.value = false
+})
 
 // Override the sidebar value for mobile to open and close the drawer
 const config = computed(() => {

--- a/packages/use-toasts/src/FlowToastContainer.vue
+++ b/packages/use-toasts/src/FlowToastContainer.vue
@@ -20,6 +20,7 @@ const { toasts } = useToasts()
   height: 100svh;
   position: fixed;
   bottom: 0;
+  left: 0;
   z-index: 1000000;
 
   box-sizing: border-box;


### PR DESCRIPTION
**Problem**
app not self contained 

**Explanation**
if someone adds padding to the app container it is not containing the apps content 

**Solution**
add position relative to reference content + fix toast layout to left
