### PR TITLE
feat: configure whether to fetch the default fonts, fix #1471

### DIFF
--- a/.changeset/olive-wombats-join.md
+++ b/.changeset/olive-wombats-join.md
@@ -1,0 +1,7 @@
+---
+"@scalar/api-reference": patch
+"@scalar/components": patch
+"@scalar/themes": patch
+---
+
+feat: separate google fonts from theme, add withoutDefaultFonts setting

--- a/.changeset/olive-wombats-join.md
+++ b/.changeset/olive-wombats-join.md
@@ -4,4 +4,4 @@
 "@scalar/themes": patch
 ---
 
-feat: separate google fonts from theme, add withoutDefaultFonts setting
+feat: separate google fonts from theme, add withDefaultFonts setting

--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ Overwrite our CSS variables. We won’t judge.
 }
 ```
 
+> Note: By default we’re using Inter and JetBrains Mono, served by Google Fonts. If you use a different font or just don’t want to use Google Fonts, pass `withoutDefaultFonts: true` to the configuration.
+
 You can [use all variables](https://github.com/scalar/scalar/blob/main/packages/themes/src/base.css) available in the base styles as well as overwrite the color theme.
 
 To build your own color themes overwrite the night mode and day mode variables. Here are some basic variables to get you started:

--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ Overwrite our CSS variables. We won’t judge.
 }
 ```
 
-> Note: By default we’re using Inter and JetBrains Mono, served by Google Fonts. If you use a different font or just don’t want to use Google Fonts, pass `withoutDefaultFonts: true` to the configuration.
+> Note: By default we’re using Inter and JetBrains Mono, served by Google Fonts. If you use a different font or just don’t want to use Google Fonts, pass `withDefaultFonts: true` to the configuration.
 
 You can [use all variables](https://github.com/scalar/scalar/blob/main/packages/themes/src/base.css) available in the base styles as well as overwrite the color theme.
 

--- a/packages/api-client/src/components/ApiClient/ApiClient.vue
+++ b/packages/api-client/src/components/ApiClient/ApiClient.vue
@@ -15,11 +15,11 @@ const props = withDefaults(
     proxyUrl?: string
     readOnly?: boolean
     theme?: ThemeId
-    withoutDefaultFonts: boolean
+    withDefaultFonts: boolean
   }>(),
   {
     readOnly: false,
-    withoutDefaultFonts: false,
+    withDefaultFonts: true,
   },
 )
 
@@ -57,7 +57,7 @@ watch(
 <template>
   <ThemeStyles
     :id="theme"
-    :withoutDefaultFonts="withoutDefaultFonts" />
+    :withDefaultFonts="withDefaultFonts" />
   <HttpMethod
     class="scalar-api-client"
     :method="activeRequest.type ?? 'get'"

--- a/packages/api-client/src/components/ApiClient/ApiClient.vue
+++ b/packages/api-client/src/components/ApiClient/ApiClient.vue
@@ -15,9 +15,11 @@ const props = withDefaults(
     proxyUrl?: string
     readOnly?: boolean
     theme?: ThemeId
+    withoutDefaultFonts: boolean
   }>(),
   {
     readOnly: false,
+    withoutDefaultFonts: false,
   },
 )
 
@@ -53,7 +55,9 @@ watch(
 </script>
 
 <template>
-  <ThemeStyles :id="theme" />
+  <ThemeStyles
+    :id="theme"
+    :withoutDefaultFonts="withoutDefaultFonts" />
   <HttpMethod
     class="scalar-api-client"
     :method="activeRequest.type ?? 'get'"

--- a/packages/api-reference/.storybook/preview.ts
+++ b/packages/api-reference/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import cssVariablesTheme from '@etchteam/storybook-addon-css-variables-theme'
-// Themeing
+// Theming
 import '@scalar/themes/base.css'
+import '@scalar/themes/fonts.css'
 import alternate from '@scalar/themes/presets/alternate.css?inline'
 import base from '@scalar/themes/presets/default.css?inline'
 import moon from '@scalar/themes/presets/moon.css?inline'

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -201,4 +201,15 @@ For OpenAuth2 it’s more looking like this:
       },
     },
   } />
+```
+
+#### withoutDefaultFonts?: boolean
+
+By default we’re using Inter and JetBrains Mono, served by Google Fonts. If you use a different font or just don’t want to use Google Fonts, pass `withoutDefaultFonts: true` to the configuration.
+
+```vue
+<ApiReference :configuration="{
+  withoutDefaultFonts: true
+} />
+```
 ````

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -203,13 +203,13 @@ For OpenAuth2 it’s more looking like this:
   } />
 ```
 
-#### withoutDefaultFonts?: boolean
+#### withDefaultFonts?: boolean
 
-By default we’re using Inter and JetBrains Mono, served by Google Fonts. If you use a different font or just don’t want to use Google Fonts, pass `withoutDefaultFonts: true` to the configuration.
+By default we’re using Inter and JetBrains Mono, served by Google Fonts. If you use a different font or just don’t want to use Google Fonts, pass `withDefaultFonts: false` to the configuration.
 
 ```vue
 <ApiReference :configuration="{
-  withoutDefaultFonts: true
+  withDefaultFonts: false
 } />
 ```
 ````

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -63,9 +63,11 @@ const isMobile = useMediaQuery('(max-width: 1000px)')
             </Sidebar>
           </div>
         </template>
+        <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withoutDefaultFonts: true` -->
         <ApiClient
           :proxyUrl="proxyUrl"
           theme="none"
+          withoutDefaultFonts
           @escapeKeyPress="hideApiClient" />
       </div>
     </div>

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -5,19 +5,13 @@ import { useMediaQuery } from '@vueuse/core'
 import { type Spec } from '../types'
 import { Sidebar } from './Sidebar'
 
-withDefaults(
-  defineProps<{
-    parsedSpec: Spec
-    overloadShow?: boolean
-    tabMode?: boolean
-    activeTab?: string
-    proxyUrl?: string
-    withoutDefaultFonts?: boolean
-  }>(),
-  {
-    withoutDefaultFonts: false,
-  },
-)
+defineProps<{
+  parsedSpec: Spec
+  overloadShow?: boolean
+  tabMode?: boolean
+  activeTab?: string
+  proxyUrl?: string
+}>()
 
 defineEmits<{
   (e: 'toggleDarkMode'): void
@@ -69,11 +63,11 @@ const isMobile = useMediaQuery('(max-width: 1000px)')
             </Sidebar>
           </div>
         </template>
-        <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withoutDefaultFonts: true` -->
+        <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withDefaultFonts: false` -->
         <ApiClient
           :proxyUrl="proxyUrl"
           theme="none"
-          :withoutDefaultFonts="withoutDefaultFonts"
+          :withDefaultFonts="false"
           @escapeKeyPress="hideApiClient" />
       </div>
     </div>

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -5,13 +5,19 @@ import { useMediaQuery } from '@vueuse/core'
 import { type Spec } from '../types'
 import { Sidebar } from './Sidebar'
 
-defineProps<{
-  parsedSpec: Spec
-  overloadShow?: boolean
-  tabMode?: boolean
-  activeTab?: string
-  proxyUrl?: string
-}>()
+withDefaults(
+  defineProps<{
+    parsedSpec: Spec
+    overloadShow?: boolean
+    tabMode?: boolean
+    activeTab?: string
+    proxyUrl?: string
+    withoutDefaultFonts?: boolean
+  }>(),
+  {
+    withoutDefaultFonts: false,
+  },
+)
 
 defineEmits<{
   (e: 'toggleDarkMode'): void
@@ -67,7 +73,7 @@ const isMobile = useMediaQuery('(max-width: 1000px)')
         <ApiClient
           :proxyUrl="proxyUrl"
           theme="none"
-          withoutDefaultFonts
+          :withoutDefaultFonts="withoutDefaultFonts"
           @escapeKeyPress="hideApiClient" />
       </div>
     </div>

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -309,9 +309,11 @@ hideModels.value = props.configuration.hideModels ?? false
           </div>
         </template>
         <!-- REST API Client Overlay -->
+        <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withoutDefaultFonts: true` -->
         <ApiClientModal
           :parsedSpec="parsedSpec"
-          :proxyUrl="configuration?.proxy">
+          :proxyUrl="configuration?.proxy"
+          withoutDefaultFonts>
           <template #sidebar-start>
             <slot
               v-bind="referenceSlotProps"

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -212,7 +212,9 @@ provide(
 hideModels.value = props.configuration.hideModels ?? false
 </script>
 <template>
-  <ThemeStyles :id="configuration?.theme" />
+  <ThemeStyles
+    :id="configuration?.theme"
+    :withoutDefaultFonts="configuration?.withoutDefaultFonts" />
   <ResetStyles v-slot="{ styles: reset }">
     <ScrollbarStyles v-slot="{ styles: scrollbars }">
       <div

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -214,7 +214,7 @@ hideModels.value = props.configuration.hideModels ?? false
 <template>
   <ThemeStyles
     :id="configuration?.theme"
-    :withoutDefaultFonts="configuration?.withoutDefaultFonts" />
+    :withDefaultFonts="configuration?.withDefaultFonts" />
   <ResetStyles v-slot="{ styles: reset }">
     <ScrollbarStyles v-slot="{ styles: scrollbars }">
       <div
@@ -309,11 +309,10 @@ hideModels.value = props.configuration.hideModels ?? false
           </div>
         </template>
         <!-- REST API Client Overlay -->
-        <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withoutDefaultFonts: true` -->
+        <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withDefaultFonts: false` -->
         <ApiClientModal
           :parsedSpec="parsedSpec"
-          :proxyUrl="configuration?.proxy"
-          withoutDefaultFonts>
+          :proxyUrl="configuration?.proxy">
           <template #sidebar-start>
             <slot
               v-bind="referenceSlotProps"

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -113,11 +113,11 @@ export type ReferenceConfiguration = {
    */
   baseServerURL?: string
   /**
-   * We’re using Inter and JetBrains Mono as the default fonts. If you want to use your own fonts, set this to true.
+   * We’re using Inter and JetBrains Mono as the default fonts. If you want to use your own fonts, set this to false.
    *
-   * @default false
+   * @default true
    */
-  withoutDefaultFonts?: boolean
+  withDefaultFonts?: boolean
 }
 
 export type PathRouting = {

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -112,6 +112,12 @@ export type ReferenceConfiguration = {
    * @example 'http://localhost:3000'
    */
   baseServerURL?: string
+  /**
+   * We’re using Inter and JetBrains Mono as the default fonts. If you want to use your own fonts, set this to true.
+   *
+   * @default false
+   */
+  withoutDefaultFonts?: boolean
 }
 
 export type PathRouting = {

--- a/packages/components/.storybook/preview.ts
+++ b/packages/components/.storybook/preview.ts
@@ -1,5 +1,6 @@
-// Themeing
+// Theming
 import '@scalar/themes/base.css'
+import '@scalar/themes/fonts.css'
 import '@scalar/themes/presets/default.css'
 import type { Preview } from '@storybook/vue3'
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -13,6 +13,7 @@ pnpm i @scalar/theme @scalar/components
 In your main setup file (main.ts etc)
 
 ```ts
+import '@scalar/themes/fonts.css'
 import '@scalar/themes/base.css'
 ```
 

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -26,6 +26,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./base.css": "./dist/base.css",
+    "./fonts.css": "./dist/fonts.css",
     "./presets/alternate.css": "./dist/presets/alternate.css",
     "./presets/default.css": "./dist/presets/default.css",
     "./presets/moon.css": "./dist/presets/moon.css",

--- a/packages/themes/src/base.css
+++ b/packages/themes/src/base.css
@@ -1,6 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900');
-@import url('https://fonts.googleapis.com/css?family=JetBrains%20Mono');
-
 @layer scalar-base {
   :root {
     --scalar-border-width: 1px;

--- a/packages/themes/src/components/DefaultFonts.vue
+++ b/packages/themes/src/components/DefaultFonts.vue
@@ -1,3 +1,3 @@
 <script setup lang="ts">
-import('../fonts.css')
+import '../fonts.css'
 </script>

--- a/packages/themes/src/components/DefaultFonts.vue
+++ b/packages/themes/src/components/DefaultFonts.vue
@@ -1,0 +1,3 @@
+<script setup lang="ts">
+import('../fonts.css')
+</script>

--- a/packages/themes/src/components/DefaultFonts.vue
+++ b/packages/themes/src/components/DefaultFonts.vue
@@ -1,3 +1,10 @@
 <script setup lang="ts">
-import '../fonts.css'
+import fonts from '../fonts.css?inline'
 </script>
+
+<template>
+  <!-- We can’t use <style> tags in Vue components. -->
+  <component :is="'style'">
+    {{ fonts }}
+  </component>
+</template>

--- a/packages/themes/src/components/DefaultFonts.vue
+++ b/packages/themes/src/components/DefaultFonts.vue
@@ -1,4 +1,12 @@
 <script setup lang="ts">
+/**
+ * There will be a point in time where someone looks at this component and wonders why it’s here. If this is you:
+ *
+ * This component is here to import the fonts from the `fonts.css` file. We can’t just use a regular import because it
+ * would be a global import and would be sent to the client in all cases, even if the component isn’t rendered.
+ *
+ * This component is a workaround to only import the fonts when the component is rendered.
+ */
 import fonts from '../fonts.css?inline'
 </script>
 

--- a/packages/themes/src/components/ThemeStyles.vue
+++ b/packages/themes/src/components/ThemeStyles.vue
@@ -6,15 +6,15 @@ import DefaultFonts from './DefaultFonts.vue'
 withDefaults(
   defineProps<{
     id?: ThemeId
-    withoutDefaultFonts?: boolean
+    withDefaultFonts?: boolean
   }>(),
   {
-    withoutDefaultFonts: false,
+    withDefaultFonts: true,
   },
 )
 </script>
 <template>
-  <DefaultFonts v-if="!withoutDefaultFonts" />
+  <DefaultFonts v-if="withDefaultFonts" />
   <component
     :is="'style'"
     v-if="id !== 'none'">

--- a/packages/themes/src/components/ThemeStyles.vue
+++ b/packages/themes/src/components/ThemeStyles.vue
@@ -1,12 +1,20 @@
 <script lang="ts" setup>
 import '../base.css'
 import { type ThemeId, getThemeById } from '../index'
+import DefaultFonts from './DefaultFonts.vue'
 
-defineProps<{
-  id?: ThemeId
-}>()
+withDefaults(
+  defineProps<{
+    id?: ThemeId
+    withoutDefaultFonts?: boolean
+  }>(),
+  {
+    withoutDefaultFonts: false,
+  },
+)
 </script>
 <template>
+  <DefaultFonts v-if="!withoutDefaultFonts" />
   <component
     :is="'style'"
     v-if="id !== 'none'">

--- a/packages/themes/src/fonts.css
+++ b/packages/themes/src/fonts.css
@@ -1,0 +1,5 @@
+/* Inter (--scalar-font) */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900');
+
+/* JetBrains Mono (--scalar-font-code) */
+@import url('https://fonts.googleapis.com/css?family=JetBrains%20Mono');

--- a/packages/themes/vite.config.ts
+++ b/packages/themes/vite.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
           dest: './',
         },
         {
+          src: 'src/fonts.css',
+          dest: './',
+        },
+        {
           src: 'src/scrollbar.css',
           dest: './',
         },


### PR DESCRIPTION
Currently, we’re fetching Inter and JetBrains Mono from Google fonts - always. Even if different fonts are used or people just don’t want to use Google Fonts (see https://github.com/elysiajs/elysia-swagger/issues/104)

This happens because the CSS imports are just part of our base styles.

This PR separates the fonts from the base styles, and adds a setting to not fetch the default fonts from Google Fonts. 

Great for perf (can save 67kb, if the fonts are not used anyway), great for privacy. Enables users to self-host the fonts, or use something else, or just use the default system font stack.

```vue
<ApiReference :configuration="{
  withoutDefaultFonts: true
} />
```