### PR TITLE
fix: urls with dynamic protocol are prefixed with the window location origin, fix #1035

### DIFF
--- a/.changeset/ten-timers-itch.md
+++ b/.changeset/ten-timers-itch.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: urls with dynamic protocol are prefixed with the window location origin

--- a/packages/api-reference/src/helpers/getUrlFromServerState.test.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.test.ts
@@ -58,4 +58,42 @@ describe('getUrlFromServerState', () => {
 
     expect(request).toMatchObject('https://example.com/v1')
   })
+
+  it('replaces variables first, and then checks whether a prefix is necessary', () => {
+    const request = getUrlFromServerState({
+      ...createEmptyServerState(),
+      variables: [
+        {
+          name: 'protocol',
+          value: 'https',
+        },
+        {
+          name: 'managementAPIHost',
+          value: 'localhost:8083',
+        },
+      ],
+      selectedServer: 0,
+      servers: [
+        {
+          url: '{protocol}://{managementAPIHost}/management/v2',
+          description: 'APIM Management API v2 - Default base URL',
+          variables: {
+            protocol: {
+              description:
+                'The protocol you want to use to communicate with the mAPI',
+              default: 'https',
+              enum: ['https', 'http'],
+            },
+            managementAPIHost: {
+              description:
+                'The domain of the server hosting your Management API',
+              default: 'localhost:8083',
+            },
+          },
+        },
+      ],
+    })
+
+    expect(request).toMatchObject('https://localhost:8083/management/v2')
+  })
 })

--- a/packages/api-reference/src/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.ts
@@ -12,7 +12,10 @@ export function getUrlFromServerState(state: ServerState) {
       : state?.servers?.[state.selectedServer]
 
   // Replace variables: {protocol}://{host}:{port}/{basePath}
-  let url = replaceVariables(server?.url, state.variables)
+  let url =
+    typeof server?.url === 'string'
+      ? replaceVariables(server?.url, state.variables)
+      : server?.url
 
   // Path `/v1`
   if (url?.startsWith('/')) {

--- a/packages/api-reference/src/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/helpers/getUrlFromServerState.ts
@@ -5,10 +5,14 @@ import { replaceVariables } from './replaceVariables'
  * Get the URL from the server state.
  */
 export function getUrlFromServerState(state: ServerState) {
-  let url =
+  // Get the selected server
+  const server =
     state.selectedServer === null
-      ? state?.servers?.[0]?.url ?? undefined
-      : state?.servers?.[state.selectedServer]?.url
+      ? state?.servers?.[0]
+      : state?.servers?.[state.selectedServer]
+
+  // Replace variables: {protocol}://{host}:{port}/{basePath}
+  let url = replaceVariables(server?.url, state.variables)
 
   // Path `/v1`
   if (url?.startsWith('/')) {
@@ -19,7 +23,7 @@ export function getUrlFromServerState(state: ServerState) {
     url = `${normalizedWindowOrigin()}/${url}`
   }
 
-  return url ? replaceVariables(url, state?.variables) : undefined
+  return url
 }
 
 /**


### PR DESCRIPTION
If an URL uses a variable instead of a static protocol (`{protocol}` vs. `http/https`), the URL is prefixed with the window.location.origin. 

This PR fixes it.

The variables are replaced first, and only then we’ll check whether it’s an absolute URL.