### PR TITLE
feat: nullable properties, fix #855

### DIFF
--- a/.changeset/tall-clouds-protect.md
+++ b/.changeset/tall-clouds-protect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: show nullable properties

--- a/packages/api-reference/src/components/Content/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema.vue
@@ -63,7 +63,6 @@ const mergedSchema = computed(() => {
         compact ? 'schema-card--compact' : ''
       } schema-card--level-${level}`">
       <div
-        v-if="mergedSchema.properties || mergedSchema.items"
         class="properties"
         :class="`properties--${
           !shouldShowToggle || visible ? 'visible' : 'hidden'

--- a/packages/api-reference/src/components/Content/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema.vue
@@ -134,7 +134,7 @@ const mergedSchema = computed(() => {
 }
 .schema-card {
   width: 100%;
-  margin-top: 24px;
+  margin-top: 12px;
   font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
   color: var(--theme-color-1, var(--default-theme-color-1));
 }

--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -107,13 +107,6 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         class="read-only">
         read-only
       </div>
-      <div
-        v-if="value?.example !== undefined"
-        class="property-example">
-        <code class="property-example-value">
-          example: {{ value.example }}
-        </code>
-      </div>
       <template
         v-for="rule in rules"
         :key="rule">
@@ -127,6 +120,13 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         v-if="value?.nullable"
         class="property-nullable">
         nullable
+      </div>
+      <div
+        v-if="value?.example !== undefined"
+        class="property-example">
+        <code class="property-example-value">
+          example: {{ value.example }}
+        </code>
       </div>
     </div>
     <!-- Description -->
@@ -321,7 +321,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 }
 
 .property-nullable {
-  font-family: var(--theme-font-code, var(--default-theme-font-code));
+  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
   color: var(--theme-color-2, var(--default-theme-color-2));
 }
 

--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -183,14 +183,16 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
       <div
         v-if="value?.[rule]"
         class="rule">
-        <Schema
+        <template
           v-for="(schema, index) in value[rule]"
-          :key="index"
-          :compact="compact"
-          hideVisibilityToggle
-          :level="level + 1"
-          :toggleVisibility="level >= 3 || toggleVisibility"
-          :value="schema" />
+          :key="index">
+          <Schema
+            :compact="compact"
+            hideVisibilityToggle
+            :level="level + 1"
+            :toggleVisibility="level >= 3 || toggleVisibility"
+            :value="schema" />
+        </template>
       </div>
       <!-- Arrays -->
       <div

--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -124,7 +124,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         </div>
       </template>
       <div
-        v-if="value?.readOnly"
+        v-if="value?.nullable"
         class="property-nullable">
         nullable
       </div>


### PR DESCRIPTION
There was a typo, so we didn’t show `nullable` for properties where it’s set.

And if `anyOf` is used to tell fields are nullable, the rendering is slightly improved.

**Before**
<img width="605" alt="Screenshot 2024-01-23 at 15 53 27" src="https://github.com/scalar/scalar/assets/1577992/55546273-735c-467d-b73a-c20b41b1224c">

**After**
<img width="605" alt="Screenshot 2024-01-23 at 15 57 56" src="https://github.com/scalar/scalar/assets/1577992/9d07a5c4-75d7-4052-a61f-8c78362c2441">


