### PR TITLE
feat: scope all scalar components using a class prefix

### DIFF
--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -91,12 +91,12 @@ watch(
       </p>
       <div class="start-cta">
         <ScalarButton
-          isFullWidth
+          fullWidth
           @click="example = 'Petstore'">
           Test Petstore
         </ScalarButton>
         <ScalarButton
-          isFullWidth
+          fullWidth
           variant="outlined"
           @click="$emit('openSwaggerEditor', 'uploadFile')">
           Upload File

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -35,7 +35,7 @@ import { ScalarButton, ScalarTextField } from '@scalar/components'
       <ScalarTextField
         class="w-full"
         label="Email Address" />
-      <ScalarButton isFullWidth>Login</ScalarButton>
+      <ScalarButton fullWidth>Login</ScalarButton>
     </div>
   </main>
 </template>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -71,6 +71,7 @@
     "npm-run-all2": "^6.1.1",
     "plugins": "^0.4.2",
     "postcss": "^8.4.31",
+    "postcss-prefix-selector": "^1.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "storybook": "^7.5.2",

--- a/packages/components/postcss.config.js
+++ b/packages/components/postcss.config.js
@@ -1,7 +1,27 @@
-export default {
+/** Global prefix class used to scoped tailwind */
+const classPrefix = 'scalar-component'
+
+const globalSelectors = ['*', ':root']
+
+export default ({ env }) => ({
   plugins: {
     'tailwindcss/nesting': {},
     'tailwindcss': {},
+    'postcss-prefix-selector': {
+      prefix: `.${classPrefix}`,
+      /**
+       * Add the scoping prefix to all selectors and their children
+       * e.g. .flex -> .scalar-component.flex, .scalar-component .flex
+       */
+      transform: (prefix, selector, prefixedSelector) => {
+        if (env === 'development') return selector
+        return `${prefix}${
+          globalSelectors.includes(selector) ? '' : selector
+        }, ${prefixedSelector}`
+      },
+    },
     'autoprefixer': {},
   },
-}
+})
+
+export { classPrefix as prefix }

--- a/packages/components/src/components/ScalarButton/ScalarButton.stories.ts
+++ b/packages/components/src/components/ScalarButton/ScalarButton.stories.ts
@@ -54,7 +54,7 @@ export const LoadingFullWidth: Story = {
       const loadingState = useLoadingState()
       return { loadingState }
     },
-    template: `<ScalarButton @click="loadingState.startLoading()" :loading="loadingState" isFullWidth>Click me</ScalarButton>`,
+    template: `<ScalarButton @click="loadingState.startLoading()" :loading="loadingState" fullWidth>Click me</ScalarButton>`,
   }),
 }
 

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.spec.ts
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.spec.ts
@@ -3,15 +3,13 @@ import { describe, expect, it } from 'vitest'
 
 import ScalarLoading, { useLoadingState } from './ScalarLoading.vue'
 
-describe('ScalarIconButton', () => {
+describe('ScalarLoading', () => {
   it('renders properly', async () => {
     const loadingState = useLoadingState()
     loadingState.startLoading()
 
     const wrapper = mount(ScalarLoading, { props: { loadingState } })
 
-    expect(wrapper.html({ raw: true })).toBe(
-      `<div data-v-845ab52a="" class="loader-wrapper"><svg data-v-845ab52a="" class="svg-loader" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path class="svg-path svg-check-mark" d="m 0 60 l 30 30 l 70 -80" data-v-845ab52a=""></path><path class="svg-path svg-x-mark" d="m 50 50 l 40 -40" data-v-845ab52a=""></path><path class="svg-path svg-x-mark" d="m 50 50 l 40 40" data-v-845ab52a=""></path><path class="svg-path svg-x-mark" d="m 50 50 l -40 -40" data-v-845ab52a=""></path><path class="svg-path svg-x-mark" d="m 50 50 l -40 40" data-v-845ab52a=""></path><g data-v-845ab52a="" class="circular-loader"><circle data-v-845ab52a="" class="loader-path" cx="50" cy="50" fill="none" r="20" stroke-width="2"></circle></g></svg></div>`,
-    )
+    expect(wrapper.find('svg').exists()).toBeTruthy()
   })
 })

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.vue
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { cx } from '@/cva'
 import { reactive } from 'vue'
 
 withDefaults(
@@ -65,7 +66,7 @@ export function useLoadingState() {
 <template>
   <div
     v-if="loadingState"
-    class="loader-wrapper">
+    :class="cx('loader-wrapper')">
     <svg
       class="svg-loader"
       :class="{

--- a/packages/components/src/components/ScalarModal/ScalarModal.stories.ts
+++ b/packages/components/src/components/ScalarModal/ScalarModal.stories.ts
@@ -34,8 +34,8 @@ export const Base: Story = {
         <div class="col gap-4 px-4">
           <div>You can put some nice content here, or even ask a nice question</div>
           <div class="col md:row gap-1">
-            <ScalarButton variant="ghost" @click="modalState.hide()" isFullWidth>Cancel</ScalarButton>
-            <ScalarButton @click="modalState.hide()" isFullWidth>Go ahead</ScalarButton>
+            <ScalarButton variant="ghost" @click="modalState.hide()" fullWidth>Cancel</ScalarButton>
+            <ScalarButton @click="modalState.hide()" fullWidth>Go ahead</ScalarButton>
           </div>
         </div>
       </ScalarModal>

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -64,7 +64,13 @@ export const useModal = () =>
     :open="state.open"
     @close="state.hide()">
     <div
-      class="scalar-modal-layout fixed left-0 top-0 z-[1001] h-[100dvh] w-[100dvw] bg-backdrop p-5 opacity-0">
+      :class="
+        cx(
+          'scalar-modal-layout fixed left-0 top-0',
+          'z-[1001] h-[100dvh] w-[100dvw]',
+          'bg-backdrop p-5 opacity-0',
+        )
+      ">
       <DialogPanel
         :class="modal({ size, variant })"
         :style="{ maxWidth }">

--- a/packages/components/src/cva.ts
+++ b/packages/components/src/cva.ts
@@ -4,13 +4,20 @@ import { extendTailwindMerge } from 'tailwind-merge'
 /**
  * Tailwind Merge Config
  *
- * By default tailwind merge only knows about the default tailwind clasess
+ * By default tailwind merge only knows about the default tailwind classes
  * this is because it does not load in the tailwind config at runtime (perf reasons)
  * we must specify any custom classes if they are getting overwritten
  *
  * https://github.com/dcastil/tailwind-merge/blob/v2.0.0/docs/configuration.md#class-groups
  */
-const tw = extendTailwindMerge({})
+const tw = extendTailwindMerge<'scalar-reset'>({
+  extend: {
+    classGroups: {
+      // Add scalar-reset as a custom set of classes to be deduped by tailwind-merge
+      'scalar-reset': ['scalar-reset'],
+    },
+  },
+})
 
 /**
  * CVA Config
@@ -19,7 +26,7 @@ const tw = extendTailwindMerge({})
  */
 const { cva, cx, compose } = defineConfig({
   hooks: {
-    onComplete: (className) => `${tw(className)} scalar-reset`,
+    onComplete: (className) => `${tw(className, 'scalar-reset')}`,
   },
 })
 

--- a/packages/components/src/cva.ts
+++ b/packages/components/src/cva.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'cva'
 import { extendTailwindMerge } from 'tailwind-merge'
 
+import { prefix } from '../postcss.config'
+
 /**
  * Tailwind Merge Config
  *
@@ -10,11 +12,11 @@ import { extendTailwindMerge } from 'tailwind-merge'
  *
  * https://github.com/dcastil/tailwind-merge/blob/v2.0.0/docs/configuration.md#class-groups
  */
-const tw = extendTailwindMerge<'scalar-reset'>({
+const tw = extendTailwindMerge<typeof prefix>({
   extend: {
     classGroups: {
-      // Add scalar-reset as a custom set of classes to be deduped by tailwind-merge
-      'scalar-reset': ['scalar-reset'],
+      // Add the scalar class prefix as a custom class to be deduped by tailwind-merge
+      [prefix]: [prefix],
     },
   },
 })
@@ -26,7 +28,7 @@ const tw = extendTailwindMerge<'scalar-reset'>({
  */
 const { cva, cx, compose } = defineConfig({
   hooks: {
-    onComplete: (className) => `${tw(className, 'scalar-reset')}`,
+    onComplete: (className) => `${tw(className, prefix)}`,
   },
 })
 

--- a/packages/components/src/tailwind/tailwind.css
+++ b/packages/components/src/tailwind/tailwind.css
@@ -3,13 +3,13 @@
 @tailwind utilities;
 
 /** 
- * Custom Scoped Reset - copied over from the tailwind reset 
- * and applied directly to classes so it doesn't leak 
+ * Custom Reset - copied over from the tailwind reset
+ * Auto-magically scoped by postcss (in postcss.config.js)
  *
  * @link https://tailwindcss.com/docs/preflight 
  */
 @layer base {
-  .scalar-reset {
+  * {
     box-sizing: border-box;
     border-width: unset;
     border-style: unset;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,6 +715,9 @@ importers:
       postcss:
         specifier: ^8.4.31
         version: 8.4.31
+      postcss-prefix-selector:
+        specifier: ^1.16.0
+        version: 1.16.0(postcss@8.4.31)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -12963,6 +12966,14 @@ packages:
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
+
+  /postcss-prefix-selector@1.16.0(postcss@8.4.31):
+    resolution: {integrity: sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==}
+    peerDependencies:
+      postcss: '>4 <9'
+    dependencies:
+      postcss: 8.4.31
+    dev: true
 
   /postcss-selector-parser@6.0.13:
     resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}


### PR DESCRIPTION
Prefixes all our classes with [`postcss-prefix-selector`](https://www.npmjs.com/package/postcss-prefix-selector)

Fixes #692 

## Tailwind classes:

![Google Chrome-2023-12-18-14-21-50@2x](https://github.com/scalar/scalar/assets/6374090/c394f22a-a7e3-4b4c-a452-8cc202b4e63b)

## Global classes:

![Google Chrome-2023-12-18-14-21-59@2x](https://github.com/scalar/scalar/assets/6374090/a1d5edfd-c338-4d0b-992f-6937fefc574a)
