### PR TITLE
fix: object description markdown

### DIFF
--- a/.changeset/proud-suns-love.md
+++ b/.changeset/proud-suns-love.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: object description markdown

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -3,6 +3,7 @@ import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon } from '@scalar/components'
 import { computed } from 'vue'
 
+import { MarkdownRenderer } from '../../MarkdownRenderer'
 import SchemaHeading from './SchemaHeading.vue'
 import SchemaProperty from './SchemaProperty.vue'
 
@@ -55,7 +56,7 @@ const handleClick = (e: MouseEvent) =>
       <div
         v-if="value?.description"
         class="schema-card-description">
-        {{ value.description }}
+        <MarkdownRenderer :value="value.description" />
       </div>
       <div
         class="schema-properties"


### PR DESCRIPTION
**Problem**
as highlighted by @databyjp in #1395 — schema descriptions do not render markdown.

<img width="500" alt="no markdown support" src="https://github.com/scalar/scalar/assets/14966155/7f57d43d-d346-48de-80a9-d3049840a498">



**Solution**
this PR is a proposal to use the markdown rendering for the schema value description.

<img width="500" alt="markdown support" src="https://github.com/scalar/scalar/assets/14966155/49b8d329-cd07-41e2-b346-723564140a46">
