### PR TITLE
feat: add SSR state to references and client

### DIFF
--- a/.changeset/wild-ears-sort.md
+++ b/.changeset/wild-ears-sort.md
@@ -1,0 +1,7 @@
+---
+"@scalar/api-reference": patch
+"@scalar/api-client": patch
+"@scalar/oas-utils": patch
+---
+
+feat: added future support for SSR server state hydration

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build:standalone": "pnpm --filter api-reference build:standalone",
     "bump": "CI=true pnpm run test && pnpm changeset version",
     "clean": "pnpm clean:nodeModules; pnpm clean:dist; pnpm clean:turbo",
+    "clean:build": "pnpm clean ; pnpm i && pnpm build:packages",
     "clean:nodeModules": "find . -name node_modules -type d -exec rm -rf {} \\;",
     "clean:dist": "find . -name dist -type d -exec rm -rf {} \\;",
     "clean:turbo": "find . -name .turbo -type d -exec rm -rf {} \\;",

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeSelector.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeSelector.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { ScalarIcon } from '@scalar/components'
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, onServerPrefetch } from 'vue'
 
 import { useAuthenticationStore } from '../../../../stores'
 
@@ -50,6 +50,10 @@ const setSecuritySchemeKey = (key: string) => {
 
   emits('input', key)
 }
+
+onServerPrefetch(() =>
+  setSecuritySchemeKey(Object.keys(props.value ?? {})[0] ?? null),
+)
 
 const isNone = (item: any) => !item?.type
 

--- a/packages/api-client/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-client/src/helpers/getRequestFromAuthentication.ts
@@ -1,7 +1,7 @@
+import type { AuthenticationState } from '@scalar/oas-utils'
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import type { HarRequest } from 'httpsnippet-lite'
 
-import type { AuthenticationState } from '../stores'
 import { encodeStringAsBase64 } from './encodeStringAsBase64'
 
 /**

--- a/packages/api-client/src/stores/useAuthenticationStore.ts
+++ b/packages/api-client/src/stores/useAuthenticationStore.ts
@@ -1,30 +1,6 @@
-import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
+import { type AuthenticationState } from '@scalar/oas-utils'
+import { ssrState } from '@scalar/oas-utils'
 import { reactive } from 'vue'
-
-export type AuthenticationState = {
-  preferredSecurityScheme: string | null
-  securitySchemes?:
-    | OpenAPIV3.ComponentsObject['securitySchemes']
-    | OpenAPIV3_1.ComponentsObject['securitySchemes']
-  http: {
-    basic: {
-      username: string
-      password: string
-    }
-    bearer: {
-      token: string
-    }
-  }
-  apiKey: {
-    token: string
-  }
-  oAuth2: {
-    clientId: string
-    scopes: string[]
-    accessToken: string
-    state: string
-  }
-}
 
 export const createEmptyAuthenticationState = (): AuthenticationState => ({
   preferredSecurityScheme: null,
@@ -49,7 +25,7 @@ export const createEmptyAuthenticationState = (): AuthenticationState => ({
 })
 
 const authentication = reactive<AuthenticationState>(
-  createEmptyAuthenticationState(),
+  ssrState['useGlobalStore-authentication'] ?? createEmptyAuthenticationState(),
 )
 
 const setAuthentication = (newState: Partial<AuthenticationState>) => {

--- a/packages/api-reference/src/components/Content/Authentication/Authentication.vue
+++ b/packages/api-reference/src/components/Content/Authentication/Authentication.vue
@@ -4,10 +4,11 @@ import {
   SecuritySchemeSelector,
   useAuthenticationStore,
 } from '@scalar/api-client'
+import { type SSRState } from '@scalar/oas-utils'
 import type { OpenAPIV3_1 } from '@scalar/openapi-parser'
-import { computed, watch } from 'vue'
+import { computed, onServerPrefetch, useSSRContext, watch } from 'vue'
 
-import { hasSecuritySchemes } from '../../../helpers'
+import { hasSecuritySchemes, sleep } from '../../../helpers'
 import { type Spec } from '../../../types'
 import { Card, CardContent, CardHeader } from '../../Card'
 
@@ -38,6 +39,13 @@ watch(
   },
   { deep: true, immediate: true },
 )
+
+// SSR hack - waits for the computed to complete and store in state
+onServerPrefetch(async () => {
+  const ctx = useSSRContext<SSRState>()
+  await sleep(1)
+  ctx!.scalarState['useGlobalStore-authentication'] = authentication
+})
 </script>
 
 <template>

--- a/packages/api-reference/src/components/Content/Lazy/Lazy.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Lazy.vue
@@ -25,7 +25,9 @@ const props = withDefaults(
 )
 
 const onIdle = (cb = () => {}) => {
-  if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
+  if (typeof window === 'undefined') {
+    // Do nothing and load on the client only
+  } else if ('requestIdleCallback' in window) {
     setTimeout(() => window.requestIdleCallback(cb), props.lazyTimeout)
   } else {
     setTimeout(() => nextTick(cb), props.lazyTimeout ?? 300)

--- a/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
@@ -13,12 +13,13 @@ import {
 } from '@scalar/oas-utils'
 import { snippetz } from '@scalar/snippetz'
 import { HTTPSnippet } from 'httpsnippet-lite'
-import { computed, inject, ref, watch } from 'vue'
+import { computed, inject, onServerPrefetch, ref, watch } from 'vue'
 
 import {
   GLOBAL_SECURITY_SYMBOL,
   getApiClientRequest,
   getUrlFromServerState,
+  sleep,
 } from '../../../helpers'
 import { useClipboard, useHttpClients } from '../../../hooks'
 import { useHttpClientStore, useServerStore } from '../../../stores'
@@ -123,6 +124,8 @@ watch(
     immediate: true,
   },
 )
+
+onServerPrefetch(async () => await sleep(1))
 
 computed(() => {
   return getApiClientRequest({

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -9,7 +9,9 @@ import remarkGfm from 'remark-gfm'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
-import { ref, watch } from 'vue'
+import { onServerPrefetch, ref, watch } from 'vue'
+
+import { sleep } from '../../helpers'
 
 const props = withDefaults(
   defineProps<{
@@ -29,7 +31,7 @@ watch(
   () => props.value,
   async () => {
     // Markdown pipeline
-    unified()
+    const result = await unified()
       // Parses markdown
       .use(remarkParse)
       // Support autolink literals, footnotes, strikethrough, tables and tasklists
@@ -58,11 +60,15 @@ watch(
       .use(rehypeStringify)
       // Run the pipeline
       .process(props.value)
-      // Puts it into the DOM
-      .then((result) => (html.value = String(result)))
+
+    // Puts it into the DOM
+    html.value = String(result.value)
   },
   { immediate: true },
 )
+
+// SSR hack - waits for the watch to complete
+onServerPrefetch(async () => await sleep(1))
 </script>
 
 <template>

--- a/packages/api-reference/src/helpers/createHash.ts
+++ b/packages/api-reference/src/helpers/createHash.ts
@@ -1,0 +1,19 @@
+/**
+ * Simple 32 bit non-secure hash from a string input
+ *
+ * @see https://stackoverflow.com/a/7616484/1624255
+ */
+export const createHash = (input?: string): number => {
+  let chr = 0
+  let hash = 0
+  let i = 0
+
+  if (!input?.length) return hash
+
+  for (i = 0; i < input.length; i++) {
+    chr = input.charCodeAt(i)
+    hash = (hash << 5) - hash + chr
+    hash |= 0 // Convert to 32bit integer
+  }
+  return hash
+}

--- a/packages/api-reference/src/helpers/getApiClientRequest.ts
+++ b/packages/api-reference/src/helpers/getApiClientRequest.ts
@@ -1,9 +1,9 @@
 import {
-  type AuthenticationState,
   type ClientRequestConfig,
   getRequestFromAuthentication,
 } from '@scalar/api-client'
 import {
+  type AuthenticationState,
   type TransformedOperation,
   getHarRequest,
   getParametersFromOperation,

--- a/packages/api-reference/src/helpers/getHeadingsFromMarkdown.ts
+++ b/packages/api-reference/src/helpers/getHeadingsFromMarkdown.ts
@@ -1,14 +1,9 @@
+import { type Heading } from '@scalar/oas-utils'
 import remarkHeadings from '@vcarl/remark-headings'
 import GithubSlugger from 'github-slugger'
 import remarkParse from 'remark-parse'
 import remarkStringify from 'remark-stringify'
 import { unified } from 'unified'
-
-export type Heading = {
-  depth: number
-  value: string
-  slug?: string
-}
 
 export type Headings = Heading[]
 

--- a/packages/api-reference/src/helpers/index.ts
+++ b/packages/api-reference/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './createHash'
 export * from './deepMerge'
 export * from './getApiClientRequest'
 export * from './getHeadingsFromMarkdown'

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -1,8 +1,8 @@
-import { type TransformedOperation } from '@scalar/oas-utils'
+import type { Heading, TransformedOperation } from '@scalar/oas-utils'
 import { slug } from 'github-slugger'
 import { onMounted, ref } from 'vue'
 
-import { type Heading, scrollToId, sleep } from '../helpers'
+import { scrollToId, sleep } from '../helpers'
 import type { Tag } from '../types'
 
 // Keeps track of the URL hash without the #

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -1,5 +1,5 @@
 import { useApiClientStore } from '@scalar/api-client'
-import { type TransformedOperation } from '@scalar/oas-utils'
+import { type TransformedOperation, ssrState } from '@scalar/oas-utils'
 import { type OpenAPIV3_1 } from '@scalar/openapi-parser'
 import { computed, reactive, ref, watch } from 'vue'
 
@@ -40,7 +40,9 @@ const parsedSpec = ref<Spec | undefined>(undefined)
 // Track which sidebar items are collapsed
 type CollapsedSidebarItems = Record<string, boolean>
 
-const collapsedSidebarItems = reactive<CollapsedSidebarItems>({})
+const collapsedSidebarItems = reactive<CollapsedSidebarItems>(
+  ssrState['useSidebarContent-collapsedSidebarItems'] ?? {},
+)
 
 function toggleCollapsedSidebarItem(key: string) {
   collapsedSidebarItems[key] = !collapsedSidebarItems[key]

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -1,5 +1,8 @@
-import type { AuthenticationState } from '@scalar/api-client'
-import type { ContentType, TransformedOperation } from '@scalar/oas-utils'
+import type {
+  AuthenticationState,
+  ContentType,
+  TransformedOperation,
+} from '@scalar/oas-utils'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import type { ThemeId } from '@scalar/themes'
 import type { MetaFlatInput } from '@unhead/schema'

--- a/packages/oas-utils/src/index.ts
+++ b/packages/oas-utils/src/index.ts
@@ -14,4 +14,5 @@ export {
   yaml,
 } from './parse'
 export { prettyPrintJson } from './prettyPrintJson'
+export { defaultStateFactory, ssrState } from './ssrState'
 export * from './types'

--- a/packages/oas-utils/src/ssrState.ts
+++ b/packages/oas-utils/src/ssrState.ts
@@ -11,6 +11,7 @@ export const defaultStateFactory = (): SSRState['scalarState'] => ({})
 /**
  * This allows us to access the server state in the front-end
  */
-export const ssrState: SSRState['scalarState'] = window?.__SCALAR__
-  ? window.__SCALAR__ ?? defaultStateFactory()
-  : defaultStateFactory()
+export const ssrState: SSRState['scalarState'] =
+  typeof window !== 'undefined'
+    ? window.__SCALAR__ ?? defaultStateFactory()
+    : defaultStateFactory()

--- a/packages/oas-utils/src/ssrState.ts
+++ b/packages/oas-utils/src/ssrState.ts
@@ -1,0 +1,16 @@
+import { type SSRState } from './types'
+
+declare global {
+  interface Window {
+    __SCALAR__: SSRState['scalarState']
+  }
+}
+
+export const defaultStateFactory = (): SSRState['scalarState'] => ({})
+
+/**
+ * This allows us to access the server state in the front-end
+ */
+export const ssrState: SSRState['scalarState'] = window?.__SCALAR__
+  ? window.__SCALAR__ ?? defaultStateFactory()
+  : defaultStateFactory()

--- a/packages/oas-utils/src/types.ts
+++ b/packages/oas-utils/src/types.ts
@@ -1,4 +1,4 @@
-import { type OpenAPIV3 } from '@scalar/openapi-parser'
+import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import type { HarRequest } from 'httpsnippet-lite'
 
 export type AnyObject = Record<string, any>
@@ -128,4 +128,51 @@ export type Schema = {
 
 export type TransformedOperation = Operation & {
   pathParameters?: Parameters[]
+}
+
+export type CollapsedSidebarItems = Record<string, boolean>
+
+export type AuthenticationState = {
+  preferredSecurityScheme: string | null
+  securitySchemes?:
+    | OpenAPIV3.ComponentsObject['securitySchemes']
+    | OpenAPIV3_1.ComponentsObject['securitySchemes']
+  http: {
+    basic: {
+      username: string
+      password: string
+    }
+    bearer: {
+      token: string
+    }
+  }
+  apiKey: {
+    token: string
+  }
+  oAuth2: {
+    clientId: string
+    scopes: string[]
+    accessToken: string
+    state: string
+  }
+}
+
+export type Heading = {
+  depth: number
+  value: string
+  slug?: string
+}
+
+export type DescriptionSectionSSRKey =
+  `components-Content-Introduction-Description-sections${number}`
+
+export type SSRState = {
+  scalarState: {
+    'useGlobalStore-authentication'?: AuthenticationState
+    'useSidebarContent-collapsedSidebarItems'?: CollapsedSidebarItems
+    [key: DescriptionSectionSSRKey]: {
+      heading: Heading
+      content: string
+    }[]
+  }
 }


### PR DESCRIPTION
The Final PR  in the SSR Prequel saga. This PR instantiates the client state from the server. This does not need to be checked, but we should just poke around and see if eveyrthing works:
- markdown
- auth
- description