### PR TITLE
feat(cli): better url support

### DIFF
--- a/.changeset/nine-sloths-tease.md
+++ b/.changeset/nine-sloths-tease.md
@@ -1,0 +1,5 @@
+---
+"@scalar/cli": patch
+---
+
+feat: add the output file argument to the format command

--- a/.changeset/rich-ants-divide.md
+++ b/.changeset/rich-ants-divide.md
@@ -1,0 +1,5 @@
+---
+"@scalar/cli": patch
+---
+
+feat: add URL support to the validate command

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,6 +42,8 @@ The given JSON file will be formatted with Prettier.
 
 ```bash
 scalar format
+scalar format openapi.json --output openapi.yaml
+scalar format https://example.com/openapi.json --output openapi.json
 ```
 
 ### validate
@@ -50,6 +52,8 @@ To check whether your OpenAPI file adheres to the Swagger 2.0, OpenAPI 3.0 or Op
 
 ```bash
 scalar validate
+scalar validate openapi.json
+scalar validate https://example.com/openapi.json
 ```
 
 ### share
@@ -58,9 +62,22 @@ To quickly share an OpenAPI file or reference with someone, you can use the shar
 
 ```bash
 scalar share
+scalar share openapi.json
 ```
 
 This will upload your OpenAPI file to the [Scalar Sandbox](https://sandbox.scalar.com/) to give you a public reference URL and a public URL to your OpenAPI JSON file.
+
+### reference
+
+You can quickly spin up a local server with an API reference based on your OpenAPI file.
+
+```bash
+scalar reference
+scalar reference openapi.json
+scalar reference openapi.json --port 1234
+scalar reference openapi.json --watch
+scalar reference https://example.com/openapi.json --watch
+```
 
 ### mock
 
@@ -84,7 +101,15 @@ You can also change the port like this:
 scalar mock openapi.json --watch --port 8080
 ```
 
+And it even works with URLs:
+
+```bash
+scalar mock https://example.com/openapi.json --watch
+```
+
 ### bundle
+
+> Warning! The bundle command isn’t ready for production yet. Circular dependencies are not supported yet.
 
 Some OpenAPI files reference other files from the file system or an URL. You can bundle those files and make them a single file:
 

--- a/packages/cli/src/commands/mock/MockCommand.ts
+++ b/packages/cli/src/commands/mock/MockCommand.ts
@@ -17,7 +17,7 @@ export function MockCommand() {
   const cmd = new Command('mock')
 
   cmd.description('Mock an API from an OpenAPI file')
-  cmd.argument('[file]', 'OpenAPI file to mock the server for')
+  cmd.argument('[file|url]', 'OpenAPI file or URL to mock the server for')
   cmd.option('-w, --watch', 'watch the file for changes')
   cmd.option('-p, --port <port>', 'set the HTTP port for the mock server')
   cmd.action(

--- a/packages/cli/src/commands/reference/ReferenceCommand.ts
+++ b/packages/cli/src/commands/reference/ReferenceCommand.ts
@@ -16,7 +16,7 @@ export function ReferenceCommand() {
   const cmd = new Command('reference')
 
   cmd.description('Serve an API Reference from an OpenAPI file')
-  cmd.argument('[file]', 'OpenAPI file to show the reference for')
+  cmd.argument('[file|url]', 'OpenAPI file or URL to show the reference for')
   cmd.option('-w, --watch', 'watch the file for changes')
   cmd.option(
     '-p, --port <port>',

--- a/packages/cli/src/commands/validate/ValidateCommand.ts
+++ b/packages/cli/src/commands/validate/ValidateCommand.ts
@@ -5,19 +5,19 @@ import fs from 'node:fs'
 import prettyjson from 'prettyjson'
 
 import { useGivenFileOrConfiguration } from '../../utils'
+import { getFileOrUrl } from '../../utils/getFileOrUrl'
 
 export function ValidateCommand() {
   const cmd = new Command('validate')
 
   cmd.description('Validate an OpenAPI file')
-  cmd.argument('[file]', 'file to validate')
-  cmd.action(async (fileArgument: string) => {
+  cmd.argument('[file|url]', 'File or URL to validate')
+  cmd.action(async (inputArgument: string) => {
     const startTime = performance.now()
 
     // Read file
-    const file = useGivenFileOrConfiguration(fileArgument)
-    // TODO: Doesn’t work with URLs
-    const specification = fs.readFileSync(file, 'utf8')
+    const input = useGivenFileOrConfiguration(inputArgument)
+    const specification = await getFileOrUrl(input)
 
     // Validate
     const result = await openapi().load(specification).validate()

--- a/packages/cli/src/utils/getFileOrUrl.ts
+++ b/packages/cli/src/utils/getFileOrUrl.ts
@@ -1,0 +1,30 @@
+import kleur from 'kleur'
+import fs from 'node:fs'
+
+import { isUrl } from './isUrl'
+
+/**
+ * Pass a file path or URL and get the content of the file.
+ */
+export async function getFileOrUrl(input: string): Promise<string> {
+  if (isUrl(input)) {
+    const response = await fetch(input)
+
+    if (!response.ok) {
+      console.error(
+        kleur.bold().red('[ERROR]'),
+        kleur.bold().red('Failed to fetch OpenAPI specification from URL.'),
+      )
+
+      return ''
+    }
+
+    return await response.text()
+  }
+
+  if (!fs.existsSync(input)) {
+    throw new Error('File not found')
+  }
+
+  return fs.readFileSync(input, 'utf-8')
+}

--- a/packages/cli/src/utils/isUrl.ts
+++ b/packages/cli/src/utils/isUrl.ts
@@ -2,5 +2,8 @@
  * Check if the input is a URL.
  */
 export function isUrl(text: string): boolean {
-  return text.startsWith('http://') || text.startsWith('https://')
+  return (
+    typeof text === 'string' &&
+    (text.startsWith('http://') || text.startsWith('https://'))
+  )
 }

--- a/packages/cli/src/utils/isYamlFileName.ts
+++ b/packages/cli/src/utils/isYamlFileName.ts
@@ -1,0 +1,12 @@
+import { isUrl } from './isUrl'
+
+/**
+ * True for all files ending with .yml or .yaml (case-insensitive).
+ */
+export function isYamlFileName(fileName: string) {
+  if (isUrl(fileName)) {
+    return false
+  }
+
+  return /\.ya?ml$/i.test(fileName)
+}

--- a/packages/cli/src/utils/loadOpenApiFile.ts
+++ b/packages/cli/src/utils/loadOpenApiFile.ts
@@ -1,8 +1,7 @@
 import { openapi } from '@scalar/openapi-parser'
 import kleur from 'kleur'
-import fs from 'node:fs'
 
-import { isUrl } from './isUrl'
+import { getFileOrUrl } from './getFileOrUrl'
 
 export async function loadOpenApiFile(input: string) {
   const specification = await getFileOrUrl(input)
@@ -52,30 +51,4 @@ export async function loadOpenApiFile(input: string) {
       ],
     }
   }
-}
-
-/**
- * Pass a file path or URL and get the content of the file.
- */
-async function getFileOrUrl(input: string): Promise<string> {
-  if (isUrl(input)) {
-    const response = await fetch(input)
-
-    if (!response.ok) {
-      console.error(
-        kleur.bold().red('[ERROR]'),
-        kleur.bold().red('Failed to fetch OpenAPI specification from URL.'),
-      )
-
-      return ''
-    }
-
-    return await response.text()
-  }
-
-  if (!fs.existsSync(input)) {
-    throw new Error('File not found')
-  }
-
-  return fs.readFileSync(input, 'utf-8')
 }


### PR DESCRIPTION
We’ve added URL support to the CLI (eg. `scalar reference https://example.com/openapi.json`). But some features were lacking, and I didn’t update the documentation.

This PR adds some missing parts.

✨ New ✨ `pnpm validate https://example.com/openapi.json`
✨ New ✨ `pnpm format openapi.json --output openapi.yaml`
✨ New ✨ `pnpm format https://example.com/openapi.json --output openapi.yaml`