### PR TITLE
refactor: use own helper instead of javascript-time-ago

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -52,7 +52,6 @@
     "@vueuse/core": "^10.4.1",
     "axios": "^1.6.5",
     "content-type": "^1.0.5",
-    "javascript-time-ago": "^2.5.9",
     "nanoid": "^5.0.1",
     "pretty-bytes": "^6.1.1",
     "pretty-ms": "^8.0.0",

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -2,12 +2,13 @@
 import { CodeMirror } from '@scalar/use-codemirror'
 import { FlowModal, useModal } from '@scalar/use-modal'
 import { useMagicKeys, whenever } from '@vueuse/core'
-// import { useMediaQuery } from '@vueuse/core'
-import TimeAgo from 'javascript-time-ago'
-import en from 'javascript-time-ago/locale/en'
 import { computed, ref } from 'vue'
 
-import { prepareClientRequestConfig, sendRequest } from '../../helpers'
+import {
+  humanDiff,
+  prepareClientRequestConfig,
+  sendRequest,
+} from '../../helpers'
 import { useRequestStore } from '../../stores/requestStore'
 import RequestHistory from './RequestHistory.vue'
 import RequestMethodSelect from './RequestMethodSelect.vue'
@@ -22,9 +23,6 @@ const emits = defineEmits<{
 
 const keys = useMagicKeys()
 whenever(keys.meta_enter, send)
-
-TimeAgo.addLocale(en)
-const timeAgo = new TimeAgo('en-US')
 
 const showHistory = ref(false)
 const loading = ref(false)
@@ -85,7 +83,7 @@ async function send() {
 const lastRequestTimestamp = computed(() => {
   const lastRequestKey = requestHistoryOrder.value[0]
   return requestHistory[lastRequestKey]
-    ? timeAgo.format(requestHistory[lastRequestKey].sentTime)
+    ? humanDiff(requestHistory[lastRequestKey].sentTime)
     : 'History'
 })
 

--- a/packages/api-client/src/components/ApiClient/RequestHistoryItem.vue
+++ b/packages/api-client/src/components/ApiClient/RequestHistoryItem.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
-import TimeAgo from 'javascript-time-ago'
-import en from 'javascript-time-ago/locale/en'
 import prettyBytes from 'pretty-bytes'
 import prettyMilliseconds from 'pretty-ms'
 
+import { humanDiff } from '../../helpers'
 import { useRequestStore } from '../../stores/requestStore'
 import { type ClientResponse } from '../../types'
 
 defineProps<{ history: string }>()
-TimeAgo.addLocale(en)
-const timeAgo = new TimeAgo('en-US')
 
 const { requestHistory, activeRequestId, setActiveResponse } = useRequestStore()
 
@@ -51,7 +48,7 @@ const getContentLength = (response: ClientResponse) => {
     </div>
     <div class="navtable-item-20 navtable-item-time">
       <span>
-        {{ timeAgo.format(requestHistory[history].sentTime) }}
+        {{ humanDiff(requestHistory[history].sentTime) }}
       </span>
     </div>
   </div>

--- a/packages/api-client/src/helpers/humanDiff.test.ts
+++ b/packages/api-client/src/helpers/humanDiff.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { humanDiff } from './humanDiff'
+
+describe('humanDiff', () => {
+  it('returns just now for the first 45 seconds', async () => {
+    expect(humanDiff(new Date().getTime() - 44 * 1000)).toBe('just now')
+  })
+
+  it('returns singular for 1 minute', async () => {
+    expect(humanDiff(new Date().getTime() - 60 * 1000)).toBe('1 minute ago')
+  })
+
+  it('returns plural for more than 1 minute', async () => {
+    expect(humanDiff(new Date().getTime() - 2 * 60 * 1000)).toBe(
+      '2 minutes ago',
+    )
+  })
+
+  it('returns 1 hour', async () => {
+    expect(humanDiff(new Date().getTime() - 60 * 60 * 1000)).toBe('1 hour ago')
+  })
+
+  it('returns 2 hours', async () => {
+    expect(humanDiff(new Date().getTime() - 2 * 60 * 60 * 1000)).toBe(
+      '2 hours ago',
+    )
+  })
+
+  it('returns 1 day', async () => {
+    expect(humanDiff(new Date().getTime() - 24 * 60 * 60 * 1000)).toBe(
+      '1 day ago',
+    )
+  })
+
+  it('returns 2 days', async () => {
+    expect(humanDiff(new Date().getTime() - 2 * 24 * 60 * 60 * 1000)).toBe(
+      '2 days ago',
+    )
+  })
+
+  it('returns 1 month', async () => {
+    expect(humanDiff(new Date().getTime() - 30 * 24 * 60 * 60 * 1000)).toBe(
+      '1 month ago',
+    )
+  })
+
+  it('returns 2 months', async () => {
+    expect(humanDiff(new Date().getTime() - 2 * 30 * 24 * 60 * 60 * 1000)).toBe(
+      '2 months ago',
+    )
+  })
+
+  it('returns more than a year ago', async () => {
+    expect(
+      humanDiff(new Date().getTime() - 2 * 365 * 24 * 60 * 60 * 1000),
+    ).toBe('more than a year ago')
+  })
+})

--- a/packages/api-client/src/helpers/humanDiff.ts
+++ b/packages/api-client/src/helpers/humanDiff.ts
@@ -1,0 +1,41 @@
+/**
+ * Get a human-readable string representing the time elapsed since the given Unix timestamp.
+ */
+export function humanDiff(unixTimestamp: number) {
+  const seconds = Math.floor((new Date().getTime() - unixTimestamp) / 1000)
+
+  if (seconds < 45) {
+    return 'just now'
+  }
+
+  // less than a minute, return the seconds
+  if (seconds < 60) {
+    return `${seconds} seconds ago`
+  }
+
+  // less than an hour, return the minutes
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) {
+    return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  }
+
+  // less than a day, return the hours
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  }
+
+  // less than a month, return the days
+  const days = Math.floor(hours / 24)
+  if (days < 30) {
+    return `${days} day${days === 1 ? '' : 's'} ago`
+  }
+
+  // less than a year, return the months
+  const months = Math.floor(days / 30)
+  if (months < 12) {
+    return `${months} month${months === 1 ? '' : 's'} ago`
+  }
+
+  return 'more than a year ago'
+}

--- a/packages/api-client/src/helpers/index.ts
+++ b/packages/api-client/src/helpers/index.ts
@@ -1,6 +1,7 @@
 export * from './concatenateUrlAndPath'
 export * from './createPlaceholderRequest'
 export * from './findVariables'
+export * from './humanDiff'
 export * from './isJsonString'
 export * from './mapFromArray'
 export * from './normalizePath'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,9 +570,6 @@ importers:
       content-type:
         specifier: ^1.0.5
         version: 1.0.5
-      javascript-time-ago:
-        specifier: ^2.5.9
-        version: 2.5.9
       nanoid:
         specifier: ^5.0.1
         version: 5.0.1
@@ -13436,12 +13433,6 @@ packages:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
     dev: true
 
-  /javascript-time-ago@2.5.9:
-    resolution: {integrity: sha512-pQ8mNco/9g9TqWXWWjP0EWl6i/lAQScOyEeXy5AB+f7MfLSdgyV9BJhiOD1zrIac/lrxPYOWNbyl/IW8CW5n0A==}
-    dependencies:
-      relative-time-format: 1.1.6
-    dev: false
-
   /jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -16923,10 +16914,6 @@ packages:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
     engines: {node: '>= 0.10'}
     dev: true
-
-  /relative-time-format@1.1.6:
-    resolution: {integrity: sha512-aCv3juQw4hT1/P/OrVltKWLlp15eW1GRcwP1XdxHrPdZE9MtgqFpegjnTjLhi2m2WI9MT/hQQtE+tjEWG1hgkQ==}
-    dev: false
 
   /remark-external-links@8.0.0:
     resolution: {integrity: sha512-5vPSX0kHoSsqtdftSHhIYofVINC8qmp0nctkeU9YoJwV3YfiBRiI6cbFRJ0oI/1F9xS+bopXG0m2KS8VFscuKA==}


### PR DESCRIPTION
With this PR `javascript-time-ago` is replaced with a tiny helper function in our repository. Should decrease the bundle size by 60kb/3%. :)
