### PR TITLE
chore(fastifyApiReference): grammar fixes in warning message

### DIFF
--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -177,7 +177,7 @@ const fastifyApiReference: FastifyPluginAsync<
     !hasSwaggerPlugin
   ) {
     fastify.log.warn(
-      '[@scalar/fastify-api-reference] You didn’t provide a spec.content or spec.url and @fastify/swagger could not be find either. Please provide one of these options.',
+      '[@scalar/fastify-api-reference] You didn’t provide a spec.content or spec.url, and @fastify/swagger could not be found. Please provide one of these options.',
     )
 
     return


### PR DESCRIPTION
**Problem**
Currently, the warning message is not grammatically correct.

**Explanation**
This happens because... 🤷 

**Solution**
With this PR, the grammar is corrected.
