### PR TITLE
fix: content modal history style

### DIFF
--- a/.changeset/loud-glasses-hang.md
+++ b/.changeset/loud-glasses-hang.md
@@ -1,0 +1,5 @@
+---
+"@scalar/use-modal": patch
+---
+
+fix: modal content history header

--- a/packages/use-modal/src/components/FlowModal.vue
+++ b/packages/use-modal/src/components/FlowModal.vue
@@ -98,6 +98,9 @@ withDefaults(
 .dark-mode .modal:before {
   background: #1a1a1a;
 }
+.dark-mode .modal-content-history:before {
+  background: inherit;
+}
 .light-mode .modal:before {
   background: #fff;
 }


### PR DESCRIPTION
**Problem**
in darkmode when a user open the request history modal, the header displays a background. according to #177 i believe this shouldn't be the case. hope i read you right @cameronrohani :). 

<img width="600" alt="before" src="https://github.com/scalar/scalar/assets/14966155/edb028be-4fb0-4ff1-b369-9b35688055bd">

**Solution**
use inherit background in modal header for darkmode.

<img width="600" alt="after" src="https://github.com/scalar/scalar/assets/14966155/36353e29-0e6b-4200-8f79-0ef872ba219f">