### PR TITLE
fix: component cjs export

### DIFF
--- a/.changeset/four-sloths-nail.md
+++ b/.changeset/four-sloths-nail.md
@@ -1,0 +1,5 @@
+---
+"@scalar/components": patch
+---
+
+fix: cjs export of components

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build:packages": "pnpm --filter './packages/**' build",
     "build:standalone": "pnpm --filter api-reference build:standalone",
     "bump": "CI=true pnpm run test && pnpm changeset version",
-    "clean": "pnpm clean:nodeModules && pnpm clean:dist && pnpm clean:turbo",
+    "clean": "pnpm clean:nodeModules; pnpm clean:dist; pnpm clean:turbo",
     "clean:nodeModules": "find . -name node_modules -type d -exec rm -rf {} \\;",
     "clean:dist": "find . -name dist -type d -exec rm -rf {} \\;",
     "clean:turbo": "find . -name .turbo -type d -exec rm -rf {} \\;",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,16 +24,12 @@
     "types:check": "vue-tsc --noEmit  --composite false"
   },
   "type": "module",
-  "main": "./dist/index.umd.cjs",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
-    },
-    "./style.css": {
-      "import": "./dist/style.css",
-      "require": "./dist/style.css"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
The cjs exports had an incorrect umd.cjs extension in the components package.

![image](https://github.com/scalar/scalar/assets/2039539/71ef1930-a587-4699-a8c1-eca647794334)
