### PR TITLE
refactor: switch to inter variable

### DIFF
--- a/packages/themes/src/fonts/inter.css
+++ b/packages/themes/src/fonts/inter.css
@@ -2,7 +2,8 @@
 @font-face {
   font-family: 'Inter';
   font-style: normal;
-  font-weight: 400;
+  font-weight: 100 900;
+  font-display: swap;
   src: url(https://cdn.scalar.com/fonts/inter-cyrillic-ext.woff2)
     format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
@@ -12,7 +13,8 @@
 @font-face {
   font-family: 'Inter';
   font-style: normal;
-  font-weight: 400;
+  font-weight: 100 900;
+  font-display: swap;
   src: url(https://cdn.scalar.com/fonts/inter-cyrillic.woff2) format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -20,7 +22,8 @@
 @font-face {
   font-family: 'Inter';
   font-style: normal;
-  font-weight: 400;
+  font-weight: 100 900;
+  font-display: swap;
   src: url(https://cdn.scalar.com/fonts/inter-greek-ext.woff2) format('woff2');
   unicode-range: U+1F00-1FFF;
 }
@@ -28,7 +31,8 @@
 @font-face {
   font-family: 'Inter';
   font-style: normal;
-  font-weight: 400;
+  font-weight: 100 900;
+  font-display: swap;
   src: url(https://cdn.scalar.com/fonts/inter-greek.woff2) format('woff2');
   unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1,
     U+03A3-03FF;
@@ -37,7 +41,8 @@
 @font-face {
   font-family: 'Inter';
   font-style: normal;
-  font-weight: 400;
+  font-weight: 100 900;
+  font-display: swap;
   src: url(https://cdn.scalar.com/fonts/inter-vietnamese.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1,
     U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
@@ -47,7 +52,8 @@
 @font-face {
   font-family: 'Inter';
   font-style: normal;
-  font-weight: 400;
+  font-weight: 100 900;
+  font-display: swap;
   src: url(https://cdn.scalar.com/fonts/inter-latin-ext.woff2) format('woff2');
   unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF,
     U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
@@ -56,7 +62,8 @@
 @font-face {
   font-family: 'Inter';
   font-style: normal;
-  font-weight: 400;
+  font-weight: 100 900;
+  font-display: swap;
   src: url(https://cdn.scalar.com/fonts/inter-latin.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,


### PR DESCRIPTION
Add support for variable width inter font. Fixes DOC-1755

@tmastrom these `woff2` files need to be uploaded to the CDN: [inter-variable.zip](https://github.com/scalar/scalar/files/15180645/inter-variable.zip)

Behold, variableness 

https://github.com/scalar/scalar/assets/6374090/edf2e6fc-f9a0-4206-b054-45c2502ff1b5

