### PR TITLE
fix: max width size and client width breakpoint & sizes

### DIFF
--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -204,7 +204,7 @@ const referenceSlotProps = computed<ReferenceSlotProps>(() => ({
 .scalar-api-reference {
   --refs-sidebar-width: var(--theme-sidebar-width, 0px);
   --refs-header-height: var(--theme-header-height, 0px);
-  --refs-content-max-width: var(--theme-content-max-width, 1120px);
+  --refs-content-max-width: var(--theme-content-max-width, 1540px);
 }
 
 .scalar-api-reference.references-classic {
@@ -314,7 +314,7 @@ const referenceSlotProps = computed<ReferenceSlotProps>(() => ({
 
 .references-sidebar {
   /* Set a default width if references are enabled */
-  --refs-sidebar-width: var(--theme-sidebar-width, 280px);
+  --refs-sidebar-width: var(--theme-sidebar-width, 250px);
 }
 
 /* Footer */

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -314,7 +314,7 @@ const referenceSlotProps = computed<ReferenceSlotProps>(() => ({
 
 .references-sidebar {
   /* Set a default width if references are enabled */
-  --refs-sidebar-width: var(--theme-sidebar-width, 250px);
+  --refs-sidebar-width: var(--theme-sidebar-width, 280px);
 }
 
 /* Footer */

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -17,7 +17,7 @@ const containerRef = ref<HTMLElement>()
 
 useResizeObserver(
   containerRef,
-  (entries) => (isSmall.value = entries[0].contentRect.width < 500),
+  (entries) => (isSmall.value = entries[0].contentRect.width < 400),
 )
 
 // Show popular clients with an icon, not just in a select.
@@ -209,7 +209,7 @@ function checkIfClientIsFeatured(client: SelectedClient) {
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  max-width: 68px;
+  max-width: 60px;
   width: 100%;
   padding: 12px 0;
   position: relative;
@@ -224,11 +224,11 @@ function checkIfClientIsFeatured(client: SelectedClient) {
   }
 }
 .code-languages-icon {
-  max-width: 48px;
+  max-width: 42px;
   width: 100%;
-  max-height: 48px;
+  max-height: 42px;
   aspect-ratio: 1;
-  padding: 7px;
+  padding: 9px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -240,7 +240,7 @@ function checkIfClientIsFeatured(client: SelectedClient) {
   );
 }
 .code-languages-background {
-  border-radius: 12px;
+  border-radius: 9px;
   position: relative;
   box-shadow: 0 0 0 1px
     var(
@@ -355,7 +355,7 @@ function checkIfClientIsFeatured(client: SelectedClient) {
   }
 }
 .code-languages span {
-  margin-top: 3px;
+  margin-top: 6px;
   color: var(--theme-color-2, var(--default-theme-color-2));
   font-size: var(--theme-micro, var(--default-theme-micro));
 }


### PR DESCRIPTION
change max width to 1540px for refs

change breakpoints + sizes of default theme client library icons

After:
<img width="627" alt="image" src="https://github.com/scalar/scalar/assets/6201407/1fd08788-132f-43b4-9143-4f72afbc7b66">

Before:
<img width="599" alt="image" src="https://github.com/scalar/scalar/assets/6201407/9dc5954e-4ef4-4752-8dab-933ee93c8595">
