### PR TITLE
fix: don't stretch markdown tables

### DIFF
--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -220,7 +220,8 @@ watch(
   overflow-x: auto;
   position: relative;
   border-collapse: collapse;
-  width: 100%;
+  width: max-content;
+  max-width: 100%;
   margin: 1em 0;
   box-shadow: 0 0 0 1px
     var(--theme-border-color, var(--default-theme-border-color));


### PR DESCRIPTION
Okay so I did a bunch of research on this and couldn't come up with a CSS way to do what we want to do. This PR mirrors how GitHub handles tables, see [this gist](https://gist.github.com/hwkr/391f2010150c199e195ad42990d15778) as an example.

* Test file: [petstorev3.json](https://github.com/scalar/scalar/files/14764505/petstorev3.json)


<img width="400" alt="Google Chrome-2024-03-26-13-34-25@2x" src="https://github.com/scalar/scalar/assets/6374090/63aa61b4-c463-45c7-b61e-2e9be1253c9f">

## Other options:

### Add a fake cell to the right

I figured out a CSS solution to always have them full width but it requires squishing content to the left and setting `white-space: nowrap` to keep them from breaking.

<img width="400" alt="Google Chrome-2024-03-26-13-25-58@2x" src="https://github.com/scalar/scalar/assets/6374090/b16b076e-c99a-4b8f-a7d3-d145709b578c">


### `table-layout: auto`

We can use `table-layout: auto` to fill the space but it breaks out of the scroll container. We would have to add something like [rehype-wrap-all](https://github.com/florentb/rehype-wrap-all) (which doesn't seem very well supported) to add a scroll container.

<img width="400" alt="Google Chrome-2024-03-26-13-40-04@2x" src="https://github.com/scalar/scalar/assets/6374090/d04c7403-d2b2-4094-bd6e-89362a9c665f">

