### PR TITLE
feat: add configuration to hide models from sidebar, search and content, fix #1312

### DIFF
--- a/.changeset/clean-houses-grin.md
+++ b/.changeset/clean-houses-grin.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: add configuration to hide models from sidebar, search and content

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -78,7 +78,17 @@ Making requests to other domains is restricted in the browser and requires [CORS
 Whether the sidebar should be shown.
 
 ```vue
-<ApiReference :configuration="{ showSidebar: true} />
+<ApiReference :configuration="{ showSidebar: true } />
+```
+
+#### showModels?: boolean
+
+Whether models (components.schemas) should be shown in the sidebar, search and content.
+
+`@default true`
+
+```vue
+<ApiReference :configuration="{ showModels: false } />
 ```
 
 ### customCss?: string

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -29,6 +29,7 @@ const configuration = computed<ReferenceConfiguration>(() => ({
   theme: 'default',
   showSidebar: true,
   isEditable: false,
+  showModels: true,
   ...props.configuration,
 }))
 

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -6,7 +6,7 @@ import {
   ThemeStyles,
 } from '@scalar/themes'
 import { useDebounceFn, useMediaQuery, useResizeObserver } from '@vueuse/core'
-import { computed, onMounted, provide, ref } from 'vue'
+import { computed, onMounted, provide, ref, watch } from 'vue'
 import { toast } from 'vue-sonner'
 
 import {
@@ -16,6 +16,7 @@ import {
 } from '../helpers'
 import { useNavState, useSidebar } from '../hooks'
 import { useToasts } from '../hooks/useToasts'
+import { useConfigurationStore } from '../stores'
 import type {
   ReferenceLayoutProps,
   ReferenceLayoutSlot,
@@ -36,6 +37,17 @@ defineEmits<{
   (e: 'linkSwaggerFile'): void
   (e: 'toggleDarkMode'): void
 }>()
+
+// Put the configuration in a globally accessible store
+const { setConfiguration } = useConfigurationStore()
+
+watch(
+  () => props.configuration,
+  () => {
+    setConfiguration(props.configuration)
+  },
+  { immediate: true, deep: true },
+)
 
 defineOptions({
   inheritAttrs: false,

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -7,7 +7,7 @@ import { useMagicKeys, whenever } from '@vueuse/core'
 import Fuse from 'fuse.js'
 import { computed, ref, toRef, watch } from 'vue'
 
-import { getHeadingsFromMarkdown } from '../helpers'
+import { getHeadingsFromMarkdown, hasModels } from '../helpers'
 import { extractRequestBody } from '../helpers/specHelpers'
 import { type ParamMap, useNavState, useOperation, useSidebar } from '../hooks'
 import type { Spec } from '../types'
@@ -164,7 +164,9 @@ watch(
     }
 
     // Adding models as well
-    const schemas = props.parsedSpec.components?.schemas
+    const schemas = hasModels(props.parsedSpec)
+      ? props.parsedSpec.components?.schemas
+      : {}
     const modelData: FuseData[] = []
 
     if (schemas) {

--- a/packages/api-reference/src/helpers/hasModels.ts
+++ b/packages/api-reference/src/helpers/hasModels.ts
@@ -1,10 +1,20 @@
-import { type Spec } from '../types'
+import { useConfigurationStore } from '../stores'
+import type { Spec } from '../types'
+
+const { configuration } = useConfigurationStore()
 
 export const hasModels = (spec?: Spec) => {
+  // Configuration
+  if (configuration?.showModels === false) {
+    return false
+  }
+
+  // Specification
   if (!spec) {
     return false
   }
 
+  // Components
   if (Object.keys(spec?.components?.schemas ?? {}).length) {
     return true
   }

--- a/packages/api-reference/src/stores/index.ts
+++ b/packages/api-reference/src/stores/index.ts
@@ -1,2 +1,3 @@
+export * from './useConfigurationStore'
 export * from './useHttpClientStore'
 export * from './useServerStore'

--- a/packages/api-reference/src/stores/useConfigurationStore.ts
+++ b/packages/api-reference/src/stores/useConfigurationStore.ts
@@ -1,0 +1,21 @@
+import { reactive, readonly } from 'vue'
+
+import type { ReferenceConfiguration } from '../types'
+
+export const createEmptyConfigurationState = (): ReferenceConfiguration => ({})
+
+const configuration = reactive<ReferenceConfiguration>(
+  createEmptyConfigurationState(),
+)
+
+const setConfiguration = (newState: Partial<ReferenceConfiguration>) => {
+  Object.assign(configuration, {
+    ...configuration,
+    ...newState,
+  })
+}
+
+export const useConfigurationStore = () => ({
+  configuration: readonly(configuration),
+  setConfiguration,
+})

--- a/packages/api-reference/src/stores/useConfigurationStore.ts
+++ b/packages/api-reference/src/stores/useConfigurationStore.ts
@@ -1,4 +1,9 @@
-import { reactive, readonly } from 'vue'
+import {
+  type DeepReadonly,
+  type UnwrapNestedRefs,
+  reactive,
+  readonly,
+} from 'vue'
 
 import type { ReferenceConfiguration } from '../types'
 
@@ -15,7 +20,13 @@ const setConfiguration = (newState: Partial<ReferenceConfiguration>) => {
   })
 }
 
-export const useConfigurationStore = () => ({
+// We need to be explicit about the return type here because of this error:
+//
+// The inferred type of 'useConfigurationStore' cannot be named without a reference to '.pnpm/zhead@2.2.4/node_modules/zhead/dist/shared/zhead.177ad851'. This is likely not portable. A type annotation is necessary.
+export const useConfigurationStore: () => {
+  configuration: DeepReadonly<UnwrapNestedRefs<ReferenceConfiguration>>
+  setConfiguration: (newState: Partial<ReferenceConfiguration>) => void
+} = () => ({
   configuration: readonly(configuration),
   setConfiguration,
 })

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -30,6 +30,12 @@ export type ReferenceConfiguration = {
   isEditable?: boolean
   /** Whether to show the sidebar */
   showSidebar?: boolean
+  /**
+   * Whether to show models in the sidebar, search, and content.
+   *
+   * @default true
+   */
+  showModels?: boolean
   /** Whether dark mode is on or off initially (light mode) */
   darkMode?: boolean
   /** Key used with CNTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k) */


### PR DESCRIPTION
Currently models (components.schemas) are always shown. As requested in #1312 this PR adds an option to hide models from the sidebar, search and content.

By default, models are shown.

This PR hooks into the `hasModels` helper. But it felt wrong to pass the configuration as a prop through all levels, so I did something I dreamed of for a while: I’ve just put the configuration in a globally accessible store (read-only).

Let me know what you think!