### PR TITLE
feat: add custom CDN

### DIFF
--- a/packages/express-api-reference/README.md
+++ b/packages/express-api-reference/README.md
@@ -69,3 +69,21 @@ app.use(
   }),
 )
 ```
+
+### Custom CDN
+
+You can use a custom CDN ，default is `https://cdn.jsdelivr.net/npm/@scalar/api-reference`.
+
+```ts
+import { apiReference } from '@scalar/nestjs-api-reference'
+
+app.use(
+  '/reference',
+  apiReference({
+    cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+    spec: {
+      content: OpenApiSpecification,
+    },
+  }),
+)
+```

--- a/packages/express-api-reference/src/expressApiReference.ts
+++ b/packages/express-api-reference/src/expressApiReference.ts
@@ -131,7 +131,7 @@ export const ApiReference = (options: ApiReferenceOptions) => {
 /**
  * The HTML template to render the API Reference.
  */
-export function apiReference(options: ReferenceConfiguration) {
+export function apiReference(options: ApiReferenceOptions) {
   return (req: Request, res: Response) => {
     res.send(`
   <!DOCTYPE html>

--- a/packages/express-api-reference/src/expressApiReference.ts
+++ b/packages/express-api-reference/src/expressApiReference.ts
@@ -1,7 +1,9 @@
 import type { ReferenceConfiguration } from '@scalar/api-reference'
 import type { Request, Response } from 'express'
 
-export type ApiReferenceOptions = ReferenceConfiguration
+export type ApiReferenceOptions = ReferenceConfiguration & {
+  cdn?: string
+}
 
 /**
  * The custom theme CSS for the API Reference.
@@ -122,7 +124,7 @@ export const ApiReference = (options: ApiReferenceOptions) => {
             : JSON.stringify(options.spec?.content)
           : ''
       }</script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+      <script src="${options.cdn || 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'}"></script>
   `
 }
 

--- a/packages/express-api-reference/test/index.test.ts
+++ b/packages/express-api-reference/test/index.test.ts
@@ -10,4 +10,15 @@ describe('ApiReference', () => {
       `https://petstore3.swagger.io/api/v3/openapi.json`,
     )
   })
+
+  it('renders the given spec URL with custom cdn', () => {
+    expect(
+      ApiReference({
+        spec: {
+          url,
+          cdn: 'https://fastly.jsdelivr.net/npm/@scalar/api-reference',
+        },
+      }).toString(),
+    ).toContain(`https://petstore3.swagger.io/api/v3/openapi.json`)
+  })
 })

--- a/packages/hono-api-reference/README.md
+++ b/packages/hono-api-reference/README.md
@@ -69,3 +69,21 @@ app.get(
   }),
 )
 ```
+
+### Custom CDN
+
+You can use a custom CDN ，default is `https://cdn.jsdelivr.net/npm/@scalar/api-reference`.
+
+```ts
+import { apiReference } from '@scalar/nestjs-api-reference'
+
+app.use(
+  '/reference',
+  apiReference({
+    cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+    spec: {
+      content: OpenApiSpecification,
+    },
+  }),
+)
+```

--- a/packages/hono-api-reference/src/honoApiReference.test.ts
+++ b/packages/hono-api-reference/src/honoApiReference.test.ts
@@ -10,4 +10,15 @@ describe('javascript', () => {
       `https://petstore3.swagger.io/api/v3/openapi.json`,
     )
   })
+
+  it('renders the given spec URL with custom cdn', () => {
+    expect(
+      javascript({
+        spec: {
+          url,
+          cdn: 'https://fastly.jsdelivr.net/npm/@scalar/api-reference',
+        },
+      }).toString(),
+    ).toContain(`https://petstore3.swagger.io/api/v3/openapi.json`)
+  })
 })

--- a/packages/hono-api-reference/src/honoApiReference.ts
+++ b/packages/hono-api-reference/src/honoApiReference.ts
@@ -4,6 +4,7 @@ import { html, raw } from 'hono/html'
 
 export type ApiReferenceOptions = ReferenceConfiguration & {
   pageTitle?: string
+  cdn?: string
 }
 
 /**
@@ -134,7 +135,8 @@ export const javascript = (configuration: ReferenceConfiguration) => {
           : '',
       )}
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script src="${configuration.cdn ||
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference'}"></script>
   `
 }
 

--- a/packages/hono-api-reference/src/honoApiReference.ts
+++ b/packages/hono-api-reference/src/honoApiReference.ts
@@ -119,7 +119,7 @@ export const customThemeCSS = `
 /**
  * The HTML to load the @scalar/api-reference JavaScript package.
  */
-export const javascript = (configuration: ReferenceConfiguration) => {
+export const javascript = (configuration: ApiReferenceOptions) => {
   return html`
     <script
       id="api-reference"

--- a/packages/nestjs-api-reference/README.md
+++ b/packages/nestjs-api-reference/README.md
@@ -81,3 +81,21 @@ app.use(
   }),
 )
 ```
+
+### Custom CDN
+
+You can use a custom CDN ，default is `https://cdn.jsdelivr.net/npm/@scalar/api-reference`.
+
+```ts
+import { apiReference } from '@scalar/nestjs-api-reference'
+
+app.use(
+  '/reference',
+  apiReference({
+    cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+    spec: {
+      content: OpenApiSpecification,
+    },
+  }),
+)
+```

--- a/packages/nestjs-api-reference/src/nestJSApiReference.ts
+++ b/packages/nestjs-api-reference/src/nestJSApiReference.ts
@@ -5,6 +5,7 @@ import { type ServerResponse } from 'http'
 
 export type NestJSReferenceConfiguration = ReferenceConfiguration & {
   withFastify?: boolean
+  cdn?: string
 }
 
 export type ApiReferenceOptions = ReferenceConfiguration
@@ -101,7 +102,7 @@ export const ApiReference = (options: ApiReferenceOptions) => {
             : JSON.stringify(options.spec?.content)
           : ''
       }</script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script src="${options.cdn || 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'}"></script>
   `
 }
 

--- a/packages/nestjs-api-reference/src/nestJSApiReference.ts
+++ b/packages/nestjs-api-reference/src/nestJSApiReference.ts
@@ -8,7 +8,9 @@ export type NestJSReferenceConfiguration = ReferenceConfiguration & {
   cdn?: string
 }
 
-export type ApiReferenceOptions = ReferenceConfiguration
+export type ApiReferenceOptions = ReferenceConfiguration & {
+  cdn?: string
+}
 
 /**
  * The custom theme CSS for the API Reference.

--- a/packages/nestjs-api-reference/test/index.test.ts
+++ b/packages/nestjs-api-reference/test/index.test.ts
@@ -10,4 +10,15 @@ describe('ApiReference', () => {
       `https://petstore3.swagger.io/api/v3/openapi.json`,
     )
   })
+
+  it('renders the given spec URL with custom cdn', () => {
+    expect(
+      ApiReference({
+        spec: {
+          url,
+          cdn: 'https://fastly.jsdelivr.net/npm/@scalar/api-reference',
+        },
+      }).toString(),
+    ).toContain(`https://petstore3.swagger.io/api/v3/openapi.json`)
+  })
 })


### PR DESCRIPTION
**Problem**
The api-reference dependency may be inaccessible in other countries (e.g. China), preventing the page from rendering
![image](https://github.com/scalar/scalar/assets/66096254/e019ba04-f332-4a54-91bc-547fee7b561d)


**Explanation**
Certain countries have banned certain domain names

**Solution**
Provide custom cdn options，e.g. https://fastly.jsdelivr.net/npm/@scalar/api-reference
![image](https://github.com/scalar/scalar/assets/66096254/4ff6c24e-4a81-4b5a-92f6-897e903700f6)

