### PR TITLE
fix: deploy preview workflow triggers

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -1,4 +1,4 @@
-name: Deploy Scalar preview
+name: Deploy Scalar examples
 
 on:
   push:
@@ -12,7 +12,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Deploy Scalar preview
+    name: Deploy Scalar examples
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/deploy-preview-examples.yml
+++ b/.github/workflows/deploy-preview-examples.yml
@@ -1,18 +1,18 @@
-name: Deploy Scalar preview
+name: Examples deploy preview
 
 on:
   push:
+    branches-ignore:
+      - 'main'
     paths:
       - 'examples/web/**'
       - '.github/workflows/deploy-preview-examples.yml'
-    branches-ignore:
-      - 'main'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Deploy Scalar preview
+    name: Examples deploy preview
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/deploy-preview-examples.yml
+++ b/.github/workflows/deploy-preview-examples.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - 'examples/web/**'
       - '.github/workflows/deploy-preview-examples.yml'
+  pull_request:
+    types:
+      - opened
+    paths:
+      - 'examples/web/**'
+      - '.github/workflows/deploy-preview-examples.yml'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -14,6 +20,8 @@ jobs:
   release:
     name: Examples deploy preview
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     strategy:
       matrix:
         node-version: [20]
@@ -57,5 +65,7 @@ jobs:
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ steps.findPr.outputs.pr }}
+          header: 'Deploy Preview'
+          recreate: true
           message: |
-            Preview deployed at https://${{env.DEPLOY_ID}}--scalar-deploy-preview.netlify.app
+            Preview deployed to https://${{env.DEPLOY_ID}}--scalar-deploy-preview.netlify.app

--- a/examples/web/src/pages/ApiClientPage.vue
+++ b/examples/web/src/pages/ApiClientPage.vue
@@ -4,10 +4,6 @@ import { watch } from 'vue'
 
 const { activeRequest, setActiveRequest } = useRequestStore()
 
-// a comment to test the ci
-const a = 1
-console.log(a)
-
 // Store active request in local storage
 watch(activeRequest, () => {
   const activeRequestFromStorage = window.localStorage.getItem('activeRequest')

--- a/examples/web/src/pages/ApiClientPage.vue
+++ b/examples/web/src/pages/ApiClientPage.vue
@@ -4,6 +4,10 @@ import { watch } from 'vue'
 
 const { activeRequest, setActiveRequest } = useRequestStore()
 
+// a comment to test the ci
+const a = 1
+console.log(a)
+
 // Store active request in local storage
 watch(activeRequest, () => {
   const activeRequestFromStorage = window.localStorage.getItem('activeRequest')


### PR DESCRIPTION
With this PR the deploy preview workflow will trigger on PR open as well as on push if there are changes to the UI. This PR also clarifies workflow naming, adds a header to the deploy preview comment and explicitly adds permissions although this may be unnecessary for a public repo. 
