### PR TITLE
fix: use scroll margin instead of padding to align scroll headers

### DIFF
--- a/.changeset/lazy-ducks-sniff.md
+++ b/.changeset/lazy-ducks-sniff.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: use scroll margin instead of padding to align scroll headers

--- a/packages/api-reference/src/components/Section/Section.vue
+++ b/packages/api-reference/src/components/Section/Section.vue
@@ -42,9 +42,10 @@ function handleScroll() {
   max-width: var(--refs-content-max-width);
   margin: auto;
 
-  /* Extend by header height to line up scroll position */
-  padding: calc(90px + var(--refs-header-height)) 0 90px 0;
-  margin-top: calc(-1 * var(--refs-header-height));
+  padding: 90px 0;
+
+  /* Offset by header height to line up scroll position */
+  scroll-margin-top: var(--refs-header-height);
 }
 .references-classic .section {
   padding: 48px 0;
@@ -53,7 +54,7 @@ function handleScroll() {
 @container narrow-references-container (max-width: 900px) {
   .references-classic .section,
   .section {
-    padding: calc(48px + var(--refs-header-height)) 24px 48px 24px;
+    padding: 48px 24px;
   }
 }
 .section:not(:last-of-type) {


### PR DESCRIPTION
Updates our scroll alignment code to use [`scroll-margin`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) to line up the scroll rather than using a negative margin trick. I hadn't used it before when I first did this alignment fix but browser support seems good 🚀 

https://github.com/scalar/scalar/assets/6374090/b418a519-b4d8-4b41-979a-76a818a04f83

