### PR TITLE
feat: move sidebar to css

### DIFF
--- a/.changeset/dull-bananas-doubt.md
+++ b/.changeset/dull-bananas-doubt.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+chore: moved sidemenu control to css

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -39,7 +39,14 @@
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./style.css": {
+      "import": "./dist/style.css",
+      "require": "./dist/style.css"
+    }
   },
   "files": [
     "dist",

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -54,14 +54,14 @@ defineSlots<{
 const isLargeScreen = useMediaQuery('(min-width: 1150px)')
 
 // Track the container height to control the sidebar height
-const elementHeight = ref(0)
+const elementHeight = ref('100dvh')
 const documentEl = ref<HTMLElement | null>(null)
 useResizeObserver(documentEl, (entries) => {
-  elementHeight.value = entries[0].contentRect.height
+  elementHeight.value = entries[0].contentRect.height + 'px'
 })
 
 // Scroll to hash if exists
-const { breadcrumb, setCollapsedSidebarItem } = useSidebar()
+const { breadcrumb, isSidebarOpen, setCollapsedSidebarItem } = useSidebar()
 const { enableHashListener, getSectionId, getTagId, hash } = useNavState()
 
 enableHashListener()
@@ -124,13 +124,14 @@ provide(GLOBAL_SECURITY_SYMBOL, () => props.parsedSpec.security)
           {
             'references-editable': configuration.isEditable,
             'references-sidebar': configuration.showSidebar,
+            'references-sidebar-mobile-open': isSidebarOpen,
             'references-classic': configuration.layout === 'classic',
           },
           reset,
           scrollbars,
           $attrs.class,
         ]"
-        :style="{ '--full-height': `${elementHeight}px` }"
+        :style="{ '--full-height': elementHeight }"
         @scroll.passive="debouncedScroll">
         <!-- Header -->
         <div class="references-header">
@@ -140,7 +141,7 @@ provide(GLOBAL_SECURITY_SYMBOL, () => props.parsedSpec.security)
         </div>
         <!-- Navigation (sidebar) wrapper -->
         <aside
-          v-show="configuration.showSidebar"
+          v-if="configuration.showSidebar"
           class="references-navigation t-doc__sidebar">
           <!-- Navigation tree / Table of Contents -->
           <div class="references-navigation-list">
@@ -254,6 +255,7 @@ provide(GLOBAL_SECURITY_SYMBOL, () => props.parsedSpec.security)
   /* Scroll vertically */
   overflow-y: auto;
   overflow-x: hidden;
+  scrollbar-gutter: stable;
 
   /*
   Calculated by a resize observer and set in the style attribute
@@ -372,7 +374,7 @@ provide(GLOBAL_SECURITY_SYMBOL, () => props.parsedSpec.security)
       'rendered'
       'footer';
   }
-  .references-sidebar {
+  .references-sidebar.references-sidebar-mobile-open {
     overflow-y: hidden;
   }
   .references-editable {
@@ -392,10 +394,15 @@ provide(GLOBAL_SECURITY_SYMBOL, () => props.parsedSpec.security)
   }
 
   .references-navigation {
+    display: none;
     position: sticky;
     top: var(--refs-header-height);
     height: 0px;
     z-index: 10;
+  }
+
+  .references-sidebar-mobile-open .references-navigation {
+    display: block;
   }
 
   .references-navigation-list {

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -2,7 +2,7 @@
 import { useMediaQuery } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 
-import { useNavState } from '../../hooks'
+import { useNavState, useSidebar } from '../../hooks'
 import { type ReferenceLayoutProps, type ReferenceSlots } from '../../types'
 import ApiReferenceLayout from '../ApiReferenceLayout.vue'
 import { DarkModeToggle } from '../DarkModeToggle'
@@ -16,41 +16,29 @@ defineEmits<{
 
 defineSlots<ReferenceSlots>()
 
-const showMobileDrawer = ref(false)
-
 const isMobile = useMediaQuery('(max-width: 1000px)')
+const { isSidebarOpen } = useSidebar()
 
 watch(isMobile, (n, o) => {
   // Close the drawer when we go from desktop to mobile
-  if (n && !o) showMobileDrawer.value = false
-})
-
-// Override the sidebar value for mobile to open and close the drawer
-const config = computed(() => {
-  const showSidebar = isMobile.value
-    ? showMobileDrawer.value
-    : props.configuration?.showSidebar
-  return { ...props.configuration, showSidebar }
+  if (n && !o) isSidebarOpen.value = false
 })
 
 const { hash } = useNavState()
-
 watch(hash, (newHash, oldHash) => {
   if (newHash && newHash !== oldHash) {
-    showMobileDrawer.value = false
+    isSidebarOpen.value = false
   }
 })
 </script>
 <template>
   <ApiReferenceLayout
     :class="{ 'scalar-api-references-standalone-mobile': isMobile }"
-    :configuration="config"
+    :configuration="configuration"
     :parsedSpec="parsedSpec"
     :rawSpec="rawSpec">
-    <template
-      v-if="isMobile"
-      #header>
-      <MobileHeader v-model:open="showMobileDrawer" />
+    <template #header>
+      <MobileHeader v-model:open="isSidebarOpen" />
     </template>
     <template #sidebar-start="{ spec }">
       <div class="scalar-api-references-standalone-search">
@@ -69,9 +57,10 @@ watch(hash, (newHash, oldHash) => {
   </ApiReferenceLayout>
 </template>
 <style>
-.scalar-api-references-standalone-mobile {
-  /* By default add a header on mobile for the navigation */
-  --theme-header-height: 50px;
+@media (max-width: 1000px) {
+  .scalar-api-references-standalone-mobile {
+    --theme-header-height: 50px;
+  }
 }
 </style>
 <style scoped>

--- a/packages/api-reference/src/components/MobileHeader.vue
+++ b/packages/api-reference/src/components/MobileHeader.vue
@@ -28,7 +28,7 @@ const { breadcrumb } = useSidebar()
 </template>
 <style scoped>
 .references-mobile-header {
-  display: flex;
+  display: none;
   align-items: center;
   gap: 12px;
   height: 100%;
@@ -57,5 +57,11 @@ const { breadcrumb } = useSidebar()
   height: 24px;
   align-items: center;
   padding-left: 4px;
+}
+
+@media (max-width: 1000px) {
+  .references-mobile-header {
+    display: flex;
+  }
 }
 </style>

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -226,6 +226,10 @@ const items = computed(() => {
   }
 })
 
+// Controls whether or not the sidebar is open on MOBILE only
+// Desktop uses the standard showSidebar prop which supercedes this one
+const isSidebarOpen = ref(false)
+
 const breadcrumb = computed(() => items.value?.titles?.[hash.value] ?? '')
 
 export function useSidebar(options?: { parsedSpec: Spec }) {
@@ -264,6 +268,7 @@ export function useSidebar(options?: { parsedSpec: Spec }) {
   return {
     breadcrumb,
     items,
+    isSidebarOpen,
     collapsedSidebarItems,
     toggleCollapsedSidebarItem,
     setCollapsedSidebarItem,


### PR DESCRIPTION
Our current JS controlled sidebar doesn't work in SSR so this uses css classses (controlled by js) to show/hide the sidebar

