### PR TITLE
feat: render images in tag markdown description

### DIFF
--- a/.changeset/yellow-timers-grab.md
+++ b/.changeset/yellow-timers-grab.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: render images in tag descriptions

--- a/packages/api-reference/src/components/Content/Tag/Endpoints.vue
+++ b/packages/api-reference/src/components/Content/Tag/Endpoints.vue
@@ -46,7 +46,9 @@ async function scrollHandler(operation: TransformedOperation) {
               {{ tag.name }}
             </Anchor>
           </SectionHeader>
-          <MarkdownRenderer :value="tag.description" />
+          <MarkdownRenderer
+            :value="tag.description"
+            withImages />
         </SectionColumn>
         <SectionColumn>
           <template v-if="tag.operations?.length > 0">


### PR DESCRIPTION
**Problem**
Currently, I can't embed images in my markdown descriptions for tag descriptions. I have UML Diagrams that describe my workflows and would like to show them there.

**Explanation**
This happens because the markdown renderer component does use the optional prop value at this time.

**Solution**
With this PR, images will get rendered in tag descriptions when using the optional `withImages` prop value.
