### PR TITLE
feat: improve custom example block, fix #899

### DIFF
--- a/.changeset/moody-snails-jog.md
+++ b/.changeset/moody-snails-jog.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: improve custom example block with try request button, path and improved select

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/CustomRequestExamples.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/CustomRequestExamples.vue
@@ -6,6 +6,7 @@ import { computed, ref, watch } from 'vue'
 
 import type { CustomRequestExample, TransformedOperation } from '../../../types'
 import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
+import TextSelect from './TextSelect.vue'
 
 const props = defineProps<{
   operation: TransformedOperation
@@ -77,26 +78,21 @@ const { copyToClipboard } = useClipboard()
         <slot name="header" />
       </div>
       <template #actions>
-        <div class="language-select">
-          <span>{{ currentExample.label }}</span>
-          <select
-            :value="selectedExample"
-            @input="
-              (event) => (
-                (selectedExample = parseInt(
-                  (event.target as HTMLSelectElement).value,
-                )),
-                10
-              )
-            ">
-            <option
-              v-for="(example, index) in examples"
-              :key="index"
-              :value="index">
-              {{ example.label }}
-            </option>
-          </select>
-        </div>
+        <TextSelect
+          :modelValue="selectedExample"
+          :options="
+            examples.map((example, index) => {
+              return {
+                value: index.toString(),
+                label: example.label,
+              }
+            })
+          "
+          @update:modelValue="
+            (value) => ((selectedExample = parseInt(value)), 10)
+          ">
+          {{ currentExample.label }}
+        </TextSelect>
         <button
           class="copy-button"
           type="button"
@@ -155,56 +151,6 @@ const { copyToClipboard } = useClipboard()
 .request-method--put {
   color: var(--theme-color-orange, var(--default-theme-color-orange));
 }
-.language-select {
-  position: relative;
-  padding-right: 9px;
-  height: fit-content;
-  padding-left: 12px;
-  border-right: 1px solid
-    var(--theme-border-color, var(--default-theme-border-color));
-}
-.language-select select {
-  border: none;
-  outline: none;
-  cursor: pointer;
-  background: var(--theme-background-3, var(--default-theme-background-3));
-  box-shadow: -2px 0 0 0
-    var(--theme-background-3, var(--default-theme-background-3));
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  appearance: none;
-}
-.language-select span {
-  font-size: var(--theme-mini, var(--default-theme-mini));
-  color: var(--theme-color-2, var(--default-theme-color-2));
-  font-weight: var(--theme-semibold, var(--default-theme-semibold));
-  white-space: nowrap;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.language-select:hover span {
-  color: var(--theme-color-1, var(--default-theme-color-1));
-}
-.language-select span:after {
-  content: '';
-  width: 7px;
-  height: 7px;
-  transform: rotate(45deg) translate3d(-2px, -2px, 0);
-  display: block;
-  margin-left: 6px;
-  box-shadow: 1px 1px 0 currentColor;
-}
-.language-select span:hover {
-  background: var(--theme-background-2, var(--default-theme-background-2));
-}
-
 .copy-button {
   appearance: none;
   -webkit-appearance: none;

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -18,6 +18,7 @@ import { useGlobalStore } from '../../../stores'
 import { useTemplateStore } from '../../../stores/template'
 import type { TransformedOperation } from '../../../types'
 import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
+import TextSelect from './TextSelect.vue'
 
 const props = defineProps<{
   operation: TransformedOperation
@@ -122,38 +123,32 @@ computed(() => {
         <slot name="header" />
       </div>
       <template #actions>
-        <div class="language-select">
-          <span>
-            {{ getTargetTitle(state.selectedClient) }}
-            {{ getClientTitle(state.selectedClient) }}
-          </span>
-          <select
-            :value="JSON.stringify(state.selectedClient)"
-            @input="
-              (event) =>
-                setItem(
-                  'selectedClient',
-                  JSON.parse((event.target as HTMLSelectElement).value),
-                )
-            ">
-            <optgroup
-              v-for="target in availableTargets"
-              :key="target.key"
-              :label="target.title">
-              <option
-                v-for="client in target.clients"
-                :key="client.key"
-                :value="
-                  JSON.stringify({
-                    targetKey: target.key,
-                    clientKey: client.key,
-                  })
-                ">
-                {{ client.title }}
-              </option>
-            </optgroup>
-          </select>
-        </div>
+        <TextSelect
+          :modelValue="JSON.stringify(state.selectedClient)"
+          :options="
+            availableTargets.map((target) => {
+              return {
+                value: target.key,
+                label: target.title,
+                options: target.clients.map((client) => {
+                  return {
+                    value: JSON.stringify({
+                      targetKey: target.key,
+                      clientKey: client.key,
+                    }),
+                    label: client.title,
+                  }
+                }),
+              }
+            })
+          "
+          @update:modelValue="
+            (value) => setItem('selectedClient', JSON.parse(value))
+          ">
+          {{ getTargetTitle(state.selectedClient) }}
+          {{ getClientTitle(state.selectedClient) }}
+        </TextSelect>
+
         <button
           class="copy-button"
           type="button"
@@ -212,55 +207,6 @@ computed(() => {
 .request-method--put {
   color: var(--theme-color-orange, var(--default-theme-color-orange));
 }
-.language-select {
-  position: relative;
-  padding-right: 9px;
-  height: fit-content;
-  padding-left: 12px;
-  border-right: 1px solid
-    var(--theme-border-color, var(--default-theme-border-color));
-}
-.language-select select {
-  border: none;
-  outline: none;
-  cursor: pointer;
-  background: var(--theme-background-3, var(--default-theme-background-3));
-  box-shadow: -2px 0 0 0
-    var(--theme-background-3, var(--default-theme-background-3));
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  appearance: none;
-}
-.language-select span {
-  font-size: var(--theme-mini, var(--default-theme-mini));
-  color: var(--theme-color-2, var(--default-theme-color-2));
-  font-weight: var(--theme-semibold, var(--default-theme-semibold));
-  white-space: nowrap;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.language-select:hover span {
-  color: var(--theme-color-1, var(--default-theme-color-1));
-}
-.language-select span:after {
-  content: '';
-  width: 7px;
-  height: 7px;
-  transform: rotate(45deg) translate3d(-2px, -2px, 0);
-  display: block;
-  margin-left: 6px;
-  box-shadow: 1px 1px 0 currentColor;
-}
-.language-select span:hover {
-  background: var(--theme-background-2, var(--default-theme-background-2));
-}
 
 .copy-button {
   appearance: none;
@@ -296,9 +242,6 @@ computed(() => {
   height: 13px;
 }
 
-.scalar-card-header-actions {
-  display: flex;
-}
 .scalar-card-footer {
   display: flex;
   justify-content: flex-end;

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
@@ -72,6 +72,9 @@ const customRequestExamples = computed(() => {
                   class="example-path"
                   :path="operation.path" />
               </template>
+              <template #footer>
+                <TryRequestButton :operation="operation" />
+              </template>
             </CustomRequestExamples>
             <ExampleRequest
               v-else

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpoint.vue
@@ -66,7 +66,13 @@ const customRequestExamples = computed(() => {
             <CustomRequestExamples
               v-if="customRequestExamples"
               :examples="customRequestExamples"
-              :operation="operation" />
+              :operation="operation">
+              <template #header>
+                <EndpointPath
+                  class="example-path"
+                  :path="operation.path" />
+              </template>
+            </CustomRequestExamples>
             <ExampleRequest
               v-else
               :operation="operation">

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/TextSelect.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/TextSelect.vue
@@ -1,0 +1,110 @@
+<script lang="ts" setup>
+defineProps<{
+  modelValue: any
+  options: {
+    value: string
+    label: string
+    options?: {
+      value: string
+      label: string
+    }[]
+  }[]
+}>()
+
+defineEmits<{
+  (event: 'update:modelValue', value: any): void
+}>()
+</script>
+
+<template>
+  <div
+    class="text-select"
+    :class="options.length === 1 ? 'text-select--single-option' : ''">
+    <span>
+      <slot />
+    </span>
+    <select
+      :value="modelValue"
+      @input="
+        (event) =>
+          $emit('update:modelValue', (event.target as HTMLSelectElement).value)
+      ">
+      <template
+        v-for="option in options"
+        :key="option.value">
+        <template v-if="option.options">
+          <optgroup :label="option.label">
+            <option
+              v-for="child in option.options"
+              :key="child.value"
+              :value="child.value">
+              {{ child.label }}
+            </option>
+          </optgroup>
+        </template>
+        <template v-else>
+          <option
+            :key="option.value"
+            :value="option.value">
+            {{ option.label }}
+          </option>
+        </template>
+      </template>
+    </select>
+  </div>
+</template>
+
+<style>
+.text-select {
+  position: relative;
+  padding-right: 9px;
+  height: fit-content;
+  padding-left: 12px;
+  border-right: 1px solid
+    var(--theme-border-color, var(--default-theme-border-color));
+}
+.text-select--single-option {
+  pointer-events: none;
+}
+.text-select select {
+  border: none;
+  outline: none;
+  cursor: pointer;
+  background: var(--theme-background-3, var(--default-theme-background-3));
+  box-shadow: -2px 0 0 0
+    var(--theme-background-3, var(--default-theme-background-3));
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+.text-select span {
+  font-size: var(--theme-mini, var(--default-theme-mini));
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.text-select:hover span {
+  color: var(--theme-color-1, var(--default-theme-color-1));
+}
+.text-select:not(.text-select--single-option) span::after {
+  content: '';
+  width: 7px;
+  height: 7px;
+  transform: rotate(45deg) translate3d(-2px, -2px, 0);
+  display: block;
+  margin-left: 6px;
+  box-shadow: 1px 1px 0 currentColor;
+}
+.text-select span:hover {
+  background: var(--theme-background-2, var(--default-theme-background-2));
+}
+</style>


### PR DESCRIPTION
This PR improves the custom example component:

* Show path
* Show Try Request button
* Add a generic TextSelect and use it for the generated request and the custom request component
* When there’s a single entry only, just show the text

See #899, #870

Example: https://sandbox.scalar.com/e/QUbEt#tag/default/post/foobar

<img width="610" alt="Screenshot 2024-01-30 at 13 26 35" src="https://github.com/scalar/scalar/assets/1577992/441b33fb-40d5-40ad-9b69-d94289d4bb2a">
<img width="601" alt="Screenshot 2024-01-30 at 13 26 25" src="https://github.com/scalar/scalar/assets/1577992/6afe479d-4f45-4625-aa8d-fa315e107118">