### PR TITLE
feat: render images from markdown, filter out XSS vulnerable tags #842

### DIFF
--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -25,7 +25,7 @@ watch(
       .use(rehypeSanitize, {
         ...defaultSchema,
         tagNames: defaultSchema.tagNames?.filter(
-          (tag) => !['img'].includes(tag),
+          (tag) => !['script', 'iframe', 'object'].includes(tag),
         ),
       })
       .use(rehypeHighlight, {


### PR DESCRIPTION
**Problem**
Currently we can't render images from markdown content included in OpenAPI spec

**Explanation**
This happens because img tags are filtered out in [MarkdownRenderer.vue](https://github.com/scalar/scalar/blob/d9b6d8104dd0f1997e45a5220c8bbc11ae2062c4/packages/api-reference/src/components/Content/MarkdownRenderer.vue#L25C1-L30C9) component

**Solution**
With this PR I exclude img tags filtering and add filtering out tags vulnerable for XSS attacks (`script`, `iframe`, `object`)
