### PR TITLE
fix: parse axios error responses as blobs

### DIFF
--- a/.changeset/blue-tomatoes-tan.md
+++ b/.changeset/blue-tomatoes-tan.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: parse axios error responses as blobs

--- a/.changeset/rare-moons-run.md
+++ b/.changeset/rare-moons-run.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client-proxy': patch
+---
+
+fix: only expose special proxy headers instead of \*

--- a/examples/web/src/components/DevApiClientOptions.vue
+++ b/examples/web/src/components/DevApiClientOptions.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { type ThemeId, availableThemes } from '@scalar/themes'
+import { computed } from 'vue'
+
+type ApiClientConfig = {
+  proxyUrl?: string
+  readOnly?: boolean
+  theme?: ThemeId
+}
+
+const props = defineProps<{
+  modelValue: ApiClientConfig
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: ApiClientConfig): void
+}>()
+
+/** Computed config proxy for v-model
+ * @see https://skirtles-code.github.io/vue-examples/patterns/computed-v-model.html#advanced-usage-proxying-objects */
+const config = computed(
+  () =>
+    new Proxy(props.modelValue, {
+      set(obj, key, value) {
+        emit('update:modelValue', { ...obj, [key]: value })
+        return true
+      },
+    }),
+)
+
+const enableProxy = computed<boolean>({
+  get: () => !!config.value.proxyUrl,
+  set: (enable) =>
+    (config.value.proxyUrl = enable ? 'http://localhost:5051' : undefined),
+})
+</script>
+<template>
+  <div>
+    <input
+      v-model="config.readOnly"
+      type="checkbox" />
+    readOnly
+  </div>
+  <div>
+    <input
+      v-model="enableProxy"
+      type="checkbox" />
+    enableProxy
+  </div>
+  <div>
+    Theme:
+    <select v-model="config.theme">
+      <option
+        v-for="theme in availableThemes"
+        :key="theme"
+        :value="theme">
+        {{ theme }}
+      </option>
+    </select>
+  </div>
+</template>

--- a/examples/web/src/components/DevReferencesOptions.vue
+++ b/examples/web/src/components/DevReferencesOptions.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { type ReferenceConfiguration } from '@scalar/api-reference'
+import { availableThemes } from '@scalar/themes'
+import { computed, ref, watch } from 'vue'
+
+const props = defineProps<{
+  modelValue: ReferenceConfiguration
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: ReferenceConfiguration): void
+}>()
+
+/** Computed config proxy for v-model
+ * @see https://skirtles-code.github.io/vue-examples/patterns/computed-v-model.html#advanced-usage-proxying-objects */
+const configuration = computed(
+  () =>
+    new Proxy(props.modelValue, {
+      set(obj, key, value) {
+        emit('update:modelValue', { ...obj, [key]: value })
+        return true
+      },
+    }),
+)
+
+// The collaborative editing configuration is an object and not just true/false, that’s
+// why we’re keeping track of it separately.
+const enableCollaborativeEditingRef = ref<boolean>(false)
+const collaborativeEditingDocumentRef = ref<string>('document-1')
+
+// This adds the collaborative editing configuration to the configuration object.
+function getCompleteConfiguration(v: any) {
+  if (enableCollaborativeEditingRef.value) {
+    return {
+      ...v,
+    }
+  }
+
+  return {
+    ...v,
+  }
+}
+
+// If one of the separate refs update, emit the new configuration
+watch([enableCollaborativeEditingRef, collaborativeEditingDocumentRef], () => {
+  emit('update:modelValue', getCompleteConfiguration(configuration.value))
+})
+</script>
+<template>
+  <div>
+    <input
+      v-model="configuration.isEditable"
+      type="checkbox" />
+    isEditable
+  </div>
+  <div>
+    <input
+      v-model="configuration.showSidebar"
+      type="checkbox" />
+    showSidebar
+  </div>
+  <div>
+    Theme:
+    <select v-model="configuration.theme">
+      <option
+        v-for="theme in availableThemes"
+        :key="theme"
+        :value="theme">
+        {{ theme }}
+      </option>
+    </select>
+  </div>
+  <div>
+    <input
+      v-model="configuration.darkMode"
+      type="checkbox" />
+    darkMode
+  </div>
+  <div>
+    Layout:
+    <select v-model="configuration.layout">
+      <option
+        v-for="layout in ['modern', 'classic']"
+        :key="layout"
+        :value="layout">
+        {{ layout }}
+      </option>
+    </select>
+  </div>
+  <div>
+    <input
+      v-model="enableCollaborativeEditingRef"
+      type="checkbox" />
+    Collaborative Editing{{ enableCollaborativeEditingRef ? ':' : '' }}
+    <select
+      v-if="enableCollaborativeEditingRef"
+      v-model="collaborativeEditingDocumentRef">
+      <option value="document-1">Document #1</option>
+      <option value="document-2">Document #2</option>
+      <option value="document-3">Document #3</option>
+    </select>
+  </div>
+</template>

--- a/examples/web/src/components/DevToolbar.vue
+++ b/examples/web/src/components/DevToolbar.vue
@@ -1,50 +1,6 @@
 <script setup lang="ts">
-import { type ReferenceConfiguration } from '@scalar/api-reference'
-import { availableThemes } from '@scalar/themes'
-import { computed, ref, watch } from 'vue'
-
-const props = defineProps<{
-  modelValue: ReferenceConfiguration
-}>()
-
-const emit = defineEmits<{
-  (e: 'update:modelValue', v: ReferenceConfiguration): void
-}>()
-
-/** Computed config proxy for v-model
- * @see https://skirtles-code.github.io/vue-examples/patterns/computed-v-model.html#advanced-usage-proxying-objects */
-const configuration = computed(
-  () =>
-    new Proxy(props.modelValue, {
-      set(obj, key, value) {
-        emit('update:modelValue', { ...obj, [key]: value })
-        return true
-      },
-    }),
-)
-
-// The collaborative editing configuration is an object and not just true/false, that’s
-// why we’re keeping track of it separately.
-const enableCollaborativeEditingRef = ref<boolean>(false)
-const collaborativeEditingDocumentRef = ref<string>('document-1')
-
-// This adds the collaborative editing configuration to the configuration object.
-function getCompleteConfiguration(v: any) {
-  if (enableCollaborativeEditingRef.value) {
-    return {
-      ...v,
-    }
-  }
-
-  return {
-    ...v,
-  }
-}
-
-// If one of the separate refs update, emit the new configuration
-watch([enableCollaborativeEditingRef, collaborativeEditingDocumentRef], () => {
-  emit('update:modelValue', getCompleteConfiguration(configuration.value))
-})
+import { ResetStyles } from '@scalar/swagger-editor'
+import { ref, watch } from 'vue'
 
 const docStyle = document.documentElement.style
 
@@ -63,87 +19,41 @@ watch(
 )
 </script>
 <template>
-  <header
-    v-if="showToolbar"
-    class="references-dev-header">
-    <a
-      class="references-dev-title"
-      href="/"
-      title="Back to homepage">
+  <ResetStyles v-slot="{ styles }">
+    <header
+      v-if="showToolbar"
+      class="dev-header"
+      :class="styles">
+      <div class="dev-title">
+        Dev Toolbar
+        <a
+          class="dev-home-link"
+          href="/"
+          title="Back to homepage">
+          &larr; Go back
+        </a>
+      </div>
+      <div class="dev-options">
+        <slot />
+        <button
+          class="dev-hide-toolbar"
+          type="button"
+          @click="showToolbar = false">
+          Hide
+        </button>
+      </div>
+    </header>
+    <button
+      v-else
+      class="dev-show-toolbar"
+      type="button"
+      @click="showToolbar = true">
       Dev Toolbar
-    </a>
-    <div class="references-dev-options">
-      <div>
-        <input
-          v-model="configuration.isEditable"
-          type="checkbox" />
-        isEditable
-      </div>
-      <div>
-        <input
-          v-model="configuration.showSidebar"
-          type="checkbox" />
-        showSidebar
-      </div>
-      <div>
-        Theme:
-        <select v-model="configuration.theme">
-          <option
-            v-for="theme in availableThemes"
-            :key="theme"
-            :value="theme">
-            {{ theme }}
-          </option>
-        </select>
-      </div>
-      <div>
-        <input
-          v-model="configuration.darkMode"
-          type="checkbox" />
-        darkMode
-      </div>
-      <div>
-        Layout:
-        <select v-model="configuration.layout">
-          <option
-            v-for="layout in ['modern', 'classic']"
-            :key="layout"
-            :value="layout">
-            {{ layout }}
-          </option>
-        </select>
-      </div>
-      <div>
-        <input
-          v-model="enableCollaborativeEditingRef"
-          type="checkbox" />
-        Collaborative Editing{{ enableCollaborativeEditingRef ? ':' : '' }}
-        <select
-          v-if="enableCollaborativeEditingRef"
-          v-model="collaborativeEditingDocumentRef">
-          <option value="document-1">Document #1</option>
-          <option value="document-2">Document #2</option>
-          <option value="document-3">Document #3</option>
-        </select>
-      </div>
-      <button
-        class="references-dev-hide-toolbar"
-        type="button"
-        @click="showToolbar = false">
-        Hide
-      </button>
-    </div>
-  </header>
-  <button
-    v-else
-    class="references-dev-show-toolbar"
-    type="button"
-    @click="showToolbar = true">
-    Dev Toolbar
-  </button>
+    </button>
+  </ResetStyles>
 </template>
 <style scoped>
-.references-dev-header {
+.dev-header {
   display: flex;
   justify-content: space-between;
   color: var(--default-theme-color-1);
@@ -154,10 +64,11 @@ watch(
   background: var(--default-theme-background-1);
   border-bottom: 1px solid var(--default-theme-border-color);
 }
-.references-dev-title {
+.dev-title {
   font-weight: bold;
   display: flex;
   align-items: center;
+  gap: 6px;
   padding: 0px 8px;
 
   min-width: 0;
@@ -166,13 +77,27 @@ watch(
   white-space: nowrap;
   overflow: hidden;
 }
+.dev-home-link {
+  font-weight: medium;
+  font-size: smaller;
+  text-decoration: none;
 
-.references-dev-options {
+  padding: 4px 6px;
+  border: 1px solid var(--default-theme-border-color);
+  color: var(--default-theme-color-1);
+  background: var(--default-theme-background-2);
+  border-radius: var(--default-theme-radius);
+}
+.dev-home-link:hover {
+  background: var(--default-theme-background-3);
+}
+
+.dev-options {
   display: flex;
   font-size: var(--default-theme-small);
 }
 
-.references-dev-options > * {
+.dev-options > :deep(*) {
   padding: 0px 12px;
   border-left: 1px solid var(--default-theme-border-color);
   display: flex;
@@ -180,7 +105,7 @@ watch(
   gap: 4px;
 }
 
-.references-dev-show-toolbar {
+.dev-show-toolbar {
   position: fixed;
   z-index: 1000;
   top: 8px;
@@ -198,8 +123,8 @@ watch(
   box-shadow: var(--default-theme-shadow-1);
 }
 
-.references-dev-show-toolbar:hover,
-.references-dev-hide-toolbar:hover {
+.dev-show-toolbar:hover,
+.dev-hide-toolbar:hover {
   background: var(--default-theme-background-2);
 }
 </style>

--- a/examples/web/src/pages/ApiClientPage.vue
+++ b/examples/web/src/pages/ApiClientPage.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { ApiClient, useRequestStore } from '@scalar/api-client'
-import { watch } from 'vue'
+import { type ThemeId } from '@scalar/themes'
+import { ref, watch } from 'vue'
+
+import DevApiClientOptions from '../components/DevApiClientOptions.vue'
+import DevToolbar from '../components/DevToolbar.vue'
 
 const { activeRequest, setActiveRequest } = useRequestStore()
 
@@ -19,8 +23,14 @@ const activeRequestFromStorage = window.localStorage.getItem('activeRequest')
 if (activeRequestFromStorage) {
   setActiveRequest(JSON.parse(activeRequestFromStorage))
 }
-</script>
 
+const config = ref({
+  proxyUrl: 'http://localhost:5051',
+  readOnly: false,
+  theme: 'default' as ThemeId,
+})
+</script>
 <template>
-  <ApiClient proxyUrl="http://localhost:5051" />
+  <DevToolbar><DevApiClientOptions v-model="config" /></DevToolbar>
+  <ApiClient v-bind="config" />
 </template>

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -5,6 +5,7 @@ import {
 } from '@scalar/api-reference'
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 
+import DevReferencesOptions from '../components/DevApiClientOptions.vue'
 import DevToolbar from '../components/DevToolbar.vue'
 import SlotPlaceholder from '../components/SlotPlaceholder.vue'
 
@@ -40,7 +41,9 @@ const configProxy = computed({
     @changeTheme="configuration.theme = $event"
     @updateContent="(v) => (content = v)">
     <template #header>
-      <DevToolbar v-model="configProxy" />
+      <DevToolbar>
+        <DevReferencesOptions v-model="configProxy" />
+      </DevToolbar>
     </template>
     <template #sidebar-start>
       <SlotPlaceholder>sidebar-start</SlotPlaceholder>

--- a/packages/api-client-proxy/src/createApiClientProxy.ts
+++ b/packages/api-client-proxy/src/createApiClientProxy.ts
@@ -97,7 +97,9 @@ export const createApiClientProxy = () => {
         res.type(response.type)
         res.set({
           ...headers,
-          'Access-Control-Expose-Headers': '*',
+          // Make sure the client can read the special headers
+          'Access-Control-Expose-Headers':
+            Object.values(ProxyHeader).join(', '),
           [ProxyHeader.StatusCode]: response.status,
           [ProxyHeader.StatusText]: response.statusText,
         })

--- a/packages/api-client/src/helpers/sendRequest.ts
+++ b/packages/api-client/src/helpers/sendRequest.ts
@@ -136,7 +136,6 @@ export async function sendRequest(
       // Result is always blob
       const blob = result.data as Blob
       const data = blob.type === 'application/json' ? await blob.text() : blob
-
       // With Proxy
       if (proxyUrl) {
         const proxyHeaders = Object.values(ProxyHeader)
@@ -165,18 +164,22 @@ export async function sendRequest(
         error: false,
       }
     })
-    .catch((error) => {
+    .catch(async (error) => {
       const { response: errorResponse } = error
+
+      const blob = errorResponse.data as Blob
+      const data = blob.type === 'application/json' ? await blob.text() : blob
 
       // We add fallbacks where we set the code, status and header type so we can
       // float all errors now to the user
       return {
         headers: {
           'content-type': 'application/json; charset=utf-8',
+          ...errorResponse['headers'],
         },
         ...errorResponse,
         statusCode: errorResponse?.status ?? 0,
-        data: JSON.stringify(errorResponse?.data ?? { error: error.code }),
+        data: data ?? JSON.stringify({ error: error.code }),
       }
     })
 


### PR DESCRIPTION
This PR does 3 things:
1. Updates `sendRequest` to still parse the data correctly when Axios throws an error for a non-200 status code
2. Updates the client proxy's `Access-Control-Expose-Headers` header to only include our special scalar proxy headers rather than exposing everything (which was showing a bunch of weird headers).
3. Adds a dev toolbar to the api client dev environment to make it easier to test

fixes #939

# Before (main)

https://github.com/scalar/scalar/assets/6374090/cf90d527-b22f-4d17-8073-52d55677d334

# After (this PR)

https://github.com/scalar/scalar/assets/6374090/4ed54f7f-e3df-487c-96aa-f07a98b0560f

