### PR TITLE
fix: don't minify theme css

### DIFF
--- a/.changeset/wild-peas-fly.md
+++ b/.changeset/wild-peas-fly.md
@@ -1,0 +1,5 @@
+---
+"@scalar/themes": patch
+---
+
+fix: don't minify theme css

--- a/packages/themes/vite.config.ts
+++ b/packages/themes/vite.config.ts
@@ -37,6 +37,8 @@ export default defineConfig({
     rollupOptions: {
       external: ['vue'],
     },
+    // Don't minify CSS so we can use it in stuff like the theme editor
+    cssMinify: false,
   },
   test: {
     coverage: {


### PR DESCRIPTION
Because we want to use the theme css in our theme editor we need to have the line breaks in there.

## Before

<img width="1453" alt="Code-2024-04-26-15-14-37@2x" src="https://github.com/scalar/scalar/assets/6374090/1069a604-6243-4da7-9c03-246f4e2a5385">

## After

<img width="1453" alt="Code-2024-04-26-15-14-48@2x" src="https://github.com/scalar/scalar/assets/6374090/d870418e-a9a8-4321-8d40-0e4fa8122b1e">
