### PR TITLE
fix: api reference code languages radiuses

### DIFF
--- a/.changeset/thick-lobsters-search.md
+++ b/.changeset/thick-lobsters-search.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: decrease border radius on code language background element

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -215,7 +215,7 @@ const checkIfClientIsFeatured = (client: HttpClientState) =>
   top: -1px;
   left: -1px;
   pointer-events: none;
-  border-radius: 12px;
+  border-radius: 8px;
   background: var(
     --theme-code-languages-background-supersede,
     var(--default-theme-code-languages-background-supersede)


### PR DESCRIPTION
**Problem**
documentation using light theme displays too important border radius on their code languages icon element [as seen on this documentation](https://docs.acctual.com/reference):

<img width="910" alt="Screenshot 2024-04-04 at 12 43 36" src="https://github.com/scalar/scalar/assets/14966155/227d1ce4-f5d5-49ca-8af8-b6d311c438cd">


**Solution**
this pr decreases the border radius applied on the `.code-languages-background:before` element in order to harmonize radiuses: 

<img width="910" alt="Screenshot 2024-04-04 at 12 45 25" src="https://github.com/scalar/scalar/assets/14966155/bb069a31-e215-4e4c-977c-128dc5bed5e4">
