### PR TITLE
fix: add markdown rendering for body schema

### DIFF
--- a/.changeset/fair-otters-visit.md
+++ b/.changeset/fair-otters-visit.md
@@ -1,0 +1,9 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/nestjs-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+---
+
+fix: add markdown rendering for body schema

--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { Badge } from '../Badge'
+import MarkdownRenderer from './MarkdownRenderer.vue'
 import Schema from './Schema.vue'
 
 withDefaults(
@@ -122,12 +123,12 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     <div
       v-if="value?.description"
       class="property-description">
-      {{ value.description }}
+      <MarkdownRenderer :value="value.description" />
     </div>
     <div
       v-else-if="generatePropertyDescription(value)"
       class="property-description">
-      {{ generatePropertyDescription(value) }}
+      <MarkdownRenderer :value="generatePropertyDescription(value) || ''" />
     </div>
     <!-- Enum -->
     <div


### PR DESCRIPTION
this fixes #756 

before
![image](https://github.com/scalar/scalar/assets/6176314/6d3ad5b7-6279-4eff-a0a7-92414f337df2)


after
<img width="737" alt="image" src="https://github.com/scalar/scalar/assets/6176314/dd605c03-b53a-4596-9c9e-93de0d5ae7f3">
