### PR TITLE
fix: sidebar headings don’t reset

### DIFF
--- a/.changeset/lazy-zebras-yell.md
+++ b/.changeset/lazy-zebras-yell.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: sidebar headings don’t reset

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -292,7 +292,7 @@ export function useSidebar(options?: { parsedSpec: Spec }) {
         const description = parsedSpec.value?.info?.description
 
         if (!description) {
-          return []
+          return (headings.value = [])
         }
 
         return (headings.value = await updateHeadings(description))


### PR DESCRIPTION
When using and then removing a specification from the editor heading entries are still displayed.

This PR properly resets the headings.

BTW The same issue exists for webhooks, but for a different reason. We’ll tackle this in a separate PR.

![image](https://github.com/scalar/scalar/assets/14966155/cadc7544-01e3-4ab3-848f-57a8327b4c31)