### PR TITLE
feat: URL support for the CLI

### DIFF
--- a/packages/cli/src/commands/reference/ReferenceCommand.ts
+++ b/packages/cli/src/commands/reference/ReferenceCommand.ts
@@ -70,29 +70,25 @@ export function ReferenceCommand() {
           if (watch) {
             watchFile(input, async () => {
               const newResult = await loadOpenApiFile(input)
+              const specificationHasChanged =
+                newResult?.specification &&
+                JSON.stringify(specification) !==
+                  JSON.stringify(newResult.specification)
 
-              if (newResult?.specification) {
-                if (
-                  newResult.specification &&
-                  JSON.stringify(specification) !==
-                    JSON.stringify(newResult.specification)
-                ) {
-                  console.log(
-                    kleur.bold().white('[INFO]'),
-                    kleur.grey('OpenAPI file modified'),
-                  )
+              if (specificationHasChanged) {
+                console.log(
+                  kleur.bold().white('[INFO]'),
+                  kleur.grey('OpenAPI file modified'),
+                )
 
-                  printSpecificationBanner({
-                    version: newResult.version,
-                    schema: newResult.schema,
-                  })
+                printSpecificationBanner({
+                  version: newResult.version,
+                  schema: newResult.schema,
+                })
 
-                  specification = newResult.specification
+                specification = newResult.specification
 
-                  s.write('data: file modified\n\n')
-                }
-              } else {
-                console.log('no change')
+                s.write('data: file modified\n\n')
               }
             })
           }

--- a/packages/cli/src/commands/reference/ReferenceCommand.ts
+++ b/packages/cli/src/commands/reference/ReferenceCommand.ts
@@ -10,6 +10,7 @@ import {
   useGivenFileOrConfiguration,
   watchFile,
 } from '../../utils'
+import { printSpecificationBanner } from '../../utils/printSpecificationBanner'
 
 export function ReferenceCommand() {
   const cmd = new Command('reference')
@@ -34,6 +35,11 @@ export function ReferenceCommand() {
       }
 
       let { specification } = result
+
+      printSpecificationBanner({
+        version: result.version,
+        schema: result.schema,
+      })
 
       if (
         specification?.paths === undefined ||
@@ -63,15 +69,24 @@ export function ReferenceCommand() {
           // watch file for changes
           if (watch) {
             watchFile(input, async () => {
-              console.log(
-                kleur.bold().white('[INFO]'),
-                kleur.grey('OpenAPI file modified'),
-              )
-
               const newResult = await loadOpenApiFile(input)
 
               if (newResult?.specification) {
-                if (specification !== newResult.specification) {
+                if (
+                  newResult.specification &&
+                  JSON.stringify(specification) !==
+                    JSON.stringify(newResult.specification)
+                ) {
+                  console.log(
+                    kleur.bold().white('[INFO]'),
+                    kleur.grey('OpenAPI file modified'),
+                  )
+
+                  printSpecificationBanner({
+                    version: newResult.version,
+                    schema: newResult.schema,
+                  })
+
                   specification = newResult.specification
 
                   s.write('data: file modified\n\n')

--- a/packages/cli/src/commands/validate/ValidateCommand.ts
+++ b/packages/cli/src/commands/validate/ValidateCommand.ts
@@ -16,6 +16,7 @@ export function ValidateCommand() {
 
     // Read file
     const file = useGivenFileOrConfiguration(fileArgument)
+    // TODO: Doesn’t work with URLs
     const specification = fs.readFileSync(file, 'utf8')
 
     // Validate

--- a/packages/cli/src/utils/isUrl.ts
+++ b/packages/cli/src/utils/isUrl.ts
@@ -1,0 +1,6 @@
+/**
+ * Check if the input is a URL.
+ */
+export function isUrl(text: string): boolean {
+  return text.startsWith('http://') || text.startsWith('https://')
+}

--- a/packages/cli/src/utils/loadOpenApiFile.ts
+++ b/packages/cli/src/utils/loadOpenApiFile.ts
@@ -2,8 +2,8 @@ import { openapi } from '@scalar/openapi-parser'
 import kleur from 'kleur'
 import fs from 'node:fs'
 
-export async function loadOpenApiFile(file: string) {
-  const specification = fs.readFileSync(file, 'utf8')
+export async function loadOpenApiFile(input: string) {
+  const specification = await getFileOrUrl(input)
 
   try {
     const result = await openapi().load(specification).resolve()
@@ -55,4 +55,33 @@ export async function loadOpenApiFile(file: string) {
     console.warn(kleur.bold().red('[ERROR]'), kleur.red(error))
     console.log()
   }
+}
+
+/**
+ * Check if the input is a URL.
+ */
+function isUrl(text: string): boolean {
+  return text.startsWith('http://') || text.startsWith('https://')
+}
+
+/**
+ * Pass a file path or URL and get the content of the file.
+ */
+async function getFileOrUrl(input: string): Promise<string> {
+  if (isUrl(input)) {
+    console.log(
+      kleur.bold().white('[INFO]'),
+      kleur.bold().white('Fetching OpenAPI specification from URL…'),
+    )
+
+    const response = await fetch(input)
+
+    return await response.text()
+  }
+
+  if (!fs.existsSync(input)) {
+    throw new Error('File not found')
+  }
+
+  return fs.readFileSync(input, 'utf-8')
 }

--- a/packages/cli/src/utils/loadOpenApiFile.ts
+++ b/packages/cli/src/utils/loadOpenApiFile.ts
@@ -9,7 +9,7 @@ export async function loadOpenApiFile(input: string) {
 
   try {
     const result = await openapi().load(specification).resolve()
-    const { valid, version, schema } = result
+    const { valid } = result
 
     // Invalid specification
     if (!valid) {
@@ -34,30 +34,6 @@ export async function loadOpenApiFile(input: string) {
       return result
     }
 
-    // Valid specification
-    console.log(
-      kleur.bold().white('[INFO]'),
-      kleur.bold().white(schema.info.title),
-      kleur.grey(`(OpenAPI v${version})`),
-    )
-
-    // Count number of paths
-    const pathsCount = Object.keys(schema.paths).length
-
-    // Count number of operations
-    const operationsCount = Object.values(schema.paths).reduce(
-      (acc, path) => acc + Object.keys(path).length,
-      0,
-    )
-
-    // Statistics
-    console.log(
-      kleur.bold().white('[INFO]'),
-      kleur.grey(`${pathsCount} paths, ${operationsCount} operations`),
-    )
-
-    console.log()
-
     return result
   } catch (error) {
     console.warn(kleur.bold().red('[ERROR]'), kleur.red(error))
@@ -65,7 +41,9 @@ export async function loadOpenApiFile(input: string) {
 
     return {
       valid: false,
-      specification: null,
+      version: undefined,
+      specification: undefined,
+      schema: undefined,
       errors: [
         {
           error: error.message,
@@ -81,11 +59,6 @@ export async function loadOpenApiFile(input: string) {
  */
 async function getFileOrUrl(input: string): Promise<string> {
   if (isUrl(input)) {
-    console.log(
-      kleur.bold().white('[INFO]'),
-      kleur.bold().white('Fetching OpenAPI specification from URL…'),
-    )
-
     const response = await fetch(input)
 
     if (!response.ok) {

--- a/packages/cli/src/utils/printSpecificationBanner.ts
+++ b/packages/cli/src/utils/printSpecificationBanner.ts
@@ -1,0 +1,33 @@
+import type { ResolvedOpenAPI } from '@scalar/openapi-parser'
+import kleur from 'kleur'
+
+export function printSpecificationBanner(result: {
+  version: string
+  schema: ResolvedOpenAPI.Document
+}) {
+  const { version, schema } = result
+
+  // Version
+  console.log(
+    kleur.bold().white('[INFO]'),
+    kleur.bold().white(schema.info.title),
+    kleur.grey(`(OpenAPI v${version})`),
+  )
+
+  // Count number of paths
+  const pathsCount = Object.keys(schema.paths).length
+
+  // Count number of operations
+  const operationsCount = Object.values(schema.paths).reduce(
+    (acc, path) => acc + Object.keys(path).length,
+    0,
+  )
+
+  // Statistics
+  console.log(
+    kleur.bold().white('[INFO]'),
+    kleur.grey(`${pathsCount} paths, ${operationsCount} operations`),
+  )
+
+  console.log()
+}

--- a/packages/cli/src/utils/watchFile.ts
+++ b/packages/cli/src/utils/watchFile.ts
@@ -2,6 +2,8 @@ import watcher from '@parcel/watcher'
 import fs from 'node:fs'
 import path from 'node:path'
 
+import { isUrl } from './isUrl'
+
 /**
  * Watch a foobar for changes and call a callback when it does.
  */
@@ -10,6 +12,12 @@ export async function watchFile(
   callback: () => void,
   options?: { immediate?: boolean },
 ) {
+  // Poll URLs
+  if (isUrl(file)) {
+    setInterval(callback, 5000)
+    return
+  }
+
   const absoluteFilePath = path.join(process.cwd(), file)
 
   // Check if file exists


### PR DESCRIPTION
Currently, the CLI works with files only. With this PR you can pass an URL to the mock and reference command. 🤯 

```bash
scalar reference https://raw.githubusercontent.com/outline/openapi/main/spec3.json
```

```bash
scalar mock https://raw.githubusercontent.com/outline/openapi/main/spec3.json
```

You can even pass the `--watch` flag to poll the URL every few seconds. 

To test it locally, use `pnpm @scalar/cli` instead of `scalar`.