### PR TITLE
feat: support x-displayName tag extension

### DIFF
--- a/.changeset/heavy-deers-sell.md
+++ b/.changeset/heavy-deers-sell.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/fastify-api-reference": patch
+---
+
+feat: support x-displayName tag extension

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -191,6 +191,16 @@ const transformResult = (schema: ResolvedOpenAPI.Document): Spec => {
     })
   })
 
+  // handle x-displayName extension
+  schema.tags.forEach((tag, tagIndex) => {
+    // @ts-expect-error TODO: We need to handle extensions
+    const xDisplayName = tag['x-displayName']
+
+    if (xDisplayName && schema.tags?.[tagIndex]) {
+      schema.tags[tagIndex].name = xDisplayName
+    }
+  })
+
   const returnedResult = {
     ...schema,
     webhooks: newWebhooks,


### PR DESCRIPTION
now you can change the names of tags with the x-displayName [extension](https://redocly.com/docs/api-reference-docs/specification-extensions/x-display-name/)

```
  "tags": [
    {
      "x-displayName": "MARC",
      "name": "pet",
      "description": "Everything about your Pets",
      "externalDocs": {
        "description": "Find out more",
        "url": "http://swagger.io"
      }
    },
```

<img width="1586" alt="image" src="https://github.com/scalar/scalar/assets/6176314/2a37ed20-d367-4682-a935-c5a75dd4cb96">
