### PR TITLE
chore: serve OpenAPI file for express example

### DIFF
--- a/examples/express-api-reference/src/index.ts
+++ b/examples/express-api-reference/src/index.ts
@@ -33,16 +33,17 @@ const OpenApiSpecification = swaggerJsdoc({
   apis: ['./src/*.ts'],
 })
 
-// TODO: Remove later
-app.get('/swagger.json', (req, res) => {
+// Serve the OpenAPI specification
+app.get('/openapi.json', (req, res) => {
   res.json(OpenApiSpecification)
 })
 
+// Serve the API Reference
 app.use(
   '/',
   apiReference({
     spec: {
-      content: OpenApiSpecification,
+      url: '/openapi.json',
     },
   }),
 )


### PR DESCRIPTION
I was just looking for TODO comments in the code base and saw that we served a `swagger.json` in the express example, but didn’t even use it.

I consider serving an OpenAPI file best practice, so I did that and removed the TODO comment.