### PR TITLE
fix: render missing schema properties (minimum, maximum and default values)

### DIFF
--- a/.changeset/warm-pumas-brake.md
+++ b/.changeset/warm-pumas-brake.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: render missing schema properties (minimum, maximum and default values)

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -107,10 +107,19 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         </template>
         <template v-if="value.uniqueItems"> unique! </template>
         <template v-if="value.format"> &middot; {{ value.format }} </template>
+        <template v-if="value.minimum">
+          &middot; min: {{ value.minimum }}
+        </template>
+        <template v-if="value.maximum">
+          &middot; max: {{ value.maximum }}
+        </template>
         <template v-if="value.pattern">
           &middot; <code class="pattern">{{ value.pattern }}</code>
         </template>
         <template v-if="value.enum"> &middot; enum </template>
+        <template v-if="value.default">
+          &middot; default: {{ value.default }}
+        </template>
       </div>
       <div
         v-if="value?.writeOnly"


### PR DESCRIPTION
**Problem**
https://github.com/scalar/scalar/discussions/1147

**Solution**

Just add some checks to render the missing properties, the order in which I added them is based on my feelings :)

![image](https://github.com/scalar/scalar/assets/49305219/745b2ebb-973c-41d5-a7fb-32e2a06fdc09)

Some things I've encountered:
1) (potential bug?) number checks like `v-if="value.minLength"`, `v-if="value.maxLength"` and so on will expand to false if they contain zero. Because of this, these properties won't be rendered at all. I could open an issue if this behavior is not intended.
2) OpenAPI specification defines [exclusiveMinimum](https://github.com/OAI/OpenAPI-Specification/blob/82810886af0033f3d0ec2568db0812a201aaab5e/schemas/v3.0/schema.json#L356) and [exclusiveMaximum](https://github.com/OAI/OpenAPI-Specification/blob/82810886af0033f3d0ec2568db0812a201aaab5e/schemas/v3.0/schema.json#L349), but because you use `min` or `max` to denote intervals, it's a bit unclear to me how they should be rendered if `exclusiveMinimum` or `exclusiveMaximum` are set. I could just subtract/add a one, but I'm not sure how good that solution is. For example, redoc behavior is to render `<`, `>`, `<=`, `>=`, `(lower_bound..upper_bound)` or `[lower_bound..upper_bound]`, which is more appealing to me.
