### PR TITLE
chore: remove alias from components package

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,7 +7,7 @@
   "singleQuote": true,
   "singleAttributePerLine": true,
   "bracketSameLine": true,
-  "importOrder": ["^@/(.*)$", "^[./]"],
+  "importOrder": ["^[./]"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true
 }

--- a/examples/api-client-proxy/vite.config.ts
+++ b/examples/api-client-proxy/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../../packages/$2/src/index.ts'),
       },
     ],

--- a/examples/echo-server/vite.config.ts
+++ b/examples/echo-server/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../../packages/$2/src/index.ts'),
       },
     ],

--- a/examples/express-api-reference/vite.config.ts
+++ b/examples/express-api-reference/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../../packages/$2/src/index.ts'),
       },
     ],

--- a/examples/fastify-api-reference/vite.config.ts
+++ b/examples/fastify-api-reference/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../../packages/$2/src/index.ts'),
       },
     ],

--- a/examples/hono-api-reference/vite.config.ts
+++ b/examples/hono-api-reference/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../../packages/$2/src/index.ts'),
       },
     ],

--- a/examples/nextjs-api-reference/tsconfig.json
+++ b/examples/nextjs-api-reference/tsconfig.json
@@ -16,10 +16,7 @@
       {
         "name": "next"
       }
-    ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/examples/react/vite.config.ts
+++ b/examples/react/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../../packages/$2/src/index.ts'),
       },
     ],

--- a/examples/web/vite.config.ts
+++ b/examples/web/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../../packages/$2/src/index.ts'),
       },
     ],

--- a/packages/api-client-proxy/vite.config.ts
+++ b/packages/api-client-proxy/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],

--- a/packages/api-client/vite.config.ts
+++ b/packages/api-client/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/components/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components|themes\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz|themes\b))(.+)/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],

--- a/packages/components/.prettierrc
+++ b/packages/components/.prettierrc
@@ -12,7 +12,7 @@
   "singleQuote": true,
   "singleAttributePerLine": true,
   "bracketSameLine": true,
-  "importOrder": ["^@lib/(.*)$", "^@guide/(.*)$", "^@/(.*)$", "^[./]"],
+  "importOrder": ["^@lib/(.*)$", "^@guide/(.*)$", "^[./]"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true
 }

--- a/packages/components/.storybook/preview.ts
+++ b/packages/components/.storybook/preview.ts
@@ -8,8 +8,7 @@ import purple from '@scalar/themes/presets/purple.css?inline'
 import solarized from '@scalar/themes/presets/solarized.css?inline'
 import type { Preview } from '@storybook/vue3'
 
-import '@/tailwind/tailwind.css'
-
+import '../src/tailwind/tailwind.css'
 import './preview.css'
 
 // Vite hack for storybook

--- a/packages/components/src/components/ScalarButton/ScalarButton.vue
+++ b/packages/components/src/components/ScalarButton/ScalarButton.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { computed, useAttrs } from 'vue'
 
-import { cx } from '@/cva'
-
+import { cx } from '../../cva'
 import { type LoadingState, ScalarLoading } from '../ScalarLoading'
 import { type Variants, variants } from './variants'
 

--- a/packages/components/src/components/ScalarButton/variants.ts
+++ b/packages/components/src/components/ScalarButton/variants.ts
@@ -1,6 +1,6 @@
 import type { VariantProps } from 'cva'
 
-import { cva } from '@/cva'
+import { cva } from '../../cva'
 
 export const styles: Record<string, Record<string, any>> = {
   solid: [

--- a/packages/components/src/components/ScalarIcon/ScalarIcon.vue
+++ b/packages/components/src/components/ScalarIcon/ScalarIcon.vue
@@ -2,8 +2,7 @@
 import { type VariantProps } from 'cva'
 import { computed } from 'vue'
 
-import { cva, cx } from '@/cva'
-
+import { cva, cx } from '../../cva'
 import SvgRenderer from './SvgRenderer'
 import { type Icon, getIcon } from './icons/'
 

--- a/packages/components/src/components/ScalarIconButton/ScalarIconButton.vue
+++ b/packages/components/src/components/ScalarIconButton/ScalarIconButton.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import type { VariantProps } from 'cva'
 
-import { cva, cx } from '@/cva'
-
+import { cva, cx } from '../../cva'
 import { styles } from '../ScalarButton'
 import { type Icon, ScalarIcon } from '../ScalarIcon'
 

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.vue
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { cx } from '@/cva'
+import { cx } from '../../cva'
 import { reactive } from 'vue'
 
 withDefaults(

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -5,7 +5,7 @@ import {
   DialogPanel,
   DialogTitle,
 } from '@headlessui/vue'
-import { cva, cx } from '@/cva'
+import { cva, cx } from '../../cva'
 
 import { reactive } from 'vue'
 import type { VariantProps } from 'cva'

--- a/packages/components/src/components/ScalarTextField/ScalarTextField.vue
+++ b/packages/components/src/components/ScalarTextField/ScalarTextField.vue
@@ -3,7 +3,7 @@ import { useTextareaAutosize } from '@vueuse/core'
 import { nanoid } from 'nanoid'
 import { type Ref, onMounted, ref, useAttrs } from 'vue'
 
-import { cva, cx } from '@/cva'
+import { cva, cx } from '../../cva'
 
 const props = withDefaults(
   defineProps<{

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,13 +1,13 @@
 import type { App } from 'vue'
 
-import { ScalarButton } from '@/components/ScalarButton'
-import { ScalarCodeBlock } from '@/components/ScalarCodeBlock'
-import { ScalarIcon } from '@/components/ScalarIcon'
-import { ScalarIconButton } from '@/components/ScalarIconButton'
-import { ScalarLoading, useLoadingState } from '@/components/ScalarLoading'
-import { ScalarModal, useModal } from '@/components/ScalarModal'
-import { ScalarTextField } from '@/components/ScalarTextField'
-import '@/tailwind/tailwind.css'
+import { ScalarButton } from './components/ScalarButton'
+import { ScalarCodeBlock } from './components/ScalarCodeBlock'
+import { ScalarIcon } from './components/ScalarIcon'
+import { ScalarIconButton } from './components/ScalarIconButton'
+import { ScalarLoading, useLoadingState } from './components/ScalarLoading'
+import { ScalarModal, useModal } from './components/ScalarModal'
+import { ScalarTextField } from './components/ScalarTextField'
+import './tailwind/tailwind.css'
 
 export default {
   install: (app: App) => {
@@ -32,4 +32,4 @@ export {
   ScalarTextField,
 }
 
-export { extend, theme } from '@/tailwind'
+export { extend, theme } from './tailwind'

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -18,10 +18,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2022",
-    "verbatimModuleSyntax": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "verbatimModuleSyntax": true
   },
   "exclude": ["node_modules"]
 }

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -46,9 +46,4 @@ export default defineConfig({
     dts({ insertTypesEntry: true, rollupTypes: true }),
     cssInjectedByJsPlugin(),
   ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
-  },
 })

--- a/packages/echo-server/vite.config.ts
+++ b/packages/echo-server/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],

--- a/packages/fastify-api-reference/vite.config.ts
+++ b/packages/fastify-api-reference/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],

--- a/packages/swagger-editor/vite.config.ts
+++ b/packages/swagger-editor/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],

--- a/packages/swagger-parser/vite.config.ts
+++ b/packages/swagger-parser/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(snippetz|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],


### PR DESCRIPTION
Currently, we import the source files for all @scalar dependencies. I mean that’s why we’re doing the monorepo thing, to have all in the same place and have a short dev cycle.

However, we made an exemption for @scalar/components and only included the build. If you want to see changes to @scalar/components in @scalar/api-reference you have to make a build.

And the only reason we did this, was the aliases. We once removed all aliases from all packages to avoid the trouble. With the current setup, if you import a source file from another package, the alias can’t be resolved. Because the Vite config isn’t read then.

This PR removes the alias from the components package and removes the exemption. Means, we have cross-package HMR for the components now. :)