### PR TITLE
chore: allow hono@v4 as peerDependency

### DIFF
--- a/.changeset/lemon-waves-enjoy.md
+++ b/.changeset/lemon-waves-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@scalar/hono-api-reference": patch
+---
+
+allow hono@v4 as peerDependency

--- a/packages/hono-api-reference/package.json
+++ b/packages/hono-api-reference/package.json
@@ -47,6 +47,6 @@
     "vitest": "^1.2.2"
   },
   "peerDependencies": {
-    "hono": "^3.0.0"
+    "hono": "^3.0.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
**Problem**
Only hono@v3 is specified in the peerDependencies of @scalar/hono-api-reference

**Solution**
With this PR, hono@v4 is allowed as well.
