### PR TITLE
fix: enter key navigating search item

### DIFF
--- a/.changeset/rude-cameras-provide.md
+++ b/.changeset/rude-cameras-provide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: enter key navigating search item

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -161,6 +161,7 @@ useKeyboardEvent({
   active: () => props.modalState.open,
   handler: () => {
     if (!window) return
+    onSearchResultClick(selectedEntry.value)
     window.location.hash = selectedEntry.value.item.href
     props.modalState.hide()
   },


### PR DESCRIPTION
now we can use the enter key to navigate a search result :) just needed to open the tag first ✨ 