### PR TITLE
chore: monitor CDN/standalone bundlesize (instead of ESM build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
         with:
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          webpackStatsFile: ./packages/api-reference/dist/webpack-stats.json
+          webpackStatsFile: ./packages/api-reference/dist/browser/webpack-stats.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,4 @@ jobs:
         with:
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          webpackStatsFile: ./packages/api-reference/dist/webpack-stats.json
+          webpackStatsFile: ./packages/api-reference/dist/browser/webpack-stats.json

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -1,6 +1,5 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
-import { webpackStats } from 'rollup-plugin-webpack-stats'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import { defineConfig } from 'vitest/config'
 
@@ -10,7 +9,7 @@ export default defineConfig({
   define: {
     'process.env.NODE_ENV': '"production"',
   },
-  plugins: [vue(), cssInjectedByJsPlugin(), webpackStats()],
+  plugins: [vue(), cssInjectedByJsPlugin()],
   build: {
     emptyOutDir: true,
     cssCodeSplit: false,

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -1,5 +1,6 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
+import { webpackStats } from 'rollup-plugin-webpack-stats'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import { defineConfig } from 'vitest/config'
@@ -25,6 +26,7 @@ export default defineConfig({
       // Whether to polyfill `node:` protocol imports.
       protocolImports: true,
     }),
+    webpackStats(),
   ],
   build: {
     emptyOutDir: false,


### PR DESCRIPTION
Currently, we’re monitoring the bundle size of the ESM build. But we’re actually more interested in the CDN/standalone build, that has **everything** included.

With this PR we’re switching to monitor the CDN/standalone build instead (which is way larger BTW).