### PR TITLE
fix: path is not prefixed, fix #937

### DIFF
--- a/.changeset/proud-spoons-decide.md
+++ b/.changeset/proud-spoons-decide.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: path isn’t prefixed (https://github.com/scalar/scalar/issues/937)

--- a/packages/api-reference/src/helpers/getUrlFromServerState.test.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.test.ts
@@ -37,4 +37,25 @@ describe('getUrlFromServerState', () => {
 
     expect(request).toMatchObject('https://unicorn.fantasy')
   })
+
+  it('prefixes path with the origin', () => {
+    global.window = {
+      // @ts-expect-error
+      location: {
+        origin: 'https://example.com',
+      },
+    }
+
+    const request = getUrlFromServerState({
+      ...createEmptyServerState(),
+      selectedServer: 0,
+      servers: [
+        {
+          url: 'v1',
+        },
+      ],
+    })
+
+    expect(request).toMatchObject('https://example.com/v1')
+  })
 })

--- a/packages/api-reference/src/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.ts
@@ -1,21 +1,32 @@
 import type { ServerState } from '../types'
 import { replaceVariables } from './replaceVariables'
 
+/**
+ * Get the URL from the server state.
+ */
 export function getUrlFromServerState(state: ServerState) {
   let url =
     state.selectedServer === null
       ? state?.servers?.[0]?.url ?? undefined
       : state?.servers?.[state.selectedServer]?.url
 
+  // Path `/v1`
   if (url?.startsWith('/')) {
-    // Remove trailing slash from window.location.origin
-    const origin = window.location.origin.endsWith('/')
-      ? window.location.origin.slice(0, -1)
-      : window.location.origin
-
-    // Prefix the URL with the window.location.origin
-    url = `${origin}${url}`
+    url = `${normalizedWindowOrigin()}${url}`
+  }
+  // Path `v1`
+  else if (url && !url?.startsWith('http://') && !url?.startsWith('https://')) {
+    url = `${normalizedWindowOrigin()}/${url}`
   }
 
   return url ? replaceVariables(url, state?.variables) : undefined
+}
+
+/**
+ * Removes trailing slashes from window.location.origin
+ */
+const normalizedWindowOrigin = () => {
+  const location = window.location.origin
+
+  return location.endsWith('/') ? location.slice(0, -1) : location
 }


### PR DESCRIPTION
When using

```json
{ "servers": [{ "url": "v1" }] }
```

the path should be prefixed with the `window.location.origin`, but it’s not. :) Let’s change it with this PR.

Read more in #937
