### PR TITLE
fix: enum under items is not being displayed

### DIFF
--- a/.changeset/lazy-dolphins-grow.md
+++ b/.changeset/lazy-dolphins-grow.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: enum under items is not being displayed

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -53,6 +53,10 @@ const generatePropertyDescription = function (property?: Record<string, any>) {
   return descriptions[property.type][property.format || '_default']
 }
 
+const getEnumFromValue = function (value?: Record<string, any>): any[] | null {
+  return value?.enum || value?.items?.enum || null
+}
+
 const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 </script>
 <template>
@@ -116,7 +120,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         <template v-if="value.pattern">
           &middot; <code class="pattern">{{ value.pattern }}</code>
         </template>
-        <template v-if="value.enum"> &middot; enum </template>
+        <template v-if="getEnumFromValue(value)"> &middot; enum </template>
         <template v-if="value.default">
           &middot; default: {{ value.default }}
         </template>
@@ -166,11 +170,11 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     </div>
     <!-- Enum -->
     <div
-      v-if="value?.enum"
+      v-if="getEnumFromValue(value)"
       class="property-enum">
       <ul class="property-enum-values">
         <li
-          v-for="enumValue in value.enum"
+          v-for="enumValue in getEnumFromValue(value)"
           :key="enumValue"
           class="property-enum-value">
           {{ enumValue }}


### PR DESCRIPTION
**Problem**
The enum definition under 'items' was omitted in the provided YAML specification. Below is a simple spec to test out:

```yaml
openapi: 3.1.0
info:
  title: Enum Test
  version: 0.0.1
paths:
  /api:
    post:
      operationId: TestEnumUnderItems
      summary: Test Enum Under Items
      requestBody:
        content:
          application/json:
            schema:
              type: object
              properties:
                field_with_enum:
                  type: array
                  items:
                    type: string
                    enum:
                      - dog
                      - cat
                      - duck
```

**Explanation**
The OpenAPI specification does not clearly state how enums should be handled under 'items'. However, based on my experience with other popular API documentation tools like Redocly and Element, I believe this is a potential oversight in how scalar renders the schema.

**Solution**
I tried to obtain the enumeration from both the property's value and 'items' if possible.

Before:
![before](https://github.com/scalar/scalar/assets/906057/a26688cd-cbe6-444e-9990-86e077050150)

After:
![after](https://github.com/scalar/scalar/assets/906057/72127009-9029-48fe-b6b7-3de0e86e2b3e)
