### PR TITLE
chore: bump fastify-api-reference version to update api-client dependency

### DIFF
--- a/.changeset/seven-lies-invite.md
+++ b/.changeset/seven-lies-invite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+chore: bump version to update api-client dependency


### PR DESCRIPTION
Just bumping the fastify-api-reference package to update the api-client dependency, was missed in the last release.
