### PR TITLE
feat: add image support to tag, operation and webhook descriptions, fix #1543

### DIFF
--- a/.changeset/large-cameras-remember.md
+++ b/.changeset/large-cameras-remember.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: add image support to tag, operation and webhook descriptions

--- a/packages/api-reference/src/components/Content/Operation/EndpointDetails.vue
+++ b/packages/api-reference/src/components/Content/Operation/EndpointDetails.vue
@@ -15,7 +15,9 @@ const { responses } = useResponses(props.operation)
 <template>
   <div class="endpoint-details">
     <div class="endpoint-description">
-      <MarkdownRenderer :value="operation.description" />
+      <MarkdownRenderer
+        :value="operation.description"
+        withImages />
     </div>
     <Parameters :parameters="parameterMap.path">
       <template #title>Path Parameters</template>

--- a/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
+++ b/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
@@ -66,7 +66,9 @@ const { copyToClipboard } = useClipboard()
     <template
       v-if="operation.description"
       #description>
-      <MarkdownRenderer :value="operation.description" />
+      <MarkdownRenderer
+        :value="operation.description"
+        withImages />
     </template>
     <div class="endpoint-content">
       <EndpointDetailsCard :operation="operation" />

--- a/packages/api-reference/src/components/Content/Tag/TagAccordion.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagAccordion.vue
@@ -25,7 +25,8 @@ const { getTagId } = useNavState()
       </SectionHeader>
       <MarkdownRenderer
         class="tag-description"
-        :value="tag.description" />
+        :value="tag.description"
+        withImages />
     </template>
     <slot />
   </SectionContainerAccordion>

--- a/packages/api-reference/src/components/Content/Webhooks/Webhooks.vue
+++ b/packages/api-reference/src/components/Content/Webhooks/Webhooks.vue
@@ -48,7 +48,8 @@ const { getWebhookId } = useNavState()
             <!-- Description -->
             <MarkdownRenderer
               v-if="webhooks[name][httpVerb]?.description"
-              :value="webhooks[name][httpVerb]?.description" />
+              :value="webhooks[name][httpVerb]?.description"
+              withImages />
 
             <!-- Details -->
             <Webhook :webhook="webhooks[name][httpVerb]" />


### PR DESCRIPTION
We support Markdown in a lot of places, but allow images only in the introduction.

This PR adds image support to the tag description, operation description and webhook description.

See #1543 for more context.