### PR TITLE
fix: actually update fastify-html

### DIFF
--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@scalar/api-reference": "workspace:*",
     "@vitest/coverage-v8": "^0.34.4",
+    "fastify-html": "^0.3.0",
     "magic-string": "^0.30.4",
     "rollup-plugin-node-externals": "^6.1.1",
     "terser": "^5.24.0",

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@scalar/api-reference": "workspace:*",
     "@vitest/coverage-v8": "^0.34.4",
-    "fastify-html": "^0.3.0",
     "magic-string": "^0.30.4",
     "rollup-plugin-node-externals": "^6.1.1",
     "terser": "^5.24.0",
@@ -58,7 +57,7 @@
   },
   "peerDependencies": {
     "fastify": "^4.0.0",
-    "fastify-html": "^0.2.0",
+    "fastify-html": "^0.3.0",
     "fastify-plugin": "^4.0.0"
   }
 }


### PR DESCRIPTION
There was a double entry of `fastify-html`, and those were not in agreement on which version should be installed.