### PR TITLE
fix: fastify api reference doesn’t load JS on proxied/prefixed routes

### DIFF
--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -72,6 +72,26 @@ describe('fastifyApiReference', () => {
     )
   })
 
+  it('prefixes the JS url', async () => {
+    const fastify = Fastify({
+      logger: false,
+    })
+
+    fastify.register(fastifyApiReference, {
+      routePrefix: '/reference',
+      webRoot: '/foobar',
+      configuration: {
+        spec: { url: '/swagger.json' },
+      },
+    })
+
+    const address = await fastify.listen({ port: 0 })
+    const response = await fetch(`${address}/reference`)
+    expect(await response.text()).toContain(
+      '/foobar/reference/@scalar/fastify-api-reference/js/browser.js',
+    )
+  })
+
   it('has the spec URL', async () => {
     const fastify = Fastify({
       logger: false,

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -79,7 +79,7 @@ describe('fastifyApiReference', () => {
 
     fastify.register(fastifyApiReference, {
       routePrefix: '/reference',
-      webRoot: '/foobar',
+      publicPath: '/foobar',
       configuration: {
         spec: { url: '/swagger.json' },
       },

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -5,12 +5,23 @@ import { getJavaScriptFile } from './utils'
 
 export type FastifyApiReferenceOptions = {
   /**
-   * Prefix for the registered route
+   * If you’re prefixing Fastify with a path, you can set it here.
+   * It’ll be added to the JavaScript URL and the route.
+   *
+   * Example: ${publicPath}${routePrefix}/@scalar/fastify-api-reference/js/browser.js
+   */
+  publicPath?: string
+  /**
+   * Prefix the route with a path. This is where the API Reference will be available.
    *
    * @default ''
    */
-  webRoot?: string
   routePrefix?: string
+  /**
+   * The universal configuration object for @scalar/api-reference.
+   *
+   * Read more: https://github.com/scalar/scalar
+   */
   configuration?: ReferenceConfiguration
 }
 
@@ -20,8 +31,8 @@ const schemaToHideRoute = {
   hide: true,
 }
 
-const getJavaScriptUrl = (routePrefix?: string, webRoot?: string) =>
-  `${webRoot ?? ''}${routePrefix ?? ''}/@scalar/fastify-api-reference/js/browser.js`.replace(
+const getJavaScriptUrl = (routePrefix?: string, publicPath?: string) =>
+  `${publicPath ?? ''}${routePrefix ?? ''}/@scalar/fastify-api-reference/js/browser.js`.replace(
     /\/\//g,
     '/',
   )
@@ -126,7 +137,7 @@ export const javascript = (options: FastifyApiReferenceOptions) => {
             : JSON.stringify(configuration?.spec?.content)
           : ''
       }</script>
-      <script src="${getJavaScriptUrl(options.routePrefix, options.webRoot)}"></script>
+      <script src="${getJavaScriptUrl(options.routePrefix, options.publicPath)}"></script>
   `
 }
 

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -9,6 +9,7 @@ export type FastifyApiReferenceOptions = {
    *
    * @default ''
    */
+  webRoot?: string
   routePrefix?: string
   configuration?: ReferenceConfiguration
 }
@@ -19,8 +20,8 @@ const schemaToHideRoute = {
   hide: true,
 }
 
-const getJavaScriptUrl = (routePrefix?: string) =>
-  `${routePrefix ?? ''}/@scalar/fastify-api-reference/js/browser.js`.replace(
+const getJavaScriptUrl = (routePrefix?: string, webRoot?: string) =>
+  `${webRoot ?? ''}${routePrefix ?? ''}/@scalar/fastify-api-reference/js/browser.js`.replace(
     /\/\//g,
     '/',
   )
@@ -125,7 +126,7 @@ export const javascript = (options: FastifyApiReferenceOptions) => {
             : JSON.stringify(configuration?.spec?.content)
           : ''
       }</script>
-      <script src="${getJavaScriptUrl(options.routePrefix)}"></script>
+      <script src="${getJavaScriptUrl(options.routePrefix, options.webRoot)}"></script>
   `
 }
 


### PR DESCRIPTION
**Problem**
In case Fastify is deployed at a non-root path, the initial HTML will incorrectly link the main JavaScript, causing the application to break.

**Explanation**
The script's src is missing an optional web root variable. I've set up a proxy to Fastify at this URL: http://domain.example/something/. When I deploy Scalar Fastify in a production environment with the "docs" prefix, the main JavaScript fails to load from the correct location, leading to a blank page, even though the Fastify route to "docs" is correct.

HTML at http://domain.example/something/docs/ loads fine with a 200 OK response.
The JS file at http://domain.example/docs/@scalar/fastify-api-reference/js/browser.js is not found, resulting in a 404 error.

**Solution**
Add an optional webRoot variable in the configuration, it will be added to script src.

I'm not completely sold on the name webRoot for this variable. If you have any better suggestions, I'd love to hear them.