### PR TITLE
feat: add multiple levels of headings to the sidebar

### DIFF
--- a/.changeset/small-lies-exist.md
+++ b/.changeset/small-lies-exist.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: show two levels of headings in the sidebar


### PR DESCRIPTION
Currently, we’re looking for Markdown headings in the `info.description` field and only add the lowest level (eg. h1) to the sidebar.

This PR adds the 2nd lowest level (eg. h2) to the sidebar, too.

* If there’s only one level of headings, they are all just added to the sidebar.
* If there’s two levels of headings, they will be added to the sidebar. The 2nd lowest level (eg. h2) will be nested under the lowest level (eg. h1).
* If there’s more than two levels (eg. h1, h2, h3), the highest level (eg. h3) will be ignored (for the sidebar).

See #906 for more context.