### PR TITLE
fix: custom operation security scheme list is ignored, fix #1112

### DIFF
--- a/.changeset/rare-windows-join.md
+++ b/.changeset/rare-windows-join.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: custom operation security scheme is ignored

--- a/packages/api-reference/src/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-reference/src/helpers/getRequestFromAuthentication.test.ts
@@ -381,4 +381,43 @@ describe('getRequestFromAuthentication', () => {
       headers: [],
     })
   })
+
+  it('uses custom security scheme for operation', () => {
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        securitySchemeKey: 'bearerAuth',
+        securitySchemes: {
+          bearerAuth: {
+            type: 'http',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+          },
+          v1Auth: {
+            type: 'apiKey',
+            name: 'X-Auth-Token',
+            in: 'header',
+            description: 'JWT token',
+          },
+        },
+        apiKey: {
+          token: '123',
+        },
+      },
+      [
+        {
+          v1Auth: [],
+        },
+      ],
+    )
+
+    expect(request).toMatchObject({
+      headers: [
+        {
+          name: 'X-Auth-Token',
+          value: '123',
+        },
+      ],
+    })
+  })
 })


### PR DESCRIPTION
We’re currently only configuring the security schemes on a global level, but OpenAPI allows to overwrite the list of available security schemes on a operation basis. See #1112 

With this PR the list is taken into account. And if the globally selected security scheme isn’t available for the operation, we’re just using the first available security scheme.

We should probably also add a way to selected the security scheme for every operation, but that’s a lot more work I guess. I’ll see this PR as a pragmatic solution though. :)