### PR TITLE
docs: add litestar, fix some grammar and spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ export default App
 
 ### With Next.js
 
-Our Next.js handler makes it easy to render a reference; just add it to an Api
+Our Next.js handler makes it easy to render a reference; just add it to an API
 route handler:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -174,8 +174,11 @@ You can [pass props to customize the API reference](https://github.com/scalar/sc
 ### With React
 
 The API Reference package is written in Vue, that shouldn’t stop you from using
-it in React though! We have created a client side (untested on SSR/SSG) wrapper
-in React:
+it in React though!
+We have created a client side wrapper in React:
+
+> [!WARNING]\
+> This is untested on SSR/SSG!
 
 ```ts
 import { ApiReferenceReact } from '@scalar/api-reference-react'

--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ export default App
 ```
 
 export default App
-```
+
+````
 
 ### With Next.js
 
@@ -218,7 +219,7 @@ const config = {
 }
 
 export const GET = ApiReference(config)
-```
+````
 
 Read more: [@scalar/nextjs-api-reference](https://github.com/scalar/scalar/tree/main/packages/nextjs-api-reference)
 

--- a/README.md
+++ b/README.md
@@ -26,23 +26,23 @@ Generate interactive API documentation from Swagger files. [Try our Demo](https:
 ## Table of Contents
 
 - [Getting Started](#getting-started)
-    - [From a CDN](#from-a-cdn)
-    - [With Nuxt](#with-nuxt)
-    - [With Vue.js](#with-vuejs)
-    - [With React](#with-react)
-    - [With Next.js](#with-nextjs)
-    - [With ElysiaJS](#with-elysiajs)
-    - [With Express](#with-express)
-    - [With NestJS](#with-nestjs)
-    - [With AdonisJS](#with-adonisjs)
-    - [With Fastify](#with-fastify)
-    - [With Platformatic](#with-platformatic)
-    - [With Hono](#with-hono)
-    - [With Docusaurus](#with-docusaurus)
-    - [With FastAPI](https://github.com/scalar/scalar/tree/main/packages/scalar_fastapi/README)
-    - [With Litestar](https://docs.litestar.dev/latest/usage/openapi/ui_plugins.html)
-    - [With Laravel](#with-laravel)
-    - [With Rust](#with-rust)
+  - [From a CDN](#from-a-cdn)
+  - [With Nuxt](#with-nuxt)
+  - [With Vue.js](#with-vuejs)
+  - [With React](#with-react)
+  - [With Next.js](#with-nextjs)
+  - [With ElysiaJS](#with-elysiajs)
+  - [With Express](#with-express)
+  - [With NestJS](#with-nestjs)
+  - [With AdonisJS](#with-adonisjs)
+  - [With Fastify](#with-fastify)
+  - [With Platformatic](#with-platformatic)
+  - [With Hono](#with-hono)
+  - [With Docusaurus](#with-docusaurus)
+  - [With FastAPI](https://github.com/scalar/scalar/tree/main/packages/scalar_fastapi/README)
+  - [With Litestar](https://docs.litestar.dev/latest/usage/openapi/ui_plugins.html)
+  - [With Laravel](#with-laravel)
+  - [With Rust](#with-rust)
 - [CLI](#cli)
 - [Hosted API Reference](#hosted-api-reference)
 - [Configuration](#configuration)
@@ -61,39 +61,38 @@ Generate interactive API documentation from Swagger files. [Try our Demo](https:
 ```html
 <!doctype html>
 <html>
-<head>
-  <title>API Reference</title>
-  <meta charset="utf-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1" />
-</head>
-<body>
-<!-- Add your own OpenAPI/Swagger spec file URL here: -->
-<!-- Note: this includes our proxy, you can remove the following line if you do not need it -->
-<!-- data-proxy-url="https://api.scalar.com/request-proxy" -->
-<script
-  id="api-reference"
-  data-url="https://petstore3.swagger.io/api/v3/openapi.json"
-  data-proxy-url="https://api.scalar.com/request-proxy"></script>
-<!-- You can also set a full configuration object like this (easier for nested objects): -->
-<script>
-  var configuration = {
-    theme: 'purple',
-  }
+  <head>
+    <title>API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <!-- Add your own OpenAPI/Swagger spec file URL here: -->
+    <!-- Note: this includes our proxy, you can remove the following line if you do not need it -->
+    <!-- data-proxy-url="https://api.scalar.com/request-proxy" -->
+    <script
+      id="api-reference"
+      data-url="https://petstore3.swagger.io/api/v3/openapi.json"
+      data-proxy-url="https://api.scalar.com/request-proxy"></script>
+    <!-- You can also set a full configuration object like this (easier for nested objects): -->
+    <script>
+      var configuration = {
+        theme: 'purple',
+      }
 
-  var apiReference = document.getElementById('api-reference')
-  apiReference.dataset.configuration = JSON.stringify(configuration)
-</script>
-<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-</body>
+      var apiReference = document.getElementById('api-reference')
+      apiReference.dataset.configuration = JSON.stringify(configuration)
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
 </html>
 ```
 
 You can also use the following syntax to directly pass an OpenAPI spec:
 
 ```html
-
 <script
   id="api-reference"
   type="application/json">
@@ -104,7 +103,6 @@ You can also use the following syntax to directly pass an OpenAPI spec:
 If you’d like to add a request proxy for the API client (to avoid CORS issues):
 
 ```html
-
 <script
   id="api-reference"
   type="application/json"
@@ -645,7 +643,7 @@ We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/scalar>
 This repository contains all our open source projects, and there’s definitely more to discover.
 
 | Package                                                                                                    | Description                                       |
-|------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | [@scalar/api-client-proxy](https://github.com/scalar/scalar/tree/main/packages/api-client-proxy)           | API request proxy                                 |
 | [@scalar/api-client](https://github.com/scalar/scalar/tree/main/packages/api-client)                       | API testing client                                |
 | [@scalar/api-reference](https://github.com/scalar/scalar/tree/main/packages/api-reference)                 | beautiful API references                          |

--- a/README.md
+++ b/README.md
@@ -18,29 +18,31 @@ Generate interactive API documentations from Swagger files. [Try our Demo](https
 - Edit your Swagger files with a live preview
 - Doesn’t look like it’s 2011
 
+> [!NOTE]\
 > [Scalar Townhall every 2nd Thursday in Discord](https://discord.gg/bcCycarP3D?event=1219363385485824000)
 >
-> Join us to see upcoming features, discuss the roadmap and chat about APIs with us. 💬
+> Join us to see upcoming features, discuss the roadmap and chat about APIs. 💬
 
 ## Table of Contents
 
 - [Getting Started](#getting-started)
-  - [From a CDN](#from-a-cdn)
-  - [With Nuxt](#with-nuxt)
-  - [With Vue.js](#with-vuejs)
-  - [With React](#with-react)
-  - [With Nextjs](#with-nextjs)
-  - [With Fastify](#with-fastify)
-  - [With Platformatic](#with-platformatic)
-  - [With Hono](#with-hono)
-  - [With ElysiaJS](#with-elysiajs)
-  - [With FastAPI](https://github.com/scalar/scalar/tree/main/packages/scalar_fastapi/README)
-  - [With Express](#with-express)
-  - [With NestJS](#with-nestjs)
-  - [With Docusaurus](#with-docusaurus)
-  - [With AdonisJS](#with-adonisjs)
-  - [With Laravel](#with-laravel)
-  - [With Rust](#with-rust)
+    - [From a CDN](#from-a-cdn)
+    - [With Nuxt](#with-nuxt)
+    - [With Vue.js](#with-vuejs)
+    - [With React](#with-react)
+    - [With Next.js](#with-nextjs)
+    - [With ElysiaJS](#with-elysiajs)
+    - [With Express](#with-express)
+    - [With NestJS](#with-nestjs)
+    - [With AdonisJS](#with-adonisjs)
+    - [With Fastify](#with-fastify)
+    - [With Platformatic](#with-platformatic)
+    - [With Hono](#with-hono)
+    - [With Docusaurus](#with-docusaurus)
+    - [With FastAPI](https://github.com/scalar/scalar/tree/main/packages/scalar_fastapi/README)
+    - [With Litestar](https://docs.litestar.dev/latest/usage/openapi/ui_plugins.html)
+    - [With Laravel](#with-laravel)
+    - [With Rust](#with-rust)
 - [CLI](#cli)
 - [Hosted API Reference](#hosted-api-reference)
 - [Configuration](#configuration)
@@ -59,38 +61,39 @@ Generate interactive API documentations from Swagger files. [Try our Demo](https
 ```html
 <!doctype html>
 <html>
-  <head>
-    <title>API Reference</title>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1" />
-  </head>
-  <body>
-    <!-- Add your own OpenAPI/Swagger spec file URL here: -->
-    <!-- Note: this includes our proxy, you can remove the following line if you do not need it -->
-    <!-- data-proxy-url="https://api.scalar.com/request-proxy" -->
-    <script
-      id="api-reference"
-      data-url="https://petstore3.swagger.io/api/v3/openapi.json"
-      data-proxy-url="https://api.scalar.com/request-proxy"></script>
-    <!-- You can also set a full configuration object like this (easier for nested objects): -->
-    <script>
-      var configuration = {
-        theme: 'purple',
-      }
+<head>
+  <title>API Reference</title>
+  <meta charset="utf-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1" />
+</head>
+<body>
+<!-- Add your own OpenAPI/Swagger spec file URL here: -->
+<!-- Note: this includes our proxy, you can remove the following line if you do not need it -->
+<!-- data-proxy-url="https://api.scalar.com/request-proxy" -->
+<script
+  id="api-reference"
+  data-url="https://petstore3.swagger.io/api/v3/openapi.json"
+  data-proxy-url="https://api.scalar.com/request-proxy"></script>
+<!-- You can also set a full configuration object like this (easier for nested objects): -->
+<script>
+  var configuration = {
+    theme: 'purple',
+  }
 
-      var apiReference = document.getElementById('api-reference')
-      apiReference.dataset.configuration = JSON.stringify(configuration)
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-  </body>
+  var apiReference = document.getElementById('api-reference')
+  apiReference.dataset.configuration = JSON.stringify(configuration)
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+</body>
 </html>
 ```
 
 You can also use the following syntax to directly pass an OpenAPI spec:
 
 ```html
+
 <script
   id="api-reference"
   type="application/json">
@@ -101,6 +104,7 @@ You can also use the following syntax to directly pass an OpenAPI spec:
 If you’d like to add a request proxy for the API client (to avoid CORS issues):
 
 ```html
+
 <script
   id="api-reference"
   type="application/json"
@@ -111,14 +115,14 @@ If you’d like to add a request proxy for the API client (to avoid CORS issues)
 
 ### With Nuxt
 
-You can easily run Scalar API References in Nuxt via the module.
+You can easily run Scalar API References in Nuxt via the module:
 
 ```bash
 npx nuxi module add @scalar/nuxt
 ```
 
-If you are using nuxt server routes you can enable scalar simply by enabling openAPI in the nitro
-config in your nuxt.config.ts
+If you are using Nuxt server routes, you can enable scalar simply by enabling openAPI in the nitro
+config in your `nuxt.config.ts`:
 
 ```ts
 export default defineNuxtConfig({
@@ -131,7 +135,7 @@ export default defineNuxtConfig({
 })
 ```
 
-If you would like to add your own OpenAPI spec file you can do so with the following minimal config
+If you would like to add your own OpenAPI spec file, you can do so with the following minimal config:
 
 ```ts
 export default defineNuxtConfig({
@@ -148,7 +152,8 @@ Read more: [@scalar/nuxt](https://github.com/scalar/scalar/tree/main/packages/nu
 
 ### With Vue.js
 
-The API Reference is built in Vue.js. If you’re working in Vue.js, too, you can directly use our Vue components. Just install them:
+The API Reference is built in Vue.js. If you’re working in Vue.js, too, you can directly use our Vue components.
+Install them via `npm`:
 
 ```bash
 npm install @scalar/api-reference
@@ -172,7 +177,7 @@ You can [pass props to customize the API reference](https://github.com/scalar/sc
 
 The API Reference package is written in Vue, that shouldn’t stop you from using
 it in React though! We have created a client side (untested on SSR/SSG) wrapper
-in react.
+in React:
 
 ```ts
 import { ApiReferenceReact } from '@scalar/api-reference-react'
@@ -181,21 +186,24 @@ import React from 'react'
 function App() {
   return (
     <ApiReferenceReact
-      configuration={{
-        spec: {
-          url: 'https://petstore3.swagger.io/api/v3/openapi.json',
-        },
-      }}
-    />
-  )
+      configuration = {
+  {
+    spec: {
+      url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+    }
+  ,
+  }
+}
+  />
+)
 }
 
 export default App
 ```
 
-### With Nextjs
+### With Next.js
 
-Our Next.js handler makes it easy to render a reference, just add it to an Api
+Our Next.js handler makes it easy to render a reference; just add it to an Api
 route handler:
 
 ```ts
@@ -215,7 +223,7 @@ Read more: [@scalar/nextjs-api-reference](https://github.com/scalar/scalar/tree/
 
 ### With Fastify
 
-Our fastify plugin makes it so easy to render a reference, there’s no excuse to not have documentation for your API.
+Our fastify plugin makes it so easy to render a reference, there’s no excuse to not have documentation for your API:
 
 ```ts
 await fastify.register(require('@scalar/fastify-api-reference'), {
@@ -234,13 +242,17 @@ await fastify.register(require('@scalar/fastify-api-reference'), {
 })
 ```
 
-We wrote a [detailed integration guide for Fastify](https://github.com/scalar/scalar/tree/main/documentation/fastify.md), too.
+We wrote
+a [detailed integration guide for Fastify](https://github.com/scalar/scalar/tree/main/documentation/fastify.md), too.
 
-Read more about the package: [@scalar/fastify-api-reference](https://github.com/scalar/scalar/tree/main/packages/fastify-api-reference)
+Read more about the
+package: [@scalar/fastify-api-reference](https://github.com/scalar/scalar/tree/main/packages/fastify-api-reference)
 
 ### With Platformatic
 
-Good news: If you’re using [a recent version of Platformatic](https://github.com/platformatic/platformatic/releases/tag/v1.16.0), the Scalar API reference is installed and configured automatically.
+Good news: If you’re
+using [a recent version of Platformatic](https://github.com/platformatic/platformatic/releases/tag/v1.16.0), the Scalar
+API reference is installed and configured automatically.
 
 ### With Hono
 
@@ -263,7 +275,7 @@ Read more: [@scalar/hono-api-reference](https://github.com/scalar/scalar/tree/ma
 
 ### With ElysiaJS
 
-The @elysiajs/swagger plugin uses our API reference by default.
+The `@elysiajs/swagger` plugin uses our API reference by default:
 
 ```ts
 import { swagger } from '@elysiajs/swagger'
@@ -321,7 +333,7 @@ Read more: [@scalar/nestjs-api-reference](https://github.com/scalar/scalar/tree/
 ### With Docusaurus
 
 Our Docusaurus plugin makes it easy to render API references. Simple add the
-following to your Docusaurus config
+following to your Docusaurus config:
 
 ```ts
 import type { ScalarOptions } from '@scalar/docusaurus'
@@ -342,17 +354,22 @@ plugins: [
 ],
 ```
 
-For more information, check out the [Docusaurus package](https://github.com/scalar/scalar/tree/main/packages/docusaurus/README.md)
+For more information, check out
+the [Docusaurus package](https://github.com/scalar/scalar/tree/main/packages/docusaurus/README.md)
 
 ### With AdonisJS
 
-There’s [a community package to generate OpenAPI files in AdonisJS](https://github.com/hanspagel/adonis-autoswagger) and it comes with support for the Scalar API reference already.
+There’s [a community package to generate OpenAPI files in AdonisJS,](https://github.com/hanspagel/adonis-autoswagger)
+and it comes with support for the
+Scalar API reference already.
 
-We wrote a [detailed integration guide for AdonisJS](https://github.com/scalar/scalar/tree/main/documentation/adonisjs.md).
+We wrote
+a [detailed integration guide for AdonisJS](https://github.com/scalar/scalar/tree/main/documentation/adonisjs.md).
 
 ### With Laravel
 
-There’s [a wonderful package to generate OpenAPI files for Laravel](https://scribe.knuckles.wtf/laravel/) already. Just set the `type` to `external_laravel` (for Blade) or `external_static` (for HTML) and `theme` to `scalar`:
+There’s [a wonderful package to generate OpenAPI files for Laravel](https://scribe.knuckles.wtf/laravel/) already.
+Set the `type` to `external_laravel` (for Blade) or `external_static` (for HTML) and `theme` to `scalar`:
 
 ```php
 <?php
@@ -366,11 +383,14 @@ return [
 ];
 ```
 
-We wrote a [detailed integration guide for Laravel Scribe](https://github.com/scalar/scalar/tree/main/documentation/laravel-scribe.md), too.
+We wrote
+a [detailed integration guide for Laravel Scribe](https://github.com/scalar/scalar/tree/main/documentation/laravel-scribe.md),
+too.
 
 ### With Rust
 
-There’s [a wonderful package to generate OpenAPI files for Rust](https://github.com/tamasfe/aide) already. Just set the `api_route` to use `Scalar` to get started:
+There’s [a wonderful package to generate OpenAPI files for Rust](https://github.com/tamasfe/aide) already.
+Set the `api_route` to use `Scalar` to get started:
 
 ```rust
 use aide::{
@@ -398,11 +418,12 @@ use aide::{
 
 ## CLI
 
-We’ve also got a nice command-line interface that you can use to play with OpenAPI files locally, integrate validation into your CI or share them easily (with us or anyone else).
+We’ve also got a nice command-line interface that you can use to play with OpenAPI files locally,
+integrate validation into your CI or share them easily (with us or anyone else).
 
 [CLI documentation](https://github.com/scalar/scalar/tree/main/packages/cli)
 
-Here’s a few use cases:
+Here are a few use cases:
 
 ### Installation
 
@@ -429,7 +450,8 @@ scalar format openapi.json --output openapi.yaml
 
 ### Validate
 
-Validate your OpenAPI file to find errors quickly, [great for CI](https://github.com/scalar/scalar/blob/main/.github/workflows/validate-openapi-file.yml):
+Validate your OpenAPI file to find errors
+quickly, [great for CI](https://github.com/scalar/scalar/blob/main/.github/workflows/validate-openapi-file.yml):
 
 ```bash
 scalar validate openapi.json
@@ -443,7 +465,8 @@ scalar validate https://example.com/openapi.json
 
 ### Preview
 
-Preview the API reference for your OpenAPI file with just one command. It can even watch your file and reload the content on file changes:
+Preview the API reference for your OpenAPI file with just one command. It can even watch your file and reload the
+content on file changes:
 
 ```bash
 scalar reference openapi.json --watch
@@ -469,7 +492,9 @@ Read [more about the CLI here](https://github.com/scalar/scalar/tree/main/packag
 
 ## Hosted API Reference
 
-Wait, this is open source and you can do whatever you want. But if you want to add a nice, customizable guide, collaborate with your team and have everything served through a CDN, create an account on [scalar.com](https://scalar.com).
+Wait, this is open source and you can do whatever you want. But if you want to add a nice, customizable guide,
+collaborate with your team and have everything served through a CDN, create an account
+on [scalar.com](https://scalar.com).
 
 ## Configuration
 
@@ -481,19 +506,22 @@ To customize the behavior of the API Reference, you can use the following config
 - `proxyUrl`: Use a proxy to send requests to other origins.
 - `darkMode`: Set dark mode on or off (light mode)
 - `layout`: The layout to use, either of `modern` or `classic` (see [#layouts](#layouts)).
-- `theme`: The them to use (see [#themes](#themes)).
+- `theme`: The theme to use (see [#themes](#themes)).
 - `showSidebar`: Whether the sidebar should be shown.
 - `customCss`: Pass custom CSS directly to the component.
 - `searchHotKey`: Key used with CTRL/CMD to open the search modal.
-- `metaData`: Configure meta information for the page.
-- `hiddenClients`: List of httpsnippet clients to hide from the clients menu, by default hides Unirest, pass `[]` to show all clients.
+- `metaData`: Configure meta-information for the page.
+- `hiddenClients`: List of `httpsnippet` clients to hide from the client's menu, by default hides Unirest,
+  pass `[]` to show all clients.
 - `onSpecUpdate`: Listen to spec changes with a callback function.
 
-For detailed information on how to use these options, refer to the [Configuration Section](https://github.com/scalar/scalar/blob/main/packages/api-reference/README.md/#configuration).
+For detailed information on how to use these options, refer to
+the [Configuration Section](https://github.com/scalar/scalar/blob/main/packages/api-reference/README.md/#configuration).
 
 ## Layouts
 
-We support two layouts at the moment, a `modern` layout (the default) and a Swagger UI inspired `classic` layout (we jazzed it up a bit though).
+We support two layouts at the moment, a `modern` layout (the default) and a Swagger UI inspired
+`classic` layout (we jazzed it up a bit though).
 
 ![layouts](https://github.com/scalar/scalar/assets/6374090/a28b89e0-8d3b-477f-a02f-bcf39f7830f0)
 
@@ -507,7 +535,9 @@ You don’t like the color scheme? We’ve prepared some themes for you:
 <ApiReference :configuration="{ theme: 'moon' }" />
 ```
 
-ℹ️ The `default` theme is … the default theme. If you want to make sure no theme is applied, pass `none`.
+> [!NOTE]\
+> The `default` theme is … the default theme.
+> If you want to make sure **no** theme is applied, pass `none`.
 
 ## Advanced: Styling
 
@@ -519,11 +549,16 @@ Overwrite our CSS variables. We won’t judge.
 }
 ```
 
-> Note: By default we’re using Inter and JetBrains Mono, served by Google Fonts. If you use a different font or just don’t want to use Google Fonts, pass `withDefaultFonts: true` to the configuration.
+> [!NOTE]\
+> By default, we’re using Inter and JetBrains Mono, served by Google Fonts.
+> If you use a different font or just don’t want to use Google Fonts,
+> pass `withDefaultFonts: true` to the configuration.
 
-You can [use all variables](https://github.com/scalar/scalar/blob/main/packages/themes/src/base.css) available in the base styles as well as overwrite the color theme.
+You can [use all variables](https://github.com/scalar/scalar/blob/main/packages/themes/src/base.css) available in the
+base styles as well as overwrite the color theme.
 
-To build your own color themes overwrite the night mode and day mode variables. Here are some basic variables to get you started:
+To build your own color themes, overwrite the night mode and day mode variables.
+Here are some basic variables to get you started:
 
 ![basic-scalar-variables](https://github.com/scalar/scalar/assets/6374090/f49256c4-4623-4797-87a1-24bdbc9b17fd)
 
@@ -586,14 +621,20 @@ Or get more advanced by styling our sidebar!
 
 ### Theme Prefix Changes
 
-We've migrated our `--theme-*` CSS variables to `--scalar-*` to avoid conflicts with other CSS variables in applications consuming the Scalar references or themes. If you're injecting your custom CSS through the [`customCss`](#configuration) configuration option we will automatically migrate your variable prefixes but display a warning in the console.
+We've migrated our `--theme-*` CSS variables to `--scalar-*` to avoid conflicts with other CSS variables in
+applications consuming the Scalar references or themes.
+If you're injecting your custom CSS through the [`customCss`](#configuration) configuration option we will automatically
+migrate your variable prefixes but display a warning in the console.
 
 We recommend updating your theme variables as soon as possible:
 
 - `--theme-*` → `--scalar-*`
 - `--sidebar-*` → `--scalar-sidebar-*`
 
-For a before and after example of an updated theme see [`legacyTheme.css`](https://github.com/scalar/scalar/tree/main/packages/themes/src/fixtures/legacyTheme.css) and [`updatedTheme.css`](https://github.com/scalar/scalar/tree/main/packages/themes/src/fixtures/updatedTheme.css) in the [`@scalar/themes`](https://github.com/scalar/scalar/tree/main/packages/themes/) package.
+For a before and after example of an updated theme
+see [`legacyTheme.css`](https://github.com/scalar/scalar/tree/main/packages/themes/src/fixtures/legacyTheme.css)
+and [`updatedTheme.css`](https://github.com/scalar/scalar/tree/main/packages/themes/src/fixtures/updatedTheme.css)
+in the [`@scalar/themes`](https://github.com/scalar/scalar/tree/main/packages/themes/) package.
 
 ## Community
 
@@ -601,10 +642,10 @@ We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/8HeZcRGP
 
 ## Packages
 
-This repository contains all our open source projects and there’s definitely more to discover.
+This repository contains all our open source projects, and there’s definitely more to discover.
 
 | Package                                                                                                    | Description                                       |
-| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+|------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
 | [@scalar/api-client-proxy](https://github.com/scalar/scalar/tree/main/packages/api-client-proxy)           | API request proxy                                 |
 | [@scalar/api-client](https://github.com/scalar/scalar/tree/main/packages/api-client)                       | API testing client                                |
 | [@scalar/api-reference](https://github.com/scalar/scalar/tree/main/packages/api-reference)                 | beautiful API references                          |

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ in the [`@scalar/themes`](https://github.com/scalar/scalar/tree/main/packages/th
 
 ## Community
 
-We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/8HeZcRGPFS>
+We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/scalar>
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can easily run Scalar API References in Nuxt via the module:
 npx nuxi module add @scalar/nuxt
 ```
 
-If you are using Nuxt server routes, you can enable scalar simply by enabling openAPI in the nitro
+If you are using Nuxt server routes, you can enable scalar simply by enabling `openAPI` in the nitro
 config in your `nuxt.config.ts`:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Release](https://github.com/scalar/scalar/actions/workflows/release.yml/badge.svg)](https://github.com/scalar/scalar/actions/workflows/release.yml)
 [![Contributors](https://img.shields.io/github/contributors/scalar/scalar)](https://github.com/scalar/scalar/graphs/contributors)
 [![GitHub License](https://img.shields.io/github/license/scalar/scalar)](https://github.com/scalar/scalar/blob/main/LICENSE)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-Generate interactive API documentations from Swagger files. [Try our Demo](https://docs.scalar.com/swagger-editor)
+Generate interactive API documentation from Swagger files. [Try our Demo](https://docs.scalar.com/swagger-editor)
 
 [![Screenshot of an API Reference](https://github.com/scalar/scalar/assets/6201407/d8beb5e1-bf64-4589-8cb0-992ba79215a8)](https://docs.scalar.com/swagger-editor)
 

--- a/README.md
+++ b/README.md
@@ -187,17 +187,17 @@ import React from 'react'
 function App() {
   return (
     <ApiReferenceReact
-      configuration = {
-  {
-    spec: {
-      url: 'https://petstore3.swagger.io/api/v3/openapi.json',
-    }
-  ,
-  }
+      configuration={{
+        spec: {
+          url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+        },
+      }}
+    />
+  )
 }
-  />
-)
-}
+
+export default App
+```
 
 export default App
 ```


### PR DESCRIPTION
**Problem**
Currently, `Litestar` is not listed

**Explanation**
This happens because someone forgot to add it

**Solution**
With this PR we add Litestar, as well as adjust some grammatical issues and add GitHub's new admonition syntax for notes
