### PR TITLE
fix: swagger 2.0 response body isn’t shown

### DIFF
--- a/.changeset/tame-buses-warn.md
+++ b/.changeset/tame-buses-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: swagger 2.0 response body isn’t shown

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
@@ -50,7 +50,9 @@ const currentResponse = computed(() => {
 })
 
 const currentJsonResponse = computed(
-  () => currentResponse.value?.content?.['application/json'],
+  () =>
+    currentResponse.value?.content?.['application/json'] ??
+    currentResponse.value,
 )
 
 const changeTab = (index: number) => {

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/PathResponses/PathResponses.vue
@@ -51,7 +51,9 @@ const currentResponse = computed(() => {
 
 const currentJsonResponse = computed(
   () =>
+    // OpenAPI 3.x
     currentResponse.value?.content?.['application/json'] ??
+    // Swagger 2.0
     currentResponse.value,
 )
 


### PR DESCRIPTION
Currently, we ignore the Swagger 2.0 response body. This PR fixes it.

See #912
