### PR TITLE
feat: make API client url editable, fix #1189

### DIFF
--- a/.changeset/heavy-hairs-sin.md
+++ b/.changeset/heavy-hairs-sin.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/api-client": patch
+---
+
+feat: make api client url editable

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -87,8 +87,6 @@ const lastRequestTimestamp = computed(() => {
     : 'History'
 })
 
-// TODO we need to not update the active request with these computed properties
-// we get an infinite loop
 const onChange = (value: string) => {
   if (readOnly.value) {
     return
@@ -98,7 +96,8 @@ const onChange = (value: string) => {
     return
   }
 
-  setActiveRequest({ ...activeRequest, url: value })
+  // TODO: We can’t easily update the active request, because CodeMirror is prefilled with two values (URL + path).
+  // setActiveRequest({ ...activeRequest, url: value })
 }
 
 const handleRequestMethodChanged = (requestMethod?: string) => {

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -7,7 +7,13 @@ import RequestHeaders from './RequestHeaders.vue'
 import RequestQuery from './RequestQuery.vue'
 import RequestVariables from './RequestVariables.vue'
 
-const { activeRequest, readOnly } = useRequestStore()
+const { activeRequest } = useRequestStore()
+
+/**
+ * TODO: This is a workaround to make the address bar editable, but not the rest. If we’d really like to have an
+ * API client where everything can be edited, we need to invest more time.
+ */
+const readOnly = true
 </script>
 <template>
   <div class="scalar-api-client__main__left custom-scroll">

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -68,7 +68,6 @@ export { useApiClientStore } from '@scalar/api-client'
         </template>
         <ApiClient
           :proxyUrl="proxyUrl"
-          readOnly
           theme="none"
           @escapeKeyPress="hideApiClient" />
       </div>


### PR DESCRIPTION
Currently, the URL in the API client isn’t editable, but sometimes people like to just jump into the address bar and change the URL (#1189).

With this PR the URL becomes editable.

We used to pass `readOnly` to the API client, that was easily removed. The address bar did update the value in the state, which isn’t easily possible though. CodeMirror is prefilled with two values (URL + path). We can’t easily update them both from one value. (Sure, we could split the string, but in OpenAPI specifications URLs can include a path … just as an example).

Also, the request name was editable then, but didn’t have any effect, so I just disabled it for now.