### PR TITLE
fix(#1355): root path on sidebar items

### DIFF
--- a/.changeset/popular-beans-matter.md
+++ b/.changeset/popular-beans-matter.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: create url for sidebar links using constructor

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -29,6 +29,13 @@ const handleClick = async () => {
   if (props.hasChildren) emit('toggleOpen')
   props.item?.select?.()
 }
+
+// Build relative URL and add hash
+const generateLink = (hash: string) => {
+  const newUrl = new URL(window.location.href)
+  newUrl.hash = hash
+  return `${newUrl.pathname}${newUrl.search}${newUrl.hash}`
+}
 </script>
 <template>
   <li
@@ -57,7 +64,7 @@ const handleClick = async () => {
       </p>
       <a
         class="sidebar-heading-link"
-        :href="`#${item.id}`">
+        :href="generateLink(item.id)">
         <ScalarIcon
           v-if="item?.icon?.src"
           class="sidebar-icon"


### PR DESCRIPTION
This will build the URL using the constructor then update the hash. This is only temporary, soon we will switch to vue-router.