### PR TITLE
chore: add vscode config

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "vue.volar",
+    "vue.vscode-typescript-vue-plugin",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "bradlc.vscode-tailwindcss",
+    "cpylua.language-postcss"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
     "typescript",
     "typescriptreact"
   ],
-  "stylelint.validate": ["css", "scss", "vue"],
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",
@@ -36,18 +35,21 @@
   "typescript.updateImportsOnFileMove.enabled": "always",
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "javascript.preferences.importModuleSpecifier": "non-relative",
-  "cssVariables.lookupFiles": [
-    "packages/api-client/assets/css/variables.css",
-    "packages/api-reference/assets/css/variables.css"
-  ],
   "html-css-class-completion.CSSLanguages": ["css"],
   "cssPeek.peekToExclude": [
     "**/node_modules/**",
     "**/bower_components/**",
     "**/dist/**"
   ],
-  "volar.completion.preferredAttrNameCase": "camel",
-  "volar.completion.preferredTagNameCase": "pascal",
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "git.pullTags": false
+  "git.pullTags": false,
+  "vue.complete.casing.props": "camel",
+  "vue.complete.casing.tags": "pascal",
+  "tailwindCSS.experimental.classRegex": [
+    ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+    ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+  ],
+  "tailwindCSS.experimental.configFile": {
+    "packages/components/tailwind.config.ts": "packages/components/**"
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
Updates the vscode config and adds some recommended extensions

Fixes #481 

Also sets up Tailwind a bit better for the components lib:

<img width="1508" alt="Code-2023-12-19-13-55-28@2x" src="https://github.com/scalar/scalar/assets/6374090/696acb9a-6b96-46d4-b7ab-029ea86b4bd8">
