### PR TITLE
fix: `onSpecUpdate` isn’t called, fix #1021

### DIFF
--- a/.changeset/thirty-keys-tap.md
+++ b/.changeset/thirty-keys-tap.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: onSpecUpdate is not called

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -76,6 +76,10 @@ const { parsedSpecRef, overwriteParsedSpecRef, errorRef } = useParser({
 
 watch(rawSpecRef, () => {
   emit('updateContent', rawSpecRef.value)
+
+  if (props?.configuration?.onSpecUpdate) {
+    props?.configuration?.onSpecUpdate(rawSpecRef.value)
+  }
 })
 
 // Use preparsed content, if it’s passed


### PR DESCRIPTION
Oops, at some point we lost the code to call a configured `onSpecUpdate` function. Let’s fix this quickly!