### PR TITLE
feat: add support of a default scheme if not present in parsedSpec

### DIFF
--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -42,7 +42,18 @@ const localServers = computed(() => {
         }`,
       },
     ]
-  } else if (fallBackServer.value) {
+  } else if (
+    props.parsedSpec.host
+  ) {
+    return [
+      {
+        url: `http://${props.parsedSpec.host}${
+          props.parsedSpec?.basePath ?? ''
+        }`,
+      },
+    ]
+  }
+   else if (fallBackServer.value) {
     return [fallBackServer.value]
   } else {
     return [{ url: '' }]


### PR DESCRIPTION
**Problem**
The request url getting generated on the basis of current window URL when no schemes present in swagger json

**Explanation**


**Solution**
Add a default HTTP scheme and generate request URL on the basis of host and basepath
