### PR TITLE
fix: meta data is not added, fix #709

### DIFF
--- a/.changeset/green-poets-smoke.md
+++ b/.changeset/green-poets-smoke.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: meta data is not added

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { createHead, useSeoMeta } from 'unhead'
 import { computed, toRef, watch } from 'vue'
 import { toast } from 'vue-sonner'
 
@@ -36,12 +35,6 @@ const { initializeToasts } = useToasts()
 initializeToasts((message) => {
   toast(message)
 })
-
-// Create the head tag if the configuration has meta data
-if (configuration.value?.metaData) {
-  createHead()
-  useSeoMeta(configuration.value.metaData)
-}
 
 // ---------------------------------------------------------------------------/
 // HANDLE MAPPING CONFIGURATION TO INTERNAL REFERENCE STATE

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -94,7 +94,6 @@ const debouncedScroll = useDebounceFn((value) => {
 
 // Create the head tag if the configuration has meta data
 if (props.configuration.metaData) {
-  console.log(props.configuration.metaData)
   createHead()
   useSeoMeta(props.configuration.metaData)
 }

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -6,6 +6,7 @@ import {
   ThemeStyles,
 } from '@scalar/themes'
 import { useDebounceFn, useMediaQuery, useResizeObserver } from '@vueuse/core'
+import { createHead, useSeoMeta } from 'unhead'
 import { computed, onMounted, ref } from 'vue'
 
 import { downloadSpecBus, downloadSpecFile } from '../helpers'
@@ -90,6 +91,13 @@ const debouncedScroll = useDebounceFn((value) => {
     hash.value = ''
   }
 })
+
+// Create the head tag if the configuration has meta data
+if (props.configuration.metaData) {
+  console.log(props.configuration.metaData)
+  createHead()
+  useSeoMeta(props.configuration.metaData)
+}
 
 /** This is passed into all of the slots so they have access to the references data */
 const referenceSlotProps = computed<ReferenceSlotProps>(() => ({


### PR DESCRIPTION
WIP 
Currently, the meta data (including the page title) isn’t added to the mark up. I think, because the code ended up being in the wrong component.

This PR moves it to the ApiReferenceLayout component, which should be used in all cases.
