### PR TITLE
fix: rebuild schema property details to truncate long strings

### DIFF
--- a/.changeset/heavy-lobsters-play.md
+++ b/.changeset/heavy-lobsters-play.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: rebuild schema property details to truncate long strings

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
-import { Badge } from '../../Badge'
 import { MarkdownRenderer } from '../../MarkdownRenderer'
 import Schema from './Schema.vue'
+import SchemaPropertyHeading from './SchemaPropertyHeading.vue'
 
 withDefaults(
   defineProps<{
@@ -20,11 +20,6 @@ withDefaults(
 )
 
 const descriptions: Record<string, Record<string, string>> = {
-  number: {
-    _default: '',
-    float: 'Floating-point numbers.',
-    double: 'Floating-point numbers with double precision.',
-  },
   integer: {
     _default: 'Integer numbers.',
     int32: 'Signed 32-bit integers (commonly used integer type).',
@@ -69,78 +64,16 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         'property--deprecated': value?.deprecated,
       },
     ]">
-    <div class="property-information">
-      <div
-        v-if="name"
-        class="property-name">
-        {{ name }}
-      </div>
-      <div
-        v-if="value?.deprecated"
-        class="property-deprecated">
-        <Badge>deprecated</Badge>
-      </div>
-      <div
-        v-if="required"
-        class="required">
-        required
-      </div>
-      <div
-        v-if="value?.type"
-        class="property-type">
-        <template v-if="value?.items && !['object'].includes(value.items.type)">
-          {{ value.type }}
-          {{ value.items.type }}[]
-        </template>
-        <template v-else>
-          {{ Array.isArray(value.type) ? value.type.join(' | ') : value.type }}
-          {{ value?.nullalbe ? ' | nullable' : '' }}
-        </template>
-        <template v-if="value.minItems || value.maxItems">
-          {{ value.minItems }}..{{ value.maxItems }}
-        </template>
-        <template v-if="value.minLength">
-          &middot; min: {{ value.minLength }}
-        </template>
-        <template v-if="value.maxLength">
-          &middot; max: {{ value.maxLength }}
-        </template>
-        <template v-if="value.uniqueItems"> unique! </template>
-        <template v-if="value.format"> &middot; {{ value.format }} </template>
-        <template v-if="value.minimum">
-          &middot; min: {{ value.minimum }}
-        </template>
-        <template v-if="value.maximum">
-          &middot; max: {{ value.maximum }}
-        </template>
-        <template v-if="value.pattern">
-          &middot; <code class="pattern">{{ value.pattern }}</code>
-        </template>
-        <template v-if="getEnumFromValue(value)"> &middot; enum </template>
-        <template v-if="value.default">
-          &middot; default: {{ value.default }}
-        </template>
-      </div>
-      <div
-        v-if="value?.writeOnly"
-        class="write-only">
-        write-only
-      </div>
-      <div
-        v-else-if="value?.readOnly"
-        class="read-only">
-        read-only
-      </div>
+    <SchemaPropertyHeading
+      :enum="!!getEnumFromValue(value)"
+      :required="required"
+      :value="value">
       <template
-        v-for="rule in rules"
-        :key="rule">
-        <div
-          v-if="value?.[rule] || value?.items?.[rule]"
-          class="property-rule-badge">
-          <Badge>{{ rule }}</Badge>
-        </div>
+        v-if="name"
+        #name>
+        {{ name }}
       </template>
-    </div>
+    </SchemaPropertyHeading>
     <!-- Description -->
     <div
       v-if="description || value?.description"
@@ -259,13 +192,6 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
   opacity: 0.75;
 }
 
-.property-information {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  white-space: nowrap;
-}
-
 .property-description {
   margin-top: 6px;
   line-height: 1.4;
@@ -284,31 +210,6 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
   flex-direction: column;
 
   padding-top: 8px;
-}
-
-.property-name {
-  font-family: var(--theme-font-code, var(--default-theme-font-code));
-}
-
-.required,
-.optional {
-  color: var(--theme-color-2, var(--default-theme-color-2));
-}
-
-.required {
-  text-transform: uppercase;
-  color: var(--theme-color-orange, var(--default-theme-color-orange));
-}
-
-.read-only,
-.write-only {
-  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
-  color: var(--theme-color-blue, var(--default-theme-color-blue));
-}
-
-.property-type {
-  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
-  color: var(--theme-color-2, var(--default-theme-color-2));
 }
 
 .property-example {
@@ -336,15 +237,6 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
   white-space: pre;
 }
 
-.pattern {
-  font-family: var(--theme-font-code, var(--default-theme-font-code));
-  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
-  color: var(--theme-color-2, var(--default-theme-color-2));
-  background: var(--theme-background-3, var(--default-theme-background-3));
-  padding: 1px 3px;
-  border-radius: var(--theme-radius, var(--default-theme-radius));
-}
-
 .property-rule {
   display: flex;
   flex-direction: column;
@@ -366,10 +258,6 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 .property-enum-values {
   margin-top: 8px;
   list-style: none;
-}
-
-.property-read-only {
-  font-family: var(--theme-font-code, var(--default-theme-font-code));
 }
 
 .property--compact .property-example {

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyDetail.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyDetail.vue
@@ -1,0 +1,58 @@
+<script lang="ts" setup>
+defineProps<{
+  truncate?: boolean
+  code?: boolean
+}>()
+</script>
+<template>
+  <span
+    class="property-detail"
+    :class="{ 'property-detail-truncate': truncate }">
+    <div
+      v-if="$slots.prefix"
+      class="property-detail-prefix">
+      <slot name="prefix" />&nbsp;
+    </div>
+    <code
+      v-if="code"
+      class="property-detail-value">
+      <slot />
+    </code>
+    <span
+      v-else
+      class="property-detail-value">
+      <slot />
+    </span>
+  </span>
+</template>
+<style scoped>
+.property-detail {
+  display: inline-flex;
+}
+.property-detail + .property-detail:before {
+  display: block;
+  content: '·';
+  margin: 0 0.5ch;
+}
+.property-detail-truncate {
+  overflow: hidden;
+}
+
+.property-detail-truncate > .property-detail-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.property-detail-prefix {
+  color: var(--theme-color-3, var(--default-theme-color-3));
+}
+
+code.property-detail-value {
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  background: var(--theme-background-3, var(--default-theme-background-3));
+  padding: 1px 3px;
+  border-radius: var(--theme-radius, var(--default-theme-radius));
+}
+</style>

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -1,0 +1,143 @@
+<script lang="ts" setup>
+import { Badge } from '../../Badge'
+import SchemaPropertyDetail from './SchemaPropertyDetail.vue'
+
+withDefaults(
+  defineProps<{
+    value?: Record<string, any>
+    enum?: boolean
+    required?: boolean
+  }>(),
+  {
+    level: 0,
+    required: false,
+  },
+)
+
+const rules = ['oneOf', 'anyOf', 'allOf', 'not']
+</script>
+<template>
+  <div class="property-heading">
+    <div
+      v-if="$slots.name"
+      class="property-name">
+      <slot name="name" />
+    </div>
+    <div
+      v-if="value?.deprecated"
+      class="property-deprecated">
+      <Badge>deprecated</Badge>
+    </div>
+    <div
+      v-if="required"
+      class="property-required">
+      required
+    </div>
+    <div
+      v-if="value?.type"
+      class="property-details">
+      <SchemaPropertyDetail>
+        <template v-if="value?.items && !['object'].includes(value.items.type)">
+          {{ value.type }}
+          {{ value.items.type }}[]
+        </template>
+        <template v-else>
+          {{ Array.isArray(value.type) ? value.type.join(' | ') : value.type }}
+          {{ value?.nullable ? ' | nullable' : '' }}
+        </template>
+        <template v-if="value.minItems || value.maxItems">
+          {{ value.minItems }}&hellip;{{ value.maxItems }}
+        </template>
+      </SchemaPropertyDetail>
+      <SchemaPropertyDetail v-if="value.minLength">
+        <template #prefix>min:</template>
+        {{ value.minLength }}
+      </SchemaPropertyDetail>
+      <SchemaPropertyDetail v-if="value.maxLength">
+        <template #prefix>max:</template>
+        {{ value.maxLength }}
+      </SchemaPropertyDetail>
+      <SchemaPropertyDetail v-if="value.uniqueItems">
+        unique!
+      </SchemaPropertyDetail>
+      <SchemaPropertyDetail v-if="value.format">{{
+        value.format
+      }}</SchemaPropertyDetail>
+      <SchemaPropertyDetail v-if="value.minimum">
+        <template #prefix>min:</template>
+        {{ value.minimum }}
+      </SchemaPropertyDetail>
+      <SchemaPropertyDetail v-if="value.maximum">
+        <template #prefix>max:</template>
+        {{ value.maximum }}
+      </SchemaPropertyDetail>
+      <SchemaPropertyDetail
+        v-if="value.pattern"
+        code
+        truncate>
+        {{ value.pattern }}
+      </SchemaPropertyDetail>
+      <SchemaPropertyDetail v-if="$props.enum">enum</SchemaPropertyDetail>
+      <SchemaPropertyDetail
+        v-if="value.default"
+        truncate>
+        <template #prefix>default:</template>
+        {{ value.default }}
+      </SchemaPropertyDetail>
+    </div>
+    <div
+      v-if="value?.writeOnly"
+      class="property-write-only">
+      write-only
+    </div>
+    <div
+      v-else-if="value?.readOnly"
+      class="property-read-only">
+      read-only
+    </div>
+    <template
+      v-for="rule in rules.filter((r) => value?.[r] || value?.items?.[r])"
+      :key="rule">
+      <Badge>{{ rule }}</Badge>
+    </template>
+  </div>
+</template>
+<style scoped>
+.property-heading {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  white-space: nowrap;
+}
+
+.property-name {
+  font-family: var(--theme-font-code, var(--default-theme-font-code));
+}
+
+.property-required,
+.property-optional {
+  color: var(--theme-color-2, var(--default-theme-color-2));
+}
+
+.property-required {
+  text-transform: uppercase;
+  color: var(--theme-color-orange, var(--default-theme-color-orange));
+}
+
+.property-read-only,
+.property-write-only {
+  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
+  color: var(--theme-color-blue, var(--default-theme-color-blue));
+}
+
+.property-details {
+  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
+  color: var(--theme-color-2, var(--default-theme-color-2));
+
+  display: flex;
+  align-items: center;
+
+  flex: 1;
+  min-width: 0;
+}
+</style>


### PR DESCRIPTION
- Refactors the property type details into components
- Adds the option to turn on truncation for any of the type values
- Fixes a typo in `$.nullable` so that actually works now
- ~~Moves rule badges and `writeOnly` / `readOnly` labels to be right aligned (I did this by accident but I think it looks better / cleaner, we can move them back to the left if we want)~~ Ignore it being on the right in the screenshots, it's back on the left
- Adjusts the color slightly of the type details prefixes to differentiate them from the detail value (e.g. `max: 100`)

**Note:** There might be slight pixel differences due to moving from an inline layout to a flex layout but we need the flex layout for the truncation.

[Cursed Petstore Test File](https://github.com/scalar/scalar/files/14709743/petstorev3.json) which I'm using in the below screenshots.

Sorry for big before / afters

## Before

<img alt="Google Chrome-2024-03-21-14-16-31@2x" src="https://github.com/scalar/scalar/assets/6374090/89f69387-943a-485b-804a-70f5d3283335">

<img alt="Google Chrome-2024-03-21-14-16-43@2x" src="https://github.com/scalar/scalar/assets/6374090/8969477c-75fd-43ed-bc3b-1f773e00eb5c">

![Google Chrome-2024-03-21-14-17-17@2x](https://github.com/scalar/scalar/assets/6374090/13418a6f-9361-45d5-aa80-3fec4fe16697)

## After

<img alt="Google Chrome-2024-03-21-14-13-56@2x" src="https://github.com/scalar/scalar/assets/6374090/d4b100d9-2dfc-4bfc-8315-bb8e78728adf">

<img  alt="Google Chrome-2024-03-21-14-14-30@2x" src="https://github.com/scalar/scalar/assets/6374090/65772649-543f-4d81-a9a5-19799c8a348d">

![Google Chrome-2024-03-21-14-15-16@2x](https://github.com/scalar/scalar/assets/6374090/25aad0b8-1c56-49b9-b258-b9b1279679db)

