### PR TITLE
fix: revert major api version

### DIFF
--- a/.changeset/dull-bananas-doubt.md
+++ b/.changeset/dull-bananas-doubt.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+chore: moved sidemenu control to css

--- a/.changeset/khaki-news-complain.md
+++ b/.changeset/khaki-news-complain.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/api-client": patch
+---
+
+feat: add authentication UI to the API client

--- a/.changeset/mean-eels-peel.md
+++ b/.changeset/mean-eels-peel.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: improper variables name + remove importants

--- a/.changeset/nervous-guests-judge.md
+++ b/.changeset/nervous-guests-judge.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": major
+---
+
+fix: toast notification doesn't show up

--- a/.changeset/nervous-guests-judge.md
+++ b/.changeset/nervous-guests-judge.md
@@ -1,5 +1,5 @@
 ---
-"@scalar/api-reference": major
+"@scalar/api-reference": patch
 ---
 
 fix: toast notification doesn't show up

--- a/packages/api-client-react/CHANGELOG.md
+++ b/packages/api-client-react/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/api-client-react
 
-## 0.2.16
-
-### Patch Changes
-
-- Updated dependencies [fd5c714]
-  - @scalar/api-client@1.1.10
-
 ## 0.2.15
 
 ### Patch Changes

--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -14,7 +14,7 @@
     "testing",
     "react"
   ],
-  "version": "0.2.16",
+  "version": "0.2.15",
   "engines": {
     "node": ">=18"
   },

--- a/packages/api-client/CHANGELOG.md
+++ b/packages/api-client/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/api-client
 
-## 1.1.10
-
-### Patch Changes
-
-- fd5c714: feat: add authentication UI to the API client
-
 ## 1.1.9
 
 ### Patch Changes

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -13,7 +13,7 @@
     "rest",
     "testing"
   ],
-  "version": "1.1.10",
+  "version": "1.1.9",
   "engines": {
     "node": ">=18"
   },

--- a/packages/api-reference-react/CHANGELOG.md
+++ b/packages/api-reference-react/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/api-reference-react
 
-## 0.1.20
-
-### Patch Changes
-
-- Updated dependencies [fe3a85f]
-- Updated dependencies [fd5c714]
-- Updated dependencies [5c1b385]
-- Updated dependencies [5f5395f]
-  - @scalar/api-reference@2.0.0
-
 ## 0.1.19
 
 ### Patch Changes

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -13,7 +13,7 @@
     "testing",
     "react"
   ],
-  "version": "0.1.20",
+  "version": "0.1.19",
   "engines": {
     "node": ">=18"
   },

--- a/packages/api-reference/CHANGELOG.md
+++ b/packages/api-reference/CHANGELOG.md
@@ -1,19 +1,5 @@
 # @scalar/api-reference
 
-## 2.0.0
-
-### Major Changes
-
-- 5f5395f: fix: toast notification doesn't show up
-
-### Patch Changes
-
-- fe3a85f: chore: moved sidemenu control to css
-- fd5c714: feat: add authentication UI to the API client
-- 5c1b385: fix: improper variables name + remove importants
-- Updated dependencies [fd5c714]
-  - @scalar/api-client@1.1.10
-
 ## 1.20.11
 
 ### Patch Changes

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -15,7 +15,7 @@
     "vue",
     "vue3"
   ],
-  "version": "2.0.0",
+  "version": "1.20.11",
   "engines": {
     "node": ">=18"
   },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @scalar/cli
 
-## 0.2.16
-
-### Patch Changes
-
-- Updated dependencies [fe3a85f]
-- Updated dependencies [fd5c714]
-- Updated dependencies [5c1b385]
-- Updated dependencies [5f5395f]
-  - @scalar/api-reference@2.0.0
-  - @scalar/mock-server@0.1.13
-
 ## 0.2.15
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "swagger",
     "cli"
   ],
-  "version": "0.2.16",
+  "version": "0.2.15",
   "engines": {
     "node": ">=18"
   },

--- a/packages/docusaurus/CHANGELOG.md
+++ b/packages/docusaurus/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/docusaurus
 
-## 0.1.20
-
-### Patch Changes
-
-- @scalar/api-reference-react@0.1.20
-
 ## 0.1.19
 
 ### Patch Changes

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -14,7 +14,7 @@
     "testing",
     "react"
   ],
-  "version": "0.1.20",
+  "version": "0.1.19",
   "engines": {
     "node": ">=18"
   },

--- a/packages/express-api-reference/CHANGELOG.md
+++ b/packages/express-api-reference/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/express-api-reference
 
-## 0.3.20
-
-### Patch Changes
-
-- Updated dependencies [fe3a85f]
-- Updated dependencies [fd5c714]
-- Updated dependencies [5c1b385]
-- Updated dependencies [5f5395f]
-  - @scalar/api-reference@2.0.0
-
 ## 0.3.19
 
 ### Patch Changes

--- a/packages/express-api-reference/package.json
+++ b/packages/express-api-reference/package.json
@@ -5,7 +5,7 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
-  "version": "0.3.20",
+  "version": "0.3.19",
   "engines": {
     "node": ">=18"
   },

--- a/packages/hono-api-reference/CHANGELOG.md
+++ b/packages/hono-api-reference/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/hono-api-reference
 
-## 0.4.20
-
-### Patch Changes
-
-- Updated dependencies [fe3a85f]
-- Updated dependencies [fd5c714]
-- Updated dependencies [5c1b385]
-- Updated dependencies [5f5395f]
-  - @scalar/api-reference@2.0.0
-
 ## 0.4.19
 
 ### Patch Changes

--- a/packages/hono-api-reference/package.json
+++ b/packages/hono-api-reference/package.json
@@ -5,7 +5,7 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
-  "version": "0.4.20",
+  "version": "0.4.19",
   "engines": {
     "node": ">=18"
   },

--- a/packages/mock-server/CHANGELOG.md
+++ b/packages/mock-server/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/mock-server
 
-## 0.1.13
-
-### Patch Changes
-
-- Updated dependencies [fe3a85f]
-- Updated dependencies [fd5c714]
-- Updated dependencies [5c1b385]
-- Updated dependencies [5f5395f]
-  - @scalar/api-reference@2.0.0
-
 ## 0.1.12
 
 ### Patch Changes

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -11,7 +11,7 @@
     "swagger",
     "cli"
   ],
-  "version": "0.1.13",
+  "version": "0.1.12",
   "engines": {
     "node": ">=18"
   },

--- a/packages/nestjs-api-reference/CHANGELOG.md
+++ b/packages/nestjs-api-reference/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/nestjs-api-reference
 
-## 0.2.20
-
-### Patch Changes
-
-- Updated dependencies [fe3a85f]
-- Updated dependencies [fd5c714]
-- Updated dependencies [5c1b385]
-- Updated dependencies [5f5395f]
-  - @scalar/api-reference@2.0.0
-
 ## 0.2.19
 
 ### Patch Changes

--- a/packages/nestjs-api-reference/package.json
+++ b/packages/nestjs-api-reference/package.json
@@ -5,7 +5,7 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
-  "version": "0.2.20",
+  "version": "0.2.19",
   "engines": {
     "node": ">=18"
   },

--- a/packages/nextjs-api-reference/CHANGELOG.md
+++ b/packages/nextjs-api-reference/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/nextjs-api-reference
 
-## 0.2.20
-
-### Patch Changes
-
-- Updated dependencies [fe3a85f]
-- Updated dependencies [fd5c714]
-- Updated dependencies [5c1b385]
-- Updated dependencies [5f5395f]
-  - @scalar/api-reference@2.0.0
-
 ## 0.2.19
 
 ### Patch Changes

--- a/packages/nextjs-api-reference/package.json
+++ b/packages/nextjs-api-reference/package.json
@@ -13,7 +13,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "0.2.20",
+  "version": "0.2.19",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
We accidentally had a major version upgrade in there, this reverts it.