### PR TITLE
fix: Restoring missing forward slash between URL and API routes

### DIFF
--- a/packages/api-reference/src/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.ts
@@ -7,7 +7,7 @@ export function getUrlFromServerState(state: ServerState) {
       ? state?.servers?.[0]?.url ?? undefined
       : state?.servers?.[state.selectedServer]?.url
 
-  if (url?.startsWith('/')) {
+  if (url?.startsWith('/') && !window.location.origin.endsWith("/")) {
     url = `${window.location.origin}${url.slice(1)}`
   }
 


### PR DESCRIPTION
**Problem**
Currently, if your `window.location.origin` doesn't end with a trailing slash and your OpenAPI docs' servers have a leading forward slash, the slash between the URL and the route is removed.

**Explanation**
This happens because the fix for doubling up on forward slashes didn't check if there was no forward slash before removing the leading slash from the server.

**Solution**
With this PR there is now a check to see if `window.location.origin` has a trailing slash before removing the leading slash from the server.
