### PR TITLE
fix: select all does not work

### DIFF
--- a/.changeset/sweet-buckets-exist.md
+++ b/.changeset/sweet-buckets-exist.md
@@ -1,0 +1,5 @@
+---
+"@scalar/use-codemirror": patch
+---
+
+fix: select all keybinding does not work

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -5,6 +5,7 @@ import * as yamlMode from '@codemirror/legacy-modes/mode/yaml'
 import { type Extension, StateEffect } from '@codemirror/state'
 import {
   EditorView,
+  type KeyBinding,
   keymap,
   lineNumbers as lineNumbersExtension,
 } from '@codemirror/view'
@@ -62,6 +63,18 @@ const hasProvider = (
   content?: MaybeRefOrGetter<string | undefined>
   provider: MaybeRefOrGetter<Extension>
 } => 'provider' in params && !!toValue(params.provider)
+
+const selectAllKeyBinding: KeyBinding = {
+  key: 'Mod-a',
+  run: (view) => {
+    // Select the entire content
+    view.dispatch({
+      selection: { anchor: 0, head: view.state.doc.length },
+      scrollIntoView: false,
+    })
+    return true
+  },
+}
 
 /** Reactive CodeMirror Integration */
 export const useCodeMirror = (
@@ -236,6 +249,7 @@ function getCodeMirrorExtensions({
   additionalExtensions?: Extension[]
 }) {
   const extensions: Extension[] = [
+    keymap.of([selectAllKeyBinding]),
     EditorView.theme({
       '.cm-line': {
         lineHeight: '20px',


### PR DESCRIPTION
Select all doesn’t work in CodeMirror. We’ve had a fix, I removed it in https://github.com/scalar/scalar/commit/3d712d7464894a07ee91f62416ec1ef3251a60ff and this PR adds it again. 🤡 