### PR TITLE
feat: tab and shift+tab codemirror, and escape codeblock hotkeys

### DIFF
--- a/.changeset/happy-pillows-cough.md
+++ b/.changeset/happy-pillows-cough.md
@@ -1,0 +1,5 @@
+---
+"@scalar/use-codemirror": patch
+---
+
+feat: tab and shift+tab codemirror, and escape codeblock hotkeys

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.12.0",
+    "@codemirror/commands": "^6.3.3",
     "@codemirror/lang-css": "^6.2.1",
     "@codemirror/lang-html": "^6.4.8",
     "@codemirror/lang-json": "^6.0.0",

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -4,6 +4,7 @@ import {
   closeBracketsKeymap,
   completionKeymap,
 } from '@codemirror/autocomplete'
+import { indentWithTab } from '@codemirror/commands'
 import { css } from '@codemirror/lang-css'
 import { html } from '@codemirror/lang-html'
 import { json } from '@codemirror/lang-json'
@@ -311,6 +312,7 @@ function getCodeMirrorExtensions({
       keymap.of([
         ...completionKeymap,
         ...closeBracketsKeymap,
+        indentWithTab,
         selectAllKeyBinding,
       ]),
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1512,6 +1512,9 @@ importers:
       '@codemirror/autocomplete':
         specifier: ^6.12.0
         version: 6.12.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(@lezer/common@1.2.1)
+      '@codemirror/commands':
+        specifier: ^6.3.3
+        version: 6.3.3
       '@codemirror/lang-css':
         specifier: ^6.2.1
         version: 6.2.1(@codemirror/view@6.24.1)


### PR DESCRIPTION
tab works!
shift tab works!
if you escape you can tab normally in the page :) an AMAZING experience boost

https://github.com/scalar/scalar/assets/6176314/1b15f649-a652-4eb4-9141-be6913d232e1

