### PR TITLE
docs: use @scalar/galaxy instead of petstore example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 [![GitHub License](https://img.shields.io/github/license/scalar/scalar)](https://github.com/scalar/scalar/blob/main/LICENSE)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-Generate interactive API documentation from Swagger files. [Try our Demo](https://docs.scalar.com/swagger-editor)
+Generate interactive API documentation from OpenAPI/Swagger files. [Try our Demo](https://docs.scalar.com/swagger-editor)
 
 [![Screenshot of an API Reference](https://github.com/scalar/scalar/assets/6201407/d8beb5e1-bf64-4589-8cb0-992ba79215a8)](https://docs.scalar.com/swagger-editor)
 
 ## Features
 
-- Uses Swagger/OpenAPI spec files
+- Uses OpenAPI/Swagger specifications
 - Request examples for a ton of languages + frameworks
 - Has an integrated API client
-- Edit your Swagger files with a live preview
+- Edit your OpenAPI/Swagger specification with a live preview
 - Doesn’t look like it’s 2011
 
 > [!NOTE]\
@@ -62,35 +62,35 @@ Generate interactive API documentation from Swagger files. [Try our Demo](https:
 <!doctype html>
 <html>
   <head>
-    <title>API Reference</title>
+    <title>Scalar API Reference</title>
     <meta charset="utf-8" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1" />
   </head>
   <body>
-    <!-- Add your own OpenAPI/Swagger spec file URL here: -->
-    <!-- Note: this includes our proxy, you can remove the following line if you do not need it -->
-    <!-- data-proxy-url="https://api.scalar.com/request-proxy" -->
+    <!-- Add your own OpenAPI/Swagger specification URL here: -->
+    <!-- Note: The example is our public proxy (to avoid CORS issues). You can remove the `data-proxy-url` attribute if you don’t need it. -->
     <script
       id="api-reference"
-      data-url="https://petstore3.swagger.io/api/v3/openapi.json"
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
       data-proxy-url="https://api.scalar.com/request-proxy"></script>
-    <!-- You can also set a full configuration object like this (easier for nested objects): -->
+
+    <!-- Optional: You can set a full configuration object like this: -->
     <script>
       var configuration = {
         theme: 'purple',
       }
 
-      var apiReference = document.getElementById('api-reference')
-      apiReference.dataset.configuration = JSON.stringify(configuration)
+      document.getElementById('api-reference').dataset.configuration =
+        JSON.stringify(configuration)
     </script>
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   </body>
 </html>
 ```
 
-You can also use the following syntax to directly pass an OpenAPI spec:
+You can also use the following syntax to directly pass an OpenAPI specification:
 
 ```html
 <script
@@ -189,7 +189,7 @@ function App() {
     <ApiReferenceReact
       configuration={{
         spec: {
-          url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
         },
       }}
     />
@@ -348,7 +348,7 @@ plugins: [
       route: '/scalar',
       configuration: {
         spec: {
-          url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
         },
       },
     } as ScalarOptions,
@@ -502,8 +502,7 @@ on [scalar.com](https://scalar.com).
 
 To customize the behavior of the API Reference, you can use the following configuration options:
 
-- `isEditable`: Whether the Swagger editor should be shown.
-- `spec.content`: Directly pass an OpenAPI/Swagger spec.
+- `spec.content`: Directly pass an OpenAPI/Swagger specifcation.
 - `spec.url`: Pass the URL of a spec file (JSON or YAML).
 - `proxyUrl`: Use a proxy to send requests to other origins.
 - `darkMode`: Set dark mode on or off (light mode)

--- a/examples/cdn-api-reference/src/public/api-reference-cdn-live.html
+++ b/examples/cdn-api-reference/src/public/api-reference-cdn-live.html
@@ -13,7 +13,7 @@
     <!-- data-proxy-url="https://api.scalar.com/request-proxy" -->
     <script
       id="api-reference"
-      data-url="https://petstore3.swagger.io/api/v3/openapi.json"
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
       data-proxy-url="https://api.scalar.com/request-proxy"></script>
     <!-- You can also set a full configuration object like this -->
     <!-- easier for nested objects -->

--- a/examples/cdn-api-reference/src/public/api-reference-cdn-localhost.html
+++ b/examples/cdn-api-reference/src/public/api-reference-cdn-localhost.html
@@ -13,7 +13,7 @@
     <!-- data-proxy-url="https://api.scalar.com/request-proxy" -->
     <script
       id="api-reference"
-      data-url="https://petstore3.swagger.io/api/v3/openapi.json"
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
       data-proxy-url="https://api.scalar.com/request-proxy"></script>
     <!-- You can also set a full configuration object like this -->
     <!-- easier for nested objects -->

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -6,7 +6,7 @@ function App() {
     <ApiReferenceReact
       configuration={{
         spec: {
-          url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
         },
       }}
     />

--- a/packages/api-reference-react/README.md
+++ b/packages/api-reference-react/README.md
@@ -22,7 +22,7 @@ function App() {
     <ApiReferenceReact
       configuration={{
         spec: {
-          url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
         },
       }}
     />

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -98,7 +98,7 @@ const getProxyUrl = () => {
 
 if (!specUrlElement && !specElement && !specScriptTag) {
   console.error(
-    'Couldn’t find a [data-spec], [data-spec-url] or <script id="api-reference" /> element. Try adding it like this: %c<div data-spec-url="https://petstore3.swagger.io/api/v3/openapi.json" />',
+    'Couldn’t find a [data-spec], [data-spec-url] or <script id="api-reference" /> element. Try adding it like this: %c<div data-spec-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml" />',
     'font-family: monospace;',
   )
 } else {

--- a/packages/express-api-reference/test/index.test.ts
+++ b/packages/express-api-reference/test/index.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { ApiReference } from '../src'
 
 describe('ApiReference', () => {
-  const url = 'https://petstore3.swagger.io/api/v3/openapi.json'
+  const url = 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml'
 
   it('renders the given spec URL', () => {
     expect(ApiReference({ spec: { url } }).toString()).toContain(
-      `https://petstore3.swagger.io/api/v3/openapi.json`,
+      `https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml`,
     )
   })
 
@@ -19,6 +19,6 @@ describe('ApiReference', () => {
           cdn: 'https://fastly.jsdelivr.net/npm/@scalar/api-reference',
         },
       }).toString(),
-    ).toContain(`https://petstore3.swagger.io/api/v3/openapi.json`)
+    ).toContain(`https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml`)
   })
 })

--- a/packages/galaxy/README.md
+++ b/packages/galaxy/README.md
@@ -19,7 +19,7 @@ npm install @scalar/galaxy
 
 | Version     | Format | URL                                                          |
 | ----------- | ------ | ------------------------------------------------------------ |
-| Latest      | JSON   | https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json |
+| Latest      | JSON   | https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml |
 | Latest      | YAML   | https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml |
 | OpenAPI 3.1 | JSON   | https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/3.1.json    |
 | OpenAPI 3.1 | YAML   | https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/3.1.yaml    |

--- a/packages/hono-api-reference/src/honoApiReference.test.ts
+++ b/packages/hono-api-reference/src/honoApiReference.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { javascript } from './honoApiReference'
 
 describe('javascript', () => {
-  const url = 'https://petstore3.swagger.io/api/v3/openapi.json'
+  const url = 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml'
 
   it('renders the given spec URL', () => {
     expect(javascript({ spec: { url } }).toString()).toContain(
-      `https://petstore3.swagger.io/api/v3/openapi.json`,
+      `https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml`,
     )
   })
 
@@ -19,6 +19,6 @@ describe('javascript', () => {
           cdn: 'https://fastly.jsdelivr.net/npm/@scalar/api-reference',
         },
       }).toString(),
-    ).toContain(`https://petstore3.swagger.io/api/v3/openapi.json`)
+    ).toContain(`https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml`)
   })
 })

--- a/packages/nestjs-api-reference/test/index.test.ts
+++ b/packages/nestjs-api-reference/test/index.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { ApiReference } from '../src'
 
 describe('ApiReference', () => {
-  const url = 'https://petstore3.swagger.io/api/v3/openapi.json'
+  const url = 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml'
 
   it('renders the given spec URL', () => {
     expect(ApiReference({ spec: { url } }).toString()).toContain(
-      `https://petstore3.swagger.io/api/v3/openapi.json`,
+      `https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml`,
     )
   })
 
@@ -19,6 +19,6 @@ describe('ApiReference', () => {
           cdn: 'https://fastly.jsdelivr.net/npm/@scalar/api-reference',
         },
       }).toString(),
-    ).toContain(`https://petstore3.swagger.io/api/v3/openapi.json`)
+    ).toContain(`https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml`)
   })
 })

--- a/packages/oas-utils/src/fetch-spec.test.ts
+++ b/packages/oas-utils/src/fetch-spec.test.ts
@@ -5,7 +5,7 @@ import { fetchSpecFromUrl } from './fetch-spec'
 describe('Fetches specs correctly', () => {
   test('Fetches without a proxy', async () => {
     const spec = await fetchSpecFromUrl(
-      'https://petstore3.swagger.io/api/v3/openapi.json',
+      'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
     )
 
     expect(typeof spec).toEqual('string')
@@ -14,7 +14,7 @@ describe('Fetches specs correctly', () => {
 
   test('Fetches with a proxy', async () => {
     const spec = await fetchSpecFromUrl(
-      'https://petstore3.swagger.io/api/v3/openapi.json',
+      'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
       'https://api.scalar.com/request-proxy',
     )
 


### PR DESCRIPTION
Currently, we’re still using the petstore HTTP url in a lot of places.

This PR switches to the `@scalar/galaxy` jsdelivr URL instead. :)

I’ve also simplified the quickstart example and made a few wording changes to the root README (focusing more on OpenAPI, less on Swagger).