### PR TITLE
style: no text wrap for method badges, fix #871

### DIFF
--- a/.changeset/angry-crabs-double.md
+++ b/.changeset/angry-crabs-double.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: text in method badges wraps for PATCH operations

--- a/packages/api-reference/src/components/SidebarElement.vue
+++ b/packages/api-reference/src/components/SidebarElement.vue
@@ -62,7 +62,9 @@ defineExpose({ el })
           v-if="item?.icon?.src"
           class="sidebar-icon"
           :src="item.icon.src" />
-        <p>{{ item.title }}</p>
+        <span>
+          {{ item.title }}
+        </span>
         <div
           v-if="item.httpVerb"
           class="sidebar-heading-type"
@@ -102,14 +104,14 @@ defineExpose({ el })
   padding-right: 12px;
   user-select: none;
 }
-.sidebar-heading.deprecated p {
+.sidebar-heading.deprecated span {
   text-decoration: line-through;
 }
 .sidebar-heading:hover {
   /* prettier-ignore */
   background: var(--sidebar-item-hover-background, var(--default-sidebar-item-hover-background, var(--theme-background-2, var(--default-theme-background-2))));
 }
-.sidebar-heading:hover p {
+.sidebar-heading:hover span {
   color: var(
     --sidebar-item-hover-color,
     var(
@@ -134,7 +136,8 @@ defineExpose({ el })
   display: flex;
   flex: 1;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
+  gap: 2px;
 }
 
 /* Sidebar link icon */
@@ -208,11 +211,10 @@ defineExpose({ el })
 }
 
 .sidebar-heading-type {
-  width: 28px;
-  height: 12px;
-  line-height: 13px;
-  top: 3.5px;
-  margin-left: 2px;
+  width: 3.9em;
+  overflow: hidden;
+  height: 1.8em;
+  line-height: 1.8em;
   border-radius: 30px;
   flex-shrink: 0;
   color: var(
@@ -228,6 +230,7 @@ defineExpose({ el })
   text-align: center;
   position: relative;
   font-family: var(--theme-font-code, var(--default-theme-font-code));
+  white-space: nowrap;
 }
 .active_page .sidebar-heading-type {
   background: transparent;


### PR DESCRIPTION
This PR improves the styling of the method badge in the sidebar.

* Text doesn’t wrap anymore.
* The size of the badge (width, height, line-height) is configured in em now, so it’s relative to the font size.
* The margin is removed, it’s using `gap` now.
* The badge is set to `overflow: hidden`.

**One thing changed:**

The link and the badge were set to `flex-start`, so they were attached to the top. For long operation names the badge was still on top, I think that was expected.

Unfortunately, this required also to fix the position of the badge for one-line operation names with a `top: 3.5px;` to make it look centered. Which feels very hacky to me, and doesn’t work well with a dynamic (em) size.

That’s why I actually centered it now:

<img width="247" alt="Screenshot 2024-01-25 at 11 55 04" src="https://github.com/scalar/scalar/assets/1577992/bdb3a53c-01fd-45af-bec1-19d11075854b">

See #871 