### PR TITLE
fix: shrink label and not actions on mobile

### DIFF
--- a/.changeset/eighty-ravens-mate.md
+++ b/.changeset/eighty-ravens-mate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: shrink label and not actions on mobile

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpointAccordion.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpointAccordion.vue
@@ -156,6 +156,10 @@ const { getOperationId } = useNavState()
 .endpoint-label-path {
   font-family: var(--default-theme-font-code);
   font-size: var(--theme-mini, var(--default-theme-mini));
+
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 .endpoint-label-path :deep(em) {
   color: var(--theme-color-2, var(--default-theme-color-2));
@@ -163,6 +167,9 @@ const { getOperationId } = useNavState()
 .endpoint-label-name {
   color: var(--theme-color-2, var(--default-theme-color-2));
   font-size: var(--theme-small, var(--default-theme-small));
+
+  /* Concatenate the name before we shrink the path */
+  flex-shrink: 1000000000;
 
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -172,7 +179,8 @@ const { getOperationId } = useNavState()
 .endpoint-try-hint {
   padding: 6px;
   height: 24px;
-  aspect-ratio: 1 / 1;
+  width: 24px;
+  flex-shrink: 0;
   opacity: 0.44;
 }
 


### PR DESCRIPTION
## Before (iOS):

<img width="300px" src="https://github.com/scalar/scalar/assets/6374090/b0e4c184-eb28-4d42-94d5-132c719955f6" />
<img width="300px" src="https://github.com/scalar/scalar/assets/6374090/b0b6a6bc-bb97-43ed-9a95-dac2e286d41e" />

## After (iOS):

<img width="300px" src="https://github.com/scalar/scalar/assets/6374090/2c5fa7a9-d07d-40aa-983e-6b5007fbc5a6" />
<img width="300px" src="https://github.com/scalar/scalar/assets/6374090/e15e1d68-00e4-4efb-b371-10a3290838f8" />
