### PR TITLE
chore: expand cdn documentation with simpler config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,18 @@ Generate interactive API documentations from Swagger files. [Try our Demo](https
     <!-- data-proxy-url="https://api.scalar.com/request-proxy" -->
     <script
       id="api-reference"
-      data-url="https://example.com/swagger.json"
+      data-url="https://petstore3.swagger.io/api/v3/openapi.json"
       data-proxy-url="https://api.scalar.com/request-proxy"></script>
+    <!-- You can also set a full configuration object like this -->
+    <!-- easier for nested objects -->
+    <script>
+      var configuration = {
+        theme: 'purple',
+      }
+
+      var apiReference = document.getElementById('api-reference')
+      apiReference.dataset.configuration = JSON.stringify(configuration)
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   </body>
 </html>


### PR DESCRIPTION
before it wasn't exactly clear on how to set the config object inline, i added a simple way of doing so with an additional script tag and setting the data attribute before loading the script. also linked petstore so people can quickly copy and paste to get a working example