### PR TITLE
fix: move theme flare behind all content

### DIFF
--- a/.changeset/cuddly-suits-return.md
+++ b/.changeset/cuddly-suits-return.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: move theme flare behind all content

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -60,7 +60,7 @@ function mapConfigToState<K extends keyof ReferenceConfiguration>(
   )
 }
 
-// Handle the events from the toggle buttons and map the configuration to the interna state
+// Handle the events from the toggle buttons and map the configuration to the internal state
 const { toggleDarkMode, setDarkMode } = useDarkModeState()
 mapConfigToState('darkMode', (newDarkMode) => {
   if (newDarkMode !== undefined) setDarkMode(newDarkMode)

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -107,5 +107,6 @@ const specVersion = computed(() => {
   top: 0;
   right: 0;
   pointer-events: none;
+  z-index: -1;
 }
 </style>


### PR DESCRIPTION

![Google Chrome-2024-03-19-18-05-35@2x](https://github.com/scalar/scalar/assets/6374090/2dac7812-ad86-4636-a78c-522d27cddd16)
<img width="1411" alt="Google Chrome-2024-03-19-18-05-19@2x" src="https://github.com/scalar/scalar/assets/6374090/679d3f85-01b6-4b90-88fb-024b1a2dfc75">
