### PR TITLE
feat: operation scoped security, fix #532 fix #843

### DIFF
--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -12,7 +12,6 @@ import {
   getRequestFromAuthentication,
   getRequestFromOperation,
   getUrlFromServerState,
-  mergeAllObjects,
 } from '../../../helpers'
 import { useSnippetTargets } from '../../../hooks'
 import { useGlobalStore } from '../../../stores'
@@ -46,7 +45,10 @@ const generateSnippet = async (): Promise<string> => {
     getRequestFromOperation(props.operation, {
       replaceVariables: true,
     }),
-    getRequestFromAuthentication(authenticationState),
+    getRequestFromAuthentication(
+      authenticationState,
+      props.operation.information?.security,
+    ),
   )
 
   // Actually generate the snippet

--- a/packages/api-reference/src/helpers/getApiClientRequest.ts
+++ b/packages/api-reference/src/helpers/getApiClientRequest.ts
@@ -30,7 +30,10 @@ export function getApiClientRequest({
       url: getUrlFromServerState(serverState),
     },
     getRequestFromOperation(operation),
-    getRequestFromAuthentication(authenticationState),
+    getRequestFromAuthentication(
+      authenticationState,
+      operation.information?.security,
+    ),
   )
 
   const requestFromOperation = getRequestFromOperation(operation)

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.test.ts
@@ -138,7 +138,7 @@ describe('getRequestFromAuthentication', () => {
     })
   })
 
-  it.only('only return required security schemes', () => {
+  it('only return required security schemes', () => {
     const request = getRequestFromAuthentication(
       {
         ...createEmptyAuthenticationState(),
@@ -173,7 +173,7 @@ describe('getRequestFromAuthentication', () => {
     })
   })
 
-  it.only('doesn’t require auth if the security schema is empty', () => {
+  it('only use required security schemes', () => {
     const request = getRequestFromAuthentication(
       {
         ...createEmptyAuthenticationState(),
@@ -205,6 +205,96 @@ describe('getRequestFromAuthentication', () => {
           value: 'Basic Zm9vYmFyOnNlY3JldA==',
         },
       ],
+    })
+  })
+
+  it('doesn’t require auth if the security schema is an empty array', () => {
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'basic',
+        securitySchemes: {
+          basic: {
+            type: 'basic',
+          },
+        },
+        http: {
+          ...createEmptyAuthenticationState().http,
+          basic: {
+            username: 'foobar',
+            password: 'secret',
+          },
+        },
+      },
+      // remove a top-level security declaration for a specific operation by using an empty array
+      [],
+    )
+
+    expect(request).toMatchObject({
+      headers: [],
+      cookies: [],
+      queryString: [],
+    })
+  })
+
+  it('doesn’t require auth if the security is undefined', () => {
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'basic',
+        securitySchemes: {
+          basic: {
+            type: 'basic',
+          },
+        },
+        http: {
+          ...createEmptyAuthenticationState().http,
+          basic: {
+            username: 'foobar',
+            password: 'secret',
+          },
+        },
+      },
+      // remove a top-level security declaration for a specific operation by not defining `security`
+      undefined,
+    )
+
+    expect(request).toMatchObject({
+      headers: [],
+      cookies: [],
+      queryString: [],
+    })
+  })
+
+  it('doesn’t require auth if an empty object is passed', () => {
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'basic',
+        securitySchemes: {
+          basic: {
+            type: 'basic',
+          },
+        },
+        http: {
+          ...createEmptyAuthenticationState().http,
+          basic: {
+            username: 'foobar',
+            password: 'secret',
+          },
+        },
+      },
+      [
+        {
+          basic: [],
+        },
+        // empty object
+        {},
+      ],
+    )
+
+    expect(request).toMatchObject({
+      headers: [],
     })
   })
 })

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.test.ts
@@ -5,20 +5,27 @@ import { getRequestFromAuthentication } from './getRequestFromAuthentication'
 
 describe('getRequestFromAuthentication', () => {
   it('apiKey in header', () => {
-    const request = getRequestFromAuthentication({
-      ...createEmptyAuthenticationState(),
-      securitySchemeKey: 'api_key',
-      securitySchemes: {
-        api_key: {
-          type: 'apiKey',
-          name: 'api_key',
-          in: 'header',
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'api_key',
+        securitySchemes: {
+          api_key: {
+            type: 'apiKey',
+            name: 'api_key',
+            in: 'header',
+          },
+        },
+        apiKey: {
+          token: '123',
         },
       },
-      apiKey: {
-        token: '123',
-      },
-    })
+      [
+        {
+          api_key: [],
+        },
+      ],
+    )
 
     expect(request).toMatchObject({
       headers: [
@@ -31,20 +38,27 @@ describe('getRequestFromAuthentication', () => {
   })
 
   it('apiKey in cookie', () => {
-    const request = getRequestFromAuthentication({
-      ...createEmptyAuthenticationState(),
-      securitySchemeKey: 'api_key',
-      securitySchemes: {
-        api_key: {
-          type: 'apiKey',
-          name: 'api_key',
-          in: 'cookie',
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'api_key',
+        securitySchemes: {
+          api_key: {
+            type: 'apiKey',
+            name: 'api_key',
+            in: 'cookie',
+          },
+        },
+        apiKey: {
+          token: '123',
         },
       },
-      apiKey: {
-        token: '123',
-      },
-    })
+      [
+        {
+          api_key: [],
+        },
+      ],
+    )
 
     expect(request).toMatchObject({
       cookies: [
@@ -57,20 +71,27 @@ describe('getRequestFromAuthentication', () => {
   })
 
   it('apiKey in query', () => {
-    const request = getRequestFromAuthentication({
-      ...createEmptyAuthenticationState(),
-      securitySchemeKey: 'api_key',
-      securitySchemes: {
-        api_key: {
-          type: 'apiKey',
-          name: 'api_key',
-          in: 'query',
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'api_key',
+        securitySchemes: {
+          api_key: {
+            type: 'apiKey',
+            name: 'api_key',
+            in: 'query',
+          },
+        },
+        apiKey: {
+          token: '123',
         },
       },
-      apiKey: {
-        token: '123',
-      },
-    })
+      [
+        {
+          api_key: [],
+        },
+      ],
+    )
 
     expect(request).toMatchObject({
       queryString: [
@@ -83,22 +104,99 @@ describe('getRequestFromAuthentication', () => {
   })
 
   it('http basic auth', () => {
-    const request = getRequestFromAuthentication({
-      ...createEmptyAuthenticationState(),
-      securitySchemeKey: 'basic',
-      securitySchemes: {
-        basic: {
-          type: 'basic',
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'basic',
+        securitySchemes: {
+          basic: {
+            type: 'basic',
+          },
+        },
+        http: {
+          ...createEmptyAuthenticationState().http,
+          basic: {
+            username: 'foobar',
+            password: 'secret',
+          },
         },
       },
-      http: {
-        ...createEmptyAuthenticationState().http,
-        basic: {
-          username: 'foobar',
-          password: 'secret',
+      [
+        {
+          basic: [],
         },
-      },
+      ],
+    )
+
+    expect(request).toMatchObject({
+      headers: [
+        {
+          name: 'Authorization',
+          value: 'Basic Zm9vYmFyOnNlY3JldA==',
+        },
+      ],
     })
+  })
+
+  it.only('only return required security schemes', () => {
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'basic',
+        securitySchemes: {
+          basic: {
+            type: 'basic',
+          },
+        },
+        http: {
+          ...createEmptyAuthenticationState().http,
+          basic: {
+            username: 'foobar',
+            password: 'secret',
+          },
+        },
+      },
+      [
+        {
+          basic: [],
+        },
+      ],
+    )
+
+    expect(request).toMatchObject({
+      headers: [
+        {
+          name: 'Authorization',
+          value: 'Basic Zm9vYmFyOnNlY3JldA==',
+        },
+      ],
+    })
+  })
+
+  it.only('doesn’t require auth if the security schema is empty', () => {
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'basic',
+        securitySchemes: {
+          basic: {
+            type: 'basic',
+          },
+        },
+        http: {
+          ...createEmptyAuthenticationState().http,
+          basic: {
+            username: 'foobar',
+            password: 'secret',
+          },
+        },
+      },
+      [
+        {
+          basic: [],
+        },
+      ],
+    )
 
     expect(request).toMatchObject({
       headers: [

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
@@ -1,4 +1,3 @@
-import { a } from '@storybook/vue3/dist/render-ddbe18a8'
 import type { HarRequest } from 'httpsnippet-lite'
 import type { OpenAPIV3 } from 'openapi-types'
 
@@ -7,16 +6,15 @@ import type { AuthenticationState } from '../types'
 /**
  * Check whether the given security scheme key is in the `security` configuration for this operation.
  **/
-function givenSecuritySchemeIsRequired(
-  key: string,
+function authenticationRequired(
   security?: OpenAPIV3.SecurityRequirementObject[],
 ): boolean {
-  // If security isn’t declared, auth isn’t required.
+  // If security is not defined, auth is not required.
   if (!security) {
     return false
   }
 
-  // If security includes an empty object `{}`, auth is not required at all.
+  // Includes empty object = auth is not required
   if (
     (security ?? []).some(
       (securityRequirement) => !Object.keys(securityRequirement).length,
@@ -25,12 +23,7 @@ function givenSecuritySchemeIsRequired(
     return false
   }
 
-  // If security includes the given key, auth is required.
-  return (security ?? []).some((securityRequirement) => {
-    return Object.keys(securityRequirement).some((securityRequirementKey) => {
-      return securityRequirementKey === key
-    })
-  })
+  return true
 }
 
 /**
@@ -44,13 +37,11 @@ export function getRequestFromAuthentication(
   const queryString: HarRequest['queryString'] = []
   const cookies: HarRequest['cookies'] = []
 
-  // Authentication
-  if (
-    !authentication.securitySchemeKey ||
-    !givenSecuritySchemeIsRequired(authentication.securitySchemeKey, security)
-  ) {
+  // Check whether auth is required
+  if (!authentication.securitySchemeKey || !authenticationRequired(security)) {
     return { headers, queryString, cookies }
   }
+
   // We’re using a parsed Swagger file here, so let’s get rid of the `ReferenceObject` type
   const securityScheme =
     authentication.securitySchemes?.[authentication.securitySchemeKey]

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
@@ -14,6 +14,11 @@ function authenticationRequired(
     return false
   }
 
+  // Don’t require auth if security is just an empty array []
+  if (Array.isArray(security) && !security.length) {
+    return false
+  }
+
   // Includes empty object = auth is not required
   if (
     (security ?? []).some(

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
@@ -1,74 +1,129 @@
+import { a } from '@storybook/vue3/dist/render-ddbe18a8'
 import type { HarRequest } from 'httpsnippet-lite'
+import type { OpenAPIV3 } from 'openapi-types'
 
 import type { AuthenticationState } from '../types'
 
+/**
+ * Check whether the given security scheme key is in the `security` configuration for this operation.
+ **/
+function givenSecuritySchemeIsRequired(
+  key: string,
+  security?: OpenAPIV3.SecurityRequirementObject[],
+): boolean {
+  // If security isn’t declared, auth isn’t required.
+  if (!security) {
+    return false
+  }
+
+  // If security includes an empty object `{}`, auth is not required at all.
+  if (
+    (security ?? []).some(
+      (securityRequirement) => !Object.keys(securityRequirement).length,
+    )
+  ) {
+    return false
+  }
+
+  // If security includes the given key, auth is required.
+  return (security ?? []).some((securityRequirement) => {
+    return Object.keys(securityRequirement).some((securityRequirementKey) => {
+      return securityRequirementKey === key
+    })
+  })
+}
+
+/**
+ * Get the request object from the authentication state.
+ */
 export function getRequestFromAuthentication(
   authentication: AuthenticationState,
+  security?: OpenAPIV3.SecurityRequirementObject[],
 ): Partial<HarRequest> {
-  const headers = []
-  const queryString = []
-  const cookies = []
+  const headers: HarRequest['headers'] = []
+  const queryString: HarRequest['queryString'] = []
+  const cookies: HarRequest['cookies'] = []
 
   // Authentication
-  if (authentication.securitySchemeKey) {
-    // We’re using a parsed Swagger file here, so let’s get rid of the `ReferenceObject` type
-    const securityScheme =
-      authentication.securitySchemes?.[authentication.securitySchemeKey]
+  if (
+    !authentication.securitySchemeKey ||
+    !givenSecuritySchemeIsRequired(authentication.securitySchemeKey, security)
+  ) {
+    return { headers, queryString, cookies }
+  }
+  // We’re using a parsed Swagger file here, so let’s get rid of the `ReferenceObject` type
+  const securityScheme =
+    authentication.securitySchemes?.[authentication.securitySchemeKey]
 
-    if (securityScheme) {
-      // API Key
-      if (securityScheme.type === 'apiKey') {
-        // Header
-        if (securityScheme.in === 'header') {
-          headers.push({
-            name: securityScheme.name,
-            value: authentication.apiKey.token,
-          })
-        }
-        // Cookie
-        else if (securityScheme.in === 'cookie') {
-          // TODO: Should we add a dedicated cookie section?
-          cookies.push({
-            name: securityScheme.name,
-            value: authentication.apiKey.token,
-          })
-        }
-        // Query
-        else if (securityScheme.in === 'query') {
-          queryString.push({
-            name: securityScheme.name,
-            value: authentication.apiKey.token,
-          })
-        }
+  if (securityScheme) {
+    // API Key
+    if (securityScheme.type === 'apiKey') {
+      // Header
+      if (securityScheme.in === 'header') {
+        const token = authentication.apiKey.token.length
+          ? authentication.apiKey.token
+          : 'YOUR_TOKEN'
+
+        headers.push({
+          name: securityScheme.name,
+          value: token,
+        })
       }
-      // HTTP Header Auth
-      else if (
-        securityScheme.type === 'http' ||
-        securityScheme.type === 'basic'
-      ) {
-        // Basic Auth
-        if (
-          securityScheme.type === 'basic' ||
-          securityScheme.scheme === 'basic'
-        ) {
-          headers.push({
-            name: 'Authorization',
-            value: `Basic ${Buffer.from(
-              `${authentication.http.basic.username}:${authentication.http.basic.password}`,
-            ).toString('base64')}`,
-          })
-        }
-        // Bearer Auth
-        else if (securityScheme.scheme === 'bearer') {
-          headers.push({
-            name: 'Authorization',
-            value: `Bearer ${authentication.http.bearer.token}`,
-          })
-        }
+      // Cookie
+      else if (securityScheme.in === 'cookie') {
+        // TODO: Should we add a dedicated cookie section?
+        const token = authentication.apiKey.token.length
+          ? authentication.apiKey.token
+          : 'YOUR_TOKEN'
+
+        cookies.push({
+          name: securityScheme.name,
+          value: token,
+        })
       }
-      // TODO: oauth2
-      // TODO: openIdConnect
+      // Query
+      else if (securityScheme.in === 'query') {
+        const token = authentication.apiKey.token.length
+          ? authentication.apiKey.token
+          : 'YOUR_TOKEN'
+
+        queryString.push({
+          name: securityScheme.name,
+          value: token,
+        })
+      }
     }
+    // HTTP Header Auth
+    else if (
+      securityScheme.type === 'http' ||
+      securityScheme.type === 'basic'
+    ) {
+      // Basic Auth
+      if (
+        securityScheme.type === 'basic' ||
+        securityScheme.scheme === 'basic'
+      ) {
+        headers.push({
+          name: 'Authorization',
+          value: `Basic ${Buffer.from(
+            `${authentication.http.basic.username}:${authentication.http.basic.password}`,
+          ).toString('base64')}`,
+        })
+      }
+      // Bearer Auth
+      else if (securityScheme.scheme === 'bearer') {
+        const token = authentication.http.bearer.token.length
+          ? authentication.http.bearer.token
+          : 'YOUR_SECRET_TOKEN'
+
+        headers.push({
+          name: 'Authorization',
+          value: `Bearer ${token}`,
+        })
+      }
+    }
+    // TODO: oauth2
+    // TODO: openIdConnect
   }
 
   return { headers, queryString, cookies }


### PR DESCRIPTION
Currently, we ignore whatever is configured in `security` on the operation level. With this PR, we’ll take the configuration into account.

* When there’s nothing configured, we take the globally configured security schemes.
* When there’s an empty array `[]`, auth is optional and won’t be added to the examples.
* When there’s an array containing an empty object `{}`, auth is optional and won’t be added to the examples.

Read the OpenAPI spec here: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md

I’ve also tested Swagger UI and got the same results.

See #532, #843