### PR TITLE
fix: set global security on sidebar navigation

### DIFF
--- a/.changeset/olive-onions-approve.md
+++ b/.changeset/olive-onions-approve.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: set global security on sidebar navigation

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -1,4 +1,4 @@
-import { useApiClientStore } from '@scalar/api-client'
+import { useApiClientStore, useOpenApiStore } from '@scalar/api-client'
 import { type TransformedOperation, ssrState } from '@scalar/oas-utils'
 import { type OpenAPIV3_1 } from '@scalar/openapi-parser'
 import { computed, reactive, ref, watch } from 'vue'
@@ -67,6 +67,9 @@ const items = computed(() => {
   // Check whether the API client is visible
   const { state } = useApiClientStore()
   const titlesById: Record<string, string> = {}
+  const {
+    openApi: { globalSecurity },
+  } = useOpenApiStore()
 
   // Introduction
   const headingEntries: SidebarEntry[] = headings.value.map((heading) => {
@@ -108,7 +111,7 @@ const items = computed(() => {
                 show: true,
                 select: () => {
                   if (state.showApiClient) {
-                    openClientFor(operation)
+                    openClientFor(operation, globalSecurity)
                   }
                 },
               }
@@ -128,7 +131,7 @@ const items = computed(() => {
             show: true,
             select: () => {
               if (state.showApiClient) {
-                openClientFor(operation)
+                openClientFor(operation, globalSecurity)
               }
             },
           }


### PR DESCRIPTION
fix  #1336  

## **Problem**

Currently, with the api client opened, when navigating through the endpoints via sidebar the global authentication header is not sent in the request.

## **Explanation**
Probably, this pull request introduced the bug https://github.com/scalar/scalar/pull/1188.

This happens because `useSidebar` was not updated, so every time the `openClientFor` function was called, without the global security parameter being passed, the `globalSecurity` of `useOpenApiStore` was set to undefined.

## **Solution**
With this PR, `useSidebar` has been updated so that `openClientFor` calls pass the `globalSecurity` parameter, thus preventing it from being overwritten

## **Follow-up ideas**

- Add e2e test to prevent regressions in this behavior;
- Solve this TODO https://github.com/scalar/scalar/blob/main/packages/api-reference/src/helpers/openClientFor.ts#L39, in order to avoid passing `globalSecurity` as a parameter.
