### PR TITLE
fix: descriptions repeat themselves

### DIFF
--- a/.changeset/fuzzy-wombats-thank.md
+++ b/.changeset/fuzzy-wombats-thank.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: use function for displaying description in schema property component

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -132,7 +132,7 @@ const handleClick = (e: MouseEvent) =>
 .schema-card {
   z-index: 0;
   position: relative;
-  font-size: var(--theme-font-size-3, var(--default-theme-font-size-3));
+  font-size: var(--theme-font-size-4, var(--default-theme-font-size-4));
   color: var(--theme-color-1, var(--default-theme-color-1));
 }
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -36,6 +36,17 @@ const descriptions: Record<string, Record<string, string>> = {
   },
 }
 
+const displayDescription = function (
+  description: string | undefined,
+  value?: Record<string, any>,
+) {
+  if (value?.properties) {
+    return null
+  }
+
+  return description || value?.description || null
+}
+
 const generatePropertyDescription = function (property?: Record<string, any>) {
   if (!property) {
     return null
@@ -76,9 +87,9 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     </SchemaPropertyHeading>
     <!-- Description -->
     <div
-      v-if="description || value?.description"
+      v-if="displayDescription(description, value)"
       class="property-description">
-      <MarkdownRenderer :value="description || value?.description" />
+      <MarkdownRenderer :value="displayDescription(description, value)" />
     </div>
     <div
       v-else-if="generatePropertyDescription(value)"


### PR DESCRIPTION
**Problem**
as described in #1318, the description of an object is duplicated, as seen below: 

<img width="1139" alt="Screenshot 2024-04-01 at 11 25 12" src="https://github.com/scalar/scalar/assets/14966155/22351e85-805e-4a01-a4d1-de76266688de">

**Solution**
this PR is an attempt to fix #1318 by introducing a function for displaying the description unless the value has properties.

after the change:
<img width="1139" alt="Screenshot 2024-04-01 at 11 30 27" src="https://github.com/scalar/scalar/assets/14966155/0c3b35f9-b205-4792-9f8c-59bead84d123">

