### PR TITLE
feat: containerize react example app

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -54,6 +54,44 @@ steps:
         '--service-account=$_SERVICE_ACCOUNT',
       ]
   # ---------------------------------------------------------------
+  # React integration
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-react-js'
+    waitFor: ['push-base']
+    args:
+      [
+        'buildx',
+        'build',
+        '--build-arg',
+        'BASE_IMAGE=gcr.io/${_PROJECT_ID}/${_BASE_BUILDER}',
+        '-t',
+        'gcr.io/${_PROJECT_ID}/${_SERVICE_REACT_JS}',
+        '-f',
+        './examples/react/Dockerfile',
+        '.',
+      ]
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'push-react-js'
+    waitFor: ['build-react-js']
+    args: ['push', 'gcr.io/${_PROJECT_ID}/${_SERVICE_REACT_JS}']
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    waitFor: ['push-react-js']
+    args:
+      [
+        'run',
+        'deploy',
+        '$_SERVICE_REACT_JS',
+        '--image=gcr.io/${_PROJECT_ID}/${_SERVICE_REACT_JS}',
+        '--region=$_REGION',
+        '--platform=managed',
+        '--allow-unauthenticated',
+        '--execution-environment=gen2',
+        '--cpu=$_CPU',
+        '--memory=$_MEMORY',
+        '--service-account=$_SERVICE_ACCOUNT',
+      ]
+  # ---------------------------------------------------------------
   # Other Integration
   # - name: OTHER INTEGRATION
 options:

--- a/examples/react/.dockerignore
+++ b/examples/react/.dockerignore
@@ -1,0 +1,52 @@
+.env
+**/.env
+**/coverage/**
+coverage
+
+.env.staging
+.env.production
+.sh
+
+# Exclude nested dockerfile to prevent cache break issues
+**/Dockerfile
+
+# compiled output
+dist
+tmp
+/out-tsc
+**/dist/**
+
+# dependencies
+node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+db.sqlite
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/examples/react/Dockerfile
+++ b/examples/react/Dockerfile
@@ -1,0 +1,41 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS builder
+WORKDIR /app
+
+# Copy everything but only install and build the main package and its dependencies
+COPY pnpm-lock.yaml .
+COPY pnpm-workspace.yaml .
+COPY package.json .
+COPY tsconfig.json .
+COPY packages/api-reference ./packages/api-reference
+COPY packages/components ./packages/components
+COPY packages/themes ./packages/themes
+COPY packages/oas-utils ./packages/oas-utils
+COPY packages/build-tooling ./packages/build-tooling
+COPY packages/api-reference-react ./packages/api-reference-react
+COPY examples/react ./examples/react
+
+# Install and build the main package and its dependencies
+RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store \
+    pnpm --filter "@scalar-examples/react" install && \
+    pnpm --filter "@scalar-examples/react" build
+
+FROM node:18-bullseye-slim AS runner
+RUN npm install -g serve
+
+# Create a non-root user
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 reactjs
+
+# Set the correct permission for the build
+RUN mkdir app
+RUN chown reactjs:nodejs app
+USER reactjs
+
+WORKDIR /app
+
+COPY --from=builder /app/examples/react /app/examples/react
+
+WORKDIR /app/examples/react
+
+CMD ["serve", "-s", "-l", "5059", "./dist"]

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -13,6 +13,7 @@
     "build": "pnpm types:check && pnpm build-only",
     "build-only": "vite build",
     "dev": "vite",
+    "docker:build": "build --platform=linux/amd64 -t ${image_name} --build-arg=\"BASE_IMAGE=scalar-base\" -f ./examples/react/Dockerfile .",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "types:check": "tsc --noEmit --skipLibCheck"


### PR DESCRIPTION
Containerize react example app. Adds Dockerfile and cloudbuild script. Uses `serve` package to serve the static js from the dist/ folder.