### PR TITLE
fix: nestjs express example

### DIFF
--- a/examples/nestjs-api-reference-express/.dockerignore
+++ b/examples/nestjs-api-reference-express/.dockerignore
@@ -1,0 +1,52 @@
+.env
+**/.env
+**/coverage/**
+coverage
+
+.env.staging
+.env.production
+.sh
+
+# Exclude nested dockerfile to prevent cache break issues
+**/Dockerfile
+
+# compiled output
+dist
+tmp
+/out-tsc
+**/dist/**
+
+# dependencies
+node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+db.sqlite
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/examples/nestjs-api-reference-express/Dockerfile
+++ b/examples/nestjs-api-reference-express/Dockerfile
@@ -1,7 +1,27 @@
-ARG BASE_IMAGE
-FROM ${BASE_IMAGE} AS builder
+FROM node:18-bullseye AS base
+
+RUN npm install pnpm@8 --global
+RUN pnpm config set store-dir ~/.pnpm-store
+
 WORKDIR /app
 
+# Copy and build all packages to share across example builds
+COPY pnpm-lock.yaml .
+COPY pnpm-workspace.yaml .
+COPY package.json .
+COPY tsconfig.json .
+COPY turbo.json .
+COPY packages ./packages
+RUN pnpm install
+RUN pnpm build:packages
+
+FROM base AS builder
+WORKDIR /app
+# Install dumb-init - minimal process init system
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
+
+# Copy everything from the base
+# only install and build the main package and its dependencies
 COPY pnpm-lock.yaml .
 COPY pnpm-workspace.yaml .
 COPY package.json .
@@ -14,39 +34,29 @@ COPY packages/build-tooling ./packages/build-tooling
 COPY packages/nestjs-api-reference ./packages/nestjs-api-reference
 COPY examples/nestjs-api-reference-express ./examples/nestjs-api-reference-express
 
+# Mount the cache where pnpm expects it and build the main package
 RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store \
     pnpm --filter @scalar-examples/nestjs-api-reference-express install --frozen-lockfile && \
     pnpm --filter @scalar-examples/nestjs-api-reference-express build
 
 FROM node:18-bullseye-slim AS runner
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
-
-RUN npm install -g pnpm
+# Copy from the previous stage to keep this image minimal
+COPY --from=builder /usr/bin/dumb-init /usr/bin/dumb-init
 ENV NODE_ENV production
 
-# Create a non-root user
-RUN addgroup --system --gid 1001 nodejs && \
-    adduser --system --uid 1001 nestjs
-
-# Set the correct permission for the build
-RUN mkdir app
-
-RUN chown nestjs:nodejs app
-
+# Use default non-root user from the node image
+USER node
 WORKDIR /app
+RUN chown node:node /app
 
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
-COPY --from=builder /app/packages/components /app/packages/components
-COPY --from=builder /app/packages/themes /app/packages/themes
-COPY --from=builder /app/packages/oas-utils /app/packages/oas-utils
-COPY --from=builder /app/packages/build-tooling /app/packages/build-tooling
-COPY --from=builder /app/packages/api-reference /app/packages/api-reference
 COPY --from=builder /app/packages/nestjs-api-reference /app/packages/nestjs-api-reference
-COPY --from=builder /app/examples/nestjs-api-reference-express /app/examples/nestjs-api-reference-express
+COPY --from=builder /app/examples/nestjs-api-reference-express/dist /app/examples/nestjs-api-reference-express/dist
+COPY --from=builder /app/examples/nestjs-api-reference-express/node_modules /app/examples/nestjs-api-reference-express/node_modules
 
 WORKDIR /app/examples/nestjs-api-reference-express
 
-USER nestjs
-
+# dumb-init runs as PID 1 and ensures all signals are forwarded
+# to the spawned node process (ensures the server receives signal to terminate)
 CMD ["dumb-init", "node", "dist/main.js"]

--- a/examples/nestjs-api-reference-express/Dockerfile
+++ b/examples/nestjs-api-reference-express/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=builder /usr/bin/dumb-init /usr/bin/dumb-init
 ENV NODE_ENV production
 # Set the PORT environment variable for the node server
 ENV PORT $PORT
+ENV HOST '0.0.0.0'
 
 # Use default non-root user from the node image
 USER node

--- a/examples/nestjs-api-reference-express/Dockerfile
+++ b/examples/nestjs-api-reference-express/Dockerfile
@@ -1,21 +1,5 @@
-FROM node:18-bullseye AS base
-
-RUN npm install pnpm@8 --global
-RUN pnpm config set store-dir ~/.pnpm-store
-
-WORKDIR /app
-
-# Copy and build all packages to share across example builds
-COPY pnpm-lock.yaml .
-COPY pnpm-workspace.yaml .
-COPY package.json .
-COPY tsconfig.json .
-COPY turbo.json .
-COPY packages ./packages
-RUN pnpm install
-RUN pnpm build:packages
-
-FROM base AS builder
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS builder
 WORKDIR /app
 # Install dumb-init - minimal process init system
 RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
@@ -42,7 +26,10 @@ RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store \
 FROM node:18-bullseye-slim AS runner
 # Copy from the previous stage to keep this image minimal
 COPY --from=builder /usr/bin/dumb-init /usr/bin/dumb-init
+
 ENV NODE_ENV production
+# Set the PORT environment variable for the node server
+ENV PORT $PORT
 
 # Use default non-root user from the node image
 USER node
@@ -52,8 +39,7 @@ RUN chown node:node /app
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/packages/nestjs-api-reference /app/packages/nestjs-api-reference
-COPY --from=builder /app/examples/nestjs-api-reference-express/dist /app/examples/nestjs-api-reference-express/dist
-COPY --from=builder /app/examples/nestjs-api-reference-express/node_modules /app/examples/nestjs-api-reference-express/node_modules
+COPY --from=builder /app/examples/nestjs-api-reference-express /app/examples/nestjs-api-reference-express
 
 WORKDIR /app/examples/nestjs-api-reference-express
 

--- a/examples/nestjs-api-reference-express/src/main.ts
+++ b/examples/nestjs-api-reference-express/src/main.ts
@@ -4,7 +4,7 @@ import { AppModule } from './app.module';
 
 import { apiReference } from '@scalar/nestjs-api-reference';
 
-const PORT = process.env.PORT || 5056;
+const PORT = Number(process.env.PORT);
 const HOST = process.env.HOST || '0.0.0.0';
 
 async function bootstrap() {

--- a/examples/nestjs-api-reference-express/src/main.ts
+++ b/examples/nestjs-api-reference-express/src/main.ts
@@ -4,6 +4,9 @@ import { AppModule } from './app.module';
 
 import { apiReference } from '@scalar/nestjs-api-reference';
 
+const PORT = process.env.PORT || 5056;
+const HOST = process.env.HOST || '0.0.0.0';
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
@@ -24,8 +27,8 @@ async function bootstrap() {
     }),
   );
 
-  await app.listen(5056, () => {
-    console.log('🦁 NestJS listening at http://localhost:5056/reference');
+  await app.listen(PORT, HOST, () => {
+    console.log(`🦁 NestJS listening at http://${HOST}:${PORT}/reference`);
   });
 }
 bootstrap();


### PR DESCRIPTION
This PR fixes the Dockerfile for the nestjs express example by allowing Cloud Run to pass in the PORT env variable. 
 * streamlines and adds comments to the Dockerfile
 * adds .dockerignore
