### PR TITLE
Marc/bug remove caching of configuration

### DIFF
--- a/.changeset/gorgeous-lies-flash.md
+++ b/.changeset/gorgeous-lies-flash.md
@@ -1,0 +1,8 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+---
+
+fix: remove caching of configuration when updating spec as prop

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { createHead, useSeoMeta } from 'unhead'
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 
-import { type ReferenceProps, type SpecConfiguration } from '../types'
+import { type ReferenceProps } from '../types'
 import Layouts from './Layouts/'
 
 const props = defineProps<ReferenceProps>()
@@ -13,18 +13,10 @@ defineEmits<{
 
 const content = ref('')
 
-// Create a local spec for caching the content if no spec is set
-const config = computed(() => {
-  const spec: SpecConfiguration = props.configuration?.spec || {
-    content: content.value,
-  }
-  return { ...props.configuration, spec }
-})
-
 // Create the head tag if the configuration has meta data
-if (config.value?.metaData) {
+if (props.configuration?.metaData) {
   createHead()
-  useSeoMeta(config.value.metaData)
+  useSeoMeta(props.configuration.metaData)
 }
 
 function handleUpdateContent(value: string) {
@@ -34,8 +26,8 @@ function handleUpdateContent(value: string) {
 </script>
 <template>
   <Component
-    :is="Layouts[config.layout || 'modern']"
-    :configuration="config"
+    :is="Layouts[configuration?.layout || 'modern']"
+    :configuration="configuration"
     @updateContent="handleUpdateContent">
     <template #footer><slot name="footer" /></template>
   </Component>


### PR DESCRIPTION
**Problem**
Currently when changing the spec passed as a prop, it would merge the spec with the old spec

**Explanation**
This happens because we merge the config objects and some funny business was happening

**Solution**
With this PR i removed the cache of the spec config : )
