### PR TITLE
feat: add default state for api client collapsed panels

### DIFF
--- a/.changeset/late-emus-fry.md
+++ b/.changeset/late-emus-fry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: add default state for api client collapsed panels

--- a/packages/api-client/src/components/ApiClient/Request/RequestBody.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestBody.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { CodeMirror } from '@scalar/use-codemirror'
+import { computed } from 'vue'
 
 import { useRequestStore } from '../../../stores/requestStore'
 import { CollapsibleSection } from '../../CollapsibleSection'

--- a/packages/api-client/src/components/ApiClient/Request/RequestCookies.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestCookies.vue
@@ -20,7 +20,9 @@ function addAnotherHandler() {
 }
 </script>
 <template>
-  <CollapsibleSection title="Cookies">
+  <CollapsibleSection
+    :defaultOpen="activeRequest.cookies && activeRequest.cookies.length > 0"
+    title="Cookies">
     <template v-if="!cookies || cookies.length === 0">
       <div class="scalar-api-client__empty-state">
         <button

--- a/packages/api-client/src/components/ApiClient/Request/RequestHeaders.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestHeaders.vue
@@ -20,7 +20,9 @@ function addAnotherHandler() {
 }
 </script>
 <template>
-  <CollapsibleSection title="Headers">
+  <CollapsibleSection
+    :defaultOpen="activeRequest.headers && activeRequest.headers.length > 0"
+    title="Headers">
     <template v-if="!headers || headers.length === 0">
       <div class="scalar-api-client__empty-state">
         <button

--- a/packages/api-client/src/components/ApiClient/Request/RequestQuery.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestQuery.vue
@@ -21,7 +21,9 @@ function addAnotherHandler() {
 }
 </script>
 <template>
-  <CollapsibleSection title="Query Parameters">
+  <CollapsibleSection
+    :defaultOpen="activeRequest.query && activeRequest.query.length > 0"
+    title="Query Parameters">
     <template v-if="!queries || queries.length === 0">
       <div class="scalar-api-client__empty-state">
         <button

--- a/packages/api-client/src/components/ApiClient/Request/RequestVariables.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestVariables.vue
@@ -21,7 +21,9 @@ function addAnotherHandler() {
 }
 </script>
 <template>
-  <CollapsibleSection title="Variables">
+  <CollapsibleSection
+    :defaultOpen="activeRequest.variables && activeRequest.variables.length > 0"
+    title="Variables">
     <template v-if="!variables || variables.length === 0">
       <div class="scalar-api-client__empty-state">
         <button

--- a/packages/api-client/src/components/CollapsibleSection/CollapsibleSection.vue
+++ b/packages/api-client/src/components/CollapsibleSection/CollapsibleSection.vue
@@ -1,19 +1,44 @@
 <script lang="ts" setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
+import { ref, watch } from 'vue'
 
-defineProps<{
-  title?: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    title?: string
+    defaultOpen?: boolean
+  }>(),
+  {
+    defaultOpen: true,
+  },
+)
+
+const collapseButton = ref<typeof DisclosureButton | null>(null)
+const disclosureButton = ref<typeof Disclosure | null>(null)
+
+const openCopy = ref(props.defaultOpen)
+
+watch(
+  () => props.defaultOpen,
+  (newValue, oldValue) => {
+    if (newValue !== oldValue && newValue !== openCopy.value) {
+      collapseButton.value?.el.click()
+    }
+  },
+)
 </script>
 
 <template>
   <Disclosure
+    ref="disclosureButton"
     v-slot="{ open }"
-    :defaultOpen="true">
+    :defaultOpen="defaultOpen">
     <div
       class="scalar-api-client__item"
       :class="{ 'scalar-api-client__item--open': open }">
-      <DisclosureButton class="scalar-api-client__toggle">
+      <DisclosureButton
+        ref="collapseButton"
+        class="scalar-api-client__toggle"
+        @click="openCopy = !openCopy">
         <svg
           class="scalar-api-client__toggle__icon"
           height="10"


### PR DESCRIPTION
**Problem**
We always show all collapsed sections even if there's no content, this can add visual clutter

https://github.com/scalar/scalar/assets/6176314/df23e939-74b8-4b9a-ad97-a0d07083105a

**Explanation**
We don't check to see the content in the section

**Solution**
We watch to see the active request, i had to do some magic with the headlessui component. but you can't have too much magic ✨ 

We might want to have a slight placeholder to show that there's nothing in the section (i.e. No Variables)

https://github.com/scalar/scalar/assets/6176314/0ecf52b1-512a-43f7-bb09-019c6689e667

