### PR TITLE
feat: use schema examples, fix #867

### DIFF
--- a/.changeset/twenty-cows-jog.md
+++ b/.changeset/twenty-cows-jog.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: use schema examples

--- a/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
@@ -11,6 +11,14 @@ describe('getExampleFromSchema', () => {
     ).toMatchObject(10)
   })
 
+  it('uses first example, if multiple are configured', () => {
+    expect(
+      getExampleFromSchema({
+        examples: [10],
+      }),
+    ).toMatchObject(10)
+  })
+
   it('takes the first enum as example', () => {
     expect(
       getExampleFromSchema({

--- a/packages/api-reference/src/helpers/getExampleFromSchema.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.ts
@@ -39,6 +39,11 @@ export const getExampleFromSchema = (
     return undefined
   }
 
+  // Use the first example, if there’s an array
+  if (Array.isArray(schema.examples) && schema.examples.length > 0) {
+    return schema.examples[0]
+  }
+
   // Use an example, if there’s one
   if (schema.example !== undefined) {
     return schema.example


### PR DESCRIPTION
Currently, we use the provided `example` in schemas to generate example payloads/responses. But not anymore! This PR checks if `examples` (with an `s`) is configured, is an array and uses the first example for our example payloads/responses.

See #867

Example: https://sandbox.scalar.com/e/YAy_o
