### PR TITLE
fix: use darkmode state hook to manage mode

### DIFF
--- a/.changeset/afraid-bugs-cry.md
+++ b/.changeset/afraid-bugs-cry.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: use darkmode state hook to manage mode

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -61,7 +61,7 @@ function mapConfigToState<K extends keyof ReferenceConfiguration>(
 }
 
 // Handle the events from the toggle buttons and map the configuration to the internal state
-const { toggleDarkMode, setDarkMode } = useDarkModeState()
+const { setDarkMode } = useDarkModeState()
 mapConfigToState('darkMode', (newDarkMode) => {
   if (newDarkMode !== undefined) setDarkMode(newDarkMode)
 })
@@ -91,7 +91,6 @@ const { parsedSpec, rawSpec } = useReactiveSpec({
     :configuration="configuration"
     :parsedSpec="parsedSpec"
     :rawSpec="rawSpec"
-    @toggleDarkMode="() => toggleDarkMode()"
     @updateContent="$emit('updateContent', $event)">
     <template #footer><slot name="footer" /></template>
   </Component>

--- a/packages/api-reference/src/components/DarkModeToggle/DarkModeIconToggle.vue
+++ b/packages/api-reference/src/components/DarkModeToggle/DarkModeIconToggle.vue
@@ -1,24 +1,19 @@
 <script lang="ts" setup>
 import { ScalarIcon } from '@scalar/components'
 
+import { useDarkModeState } from '../../hooks'
 import ScreenReader from '../ScreenReader.vue'
 
-defineProps<{
-  isDarkMode: boolean
-}>()
-
-defineEmits<{
-  (e: 'toggleDarkMode'): void
-}>()
+const { isDark, toggleDarkMode } = useDarkModeState()
 </script>
 <template>
   <button
     class="darklight"
     type="button"
-    @click="$emit('toggleDarkMode')">
-    <ScalarIcon :icon="isDarkMode ? 'DarkMode' : 'LightMode'" />
+    @click="toggleDarkMode">
+    <ScalarIcon :icon="isDark ? 'DarkMode' : 'LightMode'" />
     <ScreenReader>
-      Switch to {{ isDarkMode ? 'Light' : 'Dark' }} Mode
+      Switch to {{ isDark ? 'Light' : 'Dark' }} Mode
     </ScreenReader>
   </button>
 </template>

--- a/packages/api-reference/src/components/DarkModeToggle/DarkModeToggle.vue
+++ b/packages/api-reference/src/components/DarkModeToggle/DarkModeToggle.vue
@@ -1,22 +1,18 @@
 <script lang="ts" setup>
 import { ScalarIcon } from '@scalar/components'
 
-defineProps<{
-  isDarkMode: boolean
-}>()
+import { useDarkModeState } from '../../hooks'
 
-defineEmits<{
-  (e: 'toggleDarkMode'): void
-}>()
+const { isDark, toggleDarkMode } = useDarkModeState()
 </script>
 <template>
   <div class="darklight-reference">
     <button
       class="darklight"
       type="button"
-      @click="$emit('toggleDarkMode')">
+      @click="toggleDarkMode">
       <ScalarIcon icon="LightDarkModeToggle" />
-      <template v-if="isDarkMode">
+      <template v-if="isDark">
         <span>Light Mode</span>
       </template>
       <template v-else>

--- a/packages/api-reference/src/components/Layouts/BaseLayout.vue
+++ b/packages/api-reference/src/components/Layouts/BaseLayout.vue
@@ -9,9 +9,6 @@ import type { ReferenceLayoutProps, ReferenceSlots } from '../../types'
 
 // eslint-disable-next-line vue/no-unused-properties
 defineProps<ReferenceLayoutProps>()
-defineEmits<{
-  (e: 'toggleDarkMode'): void
-}>()
 
 defineSlots<ReferenceSlots>()
 

--- a/packages/api-reference/src/components/Layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ClassicLayout.vue
@@ -9,10 +9,6 @@ import SearchButton from '../SearchButton.vue'
 
 const props = defineProps<ReferenceLayoutProps>()
 
-defineEmits<{
-  (e: 'toggleDarkMode'): void
-}>()
-
 defineSlots<ReferenceSlots>()
 // Override the sidebar value and hide it
 const config = computed(() => ({ ...props.configuration, showSidebar: false }))
@@ -29,9 +25,7 @@ const config = computed(() => ({ ...props.configuration, showSidebar: false }))
           :searchHotKey="config.searchHotKey"
           :spec="spec" />
         <template #dark-mode-toggle>
-          <DarkModeIconToggle
-            :isDarkMode="!!configuration?.darkMode"
-            @toggleDarkMode="$emit('toggleDarkMode')" />
+          <DarkModeIconToggle />
         </template>
       </ClassicHeader>
     </template>

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -10,9 +10,6 @@ import MobileHeader from '../MobileHeader.vue'
 import SearchButton from '../SearchButton.vue'
 
 const props = defineProps<ReferenceLayoutProps>()
-defineEmits<{
-  (e: 'toggleDarkMode'): void
-}>()
 
 defineSlots<ReferenceSlots>()
 
@@ -60,9 +57,7 @@ watch(hash, (newHash, oldHash) => {
       </div>
     </template>
     <template #sidebar-end>
-      <DarkModeToggle
-        :isDarkMode="!!configuration?.darkMode"
-        @toggleDarkMode="$emit('toggleDarkMode')" />
+      <DarkModeToggle />
     </template>
     <!-- Expose the content end slot as a slot for the footer -->
     <template #content-end><slot name="footer" /></template>


### PR DESCRIPTION
I think we can just use the hook now to manage everything since the root component syncs the dark mode config to the app state.

Fixes #1248 

Let me know if I'm missing something 🤔 

### Changing via the app state

https://github.com/scalar/scalar/assets/6374090/a45a3d35-bc6d-43ab-b306-4bbbd5f1c6f4

### Changing via the config object

https://github.com/scalar/scalar/assets/6374090/52765838-0aff-459e-be68-b155d5fdec27



