### PR TITLE
fix: basePath (Swagger 2.0) is ignored, fix #745

### DIFF
--- a/.changeset/flat-turtles-cover.md
+++ b/.changeset/flat-turtles-cover.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: basePath (Swagger 2.0) is ignored

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -45,7 +45,11 @@ const localServers = computed(() => {
     props.parsedSpec.schemes.length > 0
   ) {
     return [
-      { url: `${props.parsedSpec.schemes[0]}://${props.parsedSpec.host}` },
+      {
+        url: `${props.parsedSpec.schemes[0]}://${props.parsedSpec.host}${
+          props.parsedSpec?.basePath ?? ''
+        }`,
+      },
     ]
   } else if (fallBackServer.value) {
     return [fallBackServer.value]

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -260,6 +260,7 @@ export type Spec = {
   tags?: Tag[]
   info: Info
   host?: string
+  basePath?: string
   schemes?: string[]
   externalDocs?: ExternalDocs
   servers?: Server[]


### PR DESCRIPTION
We’ve had support for `host` and `schemes`, but not for `basePath`. This PR adds it. The mentioned attributes keywords were used in Swagger 2.0.

Example file: https://petstore.swagger.io/ (Petstore v2)

See #745
