### PR TITLE
fix(#755): open sections on search click

### DIFF
--- a/.changeset/nervous-zoos-fix.md
+++ b/.changeset/nervous-zoos-fix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: open section on search result click

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -199,7 +199,7 @@ const onSearchResultClick = (entry: Fuse.FuseResult<FuseData>) => {
   let parentId = 'models'
   const tagMatch = entry.item.href.match(tagRegex)
 
-  if (tagMatch?.length && tagMatch.length > 0) {
+  if (tagMatch?.length && tagMatch.length > 1) {
     parentId = tagMatch[1]
   }
   setCollapsedSidebarItem(parentId, true)

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -10,7 +10,7 @@ import {
   getTagSectionId,
 } from '../helpers'
 import { extractRequestBody } from '../helpers/specHelpers'
-import { type ParamMap, useOperation } from '../hooks'
+import { type ParamMap, useNavigation, useOperation } from '../hooks'
 import type { Spec, TransformedOperation } from '../types'
 
 const props = defineProps<{ parsedSpec: Spec; modalState: ModalState }>()
@@ -189,6 +189,22 @@ const searchResultsWithPlaceholderResults = computed(
     return searchResults.value
   },
 )
+
+const tagRegex = /#(tag\/[^/]*)/
+const { setCollapsedSidebarItem } = useNavigation()
+
+// Ensure we open the section
+// #TODOAM refactor this in URL PR
+const onSearchResultClick = (entry: Fuse.FuseResult<FuseData>) => {
+  let parentId = 'models'
+  const tagMatch = entry.item.href.match(tagRegex)
+
+  if (tagMatch) {
+    parentId = tagMatch[1]
+  }
+  setCollapsedSidebarItem(parentId, true)
+  props.modalState.hide()
+}
 </script>
 <template>
   <FlowModal
@@ -216,7 +232,7 @@ const searchResultsWithPlaceholderResults = computed(
           'item-entry--tag': !entry.item.httpVerb,
         }"
         :href="entry.item.href"
-        @click="modalState.hide"
+        @click="onSearchResultClick(entry)"
         @focus="selectedSearchResult = index"
         @mouseover="selectedSearchResult = index">
         <div

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -199,7 +199,7 @@ const onSearchResultClick = (entry: Fuse.FuseResult<FuseData>) => {
   let parentId = 'models'
   const tagMatch = entry.item.href.match(tagRegex)
 
-  if (tagMatch?.length && tagMatch.length > 0) {
+  if (tagMatch?.length) {
     parentId = tagMatch[1]
   }
   setCollapsedSidebarItem(parentId, true)

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -199,7 +199,7 @@ const onSearchResultClick = (entry: Fuse.FuseResult<FuseData>) => {
   let parentId = 'models'
   const tagMatch = entry.item.href.match(tagRegex)
 
-  if (tagMatch) {
+  if (tagMatch?.length && tagMatch.length > 0) {
     parentId = tagMatch[1]
   }
   setCollapsedSidebarItem(parentId, true)

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -199,7 +199,7 @@ const onSearchResultClick = (entry: Fuse.FuseResult<FuseData>) => {
   let parentId = 'models'
   const tagMatch = entry.item.href.match(tagRegex)
 
-  if (tagMatch?.length) {
+  if (tagMatch?.length && tagMatch.length > 0) {
     parentId = tagMatch[1]
   }
   setCollapsedSidebarItem(parentId, true)


### PR DESCRIPTION
**Problem**
If you click on a search result from a closed section, it will not get scrolled to.

**Explanation**
This happens because the section is not being opened.

**Solution**
With this PR we open the section on click of the search result.
