### PR TITLE
chore: revert snapshot testing

### DIFF
--- a/.github/workflows/test-api-reference-cdn.yml
+++ b/.github/workflows/test-api-reference-cdn.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     # every hour
     - cron: '0 * * * *'
+  push:
+    paths:
+      - 'packages/cdn-api-reference/**'
+      - '.github/workflows/test-api-reference-cdn.yml'
 
 jobs:
   test:

--- a/tests/cdn.spec.ts
+++ b/tests/cdn.spec.ts
@@ -26,15 +26,16 @@ test('Renders petstore api reference from the live CDN', async ({
     ).toBeVisible()
   }
 
+  // TODO: fix the dev workflow
   /** Visual Regression Testing
    * use Playwright built in screenshot functionality https://playwright.dev/docs/screenshots
    * Playwright uses pixelmatch to compare screenshots
    * update screenshots with npx playwright test --update-snapshots
    */
-  await expect(page).toHaveScreenshot('cdn-snapshot.png', {
-    fullPage: true,
-    maxDiffPixels: 100,
-  })
+  // await expect(page).toHaveScreenshot('cdn-snapshot.png', {
+  //   fullPage: true,
+  //   maxDiffPixels: 100,
+  // })
 
   /** Capture into buffer
    * If we are unsatisfied with the built in visual regression testing


### PR DESCRIPTION
Currently, snapshot testing is failing due to differences between local and CI environment. More info here https://github.com/scalar/scalar/pull/1177

