### PR TITLE
feat: sidebar border indents + theme prep for future

### DIFF
--- a/.changeset/pink-rocks-shout.md
+++ b/.changeset/pink-rocks-shout.md
@@ -1,0 +1,10 @@
+---
+"@scalar/nextjs-api-reference": patch
+"@scalar/api-client-react": patch
+"@scalar/api-reference": patch
+"@scalar/api-client": patch
+"@scalar/components": patch
+"@scalar/themes": patch
+---
+
+feat: sidebar border indents + theme polish

--- a/packages/api-client-react/src/style.css
+++ b/packages/api-client-react/src/style.css
@@ -46,6 +46,10 @@
 
   --theme-scrollbar-color: rgba(255, 255, 255, 0.24);
   --theme-scrollbar-color-active: rgba(255, 255, 255, 0.48);
+
+  --default-sidebar-indent-border: transparent;
+  --default-sidebar-indent-border-hover: transparent;
+  --default-sidebar-indent-border-active: transparent;
 }
 .dark-mode .scalar-modal-layout,
 .dark-mode .scalar {

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -284,7 +284,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   font-size: var(--theme-micro, var(--default-theme-micro));
   letter-spacing: 0.25px;
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
-  color: white;
+  color: var(--theme-button-1-color, var(--default-theme-button-1-color));
   border: none;
   white-space: nowrap;
   padding: 0 12px;
@@ -294,10 +294,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   font-family: (--theme-font, var(--default-theme-font));
   border-radius: 0 var(--theme-radius, var(--default-theme-radius))
     var(--theme-radius, var(--default-theme-radius)) 0;
-  background: var(
-    --scalar-api-client-color,
-    var(--default-scalar-api-client-color)
-  );
+  background: var(--theme-button-1, var(--default-theme-button-1));
   position: relative;
   /**  #087f5b */
   display: flex;
@@ -305,20 +302,8 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   overflow: hidden;
   flex-shrink: 0;
 }
-.send-button:before {
-  content: '';
-  position: absolute;
-  top: -5%;
-  left: -5%;
-  width: 110%;
-  height: 110%;
-  pointer-events: none;
-  cursor: pointer;
-  border-radius: var(--theme-radius, var(--default-theme-radius));
-  background: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2));
-}
-.send-button:hover:before {
-  background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.1));
+.send-button:hover {
+  background: var(--theme-button-1-hover, var(--default-theme-button-1-hover));
 }
 .send-button svg {
   width: 12px;

--- a/packages/api-reference/src/components/Content/Introduction/DownloadSpec.vue
+++ b/packages/api-reference/src/components/Content/Introduction/DownloadSpec.vue
@@ -22,6 +22,7 @@ import { downloadSpecBus } from '../../../helpers'
   color: var(--theme-color-accent, var(--default-theme-color-accent));
   text-decoration: none;
   font-size: var(--theme-paragraph, var(--default-theme-paragraph));
+  cursor: pointer;
 }
 .download-cta .download-button:hover {
   text-decoration: underline;

--- a/packages/api-reference/src/components/Content/Operation/EndpointPath.vue
+++ b/packages/api-reference/src/components/Content/Operation/EndpointPath.vue
@@ -27,7 +27,7 @@ const pathParts = computed<string[]>(() => props.path.split(/({[^}]+})/))
 .endpoint-path {
   overflow: hidden;
   word-wrap: break-word;
-  font-weight: var(--theme-bold, var(--default-theme-bold));
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
 }
 .deprecated {
   text-decoration: line-through;

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -279,7 +279,7 @@ const showSchema = ref(false)
 .scalar-card-checkbox
   .scalar-card-checkbox-input:checked
   ~ .scalar-card-checkbox-checkmark {
-  background-color: var(--theme-color-1, var(--default-theme-color-1));
+  background-color: var(--theme-button-1, var(--default-theme-button-1));
   box-shadow: none;
 }
 
@@ -300,7 +300,8 @@ const showSchema = ref(false)
   top: 36.5%;
   width: 5px;
   height: 9px;
-  border: solid var(--theme-background-1, var(--default-theme-background-1));
+  border: solid 1px
+    var(--theme-button-1-color, var(--default-theme-button-1-color));
   border-width: 0 1.5px 1.5px 0;
   transform: rotate(45deg);
 }

--- a/packages/api-reference/src/components/Content/Operation/TryRequestButton.vue
+++ b/packages/api-reference/src/components/Content/Operation/TryRequestButton.vue
@@ -17,11 +17,10 @@ const getGlobalSecurity = inject(GLOBAL_SECURITY_SYMBOL)
     as="button"
     class="show-api-client-button"
     :method="operation.httpVerb"
-    property="background"
     type="button"
     @click.stop="openClientFor(operation, getGlobalSecurity?.())">
-    <span>Test Request</span>
     <ScalarIcon icon="PaperAirplane" />
+    <span>Test Request</span>
   </HttpMethod>
 </template>
 <style scoped>
@@ -29,18 +28,17 @@ const getGlobalSecurity = inject(GLOBAL_SECURITY_SYMBOL)
   appearance: none;
   outline: none;
   border: none;
-  padding: 6px;
-  height: 23px;
+  padding: 4px 6px;
   white-space: nowrap;
   border-radius: var(--theme-radius, var(--default-theme-radius));
-  text-transform: uppercase;
   display: flex;
   justify-content: center;
   align-items: center;
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
-  font-size: var(--theme-micro, var(--default-theme-micro));
+  font-size: var(--theme-mini, var(--default-theme-mini));
   color: var(--theme-background-2, var(--default-background-2));
   font-family: var(--theme-font, var(--default-theme-font));
+  background: var(--theme-button-1, var(--default-theme-button-1));
   position: relative;
   cursor: pointer;
   box-sizing: border-box;
@@ -48,29 +46,15 @@ const getGlobalSecurity = inject(GLOBAL_SECURITY_SYMBOL)
 }
 .show-api-client-button span,
 .show-api-client-button svg {
-  color: #fff;
+  color: var(--theme-button-1-color, var(--default-theme-button-1-color));
   z-index: 1;
 }
-.show-api-client-button:before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  cursor: pointer;
-  border-radius: var(--theme-radius, var(--default-theme-radius));
-}
-.show-api-client-button:before {
-  background: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2));
-}
-.show-api-client-button:hover:before {
-  background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.1));
+.show-api-client-button:hover {
+  background: var(--theme-button-1-hover, var(--default-theme-button-1-hover));
 }
 .show-api-client-button svg {
   height: 12px;
   width: auto;
-  margin-left: 9px;
+  margin-right: 9px;
 }
 </style>

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -144,6 +144,33 @@ const handleClick = async () => {
     )
   );
 }
+.sidebar-indent-nested .sidebar-indent-nested .sidebar-heading:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: calc((var(--sidebar-level, var(--default-sidebar-level)) * 12px));
+  width: 1px;
+  height: 100%;
+  background: var(
+    --sidebar-indent-border,
+    var(--default-sidebar-indent-border)
+  );
+}
+.sidebar-indent-nested .sidebar-indent-nested .sidebar-heading:hover:before {
+  background: var(
+    --sidebar-sidebar-indent-border-hover,
+    var(--default-sidebar-indent-border-hover)
+  );
+}
+.sidebar-indent-nested
+  .sidebar-indent-nested
+  .active_page.sidebar-heading:before {
+  background: var(
+    --sidebar-indent-border-active,
+    var(--default-sidebar-indent-border-active)
+  );
+}
+
 .sidebar-heading-link {
   text-decoration: none;
   color: inherit;
@@ -194,7 +221,7 @@ const handleClick = async () => {
 .toggle-nested-icon {
   border: none;
   color: currentColor;
-  padding: 2px;
+  padding: 3px;
   color: var(--sidebar-color-2, var(--default-sidebar-color-2));
 }
 .active_page .toggle-nested-icon {
@@ -269,24 +296,18 @@ const handleClick = async () => {
   position: relative;
   font-family: var(--theme-font-code, var(--default-theme-font-code));
   white-space: nowrap;
+  margin-left: 3px;
 }
 .active_page .sidebar-heading-type {
   background: transparent;
-  box-shadow: inset 0 0 0 1px
-    var(
-      --sidebar-color-active,
-      var(
-        --default-sidebar-color-active,
-        var(--theme-color-accent, var(--default-theme-color-accent))
-      )
-    );
-  color: var(
-    --sidebar-color-active,
-    var(
-      --default-sidebar-color-active,
-      var(--theme-color-accent, var(--default-theme-color-accent))
-    )
-  );
+}
+.active_page .sidebar-heading-type {
+  background: var(--method-color);
+  color: color-mix(in srgb, var(--method-color), white 85%);
+}
+.dark-mode .active_page .sidebar-heading-type {
+  background: var(--method-color);
+  color: color-mix(in srgb, var(--method-color), black 80%);
 }
 .sidebar-group-item__folder {
   color: var(

--- a/packages/components/src/components/ScalarIcon/icons/ChevronDown.svg
+++ b/packages/components/src/components/ScalarIcon/icons/ChevronDown.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M4.5 8.25L12 15.75L19.5 8.25" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.5 8.25L12 15.75L19.5 8.25" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/components/src/components/ScalarIcon/icons/ChevronLeft.svg
+++ b/packages/components/src/components/ScalarIcon/icons/ChevronLeft.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M15.75 19.5L8.25 12L15.75 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.75 19.5L8.25 12L15.75 4.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/components/src/components/ScalarIcon/icons/ChevronRight.svg
+++ b/packages/components/src/components/ScalarIcon/icons/ChevronRight.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M8.25 19.5L15.75 12L8.25 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.25 19.5L15.75 12L8.25 4.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/components/src/components/ScalarIcon/icons/ChevronUp.svg
+++ b/packages/components/src/components/ScalarIcon/icons/ChevronUp.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M19.5 15.75L12 8.25L4.5 15.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.5 15.75L12 8.25L4.5 15.75" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/components/src/components/ScalarIcon/icons/arrow-chevron-down.svg
+++ b/packages/components/src/components/ScalarIcon/icons/arrow-chevron-down.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M23.25 7.311 12.53 18.03a.749.749 0 0 1-1.06 0L.75 7.311"></path></svg>
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M23.25 7.311 12.53 18.03a.749.749 0 0 1-1.06 0L.75 7.311"></path></svg>

--- a/packages/components/src/components/ScalarIcon/icons/arrow-chevron-left.svg
+++ b/packages/components/src/components/ScalarIcon/icons/arrow-chevron-left.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" stroke-width="1.5"><path d="M16.25 23.25 5.53 12.53a.749.749 0 0 1 0-1.06L16.25.75" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" stroke-width="2"><path d="M16.25 23.25 5.53 12.53a.749.749 0 0 1 0-1.06L16.25.75" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path></svg>

--- a/packages/components/src/components/ScalarIcon/icons/arrow-chevron-right.svg
+++ b/packages/components/src/components/ScalarIcon/icons/arrow-chevron-right.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" stroke-width="1.5"><path d="m5.5.75 10.72 10.72a.749.749 0 0 1 0 1.06L5.5 23.25" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" stroke-width="2"><path d="m5.5.75 10.72 10.72a.749.749 0 0 1 0 1.06L5.5 23.25" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path></svg>

--- a/packages/components/src/components/ScalarIcon/icons/arrow-chevron-up.svg
+++ b/packages/components/src/components/ScalarIcon/icons/arrow-chevron-up.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" stroke-width="1.5"><path d="M.75 17.189 11.47 6.47a.749.749 0 0 1 1.06 0l10.72 10.719" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" stroke-width="2"><path d="M.75 17.189 11.47 6.47a.749.749 0 0 1 1.06 0l10.72 10.719" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path></svg>

--- a/packages/nextjs-api-reference/src/theme.ts
+++ b/packages/nextjs-api-reference/src/theme.ts
@@ -82,6 +82,8 @@ export const nextjsThemeCss = `
   --sidebar-search-background: var(--theme-background-2);
   --sidebar-search-border-color: var(--theme-background-2);
   --sidebar-search-color: var(--theme-color-3);
+  --sidebar-indent-border: var(--theme-border-color);
+  --sidebar-indent-border-active: #6aacf8;
 }
 .api-client-drawer .t-doc__sidebar {
   --sidebar-border-color: var(--theme-border-color);
@@ -120,21 +122,6 @@ export const nextjsThemeCss = `
 }
 .sidebar .sidebar-indent-nested .sidebar-heading {
   padding-right: 0;
-}
-.sidebar .sidebar-group .sidebar-indent-nested .sidebar-heading:before {
-  content: '';
-  position: absolute;
-  left: 11px;
-  background: var(--theme-border-color);
-  width: 1px;
-  height: 100%;
-  width: 1px;
-}
-.sidebar
-  .sidebar-group
-  .sidebar-indent-nested
-  .sidebar-heading.active_page:before {
-  background: #6aacf8;
 }
 .examples .show-api-client-button:before {
   background: var(--theme-color-1);

--- a/packages/themes/src/presets/alternate.css
+++ b/packages/themes/src/presets/alternate.css
@@ -57,6 +57,10 @@
   --default-sidebar-search-background: transparent;
   --default-sidebar-search-color: var(--default-theme-color-3);
   --default-sidebar-search-border-color: var(--default-theme-border-color);
+
+  --default-sidebar-indent-border: var(--default-sidebar-border-color);
+  --default-sidebar-indent-border-hover: var(--default-sidebar-border-color);
+  --default-sidebar-indent-border-active: var(--default-sidebar-border-color);
 }
 /* advanced */
 .light-mode .dark-mode,
@@ -67,6 +71,10 @@
   --default-theme-color-blue: #0082d0;
   --default-theme-color-orange: #fb892c;
   --default-theme-color-purple: #5203d1;
+
+  --default-theme-button-1: rgba(0, 0, 0, 1);
+  --default-theme-button-1-hover: rgba(0, 0, 0, 0.8);
+  --default-theme-button-1-color: rgba(255, 255, 255, 0.9);
 }
 .dark-mode {
   --default-theme-color-green: #00b648;
@@ -75,6 +83,10 @@
   --default-theme-color-blue: #4eb3ec;
   --default-theme-color-orange: #ff8d4d;
   --default-theme-color-purple: #b191f9;
+
+  --default-theme-button-1: rgba(255, 255, 255, 1);
+  --default-theme-button-1-hover: rgba(255, 255, 255, 0.9);
+  --default-theme-button-1-color: black;
 }
 
 .code-languages-background:before {
@@ -90,13 +102,6 @@
 .dark-mode .dark-mode.scalar-card {
   --default-theme-background-3: var(--default-theme-background-3);
 }
-.dark-mode .show-api-client-button span,
-.dark-mode .show-api-client-button svg {
-  color: var(--default-theme-background-3);
-}
-.dark-mode .show-api-client-button {
-  background: var(--default-theme-color-1) !important;
-}
 .t-doc__sidebar {
   --default-theme-color-green: var(--default-theme-color-1);
   --default-theme-color-red: var(--default-theme-color-1);
@@ -105,7 +110,7 @@
   --default-theme-color-orange: var(--default-theme-color-1);
   --default-theme-color-purple: var(--default-theme-color-1);
 }
-.download-cta a,
+.references-rendered .download-cta .download-button,
 .references-rendered .markdown a {
   color: var(--default-theme-color-1) !important;
   text-decoration: underline !important;

--- a/packages/themes/src/presets/bluePlanet.css
+++ b/packages/themes/src/presets/bluePlanet.css
@@ -60,6 +60,10 @@
   --default-theme-color-blue: #0082d0;
   --default-theme-color-orange: #fb892c;
   --default-theme-color-purple: #5203d1;
+
+  --default-theme-button-1: rgba(0, 0, 0, 1);
+  --default-theme-button-1-hover: rgba(0, 0, 0, 0.8);
+  --default-theme-button-1-color: rgba(255, 255, 255, 0.9);
 }
 .dark-mode {
   --default-theme-color-green: rgba(69, 255, 165, 0.823);
@@ -68,6 +72,10 @@
   --default-theme-color-blue: #6bc1fe;
   --default-theme-color-orange: #f98943;
   --default-theme-color-purple: #b191f9;
+
+  --default-theme-button-1: rgba(255, 255, 255, 1);
+  --default-theme-button-1-hover: rgba(255, 255, 255, 0.9);
+  --default-theme-button-1-color: black;
 }
 /* Custom theme */
 .show-api-client-button:before {
@@ -77,7 +85,7 @@
 .show-api-client-button svg {
   color: black !important;
 }
-.download-cta,
+.references-rendered .download-cta .download-button,
 .references-rendered .markdown a {
   text-decoration: underline !important;
 }

--- a/packages/themes/src/presets/deepSpace.css
+++ b/packages/themes/src/presets/deepSpace.css
@@ -31,28 +31,27 @@
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
 .dark-mode .t-doc__sidebar {
-  --sidebar-background-1: var(--default-theme-background-1);
-  --sidebar-item-hover-color: currentColor;
-  --sidebar-item-hover-background: var(--default-theme-background-2);
-  --sidebar-item-active-background: var(--default-theme-background-3);
-  --sidebar-border-color: var(--default-theme-border-color);
-  --sidebar-color-1: var(--default-theme-color-1);
-  --sidebar-color-2: var(--default-theme-color-2);
-  --sidebar-color-active: var(--default-theme-color-accent);
-  --sidebar-search-background: transparent;
-  --sidebar-search-border-color: var(--default-theme-border-color);
-  --sidebar-search-color: var(--default-theme-color-3);
+  --default-sidebar-background-1: var(--default-theme-background-1);
+  --default-sidebar-color-1: var(--default-theme-color-1);
+  --default-sidebar-color-2: var(--default-theme-color-2);
+  --default-sidebar-border-color: var(--default-theme-border-color);
+
+  --default-sidebar-item-hover-color: currentColor;
+  --default-sidebar-item-hover-background: var(--default-theme-background-2);
+
+  --default-sidebar-item-active-background: var(--default-theme-background-3);
+  --default-sidebar-color-active: var(--default-theme-color-accent);
+
+  --default-sidebar-search-background: transparent;
+  --default-sidebar-search-border-color: var(--default-theme-border-color);
+  --default-sidebar-search-color: var(--default-theme-color-3);
 }
 .light-mode .t-doc__sidebar {
-  --sidebar-item-active-background: #09090b;
-  --sidebar-color-active: var(--sidebar-background-1);
+  --default-sidebar-item-active-background: #09090b;
+  --default-sidebar-color-active: var(--default-sidebar-background-1);
 }
 /* advanced */
 .light-mode {
-  --default-theme-button-1: rgb(49 53 56);
-  --default-theme-button-1-color: #fff;
-  --default-theme-button-1-hover: rgb(28 31 33);
-
   --default-theme-color-green: #069061;
   --default-theme-color-red: #ef0006;
   --default-theme-color-yellow: #edbe20;
@@ -60,14 +59,11 @@
   --default-theme-color-orange: #fb892c;
   --default-theme-color-purple: #5203d1;
 
-  --default-theme-scrollbar-color: rgba(0, 0, 0, 0.18);
-  --default-theme-scrollbar-color-active: rgba(0, 0, 0, 0.36);
+  --default-theme-button-1: rgba(0, 0, 0, 1);
+  --default-theme-button-1-hover: rgba(0, 0, 0, 0.8);
+  --default-theme-button-1-color: rgba(255, 255, 255, 0.9);
 }
 .dark-mode {
-  --default-theme-button-1: #f6f6f6;
-  --default-theme-button-1-color: #000;
-  --default-theme-button-1-hover: #e7e7e7;
-
   --default-theme-color-green: rgba(69, 255, 165, 0.823);
   --default-theme-color-red: #ff8589;
   --default-theme-color-yellow: #ffcc4d;
@@ -75,8 +71,9 @@
   --default-theme-color-orange: #f98943;
   --default-theme-color-purple: #b191f9;
 
-  --default-theme-scrollbar-color: rgba(255, 255, 255, 0.24);
-  --default-theme-scrollbar-color-active: rgba(255, 255, 255, 0.48);
+  --default-theme-button-1: rgba(255, 255, 255, 1);
+  --default-theme-button-1-hover: rgba(255, 255, 255, 0.9);
+  --default-theme-button-1-color: black;
 }
 /* Custom theme */
 .dark-mode h2.t-editor__heading,
@@ -108,7 +105,7 @@
 .show-api-client-button svg {
   color: black !important;
 }
-.download-cta,
+.references-rendered .download-cta .download-button,
 .references-rendered .markdown a {
   text-decoration: underline !important;
 }

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -37,10 +37,8 @@
   --default-sidebar-item-hover-background: var(--default-theme-background-2);
   --default-sidebar-item-hover-color: currentColor;
 
-  --default-sidebar-item-active-background: var(
-    --default-theme-background-accent
-  );
-  --default-sidebar-color-active: var(--default-theme-color-accent);
+  --default-sidebar-item-active-background: var(--default-theme-background-2);
+  --default-sidebar-color-active: var(--default-theme-color-1);
 
   --default-sidebar-search-background: transparent;
   --default-sidebar-search-color: var(--default-theme-color-3);
@@ -55,6 +53,10 @@
   --default-theme-color-blue: #0082d0;
   --default-theme-color-orange: #fb892c;
   --default-theme-color-purple: #5203d1;
+
+  --default-theme-button-1: rgba(0, 0, 0, 1);
+  --default-theme-button-1-hover: rgba(0, 0, 0, 0.8);
+  --default-theme-button-1-color: rgba(255, 255, 255, 0.9);
 }
 .dark-mode {
   --default-theme-color-green: #00b648;
@@ -63,4 +65,8 @@
   --default-theme-color-blue: #4eb3ec;
   --default-theme-color-orange: #ff8d4d;
   --default-theme-color-purple: #b191f9;
+
+  --default-theme-button-1: rgba(255, 255, 255, 1);
+  --default-theme-button-1-hover: rgba(255, 255, 255, 0.9);
+  --default-theme-button-1-color: black;
 }

--- a/packages/themes/src/presets/kepler.css
+++ b/packages/themes/src/presets/kepler.css
@@ -60,10 +60,6 @@
 }
 /* advanced */
 .light-mode {
-  --default-theme-button-1: rgb(49 53 56);
-  --default-theme-button-1-color: #fff;
-  --default-theme-button-1-hover: rgb(28 31 33);
-
   --default-theme-color-green: #069061;
   --default-theme-color-red: #ef0006;
   --default-theme-color-yellow: #edbe20;
@@ -71,14 +67,11 @@
   --default-theme-color-orange: #fb892c;
   --default-theme-color-purple: #5203d1;
 
-  --default-theme-scrollbar-color: rgba(0, 0, 0, 0.18);
-  --default-theme-scrollbar-color-active: rgba(0, 0, 0, 0.36);
+  --default-theme-button-1: rgba(0, 0, 0, 1);
+  --default-theme-button-1-hover: rgba(0, 0, 0, 0.8);
+  --default-theme-button-1-color: rgba(255, 255, 255, 0.9);
 }
 .dark-mode {
-  --default-theme-button-1: #f6f6f6;
-  --default-theme-button-1-color: #000;
-  --default-theme-button-1-hover: #e7e7e7;
-
   --default-theme-color-green: #00b648;
   --default-theme-color-red: #dc1b19;
   --default-theme-color-yellow: #ffc90d;
@@ -86,8 +79,9 @@
   --default-theme-color-orange: #ff8d4d;
   --default-theme-color-purple: #b191f9;
 
-  --default-theme-scrollbar-color: rgba(255, 255, 255, 0.24);
-  --default-theme-scrollbar-color-active: rgba(255, 255, 255, 0.48);
+  --default-theme-button-1: rgba(255, 255, 255, 1);
+  --default-theme-button-1-hover: rgba(255, 255, 255, 0.9);
+  --default-theme-button-1-color: black;
 }
 /* Custom Theme */
 .dark-mode h2.t-editor__heading,

--- a/packages/themes/src/presets/mars.css
+++ b/packages/themes/src/presets/mars.css
@@ -57,6 +57,10 @@
   --default-theme-color-blue: #19689a;
   --default-theme-color-orange: #b26c34;
   --default-theme-color-purple: #4c2191;
+
+  --default-theme-button-1: rgba(0, 0, 0, 1);
+  --default-theme-button-1-hover: rgba(0, 0, 0, 0.8);
+  --default-theme-button-1-color: rgba(255, 255, 255, 0.9);
 }
 .dark-mode {
   --default-theme-color-green: rgba(69, 255, 165, 0.823);
@@ -65,6 +69,10 @@
   --default-theme-color-blue: #6bc1fe;
   --default-theme-color-orange: #f98943;
   --default-theme-color-purple: #b191f9;
+
+  --default-theme-button-1: rgba(255, 255, 255, 1);
+  --default-theme-button-1-hover: rgba(255, 255, 255, 0.9);
+  --default-theme-button-1-color: black;
 }
 /* Custom Theme */
 .dark-mode h2.t-editor__heading,
@@ -145,7 +153,7 @@
   right: -400px !important;
   left: initial;
 }
-.download-cta a,
-.section .markdown a {
+.references-rendered .download-cta .download-button,
+.references-rendered .markdown a {
   text-decoration: underline !important;
 }

--- a/packages/themes/src/presets/purple.css
+++ b/packages/themes/src/presets/purple.css
@@ -30,23 +30,22 @@
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
 .dark-mode .t-doc__sidebar {
-  --sidebar-background-1: var(--default-theme-background-1);
-  --sidebar-color-1: var(--default-theme-color-1);
-  --sidebar-color-2: var(--default-theme-color-2);
-  --sidebar-border-color: var(--default-theme-border-color);
+  --default-sidebar-background-1: var(--default-theme-background-1);
+  --default-sidebar-color-1: var(--default-theme-color-1);
+  --default-sidebar-color-2: var(--default-theme-color-2);
+  --default-sidebar-border-color: var(--default-theme-border-color);
 
-  /* Sidebar item hover */
-  --sidebar-item-hover-color: currentColor;
-  --sidebar-item-hover-background: var(--default-theme-background-3);
+  --default-sidebar-item-hover-color: currentColor;
+  --default-sidebar-item-hover-background: var(--default-theme-background-3);
 
-  /* Sidebar Active */
-  --sidebar-item-active-background: var(--default-theme-background-accent);
-  --sidebar-color-active: var(--default-theme-color-accent);
+  --default-sidebar-item-active-background: var(
+    --default-theme-background-accent
+  );
+  --default-sidebar-color-active: var(--default-theme-color-accent);
 
-  /* Sidebar Search */
-  --sidebar-search-background: var(--default-theme-background-1);
-  --sidebar-search-color: var(--default-theme-color-3);
-  --sidebar-search-border-color: var(--default-theme-border-color);
+  --default-sidebar-search-background: var(--default-theme-background-1);
+  --default-sidebar-search-color: var(--default-theme-color-3);
+  --default-sidebar-search-border-color: var(--default-theme-border-color);
 }
 
 /* advanced */
@@ -57,6 +56,10 @@
   --default-theme-color-blue: #1763a6;
   --default-theme-color-orange: #e25b09;
   --default-theme-color-purple: #5c3993;
+
+  --default-theme-button-1: rgba(0, 0, 0, 1);
+  --default-theme-button-1-hover: rgba(0, 0, 0, 0.8);
+  --default-theme-button-1-color: rgba(255, 255, 255, 0.9);
 }
 .dark-mode {
   --default-theme-color-green: #30a159;
@@ -65,4 +68,8 @@
   --default-theme-color-blue: #2b7abf;
   --default-theme-color-orange: #f07528;
   --default-theme-color-purple: #7a59b1;
+
+  --default-theme-button-1: rgba(255, 255, 255, 1);
+  --default-theme-button-1-hover: rgba(255, 255, 255, 0.9);
+  --default-theme-button-1-color: black;
 }

--- a/packages/themes/src/presets/saturn.css
+++ b/packages/themes/src/presets/saturn.css
@@ -62,6 +62,10 @@
   --default-theme-color-blue: #1763a6;
   --default-theme-color-orange: #e25b09;
   --default-theme-color-purple: #5c3993;
+
+  --default-theme-button-1: rgba(0, 0, 0, 1);
+  --default-theme-button-1-hover: rgba(0, 0, 0, 0.8);
+  --default-theme-button-1-color: rgba(255, 255, 255, 0.9);
 }
 .dark-mode {
   --default-theme-color-green: #30a159;
@@ -70,6 +74,10 @@
   --default-theme-color-blue: #2b7abf;
   --default-theme-color-orange: #f07528;
   --default-theme-color-purple: #7a59b1;
+
+  --default-theme-button-1: rgba(255, 255, 255, 1);
+  --default-theme-button-1-hover: rgba(255, 255, 255, 0.9);
+  --default-theme-button-1-color: black;
 }
 .dark-mode h2.t-editor__heading,
 .dark-mode .t-editor__page-title h1,


### PR DESCRIPTION
Theme Polish
<img width="1510" alt="image" src="https://github.com/scalar/scalar/assets/6201407/1c5c4f8e-ebb7-4e42-8972-520e367f29a0">

Reduce details in scalar card to prepare for future features
<img width="649" alt="image" src="https://github.com/scalar/scalar/assets/6201407/ae12ec4b-2e12-4205-afcd-25c81625df2d">

Sidebar active state changes:
<img width="307" alt="image" src="https://github.com/scalar/scalar/assets/6201407/4ae5b305-ecd8-4818-87d4-47f727af9bae">
