### PR TITLE
fix: duplicate border top

### DIFF
--- a/.changeset/big-walls-raise.md
+++ b/.changeset/big-walls-raise.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: duplicate border top

--- a/packages/api-reference/src/components/Section/SectionContainer.vue
+++ b/packages/api-reference/src/components/Section/SectionContainer.vue
@@ -8,7 +8,7 @@
   padding: 0 60px;
   width: 100%;
 }
-.section-container:not(:first-of-type) {
+.section-container:last-of-type {
   border-top: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
 }


### PR DESCRIPTION
<img width="1510" alt="image" src="https://github.com/scalar/scalar/assets/6176314/3d99dcf8-3388-4053-833b-9fa3e362e77a">

no more duplicate top bar