### PR TITLE
fix: add min height to classic layout

### DIFF
--- a/.changeset/happy-doors-walk.md
+++ b/.changeset/happy-doors-walk.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/fastify-api-reference": patch
+---
+
+fix: add min height to classic layout

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -227,6 +227,7 @@ provide(GLOBAL_SECURITY_SYMBOL, () => props.parsedSpec.security)
 .scalar-api-reference.references-classic {
   /* Classic layout is wider */
   --refs-content-max-width: var(--theme-content-max-width, 1420px);
+  min-height: 100dvh;
 }
 
 /* ----------------------------------------------------- */


### PR DESCRIPTION
before:
<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6201407/8bc1e24e-d2d8-4000-9230-df15e5d81757">

After:
<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6201407/e50b78f8-f2d2-4c84-8d95-68b2c72a15b9">
