### PR TITLE
fix: fastify ESM __dirname undefined, fix #1042

### DIFF
--- a/.changeset/cyan-radios-invent.md
+++ b/.changeset/cyan-radios-invent.md
@@ -1,0 +1,5 @@
+---
+"@scalar/fastify-api-reference": patch
+---
+
+fix: ESM envs \_\_dirname is undefined

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import fastifyApiReference from './index'
 

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -166,7 +166,7 @@ const fastifyApiReference: FastifyPluginAsync<
 
   // Register fastify-html if it isn’t registered yet.
   if (!fastify.hasPlugin('fastify-html')) {
-    // @ts-ignore
+    // @ts-expect-error fastify-html doesn’t have types for some reason
     await fastify.register(import('fastify-html'))
   }
 

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -170,7 +170,7 @@ const fastifyApiReference: FastifyPluginAsync<
     await fastify.register(import('fastify-html'))
   }
 
-  // If no spec is passed and @fastify/swagger isn’t loaded, show a warning.
+  // If no OpenAPI specification is passed and @fastify/swagger isn’t loaded, show a warning.
   if (
     !configuration?.spec?.content &&
     !configuration?.spec?.url &&

--- a/packages/fastify-api-reference/src/utils/getJavaScriptFile.ts
+++ b/packages/fastify-api-reference/src/utils/getJavaScriptFile.ts
@@ -1,19 +1,25 @@
-import fs from 'fs'
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 /**
  * Read the JavaScript file.
  */
 export function getJavaScriptFile() {
+  // Get the directory name
+  const dirname = __dirname ?? path.dirname(fileURLToPath(import.meta.url))
+
+  // Find the JavaScript file
   const filePath = [
-    path.resolve(`${__dirname}/js/standalone.js`),
-    path.resolve(`${__dirname}/../../dist/js/standalone.js`),
+    path.resolve(`${dirname}/js/standalone.js`),
+    path.resolve(`${dirname}/../../dist/js/standalone.js`),
   ].find((file: string) => fs.existsSync(file))
 
+  // Throw an error if the file is not found
   if (filePath === undefined) {
     throw new Error(
       `JavaScript file not found: ${path.resolve(
-        `${__dirname}/js/standalone.js`,
+        `${dirname}/js/standalone.js`,
       )}`,
     )
   }


### PR DESCRIPTION
Currently, our Fastify package can’t be used in ESM envs, because I removed the node shim for `__dirname`. This PR adds a fix based on #1043 by @markusgeert.

Unfortunately, I can’t reproduce the issue _inside the dev env_ so I’m kind of blind. Let’s cross fingers this works, I’ll test it once released. 🤞