### PR TITLE
fix: react example port blocks echo server

### DIFF
--- a/examples/react/vite.config.ts
+++ b/examples/react/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5052,
+    port: 5059,
   },
   resolve: {},
 })

--- a/examples/web/src/pages/StartPage.vue
+++ b/examples/web/src/pages/StartPage.vue
@@ -64,7 +64,7 @@ import PageLink from '../components/PageLink.vue'
         <template #title>Next.js</template>
         <template #description>@scalar/nextjs-api-reference</template>
       </PageLink>
-      <PageLink href="http://localhost:5052">
+      <PageLink href="http://localhost:5059">
         <template #title>React</template>
         <template #description>@scalar/api-reference</template>
       </PageLink>


### PR DESCRIPTION
Just found another port that was used twice (react example + echo server). 🙈 I swear, it’s the last time I change any port.