### PR TITLE
fix: mock server README example doesn’t work

### DIFF
--- a/packages/mock-server/README.md
+++ b/packages/mock-server/README.md
@@ -15,7 +15,7 @@ import { serve } from '@hono/node-server'
 import { createMockServer } from '@scalar/mock-server'
 
 // Your OpenAPI specification
-const openapi = {
+const specification = {
   openapi: '3.1.0',
   info: {
     title: 'Hello World',
@@ -43,7 +43,7 @@ const openapi = {
 
 // Create the mocked routes
 const app = await createMockServer({
-  openapi,
+  specification,
   onRequest({ context, operation }) {
     console.log(context.req.method, context.req.path)
   },


### PR DESCRIPTION
The mock server used to have a `openapi` property, but it was renamed to `specification` at some point.

This PR updates the README.