### PR TITLE
fix: endpoint navigation

### DIFF
--- a/.changeset/eighty-scissors-pay.md
+++ b/.changeset/eighty-scissors-pay.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: endpoint navigation

--- a/packages/api-reference/src/components/Content/Tag/Endpoints.vue
+++ b/packages/api-reference/src/components/Content/Tag/Endpoints.vue
@@ -17,19 +17,21 @@ import {
 
 const props = defineProps<{ id?: string; tag: Tag }>()
 
+const emit = defineEmits<{
+  (event: 'observeAndNavigate', value: string): void
+}>()
+
 const { getOperationId, getTagId } = useNavState()
 const { setCollapsedSidebarItem } = useSidebar()
 
-// We need to make sure the endpoint tag is open before
-// we try to scroll to it
-// we wait for next render after we open the tag
+const navigateToOperation = (operationId: string) => {
+  emit('observeAndNavigate', operationId)
+}
+
 // TODO in V2 we need to do the same loading trick as the initial load
 async function scrollHandler(operation: TransformedOperation) {
+  navigateToOperation(getOperationId(operation, props.tag))
   setCollapsedSidebarItem(getTagId(props.tag), true)
-
-  setTimeout(() => {
-    window.location.href = `#${getOperationId(operation, props.tag)}`
-  }, 0)
 }
 </script>
 <template>

--- a/packages/api-reference/src/components/Content/Tag/Tag.vue
+++ b/packages/api-reference/src/components/Content/Tag/Tag.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+
 import { useNavState, useSidebar } from '../../../hooks'
 import type { Spec, Tag } from '../../../types'
 import { SectionContainer } from '../../Section'
 import ShowMoreButton from '../../ShowMoreButton.vue'
 import Endpoints from './Endpoints.vue'
+import { observeMutations } from './mutationObserver'
 
 const props = defineProps<{
   id?: string
   tag: Tag
   spec: Spec
 }>()
+
+const sectionContainerRef = ref<HTMLElement | null>(null)
 
 const { collapsedSidebarItems } = useSidebar()
 const { getTagId } = useNavState()
@@ -18,13 +23,43 @@ const moreThanOneDefaultTag = (tag: Tag) =>
   props.spec.tags?.length !== 1 ||
   tag?.name !== 'default' ||
   tag?.description !== ''
+
+const redirectToOperation = (operationId: string) => {
+  window.location.href = `#${operationId}`
+}
+
+const observeSectionMutations = (operationId: string) => {
+  observeMutations(sectionContainerRef, (mutations, observer) => {
+    mutations.forEach((mutation) => {
+      const operationIsAdded = Array.from(mutation.addedNodes).some((node) => {
+        return node instanceof HTMLElement && node.id === operationId
+      })
+      if (operationIsAdded) {
+        redirectToOperation(operationId)
+        observer.disconnect()
+      }
+    })
+  })
+}
+
+const observeAndNavigate = (operationId: string) => {
+  const operationIsVisible = document.getElementById(operationId)
+  if (!operationIsVisible) {
+    observeSectionMutations(operationId)
+  } else {
+    redirectToOperation(operationId)
+  }
+}
 </script>
 <template>
-  <SectionContainer class="tag-section-container">
+  <SectionContainer
+    ref="sectionContainerRef"
+    class="tag-section-container">
     <Endpoints
       v-if="moreThanOneDefaultTag(tag)"
       :id="id"
-      :tag="tag" />
+      :tag="tag"
+      @observeAndNavigate="observeAndNavigate" />
     <ShowMoreButton
       v-if="!collapsedSidebarItems[getTagId(tag)] && tag.operations?.length > 1"
       :id="id ?? ''" />

--- a/packages/api-reference/src/components/Content/Tag/mutationObserver.ts
+++ b/packages/api-reference/src/components/Content/Tag/mutationObserver.ts
@@ -1,0 +1,9 @@
+import { useMutationObserver } from '@vueuse/core'
+import { type Ref } from 'vue'
+
+export const observeMutations = (
+  target: Ref<HTMLElement | null>,
+  callback: MutationCallback,
+) => {
+  useMutationObserver(target, callback, { childList: true, subtree: true })
+}


### PR DESCRIPTION
**Problem**
when a section is closed and user clicks on an operation, it opens the section and navigates toward the first operation of the list instead of the selected one.

[as seen here →](https://docs.scalar.com/project-default/version-default/reference-YCSmGxwEOVk-0oBSMCo-1#tag/store)

**Solution**
this pr is a first attempt to follow the commented instructions, in order to make sure the endpoint is accessible before navigating towards it by using the [mutation observer api](https://vueuse.org/core/useMutationObserver/) from vueuse.