### PR TITLE
chore: remove customClass attribute from parameters

### DIFF
--- a/packages/api-client/src/components/Grid/Grid.vue
+++ b/packages/api-client/src/components/Grid/Grid.vue
@@ -45,7 +45,6 @@ const showDescription = ref(false)
       class="table-row"
       :class="{
         'required-parameter': item.required,
-        [item.customClass]: !!item.customClass,
       }">
       <div class="table-row-item">
         <input

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -40,7 +40,6 @@ export type BaseParameter = {
   name: string
   description?: string | null
   value: string | number
-  customClass?: string
   required?: boolean
   enabled: boolean
 }

--- a/packages/api-reference/src/helpers/generateParameters.ts
+++ b/packages/api-reference/src/helpers/generateParameters.ts
@@ -11,7 +11,7 @@ export function generateParameters(parameters: Parameters[]) {
     const param: BaseParameter = {
       name: parameter.name,
       value: '',
-      customClass: parameter.required ? 'required-parameter' : '',
+      required: parameter.required,
       enabled: true,
     }
     param.value = ''


### PR DESCRIPTION
We added support for `required` to parameters, there’s no need to pass a `customClass` anymore. :)