### PR TITLE
chore: add Relative CI to monitor the bundle size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
         run: pnpm turbo types:check
       - name: Run tests
         run: pnpm turbo test
-      - name: Send bundle stats and build information to RelativeCI
+      - if: matrix.node-version == 20
+        name: Send bundle stats and build information to RelativeCI
         uses: relative-ci/agent-action@v2
         with:
           key: ${{ secrets.RELATIVE_CI_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,9 @@ jobs:
         run: pnpm turbo types:check
       - name: Run tests
         run: pnpm turbo test
+      - name: Send bundle stats and build information to RelativeCI
+        uses: relative-ci/agent-action@v2
+        with:
+          key: ${{ secrets.RELATIVE_CI_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          webpackStatsFile: ./packages/api-reference/dist/webpack-stats.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Send bundle stats and build information to RelativeCI
+        uses: relative-ci/agent-action@v2
+        with:
+          key: ${{ secrets.RELATIVE_CI_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          webpackStatsFile: ./packages/api-reference/dist/webpack-stats.json

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -43,6 +43,7 @@
   },
   "files": [
     "dist",
+    "!dist/webpack-stats.json",
     "CHANGELOG.md"
   ],
   "browser": "./dist/browser/standalone.js",
@@ -93,6 +94,7 @@
   },
   "devDependencies": {
     "@etchteam/storybook-addon-css-variables-theme": "^1.5.1",
+    "@relative-ci/agent": "^4.2.3",
     "@storybook/addon-essentials": "^7.5.2",
     "@storybook/addon-interactions": "^7.5.2",
     "@storybook/addon-links": "^7.5.2",
@@ -107,6 +109,7 @@
     "postcss": "^8.4.31",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "rollup-plugin-webpack-stats": "^0.2.3",
     "storybook": "^7.5.2",
     "storybook-dark-mode": "^3.0.1",
     "tsc-alias": "^1.8.8",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -94,7 +94,6 @@
   },
   "devDependencies": {
     "@etchteam/storybook-addon-css-variables-theme": "^1.5.1",
-    "@relative-ci/agent": "^4.2.3",
     "@storybook/addon-essentials": "^7.5.2",
     "@storybook/addon-interactions": "^7.5.2",
     "@storybook/addon-links": "^7.5.2",

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -1,5 +1,6 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
+import { webpackStats } from 'rollup-plugin-webpack-stats'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import { defineConfig } from 'vitest/config'
@@ -27,6 +28,7 @@ export default defineConfig({
       // Whether to polyfill `node:` protocol imports.
       protocolImports: true,
     }),
+    webpackStats(),
   ],
   build: {
     emptyOutDir: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -774,9 +774,6 @@ importers:
       '@etchteam/storybook-addon-css-variables-theme':
         specifier: ^1.5.1
         version: 1.5.1(react-dom@18.2.0)(react@18.2.0)
-      '@relative-ci/agent':
-        specifier: ^4.2.3
-        version: 4.2.3(typescript@5.3.3)
       '@storybook/addon-essentials':
         specifier: ^7.5.2
         version: 7.5.2(react-dom@18.2.0)(react@18.2.0)
@@ -3233,23 +3230,6 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@bundle-stats/plugin-webpack-filter@4.8.4(core-js@3.35.0):
-    resolution: {integrity: sha512-y2bo1FTh2dVMa5NdtYr9d8cI5280E2kKcgRVbpOeEKO2pDdnW+vRojmOnHIpDdXLPqMJBMBWJOH+Y9W2kVV9Pg==}
-    engines: {node: '>= 14.0'}
-    peerDependencies:
-      core-js: ^3.0.0
-    dependencies:
-      core-js: 3.35.0
-    dev: true
-
-  /@bundle-stats/plugin-webpack-validate@4.8.4:
-    resolution: {integrity: sha512-/5Pr+nTakUpuWwfquB9Ya0SyRHnDEyQgZrxo8r57wSd6IIMFrQfQ6w8qyEtAFD+FIF70rDVBiSeu3D7bqT04Yw==}
-    engines: {node: '>= 14.0'}
-    dependencies:
-      lodash: 4.17.21
-      superstruct: 1.0.3
-    dev: true
-
   /@changesets/apply-release-plan@6.1.4:
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
     dependencies:
@@ -5383,33 +5363,6 @@ packages:
     resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
     dependencies:
       '@babel/runtime': 7.23.2
-    dev: true
-
-  /@relative-ci/agent@4.2.3(typescript@5.3.3):
-    resolution: {integrity: sha512-GFNJrbxpowGAej6/DRWYmLd6Xtl6cAdI/KdxbvR6f8gCMXfYpsoRAbPZG5WCCQAJfJ2HLhobxj1eCxz0tzFI3A==}
-    engines: {node: '>= 14.0'}
-    hasBin: true
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0-rc.1
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-    dependencies:
-      '@bundle-stats/plugin-webpack-filter': 4.8.4(core-js@3.35.0)
-      '@bundle-stats/plugin-webpack-validate': 4.8.4
-      core-js: 3.35.0
-      cosmiconfig: 9.0.0(typescript@5.3.3)
-      debug: 4.3.4
-      dotenv: 16.3.1
-      env-ci: 7.3.0
-      fs-extra: 11.2.0
-      isomorphic-fetch: 3.0.0
-      lodash: 4.17.21
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-      - typescript
     dev: true
 
   /@rollup/plugin-inject@5.0.3(rollup@3.29.4):
@@ -9598,11 +9551,6 @@ packages:
     requiresBuild: true
     dev: true
 
-  /core-js@3.35.0:
-    resolution: {integrity: sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==}
-    requiresBuild: true
-    dev: true
-
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
@@ -9639,22 +9587,6 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
-    dev: true
-
-  /cosmiconfig@9.0.0(typescript@5.3.3):
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-      typescript: 5.3.3
     dev: true
 
   /create-ecdh@4.0.4:
@@ -10255,20 +10187,6 @@ packages:
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
-
-  /env-ci@7.3.0:
-    resolution: {integrity: sha512-L8vK54CSjKB4pwlwx0YaqeBdUSGufaLHl/pEgD+EqnMrYCVUA8HzMjURALSyvOlC57e953yN7KyXS63qDoc3Rg==}
-    engines: {node: '>=12.20'}
-    dependencies:
-      execa: 5.1.1
-      fromentries: 1.3.2
-      java-properties: 1.0.2
-    dev: true
-
-  /env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
-    dev: true
 
   /envinfo@7.10.0:
     resolution: {integrity: sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==}
@@ -11461,10 +11379,6 @@ packages:
     resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
     dev: true
 
-  /fromentries@1.3.2:
-    resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
-    dev: true
-
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: true
@@ -11480,15 +11394,6 @@ packages:
 
   /fs-extra@11.1.1:
     resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
-    engines: {node: '>=14.14'}
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.0
-    dev: true
-
-  /fs-extra@11.2.0:
-    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
     engines: {node: '>=14.14'}
     dependencies:
       graceful-fs: 4.2.11
@@ -12751,15 +12656,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /isomorphic-fetch@3.0.0:
-    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
-    dependencies:
-      node-fetch: 2.7.0
-      whatwg-fetch: 3.6.20
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
   /isomorphic-timers-promises@1.0.1:
     resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
     engines: {node: '>=10'}
@@ -12846,11 +12742,6 @@ packages:
       chalk: 4.1.2
       filelist: 1.0.4
       minimatch: 3.1.2
-    dev: true
-
-  /java-properties@1.0.2:
-    resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
-    engines: {node: '>= 0.6.0'}
     dev: true
 
   /javascript-natural-sort@0.7.1:
@@ -17273,11 +17164,6 @@ packages:
       - supports-color
     dev: true
 
-  /superstruct@1.0.3:
-    resolution: {integrity: sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==}
-    engines: {node: '>=14.0.0'}
-    dev: true
-
   /supertest@6.3.3:
     resolution: {integrity: sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==}
     engines: {node: '>=6.4.0'}
@@ -19262,10 +19148,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       iconv-lite: 0.6.3
-    dev: true
-
-  /whatwg-fetch@3.6.20:
-    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
     dev: true
 
   /whatwg-mimetype@3.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -774,6 +774,9 @@ importers:
       '@etchteam/storybook-addon-css-variables-theme':
         specifier: ^1.5.1
         version: 1.5.1(react-dom@18.2.0)(react@18.2.0)
+      '@relative-ci/agent':
+        specifier: ^4.2.3
+        version: 4.2.3(typescript@5.3.3)
       '@storybook/addon-essentials':
         specifier: ^7.5.2
         version: 7.5.2(react-dom@18.2.0)(react@18.2.0)
@@ -816,6 +819,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      rollup-plugin-webpack-stats:
+        specifier: ^0.2.3
+        version: 0.2.3(rollup@3.29.4)
       storybook:
         specifier: ^7.5.2
         version: 7.5.2
@@ -3227,6 +3233,23 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
+  /@bundle-stats/plugin-webpack-filter@4.8.4(core-js@3.35.0):
+    resolution: {integrity: sha512-y2bo1FTh2dVMa5NdtYr9d8cI5280E2kKcgRVbpOeEKO2pDdnW+vRojmOnHIpDdXLPqMJBMBWJOH+Y9W2kVV9Pg==}
+    engines: {node: '>= 14.0'}
+    peerDependencies:
+      core-js: ^3.0.0
+    dependencies:
+      core-js: 3.35.0
+    dev: true
+
+  /@bundle-stats/plugin-webpack-validate@4.8.4:
+    resolution: {integrity: sha512-/5Pr+nTakUpuWwfquB9Ya0SyRHnDEyQgZrxo8r57wSd6IIMFrQfQ6w8qyEtAFD+FIF70rDVBiSeu3D7bqT04Yw==}
+    engines: {node: '>= 14.0'}
+    dependencies:
+      lodash: 4.17.21
+      superstruct: 1.0.3
+    dev: true
+
   /@changesets/apply-release-plan@6.1.4:
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
     dependencies:
@@ -5360,6 +5383,33 @@ packages:
     resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
     dependencies:
       '@babel/runtime': 7.23.2
+    dev: true
+
+  /@relative-ci/agent@4.2.3(typescript@5.3.3):
+    resolution: {integrity: sha512-GFNJrbxpowGAej6/DRWYmLd6Xtl6cAdI/KdxbvR6f8gCMXfYpsoRAbPZG5WCCQAJfJ2HLhobxj1eCxz0tzFI3A==}
+    engines: {node: '>= 14.0'}
+    hasBin: true
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0-rc.1
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+    dependencies:
+      '@bundle-stats/plugin-webpack-filter': 4.8.4(core-js@3.35.0)
+      '@bundle-stats/plugin-webpack-validate': 4.8.4
+      core-js: 3.35.0
+      cosmiconfig: 9.0.0(typescript@5.3.3)
+      debug: 4.3.4
+      dotenv: 16.3.1
+      env-ci: 7.3.0
+      fs-extra: 11.2.0
+      isomorphic-fetch: 3.0.0
+      lodash: 4.17.21
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - typescript
     dev: true
 
   /@rollup/plugin-inject@5.0.3(rollup@3.29.4):
@@ -9548,6 +9598,11 @@ packages:
     requiresBuild: true
     dev: true
 
+  /core-js@3.35.0:
+    resolution: {integrity: sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==}
+    requiresBuild: true
+    dev: true
+
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
@@ -9584,6 +9639,22 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    dev: true
+
+  /cosmiconfig@9.0.0(typescript@5.3.3):
+    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      typescript: 5.3.3
     dev: true
 
   /create-ecdh@4.0.4:
@@ -10184,6 +10255,20 @@ packages:
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  /env-ci@7.3.0:
+    resolution: {integrity: sha512-L8vK54CSjKB4pwlwx0YaqeBdUSGufaLHl/pEgD+EqnMrYCVUA8HzMjURALSyvOlC57e953yN7KyXS63qDoc3Rg==}
+    engines: {node: '>=12.20'}
+    dependencies:
+      execa: 5.1.1
+      fromentries: 1.3.2
+      java-properties: 1.0.2
+    dev: true
+
+  /env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+    dev: true
 
   /envinfo@7.10.0:
     resolution: {integrity: sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==}
@@ -11376,6 +11461,10 @@ packages:
     resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
     dev: true
 
+  /fromentries@1.3.2:
+    resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
+    dev: true
+
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: true
@@ -11391,6 +11480,15 @@ packages:
 
   /fs-extra@11.1.1:
     resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
+  /fs-extra@11.2.0:
+    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
     engines: {node: '>=14.14'}
     dependencies:
       graceful-fs: 4.2.11
@@ -12653,6 +12751,15 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /isomorphic-fetch@3.0.0:
+    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
+    dependencies:
+      node-fetch: 2.7.0
+      whatwg-fetch: 3.6.20
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
   /isomorphic-timers-promises@1.0.1:
     resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
     engines: {node: '>=10'}
@@ -12739,6 +12846,11 @@ packages:
       chalk: 4.1.2
       filelist: 1.0.4
       minimatch: 3.1.2
+    dev: true
+
+  /java-properties@1.0.2:
+    resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
+    engines: {node: '>= 0.6.0'}
     dev: true
 
   /javascript-natural-sort@0.7.1:
@@ -16410,6 +16522,15 @@ packages:
       rollup: 3.29.4
     dev: true
 
+  /rollup-plugin-webpack-stats@0.2.3(rollup@3.29.4):
+    resolution: {integrity: sha512-X9I9eZJPaEaYpyQgHgIH0PVJ1c8v+kPXbpWrcHQWwX6LhqqqF7oW5o0RlsCsyeQBStSah1i/oRUPAlk754ClFw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      rollup: ^3.0.0 || ^4.0.0
+    dependencies:
+      rollup: 3.29.4
+    dev: true
+
   /rollup@3.29.2:
     resolution: {integrity: sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
@@ -17150,6 +17271,11 @@ packages:
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /superstruct@1.0.3:
+    resolution: {integrity: sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==}
+    engines: {node: '>=14.0.0'}
     dev: true
 
   /supertest@6.3.3:
@@ -19136,6 +19262,10 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       iconv-lite: 0.6.3
+    dev: true
+
+  /whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
     dev: true
 
   /whatwg-mimetype@3.0.0:


### PR DESCRIPTION
Relative CI does “In-depth bundle analysis and monitoring” and could help us to keep an eye on our bundle size.

More and more users install our packages, and their users probably download the bundle probably a million times already. I think we should be careful with adding more dependencies, and should actively look for ways to reduce the bundle size.

Once the integration works, there are a few possibilities. I’m mostly looking forward to an automated PR comments with the bundle size changes. What I’ve configured for testing purposes:

* New dependencies require approval
* Duplicate dependencies, require approval.
* If the bundle grows by more than 10 kb, require approval.
* If the bundle grows by more than 2 %, the GitHub check will fail.
* If the bundle grows by less than 2 %, or even shrinks, the GitHub check will be green.

Probably need to fine tune/deactive some of them eventually.

BTW it’s free for open source projects