### PR TITLE
fix: toast notification doesn't show up

### DIFF
--- a/.changeset/nervous-guests-judge.md
+++ b/.changeset/nervous-guests-judge.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": major
+---
+
+fix: toast notification doesn't show up

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -2,12 +2,9 @@
 import { useAuthenticationStore } from '@scalar/api-client'
 import { createHead, useSeoMeta } from 'unhead'
 import { computed, toRef, watch } from 'vue'
-import { toast } from 'vue-sonner'
 
 import { useDarkModeState, useHttpClients, useReactiveSpec } from '../hooks'
-import { useToasts } from '../hooks/useToasts'
 import { type ReferenceConfiguration, type ReferenceProps } from '../types'
-import CustomToaster from './CustomToaster.vue'
 import Layouts from './Layouts/'
 
 const props = defineProps<ReferenceProps>()
@@ -34,12 +31,6 @@ const configuration = computed<ReferenceConfiguration>(() => ({
   isEditable: false,
   ...props.configuration,
 }))
-
-// Configure Reference toasts to use vue-sonner
-const { initializeToasts } = useToasts()
-initializeToasts((message) => {
-  toast(message)
-})
 
 // Create the head tag if the configuration has meta data
 if (configuration.value?.metaData) {
@@ -94,8 +85,6 @@ const { parsedSpec, rawSpec } = useReactiveSpec({
     @updateContent="$emit('updateContent', $event)">
     <template #footer><slot name="footer" /></template>
   </Component>
-  <!-- Initialize the vue-sonner instance -->
-  <CustomToaster />
 </template>
 <style>
 body {

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -7,6 +7,7 @@ import {
 } from '@scalar/themes'
 import { useDebounceFn, useMediaQuery, useResizeObserver } from '@vueuse/core'
 import { computed, onMounted, provide, ref } from 'vue'
+import { toast } from 'vue-sonner'
 
 import {
   GLOBAL_SECURITY_SYMBOL,
@@ -14,6 +15,7 @@ import {
   downloadSpecFile,
 } from '../helpers'
 import { useNavState, useSidebar } from '../hooks'
+import { useToasts } from '../hooks/useToasts'
 import type {
   ReferenceLayoutProps,
   ReferenceLayoutSlot,
@@ -21,6 +23,7 @@ import type {
 } from '../types'
 import { default as ApiClientModal } from './ApiClientModal.vue'
 import { Content } from './Content'
+import CustomToaster from './CustomToaster.vue'
 import GettingStarted from './GettingStarted.vue'
 import { Sidebar } from './Sidebar'
 
@@ -36,6 +39,12 @@ defineEmits<{
 
 defineOptions({
   inheritAttrs: false,
+})
+
+// Configure Reference toasts to use vue-sonner
+const { initializeToasts } = useToasts()
+initializeToasts((message) => {
+  toast(message)
 })
 
 defineSlots<{
@@ -215,6 +224,8 @@ provide(GLOBAL_SECURITY_SYMBOL, () => props.parsedSpec.security)
       </div>
     </ScrollbarStyles>
   </ResetStyles>
+  <!-- Initialize the vue-sonner instance -->
+  <CustomToaster />
 </template>
 <style scoped>
 /* Configurable Layout Variables */


### PR DESCRIPTION
**Problem**
Toast notifications are not displayed in editor view on user actions (e.g. copy clipboard...) while they are still showing up on the API reference.

**Solution**
This PR is an attempt to fix #1207 by moving the toast initialization to the layout level.
