### PR TITLE
fix: basic auth shows encoded colon string, fix #1026

### DIFF
--- a/.changeset/lucky-lobsters-cry.md
+++ b/.changeset/lucky-lobsters-cry.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: http basic auth empty credentials should not be encoded

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -18,17 +18,17 @@ const configuration = reactive<ReferenceConfiguration>({
   showSidebar: true,
   layout: 'modern',
   spec: { content },
-  authentication: {
-    securitySchemeKey: 'petstore_auth',
-    oAuth2: {
-      clientId: 'foobar123',
-      scopes: ['read:pets', 'write:pets'],
-    },
-    // securitySchemeKey: 'api_key',
-    // apiKey: {
-    //   token: 'super-secret-token',
-    // },
-  },
+  // authentication: {
+  //   securitySchemeKey: 'petstore_auth',
+  //   oAuth2: {
+  //     clientId: 'foobar123',
+  //     scopes: ['read:pets', 'write:pets'],
+  //   },
+  //   // securitySchemeKey: 'api_key',
+  //   // apiKey: {
+  //   //   token: 'super-secret-token',
+  //   // },
+  // },
 })
 
 onMounted(() => {

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.test.ts
@@ -139,6 +139,42 @@ describe('getRequestFromAuthentication', () => {
     })
   })
 
+  it('empty http basic auth', () => {
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'basic',
+        securitySchemes: {
+          basic: {
+            // @ts-ignore
+            type: 'basic',
+          },
+        },
+        http: {
+          ...createEmptyAuthenticationState().http,
+          basic: {
+            username: '',
+            password: '',
+          },
+        },
+      },
+      [
+        {
+          basic: [],
+        },
+      ],
+    )
+
+    expect(request).toMatchObject({
+      headers: [
+        {
+          name: 'Authorization',
+          value: 'Basic',
+        },
+      ],
+    })
+  })
+
   it('oAuth2 token in header', () => {
     const request = getRequestFromAuthentication(
       {

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
@@ -102,11 +102,16 @@ export function getRequestFromAuthentication(
         (securityScheme.type === 'basic' ||
           (securityScheme.type === 'http' && securityScheme.scheme === 'basic'))
       ) {
+        const { username, password } = authentication.http.basic
+
+        const token =
+          username?.length || password?.length
+            ? Buffer.from(`${username}:${password}`).toString('base64')
+            : ''
+
         headers.push({
           name: 'Authorization',
-          value: `Basic ${Buffer.from(
-            `${authentication.http.basic.username}:${authentication.http.basic.password}`,
-          ).toString('base64')}`,
+          value: `Basic ${token}`.trim(),
         })
       }
       // Bearer Auth


### PR DESCRIPTION
For basic auth we’re encoding username and password, even if both are empty. Instead of `hans:test123` the string that we encode is then just `:`.

With this PR the token is omitted if we don’t have credentials.

It’s totally valid to send just the username or just the pasword, so we’re still showing a token for `:test123` or `hans:`.

<img width="606" alt="Screenshot 2024-02-22 at 12 09 19" src="https://github.com/scalar/scalar/assets/1577992/4ddd0b76-6d84-40f9-aab9-28cf8be780cb">
