### PR TITLE
feat: use http as default scheme for Swagger 2.0 specifications, fix #1218

### DIFF
--- a/.changeset/thin-knives-relax.md
+++ b/.changeset/thin-knives-relax.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: use http as default scheme for Swagger 2.0 specifications

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -48,14 +48,13 @@ watch(
 
     if (parsedSpec.servers && parsedSpec.servers.length > 0) {
       servers = parsedSpec.servers
-    } else if (
-      props.parsedSpec.host &&
-      props.parsedSpec.schemes &&
-      props.parsedSpec.schemes.length > 0
-    ) {
+    } else if (props.parsedSpec.host) {
+      // Use the first scheme if available, otherwise default to http
+      const scheme = props.parsedSpec.schemes?.[0] ?? 'http'
+
       servers = [
         {
-          url: `${props.parsedSpec.schemes[0]}://${props.parsedSpec.host}${
+          url: `${scheme}://${props.parsedSpec.host}${
             props.parsedSpec?.basePath ?? ''
           }`,
         },


### PR DESCRIPTION
Swagger 2.0 has a different syntax for server URLs. It’s using a `schemes` array to provide a list of available http schemes (http, https).

Currently, we expect it to be present. Turns out, some files don’t have it.

This PR makes it optional.

**Example (with schemes)**

```json
{
  "swagger": "2.0",
  "info": {
    "version": "1.0.7",
    "title": "Swagger Petstore",
  },
  "host": "petstore.swagger.io",
  "schemes": [
    "https",
    "http"
  ],
  "paths": {}
}
```

Result: `https://petstore.swagger.io`

**Example (without schemes)**

```json
{
  "swagger": "2.0",
  "info": {
    "version": "1.0.7",
    "title": "Swagger Petstore",
  },
  "host": "petstore.swagger.io",
  "paths": {}
}
```

Result: `http://petstore.swagger.io`