### PR TITLE
feat: switched css injection plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "private": true,
   "scripts": {
     "build": "turbo build",
-    "build:packages": "pnpm --filter './packages/**' build",
+    "build:packages": "turbo --filter './packages/**' build",
     "build:standalone": "pnpm --filter api-reference build:standalone",
     "bump": "CI=true pnpm run test && pnpm changeset version",
     "clean": "pnpm clean:nodeModules; pnpm clean:dist; pnpm clean:turbo",

--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -49,8 +49,8 @@
     "path": "^0.12.7",
     "react": "^18.2.0",
     "vite": "^5.1.1",
-    "vite-plugin-css-injected-by-js": "^3.4.0",
     "vite-plugin-dts": "^3.6.3",
+    "vite-plugin-lib-inject-css": "^2.0.0",
     "vue": "^3.3.0"
   },
   "peerDependencies": {

--- a/packages/api-client-react/vite.config.ts
+++ b/packages/api-client-react/vite.config.ts
@@ -1,10 +1,8 @@
 import react from '@vitejs/plugin-react'
 import * as path from 'path'
 import { defineConfig } from 'vite'
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import dts from 'vite-plugin-dts'
-
-import pkg from './package.json'
+import { libInjectCss } from 'vite-plugin-lib-inject-css'
 
 export default defineConfig({
   build: {
@@ -35,7 +33,7 @@ export default defineConfig({
   },
   plugins: [
     react(),
+    libInjectCss(),
     dts({ insertTypesEntry: true, rollupTypes: true }),
-    cssInjectedByJsPlugin(),
   ],
 })

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -63,7 +63,7 @@
     "@vitest/coverage-v8": "^1.2.2",
     "tsc-alias": "^1.8.8",
     "vite": "^5.1.1",
-    "vite-plugin-css-injected-by-js": "^3.4.0",
+    "vite-plugin-lib-inject-css": "^2.0.0",
     "vitest": "^1.2.2",
     "vue": "^3.3.0",
     "vue-tsc": "^1.8.19"

--- a/packages/api-client/vite.config.ts
+++ b/packages/api-client/vite.config.ts
@@ -1,12 +1,12 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import { libInjectCss } from 'vite-plugin-lib-inject-css'
 import { defineConfig } from 'vitest/config'
 
 import pkg from './package.json'
 
 export default defineConfig({
-  plugins: [vue(), cssInjectedByJsPlugin()],
+  plugins: [vue(), libInjectCss()],
   build: {
     cssCodeSplit: false,
     minify: false,

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -51,6 +51,7 @@
     "react": "^18.2.0",
     "vite": "^5.1.1",
     "vite-plugin-dts": "^3.6.3",
+    "vite-plugin-lib-inject-css": "^2.0.0",
     "vue": "^3.3.0"
   },
   "peerDependencies": {

--- a/packages/api-reference-react/vite.config.ts
+++ b/packages/api-reference-react/vite.config.ts
@@ -2,9 +2,14 @@ import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
+import { libInjectCss } from 'vite-plugin-lib-inject-css'
 
 export default defineConfig({
-  plugins: [react(), dts({ insertTypesEntry: true, rollupTypes: true })],
+  plugins: [
+    react(),
+    libInjectCss(),
+    dts({ insertTypesEntry: true, rollupTypes: true }),
+  ],
   build: {
     lib: {
       // Could also be a dictionary or array of multiple entry points

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -107,6 +107,7 @@
     "tsc-alias": "^1.8.8",
     "vite": "^5.1.1",
     "vite-plugin-css-injected-by-js": "^3.4.0",
+    "vite-plugin-lib-inject-css": "^2.0.0",
     "vitest": "^1.2.2",
     "vue-tsc": "^1.8.19"
   },

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     lib: {
       entry: ['src/index.ts'],
       name: '@scalar/api-reference',
-      formats: ['es'],
+      formats: ['es', 'cjs'],
     },
     rollupOptions: {
       external: [

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -1,6 +1,6 @@
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import { libInjectCss } from 'vite-plugin-lib-inject-css'
 import { defineConfig } from 'vitest/config'
 
 import pkg from './package.json'
@@ -9,7 +9,7 @@ export default defineConfig({
   define: {
     'process.env.NODE_ENV': '"production"',
   },
-  plugins: [vue(), cssInjectedByJsPlugin()],
+  plugins: [vue(), libInjectCss()],
   build: {
     emptyOutDir: true,
     cssCodeSplit: false,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,8 +76,8 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.4.2",
     "vite": "^5.1.1",
-    "vite-plugin-css-injected-by-js": "^3.4.0",
     "vite-plugin-dts": "^3.6.3",
+    "vite-plugin-lib-inject-css": "^2.0.0",
     "vitest": "^1.2.2",
     "vue": "^3.3.0",
     "vue-tsc": "^1.8.19"

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -1,9 +1,8 @@
 import vue from '@vitejs/plugin-vue'
-import { URL, fileURLToPath } from 'node:url'
 import * as path from 'path'
 import { defineConfig } from 'vite'
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import dts from 'vite-plugin-dts'
+import { libInjectCss } from 'vite-plugin-lib-inject-css'
 
 import pkg from './package.json'
 
@@ -35,7 +34,7 @@ export default defineConfig({
   },
   plugins: [
     vue(),
+    libInjectCss(),
     dts({ insertTypesEntry: true, rollupTypes: true }),
-    cssInjectedByJsPlugin(),
   ],
 })

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -47,7 +47,7 @@
     "@vitest/coverage-v8": "^1.2.2",
     "tsc-alias": "^1.8.8",
     "vite": "^5.1.1",
-    "vite-plugin-css-injected-by-js": "^3.4.0",
+    "vite-plugin-lib-inject-css": "^2.0.0",
     "vite-plugin-static-copy": "^1.0.1",
     "vitest": "^1.2.2",
     "vue-tsc": "^1.8.19"

--- a/packages/themes/vite.config.ts
+++ b/packages/themes/vite.config.ts
@@ -1,12 +1,12 @@
 import vue from '@vitejs/plugin-vue'
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import { libInjectCss } from 'vite-plugin-lib-inject-css'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [
     vue(),
-    cssInjectedByJsPlugin(),
+    libInjectCss(),
     viteStaticCopy({
       targets: [
         {
@@ -28,7 +28,7 @@ export default defineConfig({
     lib: {
       entry: ['src/index.ts'],
       name: '@scalar/themes',
-      formats: ['es'],
+      formats: ['es', 'cjs'],
     },
     rollupOptions: {
       external: ['vue'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -664,9 +664,9 @@ importers:
       vite:
         specifier: ^5.1.1
         version: 5.1.4(@types/node@20.11.22)(terser@5.28.1)
-      vite-plugin-css-injected-by-js:
-        specifier: ^3.4.0
-        version: 3.4.0(vite@5.1.4)
+      vite-plugin-lib-inject-css:
+        specifier: ^2.0.0
+        version: 2.0.0(vite@5.1.4)
       vitest:
         specifier: ^1.2.2
         version: 1.3.1(@types/node@20.11.22)(jsdom@22.1.0)
@@ -744,12 +744,12 @@ importers:
       vite:
         specifier: ^5.1.1
         version: 5.1.4(@types/node@20.11.22)(terser@5.28.1)
-      vite-plugin-css-injected-by-js:
-        specifier: ^3.4.0
-        version: 3.4.0(vite@5.1.4)
       vite-plugin-dts:
         specifier: ^3.6.3
         version: 3.7.3(@types/node@20.11.22)(typescript@5.4.2)(vite@5.1.4)
+      vite-plugin-lib-inject-css:
+        specifier: ^2.0.0
+        version: 2.0.0(vite@5.1.4)
       vue:
         specifier: ^3.3.0
         version: 3.4.21(typescript@5.4.2)
@@ -913,6 +913,9 @@ importers:
       vite-plugin-css-injected-by-js:
         specifier: ^3.4.0
         version: 3.4.0(vite@5.1.4)
+      vite-plugin-lib-inject-css:
+        specifier: ^2.0.0
+        version: 2.0.0(vite@5.1.4)
       vitest:
         specifier: ^1.2.2
         version: 1.3.1(@types/node@20.11.22)(jsdom@22.1.0)
@@ -1172,12 +1175,12 @@ importers:
       vite:
         specifier: ^5.1.1
         version: 5.1.4(@types/node@20.11.22)(terser@5.28.1)
-      vite-plugin-css-injected-by-js:
-        specifier: ^3.4.0
-        version: 3.4.0(vite@5.1.4)
       vite-plugin-dts:
         specifier: ^3.6.3
         version: 3.7.3(@types/node@20.11.22)(typescript@5.4.2)(vite@5.1.4)
+      vite-plugin-lib-inject-css:
+        specifier: ^2.0.0
+        version: 2.0.0(vite@5.1.4)
       vitest:
         specifier: ^1.2.2
         version: 1.3.1(@types/node@20.11.22)(jsdom@22.1.0)
@@ -1491,9 +1494,9 @@ importers:
       vite:
         specifier: ^5.1.1
         version: 5.1.4(@types/node@20.11.22)(terser@5.28.1)
-      vite-plugin-css-injected-by-js:
-        specifier: ^3.4.0
-        version: 3.4.0(vite@5.1.4)
+      vite-plugin-lib-inject-css:
+        specifier: ^2.0.0
+        version: 2.0.0(vite@5.1.4)
       vite-plugin-static-copy:
         specifier: ^1.0.1
         version: 1.0.1(vite@5.1.4)
@@ -7641,7 +7644,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.21(typescript@5.4.2)
-      vue-component-type-helpers: 2.0.6
+      vue-component-type-helpers: 2.0.7
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -21699,6 +21702,16 @@ packages:
       - supports-color
     dev: true
 
+  /vite-plugin-lib-inject-css@2.0.0(vite@5.1.4):
+    resolution: {integrity: sha512-5RK9eP2biW340FEbpI8eHZQfeqIz0+Glbkk4U1fZ1QKOvyaYy5K6TmW43KuhmGLizk2Vd4Nv7OwGpxq2wXclyQ==}
+    peerDependencies:
+      vite: '*'
+    dependencies:
+      magic-string: 0.30.7
+      picocolors: 1.0.0
+      vite: 5.1.4(@types/node@20.11.22)(terser@5.28.1)
+    dev: true
+
   /vite-plugin-static-copy@1.0.1(vite@5.1.4):
     resolution: {integrity: sha512-3eGL4mdZoPJMDBT68pv/XKIHR4MgVolStIxxv1gIBP4R8TpHn9C9EnaU0hesqlseJ4ycLGUxckFTu/jpuJXQlA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -21973,8 +21986,8 @@ packages:
     resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}
     dev: true
 
-  /vue-component-type-helpers@2.0.6:
-    resolution: {integrity: sha512-qdGXCtoBrwqk1BT6r2+1Wcvl583ZVkuSZ3or7Y1O2w5AvWtlvvxwjGhmz5DdPJS9xqRdDlgTJ/38ehWnEi0tFA==}
+  /vue-component-type-helpers@2.0.7:
+    resolution: {integrity: sha512-7e12Evdll7JcTIocojgnCgwocX4WzIYStGClBQ+QuWPinZo/vQolv2EMq4a3lg16TKfwWafLimG77bxb56UauA==}
     dev: true
 
   /vue-demi@0.14.7(vue@3.4.21):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,6 +956,9 @@ importers:
       vite-plugin-dts:
         specifier: ^3.6.3
         version: 3.7.3(@types/node@20.11.22)(typescript@5.4.2)(vite@5.1.4)
+      vite-plugin-lib-inject-css:
+        specifier: ^2.0.0
+        version: 2.0.0(vite@5.1.4)
       vue:
         specifier: ^3.3.0
         version: 3.4.21(typescript@5.4.2)


### PR DESCRIPTION
The current css injection plugin injects the style via JS so it doesn't work on SSR.

[This new plugin](https://www.npmjs.com/package/vite-plugin-lib-inject-css) just auto imports the css file in the component so it makes SSR friendly.
```ts
import './style.css';
```

Not sure how to test this locally because of our package aliases so I'm putting up the PR to test on the preview!