### PR TITLE
chore: ignore generated files

### DIFF
--- a/packages/nuxt/.gitignore
+++ b/packages/nuxt/.gitignore
@@ -54,3 +54,6 @@ coverage
 Network Trash Folder
 Temporary Items
 .apdisk
+
+./src/runtime/plugins/hydrateClient.d.ts
+./src/runtime/plugins/hydrateClient.mjs


### PR DESCRIPTION
generated files break CI