### PR TITLE
feat: add custom security option

### DIFF
--- a/.changeset/friendly-readers-tickle.md
+++ b/.changeset/friendly-readers-tickle.md
@@ -1,0 +1,8 @@
+---
+"@scalar/api-client": patch
+"@scalar/components": patch
+"@scalar/oas-utils": patch
+"@scalar/fastify-api-reference": patch
+---
+
+feat: add custom security option

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -20,12 +20,12 @@ const {
   openApi: { operation, globalSecurity },
 } = useOpenApiStore()
 
-const authenticationRequest = computed(() => {
-  return getRequestFromAuthentication(
+const authenticationRequest = computed(() =>
+  getRequestFromAuthentication(
     authentication,
     operation?.information?.security ?? globalSecurity,
-  )
-})
+  ),
+)
 
 /**
  * TODO: This is a workaround to make the address bar editable, but not the rest. If we’d really like to have an

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/RequestAuthentication.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/RequestAuthentication.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ScalarButton } from '@scalar/components'
 import type { OpenAPIV3_1 } from '@scalar/openapi-parser'
 import { ref } from 'vue'
 
@@ -23,7 +24,23 @@ clickGeneratedParameter.on(() => {
   })
 })
 
-const { authentication } = useAuthenticationStore()
+const { authentication, setAuthentication } = useAuthenticationStore()
+
+// When there are no security schemes in the spec, we add blank ones
+const setIntialScheme = (
+  preferredSecurityScheme: 'apiKey' | 'httpBasic' | 'httpBearer' | 'oauth2',
+) => {
+  setAuthentication({
+    customSecurity: true,
+    preferredSecurityScheme,
+    securitySchemes: {
+      apiKey: { type: 'apiKey', name: 'apiKey', in: 'header' },
+      httpBasic: { type: 'http', scheme: 'basic' },
+      httpBearer: { type: 'http', scheme: 'bearer' },
+      // TODO oauth2
+    },
+  })
+}
 </script>
 <template>
   <div ref="requestAuthenticationRef">
@@ -43,6 +60,31 @@ const { authentication } = useAuthenticationStore()
             ] as OpenAPIV3_1.SecuritySchemeObject
           " />
       </div>
+
+      <div
+        v-if="!authentication.securitySchemes"
+        class="security-scheme-empty-state">
+        <ScalarButton
+          variant="outlined"
+          @click="setIntialScheme('apiKey')"
+          >ApiKey</ScalarButton
+        >
+        <ScalarButton
+          variant="outlined"
+          @click="setIntialScheme('httpBasic')"
+          >Basic</ScalarButton
+        >
+        <ScalarButton
+          variant="outlined"
+          @click="setIntialScheme('httpBearer')"
+          >Bearer</ScalarButton
+        >
+        <ScalarButton
+          variant="outlined"
+          @click="setIntialScheme('oauth2')"
+          >oAuth2</ScalarButton
+        >
+      </div>
     </CollapsibleSection>
   </div>
 </template>
@@ -51,5 +93,18 @@ const { authentication } = useAuthenticationStore()
 .preferred-security-scheme {
   display: flex;
   width: 100%;
+}
+
+.security-scheme-empty-state {
+  flex-wrap: wrap;
+  gap: 16px;
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  justify-content: space-around;
+
+  .scalar-button {
+    width: 100px;
+  }
 }
 </style>

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/RequestAuthentication.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/RequestAuthentication.vue
@@ -64,26 +64,30 @@ const setIntialScheme = (
       <div
         v-if="!authentication.securitySchemes"
         class="security-scheme-empty-state">
-        <ScalarButton
+        <div
+          class="scalar-api-client-add"
           variant="outlined"
-          @click="setIntialScheme('apiKey')"
-          >ApiKey</ScalarButton
-        >
-        <ScalarButton
+          @click="setIntialScheme('apiKey')">
+          ApiKey
+        </div>
+        <div
+          class="scalar-api-client-add"
           variant="outlined"
-          @click="setIntialScheme('httpBasic')"
-          >Basic</ScalarButton
-        >
-        <ScalarButton
+          @click="setIntialScheme('httpBasic')">
+          Basic
+        </div>
+        <div
+          class="scalar-api-client-add"
           variant="outlined"
-          @click="setIntialScheme('httpBearer')"
-          >Bearer</ScalarButton
-        >
-        <ScalarButton
+          @click="setIntialScheme('httpBearer')">
+          Bearer
+        </div>
+        <div
+          class="scalar-api-client-add"
           variant="outlined"
-          @click="setIntialScheme('oauth2')"
-          >oAuth2</ScalarButton
-        >
+          @click="setIntialScheme('oauth2')">
+          oAuth2
+        </div>
       </div>
     </CollapsibleSection>
   </div>
@@ -96,15 +100,43 @@ const setIntialScheme = (
 }
 
 .security-scheme-empty-state {
-  flex-wrap: wrap;
-  gap: 16px;
+  border: 1px dashed
+    var(--theme-border-color, var(--default-theme-border-color));
+  width: 100%;
+  text-align: center;
+  border-radius: var(--theme-radius, var(--default-theme-radius));
+  font-size: var(--theme-small, var(--default-theme-small));
+  min-height: 58px;
   display: flex;
-  flex: 1;
-  flex-direction: row;
-  justify-content: space-around;
-
-  .scalar-button {
-    width: 100px;
-  }
+  align-items: center;
+  justify-content: center;
+}
+.scalar-api-client-add {
+  color: var(--theme-color-2, var(--default-theme-color-2));
+  padding: 3px 9px;
+  width: fit-content;
+  cursor: pointer;
+  font-size: var(--theme-micro, var(--default-theme-micro));
+  font-weight: var(--theme-semibold, var(--default-theme-semibold));
+  text-decoration: none;
+  margin: 0 6px;
+  border: none;
+  font-family: var(--theme-font);
+  appearance: none;
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
+  border-radius: 30px;
+}
+.scalar-api-client-add svg {
+  width: 12px;
+  height: 12px;
+  margin-right: 6px;
+}
+.scalar-api-client-add:hover {
+  color: var(--theme-color-1, var(--default-theme-color-1));
+}
+.scalar-api-client-add:focus-within {
+  background: var(--theme-background-3, var(--default-theme-background-3));
 }
 </style>

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/RequestAuthentication.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/RequestAuthentication.vue
@@ -82,12 +82,13 @@ const setIntialScheme = (
           @click="setIntialScheme('httpBearer')">
           Bearer
         </div>
-        <div
+        <!-- TODO implement -->
+        <!-- <div
           class="scalar-api-client-add"
           variant="outlined"
           @click="setIntialScheme('oauth2')">
           oAuth2
-        </div>
+        </div> -->
       </div>
     </CollapsibleSection>
   </div>

--- a/packages/api-client/src/components/ApiClient/Request/RequestCookies.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestCookies.vue
@@ -71,9 +71,8 @@ const hasCookies = computed(() => {
 <style>
 .scalar-api-client-add {
   color: var(--theme-color-2, var(--default-theme-color-2));
-  padding: 6px;
+  padding: 3px 9px;
   width: fit-content;
-  border-radius: var(--theme-radius, var(--default-theme-radius));
   cursor: pointer;
   font-size: var(--theme-micro, var(--default-theme-micro));
   font-weight: var(--theme-semibold, var(--default-theme-semibold));
@@ -84,6 +83,8 @@ const hasCookies = computed(() => {
   appearance: none;
   display: flex;
   align-items: center;
+  border: 1px solid var(--theme-border-color, var(--default-theme-border-color));
+  border-radius: 30px;
 }
 .scalar-api-client-add svg {
   width: 12px;

--- a/packages/api-client/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-client/src/helpers/getRequestFromAuthentication.ts
@@ -47,9 +47,11 @@ export function getRequestFromAuthentication(
   const cookies: HarRequest['cookies'] = []
 
   // Check whether auth is required
+  // Custom Security required for users that add auth on the client with none in the spec
   if (
-    !authentication.preferredSecurityScheme ||
-    !authenticationRequired(operationSecurity)
+    !authentication.customSecurity &&
+    (!authentication.preferredSecurityScheme ||
+      !authenticationRequired(operationSecurity))
   ) {
     return { headers, queryString, cookies }
   }
@@ -64,9 +66,10 @@ export function getRequestFromAuthentication(
   )
 
   // If the (globally) selected security scheme is not allowed for the operation, use the first available security scheme.
-  const operationSecurityKey = operationAllowsSelectedSecurityScheme
-    ? authentication.preferredSecurityScheme
-    : Object.keys(operationSecurity?.[0] ?? {}).pop()
+  const operationSecurityKey =
+    operationAllowsSelectedSecurityScheme || authentication.customSecurity
+      ? authentication.preferredSecurityScheme
+      : Object.keys(operationSecurity?.[0] ?? {}).pop()
 
   // We’re using a parsed OpenAPI file here, so let’s get rid of the `ReferenceObject` type
   const securityScheme =

--- a/packages/api-client/src/stores/useAuthenticationStore.ts
+++ b/packages/api-client/src/stores/useAuthenticationStore.ts
@@ -4,6 +4,8 @@ import { reactive } from 'vue'
 
 export const createEmptyAuthenticationState = (): AuthenticationState => ({
   preferredSecurityScheme: null,
+  // In case the spec has no security and the user would like to add some
+  customSecurity: false,
   http: {
     basic: {
       username: '',
@@ -28,12 +30,8 @@ const authentication = reactive<AuthenticationState>(
   ssrState['useGlobalStore-authentication'] ?? createEmptyAuthenticationState(),
 )
 
-const setAuthentication = (newState: Partial<AuthenticationState>) => {
-  Object.assign(authentication, {
-    ...authentication,
-    ...newState,
-  })
-}
+const setAuthentication = (newState: Partial<AuthenticationState>) =>
+  Object.assign(authentication, newState)
 
 export const useAuthenticationStore = () => ({
   authentication,

--- a/packages/components/src/components/ScalarButton/variants.ts
+++ b/packages/components/src/components/ScalarButton/variants.ts
@@ -9,7 +9,7 @@ export const styles: Record<string, Record<string, any>> = {
   ],
   outlined: [
     'scalar-button-outlined',
-    'active:bg-btn-1 border border-solid border-border bg-transparent text-fore-1 hocus:bg-back-2',
+    'active:bg-btn-1 border border-solid border-border bg-transparent text-fore-1 hocus:bg-border',
   ],
   ghost: [
     'scalar-button-ghost',

--- a/packages/oas-utils/src/types.ts
+++ b/packages/oas-utils/src/types.ts
@@ -133,6 +133,7 @@ export type TransformedOperation = Operation & {
 export type CollapsedSidebarItems = Record<string, boolean>
 
 export type AuthenticationState = {
+  customSecurity: boolean
   preferredSecurityScheme: string | null
   securitySchemes?:
     | OpenAPIV3.ComponentsObject['securitySchemes']


### PR DESCRIPTION
This allows users to add basic security when the spec does not contain any. This security should also persist between requests.

Currently this PR works but is missing oAuth 2