### PR TITLE
chore: Make y-codemirror external and optional

### DIFF
--- a/.changeset/silver-dingos-fold.md
+++ b/.changeset/silver-dingos-fold.md
@@ -1,0 +1,5 @@
+---
+"@scalar/use-codemirror": patch
+---
+
+Externalize y-codemirror

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -40,6 +40,9 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/use-codemirror"
   },
+  "optionalDependencies": {
+    "y-codemirror.next": "^0.3.2"
+  },
   "dependencies": {
     "@codemirror/autocomplete": "^6.12.0",
     "@codemirror/commands": "^6.3.3",
@@ -55,8 +58,7 @@
     "@lezer/lr": "^1.4.0",
     "@replit/codemirror-css-color-picker": "^6.1.0",
     "@uiw/codemirror-themes": "^4.21.21",
-    "codemirror": "^6.0.0",
-    "y-codemirror.next": "^0.3.2"
+    "codemirror": "^6.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
@@ -65,10 +67,13 @@
     "vite": "^5.2.9",
     "vitest": "^1.5.0",
     "vue": "^3.4.21",
-    "vue-tsc": "^1.8.19"
+    "vue-tsc": "^1.8.19",
+    "y-codemirror.next": "^0.3.2",
+    "yjs": "^13.6.0"
   },
   "peerDependencies": {
     "vue": "^3.3.0",
-    "yjs": "^13.6.0"
+    "yjs": "^13.6.0",
+    "y-codemirror.next": "^0.3.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1603,12 +1603,10 @@ importers:
       codemirror:
         specifier: ^6.0.0
         version: 6.0.1(@lezer/common@1.2.1)
+    optionalDependencies:
       y-codemirror.next:
         specifier: ^0.3.2
         version: 0.3.2(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(yjs@13.6.12)
-      yjs:
-        specifier: ^13.6.0
-        version: 13.6.12
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
@@ -1631,6 +1629,9 @@ importers:
       vue-tsc:
         specifier: ^1.8.19
         version: 1.8.27(typescript@5.4.3)
+      yjs:
+        specifier: ^13.6.0
+        version: 13.6.12
 
   packages/use-modal:
     devDependencies:
@@ -10103,7 +10104,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.21(typescript@5.4.3)
-      vue-component-type-helpers: 2.0.13
+      vue-component-type-helpers: 2.0.14
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18705,7 +18706,6 @@ packages:
 
   /isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
-    dev: false
 
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -19697,7 +19697,6 @@ packages:
     hasBin: true
     dependencies:
       isomorphic.js: 0.2.5
-    dev: false
 
   /light-my-request@5.11.0:
     resolution: {integrity: sha512-qkFCeloXCOMpmEdZ/MV91P8AT4fjwFXWaAFz3lUeStM8RcoM1ks4J/F8r1b3r6y/H4u3ACEJ1T+Gv5bopj7oDA==}
@@ -28223,6 +28222,10 @@ packages:
     resolution: {integrity: sha512-xNO5B7DstNWETnoYflLkVgh8dK8h2ZDgxY1M2O0zrqGeBNq5yAZ8a10yCS9+HnixouNGYNX+ggU9MQQq86HTpg==}
     dev: true
 
+  /vue-component-type-helpers@2.0.14:
+    resolution: {integrity: sha512-DInfgOyXlMyliyqAAD9frK28tTfch0+tMi4qoWJcZlRxUf+NFAtraJBnAsKLep+FOyLMiajkhfyEb3xLK08i7w==}
+    dev: true
+
   /vue-demi@0.14.7(vue@3.4.21):
     resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
     engines: {node: '>=12'}
@@ -28939,6 +28942,7 @@ packages:
 
   /y-codemirror.next@0.3.2(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(yjs@13.6.12):
     resolution: {integrity: sha512-3ksMXoietzNkrgluG9ut+5q4PNHCS6sQ+mHd44hNX1s7TBe4iDgOOIswfY3oLsdamZLAUPr+TnRdYgYuNDs7Qg==}
+    requiresBuild: true
     peerDependencies:
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
@@ -28949,6 +28953,7 @@ packages:
       lib0: 0.2.90
       yjs: 13.6.12
     dev: false
+    optional: true
 
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -29038,7 +29043,6 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     dependencies:
       lib0: 0.2.90
-    dev: false
 
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}


### PR DESCRIPTION
Should fully externalize y-codemirror and yjs from the use-codemirror package