### PR TITLE
fix: example spec on mobile

### DIFF
--- a/.changeset/silver-actors-wonder.md
+++ b/.changeset/silver-actors-wonder.md
@@ -1,0 +1,10 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/nestjs-api-reference': patch
+'@scalar/nextjs-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+---
+
+fix: example spec not loading on mobile

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -147,7 +147,7 @@ const isMobile = useMediaQuery('(max-width: 1000px)')
       :value="rawSpecRef"
       @changeTheme="$emit('changeTheme', $event)"
       @openSwaggerEditor="gettingStartedModal.hide()"
-      @updateContent="handleCloseModal(() => $emit('updateContent', $event))" />
+      @updateContent="handleCloseModal(() => setRawSpecRef($event))" />
   </FlowModal>
   <ResetStyles v-slot="{ styles }">
     <ApiReferenceLayout


### PR DESCRIPTION
Fixes setting the example spec on mobile.

1. To test shrink the screen to mobile size and open the [editable references](http://localhost:5050/editable-api-reference)
2. hit getting started then one of the example specs
3. they should fill the content now

Test this on main and it does not work, because `ModernLayout` doesn't do anything with the `updateContent` event

@marclave double checked and setting the rawSpec triggers a watcher which updatesContent so its safe
```ts
watch(rawSpecRef, () => {
  emit('updateContent', rawSpecRef.value)
})
```

