### PR TITLE
feat: custom request examples

### DIFF
--- a/.changeset/slimy-pumpkins-retire.md
+++ b/.changeset/slimy-pumpkins-retire.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add support for `x-custom-examples` (custom request examples)

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/CustomRequestExamples.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/CustomRequestExamples.vue
@@ -1,0 +1,255 @@
+<script lang="ts" setup>
+import { ScalarIcon } from '@scalar/components'
+import { useClipboard } from '@scalar/use-clipboard'
+import { CodeMirror } from '@scalar/use-codemirror'
+import { computed, ref, watch } from 'vue'
+
+import type { CustomRequestExample, TransformedOperation } from '../../../types'
+import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
+
+const props = defineProps<{
+  operation: TransformedOperation
+  examples: CustomRequestExample[]
+}>()
+
+const selectedExample = ref<number>(0)
+
+const language = computed(() => {
+  // Translate to what the CodeMirror component understands
+  const languages = {
+    'C': 'c',
+    'C#': 'csharp',
+    // 'C++': '',
+    // 'CoffeeScript': '',
+    // 'CSS': '',
+    // 'Dart': '',
+    // 'DM': '',
+    // 'Elixir': '',
+    'Go': 'go',
+    // 'Groovy': '',
+    'HTML': 'html',
+    'Java': 'java',
+    'JavaScript': 'javascript',
+    'Kotlin': 'kotlin',
+    'Objective-C': 'objc',
+    // 'Perl': '',
+    // 'PHP': '',
+    'PowerShell': 'powershell',
+    'Python': 'python',
+    'Ruby': 'ruby',
+    // 'Rust': '',
+    // 'Scala': '',
+    'Shell': 'shell',
+    'Swift': 'swift',
+    'TypeScript': 'javascript',
+    'cURL': 'shell',
+  }
+
+  return (
+    // @ts-ignore
+    languages[props.examples[selectedExample.value].lang as string] ??
+    props.examples[selectedExample.value].lang
+  )
+})
+
+const currentExample = computed(() => {
+  return props.examples[selectedExample.value]
+})
+
+watch(props.examples, () => {
+  // @ts-ignore
+  if (props.examples[selectedExample.value] === 'undefined') {
+    selectedExample.value = 0
+  }
+})
+
+const { copyToClipboard } = useClipboard()
+</script>
+<template>
+  <Card class="dark-mode">
+    <CardHeader muted>
+      <div class="request-header">
+        <span
+          class="request-method"
+          :class="`request-method--${operation.httpVerb}`">
+          {{ operation.httpVerb }}
+        </span>
+        <slot name="header" />
+      </div>
+      <template #actions>
+        <div class="language-select">
+          <span>{{ currentExample.label }}</span>
+          <select
+            :value="selectedExample"
+            @input="
+              (event) => (
+                (selectedExample = parseInt(
+                  (event.target as HTMLSelectElement).value,
+                )),
+                10
+              )
+            ">
+            <option
+              v-for="(example, index) in examples"
+              :key="index"
+              :value="index">
+              {{ example.label }}
+            </option>
+          </select>
+        </div>
+        <button
+          class="copy-button"
+          type="button"
+          @click="copyToClipboard(currentExample.source.trim())">
+          <ScalarIcon
+            icon="Clipboard"
+            width="10px" />
+        </button>
+      </template>
+    </CardHeader>
+    <CardContent
+      borderless
+      class="request-editor-section custom-scroll"
+      frameless>
+      <CodeMirror
+        :content="currentExample.source.trim()"
+        :forceDarkMode="true"
+        :languages="[language]"
+        lineNumbers
+        readOnly />
+    </CardContent>
+    <CardFooter
+      v-if="$slots.footer"
+      class="scalar-card-footer"
+      contrast>
+      <slot name="footer" />
+    </CardFooter>
+  </Card>
+</template>
+
+<style scoped>
+.request {
+  display: flex;
+  flex-wrap: nowrap;
+}
+.request-header {
+  display: flex;
+  gap: 6px;
+  text-transform: initial;
+}
+.request-method {
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+  text-transform: uppercase;
+}
+.request-method--post {
+  color: var(--theme-color-green, var(--default-theme-color-green));
+}
+.request-method--patch {
+  color: var(--theme-color-yellow, var(--default-theme-color-yellow));
+}
+.request-method--get {
+  color: var(--theme-color-blue, var(--default-theme-color-blue));
+}
+.request-method--delete {
+  color: var(--theme-color-red, var(--default-theme-color-red));
+}
+.request-method--put {
+  color: var(--theme-color-orange, var(--default-theme-color-orange));
+}
+.language-select {
+  position: relative;
+  padding-right: 9px;
+  height: fit-content;
+  padding-left: 12px;
+  border-right: 1px solid
+    var(--theme-border-color, var(--default-theme-border-color));
+}
+.language-select select {
+  border: none;
+  outline: none;
+  cursor: pointer;
+  background: var(--theme-background-3, var(--default-theme-background-3));
+  box-shadow: -2px 0 0 0
+    var(--theme-background-3, var(--default-theme-background-3));
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+.language-select span {
+  font-size: var(--theme-mini, var(--default-theme-mini));
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.language-select:hover span {
+  color: var(--theme-color-1, var(--default-theme-color-1));
+}
+.language-select span:after {
+  content: '';
+  width: 7px;
+  height: 7px;
+  transform: rotate(45deg) translate3d(-2px, -2px, 0);
+  display: block;
+  margin-left: 6px;
+  box-shadow: 1px 1px 0 currentColor;
+}
+.language-select span:hover {
+  background: var(--theme-background-2, var(--default-theme-background-2));
+}
+
+.copy-button {
+  appearance: none;
+  -webkit-appearance: none;
+  outline: none;
+  background: transparent;
+  display: flex;
+  cursor: pointer;
+  color: var(--theme-color-3, var(--default-theme-color-3));
+  margin-left: 6px;
+  margin-right: 10.5px;
+  border: none;
+  border-radius: 3px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  height: fit-content;
+}
+/* Can't use flex align center on parent (scalar-card-header-actions) so have to match sibling font size vertically align*/
+.copy-button:after {
+  content: '.';
+  color: transparent;
+  font-size: var(--theme-mini, var(--default-theme-mini));
+  line-height: 1.35;
+  width: 0px;
+}
+.copy-button:hover {
+  color: var(--theme-color-1, var(--default-theme-color-1));
+}
+
+.copy-button svg {
+  width: 13px;
+  height: 13px;
+}
+
+.scalar-card-header-actions {
+  display: flex;
+}
+.scalar-card-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 6px;
+}
+.request-editor-section {
+  display: flex;
+  flex: 1;
+}
+</style>

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import { useNavState } from '../../../hooks'
 import type { Tag, TransformedOperation } from '../../../types'
 import { Anchor } from '../../Anchor'
@@ -10,18 +12,37 @@ import {
   SectionContent,
   SectionHeader,
 } from '../../Section'
+import CustomRequestExamples from './CustomRequestExamples.vue'
 import EndpointDetails from './EndpointDetails.vue'
 import EndpointPath from './EndpointPath.vue'
 import ExampleRequest from './ExampleRequest.vue'
 import { PathResponses } from './PathResponses'
 import TryRequestButton from './TryRequestButton.vue'
 
-defineProps<{
+const props = defineProps<{
   operation: TransformedOperation
   tag: Tag
 }>()
 
 const { getOperationId } = useNavState()
+
+const customRequestExamples = computed(() => {
+  const keys = ['x-custom-examples', 'x-codeSamples', 'x-code-samples']
+
+  for (const key of keys) {
+    if (
+      props.operation.information?.[
+        key as 'x-custom-examples' | 'x-codeSamples' | 'x-code-samples'
+      ]
+    ) {
+      return props.operation.information[
+        key as 'x-custom-examples' | 'x-codeSamples' | 'x-code-samples'
+      ]
+    }
+  }
+
+  return null
+})
 </script>
 <template>
   <Section
@@ -42,7 +63,13 @@ const { getOperationId } = useNavState()
         </SectionColumn>
         <SectionColumn>
           <div class="examples">
-            <ExampleRequest :operation="operation">
+            <CustomRequestExamples
+              v-if="customRequestExamples"
+              :examples="customRequestExamples"
+              :operation="operation" />
+            <ExampleRequest
+              v-else
+              :operation="operation">
               <template #header>
                 <EndpointPath
                   class="example-path"

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -98,16 +98,34 @@ export type Response = {
   content: any
 }
 
+export type CustomRequestExample = {
+  lang: string
+  label: string
+  source: string
+}
+
 export type Information = {
-  description?: string
-  operationId?: string | number
-  parameters?: Parameters[]
-  responses?: Record<string, Response>
-  security?: OpenAPIV3.SecurityRequirementObject[]
-  requestBody?: RequestBody
-  summary?: string
-  tags?: string[]
-  deprecated?: boolean
+  'description'?: string
+  'operationId'?: string | number
+  'parameters'?: Parameters[]
+  'responses'?: Record<string, Response>
+  'security'?: OpenAPIV3.SecurityRequirementObject[]
+  'requestBody'?: RequestBody
+  'summary'?: string
+  'tags'?: string[]
+  'deprecated'?: boolean
+  /**
+   * Scalar
+   **/
+  'x-custom-examples': CustomRequestExample[]
+  /**
+   * Redocly, current
+   **/
+  'x-codeSamples': CustomRequestExample[]
+  /**
+   * Redocly, deprecated
+   **/
+  'x-code-samples': CustomRequestExample[]
 }
 
 export type Operation = {

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -117,15 +117,15 @@ export type Information = {
   /**
    * Scalar
    **/
-  'x-custom-examples': CustomRequestExample[]
+  'x-custom-examples'?: CustomRequestExample[]
   /**
    * Redocly, current
    **/
-  'x-codeSamples': CustomRequestExample[]
+  'x-codeSamples'?: CustomRequestExample[]
   /**
    * Redocly, deprecated
    **/
-  'x-code-samples': CustomRequestExample[]
+  'x-code-samples'?: CustomRequestExample[]
 }
 
 export type Operation = {


### PR DESCRIPTION
This PR adds support for custom request examples.

If it’s configured, we won’t show the generated example requests.

We’re looking for the following keys:

1. `x-custom-examples` (our default)
2. `x-codeSamples` (redocly)
3. `x-code-samples` (redocly, deprecated)

Example: https://sandbox.scalar.com/e/QUbEt

<img width="607" alt="Screenshot 2024-01-24 at 13 12 11" src="https://github.com/scalar/scalar/assets/1577992/b21da645-287e-4f5d-995b-2f3c071a5326">
