### PR TITLE
fix: request body does not reset, fix #730

### DIFF
--- a/.changeset/ninety-pugs-tickle.md
+++ b/.changeset/ninety-pugs-tickle.md
@@ -1,0 +1,6 @@
+---
+'@scalar/use-codemirror': patch
+'@scalar/api-client': patch
+---
+
+fix: request body doesn’t reset on navigating to a request without a body

--- a/packages/api-client/src/components/ApiClient/Request/RequestBody.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestBody.vue
@@ -30,11 +30,12 @@ const updateActiveRequest = (value: string) => {
     <template v-else-if="formData && formData.length > 0">
       <Grid :items="formData" />
     </template>
-    <CodeMirror
-      v-else
-      :content="activeRequest.body"
-      :languages="['json']"
-      lineNumbers
-      @change="updateActiveRequest" />
+    <template v-else>
+      <CodeMirror
+        :content="activeRequest.body"
+        :languages="['json']"
+        lineNumbers
+        @change="updateActiveRequest" />
+    </template>
   </CollapsibleSection>
 </template>

--- a/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
+++ b/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
@@ -182,9 +182,7 @@ const {
 watch(
   () => props.content,
   () => {
-    if (props.content?.length) {
-      setCodeMirrorContent(props.content)
-    }
+    setCodeMirrorContent(props.content)
   },
 )
 

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -41,7 +41,7 @@ export const useCodeMirror = (
   value: Ref<string>
   codeMirrorRef: Ref<HTMLDivElement | null>
   codeMirror: Ref<EditorView | null>
-  setCodeMirrorContent: (content: string) => void
+  setCodeMirrorContent: (content?: string) => void
   reconfigureCodeMirror: (newExtensions: Extension[]) => void
   restartCodeMirror: (newExtensions: Extension[]) => void
 } => {
@@ -144,7 +144,7 @@ export const useCodeMirror = (
     codeMirror.value?.destroy()
   }
 
-  const setCodeMirrorContent = (newValue: string) => {
+  const setCodeMirrorContent = (newValue?: string) => {
     // Check whether CodeMirror is mounted properly.
     if (!codeMirror.value) {
       return
@@ -155,9 +155,9 @@ export const useCodeMirror = (
       return
     }
 
-    value.value = newValue
+    value.value = newValue ?? ''
 
-    if (codeMirror.value.state.doc.toString() === newValue) {
+    if (codeMirror.value.state.doc.toString() === value.value) {
       // No need to set the CodeMirror content
       return
     }
@@ -171,7 +171,7 @@ export const useCodeMirror = (
       selection: {
         anchor: Math.min(
           codeMirror.value.state.selection.main.anchor,
-          newValue.length,
+          value.value.length,
         ),
       },
     })


### PR DESCRIPTION
**Problem**
Currently, the request body doesn’t reset when you navigate to a request without a request body (#730).

**Explanation**
This happens because I watched for content changes, but ignored `null`/`undefined`/`''`. I can’t remember why I did that, but I think it was just that the `setCodeMirrorContent` helper didn’t support `undefined` or `null`.

**Solution**
With this PR the `setCodeMirrorContent` helper deals with those values and we don’t ignore them anymore.
