### PR TITLE
feat: add context / dropdown menu to component library

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,6 +39,8 @@
   ],
   "module": "./dist/index.js",
   "dependencies": {
+    "@floating-ui/utils": "^0.2.2",
+    "@floating-ui/vue": "^1.0.2",
     "@headlessui/vue": "^1.7.20",
     "@scalar/oas-utils": "workspace:*",
     "@storybook/test": "^8.0.8",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,11 +45,10 @@
     "@scalar/oas-utils": "workspace:*",
     "@storybook/test": "^8.0.8",
     "@vueuse/core": "^10.9.0",
-    "class-variance-authority": "^0.7.0",
     "cva": "1.0.0-beta.1",
     "nanoid": "^5.0.1",
     "prismjs": "^1.29.0",
-    "tailwind-merge": "^2.0.0"
+    "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
     "@rise8/tailwind-pixel-perfect-preset": "^1.0.1",

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.spec.ts
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.spec.ts
@@ -1,0 +1,15 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import ScalarDropdown from './ScalarDropdown.vue'
+
+describe('ScalarDropdown', () => {
+  it('renders properly', () => {
+    const wrapper = mount(ScalarDropdown, {
+      slots: {
+        default: 'Hello Vitest',
+      },
+    })
+    expect(wrapper.text()).toContain('Hello Vitest')
+  })
+})

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.spec.ts
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.spec.ts
@@ -7,6 +7,9 @@ describe('ScalarIconButton', () => {
   it('renders properly', async () => {
     const wrapper = mount(ScalarDropdown, {
       props: {},
+      slots: {
+        default: `<button>Button</button>`,
+      },
     })
 
     expect(wrapper.exists()).toBeTruthy()

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.stories.ts
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.stories.ts
@@ -1,0 +1,37 @@
+import { placements } from '@floating-ui/utils'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+import { ScalarButton } from '../../'
+import ScalarDropdown from './ScalarDropdown.vue'
+
+const meta = {
+  component: ScalarDropdown,
+  tags: ['autodocs'],
+  argTypes: {
+    placement: {
+      control: 'select',
+      options: placements,
+    },
+  },
+  render: (args) => ({
+    components: { ScalarDropdown, ScalarButton },
+    setup() {
+      return { args }
+    },
+    template: `
+<div class="flex items-center justify-center w-screen h-screen">
+  <ScalarDropdown v-bind="args">
+    <ScalarButton>Click Me</ScalarButton>
+    <template #items>
+      Items go here
+    </template>
+  </ScalarDropdown>
+</div>
+`,
+  }),
+} satisfies Meta<typeof ScalarDropdown>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Base: Story = {}

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.stories.ts
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.stories.ts
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from '@storybook/vue3'
 
 import { ScalarButton } from '../../'
 import ScalarDropdown from './ScalarDropdown.vue'
+import ScalarDropdownDivider from './ScalarDropdownDivider.vue'
+import ScalarDropdownItem from './ScalarDropdownItem.vue'
 
 const meta = {
   component: ScalarDropdown,
@@ -14,16 +16,25 @@ const meta = {
     },
   },
   render: (args) => ({
-    components: { ScalarDropdown, ScalarButton },
+    components: {
+      ScalarDropdown,
+      ScalarDropdownItem,
+      ScalarDropdownDivider,
+      ScalarButton,
+    },
     setup() {
       return { args }
     },
     template: `
-<div class="flex items-center justify-center w-screen h-screen">
+<div class="flex items-center justify-center w-full h-screen">
   <ScalarDropdown v-bind="args">
     <ScalarButton>Click Me</ScalarButton>
     <template #items>
-      Items go here
+      <ScalarDropdownItem>An item</ScalarDropdownItem>
+      <ScalarDropdownItem>Another item</ScalarDropdownItem>
+      <ScalarDropdownDivider />
+      <ScalarDropdownItem>An item with a long label that needs to be truncated</ScalarDropdownItem>
+      <ScalarDropdownItem disabled>A disabled item</ScalarDropdownItem>
     </template>
   </ScalarDropdown>
 </div>

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -1,83 +1,30 @@
 <script setup lang="ts">
-import {
-  type Placement,
-  autoUpdate,
-  flip,
-  offset,
-  shift,
-  useFloating,
-} from '@floating-ui/vue'
 import { Menu, MenuButton, MenuItems } from '@headlessui/vue'
-import { type Ref, computed, ref, watch } from 'vue'
 
-const props = defineProps<{
-  placement?: Placement
-  resize?: boolean
-}>()
+import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
 
-defineOptions({
-  inheritAttrs: false,
-})
+defineProps<FloatingOptions>()
 
-const dropdownRef: Ref<HTMLElement | null> = ref(null)
-
-const buttonWrapper: Ref<HTMLElement | null> = ref(null)
-
-const triggerWidth = ref(0)
-const observer = new ResizeObserver(([entry]) => {
-  if (!entry) return
-  triggerWidth.value = entry.target.clientWidth
-})
-
-/** Fallback to div wrapper if a button element is not provided */
-const triggerRef = computed(
-  () => buttonWrapper.value?.children?.[0] || buttonWrapper.value,
-)
-
-// Watch the width of the trigger if fullWidth is enabled
-watch(
-  () => [props.resize, triggerRef.value],
-  ([observe]) => {
-    if (!triggerRef.value) return
-    if (observe) observer.observe(triggerRef.value)
-    else observer.disconnect()
-  },
-  { immediate: true },
-)
-
-const { floatingStyles } = useFloating(triggerRef, dropdownRef, {
-  placement: props.placement || 'bottom-start',
-  whileElementsMounted: autoUpdate,
-  middleware: [offset(5), flip(), shift()],
-})
+defineOptions({ inheritAttrs: false })
 </script>
 <template>
   <Menu>
-    <div
-      ref="buttonWrapper"
-      :class="{ contents: !!$slots.default }">
+    <ScalarFloating
+      :placement="placement ?? 'bottom-start'"
+      :resize="resize">
       <MenuButton as="template">
         <slot />
       </MenuButton>
-    </div>
-    <div
-      ref="dropdownRef"
-      class="relative z-context"
-      :style="floatingStyles">
-      <MenuItems
-        class="relative flex w-56 flex-col p-0.75"
-        :style="{ width: resize ? `${triggerWidth}px` : undefined }"
-        v-bind="$attrs">
-        <slot name="items" />
-        <div
-          class="absolute inset-0 -z-1 rounded bg-back-1 shadow-md brightness-lifted" />
-      </MenuItems>
-    </div>
+      <template #floating="{ width }">
+        <MenuItems
+          class="relative flex w-56 flex-col p-0.75"
+          :style="{ width }"
+          v-bind="$attrs">
+          <slot name="items" />
+          <div
+            class="absolute inset-0 -z-1 rounded bg-back-1 shadow-md brightness-lifted" />
+        </MenuItems>
+      </template>
+    </ScalarFloating>
   </Menu>
 </template>
-<style scoped>
-.floating {
-  position: relative;
-  z-index: 1000;
-}
-</style>

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import {
+  type Placement,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useFloating,
+} from '@floating-ui/vue'
+import { Menu, MenuButton, MenuItems } from '@headlessui/vue'
+import { type Ref, computed, ref, watch } from 'vue'
+
+const props = defineProps<{
+  placement?: Placement
+  resize?: boolean
+}>()
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const dropdownRef: Ref<HTMLElement | null> = ref(null)
+
+const buttonWrapper: Ref<HTMLElement | null> = ref(null)
+
+const triggerWidth = ref(0)
+const observer = new ResizeObserver(([entry]) => {
+  if (!entry) return
+  triggerWidth.value = entry.target.clientWidth
+})
+
+/** Fallback to div wrapper if a button element is not provided */
+const triggerRef = computed(
+  () => buttonWrapper.value?.children?.[0] || buttonWrapper.value,
+)
+
+// Watch the width of the trigger if fullWidth is enabled
+watch(
+  () => [props.resize, triggerRef.value],
+  ([observe]) => {
+    if (!triggerRef.value) return
+    if (observe) observer.observe(triggerRef.value)
+    else observer.disconnect()
+  },
+  { immediate: true },
+)
+
+const { floatingStyles } = useFloating(triggerRef, dropdownRef, {
+  placement: props.placement || 'bottom-start',
+  whileElementsMounted: autoUpdate,
+  middleware: [offset(5), flip(), shift()],
+})
+</script>
+<template>
+  <Menu>
+    <div
+      ref="buttonWrapper"
+      :class="{ contents: !!$slots.default }">
+      <MenuButton as="template">
+        <slot />
+      </MenuButton>
+    </div>
+    <div
+      ref="dropdownRef"
+      class="relative z-context"
+      :style="floatingStyles">
+      <MenuItems
+        class="relative flex w-56 flex-col p-0.75"
+        :style="{ width: resize ? `${triggerWidth}px` : undefined }"
+        v-bind="$attrs">
+        <slot name="items" />
+        <div
+          class="absolute inset-0 -z-1 rounded bg-back-1 shadow-md brightness-lifted" />
+      </MenuItems>
+    </div>
+  </Menu>
+</template>
+<style scoped>
+.floating {
+  position: relative;
+  z-index: 1000;
+}
+</style>

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdownDivider.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdownDivider.vue
@@ -1,0 +1,3 @@
+<template>
+  <div class="-mx-0.75 my-0.75 h-px bg-border" />
+</template>

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdownItem.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdownItem.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { MenuItem } from '@headlessui/vue'
+
+import { cva, cx } from '../../cva'
+
+defineProps<{
+  disabled?: boolean
+}>()
+
+defineEmits<{
+  (e: 'click', event: MouseEvent): void
+}>()
+
+const variants = cva({
+  base: [
+    // Layout
+    'min-w-0 items-center gap-3 rounded px-2.5 py-1.5 text-left',
+    'first-of-type:mt-0.75 last-of-type:mb-0.75',
+    // Text / background style
+    'truncate bg-transparent text-xs font-medium text-fore-2',
+    // Interaction
+    'cursor-pointer hover:bg-back-2 hover:text-fore-1',
+  ],
+  variants: {
+    disabled: { true: 'pointer-events-none text-fore-3' },
+    active: { true: 'bg-back-2 text-fore-1' },
+  },
+})
+</script>
+<template>
+  <MenuItem
+    v-slot="{ active }"
+    :disabled="disabled">
+    <button
+      class="item"
+      :class="cx('scalar-dropdown-item', variants({ active, disabled }))"
+      type="button"
+      @click="($event) => $emit('click', $event)">
+      <slot />
+    </button>
+  </MenuItem>
+</template>

--- a/packages/components/src/components/ScalarDropdown/index.ts
+++ b/packages/components/src/components/ScalarDropdown/index.ts
@@ -1,0 +1,1 @@
+export { default as ScalarDropdown } from './ScalarDropdown.vue'

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.spec.ts
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.spec.ts
@@ -1,11 +1,11 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 
-import ScalarDropdown from './ScalarDropdown.vue'
+import ScalarFloating from './ScalarFloating.vue'
 
 describe('ScalarIconButton', () => {
   it('renders properly', async () => {
-    const wrapper = mount(ScalarDropdown, {
+    const wrapper = mount(ScalarFloating, {
       props: {},
     })
 

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.stories.ts
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.stories.ts
@@ -1,0 +1,38 @@
+import { placements } from '@floating-ui/utils'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+import ScalarFloating from './ScalarFloating.vue'
+
+const meta = {
+  component: ScalarFloating,
+  tags: ['autodocs'],
+  argTypes: {
+    placement: {
+      control: 'select',
+      options: placements,
+    },
+  },
+  render: (args) => ({
+    components: { ScalarFloating },
+    setup() {
+      return { args }
+    },
+    template: `
+<div class="flex items-center justify-center w-full h-screen">
+  <ScalarFloating v-bind="args">
+    <div class="rounded border bg-back-2 p-1">Target for #floating</div>
+    <template #floating="{ width }">
+      <div class="rounded border shadow bg-back-2 p-1" :style="{ width }">
+        Floating
+      </div>
+    </template>
+  </ScalarDropdown>
+</div>
+`,
+  }),
+} satisfies Meta<typeof ScalarFloating>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Base: Story = {}

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue'
+import { type Ref, computed, ref, watch } from 'vue'
+
+import type { FloatingOptions } from './types'
+
+const props = defineProps<FloatingOptions>()
+
+defineOptions({ inheritAttrs: false })
+
+const floatingRef: Ref<HTMLElement | null> = ref(null)
+
+const wrapperRef: Ref<HTMLElement | null> = ref(null)
+
+const targetWidth = ref(0)
+const observer = new ResizeObserver(([entry]) => {
+  if (!entry) return
+  targetWidth.value = entry.target.clientWidth
+})
+
+/** Fallback to div wrapper if a button element is not provided */
+const targetRef = computed(
+  () => wrapperRef.value?.children?.[0] || wrapperRef.value,
+)
+
+// Watch the width of the trigger if fullWidth is enabled
+watch(
+  () => [props.resize, targetRef.value],
+  ([observe]) => {
+    if (!targetRef.value) return
+    if (observe) observer.observe(targetRef.value)
+    else observer.disconnect()
+  },
+  { immediate: true },
+)
+
+const { floatingStyles } = useFloating(targetRef, floatingRef, {
+  placement: props.placement || 'bottom',
+  whileElementsMounted: autoUpdate,
+  middleware: [offset(5), flip(), shift()],
+})
+</script>
+<template>
+  <div
+    ref="wrapperRef"
+    :class="{ contents: !!$slots.default }">
+    <slot />
+  </div>
+  <div
+    ref="floatingRef"
+    class="relative z-context"
+    :style="floatingStyles"
+    v-bind="$attrs">
+    <slot
+      name="floating"
+      :width="resize ? `${targetWidth}px` : undefined" />
+  </div>
+</template>

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -13,10 +13,13 @@ const floatingRef: Ref<HTMLElement | null> = ref(null)
 const wrapperRef: Ref<HTMLElement | null> = ref(null)
 
 const targetWidth = ref(0)
-const observer = new ResizeObserver(([entry]) => {
-  if (!entry) return
-  targetWidth.value = entry.target.clientWidth
-})
+const observer = ref<ResizeObserver>()
+
+if (typeof ResizeObserver !== 'undefined')
+  observer.value = new ResizeObserver(([entry]) => {
+    if (!entry) return
+    targetWidth.value = entry.target.clientWidth
+  })
 
 /** Fallback to div wrapper if a button element is not provided */
 const targetRef = computed(
@@ -27,9 +30,9 @@ const targetRef = computed(
 watch(
   () => [props.resize, targetRef.value],
   ([observe]) => {
-    if (!targetRef.value) return
-    if (observe) observer.observe(targetRef.value)
-    else observer.disconnect()
+    if (!targetRef.value || !observer.value) return
+    if (observe) observer.value.observe(targetRef.value)
+    else observer.value.disconnect()
   },
   { immediate: true },
 )

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -22,8 +22,9 @@ const { width: targetWidth } = useResizeWithTarget(targetRef, {
   enabled: resize,
 })
 
+const placement = computed(() => props.placement || 'bottom')
 const { floatingStyles } = useFloating(targetRef, floatingRef, {
-  placement: props.placement || 'bottom',
+  placement,
   whileElementsMounted: autoUpdate,
   middleware: [offset(5), flip(), shift()],
 })

--- a/packages/components/src/components/ScalarFloating/index.ts
+++ b/packages/components/src/components/ScalarFloating/index.ts
@@ -1,0 +1,3 @@
+export { default as ScalarFloating } from './ScalarFloating.vue'
+
+export type { FloatingOptions } from './types'

--- a/packages/components/src/components/ScalarFloating/types.ts
+++ b/packages/components/src/components/ScalarFloating/types.ts
@@ -1,0 +1,8 @@
+import type { Placement } from '@floating-ui/utils'
+
+export type FloatingOptions = {
+  /** The placement of the floating element */
+  placement?: Placement
+  /** Whether or not track the target's width */
+  resize?: boolean
+}

--- a/packages/components/src/components/ScalarFloating/useResizeWithTarget.spec.ts
+++ b/packages/components/src/components/ScalarFloating/useResizeWithTarget.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+
+import { useResizeWithTarget } from './useResizeWithTarget'
+
+/**
+ * Unfortunately we can't test the ResizeObserver with vitest but we can test the hook options
+ */
+describe('useResizeWithTarget', () => {
+  it('returns a width by default', async () => {
+    const el = ref<Element>()
+    const { width } = useResizeWithTarget(el)
+
+    expect(width.value).toBe('0px')
+  })
+
+  it('returns undefined if enabled is false', async () => {
+    const el = ref<Element>()
+    const { width } = useResizeWithTarget(el, { enabled: ref(false) })
+
+    expect(width.value).toBeUndefined()
+  })
+
+  it('is reactive to changing the enabled ref', async () => {
+    const el = ref<Element>()
+    const enabled = ref(false)
+
+    const { width } = useResizeWithTarget(el, { enabled })
+    expect(width.value).toBeUndefined()
+
+    enabled.value = true
+    expect(width.value).toBe('0px')
+
+    enabled.value = false
+    expect(width.value).toBeUndefined()
+  })
+})

--- a/packages/components/src/components/ScalarFloating/useResizeWithTarget.ts
+++ b/packages/components/src/components/ScalarFloating/useResizeWithTarget.ts
@@ -1,11 +1,11 @@
-import { type ComputedRef, type Ref, computed, ref, watch } from 'vue'
+import { type MaybeRefOrGetter, computed, ref, toValue, watch } from 'vue'
 
 type ResizeOptions = {
-  enabled?: Ref<boolean> | ComputedRef<boolean>
+  enabled?: MaybeRefOrGetter<boolean>
 }
 
 export function useResizeWithTarget(
-  target: Ref<Element | undefined>,
+  target: MaybeRefOrGetter<Element | undefined>,
   opts: ResizeOptions = { enabled: ref(true) },
 ) {
   const targetWidth = ref(0)
@@ -18,10 +18,10 @@ export function useResizeWithTarget(
     })
 
   watch(
-    () => [opts.enabled?.value, target?.value],
-    ([enabled]) => {
-      if (!target?.value || !observer.value) return
-      if (enabled) observer.value.observe(target.value)
+    [() => toValue(opts.enabled), () => toValue(target)],
+    ([enabled, element]) => {
+      if (!element || !observer.value) return
+      if (enabled) observer.value.observe(element)
       else observer.value.disconnect()
     },
     { immediate: true },
@@ -29,7 +29,7 @@ export function useResizeWithTarget(
 
   return {
     width: computed(() =>
-      opts.enabled?.value ? `${targetWidth.value}px` : undefined,
+      toValue(opts.enabled) ? `${targetWidth.value}px` : undefined,
     ),
   }
 }

--- a/packages/components/src/components/ScalarFloating/useResizeWithTarget.ts
+++ b/packages/components/src/components/ScalarFloating/useResizeWithTarget.ts
@@ -1,0 +1,35 @@
+import { type ComputedRef, type Ref, computed, ref, watch } from 'vue'
+
+type ResizeOptions = {
+  enabled?: Ref<boolean> | ComputedRef<boolean>
+}
+
+export function useResizeWithTarget(
+  target: Ref<Element | undefined>,
+  opts: ResizeOptions = { enabled: ref(true) },
+) {
+  const targetWidth = ref(0)
+  const observer = ref<ResizeObserver>()
+
+  if (typeof ResizeObserver !== 'undefined')
+    observer.value = new ResizeObserver(([entry]) => {
+      if (!entry) return
+      targetWidth.value = entry.target.clientWidth
+    })
+
+  watch(
+    () => [opts.enabled?.value, target?.value],
+    ([enabled]) => {
+      if (!target?.value || !observer.value) return
+      if (enabled) observer.value.observe(target.value)
+      else observer.value.disconnect()
+    },
+    { immediate: true },
+  )
+
+  return {
+    width: computed(() =>
+      opts.enabled?.value ? `${targetWidth.value}px` : undefined,
+    ),
+  }
+}

--- a/packages/components/src/components/ScalarFloating/useResizeWithTarget.ts
+++ b/packages/components/src/components/ScalarFloating/useResizeWithTarget.ts
@@ -14,7 +14,7 @@ export function useResizeWithTarget(
   if (typeof ResizeObserver !== 'undefined')
     observer.value = new ResizeObserver(([entry]) => {
       if (!entry) return
-      targetWidth.value = entry.target.clientWidth
+      targetWidth.value = entry.borderBoxSize[0]?.inlineSize ?? 0
     })
 
   watch(

--- a/packages/components/src/cva.ts
+++ b/packages/components/src/cva.ts
@@ -15,6 +15,7 @@ import { prefix } from '../postcss.config'
 const tw = extendTailwindMerge<typeof prefix>({
   extend: {
     classGroups: {
+      'font-size': ['text-xxs'],
       // Add the scalar class prefix as a custom class to be deduped by tailwind-merge
       [prefix]: [prefix],
     },

--- a/packages/components/src/tailwind/tailwind.theme.ts
+++ b/packages/components/src/tailwind/tailwind.theme.ts
@@ -37,6 +37,15 @@ export const theme = {
     sans: 'var(--scalar-font)',
     code: 'var(--scalar-font-code)',
   },
+  zIndex: {
+    '-1': '-1',
+    '0': '0',
+    '1': '1',
+    // Contextual overlays like dropdowns, popovers, tooltips
+    'context': '1000',
+    // Full screen overlays / modals
+    'overlay': '10000',
+  },
 } as const
 
 export const extend = {
@@ -62,5 +71,9 @@ export const extend = {
     'screen-sm': '540px',
     'screen-md': '640px',
     'screen-lg': '800px',
+  },
+  brightness: {
+    lifted: 'var(--scalar-lifted-brightness)',
+    backdrop: 'var(--scalar-backdrop-brightness)',
   },
 } as const

--- a/packages/components/src/tailwind/tailwind.theme.ts
+++ b/packages/components/src/tailwind/tailwind.theme.ts
@@ -76,4 +76,7 @@ export const extend = {
     lifted: 'var(--scalar-lifted-brightness)',
     backdrop: 'var(--scalar-backdrop-brightness)',
   },
+  spacing: {
+    px: '1px',
+  },
 } as const

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1105,9 +1105,6 @@ importers:
       '@vueuse/core':
         specifier: ^10.9.0
         version: 10.9.0(vue@3.4.21)
-      class-variance-authority:
-        specifier: ^0.7.0
-        version: 0.7.0
       cva:
         specifier: 1.0.0-beta.1
         version: 1.0.0-beta.1(typescript@5.4.3)
@@ -1118,8 +1115,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0
       tailwind-merge:
-        specifier: ^2.0.0
-        version: 2.2.1
+        specifier: ^2.3.0
+        version: 2.3.0
       vue:
         specifier: ^3.3.0
         version: 3.4.21(typescript@5.4.3)
@@ -4505,6 +4502,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
+
+  /@babel/runtime@7.24.5:
+    resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
+    dev: false
 
   /@babel/standalone@7.24.4:
     resolution: {integrity: sha512-V4uqWeedadiuiCx5P5OHYJZ1PehdMpcBccNCEptKFGPiZIY3FI5f2ClxUl4r5wZ5U+ohcQ+4KW6jX2K6xXzq4Q==}
@@ -9940,7 +9944,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.21(typescript@5.4.3)
-      vue-component-type-helpers: 2.0.15
+      vue-component-type-helpers: 2.0.16
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13629,12 +13633,6 @@ packages:
   /cjs-module-lexer@1.2.3:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
     dev: true
-
-  /class-variance-authority@0.7.0:
-    resolution: {integrity: sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==}
-    dependencies:
-      clsx: 2.0.0
-    dev: false
 
   /clean-css@4.2.4:
     resolution: {integrity: sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==}
@@ -25783,10 +25781,10 @@ packages:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
     dev: true
 
-  /tailwind-merge@2.2.1:
-    resolution: {integrity: sha512-o+2GTLkthfa5YUt4JxPfzMIpQzZ3adD1vLVkvKE1Twl9UAhGsEbIZhHHZVRttyW177S8PDJI3bTQNaebyofK3Q==}
+  /tailwind-merge@2.3.0:
+    resolution: {integrity: sha512-vkYrLpIP+lgR0tQCG6AP7zZXCTLc1Lnv/CCRT3BqJ9CZ3ui2++GPaGb1x/ILsINIMSYqqvrpqjUFsMNLlW99EA==}
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.24.5
     dev: false
 
   /tailwindcss@3.4.1(ts-node@10.9.2):
@@ -27938,8 +27936,8 @@ packages:
     resolution: {integrity: sha512-xNO5B7DstNWETnoYflLkVgh8dK8h2ZDgxY1M2O0zrqGeBNq5yAZ8a10yCS9+HnixouNGYNX+ggU9MQQq86HTpg==}
     dev: true
 
-  /vue-component-type-helpers@2.0.15:
-    resolution: {integrity: sha512-jR/Hw52gzNQxMovJBsOQ/F9E1UQ8K1Np0CVG3RnueLkaCKqWuyL9XHl/5tUBAGJx+bk5xZ+co7vK23+Pzt75Lg==}
+  /vue-component-type-helpers@2.0.16:
+    resolution: {integrity: sha512-qisL/iAfdO++7w+SsfYQJVPj6QKvxp4i1MMxvsNO41z/8zu3KuAw9LkhKUfP/kcOWGDxESp+pQObWppXusejCA==}
     dev: true
 
   /vue-demi@0.14.7(vue@3.4.21):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1087,6 +1087,12 @@ importers:
 
   packages/components:
     dependencies:
+      '@floating-ui/utils':
+        specifier: ^0.2.2
+        version: 0.2.2
+      '@floating-ui/vue':
+        specifier: ^1.0.2
+        version: 1.0.6(vue@3.4.21)
       '@headlessui/vue':
         specifier: ^1.7.20
         version: 1.7.20(vue@3.4.21)
@@ -6290,7 +6296,7 @@ packages:
   /@floating-ui/core@1.6.0:
     resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
     dependencies:
-      '@floating-ui/utils': 0.2.1
+      '@floating-ui/utils': 0.2.2
 
   /@floating-ui/dom@1.1.1:
     resolution: {integrity: sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==}
@@ -6302,7 +6308,7 @@ packages:
     resolution: {integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==}
     dependencies:
       '@floating-ui/core': 1.6.0
-      '@floating-ui/utils': 0.2.1
+      '@floating-ui/utils': 0.2.2
 
   /@floating-ui/react-dom@2.0.8(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==}
@@ -6315,14 +6321,14 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@floating-ui/utils@0.2.1:
-    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
+  /@floating-ui/utils@0.2.2:
+    resolution: {integrity: sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==}
 
   /@floating-ui/vue@1.0.6(vue@3.4.21):
     resolution: {integrity: sha512-EdrOljjkpkkqZnrpqUcPoz9NvHxuTjUtSInh6GMv3+Mcy+giY2cE2pHh9rpacRcZ2eMSCxel9jWkWXTjLmY55w==}
     dependencies:
       '@floating-ui/dom': 1.6.3
-      '@floating-ui/utils': 0.2.1
+      '@floating-ui/utils': 0.2.2
       vue-demi: 0.14.7(vue@3.4.21)
     transitivePeerDependencies:
       - '@vue/composition-api'


### PR DESCRIPTION
Todo:

- [x] Make tests actually test something
- [x] Extract resize logic into a hook?
- [x] Create checkbox thing in component library? Or maybe it should be in the other repo?

<img width="1485" alt="Google Chrome-2024-04-29-19-30-12@2x" src="https://github.com/scalar/scalar/assets/6374090/8d2b79bd-2cd5-4d5d-bf6c-071b3a84b43f">