### PR TITLE
fix: search button too big

### DIFF
--- a/packages/api-reference/src/components/SearchButton.vue
+++ b/packages/api-reference/src/components/SearchButton.vue
@@ -32,7 +32,8 @@ whenever(keys[`meta_${props.searchHotKey}`], () =>
     @click="modalState.show">
     <ScalarIcon
       class="search-icon"
-      icon="Search" />
+      icon="Search"
+      size="sm" />
     <div class="sidebar-search-input">
       <span class="sidebar-search-placeholder">Search</span>
       <span class="sidebar-search-shortcut">


### PR DESCRIPTION
Looks like I introduced a visual regression with #1057. :) This PR should fix it.

<img width="1488" alt="Screenshot 2024-02-29 at 10 44 12" src="https://github.com/scalar/scalar/assets/1577992/ac4a3dcb-370e-4019-b20f-5cc894d89be3">
