### PR TITLE
chore: release `@scalar/fastify-api-reference` together with the `@scalar/api-reference`, fix #1246

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,10 +2,10 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": ["@changesets/cli/commit", { "skipCI": false }],
-  "fixed": [],
-  "linked": [
+  "fixed": [
     ["@scalar/api-reference", "@scalar/fastify-api-reference"]
   ],
+  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",


### PR DESCRIPTION
Currently, we manually need to add a changeset for `@scalar/fastify-api-reference` to publish it with an updated version of `@scalar/api-reference`.

This is happens because the fastify package doesn’t have the core package as a direct dependency (it’s just copied in there). And my attempt to configure the release workflow accordingly didn’t have any effect.

I think I misread the documentation on “linked” packages and we actually need to configure them as “fixed” packages.

Before: https://github.com/changesets/changesets/blob/main/docs/linked-packages.md
After: https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md

See #1246