### PR TITLE
fix: pin pnpm version in docker base build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "type": "module",
-  "packageManager": "pnpm@8.10.5",
+  "packageManager": "^pnpm@8.10.5",
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
     "@playwright/test": "^1.42.0",

--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18-bullseye AS base
 
-RUN npm install pnpm --global
+RUN npm install pnpm@8 --global
 RUN pnpm config set store-dir ~/.pnpm-store
 
 WORKDIR /app


### PR DESCRIPTION
**Problem**
Base build is failing for the deployed server examples

**Explanation**
pnpm was getting bumped to latest 9.x version and project used 8.x

**Solution**
Pin that version
