### PR TITLE
fix: add explicit table alignment rules

### DIFF
--- a/.changeset/angry-mayflies-add.md
+++ b/.changeset/angry-mayflies-add.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+Fix markdown table alignment

--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -253,13 +253,13 @@ watch(
   background: var(--theme-background-2, var(--default-theme-background-2));
 }
 
-.markdown :deep(tr) > [align=left] {
+.markdown :deep(tr) > [align='left'] {
   text-align: left;
 }
-.markdown :deep(tr) > [align=right] {
+.markdown :deep(tr) > [align='right'] {
   text-align: right;
 }
-.markdown :deep(tr) > [align=center] {
+.markdown :deep(tr) > [align='center'] {
   text-align: center;
 }
 </style>

--- a/packages/api-reference/src/components/Content/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/Content/MarkdownRenderer.vue
@@ -252,6 +252,16 @@ watch(
   border-left-color: transparent;
   background: var(--theme-background-2, var(--default-theme-background-2));
 }
+
+.markdown :deep(tr) > [align=left] {
+  text-align: left;
+}
+.markdown :deep(tr) > [align=right] {
+  text-align: right;
+}
+.markdown :deep(tr) > [align=center] {
+  text-align: center;
+}
 </style>
 
 <style lang="postcss">


### PR DESCRIPTION
**Problem**
Currently, tables do not respect markdown column alignment.

**Explanation**
This happens because align key is deprecated & some browsers potentially ignore it now. You also use `text-align: left`, but disabling that doesn't fix it so I'm not 100% sure.

**Solution**
With this PR, I add explicit column alignment rules.

Note on implementation - its not a particularly graceful solution, if loops were available with something like sass or less, or if [attr](https://developer.mozilla.org/en-US/docs/Web/CSS/attr) was [supported by browsers](https://caniuse.com/css3-attr), that would be nicer but its not a huge deal.
