### PR TITLE
feat: use request and response examples, see #764

### DIFF
--- a/.changeset/hip-waves-watch.md
+++ b/.changeset/hip-waves-watch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: use provided examples for the request and the response

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/CustomRequestExamples.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/CustomRequestExamples.vue
@@ -79,6 +79,7 @@ const { copyToClipboard } = useClipboard()
       </div>
       <template #actions>
         <TextSelect
+          class="request-client-picker"
           :modelValue="selectedExample"
           :options="
             examples.map((example, index) => {
@@ -150,6 +151,12 @@ const { copyToClipboard } = useClipboard()
 }
 .request-method--put {
   color: var(--theme-color-orange, var(--default-theme-color-orange));
+}
+.request-client-picker {
+  padding-left: 12px;
+  padding-right: 9px;
+  border-right: 1px solid
+    var(--theme-border-color, var(--default-theme-border-color));
 }
 .copy-button {
   appearance: none;

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExamplePicker.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExamplePicker.vue
@@ -1,20 +1,11 @@
 <script lang="ts" setup>
-import { CodeMirror } from '@scalar/use-codemirror'
 import { ref, watch } from 'vue'
 
-import { prettyPrintJson } from '../../../helpers'
-import { Icon } from '../../Icon'
 import TextSelect from './TextSelect.vue'
 
-const props = withDefaults(
-  defineProps<{
-    examples: Record<string, any>
-    renderExample?: boolean
-  }>(),
-  {
-    renderExample: false,
-  },
-)
+const props = defineProps<{
+  examples: Record<string, any>
+}>()
 
 const emit = defineEmits<{
   (e: 'update:modelValue', v: string): void
@@ -62,28 +53,7 @@ function getLabel(key: string | null) {
 }
 </script>
 <template>
-  <div
-    v-if="renderExample"
-    class="example-selector-layout">
-    <TextSelect
-      v-model="selectedExampleKey"
-      class="example-selector"
-      :options="
-        Object.keys(examples).map((value) => ({
-          label: getLabel(value),
-          value,
-        }))
-      ">
-      {{ getLabel(selectedExampleKey) }}
-    </TextSelect>
-    <CodeMirror
-      v-if="selectedExampleKey && props.examples[selectedExampleKey]"
-      :content="prettyPrintJson(props.examples[selectedExampleKey])"
-      :languages="['json']"
-      readOnly />
-  </div>
   <TextSelect
-    v-else
     v-model="selectedExampleKey"
     class="example-selector"
     :options="
@@ -98,12 +68,5 @@ function getLabel(key: string | null) {
 <style scoped>
 .example-selector {
   padding: 4px;
-}
-.example-selector-layout {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-items: start;
-  padding-top: 6px;
 }
 </style>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -18,7 +18,7 @@ import { useGlobalStore } from '../../../stores'
 import { useTemplateStore } from '../../../stores/template'
 import type { TransformedOperation } from '../../../types'
 import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
-import SelectExample from './SelectExample.vue'
+import ExamplePicker from './ExamplePicker.vue'
 import TextSelect from './TextSelect.vue'
 
 const props = defineProps<{
@@ -194,12 +194,12 @@ computed(() => {
     </CardContent>
     <CardFooter
       v-if="hasMultipleExamples || $slots.footer"
-      class="scalar-card-footer"
+      class="request-card-footer"
       contrast>
       <div
         v-if="hasMultipleExamples"
-        class="scalar-card-footer-addon">
-        <SelectExample
+        class="request-card-footer-addon">
+        <ExamplePicker
           class="request-example-selector"
           :examples="
             operation.information?.requestBody?.content?.['application/json']
@@ -281,12 +281,12 @@ computed(() => {
   height: 13px;
 }
 
-.scalar-card-footer {
+.request-card-footer {
   display: flex;
   justify-content: end;
   padding: 6px;
 }
-.scalar-card-footer-addon {
+.request-card-footer-addon {
   display: flex;
   align-items: center;
 

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -43,9 +43,13 @@ const generateSnippet = async (): Promise<string> => {
     {
       url: getUrlFromServerState(serverState) ?? window.location.origin,
     },
-    getRequestFromOperation(props.operation, {
-      replaceVariables: true,
-    }),
+    getRequestFromOperation(
+      props.operation,
+      {
+        replaceVariables: true,
+      },
+      0,
+    ),
     getRequestFromAuthentication(
       authenticationState,
       props.operation.information?.security,

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -285,6 +285,7 @@ computed(() => {
   display: flex;
   justify-content: end;
   padding: 6px;
+  flex-shrink: 0;
 }
 .request-card-footer-addon {
   display: flex;

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -39,6 +39,16 @@ const CodeMirrorLanguages = computed(() => {
   return [state.selectedClient.targetKey]
 })
 
+const hasMultipleExamples = computed<boolean>(
+  () =>
+    props.operation.information?.requestBody?.content?.['application/json']
+      ?.examples &&
+    Object.keys(
+      props.operation.information?.requestBody?.content?.['application/json']
+        .examples,
+    ).length > 1,
+)
+
 const generateSnippet = async (): Promise<string> => {
   // Generate a request object
   const request = getHarRequest(
@@ -132,6 +142,7 @@ computed(() => {
       </div>
       <template #actions>
         <TextSelect
+          class="request-client-picker"
           :modelValue="JSON.stringify(state.selectedClient)"
           :options="
             availableTargets.map((target) => {
@@ -173,23 +184,6 @@ computed(() => {
       frameless>
       <!-- Multiple examples -->
       <div class="code-snippet">
-        <template
-          v-if="
-            operation.information?.requestBody?.content?.['application/json']
-              ?.examples &&
-            Object.keys(
-              operation.information?.requestBody?.content?.['application/json']
-                .examples,
-            ).length > 1
-          ">
-          <SelectExample
-            :examples="
-              operation.information?.requestBody?.content?.['application/json']
-                .examples
-            "
-            @update:modelValue="(value) => (selectedExampleKey = value)" />
-        </template>
-
         <!-- @vue-ignore -->
         <CodeMirror
           :content="CodeMirrorValue"
@@ -199,9 +193,20 @@ computed(() => {
       </div>
     </CardContent>
     <CardFooter
-      v-if="$slots.footer"
+      v-if="hasMultipleExamples || $slots.footer"
       class="scalar-card-footer"
       contrast>
+      <div
+        v-if="hasMultipleExamples"
+        class="scalar-card-footer-addon">
+        <SelectExample
+          class="request-example-selector"
+          :examples="
+            operation.information?.requestBody?.content?.['application/json']
+              ?.examples ?? []
+          "
+          @update:modelValue="(value) => (selectedExampleKey = value)" />
+      </div>
       <slot name="footer" />
     </CardFooter>
   </Card>
@@ -234,6 +239,12 @@ computed(() => {
 }
 .request-method--put {
   color: var(--theme-color-orange, var(--default-theme-color-orange));
+}
+.request-client-picker {
+  padding-left: 12px;
+  padding-right: 9px;
+  border-right: 1px solid
+    var(--theme-border-color, var(--default-theme-border-color));
 }
 
 .copy-button {
@@ -272,8 +283,15 @@ computed(() => {
 
 .scalar-card-footer {
   display: flex;
-  justify-content: flex-end;
+  justify-content: end;
   padding: 6px;
+}
+.scalar-card-footer-addon {
+  display: flex;
+  align-items: center;
+
+  flex: 1;
+  min-width: 0;
 }
 .request-editor-section {
   display: flex;

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/ExampleResponse.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/ExampleResponse.vue
@@ -6,7 +6,7 @@ import {
   mapFromObject,
   prettyPrintJson,
 } from '../../../../helpers'
-import SelectExample from './SelectExample.vue'
+import SelectExample from '../SelectExample.vue'
 
 defineProps<{
   response:
@@ -34,7 +34,9 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
   <!-- Multiple examples -->
   <template
     v-if="response?.examples && Object.keys(response?.examples).length > 1">
-    <SelectExample :examples="response?.examples" />
+    <SelectExample
+      :examples="response?.examples"
+      renderExample />
   </template>
   <!-- An array, but just one example -->
   <template

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/ExampleResponse.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/ExampleResponse.vue
@@ -1,18 +1,12 @@
 <script lang="ts" setup>
 import { CodeMirror } from '@scalar/use-codemirror'
 
-import {
-  getExampleFromSchema,
-  mapFromObject,
-  prettyPrintJson,
-} from '../../../../helpers'
-import SelectExample from '../SelectExample.vue'
+import { getExampleFromSchema, prettyPrintJson } from '../../../../helpers'
 
 defineProps<{
   response:
     | undefined
     | {
-        examples?: Record<string, any>
         example?: any
         schema?: any
       }
@@ -29,124 +23,101 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
   }, {})
 }
 </script>
-
 <template>
-  <!-- Multiple examples -->
-  <template
-    v-if="response?.examples && Object.keys(response?.examples).length > 1">
-    <SelectExample
-      :examples="response?.examples"
-      renderExample />
-  </template>
-  <!-- An array, but just one example -->
-  <template
-    v-else-if="
-      response?.examples && Object.keys(response?.examples).length === 1
-    ">
+  <div v-if="response?.example">
     <CodeMirror
+      :content="prettyPrintJson(response?.example)"
+      :languages="['json']"
+      readOnly />
+  </div>
+  <div v-else-if="response?.schema">
+    <!-- Single Schema -->
+    <CodeMirror
+      v-if="response?.schema.type"
       :content="
-        prettyPrintJson(mapFromObject(response?.examples)[0].value?.value)
+        prettyPrintJson(
+          getExampleFromSchema(
+            response?.schema,
+
+            {
+              emptyString: '…',
+              mode: 'read',
+            },
+          ),
+        )
       "
       :languages="['json']"
       readOnly />
-  </template>
-  <!-- Single example -->
-  <template v-else>
-    <div v-if="response?.example">
+    <!-- oneOf, anyOf, not … -->
+    <template
+      v-for="rule in rules"
+      :key="rule">
+      <div
+        v-if="
+          response?.schema[rule] &&
+          (response?.schema[rule].length > 1 || rule === 'not')
+        "
+        class="rule">
+        <div class="rule-title">
+          {{ rule }}
+        </div>
+        <ol class="rule-items">
+          <li
+            v-for="(example, index) in response?.schema[rule]"
+            :key="index"
+            class="rule-item">
+            <CodeMirror
+              :content="
+                prettyPrintJson(
+                  getExampleFromSchema(example, {
+                    emptyString: '…',
+                    mode: 'read',
+                  }),
+                )
+              "
+              :languages="['json']"
+              readOnly />
+          </li>
+        </ol>
+      </div>
       <CodeMirror
-        :content="prettyPrintJson(response?.example)"
-        :languages="['json']"
-        readOnly />
-    </div>
-    <div v-else-if="response?.schema">
-      <!-- Single Schema -->
-      <CodeMirror
-        v-if="response?.schema.type"
+        v-else-if="
+          response?.schema[rule] && response?.schema[rule].length === 1
+        "
         :content="
           prettyPrintJson(
-            getExampleFromSchema(
-              response?.schema,
-
-              {
-                emptyString: '…',
-                mode: 'read',
-              },
-            ),
+            getExampleFromSchema(response?.schema[rule][0], {
+              emptyString: '…',
+              mode: 'read',
+            }),
           )
         "
         :languages="['json']"
         readOnly />
-      <!-- oneOf, anyOf, not … -->
-      <template
-        v-for="rule in rules"
-        :key="rule">
-        <div
-          v-if="
-            response?.schema[rule] &&
-            (response?.schema[rule].length > 1 || rule === 'not')
-          "
-          class="rule">
-          <div class="rule-title">
-            {{ rule }}
-          </div>
-          <ol class="rule-items">
-            <li
-              v-for="(example, index) in response?.schema[rule]"
-              :key="index"
-              class="rule-item">
-              <CodeMirror
-                :content="
-                  prettyPrintJson(
-                    getExampleFromSchema(example, {
-                      emptyString: '…',
-                      mode: 'read',
-                    }),
-                  )
-                "
-                :languages="['json']"
-                readOnly />
-            </li>
-          </ol>
-        </div>
-        <CodeMirror
-          v-else-if="
-            response?.schema[rule] && response?.schema[rule].length === 1
-          "
-          :content="
-            prettyPrintJson(
-              getExampleFromSchema(response?.schema[rule][0], {
+    </template>
+    <!-- allOf-->
+    <CodeMirror
+      v-if="response?.schema['allOf']"
+      :content="
+        prettyPrintJson(
+          mergeAllObjects(
+            response?.schema['allOf'].map((schema: any) =>
+              getExampleFromSchema(schema, {
                 emptyString: '…',
                 mode: 'read',
               }),
-            )
-          "
-          :languages="['json']"
-          readOnly />
-      </template>
-      <!-- allOf-->
-      <CodeMirror
-        v-if="response?.schema['allOf']"
-        :content="
-          prettyPrintJson(
-            mergeAllObjects(
-              response?.schema['allOf'].map((schema: any) =>
-                getExampleFromSchema(schema, {
-                  emptyString: '…',
-                  mode: 'read',
-                }),
-              ),
             ),
-          )
-        "
-        :languages="['json']"
-        readOnly />
-    </div>
-    <div
-      v-if="!response?.example && !response?.schema"
-      class="empty-state">
-      No Body
-    </div>
-  </template>
+          ),
+        )
+      "
+      :languages="['json']"
+      readOnly />
+  </div>
+  <div
+    v-else
+    class="empty-state">
+    No Body
+  </div>
 </template>
 
 <style scoped>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
@@ -144,7 +144,7 @@ const showSchema = ref(false)
         :examples="currentJsonResponse?.examples"
         @update:modelValue="(value) => (selectedExampleKey = value)" />
       <div
-        v-if="currentResponse?.description"
+        v-else-if="currentResponse?.description"
         class="response-description">
         <MarkdownRenderer
           class="markdown"

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/SelectExample.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/SelectExample.vue
@@ -1,15 +1,10 @@
 <script lang="ts" setup>
-import {
-  Listbox,
-  ListboxButton,
-  ListboxOption,
-  ListboxOptions,
-} from '@headlessui/vue'
 import { CodeMirror } from '@scalar/use-codemirror'
 import { ref, watch } from 'vue'
 
 import { prettyPrintJson } from '../../../helpers'
 import { Icon } from '../../Icon'
+import TextSelect from './TextSelect.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -67,123 +62,48 @@ function getLabel(key: string | null) {
 }
 </script>
 <template>
-  <div class="example-switcher">
-    <label
-      class="listbox-label"
-      for="listbox-button">
-      Select Example
-    </label>
-    <Listbox
-      :modelValue="selectedExampleKey"
-      @update:modelValue="(value) => selectExampleKey(value)">
-      <ListboxButton
-        id="listbox-button"
-        class="listbox-button">
-        <div class="listbox-button-content">
-          <div class="listbox-button-label">
-            {{ getLabel(selectedExampleKey) }}
-          </div>
-          <div>
-            <Icon
-              class="icon"
-              src="line/arrow-chevron-down" />
-          </div>
-        </div>
-      </ListboxButton>
-
-      <ListboxOptions class="listbox-options">
-        <ListboxOption
-          v-for="key in Object.keys(examples)"
-          :key="key"
-          class="listbox-option"
-          :value="key">
-          {{ getLabel(key) }}
-        </ListboxOption>
-      </ListboxOptions>
-    </Listbox>
+  <div
+    v-if="renderExample"
+    class="example-selector-layout">
+    <TextSelect
+      v-model="selectedExampleKey"
+      class="example-selector"
+      :options="
+        Object.keys(examples).map((value) => ({
+          label: getLabel(value),
+          value,
+        }))
+      ">
+      {{ getLabel(selectedExampleKey) }}
+    </TextSelect>
     <CodeMirror
-      v-if="
-        renderExample &&
-        selectedExampleKey &&
-        props.examples[selectedExampleKey]
-      "
+      v-if="selectedExampleKey && props.examples[selectedExampleKey]"
       :content="prettyPrintJson(props.examples[selectedExampleKey])"
       :languages="['json']"
       readOnly />
   </div>
+  <TextSelect
+    v-else
+    v-model="selectedExampleKey"
+    class="example-selector"
+    :options="
+      Object.keys(examples).map((value) => ({
+        label: getLabel(value),
+        value,
+      }))
+    ">
+    {{ getLabel(selectedExampleKey) }}
+  </TextSelect>
 </template>
-
 <style scoped>
-.example-switcher {
+.example-selector {
+  padding: 4px;
+}
+.example-selector-layout {
   display: flex;
-  gap: 6px;
-  margin: 12px 6px 6px;
   flex-direction: column;
-}
-
-.listbox-label {
-  font-size: var(--theme-mini, var(--default-theme-mini));
-  font-weight: var(--theme-semibold, var(--default-theme-semibold));
-  margin: 0 4px;
-  color: var(--theme-color-2, var(--default-theme-color-2));
-}
-
-.listbox-button {
-  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
-  background: var(--theme-background-1, var(--default-theme-background-1));
-  padding: 6px 12px;
-  border-radius: var(--theme-radius, var(--default-theme-radius));
-  text-align: left;
-  display: block;
-  font-size: var(--theme-mini, var(--default-theme-mini));
-}
-
-.listbox-button-content {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.listbox-button-label {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: var(--theme-color-1, var(--default-theme-color-1));
-}
-
-.listbox-options {
-  background: var(--theme-background-1, var(--default-theme-background-1));
-  padding: 6px 6px;
-  border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
-  margin-top: 4px;
-  box-shadow: var(--theme-shadow-2, var(--default-theme-shadow-2));
-  position: absolute;
-  margin: 0 1px;
-  transform: translateY(-50%);
-  z-index: 100;
-  list-style: none;
-}
-
-.listbox-option {
-  padding: 6px 12px;
-  cursor: pointer;
-  color: var(--theme-color-1, var(--default-theme-color-1));
-  border-radius: var(--theme-radius, var(--default-theme-radius));
-  margin: 2px 0;
-}
-
-.listbox-option[data-headlessui-state='selected'] {
-  background: var(--theme-background-2, var(--default-theme-background-2));
-}
-
-.listbox-option:hover {
-  background: var(--theme-background-2, var(--default-theme-background-2));
-  color: var(--theme-color-2, var(--default-theme-color-2));
-}
-
-.icon {
-  width: 13px;
-  height: 13px;
-  color: var(--theme-color-3, var(--default-theme-color-3));
+  gap: 6px;
+  align-items: start;
+  padding-top: 6px;
 }
 </style>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/TextSelect.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/TextSelect.vue
@@ -57,11 +57,7 @@ defineEmits<{
 <style>
 .text-select {
   position: relative;
-  padding-right: 9px;
   height: fit-content;
-  padding-left: 12px;
-  border-right: 1px solid
-    var(--theme-border-color, var(--default-theme-border-color));
 }
 .text-select--single-option {
   pointer-events: none;

--- a/packages/api-reference/src/helpers/getRequestBodyFromOperation.test.ts
+++ b/packages/api-reference/src/helpers/getRequestBodyFromOperation.test.ts
@@ -70,7 +70,7 @@ describe('getRequestBodyFromOperation', () => {
     })
   })
 
-  it.only('uses examples', () => {
+  it('uses examples', () => {
     const request = getRequestBodyFromOperation({
       httpVerb: 'POST',
       path: '/foobar',

--- a/packages/api-reference/src/helpers/getRequestBodyFromOperation.test.ts
+++ b/packages/api-reference/src/helpers/getRequestBodyFromOperation.test.ts
@@ -69,4 +69,46 @@ describe('getRequestBodyFromOperation', () => {
       text: JSON.stringify(expectedResult, null, 2),
     })
   })
+
+  it.only('uses examples', () => {
+    const request = getRequestBodyFromOperation({
+      httpVerb: 'POST',
+      path: '/foobar',
+      information: {
+        requestBody: {
+          description: 'Sample request body',
+          required: false,
+          content: {
+            'application/json': {
+              examples: {
+                'request-example-1': {
+                  summary: 'an example of a request',
+                  description: 'a longer string than the summary',
+                  value: {
+                    someObject: {
+                      someAttribute: 'attribute1',
+                    },
+                  },
+                },
+              },
+              schema: {
+                $ref: '#/components/schemas/PutDocumentRequest',
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const expectedResult = {
+      someObject: {
+        someAttribute: 'attribute1',
+      },
+    }
+
+    expect(request?.postData).toContain({
+      mimeType: 'application/json',
+      text: JSON.stringify(expectedResult, null, 2),
+    })
+  })
 })

--- a/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
+++ b/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
@@ -9,7 +9,10 @@ import {
 /**
  * Get the request body from the operation.
  */
-export function getRequestBodyFromOperation(operation: TransformedOperation) {
+export function getRequestBodyFromOperation(
+  operation: TransformedOperation,
+  selectedExamplesIndex?: number,
+) {
   // Define all supported mime types
   const mimeTypes: ContentType[] = [
     'application/json',
@@ -26,8 +29,25 @@ export function getRequestBodyFromOperation(operation: TransformedOperation) {
       !!operation.information?.requestBody?.content?.[currentMimeType],
   )
 
-  // TODO:
-  // * Add support for formData
+  /** Examples */
+  const examples =
+    operation.information?.requestBody?.content?.['application/json']?.examples
+
+  // Let’s use the first example
+  if (
+    selectedExamplesIndex !== undefined &&
+    Object.keys(examples ?? {})[selectedExamplesIndex]
+  ) {
+    return {
+      postData: {
+        mimeType: 'application/json',
+        text: prettyPrintJson(
+          examples[Object.keys(examples)[selectedExamplesIndex]]['value'],
+        ),
+      },
+    }
+  }
+
   /**
    * Body Parameters (Swagger 2.0)
    *

--- a/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
+++ b/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
@@ -35,7 +35,7 @@ export function getRequestBodyFromOperation(
 
   // Let’s use the first example
   const selectedExample = (examples ?? {})?.[
-    selectedExampleKey ?? Object.keys(examples)[0]
+    selectedExampleKey ?? Object.keys(examples ?? {})[0]
   ]
 
   if (selectedExample) {

--- a/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
+++ b/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
@@ -11,7 +11,7 @@ import {
  */
 export function getRequestBodyFromOperation(
   operation: TransformedOperation,
-  selectedExamplesIndex?: number,
+  selectedExampleKey?: string | number,
 ) {
   // Define all supported mime types
   const mimeTypes: ContentType[] = [
@@ -34,16 +34,15 @@ export function getRequestBodyFromOperation(
     operation.information?.requestBody?.content?.['application/json']?.examples
 
   // Let’s use the first example
-  if (
-    selectedExamplesIndex !== undefined &&
-    Object.keys(examples ?? {})[selectedExamplesIndex]
-  ) {
+  const selectedExample = (examples ?? {})?.[
+    selectedExampleKey ?? Object.keys(examples)[0]
+  ]
+
+  if (selectedExample) {
     return {
       postData: {
         mimeType: 'application/json',
-        text: prettyPrintJson(
-          examples[Object.keys(examples)[selectedExamplesIndex]]['value'],
-        ),
+        text: prettyPrintJson(selectedExample?.value),
       },
     }
   }

--- a/packages/api-reference/src/helpers/getRequestFromOperation.ts
+++ b/packages/api-reference/src/helpers/getRequestFromOperation.ts
@@ -12,7 +12,7 @@ export const getRequestFromOperation = (
   options?: {
     replaceVariables?: boolean
   },
-  selectedExamplesIndex?: number,
+  selectedExampleKey?: string | number,
 ): Partial<HarRequestWithPath> => {
   // Replace all variables of the format {something} with the uppercase variable name without the brackets
   let path = operation.path
@@ -28,10 +28,7 @@ export const getRequestFromOperation = (
     }
   }
 
-  const requestBody = getRequestBodyFromOperation(
-    operation,
-    selectedExamplesIndex,
-  )
+  const requestBody = getRequestBodyFromOperation(operation, selectedExampleKey)
 
   return {
     method: operation.httpVerb.toUpperCase(),

--- a/packages/api-reference/src/helpers/getRequestFromOperation.ts
+++ b/packages/api-reference/src/helpers/getRequestFromOperation.ts
@@ -12,6 +12,7 @@ export const getRequestFromOperation = (
   options?: {
     replaceVariables?: boolean
   },
+  selectedExamplesIndex?: number,
 ): Partial<HarRequestWithPath> => {
   // Replace all variables of the format {something} with the uppercase variable name without the brackets
   let path = operation.path
@@ -27,7 +28,10 @@ export const getRequestFromOperation = (
     }
   }
 
-  const requestBody = getRequestBodyFromOperation(operation)
+  const requestBody = getRequestBodyFromOperation(
+    operation,
+    selectedExamplesIndex,
+  )
 
   return {
     method: operation.httpVerb.toUpperCase(),

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -213,6 +213,8 @@ export type RequestBodyMimeTypes = {
 }
 
 export type RequestBody = {
+  description?: string
+  required?: boolean
   content?: RequestBodyMimeTypes
 }
 


### PR DESCRIPTION
See #764.

With this PR provided example request and responses are used for the code snippets and the example response card.

If you provide multiple examples, you’ll get a select. Here’s the full version:

<img width="600" alt="Screenshot 2024-01-17 at 13 26 08" src="https://github.com/scalar/scalar/assets/1577992/a2386e71-9630-42a0-bc64-fe853e5fd1c5">

Has some CSS issues, which are resolved in #810.