### PR TITLE
fix: deprecated operations are not striked through, fix #1104

### DIFF
--- a/.changeset/ten-oranges-yell.md
+++ b/.changeset/ten-oranges-yell.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: deprecated operations are not striked through in the sidebar

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -64,10 +64,12 @@ const handleClick = async () => {
           v-if="item?.icon?.src"
           class="sidebar-icon"
           :src="item.icon.src" />
-        <p>
+        <p class="sidebar-heading-link-title">
           {{ item.title }}
         </p>
-        <p v-if="item.httpVerb">
+        <p
+          v-if="item.httpVerb"
+          class="sidebar-heading-link-method">
           &hairsp;
           <HttpMethod
             as="div"
@@ -105,7 +107,7 @@ const handleClick = async () => {
   padding-right: 9px;
   user-select: none;
 }
-.sidebar-heading.deprecated span {
+.sidebar-heading.deprecated .sidebar-heading-link-title {
   text-decoration: line-through;
 }
 .sidebar-heading:hover {


### PR DESCRIPTION
With [the recent sidebar refactor](https://github.com/scalar/scalar/pull/1059) (changed `span` to `p`) we’ve introduced a tiny regression: deprecated operations aren't striked through in the sidebar anymore.

This PR fixes it. :)

**Example**

```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "Hello World",
    "version": "1.0.0"
  },
  "paths": {
    "/foobar": {
      "post": {
        "deprecated": true
      }
    }
  }
}
```

