### PR TITLE
chore: use vitest workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check types
         run: pnpm turbo types:check
       - name: Run tests
-        run: pnpm turbo test
+        run: pnpm test
       - if: matrix.node-version == 20
         name: Send bundle stats and build information to RelativeCI
         uses: relative-ci/agent-action@v2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "bradlc.vscode-tailwindcss",
-    "cpylua.language-postcss"
+    "cpylua.language-postcss",
+    "zixuanchen.vitest-explorer"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,5 +51,7 @@
   "tailwindCSS.experimental.configFile": {
     "packages/components/tailwind.config.ts": "packages/components/**"
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "vitest.commandLine": "pnpm vitest",
+  "vitest.enable": true
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "turbo": "^1.10.15",
     "typescript": "^5.2.2",
     "vite-node": "^0.34.4",
-    "vue-eslint-parser": "^9.3.1"
+    "vue-eslint-parser": "^9.3.1",
+    "@vitest/coverage-v8": "^0.34.4",
+    "vitest": "^0.34.4"
   },
   "pnpm": {
     "patchedDependencies": {
@@ -44,7 +46,7 @@
     "lint": "pnpm -r lint:check",
     "lint:fix": "pnpm -r lint:fix",
     "preview:standalone": "pnpm --filter api-reference preview:standalone",
-    "test": "pnpm -r test",
+    "test": "vitest",
     "types:check": "pnpm -r types:check"
   }
 }

--- a/packages/components/src/components/ScalarModal/ScalarModal.spec.ts
+++ b/packages/components/src/components/ScalarModal/ScalarModal.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import ScalarModal, { useModal } from './ScalarModal.vue'
 
-describe('ScalarIconButton', () => {
+describe('ScalarModal', () => {
   it('renders properly', async () => {
     const state = useModal()
     const wrapper = mount(ScalarModal, {
@@ -12,13 +12,16 @@ describe('ScalarIconButton', () => {
       },
     })
 
-    // Wait for icon to load
+    // Wait for modal to load
     await flushPromises()
 
-    expect(wrapper.html()).toBe(
-      `<!--teleport start-->
-<!--teleport end-->
-<div style="position: fixed; height: 0px; padding: 0px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px; display: none;"></div>`,
+    // Grab the first child div
+    const el = wrapper.find('*').element as HTMLElement
+
+    // Check some of the attributes
+    expect(el.nodeName.toLowerCase()).toBe('div')
+    expect(el.style.cssText).toBe(
+      'position: fixed; height: 0px; padding: 0px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px; display: none;',
     )
   })
 })

--- a/packages/swagger-parser/src/helpers/parse.test.ts
+++ b/packages/swagger-parser/src/helpers/parse.test.ts
@@ -55,7 +55,9 @@ describe('parse', () => {
 
   it('reads yaml', () =>
     new Promise((resolve) => {
-      const swaggerYaml = getFile('./tests/fixtures/swagger.yaml')
+      const swaggerYaml = getFile(
+        './packages/swagger-parser/tests/fixtures/swagger.yaml',
+      )
 
       parse(swaggerYaml).then((result) => {
         expect(result.info.title).toBe('Sample API')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^6.7.2
         version: 6.7.2(eslint@8.49.0)(typescript@5.2.2)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.4
+        version: 0.34.4(vitest@0.34.4)
       '@vue/eslint-config-typescript':
         specifier: ^12.0.0
         version: 12.0.0(eslint-plugin-vue@9.17.0)(eslint@8.49.0)(typescript@5.2.2)
@@ -73,6 +76,9 @@ importers:
       vite-node:
         specifier: ^0.34.4
         version: 0.34.4(@types/node@20.6.3)(terser@5.24.0)
+      vitest:
+        specifier: ^0.34.4
+        version: 0.34.4(jsdom@22.1.0)
       vue-eslint-parser:
         specifier: ^9.3.1
         version: 9.3.1(eslint@8.49.0)
@@ -1514,7 +1520,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.19
+      '@jridgewell/trace-mapping': 0.3.22
 
   /@angular-devkit/core@16.1.0(chokidar@3.5.3):
     resolution: {integrity: sha512-mrWpuDvttmhrCGcLc68RIXKtTzUhkBTsE5ZZFZNO1+FSC+vO/ZpyCpPd6C+6coM68NfXYjHlms5XF6KbxeGn/Q==}
@@ -1730,7 +1736,7 @@ packages:
     dependencies:
       '@babel/types': 7.23.3
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.22
       jsesc: 2.5.2
     dev: true
 
@@ -1740,7 +1746,7 @@ packages:
     dependencies:
       '@babel/types': 7.23.6
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.22
       jsesc: 2.5.2
 
   /@babel/helper-annotate-as-pure@7.22.5:
@@ -4264,7 +4270,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.22
       '@types/node': 20.6.3
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
@@ -4298,7 +4304,7 @@ packages:
     resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.22
       callsites: 3.1.0
       graceful-fs: 4.2.11
     dev: true
@@ -4329,7 +4335,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.6
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.22
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
@@ -4375,7 +4381,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.22
 
   /@jridgewell/resolve-uri@3.1.1:
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
@@ -4400,19 +4406,13 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
-
-  /@jridgewell/trace-mapping@0.3.20:
-    resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /@jridgewell/trace-mapping@0.3.22:
     resolution: {integrity: sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -6192,7 +6192,7 @@ packages:
       express: 4.18.2
       find-cache-dir: 3.3.2
       fs-extra: 11.1.1
-      magic-string: 0.30.5
+      magic-string: 0.30.6
       rollup: 3.29.4
       typescript: 5.2.2
       vite: 4.5.2(@types/node@20.6.3)(terser@5.24.0)
@@ -6230,7 +6230,7 @@ packages:
       express: 4.18.2
       find-cache-dir: 3.3.2
       fs-extra: 11.1.1
-      magic-string: 0.30.5
+      magic-string: 0.30.6
       rollup: 3.29.4
       typescript: 5.3.3
       vite: 4.5.2(@types/node@20.6.3)(terser@5.24.0)
@@ -7953,7 +7953,7 @@ packages:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.6
-      magic-string: 0.30.4
+      magic-string: 0.30.6
       picocolors: 1.0.0
       std-env: 3.4.3
       test-exclude: 6.0.0
@@ -7982,7 +7982,7 @@ packages:
   /@vitest/snapshot@0.34.4:
     resolution: {integrity: sha512-GCsh4coc3YUSL/o+BPUo7lHQbzpdttTxL6f4q0jRx2qVGoYz/cyTRDJHbnwks6TILi6560bVWoBpYC10PuTLHw==}
     dependencies:
-      magic-string: 0.30.5
+      magic-string: 0.30.6
       pathe: 1.1.1
       pretty-format: 29.7.0
     dev: true
@@ -8084,7 +8084,7 @@ packages:
       '@vue/reactivity-transform': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.4
+      magic-string: 0.30.6
       postcss: 8.4.32
       source-map-js: 1.0.2
 
@@ -8185,7 +8185,7 @@ packages:
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.5
+      magic-string: 0.30.6
 
   /@vue/reactivity@3.3.4:
     resolution: {integrity: sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==}
@@ -14048,19 +14048,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-
-  /magic-string@0.30.5:
-    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /magic-string@0.30.6:
     resolution: {integrity: sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -17860,7 +17854,7 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.22
       '@swc/core': 1.3.64
       jest-worker: 27.5.1
       schema-utils: 3.3.0
@@ -19236,14 +19230,14 @@ packages:
       '@vitest/snapshot': 0.34.4
       '@vitest/spy': 0.34.4
       '@vitest/utils': 0.34.4
-      acorn: 8.10.0
+      acorn: 8.11.3
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4
       jsdom: 22.1.0
       local-pkg: 0.4.3
-      magic-string: 0.30.4
+      magic-string: 0.30.6
       pathe: 1.1.1
       picocolors: 1.0.0
       std-env: 3.4.3
@@ -19302,13 +19296,13 @@ packages:
       '@vitest/snapshot': 0.34.4
       '@vitest/spy': 0.34.4
       '@vitest/utils': 0.34.4
-      acorn: 8.10.0
+      acorn: 8.11.3
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4
       local-pkg: 0.4.3
-      magic-string: 0.30.4
+      magic-string: 0.30.6
       pathe: 1.1.1
       picocolors: 1.0.0
       std-env: 3.4.3

--- a/turbo.json
+++ b/turbo.json
@@ -8,9 +8,6 @@
     },
     "types:check": {
       "dependsOn": ["^build"]
-    },
-    "test": {
-      "dependsOn": ["^build"]
     }
   }
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,1 @@
+export default ['packages/*']


### PR DESCRIPTION
I just found out that vitest has a “workspaces” feature, which we could use to run the tests. The output is better than the output of `pnpm -r test`.

But one test is failing and I don’t get why. 🤔 I think the expected output isn’t really related to the test, though:

```diff
    expect(wrapper.html()).toBe(
-      `<!--teleport start-->
-<!--teleport end-->
<div style="position: fixed; height: 0px; padding: 0px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px; display: none;"></div>`,
    )
```