### PR TITLE
chore: remove collaborative editing logic from developer toolbar

### DIFF
--- a/examples/web/src/components/DevReferencesOptions.vue
+++ b/examples/web/src/components/DevReferencesOptions.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type ReferenceConfiguration } from '@scalar/api-reference'
 import { availableThemes } from '@scalar/themes'
-import { computed, ref, watch } from 'vue'
+import { computed } from 'vue'
 
 const props = defineProps<{
   modelValue: ReferenceConfiguration
@@ -22,29 +22,6 @@ const configuration = computed(
       },
     }),
 )
-
-// The collaborative editing configuration is an object and not just true/false, that’s
-// why we’re keeping track of it separately.
-const enableCollaborativeEditingRef = ref<boolean>(false)
-const collaborativeEditingDocumentRef = ref<string>('document-1')
-
-// This adds the collaborative editing configuration to the configuration object.
-function getCompleteConfiguration(v: any) {
-  if (enableCollaborativeEditingRef.value) {
-    return {
-      ...v,
-    }
-  }
-
-  return {
-    ...v,
-  }
-}
-
-// If one of the separate refs update, emit the new configuration
-watch([enableCollaborativeEditingRef, collaborativeEditingDocumentRef], () => {
-  emit('update:modelValue', getCompleteConfiguration(configuration.value))
-})
 </script>
 <template>
   <div>
@@ -91,19 +68,6 @@ watch([enableCollaborativeEditingRef, collaborativeEditingDocumentRef], () => {
         :value="layout">
         {{ layout }}
       </option>
-    </select>
-  </div>
-  <div>
-    <input
-      v-model="enableCollaborativeEditingRef"
-      type="checkbox" />
-    Collaborative Editing{{ enableCollaborativeEditingRef ? ':' : '' }}
-    <select
-      v-if="enableCollaborativeEditingRef"
-      v-model="collaborativeEditingDocumentRef">
-      <option value="document-1">Document #1</option>
-      <option value="document-2">Document #2</option>
-      <option value="document-3">Document #3</option>
     </select>
   </div>
 </template>


### PR DESCRIPTION
The dev toolbar still had options for collaborative editing, but all the Yjs stuff was removed a while ago, so we can safely remove this. Simplifies the code of the dev toolbar. :)