### PR TITLE
chore: export helpers

### DIFF
--- a/.changeset/long-spoons-pretend.md
+++ b/.changeset/long-spoons-pretend.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: export stores and helpers

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -13,4 +13,6 @@ export { default as SearchButton } from './components/SearchButton.vue'
 
 export * from './components/Card'
 
+export * from './stores'
+export * from './helpers'
 export * from './types'


### PR DESCRIPTION
**Problem**
Currently, the @scalar/api-reference helpers aren’t exported.

**Explanation**
Maybe this is a good thing, but I just need `openClientFor` outside of the package. A better solution would be to decouple them from the api-reference package and move them to the client …  but this PR is the quickest way to access them.

**Solution**
This PR exposes the helpers and the stores from @scalar/api-reference.
