### PR TITLE
chore: update axios

### DIFF
--- a/.changeset/six-radios-clean.md
+++ b/.changeset/six-radios-clean.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+chore: update axios to 1.6.5

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -50,7 +50,7 @@
     "@scalar/use-keyboard-event": "workspace:*",
     "@scalar/use-modal": "workspace:*",
     "@vueuse/core": "^10.4.1",
-    "axios": "^1.6.1",
+    "axios": "^1.6.5",
     "content-type": "^1.0.5",
     "javascript-time-ago": "^2.5.9",
     "nanoid": "^5.0.1",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -71,7 +71,7 @@
     "@vcarl/remark-headings": "^0.1.0",
     "@vueuse/core": "^10.4.1",
     "@xmldom/xmldom": "^0.8.4",
-    "axios": "^1.6.1",
+    "axios": "^1.6.5",
     "fuse.js": "^6.6.2",
     "github-slugger": "^2.0.0",
     "httpsnippet-lite": "^3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,8 +534,8 @@ importers:
         specifier: ^10.4.1
         version: 10.4.1(vue@3.3.4)
       axios:
-        specifier: ^1.6.1
-        version: 1.6.1
+        specifier: ^1.6.5
+        version: 1.6.5
       content-type:
         specifier: ^1.0.5
         version: 1.0.5
@@ -686,8 +686,8 @@ importers:
         specifier: ^0.8.4
         version: 0.8.4
       axios:
-        specifier: ^1.6.1
-        version: 1.6.1
+        specifier: ^1.6.5
+        version: 1.6.5
       fuse.js:
         specifier: ^6.6.2
         version: 6.6.2
@@ -8463,10 +8463,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /axios@1.6.1:
-    resolution: {integrity: sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==}
+  /axios@1.6.5:
+    resolution: {integrity: sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==}
     dependencies:
-      follow-redirects: 1.15.3
+      follow-redirects: 1.15.4
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -11202,6 +11202,17 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: true
+
+  /follow-redirects@1.15.4:
+    resolution: {integrity: sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}


### PR DESCRIPTION
This update axios to the latest version, which also updates follow-redirects to 1.15.4. follow-redirects 1.15.4
 resolves a security issue: https://nvd.nist.gov/vuln/detail/CVE-2023-26159
