### PR TITLE
docs: add a section about Markdown, fix #919

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,26 @@ To customize the behavior of the API Reference, you can use the following config
 For detailed information on how to use these options, refer to
 the [Configuration Section](https://github.com/scalar/scalar/blob/main/packages/api-reference/README.md/#configuration).
 
+## Markdown
+
+You can use Markdown in various places, for example in `info.description`, in your tag descriptions, in your operation
+descriptions, in your parameter descriptions and in a lot of other places. We’re using GitHub-flavored Markdown.
+What’s working here, is probably also working in the API reference:
+
+- bullet lists, numbered lists
+- _Italic_, **bold**, ~~striked~~ text
+- accordions
+- links
+- tables
+- images
+- …
+
+[Have a look at our OpenAPI example specification](https://github.com/scalar/scalar/blob/main/packages/galaxy/src/specifications/3.1.yaml)
+to see more examples.
+
+> Note: Not everything is supported in all places. For example, you can use images in most places, but not in parameter
+> descriptions.
+
 ## Layouts
 
 We support two layouts at the moment, a `modern` layout (the default) and a Swagger UI inspired

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ descriptions, in your parameter descriptions and in a lot of other places. We’
 What’s working here, is probably also working in the API reference:
 
 - bullet lists, numbered lists
-- _Italic_, **bold**, ~~striked~~ text
+- _italic_, **bold**, ~~striked~~ text
 - accordions
 - links
 - tables


### PR DESCRIPTION
This PR adds a section about Markdown to our root README. :)

See #919