### PR TITLE
fix: define color-scheme to improve request client selector readability

### DIFF
--- a/.changeset/unlucky-moles-develop.md
+++ b/.changeset/unlucky-moles-develop.md
@@ -1,0 +1,5 @@
+---
+"@scalar/themes": patch
+---
+
+fix: define color-scheme to improve request client selector readability

--- a/packages/themes/src/base.css
+++ b/packages/themes/src/base.css
@@ -76,6 +76,10 @@
   --default-theme-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
     rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 1px;
 }
+/* On some browsers, the light color scheme takes precedence when the light mode is active */
+.light-mode .dark-mode {
+  color-scheme: dark !important;
+}
 @media (max-width: 460px) {
   :root {
     --default-theme-font-size-1: 22px;

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -12,6 +12,9 @@
   --default-theme-color-accent: #0099ff;
   --default-theme-border-color: rgba(0, 0, 0, 0.1);
 }
+.light-mode .dark-mode {
+  color-scheme: dark;
+}
 .dark-mode {
   --default-theme-background-1: #0f0f0f;
   --default-theme-background-2: #1a1a1a;

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -12,9 +12,6 @@
   --default-theme-color-accent: #0099ff;
   --default-theme-border-color: rgba(0, 0, 0, 0.1);
 }
-.light-mode .dark-mode {
-  color-scheme: dark;
-}
 .dark-mode {
   --default-theme-background-1: #0f0f0f;
   --default-theme-background-2: #1a1a1a;


### PR DESCRIPTION
fix  #1125 

## **Problem**

Currently, using the default theme and light mode, the request client selector options are not really readable, since the text color is dark.

![image](https://github.com/scalar/scalar/assets/42624869/153e0fd9-ca02-4e3c-a63d-4787589d7b0f)

## **Explanation**
This happens because the request example card always uses the `dark mode`. However, when the light mode is active, its default theme colors override the theme colors from dark mode.

## **Solution**
With this PR, when light mode is active, the `dark color scheme`  is considered for every component that references the dark-mode CSS class.

![image](https://github.com/scalar/scalar/assets/42624869/4716c7e1-fd13-47b9-bde1-198ddf719624)

> 🚨 I am not totally sure if this is the best approach. However, I believe that it solves the problem without regressions
