### PR TITLE
fix: theme not selectable in the editor

### DIFF
--- a/.changeset/smart-carrots-march.md
+++ b/.changeset/smart-carrots-march.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: add label value in changeTheme event

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -81,7 +81,7 @@ const parsedSpec = asyncComputed(
     :configuration="configuration"
     :parsedSpec="parsedSpec"
     :rawSpec="content"
-    @changeTheme="configuration.theme = $event"
+    @changeTheme="configuration.theme = $event.id"
     @updateContent="(v) => (content = v)">
     <template #header>
       <DevToolbar>

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -44,7 +44,7 @@ import { Sidebar } from './Sidebar'
 const props = defineProps<Omit<ReferenceLayoutProps, 'isDark'>>()
 
 defineEmits<{
-  (e: 'changeTheme', value: ThemeId): void
+  (e: 'changeTheme', { id, label }: { id: ThemeId; label: string }): void
   (e: 'updateContent', value: string): void
   (e: 'loadSwaggerFile'): void
   (e: 'linkSwaggerFile'): void

--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -9,7 +9,7 @@ defineProps<{
 }>()
 
 const emits = defineEmits<{
-  (e: 'changeTheme', value: ThemeId): void
+  (e: 'changeTheme', { id, label }: { id: ThemeId; label: string }): void
   (e: 'loadSwaggerFile'): void
   (e: 'linkSwaggerFile'): void
   (e: 'updateContent', value: string): void
@@ -178,7 +178,9 @@ function handleEmitPetstore() {
           :key="themeId"
           class="start-item"
           :class="{ 'start-item-active': themeId === theme }"
-          @click="$emit('changeTheme', themeId)">
+          @click="
+            $emit('changeTheme', { id: themeId, label: themeLabels[themeId] })
+          ">
           {{ themeLabels[themeId] }}
         </div>
       </div>


### PR DESCRIPTION
**Problem**
some themes are not selectable from the api reference editor.

**Solution**
this pr introduces the theme label value in the `changeTheme` event in order to base the theme selection on it in the app.
