### PR TITLE
fix: scalar codeblock on SSG/SSR

### DIFF
--- a/.changeset/lucky-goats-jam.md
+++ b/.changeset/lucky-goats-jam.md
@@ -1,0 +1,5 @@
+---
+"@scalar/components": patch
+---
+
+fix: make ScalarCodeBlock SSR/SSG compatible

--- a/packages/components/env.d.ts
+++ b/packages/components/env.d.ts
@@ -3,3 +3,4 @@
 declare module '*.module.css?inline'
 declare module 'vite-plugin-scope-tailwind'
 declare module '@rise8/tailwind-pixel-perfect-preset'
+declare module 'prismjs/plugins/autoloader/prism-autoloader.js'


### PR DESCRIPTION
This makes ScalarCodeblock SSR/SSG compatible. The only downside is line numbers get added on the client side but everything else is 👍🏾 