### PR TITLE
feat: show/hide readOnly/writeOnly attributes in requests/responses, fix #774

### DIFF
--- a/.changeset/modern-bugs-accept.md
+++ b/.changeset/modern-bugs-accept.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: show/hide readOnly and writeOnly attributes in requests/responses

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/ExampleResponse.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/ExampleResponse.vue
@@ -67,6 +67,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
 
               {
                 emptyString: '…',
+                mode: 'read',
               },
             ),
           )
@@ -96,6 +97,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
                   prettyPrintJson(
                     getExampleFromSchema(example, {
                       emptyString: '…',
+                      mode: 'read',
                     }),
                   )
                 "
@@ -112,6 +114,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
             prettyPrintJson(
               getExampleFromSchema(response?.schema[rule][0], {
                 emptyString: '…',
+                mode: 'read',
               }),
             )
           "
@@ -127,6 +130,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
               response?.schema['allOf'].map((schema: any) =>
                 getExampleFromSchema(schema, {
                   emptyString: '…',
+                  mode: 'read',
                 }),
               ),
             ),

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
@@ -100,7 +100,6 @@ const showSchema = ref(false)
         <Headers :headers="currentResponse.headers" />
       </CardContent> -->
       <CardContent muted>
-<<<<<<< HEAD:packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
         <template v-if="currentJsonResponse?.schema">
           <RawSchema
             v-if="showSchema"
@@ -108,131 +107,6 @@ const showSchema = ref(false)
           <ExampleResponse
             v-else
             :response="currentJsonResponse" />
-=======
-        <!-- Multiple examples -->
-        <template
-          v-if="
-            currentJsonResponse?.examples &&
-            Object.keys(currentJsonResponse?.examples).length > 1
-          ">
-          <SelectExample :examples="currentJsonResponse?.examples" />
-        </template>
-        <!-- An array, but just one example -->
-        <template
-          v-else-if="
-            currentJsonResponse?.examples &&
-            Object.keys(currentJsonResponse?.examples).length === 1
-          ">
-          <CodeMirror
-            :content="
-              prettyPrintJson(
-                mapFromObject(currentJsonResponse?.examples)[0].value.value,
-              )
-            "
-            :languages="['json']"
-            readOnly />
-        </template>
-        <!-- Single example -->
-        <template v-else>
-          <div v-if="currentJsonResponse?.example">
-            <CodeMirror
-              :content="prettyPrintJson(currentJsonResponse?.example)"
-              :languages="['json']"
-              readOnly />
-          </div>
-          <div v-else-if="currentJsonResponse?.schema">
-            <!-- Single Schema -->
-            <CodeMirror
-              v-if="currentJsonResponse?.schema.type"
-              :content="
-                prettyPrintJson(
-                  getExampleFromSchema(
-                    currentJsonResponse?.schema,
-
-                    {
-                      emptyString: '…',
-                      mode: 'read',
-                    },
-                  ),
-                )
-              "
-              :languages="['json']"
-              readOnly />
-            <!-- oneOf, anyOf, not … -->
-            <template
-              v-for="rule in rules"
-              :key="rule">
-              <div
-                v-if="
-                  currentJsonResponse?.schema[rule] &&
-                  (currentJsonResponse?.schema[rule].length > 1 ||
-                    rule === 'not')
-                "
-                class="rule">
-                <div class="rule-title">
-                  {{ rule }}
-                </div>
-                <ol class="rule-items">
-                  <li
-                    v-for="(example, index) in currentJsonResponse?.schema[
-                      rule
-                    ]"
-                    :key="index"
-                    class="rule-item">
-                    <CodeMirror
-                      :content="
-                        prettyPrintJson(
-                          getExampleFromSchema(example, {
-                            emptyString: '…',
-                            mode: 'read',
-                          }),
-                        )
-                      "
-                      :languages="['json']"
-                      readOnly />
-                  </li>
-                </ol>
-              </div>
-              <CodeMirror
-                v-else-if="
-                  currentJsonResponse?.schema[rule] &&
-                  currentJsonResponse?.schema[rule].length === 1
-                "
-                :content="
-                  prettyPrintJson(
-                    getExampleFromSchema(currentJsonResponse?.schema[rule][0], {
-                      emptyString: '…',
-                      mode: 'read',
-                    }),
-                  )
-                "
-                :languages="['json']"
-                readOnly />
-            </template>
-            <!-- allOf-->
-            <CodeMirror
-              v-if="currentJsonResponse?.schema['allOf']"
-              :content="
-                prettyPrintJson(
-                  mergeAllObjects(
-                    currentJsonResponse?.schema['allOf'].map((schema: any) =>
-                      getExampleFromSchema(schema, {
-                        emptyString: '…',
-                        mode: 'read',
-                      }),
-                    ),
-                  ),
-                )
-              "
-              :languages="['json']"
-              readOnly />
-          </div>
-          <div
-            v-if="!currentJsonResponse?.example && !currentJsonResponse?.schema"
-            class="scalar-api-reference__empty-state">
-            No Body
-          </div>
->>>>>>> 896cf2fa (feat: don’t show readOnly attributes in requests, don’t show writeOnly attributes in responses):packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
         </template>
         <!-- Without Schema: Don’t show tabs -->
         <ExampleResponse

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
@@ -100,6 +100,7 @@ const showSchema = ref(false)
         <Headers :headers="currentResponse.headers" />
       </CardContent> -->
       <CardContent muted>
+<<<<<<< HEAD:packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
         <template v-if="currentJsonResponse?.schema">
           <RawSchema
             v-if="showSchema"
@@ -107,6 +108,131 @@ const showSchema = ref(false)
           <ExampleResponse
             v-else
             :response="currentJsonResponse" />
+=======
+        <!-- Multiple examples -->
+        <template
+          v-if="
+            currentJsonResponse?.examples &&
+            Object.keys(currentJsonResponse?.examples).length > 1
+          ">
+          <SelectExample :examples="currentJsonResponse?.examples" />
+        </template>
+        <!-- An array, but just one example -->
+        <template
+          v-else-if="
+            currentJsonResponse?.examples &&
+            Object.keys(currentJsonResponse?.examples).length === 1
+          ">
+          <CodeMirror
+            :content="
+              prettyPrintJson(
+                mapFromObject(currentJsonResponse?.examples)[0].value.value,
+              )
+            "
+            :languages="['json']"
+            readOnly />
+        </template>
+        <!-- Single example -->
+        <template v-else>
+          <div v-if="currentJsonResponse?.example">
+            <CodeMirror
+              :content="prettyPrintJson(currentJsonResponse?.example)"
+              :languages="['json']"
+              readOnly />
+          </div>
+          <div v-else-if="currentJsonResponse?.schema">
+            <!-- Single Schema -->
+            <CodeMirror
+              v-if="currentJsonResponse?.schema.type"
+              :content="
+                prettyPrintJson(
+                  getExampleFromSchema(
+                    currentJsonResponse?.schema,
+
+                    {
+                      emptyString: '…',
+                      mode: 'read',
+                    },
+                  ),
+                )
+              "
+              :languages="['json']"
+              readOnly />
+            <!-- oneOf, anyOf, not … -->
+            <template
+              v-for="rule in rules"
+              :key="rule">
+              <div
+                v-if="
+                  currentJsonResponse?.schema[rule] &&
+                  (currentJsonResponse?.schema[rule].length > 1 ||
+                    rule === 'not')
+                "
+                class="rule">
+                <div class="rule-title">
+                  {{ rule }}
+                </div>
+                <ol class="rule-items">
+                  <li
+                    v-for="(example, index) in currentJsonResponse?.schema[
+                      rule
+                    ]"
+                    :key="index"
+                    class="rule-item">
+                    <CodeMirror
+                      :content="
+                        prettyPrintJson(
+                          getExampleFromSchema(example, {
+                            emptyString: '…',
+                            mode: 'read',
+                          }),
+                        )
+                      "
+                      :languages="['json']"
+                      readOnly />
+                  </li>
+                </ol>
+              </div>
+              <CodeMirror
+                v-else-if="
+                  currentJsonResponse?.schema[rule] &&
+                  currentJsonResponse?.schema[rule].length === 1
+                "
+                :content="
+                  prettyPrintJson(
+                    getExampleFromSchema(currentJsonResponse?.schema[rule][0], {
+                      emptyString: '…',
+                      mode: 'read',
+                    }),
+                  )
+                "
+                :languages="['json']"
+                readOnly />
+            </template>
+            <!-- allOf-->
+            <CodeMirror
+              v-if="currentJsonResponse?.schema['allOf']"
+              :content="
+                prettyPrintJson(
+                  mergeAllObjects(
+                    currentJsonResponse?.schema['allOf'].map((schema: any) =>
+                      getExampleFromSchema(schema, {
+                        emptyString: '…',
+                        mode: 'read',
+                      }),
+                    ),
+                  ),
+                )
+              "
+              :languages="['json']"
+              readOnly />
+          </div>
+          <div
+            v-if="!currentJsonResponse?.example && !currentJsonResponse?.schema"
+            class="scalar-api-reference__empty-state">
+            No Body
+          </div>
+>>>>>>> 896cf2fa (feat: don’t show readOnly attributes in requests, don’t show writeOnly attributes in responses):packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleResponses/ExampleResponses.vue
         </template>
         <!-- Without Schema: Don’t show tabs -->
         <ExampleResponse

--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -93,6 +93,16 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         <template v-if="value.enum"> &middot; enum </template>
       </div>
       <div
+        v-if="value?.writeOnly"
+        class="write-only">
+        write-only
+      </div>
+      <div
+        v-else-if="value?.readOnly"
+        class="read-only">
+        read-only
+      </div>
+      <div
         v-if="value?.example !== undefined"
         class="property-example">
         <code class="property-example-value">
@@ -108,11 +118,6 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
           <Badge>{{ rule }}</Badge>
         </div>
       </template>
-      <div
-        v-if="value?.readOnly"
-        class="property-read-only">
-        read-only
-      </div>
       <div
         v-if="value?.readOnly"
         class="property-nullable">
@@ -251,6 +256,18 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 .required {
   text-transform: uppercase;
   color: var(--theme-color-orange, var(--default-theme-color-orange));
+}
+
+.read-only,
+.write-only {
+  background-color: var(
+    --theme-background-3,
+    var(--default-theme-background-3)
+  );
+  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
+  border-radius: var(--theme-radius, var(--default-theme-radius));
+  padding: 2px 5px;
+  color: var(--theme-color-2, var(--default-theme-color-2));
 }
 
 .property-type {

--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -260,14 +260,8 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 
 .read-only,
 .write-only {
-  background-color: var(
-    --theme-background-3,
-    var(--default-theme-background-3)
-  );
-  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
-  border-radius: var(--theme-radius, var(--default-theme-radius));
-  padding: 2px 5px;
-  color: var(--theme-color-2, var(--default-theme-color-2));
+  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
+  color: var(--theme-color-blue, var(--default-theme-color-blue));
 }
 
 .property-type {

--- a/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
@@ -452,4 +452,78 @@ describe('getExampleFromSchema', () => {
       }),
     ).toBe(null)
   })
+
+  it('returns readOnly attributes by default', () => {
+    expect(
+      getExampleFromSchema({
+        example: 'foobar',
+        readOnly: true,
+      }),
+    ).toMatchObject('foobar')
+  })
+
+  it('returns readOnly attributes in read mode', () => {
+    expect(
+      getExampleFromSchema(
+        {
+          example: 'foobar',
+          readOnly: true,
+        },
+        {
+          mode: 'read',
+        },
+      ),
+    ).toMatchObject('foobar')
+  })
+
+  it('doesn’t return readOnly attributes in write mode', () => {
+    expect(
+      getExampleFromSchema(
+        {
+          example: 'foobar',
+          readOnly: true,
+        },
+        {
+          mode: 'write',
+        },
+      ),
+    ).toBe(undefined)
+  })
+
+  it('returns writeOnly attributes by default', () => {
+    expect(
+      getExampleFromSchema({
+        example: 'foobar',
+        writeOnly: true,
+      }),
+    ).toMatchObject('foobar')
+  })
+
+  it('returns writeOnly attributes in write mode', () => {
+    expect(
+      getExampleFromSchema(
+        {
+          example: 'foobar',
+          writeOnly: true,
+        },
+        {
+          mode: 'write',
+        },
+      ),
+    ).toMatchObject('foobar')
+  })
+
+  it('doesn’t return writeOnly attributes in read mode', () => {
+    expect(
+      getExampleFromSchema(
+        {
+          example: 'foobar',
+          writeOnly: true,
+        },
+        {
+          mode: 'read',
+        },
+      ),
+    ).toBe(undefined)
+  })
 })

--- a/packages/api-reference/src/helpers/getExampleFromSchema.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.ts
@@ -1,3 +1,5 @@
+import { readonly } from 'vue'
+
 /**
  * This function takes a properties object and generates an example response content.
  */
@@ -14,12 +16,27 @@ export const getExampleFromSchema = (
      * @default false
      */
     xml?: boolean
+    /**
+     * Whether to show read-only/write-only properties. Otherwise all properties are shown.
+     * @default undefined
+     */
+    mode?: 'read' | 'write'
   },
   level: number = 0,
 ): any => {
   // Break an infinite loop
   if (level > 10) {
     return null
+  }
+
+  // Check if the property is read-only
+  if (options?.mode === 'write' && schema.readOnly) {
+    return undefined
+  }
+
+  // Check if the property is write-only
+  if (options?.mode === 'read' && schema.writeOnly) {
+    return undefined
   }
 
   // Use an example, if there’s one

--- a/packages/api-reference/src/helpers/getParametersFromOperation.ts
+++ b/packages/api-reference/src/helpers/getParametersFromOperation.ts
@@ -36,7 +36,7 @@ export function getParametersFromOperation(
         value: parameter.example
           ? parameter.example
           : parameter.schema
-          ? getExampleFromSchema(parameter.schema)
+          ? getExampleFromSchema(parameter.schema, { mode: 'write' })
           : '',
         required: parameter.required ?? false,
         enabled: true,

--- a/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
+++ b/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
@@ -109,7 +109,7 @@ export function getRequestBodyFromOperation(operation: TransformedOperation) {
   // JSON
   if (mimeType === 'application/json') {
     const exampleFromSchema = requestBodyObject?.schema
-      ? getExampleFromSchema(requestBodyObject?.schema)
+      ? getExampleFromSchema(requestBodyObject?.schema, { mode: 'write' })
       : null
 
     return {
@@ -126,6 +126,7 @@ export function getRequestBodyFromOperation(operation: TransformedOperation) {
     const exampleFromSchema = requestBodyObject?.schema
       ? getExampleFromSchema(requestBodyObject?.schema, {
           xml: true,
+          mode: 'write',
         })
       : null
 
@@ -154,6 +155,7 @@ export function getRequestBodyFromOperation(operation: TransformedOperation) {
     const exampleFromSchema = requestBodyObject?.schema
       ? getExampleFromSchema(requestBodyObject?.schema, {
           xml: true,
+          mode: 'write',
         })
       : null
 


### PR DESCRIPTION
Currently, we don’t deal well with readOnly/writeOnly attributes. With this PR:

* they are labeled accordingly in the body attributes table
* readOnly attributes are not part of example requests
* writeOnly attributes are not part of example responses

**Includes id and password, labels for readOnly/writeOnly attributes**
<img width="606" alt="Screenshot 2024-01-17 at 12 16 23" src="https://github.com/scalar/scalar/assets/1577992/5dce015a-06c6-4eda-9511-cf28907f4306">

**Includes password (writeOnly)**
<img width="595" alt="Screenshot 2024-01-15 at 11 34 29" src="https://github.com/scalar/scalar/assets/1577992/808d01bc-0fc4-411f-a158-5827bada5fb5">

**Includes id (readOnly)**
<img width="593" alt="Screenshot 2024-01-15 at 11 34 22" src="https://github.com/scalar/scalar/assets/1577992/23b3d7dd-5920-4b80-9b85-a531067747e6">
