### PR TITLE
fix: content not reactive

### DIFF
--- a/.changeset/strong-lobsters-juggle.md
+++ b/.changeset/strong-lobsters-juggle.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: content not reactive

--- a/packages/api-reference/src/components/ApiReferenceBase.vue
+++ b/packages/api-reference/src/components/ApiReferenceBase.vue
@@ -45,29 +45,33 @@ const slots = defineSlots<
   } & { 'editor-input': SwaggerEditorInputProps }
 >()
 
-/**
- * The editor component has heavy dependencies (process), let's lazy load it.
- */
+// The editor component has heavy dependencies (process), let's lazy load it.
 const LazyLoadedSwaggerEditor = defineAsyncComponent(() =>
   import('@scalar/swagger-editor').then((module) => module.SwaggerEditor),
 )
 
-/** Merge the default configuration with the given configuration. */
+// Merge the default configuration with the given configuration.
 const currentConfiguration = computed(
   (): ReferenceConfiguration =>
     deepMerge(props.configuration ?? {}, { ...DEFAULT_CONFIG }),
 )
 
-// Make it a ComputedRef
-const specConfiguration = computed(() => {
-  return currentConfiguration.value.spec
-})
-
 // Get the raw content
-const { rawSpecRef, setRawSpecRef } = useSpec({
-  configuration: specConfiguration,
+const { rawSpecRef, setRawSpecRef, setConfiguration } = useSpec({
+  configuration: currentConfiguration.value.spec,
   proxy: currentConfiguration.value.proxy,
 })
+
+// Update the configuration when the spec changes
+watch(
+  () => currentConfiguration.value.spec,
+  () => {
+    setConfiguration(currentConfiguration.value.spec)
+  },
+  {
+    deep: true,
+  },
+)
 
 // Parse the content
 const { parsedSpecRef, overwriteParsedSpecRef, errorRef } = useParser({

--- a/packages/api-reference/src/hooks/useSpec.ts
+++ b/packages/api-reference/src/hooks/useSpec.ts
@@ -72,13 +72,7 @@ export function useSpec({
       watch(
         configuration,
         async () => {
-          if (configuration.value !== undefined) {
-            getSpecContent(configuration.value, proxy).then((value) => {
-              if (value !== undefined) {
-                setRawSpecRef(value)
-              }
-            })
-          }
+          setConfiguration(configuration.value)
         },
         {
           immediate: true,
@@ -96,6 +90,18 @@ export function useSpec({
     }
   }
 
+  // Manually update the spec configuration
+  function setConfiguration(newConfiguration: SpecConfiguration | undefined) {
+    if (newConfiguration !== undefined) {
+      getSpecContent(newConfiguration, proxy).then((value) => {
+        if (value !== undefined) {
+          setRawSpecRef(value)
+        }
+      })
+    }
+  }
+
+  // Manually updating the unparsed specification
   function setRawSpecRef(value: string) {
     if (value === rawSpecRef.value) {
       return
@@ -107,5 +113,6 @@ export function useSpec({
   return {
     rawSpecRef,
     setRawSpecRef,
+    setConfiguration,
   }
 }


### PR DESCRIPTION
I noticed that the content wasn’t restored from local storage in dev. Turns out `configuration.spec` wasn’t reactive anymore, changes to it didn’t have any effect.

I traveled through the Git history to find out when this was introduced and it seems it was introduced with #1079, though I don't see any related change. Maybe a race condition?

Anyway, I think this PR fixes it. I’ve added a watcher for the spec configuration and added a helper method to `useSpec` to manually update the passed configuration.

I feel every watcher is introducing another problem, so I’d be open for an alternative solution that doesn’t involve a watcher. 👍 