### PR TITLE
fix: typo in Next.js version requirement, fix #938

### DIFF
--- a/.changeset/good-chefs-repeat.md
+++ b/.changeset/good-chefs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nextjs-api-reference': patch
+---
+
+fix: typo in Next.js version requirement

--- a/packages/nextjs-api-reference/package.json
+++ b/packages/nextjs-api-reference/package.json
@@ -57,7 +57,7 @@
     "vite-plugin-dts": "^3.6.3"
   },
   "peerDependencies": {
-    "next": "^13 | ^14",
+    "next": "^13 || ^14",
     "react": "^18"
   }
 }


### PR DESCRIPTION
There was a typo (single pipe vs. double pipe) in the Next.js version requirement. Let’s fix this quickly!
