### PR TITLE
fix: remove type="text" from the search button placeholder span

### DIFF
--- a/.changeset/ten-adults-film.md
+++ b/.changeset/ten-adults-film.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: remove type="text" from the search button placeholder span

--- a/packages/api-reference/src/components/SearchButton.vue
+++ b/packages/api-reference/src/components/SearchButton.vue
@@ -35,11 +35,7 @@ useKeyboardEvent({
       class="search-icon"
       icon="Search" />
     <div class="sidebar-search-input">
-      <span
-        class="sidebar-search-placeholder"
-        type="text">
-        Search
-      </span>
+      <span class="sidebar-search-placeholder">Search</span>
       <span class="sidebar-search-shortcut">
         <span class="sidebar-search-key">
           {{ isMacOS() ? '⌘' : '⌃' }}{{ searchHotKey }}


### PR DESCRIPTION
This is a span within a button so it shouldn't really have a type attribute regardless.

I'm guessing it was left there from a time when the search input was an actual input instead of a button that opened the modal.
