### PR TITLE
fix: wrap request HTTP type in url

### DIFF
--- a/.changeset/itchy-spies-vanish.md
+++ b/.changeset/itchy-spies-vanish.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: wrapping of url on request snippet url

--- a/packages/api-reference/src/components/Content/Operation/CustomRequestExamples.vue
+++ b/packages/api-reference/src/components/Content/Operation/CustomRequestExamples.vue
@@ -135,6 +135,7 @@ const { copyToClipboard } = useClipboard()
 .request-method {
   font-family: var(--theme-font-code, var(--default-theme-font-code));
   text-transform: uppercase;
+  white-space: nowrap;
 }
 .request-client-picker {
   padding-left: 12px;


### PR DESCRIPTION
before:
<img width="817" alt="image" src="https://github.com/scalar/scalar/assets/6176314/80bf8f48-12fa-46e0-80e0-fa9e8041a425">


after
<img width="556" alt="image" src="https://github.com/scalar/scalar/assets/6176314/39b92a74-9ed4-4ee1-bec5-9e6223ad23a0">
