### PR TITLE
fix: truncate search results properly

### DIFF
--- a/.changeset/three-plants-scream.md
+++ b/.changeset/three-plants-scream.md
@@ -1,0 +1,5 @@
+---
+"@scalar/components": patch
+---
+
+fix: truncate search results properly

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -40,8 +40,8 @@ const attrs = computed(() => {
         </slot>
       </div>
       <!-- Content -->
-      <div class="flex flex-1 flex-col gap-0.75">
-        <div class="flex items-center">
+      <div class="flex min-w-0 flex-1 flex-col gap-0.75">
+        <div class="flex items-center gap-1">
           <div class="flex-1 truncate text-sm font-medium">
             <slot />
           </div>

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResults.stories.ts
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResults.stories.ts
@@ -20,8 +20,8 @@ const meta = {
     <template #addon>Addon</template>
   </ScalarSearchResultItem>
   <ScalarSearchResultItem icon="Search">
-    Result 2
-    <template #description>This is a description</template>
+    Result 2 - Extra long result title that might need to be truncated
+    <template #description>This is a really long description that might need to be truncated</template>
     <template #addon>Addon</template>
   </ScalarSearchResultItem>
   <ScalarSearchResultItem icon="Search">


### PR DESCRIPTION
## Before (Main)

<img width="350" src="https://github.com/scalar/scalar/assets/6374090/17007eba-9a0e-4716-b089-0fc9c68dcb7c" />
<img width="350" src="https://github.com/scalar/scalar/assets/6374090/36d31c9b-b3e1-4551-a3ed-2ed2ae258dd5">

## After (This Branch)

<img width="350" src="https://github.com/scalar/scalar/assets/6374090/ce2c2f6b-9971-44d0-aac3-6f66f6def4b3" />
<img width="350" src="https://github.com/scalar/scalar/assets/6374090/23e2f3f7-6545-44cf-aaf9-376ad5397daa">
