### PR TITLE
fix: additional properties false is ignored

### DIFF
--- a/.changeset/twelve-drinks-decide.md
+++ b/.changeset/twelve-drinks-decide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: additionalProperties: false is ignored

--- a/packages/api-reference/src/helpers/getExampleFromSchema.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.ts
@@ -73,7 +73,10 @@ export const getExampleFromSchema = (
     }
 
     // Merge additionalProperties
-    if (schema.additionalProperties !== undefined) {
+    if (
+      schema.additionalProperties !== undefined &&
+      schema.additionalProperties !== false
+    ) {
       const additionalSchema = getExampleFromSchema(
         schema.additionalProperties,
         options,


### PR DESCRIPTION
We’ve added support for `additionalProperties`, but a valid value is `false` - which means there are no additionalProperties … This PR doesn’t add additionalProperties if it’s set to `false. :)