### PR TITLE
fix: add text plain media type in response body

### DIFF
--- a/.changeset/orange-bulldogs-collect.md
+++ b/.changeset/orange-bulldogs-collect.md
@@ -1,0 +1,10 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/nestjs-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: add text/plain support

--- a/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
+++ b/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
@@ -42,6 +42,10 @@ const codeMirrorLanguages = computed((): CodeMirrorLanguage[] | null => {
     return ['html']
   }
 
+  if (mediaType.value === 'text/plain') {
+    return ['html']
+  }
+
   return null
 })
 </script>


### PR DESCRIPTION
before
<img width="617" alt="image" src="https://github.com/scalar/scalar/assets/6176314/fb47d6e7-bd1d-4945-920c-813b351448e3">

after:
<img width="603" alt="image" src="https://github.com/scalar/scalar/assets/6176314/5224f8f7-da2a-4828-a68e-4037e955c8ea">
