### PR TITLE
chore: recommend official vitest extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,6 @@
     "esbenp.prettier-vscode",
     "bradlc.vscode-tailwindcss",
     "cpylua.language-postcss",
-    "zixuanchen.vitest-explorer"
+    "vitest.explorer"
   ]
 }


### PR DESCRIPTION
The recommended vitest extension is deprecated, let’s recommend the successor. :)

<img width="551" alt="Screenshot 2024-02-22 at 11 03 57" src="https://github.com/scalar/scalar/assets/1577992/9255e2ac-f1ee-4373-9a23-08aba3458088">

https://marketplace.visualstudio.com/items?itemName=ZixuanChen.vitest-explorer