### PR TITLE
feat: better schema support for parameters, fix #862

### DIFF
--- a/.changeset/itchy-rivers-occur.md
+++ b/.changeset/itchy-rivers-occur.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: better schema support for params

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/EndpointDetails.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/EndpointDetails.vue
@@ -36,7 +36,9 @@ const { responses } = useResponses(props.operation)
     <Parameters :parameters="parameterMap.formData">
       <template #title>Form Data</template>
     </Parameters>
-    <RequestBody :requestBody="operation.information?.requestBody">
+    <RequestBody
+      v-if="operation.information?.requestBody"
+      :requestBody="operation.information?.requestBody">
       <template #title>Body</template>
     </RequestBody>
     <Parameters :parameters="responses">

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ParameterItem.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ParameterItem.vue
@@ -2,6 +2,7 @@
 import type { Parameters } from '../../../types'
 import MarkdownRenderer from '../MarkdownRenderer.vue'
 import Schema from '../Schema.vue'
+import SchemaProperty from '../SchemaProperty.vue'
 
 withDefaults(defineProps<{ parameter: Parameters; showChildren?: boolean }>(), {
   showChildren: false,
@@ -10,52 +11,15 @@ withDefaults(defineProps<{ parameter: Parameters; showChildren?: boolean }>(), {
 <template>
   <li class="parameter-item">
     <div class="parameter-item-container">
-      <!-- Name -->
-      <span class="parameter-item-name">
-        {{ parameter.name }}
-      </span>
-
-      <!-- Optional -->
-      <template v-if="parameter.required === true">
-        <span class="parameter-item-required-optional parameter-item--required">
-          required
-        </span>
-      </template>
-      <!-- Maybe it’s cleaner to just show required, and not "optional". Makes it cleaner. -->
-      <!-- <template v-else>
-      <span class="parameter-item-required-optional parameter-item--optional">
-        optional
-      </span>
-    </template> -->
-
-      <!-- Type -->
-      <span
-        v-if="parameter.schema?.type"
-        class="parameter-item-type">
-        {{ parameter.schema?.type }}
-      </span>
-
-      <!-- Description -->
-      <MarkdownRenderer
-        v-if="parameter.description || parameter.schema?.description"
-        class="parameter-item-description"
-        :value="parameter.description || parameter.schema?.description" />
+      <SchemaProperty
+        compact
+        :description="parameter.description"
+        :level="0"
+        :name="parameter.name"
+        :required="parameter.required"
+        :toggleVisibility="!showChildren"
+        :value="parameter.schema" />
     </div>
-
-    <!-- Schema -->
-    <template
-      v-if="
-        typeof parameter.schema === 'object' &&
-        Object.keys(parameter.schema).length
-      ">
-      <div class="parameter-schema">
-        <Schema
-          compact
-          :level="1"
-          :toggleVisibility="!showChildren"
-          :value="parameter.schema" />
-      </div>
-    </template>
   </li>
 </template>
 

--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -11,6 +11,7 @@ withDefaults(
     required?: boolean
     compact?: boolean
     toggleVisibility?: boolean
+    description?: string
   }>(),
   {
     level: 0,
@@ -75,26 +76,32 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
       <div
         v-if="value?.type"
         class="property-type">
-        <template v-if="value.type !== 'object'">
-          <template
-            v-if="value?.items && !['object'].includes(value.items.type)">
-            {{ value.type }}
-            {{ value.items.type }}[]
-            <template v-if="value.items.example">
-              <code class="property-example-value">
-                example: {{ value.items.example }}
-              </code>
-            </template>
+        <template v-if="value?.items && !['object'].includes(value.items.type)">
+          {{ value.type }}
+          {{ value.items.type }}[]
+          <template v-if="value.items.example">
+            <code class="property-example-value">
+              example: {{ value.items.example }}
+            </code>
           </template>
-          <template v-else>
-            {{ value.type }}
-          </template>
-          <template v-if="value.minItems || value.maxItems">
-            {{ value.minItems }}..{{ value.maxItems }}
-          </template>
-          <template v-if="value.uniqueItems"> unique! </template>
         </template>
+        <template v-else>
+          {{ value.type }}
+        </template>
+        <template v-if="value.minItems || value.maxItems">
+          {{ value.minItems }}..{{ value.maxItems }}
+        </template>
+        <template v-if="value.minLength">
+          &middot; min: {{ value.minLength }}
+        </template>
+        <template v-if="value.maxLength">
+          &middot; max: {{ value.maxLength }}
+        </template>
+        <template v-if="value.uniqueItems"> unique! </template>
         <template v-if="value.format"> &middot; {{ value.format }} </template>
+        <template v-if="value.pattern">
+          &middot; <code class="pattern">{{ value.pattern }}</code>
+        </template>
         <template v-if="value.enum"> &middot; enum </template>
       </div>
       <div
@@ -131,9 +138,9 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     </div>
     <!-- Description -->
     <div
-      v-if="value?.description"
+      v-if="description || value?.description"
       class="property-description">
-      <MarkdownRenderer :value="value.description" />
+      <MarkdownRenderer :value="description || value?.description" />
     </div>
     <div
       v-else-if="generatePropertyDescription(value)"
@@ -212,21 +219,17 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 
 <style scoped>
 .property {
+  color: var(--theme-color-1, var(--default-theme-color-1));
   padding: 10px;
-  overflow: auto;
   font-size: var(--theme-mini, var(--default-theme-mini));
 }
+
 .property:last-of-type {
   padding-bottom: 0;
 }
 
-.property--compact:not(.property--level-0) {
-  padding: 8px;
-}
-
 .property--compact.property--level-0 {
-  padding-left: 0;
-  padding-right: 0;
+  padding: 0;
 }
 
 .property-information {
@@ -238,13 +241,19 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 
 .property-description {
   margin-top: 4px;
-  color: var(--theme-color-2, var(--default-theme-color-2));
   line-height: 1.4;
+}
+
+:deep(.property-description) * {
+  color: var(--theme-color-2, var(--default-theme-color-2)) !important;
 }
 
 .property:not(:last-of-type) {
   border-bottom: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
+}
+.children {
+  padding-top: 8px;
 }
 .children .property:first-of-type {
   border-top: 1px solid
@@ -291,6 +300,15 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     --default-theme-font-size-5,
     var(--default-default-theme-font-size-5)
   );
+}
+
+.pattern {
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  background: var(--theme-background-3, var(--default-theme-background-3));
+  padding: 1px 3px;
+  border-radius: var(--theme-radius, var(--default-theme-radius));
 }
 
 .rule {

--- a/packages/api-reference/src/components/Content/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/SchemaProperty.vue
@@ -229,7 +229,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 }
 
 .property--compact.property--level-0 {
-  padding: 0;
+  padding: 8px 0;
 }
 
 .property-information {


### PR DESCRIPTION
We have this powerful `Schema` component to render schemas, but that wasn’t really used for parameters (except for objects).

With this PR it’s used for the parameters aswell. And I’ve added support for minLength, maxLength and pattern.

Schemas are complex and allow a ton of features, we’re still not 100 % feature complete, but we’re getting there … ✨

<img width="611" alt="Screenshot 2024-01-23 at 16 57 51" src="https://github.com/scalar/scalar/assets/1577992/774db71f-78f8-4d24-b316-ea180c898612">

See #862 