### PR TITLE
fix: example for array with anyOf, allOf, oneOf schemas doesn’t have a value, fix #1180

### DIFF
--- a/.changeset/pretty-tigers-remember.md
+++ b/.changeset/pretty-tigers-remember.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: example for array with anyOf, allOf, oneOf schemas doesn’t have a value

--- a/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
@@ -195,6 +195,66 @@ describe('getExampleFromSchema', () => {
     ])
   })
 
+  it('uses the first example in anyOf', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'array',
+        items: {
+          anyOf: [
+            {
+              type: 'string',
+              example: 'foobar',
+            },
+            {
+              type: 'string',
+              example: 'barfoo',
+            },
+          ],
+        },
+      }),
+    ).toMatchObject(['foobar'])
+  })
+
+  it('uses one example in oneOf', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'array',
+        items: {
+          oneOf: [
+            {
+              type: 'string',
+              example: 'foobar',
+            },
+            {
+              type: 'string',
+              example: 'barfoo',
+            },
+          ],
+        },
+      }),
+    ).toMatchObject(['foobar'])
+  })
+
+  it('uses all examples in allOf', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'array',
+        items: {
+          allOf: [
+            {
+              type: 'string',
+              example: 'foobar',
+            },
+            {
+              type: 'string',
+              example: 'barfoo',
+            },
+          ],
+        },
+      }),
+    ).toMatchObject(['foobar', 'barfoo'])
+  })
+
   it('uses the default value', () => {
     const schema = {
       type: 'string',

--- a/packages/api-reference/src/helpers/getExampleFromSchema.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.ts
@@ -128,6 +128,34 @@ export const getExampleFromSchema = (
       return wrapItems ? { [itemsXmlTagName]: schema.example } : schema.example
     }
 
+    // Check whether the array has a anyOf, oneOf, or allOf rule
+    if (schema.items) {
+      // Check for all those rules
+      const rules = ['anyOf', 'oneOf', 'allOf']
+
+      for (const rule of rules) {
+        // Skip early if the rule is not defined
+        if (!schema.items[rule]) {
+          continue
+        }
+
+        // Otherwise generate examples for the rule
+        const schemas = ['anyOf', 'oneOf'].includes(rule)
+          ? // Use the first item only
+            schema.items[rule].slice(0, 1)
+          : // Use all items
+            schema.items[rule]
+
+        const exampleFromRule = schemas.map((item: Record<string, any>) =>
+          getExampleFromSchema(item, options, level + 1),
+        )
+
+        return wrapItems
+          ? [{ [itemsXmlTagName]: exampleFromRule }]
+          : exampleFromRule
+      }
+    }
+
     if (schema.items?.type) {
       const exampleFromSchema = getExampleFromSchema(
         schema.items,


### PR DESCRIPTION
We generate examples from schemas in a lot of places and there was a case we didn’t cover: anyOf, allOf, oneOf schemas inside of array items. 

This PR adds this.

See #1180