### PR TITLE
feat: improve nullable types

### DIFF
--- a/.changeset/modern-fishes-shout.md
+++ b/.changeset/modern-fishes-shout.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: improve nullable types in schemas

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -99,6 +99,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         </template>
         <template v-else>
           {{ Array.isArray(value.type) ? value.type.join(' | ') : value.type }}
+          {{ value?.nullalbe ? ' | nullable' : '' }}
         </template>
         <template v-if="value.minItems || value.maxItems">
           {{ value.minItems }}..{{ value.maxItems }}
@@ -144,11 +145,6 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
           <Badge>{{ rule }}</Badge>
         </div>
       </template>
-      <div
-        v-if="value?.nullable"
-        class="property-nullable">
-        nullable
-      </div>
       <div
         v-if="value?.example !== undefined"
         class="property-example">
@@ -369,11 +365,6 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 
 .property-read-only {
   font-family: var(--theme-font-code, var(--default-theme-font-code));
-}
-
-.property-nullable {
-  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
-  color: var(--theme-color-2, var(--default-theme-color-2));
 }
 
 .property--compact .property-example {

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -98,7 +98,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
           </template>
         </template>
         <template v-else>
-          {{ value.type }}
+          {{ Array.isArray(value.type) ? value.type.join(' | ') : value.type }}
         </template>
         <template v-if="value.minItems || value.maxItems">
           {{ value.minItems }}..{{ value.maxItems }}


### PR DESCRIPTION
In the recent OpenAPI version, you can set `type` to an array (`['string', 'nullable]`). This PR adds support for it. And it also makes sure the old way (`nullable: true`) is rendered exactly the same way.

**Before**
<img width="596" alt="Screenshot 2024-03-19 at 13 26 04" src="https://github.com/scalar/scalar/assets/1577992/b8da9a4d-8cdd-4d98-ac14-2eeba01892ef">

**After**
<img width="599" alt="Screenshot 2024-03-19 at 13 30 18" src="https://github.com/scalar/scalar/assets/1577992/82bb4c1b-577a-47ad-8660-88f26a84f58d">
