### PR TITLE
chore: update license year to say 2023-present

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Scalar
+Copyright (c) 2023-present Scalar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Welcome to the most important PR of the day/month/year/century? It just struck me last night, that we still have 2023 in there. :)