### PR TITLE
fix: address bar changes do not effect request, fix #1189

### DIFF
--- a/.changeset/sharp-toes-mate.md
+++ b/.changeset/sharp-toes-mate.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: address bar changes do not have an effect on the actual request

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -96,8 +96,10 @@ const onChange = (value: string) => {
     return
   }
 
-  // TODO: We can’t easily update the active request, because CodeMirror is prefilled with two values (URL + path).
-  // setActiveRequest({ ...activeRequest, url: value })
+  // The address is actually two values (URL + path). But we only have one value in the address bar.
+  // So we need to reset path, and just put everything into URL.
+  // TODO: This will bite us if we ever want to store the data and switch between environments (base URLs).
+  setActiveRequest({ ...activeRequest, url: value, path: '' })
 }
 
 const handleRequestMethodChanged = (requestMethod?: string) => {


### PR DESCRIPTION
We made the address bar editable in #1226. The address is actually two values (url + path), so I decided to not update the request state. Which means the updated address isn’t used for the actual request.

This PR fixes that bug, and updates the request state.

We can’t easily update two values with just one value. So I decided to reset the path then and just put everything into the `url` property.

This will bite us if we ever want to persist the api client state and switch between envs (different base urls), but it’s a pragmatic workaround for now. :)