### PR TITLE
feat: description with images, see #842, fix #855

### DIFF
--- a/.changeset/little-lies-film.md
+++ b/.changeset/little-lies-film.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: render images in the description

--- a/packages/api-reference/src/components/Content/Introduction/Description.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Description.vue
@@ -62,12 +62,16 @@ function handleScroll(headingId: string) {
           :id="getHeadingId(section.heading)"
           class="introduction-description-heading"
           @intersecting="() => handleScroll(getHeadingId(section.heading))">
-          <MarkdownRenderer :value="section.content" />
+          <MarkdownRenderer
+            :value="section.content"
+            withImages />
         </IntersectionObserver>
       </template>
       <!-- Without a heading -->
       <template v-else>
-        <MarkdownRenderer :value="section.content" />
+        <MarkdownRenderer
+          :value="section.content"
+          withImages />
       </template>
     </div>
   </template>

--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -10,9 +10,19 @@ import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
 import { ref, watch } from 'vue'
 
-const props = defineProps<{ value?: string }>()
+const props = withDefaults(
+  defineProps<{
+    value?: string
+    withImages: boolean
+  }>(),
+  {
+    withImages: false,
+  },
+)
 
 const html = ref<string>('')
+
+const disallowedTagNames = props.withImages ? [] : ['img', 'picture']
 
 watch(
   () => props.value,
@@ -25,7 +35,7 @@ watch(
       .use(rehypeSanitize, {
         ...defaultSchema,
         tagNames: defaultSchema.tagNames?.filter(
-          (tag) => !['img'].includes(tag),
+          (tag) => !disallowedTagNames.includes(tag),
         ),
       })
       .use(rehypeHighlight, {


### PR DESCRIPTION
This PR adds a `withImages` prop to the MarkdownRenderer. With this PR users can use images in the OpenAPI description field.

Based on @SebastianBienert’s PR #856
