### PR TITLE
fix(#1339): only update hash value on scroll

### DIFF
--- a/.changeset/tall-guests-obey.md
+++ b/.changeset/tall-guests-obey.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: update only the hash on scroll

--- a/packages/api-reference/src/components/Section/Section.vue
+++ b/packages/api-reference/src/components/Section/Section.vue
@@ -15,8 +15,11 @@ function handleScroll() {
 
   // We use replaceState so we don't trigger the url hash watcher and trigger a scroll
   // this is why we set the hash value directly
-  window.history.replaceState({}, '', `#${props.id}`)
-  hash.value = props.id ?? ''
+  const newUrl = new URL(window.location.href)
+  const id = props.id ?? ''
+  newUrl.hash = id
+  hash.value = id
+  window.history.replaceState({}, '', newUrl)
 
   // Open models on scroll
   if (props.id?.startsWith('model'))


### PR DESCRIPTION
**Problem**
We remove the rest of the path on scroll (this doesn't seem to happen on local but it has for a user)

**Explanation**
we were just passing the hash into history state

**Solution**
With this PR we create a new URL with the current href and just update the hash. This _should_ work
