### PR TITLE
docs: Update README.md for docusaurus package

### DIFF
--- a/packages/docusaurus/README.md
+++ b/packages/docusaurus/README.md
@@ -24,8 +24,7 @@ import type { ScalarOptions } from '@scalar/docusaurus'
 
 plugins: [
   [
-    '@scalar/docusaurus',
-    {
+    ['@scalar/docusaurus', {
       label: 'Scalar',
       route: '/scalar',
       configuration: {
@@ -33,7 +32,7 @@ plugins: [
           url: 'https://petstore3.swagger.io/api/v3/openapi.json',
         },
       },
-    } as ScalarOptions,
+    } as ScalarOptions],
   ],
 ],
 ```


### PR DESCRIPTION
**Problem**
The README.md for the docusaurus package has invalid usage code. The current code produces the error in the latest version of docusaurus:

```
[INFO] Starting the development server...

 >  NX    => Bad Docusaurus plugin value plugins[1].

   Example valid plugin config:
   {
     plugins: [
       ["@docusaurus/plugin-content-docs",options],
       "./myPlugin",
       ["./myPlugin",{someOption: 42}],
       function myPlugin() { },
       [function myPlugin() { },options]
     ],
   };

```

**Explanation**
This happens because the plugin array expects an array with the first element as the package name, and the second element as the options.

You can also see the following TypeScript error in your IDE:

```
TS2353: Object literal may only specify known properties, and label does not exist in type
PluginModule<unknown> | _DeepPartialArray<string | PluginOptions> | _DeepPartialArray<PluginOptions | PluginModule<unknown>>
```

**Solution**

The following change produces a valid startup:

```
[INFO] Starting the development server...
[SUCCESS] Docusaurus website is running at: http://localhost:3000/

✔ Client
  Compiled successfully in 600.13ms

client (webpack 5.90.1) compiled successfully
```
