### PR TITLE
fix: named exports fail in ESM

### DIFF
--- a/packages/api-reference/src/components/CodeBlock/CodeBlock.vue
+++ b/packages/api-reference/src/components/CodeBlock/CodeBlock.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { highlightElement, plugins } from 'prismjs'
+import prismjs from 'prismjs'
 import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-json'
 import 'prismjs/plugins/autoloader/prism-autoloader.js'
@@ -29,6 +29,12 @@ const props = withDefaults(
     lineNumbers: false,
   },
 )
+
+/**
+ * The requested module 'prismjs' is a CommonJS module, which may not support all module.exports as named exports.
+ * CommonJS modules can always be imported via the default export, for example using:
+ */
+const { plugins, highlightElement } = prismjs
 
 const el = ref(null)
 const language = computed(() => {


### PR DESCRIPTION
Unfortunately, `prismjs` is CommonJS. This causes some issues in ESM projects requiring @scalar/api-reference:

```
import { plugins as Iw, highlightElement as jm } from "prismjs";
         ^^^^^^^
SyntaxError: Named export 'plugins' not found. The requested module 'prismjs' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'prismjs';
const { plugins: Iw, highlightElement: jm } = pkg;
```

This PR adds the suggested fix. Let’s see if this helps. :)