### PR TITLE
fix: update ClientSelector styles fix #1536

### DIFF
--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -298,6 +298,7 @@ const checkIfClientIsFeatured = (client: HttpClientState) =>
 }
 .code-languages__select select {
   opacity: 0;
+  height: 100%;
   width: 100%;
   aspect-ratio: 1;
   position: absolute;
@@ -308,6 +309,7 @@ const checkIfClientIsFeatured = (client: HttpClientState) =>
   -moz-appearance: none;
   -webkit-appearance: none;
   appearance: none;
+  border: none;
 }
 .code-languages__select span {
   position: relative;


### PR DESCRIPTION
**Problem**
Currently, when user focus on "more >" text, cursor pointer appears, but select does not open on click/touch.

**Explanation**
That happens because select's parent element has padding

**Solution**
Set select size same as parent

fix #1536 