### PR TITLE
feat: add darkmode as config property

### DIFF
--- a/.changeset/clean-years-smash.md
+++ b/.changeset/clean-years-smash.md
@@ -1,0 +1,9 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/nestjs-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+---
+
+feat: expose dark mode light mode property in config

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ To customize the behavior of the API Reference, you can use the following config
 - `spec.url`: Pass the URL of a spec file (JSON or YAML).
 - `spec.preparsedContent`: Preprocess specs with `@scalar/swagger-parser` and directly pass the result.
 - `proxyUrl`: Use a proxy to send requests to other origins.
+- `darkMode`: Set dark mode on or off (light mode)
 - `showSidebar`: Whether the sidebar should be shown.
 - `customCss`: Pass custom CSS directly to the component.
 - `searchHotKey`: Key used with CNTRL/CMD to open the search modal.

--- a/examples/web/src/components/DevToolbar.vue
+++ b/examples/web/src/components/DevToolbar.vue
@@ -97,6 +97,12 @@ watch(
         </select>
       </div>
       <div>
+        <input
+          v-model="configuration.darkMode"
+          type="checkbox" />
+        darkMode
+      </div>
+      <div>
         Layout:
         <select v-model="configuration.layout">
           <option

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -95,7 +95,6 @@ const { setDarkMode } = useDarkModeState()
 watch(
   () => currentConfiguration.value.darkMode,
   (newDarkMode) => {
-    console.log('here')
     if (newDarkMode !== undefined) {
       setDarkMode(newDarkMode)
     }

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -13,6 +13,7 @@ import { computed, defineAsyncComponent, ref, watch } from 'vue'
 
 import { deepMerge } from '../helpers'
 import { useParser, useSpec } from '../hooks'
+import { useDarkModeState } from '../hooks/useDarkModeState'
 import {
   DEFAULT_CONFIG,
   type ReferenceConfiguration,
@@ -82,6 +83,21 @@ watch(
   (newContent) => {
     if (newContent) {
       overwriteParsedSpecRef(newContent as Spec)
+    }
+  },
+  {
+    immediate: true,
+  },
+)
+
+const { setDarkMode } = useDarkModeState()
+
+watch(
+  () => currentConfiguration.value.darkMode,
+  (newDarkMode) => {
+    console.log('here')
+    if (newDarkMode !== undefined) {
+      setDarkMode(newDarkMode)
     }
   },
   {

--- a/packages/api-reference/src/hooks/useDarkModeState.ts
+++ b/packages/api-reference/src/hooks/useDarkModeState.ts
@@ -39,6 +39,13 @@ export function useDarkModeState() {
     }
   }
 
+  function setDarkMode(value: boolean) {
+    isDark.value = value
+    if (typeof window !== 'undefined') {
+      window?.localStorage?.setItem('isDark', JSON.stringify(isDark.value))
+    }
+  }
+
   // Set initial value
   isDark.value = getDarkModeState()
 
@@ -55,5 +62,6 @@ export function useDarkModeState() {
   return {
     isDark,
     toggleDarkMode,
+    setDarkMode,
   }
 }

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -30,6 +30,8 @@ export type ReferenceConfiguration = {
   isEditable?: boolean
   /** Whether to show the sidebar */
   showSidebar?: boolean
+  /** Whether dark mode is on or off (light mode) */
+  darkMode?: boolean
   /** Remove the Scalar branding :( */
   // doNotPromoteScalar?: boolean
   /** Key used with CNTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k) */


### PR DESCRIPTION
Fixes #728 :) 

you can now set the light/dark mode through the configuration object. we also might in the future want to disable the toggle for the users who only have one theme :) 

https://github.com/scalar/scalar/assets/6176314/6ed15661-2271-4ba6-8d67-c721a11d67e5

