### PR TITLE
feat: show security scheme name and description, fix #792

### DIFF
--- a/.changeset/hot-knives-relax.md
+++ b/.changeset/hot-knives-relax.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: show security schema key and description

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -2,9 +2,9 @@
 import { type OpenAPIV3 } from 'openapi-types'
 import { computed } from 'vue'
 
-import { Security } from '../../../../../api-client/dist'
 import { useGlobalStore } from '../../../stores'
 import type { SecurityScheme } from '../../../types'
+import MarkdownRenderer from '../MarkdownRenderer.vue'
 import CardForm from './CardForm.vue'
 import CardFormButton from './CardFormButton.vue'
 import CardFormGroup from './CardFormGroup.vue'
@@ -183,4 +183,16 @@ const startAuthentication = (url: string) => {
       </CardFormButton>
     </CardFormGroup>
   </CardForm>
+  <CardForm v-if="value?.description">
+    <div class="description">
+      <MarkdownRenderer :value="value?.description" />
+    </div>
+  </CardForm>
 </template>
+
+<style scoped>
+.description {
+  padding: 12px 4px 4px;
+  font-size: var(--theme-mini, var(--default-theme-mini));
+}
+</style>

--- a/packages/api-reference/src/components/Content/Authentication/SecuritySchemeSelector.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecuritySchemeSelector.vue
@@ -50,7 +50,12 @@ const isHttpBearer = (item: any) =>
 const isOAuth2 = (item: any) => item.type.toLowerCase() === 'oauth2'
 
 // Translate type to label
-const getLabelForScheme = (item: any) => {
+const getLabelForScheme = (item: any, key: string) => {
+  return `${getAuthorizationTypeLabel(item)} “${key}”`
+}
+
+// Translate type to label
+const getAuthorizationTypeLabel = (item: any) => {
   if (isNone(item)) {
     return 'No Authentication'
   } else if (isApiKey(item)) {
@@ -72,7 +77,7 @@ const keys = computed(() => Object.keys(props.value))
 <template>
   <!-- Single security scheme -->
   <template v-if="keys.length === 1">
-    {{ getLabelForScheme(value[keys[0]]) }}
+    {{ getLabelForScheme(value[keys[0]], key) }}
   </template>
 
   <!-- Multiple security schemes -->
@@ -81,7 +86,10 @@ const keys = computed(() => Object.keys(props.value))
       <span>
         {{
           authentication.securitySchemeKey
-            ? getLabelForScheme(value[authentication.securitySchemeKey])
+            ? getLabelForScheme(
+                value[authentication.securitySchemeKey],
+                authentication.securitySchemeKey,
+              )
             : ''
         }}
       </span>
@@ -93,7 +101,7 @@ const keys = computed(() => Object.keys(props.value))
           v-for="key in keys"
           :key="key">
           <option :value="key ?? null">
-            {{ getLabelForScheme(value[key]) }}
+            {{ getLabelForScheme(value[key], key) }}
           </option>
         </template>
       </select>

--- a/packages/api-reference/src/components/Content/Authentication/SecuritySchemeSelector.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecuritySchemeSelector.vue
@@ -77,7 +77,7 @@ const keys = computed(() => Object.keys(props.value))
 <template>
   <!-- Single security scheme -->
   <template v-if="keys.length === 1">
-    {{ getLabelForScheme(value[keys[0]], key) }}
+    {{ getLabelForScheme(value[keys[0]], keys[0]) }}
   </template>
 
   <!-- Multiple security schemes -->

--- a/packages/api-reference/src/components/Content/Authentication/SecuritySchemeSelector.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecuritySchemeSelector.vue
@@ -51,7 +51,7 @@ const isOAuth2 = (item: any) => item.type.toLowerCase() === 'oauth2'
 
 // Translate type to label
 const getLabelForScheme = (item: any, key: string) => {
-  return `${getAuthorizationTypeLabel(item)} “${key}”`
+  return `${key} (${getAuthorizationTypeLabel(item)})`
 }
 
 // Translate type to label

--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -134,6 +134,12 @@ watch(
 .markdown :deep(a:hover) {
   text-decoration: underline !important;
 }
+.markdown :deep(em) {
+  font-style: italic;
+}
+.markdown :deep(del) {
+  text-decoration: line-through;
+}
 .markdown :deep(code) {
   font-family: var(--theme-font-code, var(--default-theme-font-code));
   background-color: var(


### PR DESCRIPTION
Currently, we don't show the security scheme key and description as pointed out in https://github.com/scalar/scalar/issues/792.

This PR adds the security schema key in quotes and shows the description (if there’s one).

It’s part of the spec, so we should show it somehow, but I’m not happy with the design. Wdyt @cameronrohani?

<img width="593" alt="Screenshot 2024-01-16 at 13 34 16" src="https://github.com/scalar/scalar/assets/1577992/74b30320-cdd8-457c-9530-9fe3b6306a3a">

<img width="587" alt="Screenshot 2024-01-16 at 13 34 35" src="https://github.com/scalar/scalar/assets/1577992/8212449e-4bb0-43fd-9c33-456049df4fd7">

<img width="594" alt="Screenshot 2024-01-16 at 13 28 05" src="https://github.com/scalar/scalar/assets/1577992/a0097ff3-ca7b-4b5e-ac75-a58e0ae8eb4d">