### PR TITLE
fix: toggle icon does not toggle, fix #805

### DIFF
--- a/.changeset/large-kiwis-pretend.md
+++ b/.changeset/large-kiwis-pretend.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: toggle icon does not toggle

--- a/packages/api-reference/src/components/SidebarElement.vue
+++ b/packages/api-reference/src/components/SidebarElement.vue
@@ -54,7 +54,7 @@ defineExpose({ el })
         :icon="open ? 'ChevronDown' : 'ChevronRight'"
         label="Toggle group"
         size="sm"
-        @click="handleClick" />
+        @click.stop="handleClick" />
       <a
         class="sidebar-heading-link"
         :href="`#${item.id}`">


### PR DESCRIPTION
Clicking on the chevron of a tag, doesn’t expand/collapse the tag.

This is because handleClick is triggered twice (the button, the parent).

Adding `@click.stop` to prevent the event from bubbling up helps. :)
