### PR TITLE
fix: move vue to devDepenencies in packages

### DIFF
--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -49,18 +49,18 @@
     "directory": "packages/api-client-react"
   },
   "dependencies": {
-    "@scalar/api-client": "workspace:*",
-    "react": "^18.2.0",
-    "vue": "^3.3.0"
+    "@scalar/api-client": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.2.60",
     "@types/react-dom": "^18.2.19",
     "@vitejs/plugin-react": "^4.2.1",
     "path": "^0.12.7",
+    "react": "^18.2.0",
     "vite": "^5.1.1",
     "vite-plugin-css-injected-by-js": "^3.4.0",
-    "vite-plugin-dts": "^3.6.3"
+    "vite-plugin-dts": "^3.6.3",
+    "vue": "^3.3.0"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/packages/api-client-react/vite.config.ts
+++ b/packages/api-client-react/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       // Could also be a dictionary or array of multiple entry points
       entry: './src/index.ts',
       name: '@scalar/api-client-react',
-      formats: ['es', 'cjs', 'umd'],
+      formats: ['es', 'cjs'],
       fileName: 'index',
     },
     minify: false,

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -54,8 +54,7 @@
     "content-type": "^1.0.5",
     "nanoid": "^5.0.1",
     "pretty-bytes": "^6.1.1",
-    "pretty-ms": "^8.0.0",
-    "vue": "^3.3.0"
+    "pretty-ms": "^8.0.0"
   },
   "devDependencies": {
     "@scalar/api-client-proxy": "workspace:*",
@@ -67,6 +66,7 @@
     "vite": "^5.1.1",
     "vite-plugin-css-injected-by-js": "^3.4.0",
     "vitest": "^1.2.2",
+    "vue": "^3.3.0",
     "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -104,8 +104,6 @@
     "eslint": "^8.56.0",
     "http-server": "^14.1.1",
     "postcss": "^8.4.31",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "rollup-plugin-webpack-stats": "^0.2.4",
     "storybook": "^7.5.2",
     "storybook-dark-mode": "^3.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,8 +48,7 @@
     "cva": "1.0.0-beta.1",
     "nanoid": "^5.0.1",
     "prismjs": "^1.29.0",
-    "tailwind-merge": "^2.0.0",
-    "vue": "^3.3.0"
+    "tailwind-merge": "^2.0.0"
   },
   "devDependencies": {
     "@etchteam/storybook-addon-css-variables-theme": "^1.5.1",
@@ -86,6 +85,10 @@
     "vite-plugin-css-injected-by-js": "^3.4.0",
     "vite-plugin-dts": "^3.6.3",
     "vitest": "^1.2.2",
+    "vue": "^3.3.0",
     "vue-tsc": "^1.8.19"
+  },
+  "peerDependencies": {
+    "vue": "^3.3.0"
   }
 }

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       // Could also be a dictionary or array of multiple entry points
       entry: './src/index.ts',
       name: '@scalar/components',
-      formats: ['es', 'cjs', 'umd'],
+      formats: ['es', 'cjs'],
       fileName: 'index',
       // the proper extensions will be added
       // fileName: 'my-lib',
@@ -31,14 +31,6 @@ export default defineConfig({
           (item) => !item.startsWith('@scalar'),
         ),
       ],
-      output: {
-        // Provide global variables to use in the UMD build
-        // for externalized deps
-        exports: 'named',
-        globals: {
-          vue: 'Vue',
-        },
-      },
     },
   },
   plugins: [

--- a/packages/swagger-editor/package.json
+++ b/packages/swagger-editor/package.json
@@ -47,8 +47,7 @@
     "@scalar/components": "workspace:*",
     "@scalar/themes": "workspace:*",
     "@scalar/use-codemirror": "workspace:*",
-    "@vueuse/core": "^10.4.1",
-    "vue": "^3.3.0"
+    "@vueuse/core": "^10.4.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
@@ -57,6 +56,7 @@
     "vite": "^5.1.1",
     "vite-plugin-css-injected-by-js": "^3.4.0",
     "vitest": "^1.2.2",
+    "vue": "^3.3.0",
     "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@apidevtools/json-schema-ref-parser': 9.0.7
 
@@ -612,9 +616,6 @@ importers:
       pretty-ms:
         specifier: ^8.0.0
         version: 8.0.0
-      vue:
-        specifier: ^3.3.0
-        version: 3.4.21(typescript@5.3.3)
     devDependencies:
       '@scalar/api-client-proxy':
         specifier: workspace:*
@@ -643,6 +644,9 @@ importers:
       vitest:
         specifier: ^1.2.2
         version: 1.3.1(@types/node@20.11.22)(jsdom@22.1.0)
+      vue:
+        specifier: ^3.3.0
+        version: 3.4.21(typescript@5.3.3)
       vue-tsc:
         specifier: ^1.8.19
         version: 1.8.27(typescript@5.3.3)
@@ -695,12 +699,6 @@ importers:
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../api-client
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      vue:
-        specifier: ^3.3.0
-        version: 3.4.21(typescript@5.3.3)
     devDependencies:
       '@types/react':
         specifier: ^18.2.60
@@ -714,6 +712,9 @@ importers:
       path:
         specifier: ^0.12.7
         version: 0.12.7
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
       vite:
         specifier: ^5.1.1
         version: 5.1.4(@types/node@20.11.22)(terser@5.28.1)
@@ -723,6 +724,9 @@ importers:
       vite-plugin-dts:
         specifier: ^3.6.3
         version: 3.7.3(@types/node@20.11.22)(typescript@5.3.3)(vite@5.1.4)
+      vue:
+        specifier: ^3.3.0
+        version: 3.4.21(typescript@5.3.3)
 
   packages/api-reference:
     dependencies:
@@ -874,12 +878,6 @@ importers:
       postcss:
         specifier: ^8.4.31
         version: 8.4.35
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
       rollup-plugin-webpack-stats:
         specifier: ^0.2.4
         version: 0.2.4(rollup@4.12.0)
@@ -934,9 +932,6 @@ importers:
       tailwind-merge:
         specifier: ^2.0.0
         version: 2.2.1
-      vue:
-        specifier: ^3.3.0
-        version: 3.4.21(typescript@5.3.3)
     devDependencies:
       '@etchteam/storybook-addon-css-variables-theme':
         specifier: ^1.5.1
@@ -1040,6 +1035,9 @@ importers:
       vitest:
         specifier: ^1.2.2
         version: 1.3.1(@types/node@20.11.22)(jsdom@22.1.0)
+      vue:
+        specifier: ^3.3.0
+        version: 3.4.21(typescript@5.3.3)
       vue-tsc:
         specifier: ^1.8.19
         version: 1.8.27(typescript@5.3.3)
@@ -1250,9 +1248,6 @@ importers:
       '@vueuse/core':
         specifier: ^10.4.1
         version: 10.9.0(vue@3.4.21)
-      vue:
-        specifier: ^3.3.0
-        version: 3.4.21(typescript@5.3.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
@@ -1272,6 +1267,9 @@ importers:
       vitest:
         specifier: ^1.2.2
         version: 1.3.1(@types/node@20.11.22)(jsdom@22.1.0)
+      vue:
+        specifier: ^3.3.0
+        version: 3.4.21(typescript@5.3.3)
       vue-tsc:
         specifier: ^1.8.19
         version: 1.8.27(typescript@5.3.3)
@@ -6173,7 +6171,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.21(typescript@5.3.3)
-      vue-component-type-helpers: 1.8.27
+      vue-component-type-helpers: 2.0.6
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18077,6 +18075,10 @@ packages:
     resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}
     dev: true
 
+  /vue-component-type-helpers@2.0.6:
+    resolution: {integrity: sha512-qdGXCtoBrwqk1BT6r2+1Wcvl583ZVkuSZ3or7Y1O2w5AvWtlvvxwjGhmz5DdPJS9xqRdDlgTJ/38ehWnEi0tFA==}
+    dev: true
+
   /vue-demi@0.14.7(vue@3.4.21):
     resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
     engines: {node: '>=12'}
@@ -18694,7 +18696,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
**Problem**
We have some double imports of vue going on

**Explanation**
We are packaging vue inside a package somewhere 🔍 

**Solution**
This PR removes one issue with vue packaging - in a package it should always be a devDependency
