### PR TITLE
fix: add deprecated path to classic layout

### DIFF
--- a/.changeset/tidy-oranges-cry.md
+++ b/.changeset/tidy-oranges-cry.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: add deprecated path to classic layout

--- a/packages/api-reference/src/components/Content/Operation/EndpointPath.vue
+++ b/packages/api-reference/src/components/Content/Operation/EndpointPath.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 
 const props = defineProps<{
   path: string
+  deprecated?: boolean
 }>()
 
 const isVariable = (part: string) => part.startsWith('{') && part.endsWith('}')
@@ -11,7 +12,9 @@ const isVariable = (part: string) => part.startsWith('{') && part.endsWith('}')
 const pathParts = computed<string[]>(() => props.path.split(/({[^}]+})/))
 </script>
 <template>
-  <span class="endpoint-path">
+  <span
+    class="endpoint-path"
+    :class="{ deprecated: deprecated }">
     <template
       v-for="(part, i) in pathParts"
       :key="i">
@@ -25,5 +28,8 @@ const pathParts = computed<string[]>(() => props.path.split(/({[^}]+})/))
   overflow: hidden;
   word-wrap: break-word;
   font-weight: var(--theme-bold, var(--default-theme-bold));
+}
+.deprecated {
+  text-decoration: line-through;
 }
 </style>

--- a/packages/api-reference/src/components/Content/Operation/Operation.vue
+++ b/packages/api-reference/src/components/Content/Operation/Operation.vue
@@ -67,6 +67,7 @@ const customRequestExamples = computed(() => {
               <template #header>
                 <EndpointPath
                   class="example-path"
+                  :deprecated="operation.information?.deprecated"
                   :path="operation.path" />
               </template>
               <template #footer>
@@ -79,6 +80,7 @@ const customRequestExamples = computed(() => {
               <template #header>
                 <EndpointPath
                   class="example-path"
+                  :deprecated="operation.information?.deprecated"
                   :path="operation.path" />
               </template>
               <template #footer>

--- a/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
+++ b/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
@@ -37,7 +37,9 @@ const { copyToClipboard } = useClipboard()
             class="endpoint-anchor">
             <div class="endpoint-label">
               <div class="endpoint-label-path">
-                <EndpointPath :path="operation.path" />
+                <EndpointPath
+                  :deprecated="operation.information?.deprecated"
+                  :path="operation.path" />
               </div>
               <div class="endpoint-label-name">{{ operation.name }}</div>
             </div>


### PR DESCRIPTION
now we have deprecated strike through for classic layout :) 

<img width="398" alt="image" src="https://github.com/scalar/scalar/assets/6176314/f1cfe4bb-79ce-4c45-ab7a-e9f8e38b6e13">
