### PR TITLE
fix: non-working `hiddenClients` configuration option 

### DIFF
--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -43,16 +43,16 @@ const featuredClients = (
       clientKey: 'libcurl',
     },
   ] as const
-).filter((featuredClient) => {
-  return availableTargets.value.find((target: AvailableTarget) => {
+).filter((featuredClient) =>
+  availableTargets.value.find((target: AvailableTarget) => {
     return (
       target.key === featuredClient.targetKey &&
       target.clients.find(
         (client: ClientInfo) => client.key === featuredClient.clientKey,
       )
     )
-  })
-})
+  }),
+)
 
 /**
  * Icons have longer names to appear in icon searches, e.g. "javascript-js" instead of just "javascript". This function

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -4,7 +4,7 @@ import type { TargetId } from 'httpsnippet-lite'
 import { ref } from 'vue'
 
 import { useHttpClients } from '../../../hooks'
-import { type HttpClientState, useHttpClientStore } from '../../../stores/'
+import { type HttpClientState, useHttpClientStore } from '../../../stores'
 
 // Use the template store to keep it accessible globally
 const { httpClient, setHttpClient, getClientTitle, getTargetTitle } =

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components'
 import type { TargetId } from 'httpsnippet-lite'
+import type { AvailableTarget } from 'httpsnippet-lite/dist/types/helpers/utils'
+import type { ClientInfo } from 'httpsnippet-lite/dist/types/targets/targets'
 import { ref } from 'vue'
 
 import { useHttpClients } from '../../../hooks'
@@ -14,32 +16,43 @@ const { availableTargets } = useHttpClients()
 const containerRef = ref<HTMLElement>()
 
 // Show popular clients with an icon, not just in a select.
-const featuredClients = [
-  {
-    targetKey: 'shell',
-    clientKey: 'curl',
-  },
-  {
-    targetKey: 'ruby',
-    clientKey: 'native',
-  },
-  {
-    targetKey: 'node',
-    clientKey: 'undici',
-  },
-  {
-    targetKey: 'php',
-    clientKey: 'guzzle',
-  },
-  {
-    targetKey: 'python',
-    clientKey: 'python3',
-  },
-  {
-    targetKey: 'c',
-    clientKey: 'libcurl',
-  },
-] as const
+const featuredClients = (
+  [
+    {
+      targetKey: 'shell',
+      clientKey: 'curl',
+    },
+    {
+      targetKey: 'ruby',
+      clientKey: 'native',
+    },
+    {
+      targetKey: 'node',
+      clientKey: 'undici',
+    },
+    {
+      targetKey: 'php',
+      clientKey: 'guzzle',
+    },
+    {
+      targetKey: 'python',
+      clientKey: 'python3',
+    },
+    {
+      targetKey: 'c',
+      clientKey: 'libcurl',
+    },
+  ] as const
+).filter((featuredClient) => {
+  return availableTargets.value.find((target: AvailableTarget) => {
+    return (
+      target.key === featuredClient.targetKey &&
+      target.clients.find(
+        (client: ClientInfo) => client.key === featuredClient.clientKey,
+      )
+    )
+  })
+})
 
 /**
  * Icons have longer names to appear in icon searches, e.g. "javascript-js" instead of just "javascript". This function

--- a/packages/api-reference/src/hooks/useHttpClients.test.ts
+++ b/packages/api-reference/src/hooks/useHttpClients.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+
+import { filterHiddenClients } from './useHttpClients'
+
+describe('useHttpClients', () => {
+  it('filters hidden targets', () => {
+    expect(
+      filterHiddenClients(
+        [
+          {
+            title: 'Node.js',
+            key: 'node',
+            extname: '.js',
+            default: 'foobar',
+            clients: [
+              {
+                title: 'Axios',
+                key: 'axios',
+                description:
+                  'Promise based HTTP client for the browser and node.js',
+                link: 'https://example.com',
+              },
+              {
+                title: 'Fetch',
+                key: 'fetch',
+                description:
+                  'The Fetch API provides an interface for fetching resources',
+                link: 'https://example.com',
+              },
+            ],
+          },
+        ],
+        // No Node.js
+        ref({ node: true }),
+      ),
+    ).toMatchObject([])
+  })
+
+  it('filters hidden clients from object', () => {
+    expect(
+      filterHiddenClients(
+        [
+          {
+            title: 'Node.js',
+            key: 'node',
+            extname: '.js',
+            default: 'foobar',
+            clients: [
+              {
+                title: 'Axios',
+                key: 'axios',
+                description:
+                  'Promise based HTTP client for the browser and node.js',
+                link: 'https://example.com',
+              },
+              {
+                title: 'Fetch',
+                key: 'fetch',
+                description:
+                  'The Fetch API provides an interface for fetching resources',
+                link: 'https://example.com',
+              },
+            ],
+          },
+        ],
+        ref({
+          // No fetch
+          node: ['fetch'],
+        }),
+      ),
+    ).toMatchObject([
+      {
+        title: 'Node.js',
+        key: 'node',
+        extname: '.js',
+        default: 'foobar',
+        clients: [
+          {
+            title: 'Axios',
+            key: 'axios',
+            description:
+              'Promise based HTTP client for the browser and node.js',
+            link: 'https://example.com',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('filters hidden clients from arrays', () => {
+    expect(
+      filterHiddenClients(
+        [
+          {
+            title: 'Node.js',
+            key: 'node',
+            extname: '.js',
+            default: 'foobar',
+            clients: [
+              {
+                title: 'Axios',
+                key: 'axios',
+                description:
+                  'Promise based HTTP client for the browser and node.js',
+                link: 'https://example.com',
+              },
+              {
+                title: 'Fetch',
+                key: 'fetch',
+                description:
+                  'The Fetch API provides an interface for fetching resources',
+                link: 'https://example.com',
+              },
+            ],
+          },
+        ],
+        // No fetch
+        ref(['fetch']),
+      ),
+    ).toMatchObject([
+      {
+        title: 'Node.js',
+        key: 'node',
+        extname: '.js',
+        default: 'foobar',
+        clients: [
+          {
+            title: 'Axios',
+            key: 'axios',
+            description:
+              'Promise based HTTP client for the browser and node.js',
+            link: 'https://example.com',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('doesn’t filter anything', () => {
+    expect(
+      filterHiddenClients(
+        [
+          {
+            title: 'Node.js',
+            key: 'node',
+            extname: '.js',
+            default: 'foobar',
+            clients: [
+              {
+                title: 'Axios',
+                key: 'axios',
+                description:
+                  'Promise based HTTP client for the browser and node.js',
+                link: 'https://example.com',
+              },
+              {
+                title: 'Fetch',
+                key: 'fetch',
+                description:
+                  'The Fetch API provides an interface for fetching resources',
+                link: 'https://example.com',
+              },
+            ],
+          },
+        ],
+        // No fetch
+        ref([]),
+      ),
+    ).toMatchObject([
+      {
+        title: 'Node.js',
+        key: 'node',
+        extname: '.js',
+        default: 'foobar',
+        clients: [
+          {
+            title: 'Axios',
+            key: 'axios',
+            description:
+              'Promise based HTTP client for the browser and node.js',
+            link: 'https://example.com',
+          },
+          {
+            title: 'Fetch',
+            key: 'fetch',
+            description:
+              'The Fetch API provides an interface for fetching resources',
+            link: 'https://example.com',
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/packages/api-reference/src/hooks/useHttpClients.test.ts
+++ b/packages/api-reference/src/hooks/useHttpClients.test.ts
@@ -192,4 +192,22 @@ describe('useHttpClients', () => {
       },
     ])
   })
+
+  it('filters targets without clients', () => {
+    expect(
+      filterHiddenClients(
+        [
+          {
+            title: 'Node.js',
+            key: 'node',
+            extname: '.js',
+            default: 'foobar',
+            clients: [],
+          },
+        ],
+        // No Node.js
+        ref({}),
+      ),
+    ).toMatchObject([])
+  })
 })

--- a/packages/api-reference/src/hooks/useHttpClients.ts
+++ b/packages/api-reference/src/hooks/useHttpClients.ts
@@ -17,7 +17,19 @@ const cachedTargets = ref<AvailableTarget[]>([])
 
 // Watch for changes in excludedClients and update the cachedTargets accordingly
 watchEffect(() => {
-  cachedTargets.value = filterHiddenClients(allTargets(), excludedClients)
+  const targets = allTargets()
+
+  // Add undici to node (@scalar/snippetz)
+  targets
+    .find((target) => target.key === 'node')
+    ?.clients.unshift({
+      description: 'An HTTP/1.1 client, written from scratch for Node.js.',
+      key: 'undici',
+      link: 'https://github.com/nodejs/undici',
+      title: 'undici',
+    })
+
+  cachedTargets.value = filterHiddenClients(targets, excludedClients)
 })
 
 export function filterHiddenClients(

--- a/packages/api-reference/src/hooks/useHttpClients.ts
+++ b/packages/api-reference/src/hooks/useHttpClients.ts
@@ -1,6 +1,6 @@
 import { availableTargets as allTargets } from 'httpsnippet-lite'
 import type { AvailableTarget } from 'httpsnippet-lite/dist/types/helpers/utils'
-import { type Ref, computed, readonly, ref, watchEffect } from 'vue'
+import { type Ref, computed, readonly, ref } from 'vue'
 
 import type { HiddenClients } from '../types'
 
@@ -12,14 +12,54 @@ const excludedClients = ref<HiddenClients>({
   ...DEFAULT_EXCLUDED_CLIENTS,
 })
 
-// Use a reactive reference for caching the computed targets
-const cachedTargets = ref<AvailableTarget[]>([])
+export function filterHiddenClients(
+  targets: AvailableTarget[],
+  exclude: Ref<HiddenClients>,
+): AvailableTarget[] {
+  return targets.flatMap((target: AvailableTarget) => {
+    // NOTE: This is for backwards compatibility with the previous behavior,
+    // If exclude is an array, it will exclude the matching clients from all targets.
+    //
+    // Example: ['fetch', 'xhr']
+    if (Array.isArray(exclude.value)) {
+      target.clients = target.clients.filter(
+        // @ts-expect-error We checked whether it’s an Array already.
+        (client) => !exclude.value.includes(client.key),
+      )
 
-// Watch for changes in excludedClients and update the cachedTargets accordingly
-watchEffect(() => {
+      return [target]
+    }
+
+    // Determine if the whole target (language) is to be excluded
+    // Example: { node: true }
+    if (exclude.value[target.key] === true) {
+      return []
+    }
+
+    // Filter out excluded clients within the target
+    // Example: { node: ['fetch', 'xhr'] }
+    if (Array.isArray(exclude.value[target.key])) {
+      target.clients = target.clients.filter((client) => {
+        return !(
+          // @ts-expect-error We checked whether it’s an Array already.
+          exclude.value[target.key].includes(client.key)
+        )
+      })
+    }
+
+    // Remove targets that don’t have any clients left
+    if (!target?.clients?.length) {
+      return []
+    }
+
+    return [target]
+  })
+}
+
+const availableTargets = computed(() => {
   const targets = allTargets()
 
-  // Add undici to node (@scalar/snippetz)
+  // Add undici to node (comes from @scalar/snippetz)
   targets
     .find((target) => target.key === 'node')
     ?.clients.unshift({
@@ -29,65 +69,10 @@ watchEffect(() => {
       title: 'undici',
     })
 
-  cachedTargets.value = filterHiddenClients(targets, excludedClients)
+  return filterHiddenClients(targets, excludedClients)
 })
 
-export function filterHiddenClients(
-  targets: AvailableTarget[],
-  exclude: Ref<HiddenClients>,
-): AvailableTarget[] {
-  // @ts-expect-error We checked whether it has content already.
-  return (
-    targets
-      // Remove all targets that are excluded (`node: false`)
-      .filter((target) => {
-        // Make sure it’s object with `target.key` as an index
-        if (Array.isArray(exclude.value)) {
-          return true
-        }
-
-        return !(exclude.value[target.key] === true)
-      })
-      // Remove all clients that are excluded (`node: ['fetch']`)
-      .map((target: AvailableTarget) => {
-        // NOTE: This is for backwards compatibility with the previous behavior,
-        //  If exclude is an array, it will exclude the matching clients from all targets.
-        // Example: { node: ['fetch', 'xhr'] }
-        if (Array.isArray(exclude.value)) {
-          target.clients = target.clients.filter(
-            // @ts-expect-error We checked whether it’s an Array already.
-            (client) => !exclude.value.includes(client.key),
-          )
-
-          return target
-        }
-
-        // Determine if the whole target (language) is to be excluded
-        // Example: { node: true }
-        if (exclude.value[target.key] === true) {
-          return null // Exclude the entire target by returning null
-        }
-
-        // Filter out excluded clients within the target
-        if (Array.isArray(exclude.value[target.key])) {
-          target.clients = target.clients.filter((client) => {
-            return !(
-              // @ts-expect-error We checked whether it’s an Array already.
-              exclude.value[target.key].includes(client.key)
-            )
-          })
-        }
-
-        return target
-      })
-      .filter((target) => target?.clients?.length)
-  )
-}
-
 export function useHttpClients() {
-  // Use computed to provide a reactive interface to the cached targets
-  const availableTargets = computed(() => cachedTargets.value)
-
   return {
     availableTargets,
     excludedClients: readonly(excludedClients),

--- a/packages/api-reference/src/hooks/useHttpClients.ts
+++ b/packages/api-reference/src/hooks/useHttpClients.ts
@@ -91,6 +91,6 @@ export function useHttpClients() {
   return {
     availableTargets,
     excludedClients: readonly(excludedClients),
-    setExcludedClients: (v: string[]) => (excludedClients.value = v),
+    setExcludedClients: (v: HiddenClients) => (excludedClients.value = v),
   }
 }

--- a/packages/api-reference/src/hooks/useHttpClients.ts
+++ b/packages/api-reference/src/hooks/useHttpClients.ts
@@ -1,41 +1,85 @@
 import { availableTargets as allTargets } from 'httpsnippet-lite'
-import { computed, readonly, ref, watchEffect } from 'vue'
+import type { AvailableTarget } from 'httpsnippet-lite/dist/types/helpers/utils'
+import type {
+  ClientInfo,
+  TargetInfo,
+} from 'httpsnippet-lite/dist/types/targets/targets'
+import { type Ref, computed, readonly, ref, watchEffect } from 'vue'
 
-const DEFAULT_EXCLUDED_CLIENTS = ['unirest'] as const
+type ExcludedClientsConfiguration =
+  // Exclude whole targets or just specific clients
+  | Partial<Record<TargetInfo['key'], boolean | ClientInfo['key'][]>>
+  // Backwards compatibility with the previous behavior ['fetch', 'xhr']
+  | ClientInfo['key'][]
 
-const excludedClients = ref<string[]>([...DEFAULT_EXCLUDED_CLIENTS])
+const DEFAULT_EXCLUDED_CLIENTS = {
+  // node: false,
+  // TODO: Unirest
+} as ExcludedClientsConfiguration
+
+const excludedClients = ref<ExcludedClientsConfiguration>({
+  ...DEFAULT_EXCLUDED_CLIENTS,
+})
 
 // Use a reactive reference for caching the computed targets
-const cachedTargets = ref([])
+const cachedTargets = ref<AvailableTarget[]>([])
 
 // Watch for changes in excludedClients and update the cachedTargets accordingly
 watchEffect(() => {
-  cachedTargets.value = allTargets()
-    .map((target) => {
-      // NOTE: This is for backwards compatibility with the previous behavior,
-      //  If excludedClients is an array, it will exclude the matching clients from all targets.
-      if (Array.isArray(excludedClients.value)) {
-        target.clients = target.clients.filter(
-          (client) => !excludedClients.value.includes(client.key),
-        )
-      }
-
-      // Determine if the whole target (language) is to be excluded
-      if (excludedClients.value[target.key] === true) {
-        return null // Exclude the entire target by returning null
-      }
-
-      // Filter out excluded clients within the target
-      if (Array.isArray(excludedClients.value[target.key])) {
-        target.clients = target.clients.filter(
-          (client) => !excludedClients.value[target.key].includes(client.key),
-        )
-      }
-
-      return target
-    })
-    .filter((target) => target?.clients.length)
+  cachedTargets.value = filterHiddenClients(allTargets(), excludedClients)
 })
+
+export function filterHiddenClients(
+  targets: AvailableTarget[],
+  exclude: Ref<ExcludedClientsConfiguration>,
+): AvailableTarget[] {
+  // @ts-expect-error We checked whether it has content already.
+  return (
+    targets
+      // Remove all targets that are excluded (`node: false`)
+      .filter((target) => {
+        // Make sure it’s object with `target.key` as an index
+        if (Array.isArray(exclude.value)) {
+          return true
+        }
+
+        return !(exclude.value[target.key] === true)
+      })
+      // Remove all clients that are excluded (`node: ['fetch']`)
+      .map((target: AvailableTarget) => {
+        // NOTE: This is for backwards compatibility with the previous behavior,
+        //  If exclude is an array, it will exclude the matching clients from all targets.
+        // Example: { node: ['fetch', 'xhr'] }
+        if (Array.isArray(exclude.value)) {
+          target.clients = target.clients.filter(
+            // @ts-expect-error We checked whether it’s an Array already.
+            (client) => !exclude.value.includes(client.key),
+          )
+
+          return target
+        }
+
+        // Determine if the whole target (language) is to be excluded
+        // Example: { node: true }
+        if (exclude.value[target.key] === true) {
+          return null // Exclude the entire target by returning null
+        }
+
+        // Filter out excluded clients within the target
+        if (Array.isArray(exclude.value[target.key])) {
+          target.clients = target.clients.filter((client) => {
+            return !(
+              // @ts-expect-error We checked whether it’s an Array already.
+              exclude.value[target.key].includes(client.key)
+            )
+          })
+        }
+
+        return target
+      })
+      .filter((target) => target?.clients?.length)
+  )
+}
 
 export function useHttpClients() {
   // Use computed to provide a reactive interface to the cached targets

--- a/packages/api-reference/src/hooks/useHttpClients.ts
+++ b/packages/api-reference/src/hooks/useHttpClients.ts
@@ -1,22 +1,14 @@
 import { availableTargets as allTargets } from 'httpsnippet-lite'
 import type { AvailableTarget } from 'httpsnippet-lite/dist/types/helpers/utils'
-import type {
-  ClientInfo,
-  TargetInfo,
-} from 'httpsnippet-lite/dist/types/targets/targets'
 import { type Ref, computed, readonly, ref, watchEffect } from 'vue'
 
-type ExcludedClientsConfiguration =
-  // Exclude whole targets or just specific clients
-  | Partial<Record<TargetInfo['key'], boolean | ClientInfo['key'][]>>
-  // Backwards compatibility with the previous behavior ['fetch', 'xhr']
-  | ClientInfo['key'][]
+import type { HiddenClients } from '../types'
 
 const DEFAULT_EXCLUDED_CLIENTS = {
   node: ['unirest'],
-} as ExcludedClientsConfiguration
+} as HiddenClients
 
-const excludedClients = ref<ExcludedClientsConfiguration>({
+const excludedClients = ref<HiddenClients>({
   ...DEFAULT_EXCLUDED_CLIENTS,
 })
 
@@ -30,7 +22,7 @@ watchEffect(() => {
 
 export function filterHiddenClients(
   targets: AvailableTarget[],
-  exclude: Ref<ExcludedClientsConfiguration>,
+  exclude: Ref<HiddenClients>,
 ): AvailableTarget[] {
   // @ts-expect-error We checked whether it has content already.
   return (

--- a/packages/api-reference/src/hooks/useHttpClients.ts
+++ b/packages/api-reference/src/hooks/useHttpClients.ts
@@ -13,8 +13,7 @@ type ExcludedClientsConfiguration =
   | ClientInfo['key'][]
 
 const DEFAULT_EXCLUDED_CLIENTS = {
-  // node: false,
-  // TODO: Unirest
+  node: ['unirest'],
 } as ExcludedClientsConfiguration
 
 const excludedClients = ref<ExcludedClientsConfiguration>({

--- a/packages/api-reference/src/hooks/useHttpClients.ts
+++ b/packages/api-reference/src/hooks/useHttpClients.ts
@@ -12,14 +12,29 @@ const cachedTargets = ref([])
 watchEffect(() => {
   cachedTargets.value = allTargets()
     .map((target) => {
-      // Filter out excluded clients
-      target.clients = target.clients.filter(
-        (client) => !excludedClients.value.includes(client.key),
-      )
+      // NOTE: This is for backwards compatibility with the previous behavior,
+      //  If excludedClients is an array, it will exclude the matching clients from all targets.
+      if (Array.isArray(excludedClients.value)) {
+        target.clients = target.clients.filter(
+          (client) => !excludedClients.value.includes(client.key),
+        )
+      }
+
+      // Determine if the whole target (language) is to be excluded
+      if (excludedClients.value[target.key] === true) {
+        return null // Exclude the entire target by returning null
+      }
+
+      // Filter out excluded clients within the target
+      if (Array.isArray(excludedClients.value[target.key])) {
+        target.clients = target.clients.filter(
+          (client) => !excludedClients.value[target.key].includes(client.key),
+        )
+      }
 
       return target
     })
-    .filter((target) => target.clients.length)
+    .filter((target) => target?.clients.length)
 })
 
 export function useHttpClients() {

--- a/packages/api-reference/src/stores/useHttpClientStore.ts
+++ b/packages/api-reference/src/stores/useHttpClientStore.ts
@@ -1,4 +1,8 @@
 import type { TargetId } from 'httpsnippet-lite'
+import type {
+  ClientInfo,
+  TargetInfo,
+} from 'httpsnippet-lite/dist/types/targets/targets'
 import { computed, reactive, readonly } from 'vue'
 
 import { objectMerge } from '../helpers'

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -7,6 +7,10 @@ import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import type { ThemeId } from '@scalar/themes'
 import type { UseSeoMetaInput } from '@unhead/schema'
 import type { HarRequest } from 'httpsnippet-lite'
+import type {
+  ClientInfo,
+  TargetInfo,
+} from 'httpsnippet-lite/dist/types/targets/targets'
 import type { Slot } from 'vue'
 
 export type ReferenceProps = {
@@ -19,6 +23,12 @@ export type ReferenceLayoutProps = {
   rawSpec: string
   isDark: boolean
 }
+
+export type HiddenClients =
+  // Exclude whole targets or just specific clients
+  | Partial<Record<TargetInfo['key'], boolean | ClientInfo['key'][]>>
+  // Backwards compatibility with the previous behavior ['fetch', 'xhr']
+  | ClientInfo['key'][]
 
 export type ReferenceConfiguration = {
   /** A string to use one of the color presets */
@@ -83,9 +93,8 @@ export type ReferenceConfiguration = {
   /**
    * List of httpsnippet clients to hide from the clients menu
    * By default hides Unirest, pass `[]` to show all clients
-   * @see https://github.com/Kong/httpsnippet/wiki/Targets
    */
-  hiddenClients?: string[]
+  hiddenClients?: HiddenClients
   /** Custom CSS to be added to the page */
   customCss?: string
   /** onSpecUpdate is fired on spec/swagger content change */


### PR DESCRIPTION
**Problem**
Because the "allTargets()..."-code is defined outside of the usehttpClients() hook, it will only run once (which was probably done due to performance benefits), however this breaks this feature as only the DEFAULT_EXCLUDED_CLIENTS will be applied the first time this runs, and the next time this is meant to run to filter the targets and clients based on the provided user configuration, it is not updated, aka, doesnt work, this is references in #1250.

**Solution**

This commit fixes the bug, and retains the performance benefit by caching the target list using watchEffect to only update/recompute the target list when the configuration changes.

**Further improvements** 

I'm working on an additional fix, that will add the ability to specify clients in specific targets to ignore/include, since the behaviour right now will hide all the "curl"-s instead of only hiding the "php"-curl if you wanted to do so. 


Still WIP, but feedback and pointers welcome, struggling a bit with TypeScript errors, even though running the embedding demo with this config works in the browser:

```html
const configuration = reactive<ReferenceConfiguration>({
  proxy: import.meta.env.VITE_REQUEST_PROXY_URL,
  isEditable: false,
  spec: { content },
  hiddenClients: {
    php: true, // Example: Exclude all PHP clients
    python: true, // Example: Exclude all Python clients
    c: ['libcurl'],
    node: ['fetch'], // We expect the (browser) javascript fetch client to still be available
    javascript: ['jquery', 'xhr'], // Exclude specific JavaScript clients
  },
})

```