### PR TITLE
style: replace resize observer with container query

### DIFF
--- a/.changeset/wicked-jeans-rush.md
+++ b/.changeset/wicked-jeans-rush.md
@@ -1,0 +1,13 @@
+---
+"@scalar/api-reference": patch
+"@scalar/docusaurus": patch
+"@scalar/oas-utils": patch
+"@scalar/api-reference-react": patch
+"@scalar/express-api-reference": patch
+"@scalar/fastify-api-reference": patch
+"@scalar/hono-api-reference": patch
+"@scalar/nestjs-api-reference": patch
+"@scalar/nextjs-api-reference": patch
+---
+
+style: replace resize observer with css container queries

--- a/packages/api-reference/src/components/ClassicHeader.vue
+++ b/packages/api-reference/src/components/ClassicHeader.vue
@@ -18,14 +18,16 @@
   margin: auto;
   padding: 12px 0;
 }
-.references-narrow .references-classic-header {
-  padding: 12px 24px;
-}
 .references-classic-header-container {
   padding: 0 60px;
 }
-.references-narrow .references-classic-header-container {
-  padding: 0;
+@container narrow-references-container (max-width: 900px) {
+  .references-classic-header {
+    padding: 12px 24px;
+  }
+  .references-classic-header-container {
+    padding: 0;
+  }
 }
 .references-classic-header-icon {
   height: 24px;

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { useResizeObserver } from '@vueuse/core'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 
 import { hasModels } from '../../helpers'
 import { useNavState, useRefOnMount } from '../../hooks'
@@ -20,15 +19,7 @@ const props = defineProps<{
   layout?: 'default' | 'accordion'
 }>()
 
-const referenceEl = ref<HTMLElement | null>(null)
-const isNarrow = ref(true)
-
 const { getOperationId, getTagId } = useNavState()
-
-useResizeObserver(
-  referenceEl,
-  (entries) => (isNarrow.value = entries[0].contentRect.width < 900),
-)
 
 const fallBackServer = useRefOnMount(() => {
   return {
@@ -75,11 +66,7 @@ const isLazy =
   !window.location.hash.startsWith('#model')
 </script>
 <template>
-  <div
-    ref="referenceEl"
-    :class="{
-      'references-narrow': isNarrow,
-    }">
+  <div class="narrow-references-container">
     <slot name="start" />
 
     <Loading
@@ -146,6 +133,12 @@ const isLazy =
     <slot name="end" />
   </div>
 </template>
+<style>
+.narrow-references-container {
+  container-name: narrow-references-container;
+  container-type: inline-size;
+}
+</style>
 <style scoped>
 .render-loading {
   height: calc(var(--full-height) - var(--refs-header-height));
@@ -175,9 +168,11 @@ const isLazy =
     max-width: 100%;
   }
 }
-.references-narrow .introduction-cards-row {
-  flex-direction: column;
-  align-items: stretch;
+@container (max-width: 900px) {
+  .introduction-cards-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }
 .references-classic .introduction-cards-row :deep(.card-footer),
 .references-classic .introduction-cards-row :deep(.scalar-card),

--- a/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
+++ b/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
@@ -191,8 +191,10 @@ const { copyToClipboard } = useClipboard()
   padding: 9px;
 }
 
-.references-narrow .endpoint-content {
-  grid-template-columns: 1fr;
+@container (max-width: 900px) {
+  .endpoint-content {
+    grid-template-columns: 1fr;
+  }
 }
 
 .endpoint-content > * {

--- a/packages/api-reference/src/components/Section/Section.vue
+++ b/packages/api-reference/src/components/Section/Section.vue
@@ -50,8 +50,11 @@ function handleScroll() {
   padding: 48px 0;
   gap: 24px;
 }
-.references-narrow .section {
-  padding: calc(48px + var(--refs-header-height)) 24px 48px 24px;
+@container narrow-references-container (max-width: 900px) {
+  .references-classic .section,
+  .section {
+    padding: calc(48px + var(--refs-header-height)) 24px 48px 24px;
+  }
 }
 .section:not(:last-of-type) {
   border-bottom: 1px solid

--- a/packages/api-reference/src/components/Section/SectionColumn.vue
+++ b/packages/api-reference/src/components/Section/SectionColumn.vue
@@ -10,7 +10,9 @@
 .section-column:nth-of-type(2) {
   padding-top: 48px;
 }
-.references-narrow .section-column:nth-of-type(2) {
-  padding-top: 0;
+@container narrow-references-container (max-width: 900px) {
+  .section-column:nth-of-type(2) {
+    padding-top: 0;
+  }
 }
 </style>

--- a/packages/api-reference/src/components/Section/SectionColumns.vue
+++ b/packages/api-reference/src/components/Section/SectionColumns.vue
@@ -9,9 +9,10 @@
   display: flex;
   gap: 48px;
 }
-
-.references-narrow .section-columns {
-  flex-direction: column;
-  gap: 24px;
+@container narrow-references-container (max-width: 900px) {
+  .section-columns {
+    flex-direction: column;
+    gap: 24px;
+  }
 }
 </style>

--- a/packages/api-reference/src/components/Section/SectionContainer.vue
+++ b/packages/api-reference/src/components/Section/SectionContainer.vue
@@ -13,7 +13,9 @@
     var(--theme-border-color, var(--default-theme-border-color));
 }
 
-.references-narrow .section-container {
-  padding: 0;
+@container narrow-references-container (max-width: 900px) {
+  .section-container {
+    padding: 0;
+  }
 }
 </style>

--- a/packages/api-reference/src/components/Section/SectionContainerAccordion.vue
+++ b/packages/api-reference/src/components/Section/SectionContainerAccordion.vue
@@ -72,12 +72,14 @@ import { ScalarIcon } from '@scalar/components'
 .section-accordion-title :deep(.section-header) {
   margin-bottom: 0;
 }
-.references-narrow .section-accordion-chevron {
-  width: 16px;
-  left: -16px;
-  top: 14px;
-}
-.references-narrow .section-accordion-wrapper {
-  padding: calc(var(--refs-header-height)) 24px 0 24px;
+@container narrow-references-container (max-width: 900px) {
+  .section-accordion-chevron {
+    width: 16px;
+    left: -16px;
+    top: 14px;
+  }
+  .section-accordion-wrapper {
+    padding: calc(var(--refs-header-height)) 24px 0 24px;
+  }
 }
 </style>

--- a/packages/api-reference/src/components/Section/SectionContent.vue
+++ b/packages/api-reference/src/components/Section/SectionContent.vue
@@ -21,11 +21,10 @@ withDefaults(
 </template>
 
 <style scoped>
-.section-content {
-}
-
-.references-narrow .section-content--with-columns {
-  flex-direction: column;
-  gap: 24px;
+@container narrow-references-container (max-width: 900px) {
+  .section-content--with-columns {
+    flex-direction: column;
+    gap: 24px;
+  }
 }
 </style>

--- a/packages/api-reference/src/components/ShowMoreButton.vue
+++ b/packages/api-reference/src/components/ShowMoreButton.vue
@@ -54,9 +54,11 @@ const { setCollapsedSidebarItem } = useSidebar()
   box-shadow: 0 0 0 1px
     var(--theme-border-color, var(--default-theme-border-color));
 }
-.references-narrow .show-more {
-  margin-top: -25px;
-  margin-bottom: 25px;
+@container narrow-references-container (max-width: 900px) {
+  .show-more {
+    margin-top: -25px;
+    margin-bottom: 25px;
+  }
 }
 @media (max-width: 1165px) {
   .show-more {

--- a/packages/docusaurus/src/theme.css
+++ b/packages/docusaurus/src/theme.css
@@ -271,8 +271,10 @@ html[data-theme='light'] .api-client-drawer {
 .tag-section-container .scalar-card {
   border: none !important;
 }
-.references-narrow .section {
-  padding-top: calc(var(--refs-header-height) + 48px) !important;
+@container narrow-references-container (max-width: 900px) {
+  .section {
+    padding-top: calc(var(--refs-header-height) + 48px) !important;
+  }
 }
 @media screen and (max-width: 996px) {
   .references-header {


### PR DESCRIPTION
Fixes docusaurus as well as sentry errors. Also replaces JS with css which is always ⚜️