### PR TITLE
feat: add fetch examples, fix #737

### DIFF
--- a/.changeset/few-tools-sleep.md
+++ b/.changeset/few-tools-sleep.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add fetch examples

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -57,7 +57,7 @@
     "@headlessui/vue": "^1.7.16",
     "@scalar/api-client": "workspace:*",
     "@scalar/components": "workspace:*",
-    "@scalar/snippetz": "^0.1.3",
+    "@scalar/snippetz": "^0.1.4",
     "@scalar/swagger-editor": "workspace:*",
     "@scalar/swagger-parser": "workspace:*",
     "@scalar/themes": "workspace:*",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -57,7 +57,7 @@
     "@headlessui/vue": "^1.7.16",
     "@scalar/api-client": "workspace:*",
     "@scalar/components": "workspace:*",
-    "@scalar/snippetz": "^0.1.4",
+    "@scalar/snippetz": "^0.1.5",
     "@scalar/swagger-editor": "workspace:*",
     "@scalar/swagger-parser": "workspace:*",
     "@scalar/themes": "workspace:*",

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -49,6 +49,15 @@ const generateSnippet = async (): Promise<string> => {
   // Actually generate the snippet
   try {
     // Snippetz
+    console.log(
+      state.selectedClient.targetKey,
+      state.selectedClient.clientKey,
+      snippetz().hasPlugin(
+        // @ts-ignore
+        state.selectedClient.targetKey,
+        state.selectedClient.clientKey,
+      ),
+    )
     if (
       snippetz().hasPlugin(
         // @ts-ignore

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -49,26 +49,18 @@ const generateSnippet = async (): Promise<string> => {
   // Actually generate the snippet
   try {
     // Snippetz
-    console.log(
-      state.selectedClient.targetKey,
-      state.selectedClient.clientKey,
-      snippetz().hasPlugin(
-        // @ts-ignore
-        state.selectedClient.targetKey,
-        state.selectedClient.clientKey,
-      ),
-    )
     if (
       snippetz().hasPlugin(
         // @ts-ignore
-        state.selectedClient.targetKey,
+        state.selectedClient.targetKey.replace('javascript', 'js'),
+        // @ts-ignore
         state.selectedClient.clientKey,
       )
     ) {
       return (
         snippetz().print(
           // @ts-ignore
-          state.selectedClient.targetKey,
+          state.selectedClient.targetKey.replace('javascript', 'js'),
           state.selectedClient.clientKey,
           request,
         ) ?? ''

--- a/packages/api-reference/src/helpers/getAvailableTargets.ts
+++ b/packages/api-reference/src/helpers/getAvailableTargets.ts
@@ -29,6 +29,19 @@ export function getAvailableTargets() {
       })
     }
 
+    // JS
+    if (target.key === 'javascript') {
+      target.default = 'fetch'
+
+      target.clients.unshift({
+        description:
+          'A browser-compatible implementation of the fetch() function.',
+        key: 'fetch',
+        link: 'https://nodejs.org/dist/latest/docs/api/globals.html#fetch',
+        title: 'fetch',
+      })
+    }
+
     return target
   })
 }

--- a/packages/api-reference/src/helpers/getAvailableTargets.ts
+++ b/packages/api-reference/src/helpers/getAvailableTargets.ts
@@ -4,9 +4,22 @@ export function getAvailableTargets() {
   const targets = availableTargets()
 
   return targets.map((target) => {
+    // Remove clients
+    target.clients = target.clients.filter((client) => {
+      return !['fetch', 'unirest'].includes(client.key)
+    })
+
     // Node.js
     if (target.key === 'node') {
       target.default = 'undici'
+
+      target.clients.unshift({
+        description:
+          'A browser-compatible implementation of the fetch() function.',
+        key: 'fetch',
+        link: 'https://nodejs.org/dist/latest/docs/api/globals.html#fetch',
+        title: 'fetch',
+      })
 
       target.clients.unshift({
         description: 'An HTTP/1.1 client, written from scratch for Node.js.',
@@ -15,11 +28,6 @@ export function getAvailableTargets() {
         title: 'undici',
       })
     }
-
-    // Remove clients
-    target.clients = target.clients.filter((client) => {
-      return !['fetch', 'unirest'].includes(client.key)
-    })
 
     return target
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,8 +553,8 @@ importers:
         specifier: workspace:*
         version: link:../components
       '@scalar/snippetz':
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^0.1.4
+        version: 0.1.4
       '@scalar/swagger-editor':
         specifier: workspace:*
         version: link:../swagger-editor
@@ -5173,23 +5173,30 @@ packages:
       string-argv: 0.3.2
     dev: true
 
-  /@scalar/snippetz-core@0.1.1:
-    resolution: {integrity: sha512-pSuSfLMBI+pyy0XlvGHeoQytD4MPfSH2RZexLwQJwo86tWCk0pm0XxVFk+ezsP/RmmIia328ZUbGvJ6uWt9Rmw==}
+  /@scalar/snippetz-core@0.1.2:
+    resolution: {integrity: sha512-w5uUD3iyM03iFW2Vo3n542BKt0BexQXYinu2WJPUVqqaEcxTMw0Qibix+n9KePjBXTys86OuhishlUz8AZdfgg==}
     dependencies:
       '@types/har-format': 1.2.15
     dev: false
 
-  /@scalar/snippetz-plugin-node-undici@0.1.3:
-    resolution: {integrity: sha512-eHFkDfEi7NMt8qS6L6o1v77ufGHrG3o9Fp8nmamfTtHlbXKNP9Lub0lOf0Oavym0xwjpMtbD6NyNSEojla3cLQ==}
+  /@scalar/snippetz-plugin-node-fetch@0.1.0:
+    resolution: {integrity: sha512-JRjg9TVhc9NbvIT/wfox7M6rkfd8fT+BoGWKNn+i3rCM1w+oKzydQu0BhG6VVdepM4CttlNH8f0QX3RJMMIAIA==}
     dependencies:
-      '@scalar/snippetz-core': 0.1.1
+      '@scalar/snippetz-core': 0.1.2
     dev: false
 
-  /@scalar/snippetz@0.1.3:
-    resolution: {integrity: sha512-pSFy223TDwYW/j65UacIyplXgCXcNYBngxWFQc41S/FsB8qmpxphoobC7xzlEvmz2OwgQjZRMCV3Tf15Abq1dw==}
+  /@scalar/snippetz-plugin-node-undici@0.1.4:
+    resolution: {integrity: sha512-eK/bnoeYfibssBZKcIV6+JIifQ7I4tbi1H7KIxkQoM/pPnTI0g+evs0e2G9lAnohAvAr3zLPYPaj77YoVbRsdA==}
     dependencies:
-      '@scalar/snippetz-core': 0.1.1
-      '@scalar/snippetz-plugin-node-undici': 0.1.3
+      '@scalar/snippetz-core': 0.1.2
+    dev: false
+
+  /@scalar/snippetz@0.1.4:
+    resolution: {integrity: sha512-Y+tLMhVfwef2IcGN+TZveApJwspV9QWLmg+6q0BMaQWpmWLs9mTL8N7ygD5rRFMG67yvbgVEOiNO6bOrtkkgfw==}
+    dependencies:
+      '@scalar/snippetz-core': 0.1.2
+      '@scalar/snippetz-plugin-node-fetch': 0.1.0
+      '@scalar/snippetz-plugin-node-undici': 0.1.4
     dev: false
 
   /@sinclair/typebox@0.27.8:
@@ -6318,7 +6325,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.3.4
-      vue-component-type-helpers: 1.8.25
+      vue-component-type-helpers: 1.8.27
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18285,8 +18292,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /vue-component-type-helpers@1.8.25:
-    resolution: {integrity: sha512-NCA6sekiJIMnMs4DdORxATXD+/NRkQpS32UC+I1KQJUasx+Z7MZUb3Y+MsKsFmX+PgyTYSteb73JW77AibaCCw==}
+  /vue-component-type-helpers@1.8.27:
+    resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}
     dev: true
 
   /vue-component-type-helpers@1.8.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,8 +553,8 @@ importers:
         specifier: workspace:*
         version: link:../components
       '@scalar/snippetz':
-        specifier: ^0.1.4
-        version: 0.1.4
+        specifier: ^0.1.5
+        version: 0.1.5
       '@scalar/swagger-editor':
         specifier: workspace:*
         version: link:../swagger-editor
@@ -5173,30 +5173,37 @@ packages:
       string-argv: 0.3.2
     dev: true
 
-  /@scalar/snippetz-core@0.1.2:
-    resolution: {integrity: sha512-w5uUD3iyM03iFW2Vo3n542BKt0BexQXYinu2WJPUVqqaEcxTMw0Qibix+n9KePjBXTys86OuhishlUz8AZdfgg==}
+  /@scalar/snippetz-core@0.1.3:
+    resolution: {integrity: sha512-pHRi23VhxMddKMo/2zEnaRcc1QUTEva5H2tryuq+tER7imGWf2O09IGexiV9vY/8jzYh0QVl/2dlJUmnF9Ww5w==}
     dependencies:
       '@types/har-format': 1.2.15
     dev: false
 
-  /@scalar/snippetz-plugin-node-fetch@0.1.0:
-    resolution: {integrity: sha512-JRjg9TVhc9NbvIT/wfox7M6rkfd8fT+BoGWKNn+i3rCM1w+oKzydQu0BhG6VVdepM4CttlNH8f0QX3RJMMIAIA==}
+  /@scalar/snippetz-plugin-js-fetch@0.1.0:
+    resolution: {integrity: sha512-lliZSIqtbZawm+XXmMXEpCcpIQprRwJXNUxLAvryB9AGm9qTu0dIfsvjJPjiTAfRew5+sgebNQ8cEF4esMnnlQ==}
     dependencies:
-      '@scalar/snippetz-core': 0.1.2
+      '@scalar/snippetz-core': 0.1.3
     dev: false
 
-  /@scalar/snippetz-plugin-node-undici@0.1.4:
-    resolution: {integrity: sha512-eK/bnoeYfibssBZKcIV6+JIifQ7I4tbi1H7KIxkQoM/pPnTI0g+evs0e2G9lAnohAvAr3zLPYPaj77YoVbRsdA==}
+  /@scalar/snippetz-plugin-node-fetch@0.1.1:
+    resolution: {integrity: sha512-U6kqtQi1xAME8AWgJmEVAFA/uhcJ1RUNKtyVDjupd77LQu2FEOPwqI5dPSltxvnJdYrUjLhDcfIa8EO8uO43zw==}
     dependencies:
-      '@scalar/snippetz-core': 0.1.2
+      '@scalar/snippetz-core': 0.1.3
     dev: false
 
-  /@scalar/snippetz@0.1.4:
-    resolution: {integrity: sha512-Y+tLMhVfwef2IcGN+TZveApJwspV9QWLmg+6q0BMaQWpmWLs9mTL8N7ygD5rRFMG67yvbgVEOiNO6bOrtkkgfw==}
+  /@scalar/snippetz-plugin-node-undici@0.1.5:
+    resolution: {integrity: sha512-ctOvCK3/Ta7ibuZjhV85M/gBuKURpeqgkWQHDFJubTHgUhQZudn60N5MY3ZtjoLFY7z9DCC5UenNYINveCdKJw==}
     dependencies:
-      '@scalar/snippetz-core': 0.1.2
-      '@scalar/snippetz-plugin-node-fetch': 0.1.0
-      '@scalar/snippetz-plugin-node-undici': 0.1.4
+      '@scalar/snippetz-core': 0.1.3
+    dev: false
+
+  /@scalar/snippetz@0.1.5:
+    resolution: {integrity: sha512-jHU8/KOO9vKbQFhsruflKugekgAtDm5GIAKZCYN+XtzqQ3jPGAjzkEZMXXvRDS2YPtFSzH2vzfqNMLB+q2Zupw==}
+    dependencies:
+      '@scalar/snippetz-core': 0.1.3
+      '@scalar/snippetz-plugin-js-fetch': 0.1.0
+      '@scalar/snippetz-plugin-node-fetch': 0.1.1
+      '@scalar/snippetz-plugin-node-undici': 0.1.5
     dev: false
 
   /@sinclair/typebox@0.27.8:


### PR DESCRIPTION
This PR adds Node `fetch()` and JavaScript `fetch()` (they have the same syntax) examples.