### PR TITLE
fix: remove auto open tags on scroll

### DIFF
--- a/.changeset/hungry-masks-grow.md
+++ b/.changeset/hungry-masks-grow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: only open models sidebar section on scroll

--- a/packages/api-reference/src/components/Section/Section.vue
+++ b/packages/api-reference/src/components/Section/Section.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useNavState, useSidebar } from '../../hooks'
+import { useNavState } from '../../hooks'
 import IntersectionObserver from '../IntersectionObserver.vue'
 
 const props = defineProps<{
@@ -7,8 +7,7 @@ const props = defineProps<{
   label?: string
 }>()
 
-const { getSectionId, hash, isIntersectionEnabled } = useNavState()
-const { setCollapsedSidebarItem } = useSidebar()
+const { hash, isIntersectionEnabled } = useNavState()
 
 function handleScroll() {
   if (!props.label || !isIntersectionEnabled.value) return
@@ -17,9 +16,6 @@ function handleScroll() {
   // this is why we set the hash value directly
   window.history.replaceState({}, '', `#${props.id}`)
   hash.value = props.id ?? ''
-
-  // We can also open the next section if we are continuing to scroll down
-  setCollapsedSidebarItem(getSectionId(props.id), true)
 }
 </script>
 <template>

--- a/packages/api-reference/src/components/Section/Section.vue
+++ b/packages/api-reference/src/components/Section/Section.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useNavState } from '../../hooks'
+import { useNavState, useSidebar } from '../../hooks'
 import IntersectionObserver from '../IntersectionObserver.vue'
 
 const props = defineProps<{
@@ -7,7 +7,8 @@ const props = defineProps<{
   label?: string
 }>()
 
-const { hash, isIntersectionEnabled } = useNavState()
+const { getSectionId, hash, isIntersectionEnabled } = useNavState()
+const { setCollapsedSidebarItem } = useSidebar()
 
 function handleScroll() {
   if (!props.label || !isIntersectionEnabled.value) return
@@ -16,6 +17,10 @@ function handleScroll() {
   // this is why we set the hash value directly
   window.history.replaceState({}, '', `#${props.id}`)
   hash.value = props.id ?? ''
+
+  // Open models on scroll
+  if (props.id?.startsWith('model'))
+    setCollapsedSidebarItem(getSectionId(props.id), true)
 }
 </script>
 <template>


### PR DESCRIPTION
**Problem**
Tags will auto-open as you scroll down

**Solution**
With this PR we remove that auto-open. Maybe we can add it as an option down the road when we fix performance.
