### PR TITLE
feat: prefill authentication, fix #984 

### DIFF
--- a/.changeset/kind-lamps-brake.md
+++ b/.changeset/kind-lamps-brake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: prefill the authentication data

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -18,6 +18,17 @@ const configuration = reactive<ReferenceConfiguration>({
   showSidebar: true,
   layout: 'modern',
   spec: { content },
+  authentication: {
+    securitySchemeKey: 'petstore_auth',
+    oAuth2: {
+      clientId: 'foobar123',
+      scopes: ['read:pets', 'write:pets'],
+    },
+    // securitySchemeKey: 'api_key',
+    // apiKey: {
+    //   token: 'super-secret-token',
+    // },
+  },
 })
 
 onMounted(() => {

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -189,5 +189,4 @@ For OpenAuth2 it’s more looking like this:
       },
     },
   } />
-``
 ````

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -154,3 +154,40 @@ You can listen to spec changes with onSpecUpdate that runs on spec/swagger conte
     }
   } />
 ```
+
+#### authentication?: Partial<AuthenticationState>
+
+To make authentication easier you can prefill the credentials for your users:
+
+````vue
+<ApiReference :configuration="{
+  authentication: {
+      // The OpenAPI file has keys for all security schemes
+      // Which one should be used by default?
+      securitySchemeKey: 'api_key',
+      // Okay, the `api_key` security scheme is of type `apiKey`, so prefill the token:
+      apiKey: {
+        token: 'super-secret-token',
+      },
+    },
+  } />
+``
+
+For OpenAuth2 it’s more looking like this:
+
+```vue
+<ApiReference :configuration="{
+  authentication: {
+      // The OpenAPI file has keys for all security schemes
+      // Which one should be used by default?
+      securitySchemeKey: 'petstore_auth',
+      // Okay, the `api_key` security scheme is of type `oAuth2`, so prefill the client id and the scopes:
+      oAuth2: {
+        clientId: 'foobar123',
+        // optional:
+        scopes: ['read:pets', 'write:pets'],
+      },
+    },
+  } />
+``
+````

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -14,6 +14,7 @@ import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { deepMerge } from '../helpers'
 import { useParser, useSnippetTargets, useSpec } from '../hooks'
 import { useDarkModeState } from '../hooks/useDarkModeState'
+import { useGlobalStore } from '../stores'
 import {
   DEFAULT_CONFIG,
   type ReferenceConfiguration,
@@ -129,6 +130,13 @@ function handleCloseModal(passThrough: () => void) {
 }
 
 const isMobile = useMediaQuery('(max-width: 1000px)')
+
+// Prefill authentication
+const { setAuthentication } = useGlobalStore()
+
+if (props.configuration?.authentication) {
+  setAuthentication(props.configuration?.authentication)
+}
 </script>
 <template>
   <component

--- a/packages/api-reference/src/components/Content/Authentication/SecuritySchemeSelector.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecuritySchemeSelector.vue
@@ -33,6 +33,11 @@ const handleAuthenticationTypeInput = (event: Event) => {
 
 // Use first security scheme as default
 onMounted(() => {
+  // Oh, the key was set already!
+  if (authentication.securitySchemeKey) {
+    return
+  }
+
   // Set the authentication type to the first security scheme
   setSecuritySchemeKey(Object.keys(props.value ?? {})[0] ?? null)
 })

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.test.ts
@@ -139,6 +139,48 @@ describe('getRequestFromAuthentication', () => {
     })
   })
 
+  it('oAuth2 token in header', () => {
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'petstore_auth',
+        securitySchemes: {
+          petstore_auth: {
+            type: 'oauth2',
+            flows: {
+              implicit: {
+                authorizationUrl:
+                  'https://petstore3.swagger.io/oauth/authorize',
+                scopes: {
+                  'write:pets': 'modify pets in your account',
+                  'read:pets': 'read your pets',
+                },
+              },
+            },
+          },
+        },
+        oAuth2: {
+          clientId: '123',
+          scopes: [],
+        },
+      },
+      [
+        {
+          petstore_auth: [],
+        },
+      ],
+    )
+
+    expect(request).toMatchObject({
+      headers: [
+        {
+          name: 'Authorization',
+          value: 'Bearer 123',
+        },
+      ],
+    })
+  })
+
   it('only return required security schemes', () => {
     const request = getRequestFromAuthentication(
       {

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
@@ -126,6 +126,20 @@ export function getRequestFromAuthentication(
       }
     }
     // TODO: oauth2
+    else if (
+      'type' in securityScheme &&
+      // @ts-ignore
+      securityScheme.type.toLowerCase() === 'oauth2'
+    ) {
+      const token = authentication.oAuth2.clientId.length
+        ? authentication.oAuth2.clientId
+        : 'YOUR_SECRET_TOKEN'
+
+      headers.push({
+        name: 'Authorization',
+        value: `Bearer ${token}`,
+      })
+    }
     // TODO: openIdConnect
   }
 

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -13,15 +13,6 @@ export type ReferenceProps = {
   configuration?: ReferenceConfiguration
 }
 
-export type SpecConfiguration = {
-  /** URL to a Swagger/OpenAPI file */
-  url?: string
-  /** Swagger/Open API spec */
-  content?: string | Record<string, any> | (() => Record<string, any>)
-  /** The result of @scalar/swagger-parser */
-  preparsedContent?: Record<any, any>
-}
-
 export type ReferenceConfiguration = {
   /** A string to use one of the color presets */
   theme?: ThemeId
@@ -54,6 +45,17 @@ export type ReferenceConfiguration = {
   customCss?: string
   /** onSpecUpdate is fired on spec/swagger content change */
   onSpecUpdate?: (spec: string) => void
+  /** Prefill authentication */
+  authentication?: Partial<AuthenticationState>
+}
+
+export type SpecConfiguration = {
+  /** URL to a Swagger/OpenAPI file */
+  url?: string
+  /** Swagger/Open API spec */
+  content?: string | Record<string, any> | (() => Record<string, any>)
+  /** The result of @scalar/swagger-parser */
+  preparsedContent?: Record<any, any>
 }
 
 /** Default reference configuration */


### PR DESCRIPTION
With this PR the authentication data can be prefilled through the universal configuration object.

```vue
<ApiReference :configuration="{
  authentication: {
      // The OpenAPI file has keys for all security schemes
      // Which one should be used by default?
      securitySchemeKey: 'petstore_auth',
      // Okay, the `api_key` security scheme is of type `oAuth2`, so prefill the client id and the scopes:
      oAuth2: {
        clientId: 'foobar123',
        // optional:
        scopes: ['read:pets', 'write:pets'],
      },
    },
  } />
````

<img width="600" alt="Screenshot 2024-02-12 at 14 15 31" src="https://github.com/scalar/scalar/assets/1577992/4ea49cd6-011b-4e28-8252-4cd7993ae633">

See #984.