### PR TITLE
fix: response examples with a single value do not render, fix #894

### DIFF
--- a/.changeset/slimy-paws-confess.md
+++ b/.changeset/slimy-paws-confess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: response examples with a single value don’t render

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/ExampleResponse.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/ExampleResponse.vue
@@ -43,7 +43,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
     ">
     <CodeMirror
       :content="
-        prettyPrintJson(mapFromObject(response?.examples)[0].response.response)
+        prettyPrintJson(mapFromObject(response?.examples)[0].value?.value)
       "
       :languages="['json']"
       readOnly />


### PR DESCRIPTION
There was a typo within the example responses. This PR fixes it. :)

For more context, see #894.
