### PR TITLE
fix: don't scale codemirror text on mobile webkit

### DIFF
--- a/.changeset/mighty-rockets-watch.md
+++ b/.changeset/mighty-rockets-watch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-codemirror': patch
+---
+
+fix: don't scale codemirror text on mobile webkit

--- a/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
+++ b/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
@@ -234,6 +234,8 @@ defineExpose({
   max-width: 100%;
   cursor: text;
   font-size: var(--theme-small, var(--default-theme-small));
+  /* Don't scale wide text on mobile because we let it scroll */
+  -webkit-text-size-adjust: 100%;
 }
 
 /** URL input */


### PR DESCRIPTION
Mobile safari is cursed

https://stackoverflow.com/questions/5303263/fix-font-size-issue-on-mobile-safari-iphone-where-text-is-rendered-inconsisten

<img width="400px" src="https://github.com/scalar/scalar/assets/6374090/fb9fbd48-7c44-4b3c-bec7-dcab048c3bd5" />
<img width="400px" src="https://github.com/scalar/scalar/assets/6374090/7b850f56-8c9f-4d5c-bb8f-2a4ed055f420" />

