### PR TITLE
feat: show deprecated badge for schema attributes, fix #1052

### DIFF
--- a/.changeset/green-rocks-relax.md
+++ b/.changeset/green-rocks-relax.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: show badge for deprecated schema attributes

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -58,12 +58,23 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 <template>
   <div
     class="property"
-    :class="[`property--level-${level}`, { 'property--compact': compact }]">
+    :class="[
+      `property--level-${level}`,
+      {
+        'property--compact': compact,
+        'property--deprecated': value?.deprecated,
+      },
+    ]">
     <div class="property-information">
       <div
         v-if="name"
         class="property-name">
         {{ name }}
+      </div>
+      <div
+        v-if="value?.deprecated"
+        class="property-deprecated">
+        <Badge>deprecated</Badge>
       </div>
       <div
         v-if="required"
@@ -222,6 +233,21 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 
 .property--compact.property--level-0 {
   padding: 10px 0;
+}
+
+.property--deprecated {
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--theme-background-2, var(--default-theme-background-2)) 0,
+    var(--theme-background-2, var(--default-theme-background-2)) 2px,
+    transparent 2px,
+    transparent 5px
+  );
+  background-size: 100%;
+}
+
+.property--deprecated > * {
+  opacity: 0.75;
 }
 
 .property-information {


### PR DESCRIPTION
Currently, we don’t show any indication when schema attributes are marked as deprecated. See #1052

With this PR a “deprecated“ badge is added (the same badge we use for deprecated paths) and I’ve added diagonal lines to the background. @cameronrohani Wdyt? I bet you’ll come up with something better, feel free to add to the PR.

<img width="588" alt="Screenshot 2024-02-28 at 14 27 45" src="https://github.com/scalar/scalar/assets/1577992/65555390-5fc7-4c43-b3ad-f4c38e70f39c">
