### PR TITLE
fix: example for object with anyOf, allOf, oneOf schemas doesn’t have a value

### DIFF
--- a/.changeset/plenty-brooms-admire.md
+++ b/.changeset/plenty-brooms-admire.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: example for object with anyOf, allOf, oneOf schemas doesn’t have a value

--- a/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.test.ts
@@ -195,7 +195,73 @@ describe('getExampleFromSchema', () => {
     ])
   })
 
-  it('uses the first example in anyOf', () => {
+  it('uses the first example in object anyOf', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              foo: { type: 'number' },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              bar: { type: 'string' },
+            },
+          },
+        ],
+      }),
+    ).toMatchObject({ foo: 1 })
+  })
+
+  it('uses the first example in object oneOf', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              foo: { type: 'number' },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              bar: { type: 'string' },
+            },
+          },
+        ],
+      }),
+    ).toMatchObject({ foo: 1 })
+  })
+
+  it('uses all examples in object allOf', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              foo: { type: 'number' },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              bar: { type: 'string' },
+            },
+          },
+        ],
+      }),
+    ).toMatchObject({ foo: 1, bar: '' })
+  })
+
+  it('uses the first example in array anyOf', () => {
     expect(
       getExampleFromSchema({
         type: 'array',
@@ -215,7 +281,7 @@ describe('getExampleFromSchema', () => {
     ).toMatchObject(['foobar'])
   })
 
-  it('uses one example in oneOf', () => {
+  it('uses one example in array oneOf', () => {
     expect(
       getExampleFromSchema({
         type: 'array',
@@ -235,7 +301,7 @@ describe('getExampleFromSchema', () => {
     ).toMatchObject(['foobar'])
   })
 
-  it('uses all examples in allOf', () => {
+  it('uses all examples in array allOf', () => {
     expect(
       getExampleFromSchema({
         type: 'array',

--- a/packages/api-reference/src/helpers/getExampleFromSchema.ts
+++ b/packages/api-reference/src/helpers/getExampleFromSchema.ts
@@ -75,6 +75,29 @@ export const getExampleFromSchema = (
       })
     }
 
+    if (schema.anyOf !== undefined) {
+      Object.assign(
+        response,
+        getExampleFromSchema(schema.anyOf[0]),
+        options,
+        level + 1,
+      )
+    } else if (schema.oneOf !== undefined) {
+      Object.assign(
+        response,
+        getExampleFromSchema(schema.oneOf[0]),
+        options,
+        level + 1,
+      )
+    } else if (schema.allOf !== undefined) {
+      Object.assign(
+        response,
+        ...schema.allOf.map((item: Record<string, any>) =>
+          getExampleFromSchema(item, options, level + 1),
+        ),
+      )
+    }
+
     // Merge additionalProperties
     if (
       schema.additionalProperties !== undefined &&


### PR DESCRIPTION
**Problem**
We generate examples from schemas in a lot of places and there was a case we didn’t cover: object schemas with top level anyOf, allOf, oneOf.

**Solution**
With this PR getExampleFromSchema can not handle the above properly.

See https://github.com/scalar/scalar/issues/1180.
