### PR TITLE
fix: intersection observer detection

### DIFF
--- a/.changeset/pink-bananas-exist.md
+++ b/.changeset/pink-bananas-exist.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: intersection observer detection

--- a/packages/api-reference/src/components/IntersectionObserver.vue
+++ b/packages/api-reference/src/components/IntersectionObserver.vue
@@ -13,23 +13,36 @@ const emit = defineEmits<{
 
 const intersectionObserverRef = ref<HTMLElement>()
 
-onMounted(() => {
-  useIntersectionObserver(
-    intersectionObserverRef,
-    ([{ isIntersecting }]) => {
-      if (!props.id) {
-        return
-      }
+const calculateRootMargin = (element: HTMLElement) => {
+  const height = element.offsetHeight
+  // Use of a margin on height to ensure sooner intersection detection.
+  return `${height / 2}px 0px ${height / 2}px 0px`
+}
 
-      if (isIntersecting) {
-        emit('intersecting')
-      }
-    },
-    {
-      rootMargin: '0px 0px 50% 0px',
-      threshold: 0.2,
-    },
-  )
+const calculateThreshold = (element: HTMLElement) => {
+  const height = element.offsetHeight
+  // Favor larger threshold if the element is smaller that the screen
+  // to ensure that it is selected
+  return height < window.innerHeight ? 0.8 : 0.5
+}
+
+onMounted(() => {
+  if (intersectionObserverRef.value) {
+    const options = {
+      rootMargin: calculateRootMargin(intersectionObserverRef.value),
+      threshold: calculateThreshold(intersectionObserverRef.value),
+    }
+
+    useIntersectionObserver(
+      intersectionObserverRef,
+      ([{ isIntersecting }]) => {
+        if (isIntersecting && props.id) {
+          emit('intersecting')
+        }
+      },
+      options,
+    )
+  }
 })
 </script>
 <template>


### PR DESCRIPTION
**Problem**
when a low height element lies between two others, it is not always detected by the observer as the next one according to scroll speed is already in the viewport and therefore not highlighted in the sidebar.

https://github.com/scalar/scalar/assets/14966155/9e75c2d3-4cf5-460a-af91-3f3086fb618c

**Solution**
this pr attempt adds two methods in order to calculate a margin + set the threshold according to the element height. good scroll yall!

https://github.com/scalar/scalar/assets/14966155/dd1d921b-fdb7-46d1-b321-4833da97ed38

