### PR TITLE
fix: does not add cookies

### DIFF
--- a/packages/api-client/src/components/ApiClient/Request/RequestCookies.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestCookies.vue
@@ -12,6 +12,10 @@ function handleDeleteIndex(index: number) {
 }
 
 function addAnotherHandler() {
+  if (activeRequest.cookies === undefined) {
+    activeRequest.cookies = []
+  }
+
   activeRequest.cookies?.push({ name: '', value: '', enabled: true })
 }
 </script>

--- a/packages/api-client/src/components/ApiClient/Request/RequestHeaders.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestHeaders.vue
@@ -12,6 +12,10 @@ function handleDeleteIndex(index: number) {
 }
 
 function addAnotherHandler() {
+  if (activeRequest.headers === undefined) {
+    activeRequest.headers = []
+  }
+
   activeRequest.headers?.push({ name: '', value: '', enabled: true })
 }
 </script>

--- a/packages/api-client/src/components/ApiClient/Request/RequestQuery.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestQuery.vue
@@ -13,6 +13,10 @@ function handleDeleteIndex(index: number) {
 }
 
 function addAnotherHandler() {
+  if (activeRequest.query === undefined) {
+    activeRequest.query = []
+  }
+
   activeRequest.query?.push({ name: '', value: '', enabled: true })
 }
 </script>

--- a/packages/api-client/src/components/ApiClient/Request/RequestVariables.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestVariables.vue
@@ -13,6 +13,10 @@ function handleDeleteIndex(index: number) {
 }
 
 function addAnotherHandler() {
+  if (activeRequest.variables === undefined) {
+    activeRequest.variables = []
+  }
+
   activeRequest.variables?.push({ name: '', value: '', enabled: true })
 }
 </script>


### PR DESCRIPTION
**Problem**
Currently, you can’t add cookies if the list is empty.

**Explanation**
This happens because in some cases `cookies` is undefined and a `push()` to undefined fails. 

**Solution**
With this PR variables, queryStrings, headers and cookies are initialized before we try to use `push()` on it.
