### PR TITLE
fix: only lowercase hostname

### DIFF
--- a/.changeset/hot-islands-shop.md
+++ b/.changeset/hot-islands-shop.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: only lowercase hostname

--- a/packages/api-client/src/helpers/normalizeUrl.test.ts
+++ b/packages/api-client/src/helpers/normalizeUrl.test.ts
@@ -15,6 +15,12 @@ describe('normalizeUrl', () => {
     expect(normalizeUrl('http://EXAMPLE.COM')).toBe('http://example.com')
   })
 
+  it('makes hostname lowercase', async () => {
+    expect(normalizeUrl('http://EXAMPLE.COM/API/v1/TeSt')).toBe(
+      'http://example.com/API/v1/TeSt',
+    )
+  })
+
   it('adds http://', async () => {
     expect(normalizeUrl('example.com')).toBe('http://example.com')
   })

--- a/packages/api-client/src/helpers/normalizeUrl.test.ts
+++ b/packages/api-client/src/helpers/normalizeUrl.test.ts
@@ -4,15 +4,11 @@ import { normalizeUrl } from './normalizeUrl'
 
 describe('normalizeUrl', () => {
   it('keeps URLs as is', async () => {
-    expect(normalizeUrl('http://127.0.0.1')).toBe('http://127.0.0.1')
-  })
-
-  it('keeps slashes', async () => {
-    expect(normalizeUrl('http://127.0.0.1/')).toBe('http://127.0.0.1/')
+    expect(normalizeUrl('http://127.0.0.1')).toBe('http://127.0.0.1/')
   })
 
   it('makes URLs lowercase', async () => {
-    expect(normalizeUrl('http://EXAMPLE.COM')).toBe('http://example.com')
+    expect(normalizeUrl('http://EXAMPLE.COM')).toBe('http://example.com/')
   })
 
   it('makes hostname lowercase', async () => {
@@ -22,11 +18,28 @@ describe('normalizeUrl', () => {
   })
 
   it('adds http://', async () => {
-    expect(normalizeUrl('example.com')).toBe('http://example.com')
+    expect(normalizeUrl('example.com')).toBe('http://example.com/')
   })
 
   it('trims whitespace', async () => {
-    expect(normalizeUrl('http://example.com ')).toBe('http://example.com')
+    expect(normalizeUrl('http://marc.com ')).toBe('http://marc.com/')
+  })
+
+  it('keeps paths as is ', async () => {
+    expect(normalizeUrl('http://marc.com ')).toBe('http://marc.com/')
+    expect(normalizeUrl('http://marc.com/path/ ')).toBe('http://marc.com/path/')
+    expect(normalizeUrl('http://marc.com/path/v1 ')).toBe(
+      'http://marc.com/path/v1',
+    )
+  })
+
+  it('keeps query params as is ', async () => {
+    expect(normalizeUrl('http://marc.com?marc=true')).toBe(
+      'http://marc.com/?marc=true',
+    )
+    expect(normalizeUrl('http://marc.com/path/?okay=cool&neat=fun')).toBe(
+      'http://marc.com/path/?okay=cool&neat=fun',
+    )
   })
 
   it('ignores other types', async () => {

--- a/packages/api-client/src/helpers/normalizeUrl.ts
+++ b/packages/api-client/src/helpers/normalizeUrl.ts
@@ -10,7 +10,11 @@ export const normalizeUrl = (url?: string) => {
     return ''
   }
 
-  let normalizedUrl = url.trim().toLowerCase()
+  const urlObject = new URL(url)
+  // we only want to lowercase the hostname, and not the path
+  urlObject.hostname = urlObject.hostname.trim().toLowerCase()
+
+  let normalizedUrl = urlObject.toString()
 
   if (!normalizedUrl.startsWith('http')) {
     console.warn(

--- a/packages/api-client/src/helpers/normalizeUrl.ts
+++ b/packages/api-client/src/helpers/normalizeUrl.ts
@@ -10,19 +10,19 @@ export const normalizeUrl = (url?: string) => {
     return ''
   }
 
-  const urlObject = new URL(url)
-  // we only want to lowercase the hostname, and not the path
-  urlObject.hostname = urlObject.hostname.trim().toLowerCase()
+  let sanitizedUrl = url
 
-  let normalizedUrl = urlObject.toString()
-
-  if (!normalizedUrl.startsWith('http')) {
+  if (!sanitizedUrl.startsWith('http')) {
     console.warn(
       `[sendRequest] URL does not start with http. Adding http:// as the default prefix.`,
     )
 
-    normalizedUrl = `http://${normalizedUrl}`
+    sanitizedUrl = `http://${sanitizedUrl}`
   }
 
-  return normalizedUrl
+  const urlObject = new URL(sanitizedUrl)
+  // we only want to lowercase the hostname, and not the path
+  urlObject.hostname = urlObject.hostname.trim().toLowerCase()
+
+  return urlObject.toString()
 }


### PR DESCRIPTION
now `https://petstore3.swagger.io/API/v3/pet` will send as `https://petstore3.swagger.io/API/v3/pet` vs `https://petstore3.swagger.io/api/v3/pet`

i also wrote some tests 😏 