### PR TITLE
feat: path routing

### DIFF
--- a/.changeset/neat-horses-allow.md
+++ b/.changeset/neat-horses-allow.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/oas-utils": patch
+---
+
+feat: add path routing option to references

--- a/.changeset/slow-goats-confess.md
+++ b/.changeset/slow-goats-confess.md
@@ -1,0 +1,5 @@
+---
+"@scalar/components": patch
+---
+
+feat: add better SSR support to ScalarCodeBlock

--- a/examples/web/src/pages/StandaloneApiReferencePage.vue
+++ b/examples/web/src/pages/StandaloneApiReferencePage.vue
@@ -11,6 +11,12 @@ import content from '../fixtures/petstorev3.json'
 const configuration = reactive<ReferenceConfiguration>({
   proxy: import.meta.env.VITE_REQUEST_PROXY_URL,
   isEditable: false,
+  // Add path routing option
+  ...(window.location.pathname.startsWith('/path-routing')
+    ? {
+        pathRouting: { basePath: '/path-routing' },
+      }
+    : {}),
   spec: { content },
 })
 </script>

--- a/examples/web/src/pages/StartPage.vue
+++ b/examples/web/src/pages/StartPage.vue
@@ -47,6 +47,12 @@ import PageLink from '../components/PageLink.vue'
           API documentation within a pre-existing website.
         </template>
       </PageLink>
+      <PageLink to="path-routing-api-reference">
+        <template #title>API Reference with Path Routing</template>
+        <template #description>
+          Standalone API Reference with path routing instead of hash routing
+        </template>
+      </PageLink>
     </div>
     <h1>@scalar/api-client</h1>
     <div class="page-links">

--- a/examples/web/src/routes.ts
+++ b/examples/web/src/routes.ts
@@ -19,6 +19,11 @@ export const routes = [
     component: StandaloneApiReferencePage,
   },
   {
+    path: '/path-routing/:custom(.*)?',
+    name: 'path-routing-api-reference',
+    component: StandaloneApiReferencePage,
+  },
+  {
     path: '/classic-api-reference',
     name: 'classic-api-reference',
     component: ClassicApiReferencePage,

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -117,7 +117,7 @@ onMounted(() => {
 
   // This is what updates the hash ref from hash changes
   window.onhashchange = async () =>
-    scrollToSection(window.location.hash.replace(/^#/, ''))
+    scrollToSection(decodeURIComponent(window.location.hash.replace(/^#/, '')))
 
   // Handle back for path routing
   window.onpopstate = async () =>

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -11,6 +11,7 @@ import { useDebounceFn, useMediaQuery, useResizeObserver } from '@vueuse/core'
 import {
   computed,
   getCurrentInstance,
+  onBeforeMount,
   onMounted,
   onServerPrefetch,
   provide,
@@ -24,6 +25,8 @@ import {
   HIDE_DOWNLOAD_BUTTON_SYMBOL,
   downloadSpecBus,
   downloadSpecFile,
+  scrollToId,
+  sleep,
 } from '../helpers'
 import { useNavState, useSidebar } from '../hooks'
 import { useToasts } from '../hooks/useToasts'
@@ -79,29 +82,47 @@ const {
   setCollapsedSidebarItem,
   hideModels,
 } = useSidebar()
-const { enableHashListener, getSectionId, getTagId, hash } = useNavState()
+const {
+  getPathRoutingId,
+  getSectionId,
+  getTagId,
+  hash,
+  isIntersectionEnabled,
+  pathRouting,
+  updateHash,
+} = useNavState()
 
-enableHashListener()
+pathRouting.value = props.configuration.pathRouting
+
+// Ideally this triggers absolutely first on the client so we can set hash value
+onBeforeMount(() => {
+  updateHash()
+})
+
+// Disables intersection observer and scrolls to section
+const scrollToSection = async (id?: string) => {
+  isIntersectionEnabled.value = false
+  updateHash()
+
+  if (id) scrollToId(id)
+  else documentEl.value?.scrollTo(0, 0)
+
+  await sleep(100)
+  isIntersectionEnabled.value = true
+}
 
 onMounted(() => {
-  if (!hash.value) {
-    document.querySelector('#tippy')?.scrollTo({
-      top: 0,
-      left: 0,
-    })
-  }
-
-  // Ensure section is open for SSG
-  const firstTag = props.parsedSpec.tags?.[0]
-  let sectionId: string | null = null
-
-  if (hash.value) sectionId = getSectionId(hash.value)
-  else if (firstTag) sectionId = getTagId(firstTag)
-
-  if (sectionId) setCollapsedSidebarItem(sectionId, true)
-
   // Enable the spec download event bus
   downloadSpecBus.on(() => downloadSpecFile(props.rawSpec))
+
+  // This is what updates the hash ref from hash changes
+  window.onhashchange = async () =>
+    scrollToSection(window.location.hash.replace(/^#/, ''))
+
+  // Handle back for path routing
+  window.onpopstate = async () =>
+    pathRouting.value &&
+    scrollToSection(getPathRoutingId(window.location.pathname))
 })
 
 const showRenderedContent = computed(
@@ -129,15 +150,33 @@ const referenceSlotProps = computed<ReferenceSlotProps>(() => ({
 
 // Initialize the server state
 onServerPrefetch(() => {
-  const firstTag = props.parsedSpec.tags?.[0]
-  if (firstTag) setCollapsedSidebarItem(getTagId(firstTag), true)
-
   const ctx = useSSRContext<SSRState>()
   if (!ctx) return
 
   ctx.payload.data ||= defaultStateFactory()
-  ctx.payload.data['useSidebarContent-collapsedSidebarItems'] =
-    collapsedSidebarItems
+
+  // Set initial hash value
+  if (props.configuration.pathRouting) {
+    const id = getPathRoutingId(ctx.url)
+    hash.value = id
+    ctx.payload.data.hash = id
+
+    // For sidebar items we need to reset the state as it persists between requests
+    // This is a temp hack, need to come up with a better solution
+    for (const key in collapsedSidebarItems) {
+      if (Object.hasOwn(collapsedSidebarItems, key))
+        delete collapsedSidebarItems[key]
+    }
+
+    if (id) {
+      setCollapsedSidebarItem(getSectionId(id), true)
+    } else {
+      const firstTag = props.parsedSpec.tags?.[0]
+      if (firstTag) setCollapsedSidebarItem(getTagId(firstTag), true)
+    }
+    ctx.payload.data['useSidebarContent-collapsedSidebarItems'] =
+      collapsedSidebarItems
+  }
 })
 
 /**

--- a/packages/api-reference/src/components/Content/Introduction/Description.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Description.vue
@@ -51,15 +51,24 @@ const sections = computedAsync(
   ssrState[ssrStateKey] ?? [], // initial state
 )
 
-const { getHeadingId, hash, isIntersectionEnabled } = useNavState()
+const { getHeadingId, hash, isIntersectionEnabled, pathRouting } = useNavState()
 
-function handleScroll(headingId: string) {
+function handleScroll(headingId = '') {
   if (!isIntersectionEnabled.value) return
+
+  const newUrl = new URL(window.location.href)
+
+  // If we are pathrouting, set path instead of hash
+  if (pathRouting.value) {
+    newUrl.pathname = pathRouting.value.basePath + '/' + headingId
+  } else {
+    newUrl.hash = headingId
+  }
+  hash.value = headingId
 
   // We use replaceState so we don't trigger the url hash watcher and trigger a scroll
   // this is why we set the hash value directly
-  window.history.replaceState({}, '', `#${headingId}`)
-  hash.value = headingId ?? ''
+  window.history.replaceState({}, '', newUrl)
 }
 
 // SSR hack - waits for the computedAsync to complete then we save the state

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -40,16 +40,14 @@ const props = withDefaults(
 )
 
 const hideTag = ref(false)
-const isLoading = ref(
-  typeof window !== 'undefined' &&
-    !!window.location.hash &&
-    props.layout !== 'accordion',
-)
+
 const tags = ref<(TagType & { lazyOperations: TransformedOperation[] })[]>([])
 const models = ref<string[]>([])
 
 const { getModelId, getSectionId, getTagId, hash, isIntersectionEnabled } =
   useNavState()
+
+const isLoading = ref(props.layout !== 'accordion' && hash.value)
 
 // Ensure we have a spec loaded
 watch(

--- a/packages/api-reference/src/components/Section/Section.vue
+++ b/packages/api-reference/src/components/Section/Section.vue
@@ -7,7 +7,7 @@ const props = defineProps<{
   label?: string
 }>()
 
-const { getSectionId, hash, isIntersectionEnabled } = useNavState()
+const { getSectionId, hash, isIntersectionEnabled, pathRouting } = useNavState()
 const { setCollapsedSidebarItem } = useSidebar()
 
 function handleScroll() {
@@ -17,8 +17,15 @@ function handleScroll() {
   // this is why we set the hash value directly
   const newUrl = new URL(window.location.href)
   const id = props.id ?? ''
-  newUrl.hash = id
+
+  // If we are pathrouting, set path instead of hash
+  if (pathRouting.value) {
+    newUrl.pathname = pathRouting.value.basePath + '/' + id
+  } else {
+    newUrl.hash = id
+  }
   hash.value = id
+
   window.history.replaceState({}, '', newUrl)
 
   // Open models on scroll

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 
 import { sleep } from '../../helpers'
 import { useNavState, useSidebar } from '../../hooks'
@@ -28,7 +28,12 @@ const disableScroll = ref(true)
 // but not when we click, only on scroll.
 // Also disable scroll on expansion of sidebar tag
 watch(hash, (id) => {
-  if (!isIntersectionEnabled.value || disableScroll.value) return
+  if (
+    !isIntersectionEnabled.value ||
+    disableScroll.value ||
+    typeof window === 'undefined'
+  )
+    return
   scrollSidebar(id)
 })
 
@@ -55,9 +60,7 @@ const scrollSidebar = (id: string) => {
 
 // TODO timeout is due to sidebar section opening time
 onMounted(() => {
-  setTimeout(() => {
-    scrollSidebar(window.location.hash.replace(/^#/, ''))
-  }, 500)
+  setTimeout(() => scrollSidebar(hash.value), 500)
   disableScroll.value = false
 })
 </script>

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -77,7 +77,7 @@ const getSectionId = (hashStr = hash.value) => {
 const updateHash = () => {
   hash.value = pathRouting.value
     ? getPathRoutingId(window.location.pathname)
-    : window.location.hash.replace(/^#/, '')
+    : decodeURIComponent(window.location.hash.replace(/^#/, ''))
 }
 
 /**

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -1,12 +1,18 @@
-import type { Heading, TransformedOperation } from '@scalar/oas-utils'
+import {
+  type Heading,
+  type TransformedOperation,
+  ssrState,
+} from '@scalar/oas-utils'
 import { slug } from 'github-slugger'
-import { onMounted, ref } from 'vue'
+import { ref } from 'vue'
 
-import { scrollToId, sleep } from '../helpers'
-import type { Tag } from '../types'
+import type { PathRouting, Tag } from '../types'
 
 // Keeps track of the URL hash without the #
-const hash = ref('')
+const hash = ref(ssrState.hash ?? '')
+
+// Are we using path routing
+const pathRouting = ref<PathRouting | undefined>()
 
 // To disable the intersection observer on click
 const isIntersectionEnabled = ref(false)
@@ -20,6 +26,13 @@ const getHeadingId = (heading: Heading) => {
   }
 
   return ''
+}
+
+const getPathRoutingId = (pathName: string) => {
+  if (!pathRouting.value) return ''
+
+  const reggy = new RegExp('^' + pathRouting.value?.basePath + '/?')
+  return decodeURIComponent(pathName.replace(reggy, ''))
 }
 
 const getWebhookId = (name?: string, httpVerb?: string) => {
@@ -61,25 +74,11 @@ const getSectionId = (hashStr = hash.value) => {
 }
 
 // Update the reactive hash state
-const updateHash = () =>
-  (hash.value = decodeURIComponent(window.location.hash.replace(/^#/, '')))
-
-// We should call this as little as possible, ideally once
-const enableHashListener = () =>
-  onMounted(async () => {
-    updateHash()
-    window.onhashchange = async () => {
-      isIntersectionEnabled.value = false
-      updateHash()
-
-      // TODO: we should be able to remove this once we find the cause
-      // for some reason pressing back doesn't always scroll to the correct section
-      scrollToId(hash.value)
-
-      await sleep(100)
-      isIntersectionEnabled.value = true
-    }
-  })
+const updateHash = () => {
+  hash.value = pathRouting.value
+    ? getPathRoutingId(window.location.pathname)
+    : window.location.hash.replace(/^#/, '')
+}
 
 /**
  * Hook which provides reactive hash state from the URL
@@ -87,20 +86,17 @@ const enableHashListener = () =>
  *
  * isIntersectionEnabled is a hack to prevent intersection observer from triggering
  * when clicking on sidebar links or going backwards
- *
- *
- * @param hasLifecyle - we cannot use lifecycle hooks when called from another composable, this prevents that
  */
-export const useNavState = () => {
-  return {
-    hash,
-    getWebhookId,
-    getModelId,
-    getHeadingId,
-    getOperationId,
-    getSectionId,
-    getTagId,
-    isIntersectionEnabled,
-    enableHashListener,
-  }
-}
+export const useNavState = () => ({
+  hash,
+  getWebhookId,
+  getModelId,
+  getHeadingId,
+  getOperationId,
+  getPathRoutingId,
+  getSectionId,
+  getTagId,
+  isIntersectionEnabled,
+  pathRouting,
+  updateHash,
+})

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -248,9 +248,9 @@ export function useSidebar(options?: { parsedSpec: Spec }) {
     watch(
       () => parsedSpec.value?.tags?.length,
       () => {
-        if (window?.location.hash) {
-          const hashSectionId = getSectionId(window.location.hash)
-          if (!hashSectionId) setCollapsedSidebarItem(hashSectionId, true)
+        if (hash.value) {
+          const hashSectionId = getSectionId(hash.value)
+          if (hashSectionId) setCollapsedSidebarItem(hashSectionId, true)
         } else {
           const firstTag = parsedSpec.value?.tags?.[0]
           if (firstTag) setCollapsedSidebarItem(getTagId(firstTag), true)

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -1,6 +1,7 @@
 export { default as ApiClientModal } from './components/ApiClientModal.vue'
 export { default as ApiReference } from './components/ApiReference.vue'
 export { default as ApiReferenceLayout } from './components/ApiReferenceLayout.vue'
+export { default as ModernLayout } from './components/Layouts/ModernLayout.vue'
 export { default as RenderedReference } from './components/Content/Content.vue'
 export { default as SearchModal } from './components/SearchModal.vue'
 export { default as SearchButton } from './components/SearchButton.vue'

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -92,6 +92,21 @@ export type ReferenceConfiguration = {
   onSpecUpdate?: (spec: string) => void
   /** Prefill authentication */
   authentication?: Partial<AuthenticationState>
+  /**
+   * Route using paths instead of hashes, your server MUST support this
+   * for example vue router needs a catch all so any subpaths are included
+   *
+   * @example
+   * '/standalone-api-reference/:custom(.*)?'
+   *
+   * @experimental
+   * @default undefined
+   */
+  pathRouting?: PathRouting
+}
+
+export type PathRouting = {
+  basePath: string
 }
 
 export type SpecConfiguration = {


### PR DESCRIPTION
This PR adds path routing as an option. It also adds a page to the start page for testing. Currently I have it pointing to the other PR since it builds off of it, but once its merged can re-base from main.

![image](https://github.com/scalar/scalar/assets/2039539/34a6f328-bb47-4b74-8ba3-fde21f4912d5)
