### PR TITLE
feat: add header example

### DIFF
--- a/examples/cdn-api-reference/src/index.ts
+++ b/examples/cdn-api-reference/src/index.ts
@@ -13,6 +13,10 @@ app.get('/live', (_request, reply) => {
   reply.sendFile('api-reference-cdn-live.html', { cacheControl: false }) // overriding the options disabling cache-control headers) // serving path.join(__dirname, 'public', 'myHtml.html') directly
 })
 
+app.get('/with-header', (_request, reply) => {
+  reply.sendFile('api-reference-cdn-with-header.html', { cacheControl: false }) // overriding the options disabling cache-control headers) // serving path.join(__dirname, 'public', 'myHtml.html') directly
+})
+
 app.get('/localhost', (_request, reply) => {
   reply.sendFile('api-reference-cdn-localhost.html', { cacheControl: false }) // overriding the options disabling cache-control headers) // serving path.join(__dirname, 'public', 'myHtml.html') directly
 })

--- a/examples/cdn-api-reference/src/public/api-reference-cdn-with-header.html
+++ b/examples/cdn-api-reference/src/public/api-reference-cdn-with-header.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+  <head>
+    <title>API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+    <style>
+      .layout {
+        display: grid;
+        grid-template-rows: auto 1fr;
+        height: 100dvh;
+      }
+      .my-header {
+        font-family: var(--default-theme-font);
+        font-style: italic;
+        color: var(--default-theme-color-1);
+        background: var(--default-theme-background-1);
+        border-bottom: 1px solid var(--default-theme-border-color);
+        padding: 12px 16px;
+      }
+      /* Target the references div */
+      .my-header + div {
+        display: flex;
+        min-height: 0;
+      }
+    </style>
+  </head>
+  <body class="layout">
+    <header class="my-header">Scalar API References</header>
+    <!-- References will be injected here  -->
+    <script id="api-reference"></script>
+    <!-- References Configuration -->
+    <script>
+      var configuration = {
+        theme: 'purple',
+        spec: { url: 'https://petstore3.swagger.io/api/v3/openapi.json' },
+        proxy: 'https://api.scalar.com/request-proxy',
+      }
+      var apiReference = document.getElementById('api-reference')
+      apiReference.dataset.configuration = JSON.stringify(configuration)
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>

--- a/examples/cdn-api-reference/src/public/api-reference-cdn-with-header.html
+++ b/examples/cdn-api-reference/src/public/api-reference-cdn-with-header.html
@@ -20,8 +20,7 @@
         border-bottom: 1px solid var(--default-theme-border-color);
         padding: 12px 16px;
       }
-      /* Target the references div */
-      .my-header + div {
+      #api-reference {
         display: flex;
         min-height: 0;
       }
@@ -41,6 +40,6 @@
       var apiReference = document.getElementById('api-reference')
       apiReference.dataset.configuration = JSON.stringify(configuration)
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script src="http://localhost:5053/@scalar/fastify-api-reference/js/browser.js"></script>
   </body>
 </html>

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -7,7 +7,9 @@ import { createApp } from 'vue'
 import { default as ApiReference } from './components/ApiReference.vue'
 import { type ReferenceConfiguration } from './types'
 
-const specScriptTag = document.querySelector('#api-reference')
+const REFS_TAG_ID = '#api-reference'
+
+const specScriptTag = document.querySelector(REFS_TAG_ID)
 const specElement = document.querySelector('[data-spec]')
 const specUrlElement = document.querySelector('[data-spec-url]')
 const configurationScriptElement = document.querySelector(
@@ -113,11 +115,17 @@ if (!specUrlElement && !specElement && !specScriptTag) {
   document.querySelector('body')?.classList.add('light-mode')
 
   // If it’s a script tag, we can’t mount the Vue.js app inside that tag.
-  // We need to add a new container div before the script tag.
+  // We need to replace the script tag with a container div for the app
   let container: HTMLElement | string | null = null
   if (specScriptTag) {
-    container = document.createElement('div')
-    specScriptTag?.parentNode?.insertBefore(container, specScriptTag)
+    const target = document.createElement('div')
+    const attrs = [...specScriptTag.attributes]
+    attrs.forEach((attr) =>
+      target.setAttribute(attr.nodeName, attr.nodeValue || ''),
+    )
+    specScriptTag?.parentNode?.insertBefore(target, specScriptTag)
+    specScriptTag.remove()
+    container = target
   } else {
     container = specElement
       ? '[data-spec]'


### PR DESCRIPTION
This shows what is could look like if we replaced the `<script>`  tag instead of injecting next to it. I don't _think_ this would have any downstream effects for users. If we want to take a safer route we could also just add a class or id to the div we inject.

Here's what the DOM looks like with this approach:

<img width="1113" alt="Google Chrome-2024-04-02-15-07-02@2x" src="https://github.com/scalar/scalar/assets/6374090/b7be896d-87a9-4ad0-b02a-965ce506e5e1">

Vs how we do it now:

![Google Chrome-2024-04-02-15-13-14@2x](https://github.com/scalar/scalar/assets/6374090/1bf1600e-76e0-48b2-b374-3a0efd8f36b6)

