### PR TITLE
feat: Add dynamic content type selection for request body

### DIFF
--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/RequestBody.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/RequestBody.vue
@@ -5,6 +5,7 @@ import type { ContentType, RequestBody } from '../../../types'
 import Schema from '../Schema.vue'
 
 const prop = defineProps<{ requestBody?: RequestBody }>()
+
 const selectedContentType = ref<ContentType>('application/json')
 if (prop.requestBody?.content) {
   const keys = Object.keys(prop?.requestBody?.content)
@@ -17,17 +18,19 @@ if (prop.requestBody?.content) {
   <div v-if="prop?.requestBody">
     <div class="request-body-title">
       <slot name="title" />
-      <select
-        v-if="prop?.requestBody"
-        v-model="selectedContentType"
-        style="display: block">
-        <option
-          v-for="(value, key) in prop.requestBody?.content"
-          :key="key"
-          :value="key">
-          {{ key }}
-        </option>
-      </select>
+      <div class="request-body-title-select">
+        <span>{{ selectedContentType }}</span>
+        <select
+          v-if="prop?.requestBody"
+          v-model="selectedContentType">
+          <option
+            v-for="(value, key) in prop.requestBody?.content"
+            :key="key"
+            :value="key">
+            {{ key }}
+          </option>
+        </select>
+      </div>
     </div>
     <div
       v-if="prop?.requestBody.content?.[selectedContentType]"
@@ -42,6 +45,8 @@ if (prop.requestBody?.content) {
 
 <style scoped>
 .request-body-title {
+  display: flex;
+  align-items: center;
   font-size: var(--theme-heading-4, var(--default-theme-heading-4));
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
   color: var(--theme-color-1, var(--default-theme-color-1));
@@ -50,5 +55,51 @@ if (prop.requestBody?.content) {
   padding-bottom: 12px;
   border-bottom: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
+}
+.request-body-title-select {
+  position: relative;
+  padding-left: 9px;
+  height: fit-content;
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
+  display: flex;
+  align-items: center;
+}
+.request-body-title-select span {
+  display: flex;
+  align-items: center;
+}
+.request-body-title-select:after {
+  content: '';
+  width: 7px;
+  height: 7px;
+  transform: rotate(45deg) translate3d(-2px, -4px, 0);
+  display: block;
+  margin-left: 7px;
+  box-shadow: 1px 1px 0 currentColor;
+}
+.request-body-title-select select {
+  border: none;
+  outline: none;
+  cursor: pointer;
+  background: var(--theme-background-3, var(--default-theme-background-3));
+  box-shadow: -2px 0 0 0
+    var(--theme-background-3, var(--default-theme-background-3));
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  appearance: none;
+}
+.request-body-title-select:hover {
+  color: var(--theme-color-1, var(--default-theme-color-1));
+}
+@media (max-width: 460px) {
+  .request-body-title-select {
+    margin-left: auto;
+    padding-right: 3px;
+  }
 }
 </style>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/RequestBody.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/RequestBody.vue
@@ -1,16 +1,22 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import type { ContentType, RequestBody } from '../../../types'
 import Schema from '../Schema.vue'
 
 const prop = defineProps<{ requestBody?: RequestBody }>()
 
+const contentTypes = computed(() => {
+  if (prop.requestBody?.content) {
+    return Object.keys(prop.requestBody.content)
+  }
+  return []
+})
+
 const selectedContentType = ref<ContentType>('application/json')
 if (prop.requestBody?.content) {
-  const keys = Object.keys(prop?.requestBody?.content)
-  if (keys.length > 0) {
-    selectedContentType.value = keys[0] as ContentType
+  if (contentTypes.value.length > 0) {
+    selectedContentType.value = contentTypes.value[0] as ContentType
   }
 }
 </script>
@@ -18,10 +24,12 @@ if (prop.requestBody?.content) {
   <div v-if="prop?.requestBody">
     <div class="request-body-title">
       <slot name="title" />
-      <div class="request-body-title-select">
+      <div
+        class="request-body-title-select"
+        :class="{ 'request-body-title-no-select': contentTypes.length <= 1 }">
         <span>{{ selectedContentType }}</span>
         <select
-          v-if="prop?.requestBody"
+          v-if="prop?.requestBody && contentTypes.length > 1"
           v-model="selectedContentType">
           <option
             v-for="(value, key) in prop.requestBody?.content"
@@ -64,6 +72,12 @@ if (prop.requestBody?.content) {
   font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
   display: flex;
   align-items: center;
+}
+.request-body-title-no-select.request-body-title-select {
+  pointer-events: none;
+}
+.request-body-title-no-select.request-body-title-select:after {
+  display: none;
 }
 .request-body-title-select span {
   display: flex;

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/RequestBody.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/RequestBody.vue
@@ -1,15 +1,17 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
-import type { RequestBody } from '../../../types'
+import type { ContentType, RequestBody } from '../../../types'
 import Schema from '../Schema.vue'
 
 const prop = defineProps<{ requestBody?: RequestBody }>()
-const selectedContentType = ref(
-  prop?.requestBody?.content
-    ? Object.keys(prop?.requestBody?.content)[0]
-    : undefined,
-)
+const selectedContentType = ref<ContentType>('application/json')
+if (prop.requestBody?.content) {
+  const keys = Object.keys(prop?.requestBody?.content)
+  if (keys.length > 0) {
+    selectedContentType.value = keys[0] as ContentType
+  }
+}
 </script>
 <template>
   <div v-if="prop?.requestBody">

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/RequestBody.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/RequestBody.vue
@@ -1,21 +1,39 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+
 import type { RequestBody } from '../../../types'
 import Schema from '../Schema.vue'
 
-defineProps<{ requestBody?: RequestBody }>()
+const prop = defineProps<{ requestBody?: RequestBody }>()
+const selectedContentType = ref(
+  prop?.requestBody?.content
+    ? Object.keys(prop?.requestBody?.content)[0]
+    : undefined,
+)
 </script>
 <template>
-  <div v-if="requestBody && requestBody.content?.['application/json']">
+  <div v-if="prop?.requestBody">
     <div class="request-body-title">
       <slot name="title" />
+      <select
+        v-if="prop?.requestBody"
+        v-model="selectedContentType"
+        style="display: block">
+        <option
+          v-for="(value, key) in prop.requestBody?.content"
+          :key="key"
+          :value="key">
+          {{ key }}
+        </option>
+      </select>
     </div>
     <div
-      v-if="requestBody.content?.['application/json']"
+      v-if="prop?.requestBody.content?.[selectedContentType]"
       class="request-body-schema">
       <Schema
         compact
         toggleVisibility
-        :value="requestBody.content['application/json'].schema" />
+        :value="prop?.requestBody.content[selectedContentType].schema" />
     </div>
   </div>
 </template>

--- a/packages/api-reference/src/petstorev3.json
+++ b/packages/api-reference/src/petstorev3.json
@@ -452,6 +452,54 @@
         ]
       }
     },
+    "/pet/{petId}/uploadImageForm": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "uploads an image using form data",
+        "description": "",
+        "operationId": "uploadFileForm",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "petId": {
+                    "type": "string",
+                    "example": "1"
+                  },
+                  "additionalMetadata": {
+                    "type": "string"
+                  },
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": ["petId"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
     "/store/inventory": {
       "get": {
         "tags": ["store"],


### PR DESCRIPTION
**Problem**
Currently, the request body of all other content-types are empty except `application/json`

before:
![Screenshot_1](https://github.com/scalar/scalar/assets/49154622/7fa97c45-7bf2-4014-a9a6-1525886e2a7a)
![Screenshot_2](https://github.com/scalar/scalar/assets/49154622/71bf034d-7598-48c2-83c5-1e9571abbe29)

after:
![image](https://github.com/scalar/scalar/assets/49154622/72a9fb08-5dd8-473a-95eb-be2822a0ebfe)

In addition, I have also added `multipart/form-data` example `uploads an image using form data` in the pet

**Explanation**
Because v-if only specifies that the body section of application/json can be displayed.
In the requestBody.content, there are content-type keys corresponding to the openapi schema, so we can directly use it to generate a select.

**Solution**
- Add dynamic content type selection for request body display
  - Generate select using the key of `requestBody?.content`
- User can view the request body with a specified content-type
- Add an example of `multipart/form-data` in petstore
- Probably related to #705 and #597
