### PR TITLE
fix: example response with content encoding is not shown, fix #920

### DIFF
--- a/.changeset/seven-balloons-shave.md
+++ b/.changeset/seven-balloons-shave.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: example response with encoding in content type is not shown

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -61,6 +61,7 @@ const currentJsonResponse = computed(
   () =>
     // OpenAPI 3.x
     currentResponse.value?.content?.['application/json'] ??
+    currentResponse.value?.content?.['application/json; charset=utf-8'] ??
     currentResponse.value?.content?.['application/problem+json'] ??
     // Swagger 2.0
     currentResponse.value,


### PR DESCRIPTION
Currently, when you add an encoding to the content type of the example responses, they are not shown anymore. See #920.

This PR fixes exactly this (but not more). There is probably a better solution to get “any json content type” from the object, but let’s add this pragmatic fix for now.