### PR TITLE
fix: cli does not watch files outside of cwd

### DIFF
--- a/.changeset/heavy-hairs-attack.md
+++ b/.changeset/heavy-hairs-attack.md
@@ -1,0 +1,5 @@
+---
+"@scalar/cli": patch
+---
+
+fix: cli does not watch files outside of process.cwd

--- a/packages/cli/src/utils/watchFile.ts
+++ b/packages/cli/src/utils/watchFile.ts
@@ -20,8 +20,11 @@ export async function watchFile(
   // Watch the file for changes
   console.log(`[INFO] Watch ${file}`)
 
+  // Get path where the file is located
+  const directory = path.dirname(absoluteFilePath)
+
   // Start the watcher
-  await watcher.subscribe(process.cwd(), (err, events) => {
+  await watcher.subscribe(directory, (err, events) => {
     // Match the file path
     if (events.some((event) => event.path === absoluteFilePath)) {
       callback()


### PR DESCRIPTION
Currently, the CLI watches for changes in process.cwd. If the file is somewhere else, file changes aren’t detected.

With this PR we’re watching the directory where the OpenAPI specification is located instead.