### PR TITLE
fix: tab overflow hidden

### DIFF
--- a/.changeset/green-badgers-swim.md
+++ b/.changeset/green-badgers-swim.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: tab overflow hidden

--- a/packages/api-reference/src/components/Card/CardTabHeader.vue
+++ b/packages/api-reference/src/components/Card/CardTabHeader.vue
@@ -12,9 +12,9 @@ const changeTab = (index: number) => {
 }
 </script>
 <template>
-  <CardHeader>
+  <CardHeader class="scalar-card-header-tabs">
     <TabGroup @change="changeTab">
-      <TabList class="tab-list">
+      <TabList class="tab-list custom-scroll">
         <slot />
       </TabList>
     </TabGroup>
@@ -29,5 +29,10 @@ const changeTab = (index: number) => {
   gap: 6px;
   position: relative;
   flex: 1;
+  padding: 9px 12px;
+  overflow: auto;
+}
+.scalar-card-header-tabs {
+  padding: 0;
 }
 </style>

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -231,8 +231,8 @@ const showSchema = ref(false)
 .scalar-card-checkbox {
   display: flex;
   align-items: center;
+  justify-content: center;
   position: relative;
-  padding-right: 27px;
   min-height: 17px;
   cursor: pointer;
   user-select: none;
@@ -242,6 +242,7 @@ const showSchema = ref(false)
   width: fit-content;
   white-space: nowrap;
   margin-right: 9px;
+  gap: 6px;
 }
 .scalar-card-checkbox:hover {
   color: var(--theme-color--1, var(--default-theme-color-1));
@@ -255,9 +256,6 @@ const showSchema = ref(false)
 }
 
 .scalar-card-checkbox-checkmark {
-  position: absolute;
-  top: 0;
-  right: 0;
   height: 17px;
   width: 17px;
   border-radius: var(--theme-radius, var(--default-theme-radius));
@@ -293,9 +291,9 @@ const showSchema = ref(false)
 }
 
 .scalar-card-checkbox .scalar-card-checkbox-checkmark:after {
-  left: 7px;
-  top: 3.5px;
-  width: 4px;
+  right: 6px;
+  top: 36.5%;
+  width: 5px;
   height: 9px;
   border: solid var(--theme-background-1, var(--default-theme-background-1));
   border-width: 0 1.5px 1.5px 0;


### PR DESCRIPTION
before:
<img width="301" alt="image" src="https://github.com/scalar/scalar/assets/6176314/e0150ddd-c7af-46a1-bd53-0e0c0a907082">


after:
<img width="672" alt="image" src="https://github.com/scalar/scalar/assets/6176314/a60ccda6-7ec3-4236-bc35-c58ce48c59b4">
