### PR TITLE
fix: stop rendering infinite child attributes

### DIFF
--- a/.changeset/quiet-plants-ring.md
+++ b/.changeset/quiet-plants-ring.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: stop rendering infinite child attributes

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -159,7 +159,10 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     </div>
     <!-- Object -->
     <div
-      v-if="value?.properties || value?.additionalProperties"
+      v-if="
+        value?.type === 'object' &&
+        (value?.properties || value?.additionalProperties)
+      "
       class="children">
       <Schema
         :compact="compact"


### PR DESCRIPTION
fix: https://github.com/scalar/scalar/discussions/1049

## **Problem**
Currently, when defining a `Record` as part of a request body it is possible to infinitely show child attributes.

https://github.com/scalar/scalar/assets/42624869/05b35afb-5e00-49af-9523-78fb6b2f60a7

![image](https://github.com/scalar/scalar/assets/42624869/8414f395-7936-4186-88e4-1001f689f609)

## **Explanation**
This happens because the `SchemaProperty` component does not check if the current value is an object before rendering a child `Schema` component. 

## **Solution**
With this PR the `SchemaProperty` is changed to only render a child schema when the current value is an object.

https://github.com/scalar/scalar/assets/42624869/f4cac496-8716-4d7e-a1c6-598bd48d3e0e

![image](https://github.com/scalar/scalar/assets/42624869/582ff7ad-02d4-410e-b0ca-8f0c3e7caa28)



