### PR TITLE
chore: remove preparsed content configuration

### DIFF
--- a/.changeset/friendly-goats-begin.md
+++ b/.changeset/friendly-goats-begin.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+chore: remove preparsed content

--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ To customize the behavior of the API Reference, you can use the following config
 - `isEditable`: Whether the Swagger editor should be shown.
 - `spec.content`: Directly pass an OpenAPI/Swagger spec.
 - `spec.url`: Pass the URL of a spec file (JSON or YAML).
-- `spec.preparsedContent`: Preprocess specs with `@scalar/swagger-parser` and directly pass the result.
 - `proxyUrl`: Use a proxy to send requests to other origins.
 - `darkMode`: Set dark mode on or off (light mode)
 - `layout`: The layout to use, either of `modern` or `classic` (see [#layouts](#layouts)).

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -58,14 +58,6 @@ Pass the URL of a spec file (JSON or Yaml).
 <ApiReference :configuration="{ spec: { url: '/swagger.json' } }" />
 ```
 
-#### spec.preparsedContent?: string
-
-You can preprocess specs with `@scalar/swagger-parser` and directly pass the result.
-
-```vue
-<ApiReference :configuration="{ spec: { preparsedContent : '{ … }' } } />
-```
-
 #### proxyUrl?: string
 
 Making requests to other domains is restricted in the browser and requires [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS). It’s recommended to use a proxy to send requests to other origins.

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -82,19 +82,6 @@ watch(rawSpecRef, () => {
   }
 })
 
-// Use preparsed content, if it’s passed
-watch(
-  () => currentConfiguration.value.spec?.preparsedContent,
-  (newContent) => {
-    if (newContent) {
-      overwriteParsedSpecRef(newContent as Spec)
-    }
-  },
-  {
-    immediate: true,
-  },
-)
-
 const { setDarkMode } = useDarkModeState()
 watch(
   () => currentConfiguration.value.darkMode,

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -70,13 +70,6 @@ const showRenderedContent = computed(
   () => isLargeScreen.value || !props.configuration.isEditable,
 )
 
-const showSwaggerEditor = computed(() => {
-  return (
-    !props.configuration.spec?.preparsedContent &&
-    props.configuration?.isEditable
-  )
-})
-
 // To clear hash when scrolled to the top
 const debouncedScroll = useDebounceFn((value) => {
   const scrollDistance = value.target.scrollTop ?? 0
@@ -102,7 +95,7 @@ const referenceSlotProps = computed<ReferenceSlotProps>(() => ({
     class="scalar-api-reference references-layout"
     :class="[
       {
-        'references-editable': showSwaggerEditor,
+        'references-editable': configuration.isEditable,
         'references-sidebar': configuration.showSidebar,
         'references-classic': configuration.layout === 'classic',
       },
@@ -137,7 +130,7 @@ const referenceSlotProps = computed<ReferenceSlotProps>(() => ({
     </aside>
     <!-- Swagger file editing -->
     <div
-      v-show="showSwaggerEditor"
+      v-show="configuration.isEditable"
       class="references-editor">
       <div class="references-editor-textarea">
         <slot

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -75,8 +75,6 @@ export type SpecConfiguration = {
   url?: string
   /** Swagger/Open API spec */
   content?: string | Record<string, any> | (() => Record<string, any>)
-  /** The result of @scalar/swagger-parser */
-  preparsedContent?: Record<any, any>
 }
 
 /** Default reference configuration */
@@ -84,7 +82,6 @@ export const DEFAULT_CONFIG: DeepReadonly<ReferenceConfiguration> = {
   spec: {
     content: undefined,
     url: undefined,
-    preparsedContent: undefined,
   },
   proxy: undefined,
   theme: 'default',


### PR DESCRIPTION
Once upon a time, I thought we could provide a variant of @scalar/api-reference without a parser. I thought we could just parse the specification once and pass it, to remove the parser from the package and decrease the bundle size.

Unfortunately, that’s not as easy as a I thought. There’s no way to just JSON.stringify the result of the parser, because circular references can’t be stringified.

I mean, we could kind of come up with our own format and add a light-weight parser to restore from that custom format, but that’s out of scope for now.

I don’t think anyone used the preparsed content, there was no benefit in doing it. So I’ve just removed it (without deprecating it).