### PR TITLE
style: improve text in markdown tables

### DIFF
--- a/.changeset/silent-apes-serve.md
+++ b/.changeset/silent-apes-serve.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+style: improve text in markdown tables

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -210,13 +210,12 @@ watch(
 }
 
 .markdown :deep(table) {
-  display: table;
+  display: block;
+  overflow-x: auto;
   position: relative;
   border-collapse: collapse;
-  table-layout: fixed;
   width: 100%;
   margin: 1em 0;
-  overflow: hidden;
   box-shadow: 0 0 0 1px
     var(--theme-border-color, var(--default-theme-border-color));
   border-radius: var(--theme-radius-lg, var(--default-theme-radius-lg));
@@ -244,6 +243,7 @@ watch(
   vertical-align: top;
   line-height: 1.5;
   position: relative;
+  word-break: initial;
   font-size: var(--theme-small, var(--default-theme-small));
   color: var(--theme-color-1, var(--default-theme-color-1));
   font-weight: var(

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -123,7 +123,6 @@ watch(
     var(--default-font-size),
     var(--theme-paragraph, var(--default-theme-paragraph))
   );
-  /* prettier-ignore */
   color: var(--theme-color-1, var(--default-theme-color-1));
   font-weight: var(
     --font-weight,
@@ -243,9 +242,15 @@ watch(
   min-width: 1em;
   padding: 6px 9px;
   vertical-align: top;
-  box-sizing: border-box;
+  line-height: 1.5;
   position: relative;
-  word-break: break-all;
+  font-size: var(--theme-small, var(--default-theme-small));
+  color: var(--theme-color-1, var(--default-theme-color-1));
+  font-weight: var(
+    --font-weight,
+    var(--default-font-weight),
+    var(--theme-small, var(--default-theme-small))
+  );
   border-right: 1px solid
     var(--theme-border-color, var(--default-theme-border-color));
   border-bottom: 1px solid


### PR DESCRIPTION
The Markdown tables needed some love!

Columns with few content are huge, though. But when we remove `table-layout: fixed;` small columns get crammed. @cameronrohani any CSS magic, that we can apply here?

**Before**

* every word breaks
* font size too high
* line height too small
<img width="590" alt="Screenshot 2024-03-19 at 08 34 35" src="https://github.com/scalar/scalar/assets/1577992/5809fa9d-1a6a-4b72-8b0a-1112086f42ed">

**After**

* scroll if content is too wide
* smaller font size
* bigger line height

<img width="593" alt="Screenshot 2024-03-19 at 13 53 04" src="https://github.com/scalar/scalar/assets/1577992/646318bb-b6b3-4270-9cc2-11d1d3475376">

<img width="609" alt="Screenshot 2024-03-19 at 13 50 30" src="https://github.com/scalar/scalar/assets/1577992/912fc96f-7d9f-4440-9942-01c47866dde4">


