### PR TITLE
style: set scroll and border on response body

### DIFF
--- a/.changeset/cold-timers-remember.md
+++ b/.changeset/cold-timers-remember.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+style: added scrollbar and border to api-client

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -66,10 +66,12 @@ const { activeRequest, readOnly } = useRequestStore()
   width: 100%;
   min-height: 63px;
 }
+.scalar-api-client__item__content .scalar-codeblock-pre,
 .scalar-api-client__item__content .cm-s-default {
   border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
 }
+.scalar-api-client__item__content .scalar-codeblock-pre,
 .scalar-api-client__item__content .codemirror-container {
   width: 100%;
   max-height: calc(100vh - 300px);

--- a/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
+++ b/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
@@ -57,6 +57,7 @@ const codeMirrorLanguage = computed((): string | null => {
     <template v-if="active">
       <ScalarCodeBlock
         v-if="codeMirrorLanguage"
+        class="custom-scroll"
         :content="data"
         :lang="codeMirrorLanguage" />
       <div


### PR DESCRIPTION
Noticed a little issue with the api-client since switching to prismjs. This PR sets a max height + little border so it matches the look of codemirror.
Before:
![image](https://github.com/scalar/scalar/assets/2039539/23f6c677-b1b5-47cb-b536-2a42fe84dc84)
After:
![image](https://github.com/scalar/scalar/assets/2039539/a50dd826-86ee-4747-9d7a-8a70f55f28d2)
