### PR TITLE
feat: add headings from the description to the search index, fix #299

### DIFF
--- a/.changeset/calm-ghosts-sort.md
+++ b/.changeset/calm-ghosts-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add headings from the description to the search


### PR DESCRIPTION
With this PR headings from info.description are added to the search index.

See #299

<img width="562" alt="Screenshot 2024-01-16 at 15 22 32" src="https://github.com/scalar/scalar/assets/1577992/1a15e4ec-4e6f-475f-947b-609d30dca855">

