### PR TITLE
docs: Update Scalar Hono API Reference Plugin README.md on 

### DIFF
--- a/packages/hono-api-reference/README.md
+++ b/packages/hono-api-reference/README.md
@@ -17,7 +17,7 @@ npm install @scalar/hono-api-reference
 
 ## Usage
 
-Set up [Zod OpenAPI Hono](https://hono.dev/guides/openapi) and pass the configured URL to the `apiReference` middleware:
+Set up [Zod OpenAPI Hono](https://github.com/honojs/middleware/tree/main/packages/zod-openapi) and pass the configured URL to the `apiReference` middleware:
 
 ```ts
 import { apiReference } from '@scalar/hono-api-reference'


### PR DESCRIPTION
**Problem**
Currently, on Scalar Hono API Reference Plugin README, when I click on link `Zod OpenAPI Hono`, it redirects to 404 page.

**Explanation**
This happens because `https://hono.dev/guides/openapi` not exist anymore

**Solution**
With this PR, I change the URL from `https://hono.dev/guides/openapi` to `https://github.com/honojs/middleware/tree/main/packages/zod-openapi`
