### PR TITLE
docs: install playwright and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lint:fix": "pnpm -r lint:fix",
     "pack:packages": "./scripts/pack.sh",
     "preview:standalone": "pnpm --filter api-reference preview:standalone",
+    "playwright:install": "npx playwright install --with-deps",
     "test": "vitest",
     "test:ci": "CI=1 vitest --silent",
     "test:e2e": "playwright test",

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,9 +1,12 @@
 # Playwright Testing
 
-Ensure the `api reference` CDN static server is running
-`pnpm --filter cdn-api-reference dev`
+1. Ensure you have downloaded Playwright and all its dependencies including the browsers necessary for running the tests
+   `pnpm playwright:install` or `npx playwright install --with-deps`
 
-Run Playwright e2e tests with `pnpm test:e2e` or `pnpm test:e2e:ui`
+2. Ensure the `api reference` CDN static server is running
+   `pnpm --filter cdn-api-reference dev`
+
+3. Run Playwright e2e tests with `pnpm test:e2e` or `pnpm test:e2e:ui`
 
 ## Visual Regression Testing
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,7 +23,7 @@ Update localhost calls in the Playwright tests to `host.docker.internal` (mac) 
 ### Example
 
 ```ts
-await page.goto('http://host.docker.internal:3173/live')
+await page.goto('http://127.0.0.1:3173/live')
 ```
 
 instead of


### PR DESCRIPTION
Currently, it can be unclear why e2e tests are failing. This PR adds documentation and related script to clear up confusion around running the Playwright e2e tests locally. 
