### PR TITLE
feat: support tags with no operations

### DIFF
--- a/.changeset/funny-gorillas-switch.md
+++ b/.changeset/funny-gorillas-switch.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/fastify-api-reference": patch
+---
+
+feat: support tags with no operations

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -109,7 +109,6 @@ const isLazy =
       :isLazy="isLazy">
       <Component
         :is="tagLayout"
-        v-if="tag.operations && tag.operations.length > 0"
         :id="getTagId(tag)"
         :spec="parsedSpec"
         :tag="tag">

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -206,12 +206,5 @@ const transformResult = (schema: ResolvedOpenAPI.Document): Spec => {
     webhooks: newWebhooks,
   } as unknown as Spec
 
-  return removeTagsWithoutOperations(returnedResult)
-}
-
-const removeTagsWithoutOperations = (spec: Spec) => {
-  return {
-    ...spec,
-    tags: spec.tags?.filter((tag) => tag.operations?.length > 0),
-  }
+  return returnedResult
 }


### PR DESCRIPTION
you can write out sections without operations

<img width="1598" alt="image" src="https://github.com/scalar/scalar/assets/6176314/15689b7a-9773-4eac-9186-d1d916e5492c">
