### PR TITLE
fix: operator will always return left

### DIFF
--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -43,7 +43,7 @@ type CollapsedSidebarItems = Record<string, boolean>
 const collapsedSidebarItems = reactive<CollapsedSidebarItems>({})
 
 function toggleCollapsedSidebarItem(key: string) {
-  collapsedSidebarItems[key] = !collapsedSidebarItems[key] ?? true
+  collapsedSidebarItems[key] = !collapsedSidebarItems[key]
 }
 
 function setCollapsedSidebarItem(key: string, value: boolean) {


### PR DESCRIPTION
The build process had this warning for a while:

> The "??" operator here will always return the left operand

This PR drops the right side. :)

