### PR TITLE
fix: show example picker if the list only has one example

### DIFF
--- a/.changeset/seven-actors-film.md
+++ b/.changeset/seven-actors-film.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: show example picker if the list only has one example

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -41,9 +41,7 @@ const orderedStatusCodes = computed(() => {
 })
 
 const hasMultipleExamples = computed<boolean>(
-  () =>
-    !!currentJsonResponse.value.examples &&
-    Object.keys(currentJsonResponse.value.examples).length > 1,
+  () => !!currentJsonResponse.value.examples,
 )
 
 // Keep track of the current selected tab

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -69,7 +69,8 @@ const currentResponseWithExample = computed(() => ({
   ...currentJsonResponse.value,
   example:
     hasMultipleExamples.value && selectedExampleKey.value
-      ? currentJsonResponse.value.examples[selectedExampleKey.value]
+      ? currentJsonResponse.value.examples[selectedExampleKey.value].value ??
+        currentJsonResponse.value.examples[selectedExampleKey.value]
       : currentJsonResponse.value.example,
 }))
 


### PR DESCRIPTION
Fixes #1406

### Test Spec

```json
{
  "openapi": "3.0.0",
  "components": {
    "examples": {},
    "headers": {},
    "parameters": {},
    "requestBodies": {},
    "responses": {}
  },
  "paths": {
    "/example": {
      "get": {
        "summary": "Single example in `examples`",
        "responses": {
          "200": {
            "description": "Ok",
            "content": {
              "application/json": {
                "schema": {
                  "type": "object"
                },
                "examples": {
                  "one": {
                    "value": {
                      "hello": "example nested"
                    }
                  }
                }
              }
            }
          }
        }
      }
    },
    "/example2": {
      "get": {
        "summary": "Multiple examples in `examples`",
        "responses": {
          "200": {
            "description": "Ok",
            "content": {
              "application/json": {
                "schema": {
                  "type": "object"
                },
                "examples": {
                  "one": {
                    "value": {
                      "hello": "example"
                    }
                  },
                  "two": {
                    "value": {
                      "hello": "example"
                    }
                  }
                }
              }
            }
          }
        }
      }
    },
    "/example3": {
      "get": {
        "summary": "Single example",
        "responses": {
          "200": {
            "description": "Ok",
            "content": {
              "application/json": {
                "schema": {
                  "type": "object"
                },
                "example": {
                      "hello": "example"
                }
              }
            }
          }
        }
      }
    }
  }
}
```

## Before (Main)

![Google Chrome-2024-04-09-12-51-46@2x](https://github.com/scalar/scalar/assets/6374090/7940aa24-b38a-44d6-8cc4-e276aa849f3a)


## After (This PR)

![Google Chrome-2024-04-09-12-50-48@2x](https://github.com/scalar/scalar/assets/6374090/7aa34442-a33b-4484-b0f7-e6d8c04565e2)

