### PR TITLE
chore: use same example page title everywhere

### DIFF
--- a/.changeset/violet-bears-smile.md
+++ b/.changeset/violet-bears-smile.md
@@ -1,0 +1,10 @@
+---
+"@scalar/express-api-reference": patch
+"@scalar/fastify-api-reference": patch
+"@scalar/nestjs-api-reference": patch
+"@scalar/nextjs-api-reference": patch
+"@scalar/api-reference": patch
+"@scalar/cli": patch
+---
+
+chore: update example page title

--- a/examples/cdn-api-reference/src/public/api-reference-cdn-live.html
+++ b/examples/cdn-api-reference/src/public/api-reference-cdn-live.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>API Reference</title>
+    <title>Scalar API Reference</title>
     <meta charset="utf-8" />
     <meta
       name="viewport"

--- a/examples/cdn-api-reference/src/public/api-reference-cdn-localhost.html
+++ b/examples/cdn-api-reference/src/public/api-reference-cdn-localhost.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>API Reference</title>
+    <title>Scalar API Reference</title>
     <meta charset="utf-8" />
     <meta
       name="viewport"

--- a/examples/react/index.html
+++ b/examples/react/index.html
@@ -13,7 +13,7 @@
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
-    <title>Scalar API Reference (React)</title>
+    <title>Scalar API Reference</title>
   </head>
   <body class="light-mode">
     <div id="root"></div>

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>API Reference</title>
+    <title>Scalar API Reference</title>
     <meta charset="utf-8" />
     <meta
       name="viewport"

--- a/packages/cli/src/utils/getHtmlDocument.ts
+++ b/packages/cli/src/utils/getHtmlDocument.ts
@@ -7,7 +7,7 @@ export function getHtmlDocument(
   return `<!doctype html>
     <html>
       <head>
-        <title>API Reference</title>
+        <title>Scalar API Reference</title>
         <meta charset="utf-8" />
         <meta
           name="viewport"

--- a/packages/express-api-reference/src/expressApiReference.ts
+++ b/packages/express-api-reference/src/expressApiReference.ts
@@ -134,7 +134,7 @@ export function apiReference(options: ApiReferenceOptions) {
   <!DOCTYPE html>
   <html>
     <head>
-      <title>API Reference</title>
+      <title>Scalar API Reference</title>
       <meta charset="utf-8" />
       <meta
         name="viewport"

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -193,7 +193,9 @@ describe('fastifyApiReference', () => {
 
     const address = await fastify.listen({ port: 0 })
     const response = await fetch(`${address}/reference`)
-    expect(await response.text()).toContain('<title>API Reference</title>')
+    expect(await response.text()).toContain(
+      '<title>Scalar API Reference</title>',
+    )
   })
 
   it('has the correct content type', async () => {

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -150,7 +150,7 @@ export function htmlDocument(options: FastifyApiReferenceOptions) {
 <!DOCTYPE html>
 <html>
   <head>
-    <title>API Reference</title>
+    <title>Scalar API Reference</title>
     <meta charset="utf-8" />
     <meta
       name="viewport"

--- a/packages/nestjs-api-reference/src/nestJSApiReference.ts
+++ b/packages/nestjs-api-reference/src/nestJSApiReference.ts
@@ -113,7 +113,7 @@ export function apiReference(options: NestJSReferenceConfiguration) {
     <!DOCTYPE html>
     <html>
       <head>
-        <title>API Reference</title>
+        <title>Scalar API Reference</title>
         <meta charset="utf-8" />
         <meta
           name="viewport"

--- a/packages/nextjs-api-reference/src/ApiReference.ts
+++ b/packages/nextjs-api-reference/src/ApiReference.ts
@@ -43,8 +43,7 @@ export const ApiReference = (refConfig: ReferenceConfiguration) => {
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Scalar API Reference for Next.js</title>
-    <meta name="description" content="Example to show how to use Scalar API Reference for Next.js">
+    <title>Scalar API Reference</title>
   </head>
   <body>
     <script


### PR DESCRIPTION
Currently, we’re using `API Reference` as the page title everywhere.

This PR proposes to use `Scalar API Reference` as the default (can be overwritten through configuration).

People refer to our API reference as ”Scalar”, I think it’s good to use that in the default page title.