### PR TITLE
feat: return zip files from echo server, see #770

### DIFF
--- a/.changeset/brown-waves-report.md
+++ b/.changeset/brown-waves-report.md
@@ -1,0 +1,5 @@
+---
+'@scalar/echo-server': patch
+---
+
+feat: return zip files for all requests to /\*.zip

--- a/packages/echo-server/src/createEchoServer.ts
+++ b/packages/echo-server/src/createEchoServer.ts
@@ -16,7 +16,26 @@ export const createEchoServer = () => {
   app.use(Express.json())
   app.disable('x-powered-by')
 
-  // Post request to / are proxied to the target url.
+  // Return zip files for all requests ending with .zip
+  app.all('/*.zip', async (req, res) => {
+    console.log(`${req.method} ${req.path}`)
+
+    const blob = new Blob(
+      [
+        new Uint8Array([
+          80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]).buffer,
+      ],
+      {
+        type: 'application/zip',
+      },
+    )
+
+    res.set('Content-Type', 'application/zip')
+    res.send(blob)
+  })
+
+  // All other requests just respond with a JSON containing all the request data
   app.all('/*', async (req, res) => {
     console.log(`${req.method} ${req.path}`)
 


### PR DESCRIPTION
With this PR the echo server responds with an empty zip file for all request URLs ending with *.zip.

Preparation for #770.
