### PR TITLE
chore: remove body margin reset everywhere, fix #1172

### DIFF
--- a/.changeset/angry-coats-care.md
+++ b/.changeset/angry-coats-care.md
@@ -1,0 +1,10 @@
+---
+"@scalar/express-api-reference": patch
+"@scalar/fastify-api-reference": patch
+"@scalar/nestjs-api-reference": patch
+"@scalar/nextjs-api-reference": patch
+"@scalar/hono-api-reference": patch
+"@scalar/api-reference": patch
+---
+
+chore: remove body margin reset everywhere, it’s not needed anymore

--- a/README.md
+++ b/README.md
@@ -61,11 +61,6 @@ Generate interactive API documentations from Swagger files. [Try our Demo](https
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1" />
-    <style>
-      body {
-        margin: 0;
-      }
-    </style>
   </head>
   <body>
     <!-- Add your own OpenAPI/Swagger spec file URL here: -->

--- a/examples/cdn-api-reference/src/public/api-reference-cdn-live.html
+++ b/examples/cdn-api-reference/src/public/api-reference-cdn-live.html
@@ -6,11 +6,6 @@
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1" />
-    <style>
-      body {
-        margin: 0;
-      }
-    </style>
   </head>
   <body>
     <!-- Add your own OpenAPI/Swagger spec file URL here: -->

--- a/examples/cdn-api-reference/src/public/api-reference-cdn-localhost.html
+++ b/examples/cdn-api-reference/src/public/api-reference-cdn-localhost.html
@@ -6,11 +6,6 @@
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1" />
-    <style>
-      body {
-        margin: 0;
-      }
-    </style>
   </head>
   <body>
     <!-- Add your own OpenAPI/Swagger spec file URL here: -->

--- a/examples/react/src/index.css
+++ b/examples/react/src/index.css
@@ -1,3 +1,0 @@
-body {
-  margin: 0;
-}

--- a/examples/react/src/main.tsx
+++ b/examples/react/src/main.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 
 import App from './App'
-import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/examples/ssg/src/main.ts
+++ b/examples/ssg/src/main.ts
@@ -2,7 +2,6 @@
 import { ViteSSG } from 'vite-ssg/single-page'
 
 import App from './App.vue'
-import './style.css'
 
 // `export const createApp` is required instead of the original `createApp(App).mount('#app')`
 export const createApp = ViteSSG(App)

--- a/examples/ssg/src/style.css
+++ b/examples/ssg/src/style.css
@@ -1,3 +1,0 @@
-body {
-  margin: 0;
-}

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -6,11 +6,6 @@
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1" />
-    <style>
-      body {
-        margin: 0;
-      }
-    </style>
   </head>
   <body>
     <!-- <script id="api-reference" data-url="/scalar.json"></script> -->

--- a/packages/express-api-reference/src/expressApiReference.ts
+++ b/packages/express-api-reference/src/expressApiReference.ts
@@ -143,10 +143,6 @@ export function apiReference(options: ApiReferenceOptions) {
         name="viewport"
         content="width=device-width, initial-scale=1" />
       <style>
-        body {
-          margin: 0;
-        }
-
         ${options.theme ? null : customThemeCSS}
       </style>
     </head>

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -142,11 +142,6 @@ export function htmlDocument(options: FastifyApiReferenceOptions) {
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1" />
-    <style>
-      body {
-        margin: 0;
-      }
-    </style>
   </head>
   <body>
     ${javascript(options)}

--- a/packages/hono-api-reference/src/honoApiReference.ts
+++ b/packages/hono-api-reference/src/honoApiReference.ts
@@ -156,10 +156,6 @@ export const apiReference =
             name="viewport"
             content="width=device-width, initial-scale=1" />
           <style>
-            body {
-              margin: 0;
-            }
-
             ${options.theme ? null : customThemeCSS}
           </style>
         </head>

--- a/packages/nestjs-api-reference/src/nestJSApiReference.ts
+++ b/packages/nestjs-api-reference/src/nestJSApiReference.ts
@@ -122,10 +122,6 @@ export function apiReference(options: NestJSReferenceConfiguration) {
           name="viewport"
           content="width=device-width, initial-scale=1" />
         <style>
-          body {
-            margin: 0;
-          }
-  
           ${options.theme ? null : customThemeCSS}
         </style>
       </head>

--- a/packages/nextjs-api-reference/src/ApiReference.ts
+++ b/packages/nextjs-api-reference/src/ApiReference.ts
@@ -45,11 +45,6 @@ export const ApiReference = (refConfig: ReferenceConfiguration) => {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Scalar API Reference for Next.js</title>
     <meta name="description" content="Example to show how to use Scalar API Reference for Next.js">
-    <style>
-      body { 
-        margin: 0; 
-      }
-    </style>
   </head>
   <body>
     <script


### PR DESCRIPTION
This PR removes `body { margin: 0 }` everywhere. It’s not needed anymore, we have this in `ApiReference.vue` now. :)

Makes the CDN example in the root README shorter. 🌟 