### PR TITLE
fix: autocomplete for search input, fix #885

### DIFF
--- a/.changeset/forty-garlics-exist.md
+++ b/.changeset/forty-garlics-exist.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: search input has autocomplete enabled

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -272,8 +272,12 @@ const onSearchResultClick = (entry: Fuse.FuseResult<FuseData>) => {
       class="ref-search-container">
       <input
         v-model="searchText"
+        autocapitalize="off"
+        autocomplete="off"
+        autocorrect="off"
         class="ref-search-input"
         placeholder="Search …"
+        spellcheck="false"
         type="text"
         @input="fuseSearch" />
     </div>


### PR DESCRIPTION
This PR disables autocomplete, autocorrect, autocapitalize and spellcheck for the search input.

IMHO those smart features aren’t very helpful when searching in a technical reference.

See #885
