### PR TITLE
fix: handle circular references in code blocks, fix #1511

### DIFF
--- a/.changeset/lemon-spies-march.md
+++ b/.changeset/lemon-spies-march.md
@@ -1,0 +1,5 @@
+---
+"@scalar/components": patch
+---
+
+fix: circular references in code blocks throw errors

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -160,6 +160,7 @@ onServerPrefetch(async () => {
 // Here we overwrite the SSR with client rendered syntax highlighting
 onMounted(async () => {
   // This bit async autoloads any syntax we have not pre-loaded
+  // @ts-expect-error This is a dynamic import
   await import('prismjs/plugins/autoloader/prism-autoloader.js')
   plugins.autoloader.languages_path =
     'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/'

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -19,6 +19,8 @@ import {
   watch,
 } from 'vue'
 
+import { prettyPrintString } from './utils/prettyPrintString'
+
 /**
  * Uses prism.js for syntax highlighting
  * Comes with js, css, bash and json
@@ -40,11 +42,7 @@ const props = withDefaults(
   },
 )
 
-const ssrHash = createHash(
-  typeof props.content === 'object'
-    ? JSON.stringify(props.content)
-    : props.content,
-)
+const ssrHash = createHash(prettyPrintString(props.content))
 
 const ssrStateKey =
   `components-scalar-code-block${ssrHash}` satisfies CodeBlockSSRKey
@@ -145,9 +143,7 @@ onServerPrefetch(async () => {
   }
 
   const html = prismjs.highlight(
-    typeof props.content === 'object'
-      ? JSON.stringify(props.content)
-      : props.content,
+    prettyPrintString(props.content),
     prismjs.languages[language.value]!,
     language.value,
   )
@@ -176,13 +172,13 @@ onMounted(async () => {
       {
         'line-numbers': lineNumbers,
       },
-    ]"><!-- 
-        SSR generated highlighting 
+    ]"><!--
+        SSR generated highlighting
         * Do not remove these strange comments and line breaks as any line breaks
           inside of pre will show in the dom
-      --><code v-if="ssrContent" :class="`scalar-codeblock-code language-${language}`" v-html="ssrContent" /><!-- 
+      --><code v-if="ssrContent" :class="`scalar-codeblock-code language-${language}`" v-html="prettyPrintString(ssrContent)" /><!--
         Client side generated highlighting
-      --><code v-else ref="el" :class="`scalar-codeblock-code language-${language}`">{{content}}</code></pre>
+      --><code v-else ref="el" :class="`scalar-codeblock-code language-${language}`">{{prettyPrintString(content)}}</code></pre>
 </template>
 <style>
 .scalar-codeblock-code[class*='language-'],

--- a/packages/components/src/components/ScalarCodeBlock/utils/prettyPrintString.ts
+++ b/packages/components/src/components/ScalarCodeBlock/utils/prettyPrintString.ts
@@ -1,0 +1,20 @@
+import { replaceCircularDependencies } from './replaceCircularReferences'
+
+/**
+ * Prints strings, stringifies objects, and handles circular dependencies.
+ */
+export function prettyPrintString(content: any) {
+  if (typeof content === 'string') {
+    return content
+  }
+
+  if (typeof content === 'object') {
+    try {
+      return JSON.stringify(content, null, 2)
+    } catch (e) {
+      return replaceCircularDependencies(content)
+    }
+  }
+
+  return content
+}

--- a/packages/components/src/components/ScalarCodeBlock/utils/replaceCircularReferences.ts
+++ b/packages/components/src/components/ScalarCodeBlock/utils/replaceCircularReferences.ts
@@ -1,0 +1,21 @@
+/**
+ * JSON.stringify, but with circular dependencies replaced with '[Circular]'
+ */
+export function replaceCircularDependencies(content: any) {
+  const cache = new Set()
+
+  return JSON.stringify(
+    content,
+    (key, value) => {
+      if (typeof value === 'object' && value !== null) {
+        if (cache.has(value)) {
+          return '[Circular]'
+        }
+
+        cache.add(value)
+      }
+      return value
+    },
+    2,
+  )
+}

--- a/packages/components/src/components/ScalarIcon/icons/index.ts
+++ b/packages/components/src/components/ScalarIcon/icons/index.ts
@@ -2,6 +2,7 @@ import { defineAsyncComponent } from 'vue'
 
 import { type ICONS } from './icons'
 
+// @ts-expect-error This is a dynamic import
 const icons = import.meta.glob<SVGElement>('./*.svg')
 
 /**

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -20,5 +20,6 @@
     "target": "es2022",
     "verbatimModuleSyntax": true
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "include": ["src"]
 }


### PR DESCRIPTION
Currently, passing an object with circular references to `ScalarCodeBlock` throws an error as reported in #1511.

This is because we’re just running `JSON.stringify` and it doesn’t know what to do with the circular references.

This PR adds handling for circular references to `ScalarCodeBlock`. I’d love to add a storybook example, but storybook doesn’t deal with JS objects with circular references and throws an error. Which took me way too long to find out. 🤡 