### PR TITLE
refactor: move theme labels to @scalar/themes

### DIFF
--- a/.changeset/spicy-bobcats-appear.md
+++ b/.changeset/spicy-bobcats-appear.md
@@ -1,0 +1,6 @@
+---
+"@scalar/themes": minor
+"@scalar/api-reference": patch
+---
+
+refactor: move theme labels to @scalar/themes

--- a/.changeset/spicy-bobcats-appear.md
+++ b/.changeset/spicy-bobcats-appear.md
@@ -1,5 +1,5 @@
 ---
-"@scalar/themes": minor
+"@scalar/themes": patch
 "@scalar/api-reference": patch
 ---
 

--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ScalarButton } from '@scalar/components'
-import { type ThemeId } from '@scalar/themes'
+import { type ThemeId, themeLabels } from '@scalar/themes'
 
 import petstore from '../specs/petstorev3.json?raw'
 
@@ -27,20 +27,6 @@ const themeIds: ThemeId[] = [
   'mars',
   'deepSpace',
 ]
-
-const themeNames: Record<ThemeId, string> = {
-  default: 'Default',
-  alternate: 'Alternate',
-  moon: 'Moon',
-  purple: 'Purple',
-  solarized: 'Solarized',
-  bluePlanet: 'Blue Planet',
-  saturn: 'Saturn',
-  kepler: 'Kepler-11e',
-  mars: 'Mars',
-  deepSpace: 'Deep Space',
-  none: '',
-}
 
 function handleEmitPetstore() {
   emits('updateContent', petstore)
@@ -193,7 +179,7 @@ function handleEmitPetstore() {
           class="start-item"
           :class="{ 'start-item-active': themeId === theme }"
           @click="$emit('changeTheme', themeId)">
-          {{ themeNames[themeId] }}
+          {{ themeLabels[themeId] }}
         </div>
       </div>
     </div>

--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -38,6 +38,23 @@ export type ThemeId =
   | 'none'
 
 /**
+ * User readable theme names / labels
+ */
+export const themeLabels: Record<ThemeId, string> = {
+  default: 'Default',
+  alternate: 'Alternate',
+  moon: 'Moon',
+  purple: 'Purple',
+  solarized: 'Solarized',
+  bluePlanet: 'Blue Planet',
+  saturn: 'Saturn',
+  kepler: 'Kepler-11e',
+  mars: 'Mars',
+  deepSpace: 'Deep Space',
+  none: '',
+}
+
+/**
  * List of available theme presets.
  */
 export const presets: Record<Exclude<ThemeId, 'none'>, string> = {


### PR DESCRIPTION
Just exposes the theme labels object so we can use it elsewhere