### PR TITLE
fix: does not show schema, fix #1291

### DIFF
--- a/.changeset/shiny-shirts-laugh.md
+++ b/.changeset/shiny-shirts-laugh.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: does not show schema

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -101,8 +101,7 @@ const showSchema = ref(false)
           @click="() => copyToClipboard(currentJsonResponse?.example)">
           <ScalarIcon
             icon="Clipboard"
-            width="10px"
-            x="asd" />
+            width="10px" />
         </button>
         <label
           v-if="currentJsonResponse?.schema"

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { ScalarCodeBlock, ScalarIcon } from '@scalar/components'
-import type { TransformedOperation } from '@scalar/oas-utils'
+import { type TransformedOperation, prettyPrintJson } from '@scalar/oas-utils'
 import { computed, ref } from 'vue'
 
 import { useClipboard } from '../../../../hooks'
@@ -125,8 +125,8 @@ const showSchema = ref(false)
       <CardContent muted>
         <template v-if="currentJsonResponse?.schema">
           <ScalarCodeBlock
-            v-if="showSchema && currentResponseWithExample"
-            :content="currentResponseWithExample"
+            v-if="showSchema && currentJsonResponse.schema"
+            :content="prettyPrintJson(currentJsonResponse.schema)"
             lang="json" />
           <ExampleResponse
             v-else


### PR DESCRIPTION
Since we merged #1276 the schema is shown as `[Object object]`. This PR makes sure the schema is transformed to a string to fix that.

Actually, that shouldn’t be necessary. The code block checks the format anyway, but for some reason it is! So let’s just roll with it. :)