### PR TITLE
fix: hide header when no mobile sidebar

### DIFF
--- a/.changeset/neat-lions-yawn.md
+++ b/.changeset/neat-lions-yawn.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: hide mobile header when showSidebar: false

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -33,12 +33,17 @@ watch(hash, (newHash, oldHash) => {
 </script>
 <template>
   <ApiReferenceLayout
-    :class="{ 'scalar-api-references-standalone-mobile': isMobile }"
+    :class="{
+      'scalar-api-references-standalone-mobile':
+        isMobile && configuration.showSidebar,
+    }"
     :configuration="configuration"
     :parsedSpec="parsedSpec"
     :rawSpec="rawSpec">
     <template #header>
-      <MobileHeader v-model:open="isSidebarOpen" />
+      <MobileHeader
+        v-if="props.configuration.showSidebar"
+        v-model:open="isSidebarOpen" />
     </template>
     <template #sidebar-start="{ spec }">
       <div class="scalar-api-references-standalone-search">

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -33,7 +33,9 @@ watch(hash, (newHash, oldHash) => {
 </script>
 <template>
   <ApiReferenceLayout
-    class="scalar-api-references-standalone-mobile"
+    :class="{
+      'scalar-api-references-standalone-mobile': configuration.showSidebar,
+    }"
     :configuration="configuration"
     :parsedSpec="parsedSpec"
     :rawSpec="rawSpec">


### PR DESCRIPTION
closes #1421 

I couldn't replicate the sidebar showing, but I did see the header was still there. Just hid it when `showSidebar: false`. Wanna make sure this has no knock-on effects