### PR TITLE
feat: add custom header example

### DIFF
--- a/examples/cdn-api-reference/src/index.ts
+++ b/examples/cdn-api-reference/src/index.ts
@@ -13,6 +13,10 @@ app.get('/live', (_request, reply) => {
   reply.sendFile('api-reference-cdn-live.html', { cacheControl: false }) // overriding the options disabling cache-control headers) // serving path.join(__dirname, 'public', 'myHtml.html') directly
 })
 
+app.get('/with-header', (_request, reply) => {
+  reply.sendFile('api-reference-cdn-with-header.html', { cacheControl: false }) // overriding the options disabling cache-control headers) // serving path.join(__dirname, 'public', 'myHtml.html') directly
+})
+
 app.get('/localhost', (_request, reply) => {
   reply.sendFile('api-reference-cdn-localhost.html', { cacheControl: false }) // overriding the options disabling cache-control headers) // serving path.join(__dirname, 'public', 'myHtml.html') directly
 })

--- a/examples/cdn-api-reference/src/public/api-reference-cdn-with-header.html
+++ b/examples/cdn-api-reference/src/public/api-reference-cdn-with-header.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+  <head>
+    <title>API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+    <style>
+      .layout {
+        display: grid;
+        grid-template-rows: auto 1fr;
+        height: 100dvh;
+      }
+      .my-header {
+        font-family: var(--default-theme-font);
+        font-style: italic;
+        color: var(--default-theme-color-1);
+        background: var(--default-theme-background-1);
+        border-bottom: 1px solid var(--default-theme-border-color);
+        padding: 12px 16px;
+      }
+      /* Target the references div */
+      .my-header + div {
+        display: flex;
+        min-height: 0;
+      }
+    </style>
+  </head>
+  <body class="layout">
+    <header class="my-header">Scalar API References</header>
+    <!-- References will be injected here  -->
+    <script id="api-reference"></script>
+    <!-- References Configuration -->
+    <script>
+      var configuration = {
+        theme: 'purple',
+        spec: { url: 'https://petstore3.swagger.io/api/v3/openapi.json' },
+        proxy: 'https://api.scalar.com/request-proxy',
+      }
+      var apiReference = document.getElementById('api-reference')
+      apiReference.dataset.configuration = JSON.stringify(configuration)
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>


### PR DESCRIPTION
Okay so this adds a custom header example, I haven't added docs _yet_.

Actually targeting the references `<div>` is quite hard because we inject it before the script tag with no identifying features (such as an id or class). In the example I'm targeting it using an adjacent sibling selector `.my-header + div` but that's a pretty brute force way of doing it.

I think we should maybe improve the styling experience for the CDN script before we add instructions?

Some options to make it better:

1. Instead of inject above the script tag we could replace it with our app div and set `id="api-reference"` on that div
2. We could set another `id` or class on the tag we inject
3. We could inject the div after the `<script>` tag so at least we can target it with `#api-reference + div`

Preview of example:

<img width="1434" alt="Google Chrome-2024-03-28-00-12-33@2x" src="https://github.com/scalar/scalar/assets/6374090/22193826-8c33-4ddb-a626-40e2c0e00bf2">
