### PR TITLE
fix: requestBody example is not used

### DIFF
--- a/.changeset/few-bottles-run.md
+++ b/.changeset/few-bottles-run.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: example requestBody isn’t shown in the api client

--- a/packages/api-reference/src/helpers/getRequestBodyFromOperation.test.ts
+++ b/packages/api-reference/src/helpers/getRequestBodyFromOperation.test.ts
@@ -70,6 +70,42 @@ describe('getRequestBodyFromOperation', () => {
     })
   })
 
+  it('uses example', () => {
+    const request = getRequestBodyFromOperation({
+      httpVerb: 'POST',
+      path: '/foobar',
+      information: {
+        requestBody: {
+          description: 'Sample request body',
+          required: false,
+          content: {
+            'application/json': {
+              example: {
+                someObject: {
+                  someAttribute: 'attribute1',
+                },
+              },
+              schema: {
+                $ref: '#/components/schemas/PutDocumentRequest',
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const expectedResult = {
+      someObject: {
+        someAttribute: 'attribute1',
+      },
+    }
+
+    expect(request?.postData).toMatchObject({
+      mimeType: 'application/json',
+      text: JSON.stringify(expectedResult, null, 2),
+    })
+  })
+
   it('uses examples', () => {
     const request = getRequestBodyFromOperation({
       httpVerb: 'POST',

--- a/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
+++ b/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
@@ -135,7 +135,7 @@ export function getRequestBodyFromOperation(
       headers,
       postData: {
         mimeType: mimeType,
-        text: example ?? JSON.stringify(exampleFromSchema, null, 2),
+        text: JSON.stringify(example ?? exampleFromSchema, null, 2),
       },
     }
   }

--- a/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
+++ b/packages/api-reference/src/helpers/getRequestBodyFromOperation.ts
@@ -131,11 +131,13 @@ export function getRequestBodyFromOperation(
       ? getExampleFromSchema(requestBodyObject?.schema, { mode: 'write' })
       : null
 
+    const body = example ?? exampleFromSchema
+
     return {
       headers,
       postData: {
         mimeType: mimeType,
-        text: JSON.stringify(example ?? exampleFromSchema, null, 2),
+        text: typeof body === 'string' ? body : JSON.stringify(body, null, 2),
       },
     }
   }


### PR DESCRIPTION
Currently, we use provided `examples`, but not `example` to prefill the API client. This PR fixes the issue that we had here.

**Example**
```json
{
    "openapi": "3.1.0",
    "info": {
        "title": "Hello World",
        "version": "1.0"
    },
    "paths": {
        "/api/v1/content/_media": {
            "post": {
                "responses": {
                    "default": {
                        "description": "default"
                    }
                },
                "requestBody": {
                    "content": {
                        "application/json": {
                            "example": {
                                "id": "_media-698d20aa-193a-47b3-be4d-550c1aab47e7",
                                "fileName": "example.png"
                            }
                        }
                    }
                }
            }
        }
    }
}
```