### PR TITLE
fix: only run cdn ci test on cron schedule

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     # every hour
     - cron: '0 * * * *'
-  push:
 
 jobs:
   test:


### PR DESCRIPTION
**Problem**
Currently, the CDN UI test runs on `push:` so when there are changes in a feature branch, the test fails. 

**Explanation**
This happens because this is a test for the live CDN and changes are not propagated here from feature branches. 

**Solution**
Only run this test on the cron schedule, not for feature branch changes. Testing on the local branch coming soon... 
