### PR TITLE
fix: getting started themes

### DIFF
--- a/.changeset/modern-shirts-argue.md
+++ b/.changeset/modern-shirts-argue.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: start section theme name

--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -329,7 +329,10 @@ function handleEmitPetstore() {
 .start-section-colors .start-item:not(:last-of-type) {
   border-right: none;
 }
-.start-section-colors .start-item:not(:nth-of-type(3n)) {
+.start-section-colors .start-item:last-of-type {
+  border-radius: 0 0 var(--scalar-radius-lg) var(--scalar-radius-lg);
+}
+.start-section-colors .start-item:not(:nth-of-type(3n)):not(:last-of-type) {
   border-right: 1px solid var(--scalar-border-color);
 }
 .start-section-colors .start-item:nth-of-type(n + 4) {

--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -28,6 +28,20 @@ const themeIds: ThemeId[] = [
   'deepSpace',
 ]
 
+const themeNames: Record<ThemeId, string> = {
+  default: 'Default',
+  alternate: 'Alternate',
+  moon: 'Moon',
+  purple: 'Purple',
+  solarized: 'Solarized',
+  bluePlanet: 'Blue Planet',
+  saturn: 'Saturn',
+  kepler: 'Kepler-11e',
+  mars: 'Mars',
+  deepSpace: 'Deep Space',
+  none: '',
+}
+
 function handleEmitPetstore() {
   emits('updateContent', petstore)
 }
@@ -179,7 +193,7 @@ function handleEmitPetstore() {
           class="start-item"
           :class="{ 'start-item-active': themeId === theme }"
           @click="$emit('changeTheme', themeId)">
-          {{ themeId.toLocaleLowerCase() }}
+          {{ themeNames[themeId] }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Problem**
theme from starting section are displaying raw name value

<img width="1022" alt="image" src="https://github.com/scalar/scalar/assets/14966155/b0cfdc77-7680-460e-8bf7-51e078957862">

**Solution**
this displays theme name right format + fix last theme excess border / hover radiuses

<img width="1022" alt="image" src="https://github.com/scalar/scalar/assets/14966155/7e47fdad-0712-45f1-8181-595ca4138369">