### PR TITLE
Brynn/fix nullable additional props

### DIFF
--- a/.changeset/red-plums-doubt.md
+++ b/.changeset/red-plums-doubt.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: allow nullable additional properties

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -112,13 +112,14 @@ const handleClick = (e: MouseEvent) =>
               <SchemaProperty
                 v-if="
                   value.additionalProperties === true ||
-                  Object.keys(value.additionalProperties).length === 0
+                  Object.keys(value.additionalProperties).length === 0 ||
+                  !value.additionalProperties.type
                 "
                 additional
                 :compact="compact"
                 :level="level"
                 noncollapsible
-                :value="{ type: 'any' }" />
+                :value="{ type: 'any', ...value.additionalProperties }" />
               <!-- Allows a specific type of additional property value -->
               <SchemaProperty
                 v-else


### PR DESCRIPTION
Allows additional properties with without a type to be rendered as the "any" type.

### Test Spec

```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "Hello World",
    "version": "1.0.0"
  },
  "paths": {
    "/": {
      "get": {
        "requestBody": {
          "description": "I am a description",
          "content": {
            "application/json": {
              "schema": {
                "type": "object",
                "properties": {
                  "metadata": {
                    "type": "object",
                    "additionalProperties": {
                      "nullable": true
                    },
                    "description": "I am another description"
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}

```

## Before (main)

<img width="550" alt="Google Chrome-2024-04-23-13-43-13@2x" src="https://github.com/scalar/scalar/assets/6374090/c5d09135-94cf-4a41-8781-0c529c7652d1">

(Double description issue is logged as #1498)

## After (this branch)

<img width="535" alt="Google Chrome-2024-04-23-13-42-29@2x" src="https://github.com/scalar/scalar/assets/6374090/1135c1ba-a356-4950-8125-47197cef1dfa">
