### PR TITLE
fix: declare theme font for buttons and fix regressed font weight

### DIFF
--- a/.changeset/chilly-tables-clean.md
+++ b/.changeset/chilly-tables-clean.md
@@ -1,0 +1,10 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/nestjs-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/swagger-editor': patch
+'@scalar/api-reference': patch
+---
+
+fix: declare theme font for buttons and fix regressed font weight

--- a/packages/api-reference/src/components/Content/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema.vue
@@ -166,6 +166,7 @@ const visible = ref<boolean>(false)
   align-items: center;
   user-select: none;
   font-family: var(--theme-font, var(--default-theme-font));
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
 }
 .schema-visibility-toggle:hover {
   color: var(--theme-color-1, var(--default-theme-color-1));

--- a/packages/api-reference/src/components/DarkModeToggle.vue
+++ b/packages/api-reference/src/components/DarkModeToggle.vue
@@ -29,6 +29,7 @@ const { toggleDarkMode, isDark } = useDarkModeState()
 </template>
 <style scoped>
 .darklight {
+  font-family: var(--theme-font, var(--default-theme-font));
   border: none;
   border-top: 1px solid
     var(

--- a/packages/api-reference/src/components/SearchButton.vue
+++ b/packages/api-reference/src/components/SearchButton.vue
@@ -62,6 +62,7 @@ useKeyboardEvent({
   padding: 0 3px 0 12px;
   min-width: 220px;
   max-width: 100%;
+  font-family: var(--theme-font, var(--default-theme-font));
   background: var(
     --sidebar-search-background,
     var(

--- a/packages/swagger-editor/src/components/SwaggerEditor/HeaderTabButton.vue
+++ b/packages/swagger-editor/src/components/SwaggerEditor/HeaderTabButton.vue
@@ -7,6 +7,7 @@
 </template>
 <style scoped>
 .swagger-editor-header-button {
+  font-family: var(--theme-font, var(--default-theme-font));
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
   border-radius: var(--theme-radius, var(--default-theme-radius))
     var(--theme-radius, var(--default-theme-radius)) 0 0;


### PR DESCRIPTION
Before:
<img width="907" alt="image" src="https://github.com/scalar/scalar/assets/6201407/9c27a5f6-fe98-4148-86ab-06eba9d2be9e">

After:
<img width="909" alt="image" src="https://github.com/scalar/scalar/assets/6201407/24546c90-88f6-44c1-94f7-17ea4e363597">

Before:
<img width="227" alt="image" src="https://github.com/scalar/scalar/assets/6201407/873e5f63-1983-4235-8944-e1f523f13058">

After:
<img width="245" alt="image" src="https://github.com/scalar/scalar/assets/6201407/ee94eec3-5ee2-4400-85bf-444ab812ad28">
