### PR TITLE
feat: update components to support all basic http request methods

### DIFF
--- a/.changeset/sour-brooms-kick.md
+++ b/.changeset/sour-brooms-kick.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': minor
+'@scalar/api-client': minor
+---
+
+feat: update components to support all basic http request methods

--- a/packages/api-client/src/components/ApiClient/ApiClient.vue
+++ b/packages/api-client/src/components/ApiClient/ApiClient.vue
@@ -6,6 +6,7 @@ import { useMediaQuery } from '@vueuse/core'
 import { ref, watch } from 'vue'
 
 import { useRequestStore } from '../../stores'
+import HttpMethod from '../HttpMethod.vue'
 import AddressBar from './AddressBar.vue'
 import { Request } from './Request'
 import { Response } from './Response'
@@ -56,9 +57,10 @@ useKeyboardEvent({
 
 <template>
   <ThemeStyles :id="theme" />
-  <div
+  <HttpMethod
     class="scalar-api-client"
-    :class="`scalar-api-client--${activeRequest.type.toLowerCase() || 'get'}`"
+    :method="activeRequest.type ?? 'get'"
+    property="--default-scalar-api-client-color"
     @keydown.esc="emit('escapeKeyPress')">
     <AddressBar
       :proxyUrl="proxyUrl"
@@ -107,7 +109,7 @@ useKeyboardEvent({
         </TabGroup>
       </template>
     </div>
-  </div>
+  </HttpMethod>
 </template>
 
 <style>
@@ -141,61 +143,6 @@ useKeyboardEvent({
 }
 .scalar-api-client pre {
   font-family: var(--theme-font-code, var(--default-theme-font-code));
-}
-
-.scalar-api-client--post {
-  --default-scalar-api-client-color: var(
-    --theme-color-green,
-    var(--default-theme-color-green)
-  );
-  --default-scalar-api-client-background: var(
-    --theme-post-background,
-    var(--default-theme-post-background)
-  );
-}
-
-.scalar-api-client--delete {
-  --default-scalar-api-client-color: var(
-    --theme-color-red,
-    var(--default-theme-color-red)
-  );
-  --default-scalar-api-client-background: var(
-    --theme-delete-background,
-    var(--default-theme-delete-background)
-  );
-}
-
-.scalar-api-client--patch {
-  --default-scalar-api-client-color: var(
-    --theme-color-yellow,
-    var(--default-theme-color-yellow)
-  );
-  --default-scalar-api-client-background: var(
-    --theme-patch-background,
-    var(--default-theme-patch-background)
-  );
-}
-
-.scalar-api-client--get {
-  --default-scalar-api-client-color: var(
-    --theme-color-blue,
-    var(--default-theme-color-blue)
-  );
-  --default-scalar-api-client-background: var(
-    --theme-get-background,
-    var(--default-theme-get-background)
-  );
-}
-
-.scalar-api-client--put {
-  --default-scalar-api-client-color: var(
-    --theme-color-orange,
-    var(--default-theme-color-orange)
-  );
-  --default-scalar-api-client-background: var(
-    --theme-put-background,
-    var(--default-theme-put-background)
-  );
 }
 
 .scalar-api-client__mobile-navigation {

--- a/packages/api-client/src/components/HttpMethod.vue
+++ b/packages/api-client/src/components/HttpMethod.vue
@@ -8,9 +8,9 @@ import {
 } from '../fixtures'
 
 const props = defineProps<{
-  /** The type of element to render as, defaults to `div` */
+  /** The type of element to render as, defaults to `span` */
   as?: Component | string
-  /** The css style property or variable that will be set to the request method color */
+  /** The css style property or variable that will be set to the request method color, defaults to `color` */
   property?: string
   /** Whether or not to abbreviated the slot content */
   short?: boolean
@@ -31,15 +31,11 @@ const color = computed<string>(() => {
     return requestMethodColors[normalized.value]
   return 'var(--theme-color-ghost, var(--default-theme-color-ghost))'
 })
-
-const style = computed<object>(() =>
-  props.property ? { [props.property]: color.value } : {},
-)
 </script>
 <template>
   <component
-    :is="as ?? 'div'"
-    :style="style">
+    :is="as ?? 'span'"
+    :style="{ [property || 'color']: color }">
     <slot v-bind="{ normalized, abbreviated, color }">{{
       short ? abbreviated : normalized
     }}</slot>

--- a/packages/api-client/src/components/HttpMethod.vue
+++ b/packages/api-client/src/components/HttpMethod.vue
@@ -1,29 +1,47 @@
 <script setup lang="ts">
 import { type Component, computed } from 'vue'
 
-import { isRequestMethod, requestMethodColors } from '../fixtures'
+import {
+  isRequestMethod,
+  requestMethodAbbreviations,
+  requestMethodColors,
+} from '../fixtures'
 
 const props = defineProps<{
   /** The type of element to render as, defaults to `div` */
   as?: Component | string
-  /** The css property or variable that will be set to the request method color, defaults to `color` */
+  /** The css style property or variable that will be set to the request method color */
   property?: string
+  /** Whether or not to abbreviated the slot content */
+  short?: boolean
   /** The HTTP method to show */
   method: string
 }>()
 
-const uppercase = computed(() => props.method.toUpperCase())
+/** A trimmed and uppercase version of the method */
+const normalized = computed(() => props.method.trim().toUpperCase())
 
+const abbreviated = computed<string>(() => {
+  if (isRequestMethod(normalized.value))
+    return requestMethodAbbreviations[normalized.value]
+  return normalized.value.slice(0, 4)
+})
 const color = computed<string>(() => {
-  if (isRequestMethod(uppercase.value))
-    return requestMethodColors[uppercase.value]
+  if (isRequestMethod(normalized.value))
+    return requestMethodColors[normalized.value]
   return 'var(--theme-color-ghost, var(--default-theme-color-ghost))'
 })
+
+const style = computed<object>(() =>
+  props.property ? { [props.property]: color.value } : {},
+)
 </script>
 <template>
   <component
     :is="as ?? 'div'"
-    :style="{ [property ?? 'color']: color }">
-    <slot v-bind="{ uppercase, color }">{{ uppercase }}</slot>
+    :style="style">
+    <slot v-bind="{ normalized, abbreviated, color }">{{
+      short ? abbreviated : normalized
+    }}</slot>
   </component>
 </template>

--- a/packages/api-client/src/components/HttpMethod.vue
+++ b/packages/api-client/src/components/HttpMethod.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { type Component, computed } from 'vue'
+
+import { isRequestMethod, requestMethodColors } from '../fixtures'
+
+const props = defineProps<{
+  /** The type of element to render as, defaults to `div` */
+  as?: Component | string
+  /** The css property or variable that will be set to the request method color, defaults to `color` */
+  property?: string
+  /** The HTTP method to show */
+  method: string
+}>()
+
+const uppercase = computed(() => props.method.toUpperCase())
+
+const color = computed<string>(() => {
+  if (isRequestMethod(uppercase.value))
+    return requestMethodColors[uppercase.value]
+  return 'var(--theme-color-ghost, var(--default-theme-color-ghost))'
+})
+</script>
+<template>
+  <component
+    :is="as ?? 'div'"
+    :style="{ [property ?? 'color']: color }">
+    <slot v-bind="{ uppercase, color }">{{ uppercase }}</slot>
+  </component>
+</template>

--- a/packages/api-client/src/fixtures/httpRequestMethods.ts
+++ b/packages/api-client/src/fixtures/httpRequestMethods.ts
@@ -23,9 +23,9 @@ export const requestMethodColors: { [x in RequestMethod]: string } = {
     GET: 'var(--theme-color-blue, var(--default-theme-color-blue))',
     PUT: 'var(--theme-color-orange, var(--default-theme-color-orange))',
     OPTIONS: 'var(--theme-color-purple, var(--default-theme-color-purple))',
-    HEAD: 'var(--theme-color-ghost, var(--default-theme-color-ghost))',
-    CONNECT: 'var(--theme-color-ghost, var(--default-theme-color-ghost))',
-    TRACE: 'var(--theme-color-ghost, var(--default-theme-color-ghost))',
+    HEAD: 'var(--theme-color-2, var(--default-theme-color-2))',
+    CONNECT: 'var(--theme-color-2, var(--default-theme-color-2))',
+    TRACE: 'var(--theme-color-2, var(--default-theme-color-2))',
 }
 
 export const requestMethodAbbreviations: { [x in RequestMethod]: string } = {

--- a/packages/api-client/src/fixtures/httpRequestMethods.ts
+++ b/packages/api-client/src/fixtures/httpRequestMethods.ts
@@ -8,4 +8,23 @@ export const validRequestMethods = [
     'OPTIONS',
     'CONNECT',
     'TRACE',
-]
+] as const
+
+export type RequestMethod = typeof validRequestMethods[number];
+
+
+export function isRequestMethod(s: string): s is RequestMethod {
+return validRequestMethods.includes(s as RequestMethod)
+}
+
+export const requestMethodColors: { [x in RequestMethod]: string } = {
+    POST: 'var(--theme-color-green, var(--default-theme-color-green))',
+    DELETE: 'var(--theme-color-red, var(--default-theme-color-red))',
+    PATCH: 'var(--theme-color-yellow, var(--default-theme-color-yellow))',
+    GET: 'var(--theme-color-blue, var(--default-theme-color-blue))',
+    PUT: 'var(--theme-color-orange, var(--default-theme-color-orange))',
+    OPTIONS: 'var(--theme-color-purple, var(--default-theme-color-purple))',
+    HEAD: 'var(--theme-color-ghost, var(--default-theme-color-ghost))',
+    CONNECT: 'var(--theme-color-ghost, var(--default-theme-color-ghost))',
+    TRACE: 'var(--theme-color-ghost, var(--default-theme-color-ghost))',
+}

--- a/packages/api-client/src/fixtures/httpRequestMethods.ts
+++ b/packages/api-client/src/fixtures/httpRequestMethods.ts
@@ -10,8 +10,7 @@ export const validRequestMethods = [
     'TRACE',
 ] as const
 
-export type RequestMethod = typeof validRequestMethods[number];
-
+type RequestMethod = typeof validRequestMethods[number];
 
 export function isRequestMethod(s: string): s is RequestMethod {
 return validRequestMethods.includes(s as RequestMethod)
@@ -27,4 +26,16 @@ export const requestMethodColors: { [x in RequestMethod]: string } = {
     HEAD: 'var(--theme-color-ghost, var(--default-theme-color-ghost))',
     CONNECT: 'var(--theme-color-ghost, var(--default-theme-color-ghost))',
     TRACE: 'var(--theme-color-ghost, var(--default-theme-color-ghost))',
+}
+
+export const requestMethodAbbreviations: { [x in RequestMethod]: string } = {
+    POST: 'POST',
+    DELETE: 'DEL',
+    PATCH: 'PATCH',
+    GET: 'GET',
+    PUT: 'PUT',
+    OPTIONS: 'OPTS',
+    HEAD: 'HEAD',
+    CONNECT: 'CONN',
+    TRACE: 'TRACE',
 }

--- a/packages/api-client/src/helpers/normalizeRequestMethod.ts
+++ b/packages/api-client/src/helpers/normalizeRequestMethod.ts
@@ -1,4 +1,4 @@
-import { validRequestMethods } from '../fixtures'
+import { isRequestMethod } from '../fixtures'
 
 const defaultRequestMethod = 'GET'
 
@@ -18,10 +18,7 @@ export const normalizeRequestMethod = (method?: string) => {
   // Normalize the string
   const normalizedMethod = method.trim().toUpperCase()
 
-  // Make sure it’s a valid request method
-  const isValidRequestMethod = validRequestMethods.includes(normalizedMethod)
-
-  if (!isValidRequestMethod) {
+  if (!isRequestMethod(normalizedMethod)) {
     console.warn(
       `[sendRequest] ${method} is not a valid request method. Using ${defaultRequestMethod} as the default.`,
     )

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,4 +1,5 @@
 export { ApiClient } from './components/ApiClient'
+export { default as HttpMethod } from './components/HttpMethod.vue'
 
 export * from './helpers'
 export * from './stores/apiClientStore'

--- a/packages/api-reference/src/components/Content/EndpointsOverview.vue
+++ b/packages/api-reference/src/components/Content/EndpointsOverview.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { HttpMethod } from '@scalar/api-client'
 import { nextTick } from 'vue'
 
 import { useNavState, useSidebar } from '../../hooks'
@@ -53,9 +54,7 @@ async function scrollHandler(operation: TransformedOperation) {
                     :key="getOperationId(operation, tag)"
                     class="endpoint"
                     @click="scrollHandler(operation)">
-                    <span :class="operation.httpVerb">{{
-                      operation.httpVerb
-                    }}</span>
+                    <HttpMethod :method="operation.httpVerb" />
                     <span>{{ operation.path }}</span>
                   </a>
                 </div>
@@ -91,21 +90,6 @@ async function scrollHandler(operation: TransformedOperation) {
 }
 .endpoint span:first-of-type {
   text-transform: uppercase;
-}
-.endpoint .post {
-  color: var(--theme-color-green, var(--default-theme-color-green));
-}
-.endpoint .patch {
-  color: var(--theme-color-yellow, var(--default-theme-color-yellow));
-}
-.endpoint .get {
-  color: var(--theme-color-blue, var(--default-theme-color-blue));
-}
-.endpoint .delete {
-  color: var(--theme-color-red, var(--default-theme-color-red));
-}
-.endpoint .put {
-  color: var(--theme-color-orange, var(--default-theme-color-orange));
 }
 .endpoint .post,
 .endpoint .get,

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/CustomRequestExamples.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/CustomRequestExamples.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { HttpMethod } from '@scalar/api-client'
 import { ScalarIcon } from '@scalar/components'
 import { useClipboard } from '@scalar/use-clipboard'
 import { CodeMirror } from '@scalar/use-codemirror'
@@ -70,11 +71,9 @@ const { copyToClipboard } = useClipboard()
   <Card class="dark-mode">
     <CardHeader muted>
       <div class="request-header">
-        <span
+        <HttpMethod
           class="request-method"
-          :class="`request-method--${operation.httpVerb}`">
-          {{ operation.httpVerb }}
-        </span>
+          :method="operation.httpVerb" />
         <slot name="header" />
       </div>
       <template #actions>
@@ -136,21 +135,6 @@ const { copyToClipboard } = useClipboard()
 .request-method {
   font-family: var(--theme-font-code, var(--default-theme-font-code));
   text-transform: uppercase;
-}
-.request-method--post {
-  color: var(--theme-color-green, var(--default-theme-color-green));
-}
-.request-method--patch {
-  color: var(--theme-color-yellow, var(--default-theme-color-yellow));
-}
-.request-method--get {
-  color: var(--theme-color-blue, var(--default-theme-color-blue));
-}
-.request-method--delete {
-  color: var(--theme-color-red, var(--default-theme-color-red));
-}
-.request-method--put {
-  color: var(--theme-color-orange, var(--default-theme-color-orange));
 }
 .request-client-picker {
   padding-left: 12px;

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ExampleRequest.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { HttpMethod } from '@scalar/api-client'
 import { ScalarIcon } from '@scalar/components'
 import { snippetz } from '@scalar/snippetz'
 import { useClipboard } from '@scalar/use-clipboard'
@@ -133,11 +134,10 @@ computed(() => {
   <Card class="dark-mode">
     <CardHeader muted>
       <div class="request-header">
-        <span
+        <HttpMethod
+          as="span"
           class="request-method"
-          :class="`request-method--${operation.httpVerb}`">
-          {{ operation.httpVerb }}
-        </span>
+          :method="operation.httpVerb" />
         <slot name="header" />
       </div>
       <template #actions>
@@ -224,21 +224,6 @@ computed(() => {
 .request-method {
   font-family: var(--theme-font-code, var(--default-theme-font-code));
   text-transform: uppercase;
-}
-.request-method--post {
-  color: var(--theme-color-green, var(--default-theme-color-green));
-}
-.request-method--patch {
-  color: var(--theme-color-yellow, var(--default-theme-color-yellow));
-}
-.request-method--get {
-  color: var(--theme-color-blue, var(--default-theme-color-blue));
-}
-.request-method--delete {
-  color: var(--theme-color-red, var(--default-theme-color-red));
-}
-.request-method--put {
-  color: var(--theme-color-orange, var(--default-theme-color-orange));
 }
 .request-client-picker {
   padding-left: 12px;

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpointAccordion.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/ReferenceEndpointAccordion.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { HttpMethod } from '@scalar/api-client'
 import { ScalarIcon, ScalarIconButton } from '@scalar/components'
 import { useClipboard } from '@scalar/use-clipboard'
 
@@ -25,12 +26,14 @@ const { getOperationId } = useNavState()
   <SectionAccordion
     :id="getOperationId(operation, tag)"
     class="reference-endpoint"
-    :class="`reference-endpoint--${operation.httpVerb}`"
     transparent>
     <template #title>
       <h3 class="endpoint-header">
         <div class="endpoint-details">
-          <span class="endpoint-type">{{ operation.httpVerb }}</span>
+          <HttpMethod
+            class="endpoint-type"
+            :method="operation.httpVerb"
+            short />
           <Anchor
             :id="getOperationId(operation, tag)"
             class="endpoint-anchor">
@@ -74,22 +77,6 @@ const { getOperationId } = useNavState()
 </template>
 
 <style scoped>
-.reference-endpoint.reference-endpoint--post {
-  color: var(--theme-color-green, var(--default-theme-color-green));
-}
-.reference-endpoint.reference-endpoint--patch {
-  color: var(--theme-color-yellow, var(--default-theme-color-yellow));
-}
-.reference-endpoint.reference-endpoint--get {
-  color: var(--theme-color-blue, var(--default-theme-color-blue));
-}
-.reference-endpoint.reference-endpoint--delete {
-  color: var(--theme-color-red, var(--default-theme-color-red));
-}
-.reference-endpoint.reference-endpoint--put {
-  color: var(--theme-color-orange, var(--default-theme-color-orange));
-}
-
 .endpoint-header {
   display: flex;
   justify-content: space-between;
@@ -112,8 +99,9 @@ const { getOperationId } = useNavState()
   position: relative;
   z-index: 0;
 
-  width: 70px;
+  width: 60px;
   padding: 6px;
+  flex-shrink: 0;
 
   font-size: var(--theme-small, var(--default-theme-small));
 

--- a/packages/api-reference/src/components/Content/ReferenceEndpoint/TryRequestButton.vue
+++ b/packages/api-reference/src/components/Content/ReferenceEndpoint/TryRequestButton.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { HttpMethod } from '@scalar/api-client'
 import { ScalarIcon } from '@scalar/components'
 
 import { openClientFor } from '../../../helpers'
@@ -9,14 +10,16 @@ defineProps<{
 }>()
 </script>
 <template>
-  <button
+  <HttpMethod
+    as="button"
     class="show-api-client-button"
-    :class="`show-api-client-button--${operation.httpVerb}`"
+    :method="operation.httpVerb"
+    property="background"
     type="button"
     @click.stop="openClientFor(operation)">
     <span>Test Request</span>
     <ScalarIcon icon="PaperAirplane" />
-  </button>
+  </HttpMethod>
 </template>
 <style scoped>
 .show-api-client-button {
@@ -66,20 +69,5 @@ defineProps<{
   height: 12px;
   width: auto;
   margin-left: 9px;
-}
-.show-api-client-button--post {
-  background: var(--theme-color-green, var(--default-theme-color-green));
-}
-.show-api-client-button--patch {
-  background: var(--theme-color-yellow, var(--default-theme-color-yellow));
-}
-.show-api-client-button--get {
-  background: var(--theme-color-blue, var(--default-theme-color-blue));
-}
-.show-api-client-button--delete {
-  background: var(--theme-color-red, var(--default-theme-color-red));
-}
-.show-api-client-button--put {
-  background: var(--theme-color-orange, var(--default-theme-color-orange));
 }
 </style>

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { HttpMethod } from '@scalar/api-client'
 import { useKeyboardEvent } from '@scalar/use-keyboard-event'
 import { FlowModal, type ModalState } from '@scalar/use-modal'
 import Fuse from 'fuse.js'
@@ -296,11 +297,11 @@ const onSearchResultClick = (entry: Fuse.FuseResult<FuseData>) => {
         :href="entry.item.href"
         @click="onSearchResultClick(entry)"
         @focus="selectedSearchResult = index">
-        <div
+        <HttpMethod
+          as="div"
           class="item-entry-http-verb"
-          :class="`item-entry-http-verb--${entry.item.httpVerb}`">
-          {{ entry.item.httpVerb }}
-        </div>
+          :method="entry.item.httpVerb ?? 'get'"
+          short />
         <div
           v-if="entry.item.title"
           class="item-entry-title">
@@ -419,28 +420,6 @@ a {
   position: relative;
   /* optically center since all characters  above baseline*/
   top: 0.5px;
-}
-.item-entry-http-verb--post {
-  color: var(--theme-color-green, var(--default-theme-color-green));
-}
-.item-entry-http-verb--patch {
-  color: var(--theme-color-yellow, var(--default-theme-color-yellow));
-}
-.item-entry-http-verb--get {
-  color: var(--theme-color-blue, var(--default-theme-color-blue));
-}
-.item-entry-http-verb--delete {
-  color: var(--theme-color-red, var(--default-theme-color-red));
-}
-.item-entry-http-verb--delete {
-  font-size: 0;
-}
-.item-entry-http-verb--delete:after {
-  content: 'DEL';
-  font-size: var(--theme-font-size-4, var(--default-theme-font-size-4));
-}
-.item-entry-http-verb--put {
-  color: var(--theme-color-orange, var(--default-theme-color-orange));
 }
 .item-entry-path {
   color: var(--theme-color-3, var(--default-theme-color-3));

--- a/packages/api-reference/src/components/SidebarElement.vue
+++ b/packages/api-reference/src/components/SidebarElement.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { HttpMethod } from '@scalar/api-client'
 import { ScalarIconButton } from '@scalar/components'
 import { ref } from 'vue'
 
@@ -65,14 +66,12 @@ defineExpose({ el })
         <span>
           {{ item.title }}
         </span>
-        <div
+        <HttpMethod
           v-if="item.httpVerb"
           class="sidebar-heading-type"
-          :class="[
-            item.httpVerb ? `sidebar-heading-type--${item.httpVerb}` : '',
-          ]">
-          {{ item.httpVerb === 'delete' ? 'del' : item.httpVerb }}
-        </div>
+          :method="item.httpVerb"
+          property="--method-color"
+          short />
       </a>
     </div>
     <slot v-if="open" />
@@ -224,7 +223,10 @@ defineExpose({ el })
       var(--theme-background-1, var(--default-theme-background-1))
     )
   );
-  background: var(--theme-color-ghost, var(--default-theme-color-ghost));
+  background: var(
+    --method-color,
+    var(--theme-color-ghost, var(--default-theme-color-ghost))
+  );
   text-transform: uppercase;
   font-size: 8px;
   font-weight: bold;
@@ -253,20 +255,5 @@ defineExpose({ el })
 }
 .sidebar-group-item__folder .sidebar-heading-type {
   display: none;
-}
-.sidebar-heading-type--post {
-  background: var(--theme-color-green, var(--default-theme-color-green));
-}
-.sidebar-heading-type--delete {
-  background: var(--theme-color-red, var(--default-theme-color-red));
-}
-.sidebar-heading-type--patch {
-  background: var(--theme-color-yellow, var(--default-theme-color-yellow));
-}
-.sidebar-heading-type--get {
-  background: var(--theme-color-blue, var(--default-theme-color-blue));
-}
-.sidebar-heading-type--put {
-  background: var(--theme-color-orange, var(--default-theme-color-orange));
 }
 </style>

--- a/packages/api-reference/src/components/SidebarElement.vue
+++ b/packages/api-reference/src/components/SidebarElement.vue
@@ -224,6 +224,7 @@ defineExpose({ el })
       var(--theme-background-1, var(--default-theme-background-1))
     )
   );
+  background: var(--theme-color-ghost, var(--default-theme-color-ghost));
   text-transform: uppercase;
   font-size: 8px;
   font-weight: bold;

--- a/packages/api-reference/src/components/SidebarElement.vue
+++ b/packages/api-reference/src/components/SidebarElement.vue
@@ -68,6 +68,7 @@ defineExpose({ el })
         </span>
         <HttpMethod
           v-if="item.httpVerb"
+          as="div"
           class="sidebar-heading-type"
           :method="item.httpVerb"
           property="--method-color"
@@ -225,7 +226,7 @@ defineExpose({ el })
   );
   background: var(
     --method-color,
-    var(--theme-color-ghost, var(--default-theme-color-ghost))
+    var(--theme-color-2, var(--default-theme-color-2))
   );
   text-transform: uppercase;
   font-size: 8px;


### PR DESCRIPTION
Creates an `HttpMethod` component which can be used to display a color coded http method label, badge or button (or whatever). Also makes is so we can render all basic http methods including `GET`, `POST`, `PUT`, `HEAD`, `DELETE`, `PATCH`, `OPTIONS`, `CONNECT` and `TRACE`.

fixes #935

# Before & Afters

## Sidebar
<img width="250" alt="Google Chrome-2024-02-06-19-21-07@2x" src="https://github.com/scalar/scalar/assets/6374090/81252c42-ddd0-468e-be57-bd07ddacf1b5">
<img width="250" alt="Google Chrome-2024-02-06-19-19-54@2x" src="https://github.com/scalar/scalar/assets/6374090/e4843f6e-2c05-4e79-916e-8ecf5719d4e8">

## Endpoints Overview
<img width="350" alt="Google Chrome-2024-02-06-19-21-27@2x" src="https://github.com/scalar/scalar/assets/6374090/b0dff650-0b3a-4a87-9a95-8a720f6aa26f">
<img width="350" alt="Google Chrome-2024-02-06-19-20-24@2x" src="https://github.com/scalar/scalar/assets/6374090/f532834d-c612-4c2c-9d36-837b6358e86d">

## Example Requests
<img width="350" alt="Google Chrome-2024-02-06-19-21-17@2x" src="https://github.com/scalar/scalar/assets/6374090/ccb9b067-983a-4c2c-baa0-f76274b73815">
<img width="350" alt="Google Chrome-2024-02-06-19-09-56@2x" src="https://github.com/scalar/scalar/assets/6374090/bd7680ad-f161-4de6-bd87-12cd3335a101">

## Search
<img width="350" alt="Google Chrome-2024-02-06-19-21-35@2x" src="https://github.com/scalar/scalar/assets/6374090/2d039c3d-1d5f-409c-8f2c-6cb74461e492">
<img width="350" alt="Google Chrome-2024-02-06-19-09-45@2x" src="https://github.com/scalar/scalar/assets/6374090/1a1ecab2-d8b7-4ea9-9660-7078bfe8bed3">


## API Client

### Before
<img width="1200" alt="Google Chrome-2024-02-06-19-22-54@2x" src="https://github.com/scalar/scalar/assets/6374090/8ccf632c-07e5-4a80-a74c-f9208d494bbb">

### After
<img width="1200" alt="Google Chrome-2024-02-06-19-20-41@2x" src="https://github.com/scalar/scalar/assets/6374090/a978cc5d-07d0-4dac-a2f7-8391bbb18025">

## Classic Theme Endpoints

### Before
<img width="1200" alt="Google Chrome-2024-02-06-19-22-05@2x" src="https://github.com/scalar/scalar/assets/6374090/0f64b152-acb8-410b-b4b6-2915245dc2b3">

### After
<img width="1200" alt="Google Chrome-2024-02-06-19-19-30@2x" src="https://github.com/scalar/scalar/assets/6374090/d2755a1c-1d9e-4cc5-9192-5624bfd66c96">




