### PR TITLE
fix: nextjs example port blocked

### DIFF
--- a/examples/nextjs-api-reference/package.json
+++ b/examples/nextjs-api-reference/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "next build",
-    "dev": "next dev -p 5051",
+    "dev": "next dev -p 5058",
     "lint": "next lint",
     "start": "next start"
   },

--- a/examples/web/src/pages/StartPage.vue
+++ b/examples/web/src/pages/StartPage.vue
@@ -60,7 +60,7 @@ import PageLink from '../components/PageLink.vue'
     </div>
     <h1>Examples</h1>
     <div class="page-links">
-      <PageLink href="http://localhost:5051">
+      <PageLink href="http://localhost:5058">
         <template #title>Next.js</template>
         <template #description>@scalar/nextjs-api-reference</template>
       </PageLink>


### PR DESCRIPTION
I don’t know how this happened, but I used one port twice (proxy + nextjs). This PR moves the Nextjs example to another port. :)