### PR TITLE
fix: search keyboard navigation doesn’t work when the mouse hovers the results, fix #827

### DIFF
--- a/.changeset/popular-papayas-kneel.md
+++ b/.changeset/popular-papayas-kneel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: search keyboard navigation doesn’t work when the mouse hovers the results

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -263,8 +263,7 @@ const onSearchResultClick = (entry: Fuse.FuseResult<FuseData>) => {
         }"
         :href="entry.item.href"
         @click="onSearchResultClick(entry)"
-        @focus="selectedSearchResult = index"
-        @mouseover="selectedSearchResult = index">
+        @focus="selectedSearchResult = index">
         <div
           class="item-entry-http-verb"
           :class="`item-entry-http-verb--${entry.item.httpVerb}`">
@@ -347,7 +346,8 @@ a {
 .ref-search-container {
   padding: 12px;
 }
-.item-entry--active {
+.item-entry--active,
+.item-entry:hover {
   background: var(--theme-background-2, var(--default-theme-background-2));
   cursor: pointer;
 }


### PR DESCRIPTION
When hovering the search results and then pressing the arrow keys, the list of results sticks to where it’s at.

This is because there was an @mouseover listener overwriting the selected item.

See #827
