### PR TITLE
fix: mobile backgrounds for mars and blueplanet

### DIFF
--- a/.changeset/gentle-suns-tan.md
+++ b/.changeset/gentle-suns-tan.md
@@ -1,0 +1,5 @@
+---
+"@scalar/themes": patch
+---
+
+fix: mobile backgrounds for mars and blueplanet

--- a/packages/themes/src/presets/bluePlanet.css
+++ b/packages/themes/src/presets/bluePlanet.css
@@ -33,7 +33,7 @@
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
 .dark-mode .t-doc__sidebar {
-  --default-sidebar-background-1: transparent;
+  --default-sidebar-background-1: var(--default-theme-background-1);
   --default-sidebar-color-1: var(--default-theme-color-1);
   --default-sidebar-color-2: var(--default-theme-color-2);
   --default-sidebar-border-color: var(--default-theme-border-color);

--- a/packages/themes/src/presets/mars.css
+++ b/packages/themes/src/presets/mars.css
@@ -33,7 +33,7 @@
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
 .dark-mode .t-doc__sidebar {
-  --default-sidebar-background-1: transparent;
+  --default-sidebar-background-1: var(--default-theme-background-1);
   --default-sidebar-color-1: var(--default-theme-color-1);
   --default-sidebar-color-2: var(--default-theme-color-2);
   --default-sidebar-border-color: var(--default-theme-border-color);


### PR DESCRIPTION
mars and blue planet need none transparent backgrounds with the theme updates