### PR TITLE
fix: fastify-api-reference 1.17 not working with ESM

### DIFF
--- a/packages/fastify-api-reference/src/utils/getJavaScriptFile.ts
+++ b/packages/fastify-api-reference/src/utils/getJavaScriptFile.ts
@@ -1,10 +1,13 @@
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
 /**
  * Read the JavaScript file.
  */
 export function getJavaScriptFile() {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
   const filePath = [
     path.resolve(`${__dirname}/js/standalone.js`),
     path.resolve(`${__dirname}/../../dist/js/standalone.js`),


### PR DESCRIPTION
**Problem**
Currently, @scalar/fastify-api-reference breaks with version 1.17.x. This seems to be introduced by PR #994. The problem is described by the issue #1042.

**Explanation**
This happens because the `__dirname` variable is not defined in ES module scope.

**Solution**
With this PR the `__dirname` variable is explicitly set in the `getJavascriptFile` function, fixing the bug.