### PR TITLE
fix: token null throws exception, fix #1519

### DIFF
--- a/.changeset/breezy-walls-shake.md
+++ b/.changeset/breezy-walls-shake.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: passing a prefilled token as null throws an exception

--- a/packages/api-client/src/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-client/src/helpers/getRequestFromAuthentication.test.ts
@@ -420,4 +420,38 @@ describe('getRequestFromAuthentication', () => {
       ],
     })
   })
+
+  it('doesn’t complain about token being null', () => {
+    const request = getRequestFromAuthentication(
+      {
+        ...createEmptyAuthenticationState(),
+        preferredSecurityScheme: 'api_key',
+        securitySchemes: {
+          api_key: {
+            type: 'apiKey',
+            name: 'api_key',
+            in: 'header',
+          },
+        },
+        apiKey: {
+          // @ts-ignore
+          token: null,
+        },
+      },
+      [
+        {
+          api_key: [],
+        },
+      ],
+    )
+
+    expect(request).toMatchObject({
+      headers: [
+        {
+          name: 'api_key',
+          value: 'YOUR_TOKEN',
+        },
+      ],
+    })
+  })
 })

--- a/packages/api-client/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-client/src/helpers/getRequestFromAuthentication.ts
@@ -80,7 +80,7 @@ export function getRequestFromAuthentication(
     if ('type' in securityScheme && securityScheme.type === 'apiKey') {
       // Header
       if ('in' in securityScheme && securityScheme.in === 'header') {
-        const token = authentication.apiKey.token.length
+        const token = authentication.apiKey.token?.length
           ? authentication.apiKey.token
           : 'YOUR_TOKEN'
 


### PR DESCRIPTION
Currently, if you prefill the authentication data and pass `token: null` it throws an exception.

This PR fixes it and adds a test for it.

See #1519 for more context