### PR TITLE
chore: use new Discord URL everywhere

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://github.com/scalar/scalar/discussions/new?category=ideas
     about: Suggest any ideas you have using our discussion forums.
   - name: 💬 Chat with us
-    url: https://discord.gg/8HeZcRGPFS
+    url: https://discord.gg/scalar
     about: Suggest any ideas you have using our discussion forums.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Generate interactive API documentation from Swagger files. [Try our Demo](https:
 - Doesn’t look like it’s 2011
 
 > [!NOTE]\
-> [Scalar Townhall every 2nd Thursday in Discord](https://discord.gg/bcCycarP3D?event=1219363385485824000)
+> [Scalar Townhall every 2nd Thursday in Discord](https://discord.gg/scalar?event=1219363385485824000)
 >
 > Join us to see upcoming features, discuss the roadmap and chat about APIs. 💬
 

--- a/packages/api-client-proxy/README.md
+++ b/packages/api-client-proxy/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/api-client-proxy)](https://www.npmjs.com/package/@scalar/api-client-proxy)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/api-client-proxy)](https://www.npmjs.com/package/@scalar/api-client-proxy)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fapi-client-proxy)](https://www.npmjs.com/package/@scalar/api-client-proxy)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 The Scalar API Client Proxy redirects requests to another server to avoid CORS issues. Works well with the Scalar API Client.
 

--- a/packages/api-client-react/README.md
+++ b/packages/api-client-react/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/api-client-react)](https://www.npmjs.com/package/@scalar/api-client-react)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/api-client-react)](https://www.npmjs.com/package/@scalar/api-client-react)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fapi-client-react)](https://www.npmjs.com/package/@scalar/api-client-react)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 ## Installation
 

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/api-client)](https://www.npmjs.com/package/@scalar/api-client)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/api-client)](https://www.npmjs.com/package/@scalar/api-client)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fapi-client)](https://www.npmjs.com/package/@scalar/api-client)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 ## Installation
 

--- a/packages/api-reference-react/README.md
+++ b/packages/api-reference-react/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/api-reference-react)](https://www.npmjs.com/package/@scalar/api-reference-react)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/api-reference-react)](https://www.npmjs.com/package/@scalar/api-reference-react)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fapi-reference-react)](https://www.npmjs.com/package/@scalar/api-reference-react)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 ## Installation
 

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -4,7 +4,7 @@
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/api-reference)](https://www.npmjs.com/package/@scalar/api-reference)
 [![Hits on jsdelivr](https://img.shields.io/jsdelivr/npm/hm/%40scalar%2Fapi-reference)](https://www.jsdelivr.com/package/npm/@scalar/api-reference)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fapi-reference)](https://www.npmjs.com/package/@scalar/api-reference)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 Generate interactive API documentations from Swagger files. [Try our Demo](https://docs.scalar.com/swagger-editor)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/cli)](https://www.npmjs.com/package/@scalar/cli)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/cli)](https://www.npmjs.com/package/@scalar/cli)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fapi-reference)](https://www.npmjs.com/package/@scalar/cli)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 Command-line interface to work with OpenAPI files
 

--- a/packages/draggable/README.md
+++ b/packages/draggable/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/draggable)](https://www.npmjs.com/package/@scalar/draggable)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/draggable)](https://www.npmjs.com/package/@scalar/draggable)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fdraggable)](https://www.npmjs.com/package/@scalar/draggable)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 ## Installation
 

--- a/packages/echo-server/README.md
+++ b/packages/echo-server/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/echo-server)](https://www.npmjs.com/package/@scalar/echo-server)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/echo-server)](https://www.npmjs.com/package/@scalar/echo-server)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fecho-server)](https://www.npmjs.com/package/@scalar/echo-server)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 The Scalar Echo Server is an Express server, which replies with the request data. Works well with the Scalar API Client.
 

--- a/packages/express-api-reference/README.md
+++ b/packages/express-api-reference/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/express-api-reference)](https://www.npmjs.com/package/@scalar/express-api-reference)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/express-api-reference)](https://www.npmjs.com/package/@scalar/express-api-reference)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fexpress-api-reference)](https://www.npmjs.com/package/@scalar/express-api-reference)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 This middleware provides an easy way to render a beautiful API reference based on an OpenAPI/Swagger file with Express.
 

--- a/packages/fastify-api-reference/README.md
+++ b/packages/fastify-api-reference/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/fastify-api-reference)](https://www.npmjs.com/package/@scalar/fastify-api-reference)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/fastify-api-reference)](https://www.npmjs.com/package/@scalar/fastify-api-reference)
 [![License](https://img.shields.io/npm/l/%40scalar%2Ffastify-api-reference)](https://www.npmjs.com/package/@scalar/fastify-api-reference)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 This plugin provides an easy way to render a beautiful API reference based on a OpenAPI/Swagger file with Fastify.
 

--- a/packages/galaxy/README.md
+++ b/packages/galaxy/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/galaxy)](https://www.npmjs.com/package/@scalar/galaxy)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/galaxy)](https://www.npmjs.com/package/@scalar/galaxy)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fgalaxy)](https://www.npmjs.com/package/@scalar/galaxy)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 An OpenAPI example specification in YAML and JSON to test OpenAPI tooling, run test suites or learn about OpenAPI.
 

--- a/packages/hono-api-reference/README.md
+++ b/packages/hono-api-reference/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/hono-api-reference)](https://www.npmjs.com/package/@scalar/hono-api-reference)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/hono-api-reference)](https://www.npmjs.com/package/@scalar/hono-api-reference)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fhono-api-reference)](https://www.npmjs.com/package/@scalar/hono-api-reference)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 This middleware provides an easy way to render a beautiful API reference based on an OpenAPI/Swagger file with Hono.
 

--- a/packages/nestjs-api-reference/README.md
+++ b/packages/nestjs-api-reference/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/nestjs-api-reference)](https://www.npmjs.com/package/@scalar/nestjs-api-reference)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/nestjs-api-reference)](https://www.npmjs.com/package/@scalar/nestjs-api-reference)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fnestjs-api-reference)](https://www.npmjs.com/package/@scalar/nestjs-api-reference)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 This middleware provides an easy way to render a beautiful API reference based on an OpenAPI/Swagger file with NestJS.
 

--- a/packages/nextjs-api-reference/README.md
+++ b/packages/nextjs-api-reference/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/nextjs-api-reference)](https://www.npmjs.com/package/@scalar/nextjs-api-reference)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/nextjs-api-reference)](https://www.npmjs.com/package/@scalar/nextjs-api-reference)
 [![License](https://img.shields.io/npm/l/%40scalar%2fnextjs-api-reference)](https://www.npmjs.com/package/@scalar/nextjs-api-reference)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 This plugin provides an easy way to render a beautiful API reference based on an OpenAPI/Swagger file with Next.js.
 

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/nuxt)](https://www.npmjs.com/package/@scalar/nuxt)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/nuxt)](https://www.npmjs.com/package/@scalar/nuxt)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fnuxt)](https://www.npmjs.com/package/@scalar/nuxt)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 This plugin provides an easy way to render a beautiful API reference based on a OpenAPI/Swagger file with Nuxt.
 

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/themes)](https://www.npmjs.com/package/@scalar/themes)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/themes)](https://www.npmjs.com/package/@scalar/themes)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fthemes)](https://www.npmjs.com/package/@scalar/themes)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 ## Installation
 

--- a/packages/use-codemirror/README.md
+++ b/packages/use-codemirror/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/use-codemirror)](https://www.npmjs.com/package/@scalar/use-codemirror)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/use-codemirror)](https://www.npmjs.com/package/@scalar/use-codemirror)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fuse-codemirror)](https://www.npmjs.com/package/@scalar/use-codemirror)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 ## Installation
 

--- a/packages/use-tooltip/README.md
+++ b/packages/use-tooltip/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/npm/v/%40scalar/use-tooltip)](https://www.npmjs.com/package/@scalar/use-tooltip)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/use-tooltip)](https://www.npmjs.com/package/@scalar/use-tooltip)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fuse-tooltip)](https://www.npmjs.com/package/@scalar/use-tooltip)
-[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/8HeZcRGPFS)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
 ## Installation
 


### PR DESCRIPTION
Currently, we’re still using the URL Discord hash URL in a lot of places.

Let’s switch to the new vanity URL. :)