### PR TITLE
fix: set max height on request body codemirror

### DIFF
--- a/.changeset/honest-students-cough.md
+++ b/.changeset/honest-students-cough.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: set max height on request body codemirror

--- a/packages/api-client/src/components/ApiClient/ApiClient.vue
+++ b/packages/api-client/src/components/ApiClient/ApiClient.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/vue'
 import { type ThemeId, ThemeStyles } from '@scalar/themes'
-import { useMagicKeys, whenever } from '@vueuse/core'
-import { useMediaQuery } from '@vueuse/core'
+import { useMagicKeys, useMediaQuery, whenever } from '@vueuse/core'
 import { ref, watch } from 'vue'
 
 import { useRequestStore } from '../../stores'

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -70,9 +70,9 @@ const { activeRequest, readOnly } = useRequestStore()
   border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
 }
-.scalar-api-client__item__content .scalar-api-client__item__content--code {
+.scalar-api-client__item__content .codemirror-container {
   width: 100%;
-  max-height: calc(100vh - 200px);
+  max-height: calc(100vh - 300px);
   overflow: auto;
 }
 .scalar-api-client__item__content .cm-scroller {

--- a/packages/api-client/src/components/ApiClient/Request/RequestBody.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestBody.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { CodeMirror } from '@scalar/use-codemirror'
-import { computed } from 'vue'
 
 import { useRequestStore } from '../../../stores/requestStore'
 import { CollapsibleSection } from '../../CollapsibleSection'


### PR DESCRIPTION
The code was already there just the class got removed from the codemirror element

<img width="1479" alt="Google Chrome-2024-02-20-15-50-01@2x" src="https://github.com/scalar/scalar/assets/6374090/82336796-afb2-43a8-9497-37c3031bf07c">
