### PR TITLE
chore: deploy express example

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -130,6 +130,44 @@ steps:
         '--service-account=$_SERVICE_ACCOUNT',
       ]
   # ---------------------------------------------------------------
+  # Express integration
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-express-js'
+    waitFor: ['push-base']
+    args:
+      [
+        'buildx',
+        'build',
+        '--build-arg',
+        'BASE_IMAGE=gcr.io/${_PROJECT_ID}/${_BASE_BUILDER}',
+        '-t',
+        'gcr.io/${_PROJECT_ID}/${_SERVICE_EXPRESS}',
+        '-f',
+        './examples/express-api-reference/Dockerfile',
+        '.',
+      ]
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'push-express-js'
+    waitFor: ['build-express-js']
+    args: ['push', 'gcr.io/${_PROJECT_ID}/${_SERVICE_EXPRESS}']
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    waitFor: ['push-express-js']
+    args:
+      [
+        'run',
+        'deploy',
+        '$_SERVICE_EXPRESS',
+        '--image=gcr.io/${_PROJECT_ID}/${_SERVICE_EXPRESS}',
+        '--region=$_REGION',
+        '--platform=managed',
+        '--allow-unauthenticated',
+        '--execution-environment=gen2',
+        '--cpu=$_CPU',
+        '--memory=$_MEMORY',
+        '--service-account=$_SERVICE_ACCOUNT',
+      ]
+  # ---------------------------------------------------------------
   # Other Integration
   # - name: OTHER INTEGRATION
 # ---------------------------------------------------------------

--- a/examples/express-api-reference/.dockerignore
+++ b/examples/express-api-reference/.dockerignore
@@ -1,0 +1,52 @@
+.env
+**/.env
+**/coverage/**
+coverage
+
+.env.staging
+.env.production
+.sh
+
+# Exclude nested dockerfile to prevent cache break issues
+**/Dockerfile
+
+# compiled output
+dist
+tmp
+/out-tsc
+**/dist/**
+
+# dependencies
+node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+db.sqlite
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/examples/express-api-reference/Dockerfile
+++ b/examples/express-api-reference/Dockerfile
@@ -41,8 +41,4 @@ WORKDIR /app/examples/express-api-reference
 
 USER node
 
-EXPOSE 5050
-ENV PORT 5050
-ENV HOSTNAME "0.0.0.0"
-
 CMD ["dumb-init", "node", "dist/index.js"]

--- a/examples/express-api-reference/Dockerfile
+++ b/examples/express-api-reference/Dockerfile
@@ -1,0 +1,49 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS builder
+WORKDIR /app
+
+COPY pnpm-lock.yaml .
+COPY pnpm-workspace.yaml .
+COPY package.json .
+COPY tsconfig.json .
+COPY packages/api-reference ./packages/api-reference
+COPY packages/components ./packages/components
+COPY packages/themes ./packages/themes
+COPY packages/oas-utils ./packages/oas-utils
+COPY packages/build-tooling ./packages/build-tooling
+COPY packages/express-api-reference ./packages/express-api-reference
+COPY examples/express-api-reference ./examples/express-api-reference
+
+RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store \
+    pnpm --filter @scalar-examples/express-api-reference install --frozen-lockfile && \
+    pnpm --filter @scalar-examples/express-api-reference build
+
+
+FROM node:18-bullseye-slim AS runner
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
+
+RUN npm install -g pnpm
+ENV NODE_ENV production
+
+WORKDIR /app
+
+# Copy root node modules and any utilized packages
+COPY --from=builder --chown=node:node /app/node_modules /app/node_modules
+COPY --from=builder --chown=node:node /app/packages/components /app/packages/components
+COPY --from=builder --chown=node:node /app/packages/themes /app/packages/themes
+COPY --from=builder --chown=node:node /app/packages/oas-utils /app/packages/oas-utils
+COPY --from=builder --chown=node:node /app/packages/build-tooling /app/packages/build-tooling
+COPY --from=builder --chown=node:node /app/packages/api-reference /app/packages/api-reference
+COPY --from=builder --chown=node:node /app/packages/express-api-reference /app/packages/express-api-reference
+COPY --from=builder --chown=node:node /app/examples/express-api-reference /app/examples/express-api-reference
+
+WORKDIR /app/examples/express-api-reference
+
+USER node
+
+# Cloud build requires port 8080 to be exposed
+EXPOSE 8080
+ENV PORT 8080
+ENV HOSTNAME "0.0.0.0"
+
+CMD ["node", "dist/index.js"]

--- a/examples/express-api-reference/Dockerfile
+++ b/examples/express-api-reference/Dockerfile
@@ -27,15 +27,18 @@ ENV NODE_ENV production
 
 WORKDIR /app
 
+# Set the correct permission for prerender cache
+RUN chown node:node app
+
 # Copy root node modules and any utilized packages
-COPY --from=builder --chown=node:node /app/node_modules /app/node_modules
-COPY --from=builder --chown=node:node /app/packages/components /app/packages/components
-COPY --from=builder --chown=node:node /app/packages/themes /app/packages/themes
-COPY --from=builder --chown=node:node /app/packages/oas-utils /app/packages/oas-utils
-COPY --from=builder --chown=node:node /app/packages/build-tooling /app/packages/build-tooling
-COPY --from=builder --chown=node:node /app/packages/api-reference /app/packages/api-reference
-COPY --from=builder --chown=node:node /app/packages/express-api-reference /app/packages/express-api-reference
-COPY --from=builder --chown=node:node /app/examples/express-api-reference /app/examples/express-api-reference
+COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/packages/components /app/packages/components
+COPY --from=builder /app/packages/themes /app/packages/themes
+COPY --from=builder /app/packages/oas-utils /app/packages/oas-utils
+COPY --from=builder /app/packages/build-tooling /app/packages/build-tooling
+COPY --from=builder /app/packages/api-reference /app/packages/api-reference
+COPY --from=builder /app/packages/express-api-reference /app/packages/express-api-reference
+COPY --from=builder /app/examples/express-api-reference /app/examples/express-api-reference
 
 WORKDIR /app/examples/express-api-reference
 

--- a/examples/express-api-reference/Dockerfile
+++ b/examples/express-api-reference/Dockerfile
@@ -47,6 +47,6 @@ COPY --from=builder /app/examples/express-api-reference /app/examples/express-ap
 
 WORKDIR /app/examples/express-api-reference
 
-USER node
+USER expressjs
 
 CMD ["dumb-init", "node", "dist/index.js"]

--- a/examples/express-api-reference/Dockerfile
+++ b/examples/express-api-reference/Dockerfile
@@ -41,9 +41,8 @@ WORKDIR /app/examples/express-api-reference
 
 USER node
 
-# Cloud build requires port 8080 to be exposed
-EXPOSE 8080
-ENV PORT 8080
+EXPOSE 5050
+ENV PORT 5050
 ENV HOSTNAME "0.0.0.0"
 
-CMD ["node", "dist/index.js"]
+CMD ["dumb-init", "node", "dist/index.js"]

--- a/examples/express-api-reference/Dockerfile
+++ b/examples/express-api-reference/Dockerfile
@@ -25,10 +25,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
 RUN npm install -g pnpm
 ENV NODE_ENV production
 
-WORKDIR /app
+# Create a non-root user
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 expressjs
 
-# Set the correct permission for prerender cache
-RUN chown node:node app
+# Set the correct permission for the build
+RUN mkdir app
+RUN chown expressjs:nodejs app
+
+WORKDIR /app
 
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules

--- a/examples/express-api-reference/package.json
+++ b/examples/express-api-reference/package.json
@@ -24,7 +24,7 @@
     "@types/swagger-jsdoc": "^6.0.3",
     "nodemon": "^3.0.1",
     "tsc-alias": "^1.8.8",
-    "vite": "^5.2.9",
+    "vite": "^5.2.10",
     "vite-node": "^1.2.2"
   }
 }

--- a/examples/express-api-reference/package.json
+++ b/examples/express-api-reference/package.json
@@ -9,8 +9,11 @@
     "node": ">=18"
   },
   "scripts": {
-    "dev": "nodemon --exec \"vite-node src/index.ts\" --ext ts --quiet --watch ../../packages/express-api-reference --watch ./"
+    "build": "tsc --p tsconfig.json && tsc-alias -p tsconfig.json",
+    "dev": "nodemon --exec \"vite-node src/index.ts\" --ext ts --quiet --watch ../../packages/express-api-reference --watch ./",
+    "docker:build": "build --platform=linux/amd64 -t ${image_name} --build-arg=\"BASE_IMAGE=scalar-base\" -f ./examples/express-api-reference/Dockerfile ."
   },
+  "type": "module",
   "dependencies": {
     "@scalar/express-api-reference": "workspace:*",
     "express": "^4.19.2",
@@ -20,6 +23,8 @@
     "@types/express": "^4.17.21",
     "@types/swagger-jsdoc": "^6.0.3",
     "nodemon": "^3.0.1",
+    "tsc-alias": "^1.8.8",
+    "vite": "^5.2.9",
     "vite-node": "^1.2.2"
   }
 }

--- a/examples/express-api-reference/src/index.ts
+++ b/examples/express-api-reference/src/index.ts
@@ -2,8 +2,6 @@ import { apiReference } from '@scalar/express-api-reference'
 import Express from 'express'
 import swaggerJsdoc from 'swagger-jsdoc'
 
-const env = process.env.PORT
-
 // Initialize Express
 const app = Express()
 

--- a/examples/express-api-reference/src/index.ts
+++ b/examples/express-api-reference/src/index.ts
@@ -2,6 +2,8 @@ import { apiReference } from '@scalar/express-api-reference'
 import Express from 'express'
 import swaggerJsdoc from 'swagger-jsdoc'
 
+const env = process.env.PORT
+
 // Initialize Express
 const app = Express()
 
@@ -49,8 +51,8 @@ app.use(
 )
 
 // Listen
-const PORT = import.meta.env.PORT || 5055
-const HOST = import.meta.env.HOST || '0.0.0.0'
+const PORT = Number(process.env.PORT) || 5055
+const HOST = process.env.HOST || '0.0.0.0'
 app.listen(PORT, HOST, () => {
   console.log(`💻 Express listening on http://${HOST}:${PORT}`)
 })

--- a/examples/express-api-reference/src/index.ts
+++ b/examples/express-api-reference/src/index.ts
@@ -49,6 +49,7 @@ app.use(
 )
 
 // Listen
-app.listen(5055, () => {
-  console.log('💻 Express listening on http://localhost:5055')
+const PORT = 8080
+app.listen(PORT, () => {
+  console.log(`💻 Express listening on http://localhost:${PORT}`)
 })

--- a/examples/express-api-reference/src/index.ts
+++ b/examples/express-api-reference/src/index.ts
@@ -49,8 +49,8 @@ app.use(
 )
 
 // Listen
-const PORT = 5055
-const HOST = '0.0.0.0'
+const PORT = import.meta.env.PORT || 5055
+const HOST = import.meta.env.HOST || '0.0.0.0'
 app.listen(PORT, HOST, () => {
   console.log(`💻 Express listening on http://${HOST}:${PORT}`)
 })

--- a/examples/express-api-reference/src/index.ts
+++ b/examples/express-api-reference/src/index.ts
@@ -49,7 +49,7 @@ app.use(
 )
 
 // Listen
-const PORT = 8080
+const PORT = 5055
 app.listen(PORT, () => {
   console.log(`💻 Express listening on http://localhost:${PORT}`)
 })

--- a/examples/express-api-reference/src/index.ts
+++ b/examples/express-api-reference/src/index.ts
@@ -50,6 +50,7 @@ app.use(
 
 // Listen
 const PORT = 5055
-app.listen(PORT, () => {
-  console.log(`💻 Express listening on http://localhost:${PORT}`)
+const HOST = '0.0.0.0'
+app.listen(PORT, HOST, () => {
+  console.log(`💻 Express listening on http://${HOST}:${PORT}`)
 })

--- a/examples/express-api-reference/tsconfig.json
+++ b/examples/express-api-reference/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "exclude": ["dist", "test", "vite.config.ts", "**/*.test.ts"],
+  "compilerOptions": {
+    "types": ["vite/client"],
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "outDir": "dist/"
+  }
+}

--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -12,10 +12,6 @@ const emits = defineEmits<{
   (e: 'linkSwaggerFile'): void
   (e: 'updateContent', value: string): void
 }>()
-const placeholderSpecificationRes = await fetch(
-  'https://cdn.scalar.com/spec/scalar-galaxy-3.1.yaml',
-)
-const placeholderSpecification = await placeholderSpecificationRes.text()
 
 const themeIds: ThemeId[] = [
   'default',

--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -6,13 +6,16 @@ import { type ThemeId, themeLabels } from '@scalar/themes'
 defineProps<{
   theme: ThemeId
 }>()
-
 const emits = defineEmits<{
   (e: 'changeTheme', { id, label }: { id: ThemeId; label: string }): void
   (e: 'loadSwaggerFile'): void
   (e: 'linkSwaggerFile'): void
   (e: 'updateContent', value: string): void
 }>()
+const placeholderSpecificationRes = await fetch(
+  'https://cdn.scalar.com/spec/scalar-galaxy-3.1.yaml',
+)
+const placeholderSpecification = await placeholderSpecificationRes.text()
 
 const themeIds: ThemeId[] = [
   'default',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: ^1.8.8
         version: 1.8.8
       vite:
-        specifier: ^5.2.9
-        version: 5.2.9(@types/node@20.11.22)(terser@5.30.0)
+        specifier: ^5.2.10
+        version: 5.2.10(@types/node@20.11.22)(terser@5.30.0)
       vite-node:
         specifier: ^1.2.2
         version: 1.3.1(@types/node@20.11.22)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,12 @@ importers:
       nodemon:
         specifier: ^3.0.1
         version: 3.1.0
+      tsc-alias:
+        specifier: ^1.8.8
+        version: 1.8.8
+      vite:
+        specifier: ^5.2.9
+        version: 5.2.9(@types/node@20.11.22)(terser@5.30.0)
       vite-node:
         specifier: ^1.2.2
         version: 1.3.1(@types/node@20.11.22)


### PR DESCRIPTION
Deploy the express api reference example using Docker and CloudBuild. This PR also updates the api reference to fetch the scalar-galaxy spec from the CDN to avoid issues in Docker with relative path imports
