### PR TITLE
chore: clean up CodeMirror CSS

### DIFF
--- a/.changeset/modern-rats-lay.md
+++ b/.changeset/modern-rats-lay.md
@@ -1,0 +1,6 @@
+---
+"@scalar/use-codemirror": patch
+"@scalar/api-client": patch
+---
+
+chore: remove unused CodeMirror CSS

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -207,6 +207,13 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
     </div>
   </div>
 </template>
+
+<style>
+.scalar-api-client__variable {
+  color: var(--scalar-api-client-color, var(--default-scalar-api-client-color));
+}
+</style>
+
 <style scoped>
 .loader {
   position: absolute;
@@ -218,7 +225,6 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   );
   animation: loading 5s cubic-bezier(0, 0.5, 0.25, 1);
 }
-
 @keyframes loading {
   0% {
     width: 0;
@@ -227,7 +233,6 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
     width: 100%;
   }
 }
-
 .scalar-api-client__address-bar {
   width: 100%;
   padding: 12px 12px 10px 12px;
@@ -242,7 +247,6 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   align-items: stretch;
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
 }
-
 .scalar-api-client__url-form:deep(.cm-content) {
   display: flex;
   align-items: center;
@@ -258,56 +262,13 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   overflow: hidden;
   min-height: 31px;
 }
-.scalar-api-client__address-bar-data {
-  width: 100%;
-}
-.scalar-api-client__address-bar-data-meta {
-  display: flex;
-  margin-top: 5px;
-}
-
 .scalar-api-client__url-input {
   color: var(--theme-color-1, var(--default-theme-color-1));
 }
-
-.scalar-api-client__request-type {
-  display: flex;
-  align-items: center;
-  color: var(--theme-color-3, var(--default-theme-color-3));
-  appearance: none;
-  -webkit-appearance: none;
-  padding: 0 12px;
-  border-right: 1px solid
-    var(--theme-border-color, var(--default-theme-border-color));
-  position: relative;
-}
-.scalar-api-client__request-type span {
-  font-family: var(--theme-font-code, var(--default-theme-font-code));
-  font-size: var(--theme-micro, var(--default-theme-micro));
-  text-transform: uppercase;
-}
-.scalar-api-client__request-type svg {
-  margin-left: 6px;
-  width: 8px;
-}
-.scalar-api-client__request-type i {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  margin-right: 6px;
-  text-align: center;
-  line-height: 18px;
-  font-style: normal;
-  flex-shrink: 0;
-  display: inline-block;
-  color: var(--theme-color-3, var(--default-theme-color-3));
-  background: var(
-    --scalar-api-client-color,
-    var(--default-scalar-api-client-color)
-  );
-}
-.meta-request-break {
-  margin: 0 5px;
+.scalar-api-client__url-input {
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
+  min-height: auto;
+  padding-top: 0;
 }
 .scalar-api-client__history {
   appearance: none;
@@ -319,6 +280,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   border-radius: var(--theme-radius, var(--default-theme-radius));
   height: 100%;
 }
+
 .scalar-api-client__send-request-button[type='submit'] {
   font-size: var(--theme-micro, var(--default-theme-micro));
   letter-spacing: 0.25px;
@@ -380,14 +342,12 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
     margin-right: 0;
   }
 }
-
 .scalar-api-client__send-request-button[disabled] {
   pointer-events: none;
   color: var(--theme-color-2, var(--default-theme-color-2));
   background: var(--theme-background-3, var(--default-theme-background-3));
   border: 1px solid var(--default-theme-border-color);
 }
-
 .scalar-api-client__history-toggle {
   padding: 0 12px;
   line-height: 30px;
@@ -416,15 +376,6 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   margin-right: 6px;
   color: var(--theme-color-3, var(--default-theme-color-3));
 }
-.scalar-api-client__address-bar-close {
-  fill: var(--theme-color-3, var(--default-theme-color-3));
-  margin-left: 12px;
-  height: 24px;
-}
-.scalar-api-client__address-bar-close:hover {
-  cursor: pointer;
-  fill: var(--theme-color-1, var(--default-theme-color-1));
-}
 .scalar-api-client__address-bar__content {
   width: 640px;
   height: 100%;
@@ -440,11 +391,6 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
     opacity 0.01s ease-in-out 0.5s;
   pointer-events: none;
 }
-.scalar-api-client__address-bar-content-item {
-  height: 100vh;
-  max-height: 100vh;
-  overflow: auto;
-}
 .scalar-api-client__address-bar__on {
   z-index: 100000;
 }
@@ -459,37 +405,15 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   pointer-events: all;
   cursor: pointer;
 }
-.scalar-api-client__address-bar .navtable-item__active {
-  background: var(--theme-background-2, var(--default-theme-background-2));
-  cursor: default;
-}
-.scalar-api-client__address-bar .navtable-item__active .radio:before {
-  display: none;
-}
-.navigation-back {
-  stroke: var(--theme-color-2, var(--default-theme-color-2));
-  cursor: pointer;
-}
-.navigation-back:hover {
-  stroke: var(--theme-color-1, var(--default-theme-color-1));
-}
 .scalar-api-client__address-bar__close {
   width: 100%;
   height: 100%;
   position: fixed;
   top: 0;
   left: 0;
-  /* background: rgba(0,0,0,.55);
-	 */
   pointer-events: none;
   opacity: 0;
   transition: all 0.1s ease-in-out;
   z-index: 1000;
-}
-.navtable-item-time {
-  font-size: var(--theme-micro, var(--default-theme-micro));
-  color: var(--theme-color-1, var(--default-theme-color-1));
-  text-transform: capitalize;
-  padding: 0 9px;
 }
 </style>

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -209,7 +209,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
 </template>
 
 <style>
-.scalar-api-client__variable {
+.api-client-url-variable {
   color: var(--scalar-api-client-color, var(--default-scalar-api-client-color));
 }
 </style>

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -121,16 +121,16 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
     v-if="loading"
     class="loader"></div>
   <div
-    class="scalar-api-client__address-bar"
-    :class="{ 'scalar-api-client__address-bar__on': showHistory }">
-    <div class="scalar-api-client__url-form">
-      <div class="scalar-api-client__field">
+    class="address-bar"
+    :class="{ 'address-bar--with-history': showHistory }">
+    <div class="url-form">
+      <div class="url-form-field">
         <RequestMethodSelect
           :readOnly="readOnly"
           :requestMethod="requestType"
           @change="handleRequestMethodChanged" />
         <CodeMirror
-          class="scalar-api-client__url-input"
+          class="url-form-input"
           :content="formattedUrl"
           disableEnter
           :readOnly="readOnly"
@@ -139,7 +139,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
           @change="onChange" />
       </div>
       <button
-        class="scalar-api-client__send-request-button"
+        class="send-button"
         :disabled="!formattedUrl.trim().length"
         type="submit"
         @click="send">
@@ -162,9 +162,9 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
       </button>
     </div>
     <div
-      class="scalar-api-client__address-bar__close"
+      class="address-bar-close"
       @click="showHistory = false" />
-    <div class="scalar-api-client__address-bar__content">
+    <div class="address-bar-content">
       <FlowModal
         :state="historyModal"
         title="Request History"
@@ -177,9 +177,9 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
 
     <div
       v-if="requestHistoryOrder.length"
-      class="scalar-api-client__history">
+      class="history">
       <div
-        class="scalar-api-client__history-toggle"
+        class="history-toggle"
         @click="historyModal.show()">
         <svg
           fill="none"
@@ -233,7 +233,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
     width: 100%;
   }
 }
-.scalar-api-client__address-bar {
+.address-bar {
   width: 100%;
   padding: 12px 12px 10px 12px;
   display: flex;
@@ -241,17 +241,17 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   position: relative;
   background: var(--theme-background-1, var(--default-theme-background-1));
 }
-.scalar-api-client__url-form {
+.url-form {
   display: flex;
   width: 100%;
   align-items: stretch;
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
 }
-.scalar-api-client__url-form:deep(.cm-content) {
+.url-form:deep(.cm-content) {
   display: flex;
   align-items: center;
 }
-.scalar-api-client__field {
+.url-form-field {
   border-right: 0;
   background: var(--theme-background-2, var(--default-theme-background-2));
   border-radius: var(--theme-radius, var(--default-theme-radius)) 0 0
@@ -262,15 +262,15 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   overflow: hidden;
   min-height: 31px;
 }
-.scalar-api-client__url-input {
+.url-form-input {
   color: var(--theme-color-1, var(--default-theme-color-1));
 }
-.scalar-api-client__url-input {
+.url-form-input {
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
   min-height: auto;
   padding-top: 0;
 }
-.scalar-api-client__history {
+.history {
   appearance: none;
   -webkit-appearance: none;
   background: transparent;
@@ -281,7 +281,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   height: 100%;
 }
 
-.scalar-api-client__send-request-button[type='submit'] {
+.send-button[type='submit'] {
   font-size: var(--theme-micro, var(--default-theme-micro));
   letter-spacing: 0.25px;
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
@@ -306,7 +306,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   overflow: hidden;
   flex-shrink: 0;
 }
-.scalar-api-client__send-request-button:before {
+.send-button:before {
   content: '';
   position: absolute;
   top: -5%;
@@ -318,10 +318,10 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   border-radius: var(--theme-radius, var(--default-theme-radius));
   background: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2));
 }
-.scalar-api-client__send-request-button:hover:before {
+.send-button:hover:before {
   background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.1));
 }
-.scalar-api-client__send-request-button svg {
+.send-button svg {
   width: 12px;
   height: 12px;
   flex-shrink: 0;
@@ -329,26 +329,26 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   position: relative;
 }
 
-.scalar-api-client__send-request-button span {
+.send-button span {
   position: relative;
 }
 @media screen and (max-width: 720px) {
-  .scalar-api-client__history-toggle span,
-  .scalar-api-client__send-request-button span {
+  .history-toggle span,
+  .send-button span {
     display: none;
   }
-  .scalar-api-client__history-toggle svg,
-  .scalar-api-client__send-request-button svg {
+  .history-toggle svg,
+  .send-button svg {
     margin-right: 0;
   }
 }
-.scalar-api-client__send-request-button[disabled] {
+.send-button[disabled] {
   pointer-events: none;
   color: var(--theme-color-2, var(--default-theme-color-2));
   background: var(--theme-background-3, var(--default-theme-background-3));
   border: 1px solid var(--default-theme-border-color);
 }
-.scalar-api-client__history-toggle {
+.history-toggle {
   padding: 0 12px;
   line-height: 30px;
   color: var(--theme-color-3, var(--default-theme-color-3));
@@ -367,16 +367,16 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   border-radius: var(--theme-radius, var(--default-theme-radius));
   user-select: none;
 }
-.scalar-api-client__history-toggle:hover {
+.history-toggle:hover {
   background: var(--theme-background-2, var(--default-theme-background-2));
 }
-.scalar-api-client__history-toggle svg {
+.history-toggle svg {
   height: 13px;
   width: 13px;
   margin-right: 6px;
   color: var(--theme-color-3, var(--default-theme-color-3));
 }
-.scalar-api-client__address-bar__content {
+.address-bar-content {
   width: 640px;
   height: 100%;
   background: var(--theme-background-1, var(--default-theme-background-1));
@@ -391,21 +391,21 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
     opacity 0.01s ease-in-out 0.5s;
   pointer-events: none;
 }
-.scalar-api-client__address-bar__on {
+.address-bar--with-history {
   z-index: 100000;
 }
-.scalar-api-client__address-bar__on .scalar-api-client__address-bar__content {
+.address-bar--with-history .address-bar-content {
   transform: translate3d(0, 0, 0);
   opacity: 1;
   pointer-events: all;
   transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1);
 }
-.scalar-api-client__address-bar__on .scalar-api-client__address-bar__close {
+.address-bar--with-history .address-bar-close {
   opacity: 1;
   pointer-events: all;
   cursor: pointer;
 }
-.scalar-api-client__address-bar__close {
+.address-bar-close {
   width: 100%;
   height: 100%;
   position: fixed;

--- a/packages/api-client/src/components/ApiClient/RequestHistoryItem.vue
+++ b/packages/api-client/src/components/ApiClient/RequestHistoryItem.vue
@@ -56,3 +56,13 @@ const getContentLength = (response: ClientResponse) => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.navtable-item-time {
+  text-transform: capitalize;
+}
+.navtable-item__active {
+  background: var(--theme-background-2, var(--default-theme-background-2));
+  cursor: default;
+}
+</style>

--- a/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
+++ b/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref, toRef } from 'vue'
+import { ref, toRef } from 'vue'
 
 import { useCodeMirror } from '../../hooks'
 import type { CodeMirrorLanguage } from '../../types'
@@ -24,15 +24,6 @@ const emit = defineEmits<{
 }>()
 
 // CSS Class
-const classes = computed(() =>
-  props.readOnly
-    ? [
-        'scalar-api-client__codemirror',
-        'scalar-api-client__codemirror--read-only',
-      ]
-    : ['scalar-api-client__codemirror'],
-)
-
 const codeMirrorRef = ref<HTMLDivElement | null>(null)
 
 useCodeMirror({
@@ -45,19 +36,18 @@ useCodeMirror({
   disableEnter: toRef(() => props.disableEnter),
   onChange: (v: string) => emit('change', v || ''),
   codeMirrorRef,
-  classes,
+  classes: ['codemirror'],
 })
 </script>
 
 <template>
   <div
     ref="codeMirrorRef"
-    class="scalar-api-client__codemirror__wrapper" />
+    class="codemirror-wrapper" />
 </template>
 
 <style>
-/** Basics */
-.scalar-api-client__codemirror__wrapper {
+.codemirror-wrapper {
   width: 100%;
   height: 100%;
   padding-top: 4px;
@@ -67,7 +57,8 @@ useCodeMirror({
   display: flex;
   align-items: stretch;
 }
-.scalar-api-client__codemirror {
+
+.codemirror {
   flex-grow: 1;
   max-width: 100%;
   cursor: text;
@@ -76,20 +67,6 @@ useCodeMirror({
   -webkit-text-size-adjust: 100%;
 }
 
-/** URL input */
-.scalar-api-client__url-input {
-  font-weight: var(--theme-semibold, var(--default-theme-semibold));
-  min-height: auto;
-  padding-top: 0;
-}
-
-.scalar-api-client__url-input .ͼ1 .cm-scroller {
-  align-items: center !important;
-}
-
-.scalar-api-client__variable {
-  color: var(--scalar-api-client-color, var(--default-scalar-api-client-color));
-}
 .cm-focused {
   outline: none !important;
 }

--- a/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
+++ b/packages/use-codemirror/src/components/CodeMirror/CodeMirror.vue
@@ -43,11 +43,11 @@ useCodeMirror({
 <template>
   <div
     ref="codeMirrorRef"
-    class="codemirror-wrapper" />
+    class="codemirror-container" />
 </template>
 
-<style>
-.codemirror-wrapper {
+<style scoped>
+.codemirror-container {
   width: 100%;
   height: 100%;
   padding-top: 4px;
@@ -58,6 +58,12 @@ useCodeMirror({
   align-items: stretch;
 }
 
+.copy-to-clipboard-button {
+  background: red;
+}
+</style>
+
+<style>
 .codemirror {
   flex-grow: 1;
   max-width: 100%;

--- a/packages/use-codemirror/src/hooks/variables.ts
+++ b/packages/use-codemirror/src/hooks/variables.ts
@@ -12,7 +12,7 @@ const variableHighlighterDecoration = new MatchDecorator({
   decoration: () =>
     Decoration.mark({
       attributes: {
-        class: 'scalar-api-client__variable',
+        class: 'api-client-url-variable',
       },
     }),
 })


### PR DESCRIPTION
This PR:

* removes unused CSS from the CodeMirror component
* moves CSS for the API client address bar to the address bar component
* scopes the remaining CSS