### PR TITLE
feat: show warnings for invalid specifications

### DIFF
--- a/.changeset/big-news-begin.md
+++ b/.changeset/big-news-begin.md
@@ -1,0 +1,5 @@
+---
+"@scalar/cli": patch
+---
+
+feat: show warnings for invalid specifications

--- a/packages/cli/src/utils/loadOpenApiFile.ts
+++ b/packages/cli/src/utils/loadOpenApiFile.ts
@@ -34,8 +34,20 @@ export async function loadOpenApiFile(file: string) {
     } else {
       console.warn(
         kleur.bold().yellow('[WARN]'),
-        kleur.yellow('File doesn’t match the OpenAPI specification.'),
+        kleur.bold().yellow('File doesn’t match the OpenAPI specification.'),
       )
+
+      console.log()
+
+      // Loop through result.errors if present
+      result.errors?.forEach((error: any) => {
+        console.warn(
+          kleur.bold().yellow('[WARN]'),
+          kleur.yellow(error.error),
+          kleur.yellow(`(${error.path})`),
+        )
+      })
+
       console.log()
     }
     return result


### PR DESCRIPTION
Currently, the CLI only shows "specification invalid" without further information.

With this PR the CLI outputs warnings on the console. The error messages aren’t that good and need some love, but at least it’s a hint.

<img width="1205" alt="Screenshot 2024-03-19 at 13 44 34" src="https://github.com/scalar/scalar/assets/1577992/fd06a567-3545-479a-b420-7a24393d1f16">