### PR TITLE
feat: use schema property title if available, fix #1473

### DIFF
--- a/.changeset/cyan-dolls-help.md
+++ b/.changeset/cyan-dolls-help.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: use schema property title if available

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -74,10 +74,10 @@ const handleClick = (e: MouseEvent) =>
                 points="14 8 8 8 8 14 6 14 6 8 0 8 0 6 6 6 6 0 8 0 8 6 14 6" />
             </svg>
             <template v-if="open">
-              Hide {{ value.title ?? 'Child Attributes' }}
+              Hide {{ value?.title ?? 'Child Attributes' }}
             </template>
             <template v-else>
-              Show {{ value.title ?? 'Child Attributes' }}
+              Show {{ value?.title ?? 'Child Attributes' }}
             </template>
           </template>
           <template v-else>
@@ -88,7 +88,7 @@ const handleClick = (e: MouseEvent) =>
               icon="ChevronRight"
               size="md" />
             <SchemaHeading
-              :name="value.title ?? name"
+              :name="value?.title ?? name"
               :value="value" />
           </template>
         </DisclosureButton>

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -73,8 +73,12 @@ const handleClick = (e: MouseEvent) =>
                 fill-rule="nonzero"
                 points="14 8 8 8 8 14 6 14 6 8 0 8 0 6 6 6 6 0 8 0 8 6 14 6" />
             </svg>
-            <template v-if="open">Hide Child Attributes</template>
-            <template v-else>Show Child Attributes</template>
+            <template v-if="open">
+              Hide {{ value.title ?? 'Child Attributes' }}
+            </template>
+            <template v-else>
+              Show {{ value.title ?? 'Child Attributes' }}
+            </template>
           </template>
           <template v-else>
             <ScalarIcon
@@ -84,7 +88,7 @@ const handleClick = (e: MouseEvent) =>
               icon="ChevronRight"
               size="md" />
             <SchemaHeading
-              :name="name"
+              :name="value.title ?? name"
               :value="value" />
           </template>
         </DisclosureButton>


### PR DESCRIPTION
Currently, we just show “Show Child Attributes” or the property type. That can be confusing when having a list of schemas, see #1473 for more context.

This PR uses the property title if it’s available.

<img width="587" alt="Screenshot 2024-05-02 at 12 39 23" src="https://github.com/scalar/scalar/assets/1577992/46542305-a297-41d3-ab04-98840d1f785f">

<img width="594" alt="Screenshot 2024-05-02 at 12 40 44" src="https://github.com/scalar/scalar/assets/1577992/f065fc72-14e9-48b6-b075-c265696f6373">
