### PR TITLE
feat: hide secret credentials, fix #1062

### DIFF
--- a/.changeset/fuzzy-dolphins-try.md
+++ b/.changeset/fuzzy-dolphins-try.md
@@ -1,0 +1,7 @@
+---
+"@scalar/api-reference": patch
+"@scalar/api-client": patch
+"@scalar/components": patch
+---
+
+feat: hide secret credentials

--- a/packages/api-client/src/components/Grid/Grid.vue
+++ b/packages/api-client/src/components/Grid/Grid.vue
@@ -2,7 +2,7 @@
 import { ScalarIcon } from '@scalar/components'
 import { ref } from 'vue'
 
-const props = defineProps<{
+defineProps<{
   items: any[]
   addLabel?: string
   showMoreFilter?: boolean

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -115,6 +115,7 @@ const startAuthentication = (url: string) => {
       v-if="value.type === 'apiKey'"
       :id="`security-scheme-${value.name}`"
       placeholder="Token"
+      type="password"
       :value="authentication.apiKey.token"
       @input="handleApiKeyTokenInput">
       {{ value.in.charAt(0).toUpperCase() + value.in.slice(1) }} API Key
@@ -146,6 +147,7 @@ const startAuthentication = (url: string) => {
         v-else-if="value.type === 'http' && value.scheme === 'bearer'"
         id="http.bearer.token"
         placeholder="Token"
+        type="password"
         :value="authentication.http.bearer.token"
         @input="handleHttpBearerTokenInput">
         Bearer Token

--- a/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
+++ b/packages/api-reference/src/components/Content/Authentication/SecurityScheme.vue
@@ -162,6 +162,7 @@ const startAuthentication = (url: string) => {
       <CardFormTextInput
         id="oAuth2.clientId"
         placeholder="Token"
+        type="password"
         :value="authentication.oAuth2.clientId"
         @input="handleOpenAuth2ClientIdInput">
         Client ID

--- a/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
@@ -7,6 +7,7 @@ import { computed, ref, watch } from 'vue'
 
 import {
   getApiClientRequest,
+  getBase64Token,
   getHarRequest,
   getRequestFromAuthentication,
   getRequestFromOperation,
@@ -68,7 +69,6 @@ const generateSnippet = async (): Promise<string> => {
     // Snippetz
     if (
       snippetz().hasPlugin(
-        // @ts-ignore
         state.selectedClient.targetKey.replace('javascript', 'js'),
         // @ts-ignore
         state.selectedClient.clientKey,
@@ -178,9 +178,21 @@ computed(() => {
       frameless>
       <!-- Multiple examples -->
       <div class="code-snippet">
-        <!-- @vue-ignore -->
         <ScalarCodeBlock
           :content="CodeMirrorValue"
+          :hideCredentials="
+            [
+              authenticationState.apiKey.token,
+              authenticationState.http.bearer.token,
+              // The basic auth token is the base64 encoded username and password
+              getBase64Token(
+                authenticationState.http.basic.username,
+                authenticationState.http.basic.password,
+              ),
+              // The plain text password shouldn’t appear anyway, but just in case
+              authenticationState.http.basic.password,
+            ].filter(Boolean)
+          "
           :lang="state.selectedClient.targetKey"
           lineNumbers />
       </div>

--- a/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
@@ -7,10 +7,10 @@ import { computed, ref, watch } from 'vue'
 
 import {
   getApiClientRequest,
-  getBase64Token,
   getHarRequest,
   getRequestFromAuthentication,
   getRequestFromOperation,
+  getSecretCredentialsFromAuthentication,
   getUrlFromServerState,
 } from '../../../helpers'
 import { useClipboard, useSnippetTargets } from '../../../hooks'
@@ -181,17 +181,7 @@ computed(() => {
         <ScalarCodeBlock
           :content="CodeMirrorValue"
           :hideCredentials="
-            [
-              authenticationState.apiKey.token,
-              authenticationState.http.bearer.token,
-              // The basic auth token is the base64 encoded username and password
-              getBase64Token(
-                authenticationState.http.basic.username,
-                authenticationState.http.basic.password,
-              ),
-              // The plain text password shouldn’t appear anyway, but just in case
-              authenticationState.http.basic.password,
-            ].filter(Boolean)
+            getSecretCredentialsFromAuthentication(authenticationState)
           "
           :lang="state.selectedClient.targetKey"
           lineNumbers />

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
@@ -104,10 +104,7 @@ export function getRequestFromAuthentication(
       ) {
         const { username, password } = authentication.http.basic
 
-        const token =
-          username?.length || password?.length
-            ? Buffer.from(`${username}:${password}`).toString('base64')
-            : ''
+        const token = getBase64Token(username, password)
 
         headers.push({
           name: 'Authorization',
@@ -149,4 +146,10 @@ export function getRequestFromAuthentication(
   }
 
   return { headers, queryString, cookies }
+}
+
+export function getBase64Token(username: string, password: string) {
+  return username?.length || password?.length
+    ? Buffer.from(`${username}:${password}`).toString('base64')
+    : ''
 }

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.ts
@@ -153,3 +153,20 @@ export function getBase64Token(username: string, password: string) {
     ? Buffer.from(`${username}:${password}`).toString('base64')
     : ''
 }
+
+export function getSecretCredentialsFromAuthentication(
+  authentication: AuthenticationState,
+) {
+  return [
+    authentication.apiKey.token,
+    authentication.http.bearer.token,
+    authentication.oAuth2.clientId,
+    // The basic auth token is the base64 encoded username and password
+    getBase64Token(
+      authentication.http.basic.username,
+      authentication.http.basic.password,
+    ),
+    // The plain text password shouldn’t appear anyway, but just in case
+    authentication.http.basic.password,
+  ].filter(Boolean)
+}

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.stories.ts
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.stories.ts
@@ -82,3 +82,12 @@ export const LineNumbers: Story = {
 export const JSON: Story = {
   args: { content: contentJson, lineNumbers: true, lang: 'json' },
 }
+
+export const HideCredentials: Story = {
+  args: {
+    content: `curl --request PUT \
+  --url https://petstore3.swagger.io/api/v3/pet \
+  --header 'Authorization: Bearer 123234324'`,
+    hideCredentials: ['123234324'],
+  },
+}


### PR DESCRIPTION
Currently, we’re showing all tokens/passwords/keys in plain text. See #1062.

With this PR:
* the relevant inputs become password fields
* the secret credentials are hidden in the code blocks (but still there if you copy the content)

The current approach has one downside. If someone passes "curl" or just a single letter as a token, all those are hidden in the example. The passed strings are considered secret and whenever they appear in the code block they are hidden.

But they are still visible in the API client. We could hide the `Authorization` header value always, but not everyone uses the `Authorization` header. They are plenty of alternatives (cookies, URL, other header names …).

So we could pass the credentials and just match them, but what if you change the credentials in the API client? Are they shown then?

In an ideal world the API clients would know about the OpenAPI specification and could hide the exact fields, but we’re not there yet.

<img width="590" alt="Screenshot 2024-02-28 at 13 22 58" src="https://github.com/scalar/scalar/assets/1577992/b00fe80a-cff1-417a-9fb9-03ab6862a887">
