### PR TITLE
chore: add .dockerignore to base builder image

### DIFF
--- a/tooling/base-docker-builder/.dockerignore
+++ b/tooling/base-docker-builder/.dockerignore
@@ -1,0 +1,52 @@
+.env
+**/.env
+**/coverage/**
+coverage
+
+.env.staging
+.env.production
+.sh
+
+# Exclude nested dockerfile to prevent cache break issues
+**/Dockerfile
+
+# compiled output
+dist
+tmp
+/out-tsc
+**/dist/**
+
+# dependencies
+node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+db.sqlite
+
+# System Files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Add missing `.dockerignore` to the base builder image.
