### PR TITLE
fix: avoid prepending path when running standalone from an html file without a server

### DIFF
--- a/.changeset/long-turtles-begin.md
+++ b/.changeset/long-turtles-begin.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: avoid prepending path when running standalone from an html file without a server

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -27,7 +27,7 @@ const { hideModels, collapsedSidebarItems } = useSidebar()
 
 const prependRelativePath = (server: Server) => {
   // URLs that don't start with http[s]://
-  if (server.url.match(/^(?!https?:\/\/).+/)) {
+  if (server.url.match(/^(?!(https?|file):\/\/).+/)) {
     let baseURL = props.baseServerURL ?? window.location.origin
 
     // Handle slashes


### PR DESCRIPTION
this was due to loading from a file:// path