### PR TITLE
fix: cli watcher exists when specification is invalid

### DIFF
--- a/.changeset/twelve-cobras-marry.md
+++ b/.changeset/twelve-cobras-marry.md
@@ -1,0 +1,5 @@
+---
+"@scalar/cli": patch
+---
+
+fix: cli watcher exits when specification is invalid

--- a/packages/cli/src/commands/reference/ReferenceCommand.ts
+++ b/packages/cli/src/commands/reference/ReferenceCommand.ts
@@ -54,7 +54,7 @@ export function ReferenceCommand() {
       })
 
       app.get('/__watcher', (c) => {
-        return stream(c, async (stream) => {
+        return stream(c, async (s) => {
           // watch file for changes
           if (watch) {
             watchFile(file, async () => {
@@ -63,12 +63,16 @@ export function ReferenceCommand() {
                 kleur.grey('OpenAPI file modified'),
               )
 
-              specification = (await loadOpenApiFile(file)).specification
+              const result = await loadOpenApiFile(file)
+              if (result?.specification) {
+                specification = result.specification
+              }
 
-              stream.write('data: file modified\n\n')
+              s.write('data: file modified\n\n')
             })
           }
 
+          // eslint-disable-next-line no-constant-condition
           while (true) {
             await new Promise((resolve) => setTimeout(resolve, 100))
           }

--- a/packages/cli/src/utils/loadOpenApiFile.ts
+++ b/packages/cli/src/utils/loadOpenApiFile.ts
@@ -5,38 +5,42 @@ import fs from 'node:fs'
 export async function loadOpenApiFile(file: string) {
   const specification = fs.readFileSync(file, 'utf8')
 
-  const result = await openapi().load(specification).resolve()
-  const { valid, version, schema } = result
+  try {
+    const result = await openapi().load(specification).resolve()
+    const { valid, version, schema } = result
 
-  if (valid) {
-    console.log(
-      kleur.bold().white('[INFO]'),
-      kleur.bold().white(schema.info.title),
-      kleur.grey(`(OpenAPI v${version})`),
-    )
-    // Stats
-    const pathsCount = Object.keys(schema.paths).length
+    if (valid) {
+      console.log(
+        kleur.bold().white('[INFO]'),
+        kleur.bold().white(schema.info.title),
+        kleur.grey(`(OpenAPI v${version})`),
+      )
+      // Stats
+      const pathsCount = Object.keys(schema.paths).length
 
-    let operationsCount = 0
-    for (const path in schema.paths) {
-      for (const method in schema.paths[path]) {
-        operationsCount++
+      let operationsCount = 0
+      for (const path in schema.paths) {
+        for (const method in schema.paths[path]) {
+          operationsCount++
+        }
       }
+
+      console.log(
+        kleur.bold().white('[INFO]'),
+        kleur.grey(`${pathsCount} paths, ${operationsCount} operations`),
+      )
+
+      console.log()
+    } else {
+      console.warn(
+        kleur.bold().yellow('[WARN]'),
+        kleur.yellow('File doesn’t match the OpenAPI specification.'),
+      )
+      console.log()
     }
-
-    console.log(
-      kleur.bold().white('[INFO]'),
-      kleur.grey(`${pathsCount} paths, ${operationsCount} operations`),
-    )
-
-    console.log()
-  } else {
-    console.warn(
-      kleur.bold().yellow('[WARN]'),
-      kleur.yellow('File doesn’t match the OpenAPI specification.'),
-    )
+    return result
+  } catch (error) {
+    console.warn(kleur.bold().red('[ERROR]'), kleur.red(error))
     console.log()
   }
-
-  return result
 }


### PR DESCRIPTION
Currently, the file watch (e.g. `scalar reference openapi.json --watch`) exits when the specification is invalid.

With this PR it’ll show a warning, but keeps running. Easier for local tinkering. :)

Not perfect, need to add this to more commands, but better than what we had and I’m focused on sth. else rn.