### PR TITLE
feat: add scalar popover

### DIFF
--- a/.changeset/nice-buckets-appear.md
+++ b/.changeset/nice-buckets-appear.md
@@ -1,0 +1,5 @@
+---
+"@scalar/components": minor
+---
+
+feat: add scalar popover

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.stories.ts
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.stories.ts
@@ -10,6 +10,9 @@ const meta = {
   component: ScalarDropdown,
   tags: ['autodocs'],
   argTypes: {
+    resize: {
+      control: 'boolean',
+    },
     placement: {
       control: 'select',
       options: placements,

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -3,7 +3,7 @@ import { Menu, MenuButton, MenuItems } from '@headlessui/vue'
 
 import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
 
-defineProps<FloatingOptions>()
+defineProps<Omit<FloatingOptions, 'middleware'>>()
 
 defineOptions({ inheritAttrs: false })
 </script>

--- a/packages/components/src/components/ScalarDropdown/index.ts
+++ b/packages/components/src/components/ScalarDropdown/index.ts
@@ -1,1 +1,3 @@
 export { default as ScalarDropdown } from './ScalarDropdown.vue'
+export { default as ScalarDropdownDivider } from './ScalarDropdownDivider.vue'
+export { default as ScalarDropdownItem } from './ScalarDropdownItem.vue'

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.stories.ts
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.stories.ts
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/vue3'
 
 import ScalarFloating from './ScalarFloating.vue'
 
-const meta = {
+const meta: Meta = {
   component: ScalarFloating,
   tags: ['autodocs'],
   argTypes: {
@@ -20,9 +20,11 @@ const meta = {
     template: `
 <div class="flex items-center justify-center w-full h-screen">
   <ScalarFloating v-bind="args">
-    <div class="rounded border bg-back-2 p-1">Target for #floating</div>
-    <template #floating="{ width }">
-      <div class="rounded border shadow bg-back-2 p-1" :style="{ width }">
+    <div class="rounded border bg-back-2 p-2">Target for #floating</div>
+    <template #floating="{ width, height }">
+      <div 
+        class="flex items-center justify-center rounded border shadow bg-back-2 p-1" 
+        :style="{ width, height }">
         Floating
       </div>
     </template>

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { getSideAxis } from '@floating-ui/utils'
 import {
   type MiddlewareData,
   autoUpdate,
@@ -19,9 +20,9 @@ defineSlots<{
   default(): any
   /** The floating element */
   floating(props: {
-    /** The width of the reference element if `resize` is true */
+    /** The width of the reference element if `resize` is true and placement is on the y axis */
     width?: string
-    /** The height of the reference element if `resize` is true */
+    /** The height of the reference element if `resize` is true and placement is on the x axis */
     height?: string
     /** The middleware data return by Floating UI */
     data?: MiddlewareData
@@ -41,6 +42,18 @@ const targetRef = computed(
 const targetSize = useResizeWithTarget(targetRef, {
   enabled: computed(() => props.resize),
 })
+
+const targetWidth = computed(() =>
+  getSideAxis(props.placement || 'bottom') === 'y'
+    ? targetSize.width.value
+    : undefined,
+)
+
+const targetHeight = computed(() =>
+  getSideAxis(props.placement || 'bottom') === 'x'
+    ? targetSize.height.value
+    : undefined,
+)
 
 const { floatingStyles, middlewareData } = useFloating(targetRef, floatingRef, {
   placement: computed(() => props.placement),
@@ -66,8 +79,8 @@ const { floatingStyles, middlewareData } = useFloating(targetRef, floatingRef, {
     v-bind="$attrs">
     <slot
       :data="middlewareData"
-      :height="targetSize.height.value"
+      :height="targetHeight"
       name="floating"
-      :width="targetSize.width.value" />
+      :width="targetWidth" />
   </div>
 </template>

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -1,11 +1,32 @@
 <script setup lang="ts">
-import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue'
+import {
+  type MiddlewareData,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useFloating,
+} from '@floating-ui/vue'
 import { type Ref, computed, ref } from 'vue'
 
 import type { FloatingOptions } from './types'
 import { useResizeWithTarget } from './useResizeWithTarget'
 
 const props = defineProps<FloatingOptions>()
+
+defineSlots<{
+  /** The reference element for the element in the #floating slot */
+  default(): any
+  /** The floating element */
+  floating(props: {
+    /** The width of the reference element if `resize` is true */
+    width?: string
+    /** The height of the reference element if `resize` is true */
+    height?: string
+    /** The middleware data return by Floating UI */
+    data?: MiddlewareData
+  }): any
+}>()
 
 defineOptions({ inheritAttrs: false })
 
@@ -17,16 +38,19 @@ const targetRef = computed(
   () => (wrapperRef.value?.children?.[0] || wrapperRef.value) ?? undefined,
 )
 
-const resize = computed(() => props.resize)
-const { width: targetWidth } = useResizeWithTarget(targetRef, {
-  enabled: resize,
+const targetSize = useResizeWithTarget(targetRef, {
+  enabled: computed(() => props.resize),
 })
 
-const placement = computed(() => props.placement || 'bottom')
-const { floatingStyles } = useFloating(targetRef, floatingRef, {
-  placement,
+const { floatingStyles, middlewareData } = useFloating(targetRef, floatingRef, {
+  placement: computed(() => props.placement),
   whileElementsMounted: autoUpdate,
-  middleware: [offset(5), flip(), shift()],
+  middleware: computed(() => [
+    offset(5),
+    flip(),
+    shift(),
+    ...(props.middleware ?? []),
+  ]),
 })
 </script>
 <template>
@@ -41,7 +65,9 @@ const { floatingStyles } = useFloating(targetRef, floatingRef, {
     :style="floatingStyles"
     v-bind="$attrs">
     <slot
+      :data="middlewareData"
+      :height="targetSize.height.value"
       name="floating"
-      :width="targetWidth" />
+      :width="targetSize.width.value" />
   </div>
 </template>

--- a/packages/components/src/components/ScalarFloating/types.ts
+++ b/packages/components/src/components/ScalarFloating/types.ts
@@ -1,8 +1,19 @@
-import type { Placement } from '@floating-ui/utils'
+import type { Middleware, Placement } from '@floating-ui/vue'
 
 export type FloatingOptions = {
-  /** The placement of the floating element */
+  /**
+   * Where to place the floating element relative to its reference element.
+   * @default 'bottom'
+   * */
   placement?: Placement
-  /** Whether or not track the target's width */
+  /**
+   * Whether or not track the reference element's width
+   * If enabled it will set `width` slot prop of the floating slot
+   */
   resize?: boolean
+  /**
+   * Floating UI Middleware to be passed to Floating UI
+   * @see https://floating-ui.com/docs/computePosition#middleware
+   */
+  middleware?: Middleware[]
 }

--- a/packages/components/src/components/ScalarFloating/useResizeWithTarget.ts
+++ b/packages/components/src/components/ScalarFloating/useResizeWithTarget.ts
@@ -9,12 +9,14 @@ export function useResizeWithTarget(
   opts: ResizeOptions = { enabled: ref(true) },
 ) {
   const targetWidth = ref(0)
+  const targetHeight = ref(0)
   const observer = ref<ResizeObserver>()
 
   if (typeof ResizeObserver !== 'undefined')
     observer.value = new ResizeObserver(([entry]) => {
       if (!entry) return
       targetWidth.value = entry.borderBoxSize[0]?.inlineSize ?? 0
+      targetHeight.value = entry.borderBoxSize[0]?.blockSize ?? 0
     })
 
   watch(
@@ -30,6 +32,9 @@ export function useResizeWithTarget(
   return {
     width: computed(() =>
       toValue(opts.enabled) ? `${targetWidth.value}px` : undefined,
+    ),
+    height: computed(() =>
+      toValue(opts.enabled) ? `${targetHeight.value}px` : undefined,
     ),
   }
 }

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.spec.ts
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.spec.ts
@@ -1,0 +1,17 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import ScalarPopover from './ScalarPopover.vue'
+
+describe('ScalarPopover', () => {
+  it('renders properly', async () => {
+    const wrapper = mount(ScalarPopover, {
+      props: {},
+      slots: {
+        default: `<button>Button</button>`,
+      },
+    })
+
+    expect(wrapper.exists()).toBeTruthy()
+  })
+})

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.stories.ts
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.stories.ts
@@ -1,0 +1,45 @@
+import { placements } from '@floating-ui/utils'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+import { ScalarButton } from '../../'
+import ScalarPopover from './ScalarPopover.vue'
+
+const meta = {
+  component: ScalarPopover,
+  tags: ['autodocs'],
+  argTypes: {
+    resize: {
+      control: 'boolean',
+    },
+    placement: {
+      control: 'select',
+      options: placements,
+    },
+  },
+  render: (args) => ({
+    components: {
+      ScalarPopover,
+      ScalarButton,
+    },
+    setup() {
+      return { args }
+    },
+    template: `
+<div class="flex items-center justify-center w-full h-screen">
+  <ScalarPopover v-bind="args">
+    <ScalarButton>Click Me</ScalarButton>
+    <template #popover>
+      <div class="h-full flex items-center justify-center p-1">
+        Pop pop
+      </div>
+    </template>
+  </ScalarPopover>
+</div>
+`,
+  }),
+} satisfies Meta<typeof ScalarPopover>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Base: Story = {}

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.vue
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
+
+import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
+
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<Omit<FloatingOptions, 'middleware'>>()
+
+defineOptions({ inheritAttrs: false })
+</script>
+<template>
+  <Popover>
+    <ScalarFloating v-bind="$props">
+      <PopoverButton as="template">
+        <slot />
+      </PopoverButton>
+      <template #floating="{ width, height }">
+        <PopoverPanel
+          class="relative flex flex-col p-0.75"
+          :style="{ width, height }"
+          v-bind="$attrs">
+          <slot name="popover" />
+          <div
+            class="absolute inset-0 -z-1 rounded bg-back-1 shadow-md brightness-lifted" />
+        </PopoverPanel>
+      </template>
+    </ScalarFloating>
+  </Popover>
+</template>

--- a/packages/components/src/components/ScalarPopover/index.ts
+++ b/packages/components/src/components/ScalarPopover/index.ts
@@ -1,0 +1,1 @@
+export { default as ScalarPopover } from './ScalarPopover.vue'

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -2,10 +2,17 @@ import type { App } from 'vue'
 
 import { ScalarButton } from './components/ScalarButton'
 import { ScalarCodeBlock } from './components/ScalarCodeBlock'
+import {
+  ScalarDropdown,
+  ScalarDropdownDivider,
+  ScalarDropdownItem,
+} from './components/ScalarDropdown'
+import { ScalarFloating } from './components/ScalarFloating'
 import { type Icon, ScalarIcon } from './components/ScalarIcon'
 import { ScalarIconButton } from './components/ScalarIconButton'
 import { ScalarLoading, useLoadingState } from './components/ScalarLoading'
 import { ScalarModal, useModal } from './components/ScalarModal'
+import { ScalarPopover } from './components/ScalarPopover'
 import { ScalarSearchInput } from './components/ScalarSearchInput'
 import {
   ScalarSearchResultItem,
@@ -17,10 +24,15 @@ import './tailwind/tailwind.css'
 export default {
   install: (app: App) => {
     app.component('ScalarButton', ScalarButton)
+    app.component('ScalarDropdown', ScalarDropdown)
+    app.component('ScalarDropdownDivider', ScalarDropdownDivider)
+    app.component('ScalarDropdownItem', ScalarDropdownItem)
+    app.component('ScalarFloating', ScalarFloating)
     app.component('ScalarIcon', ScalarIcon)
     app.component('ScalarIconButton', ScalarIconButton)
     app.component('ScalarLoading', ScalarLoading)
     app.component('ScalarModal', ScalarModal)
+    app.component('ScalarPopover', ScalarPopover)
     app.component('ScalarSearchInput', ScalarSearchInput)
     app.component('ScalarSearchResultItem', ScalarSearchResultItem)
     app.component('ScalarSearchResultList', ScalarSearchResultList)
@@ -31,10 +43,15 @@ export default {
 export {
   ScalarButton,
   ScalarCodeBlock,
+  ScalarDropdown,
+  ScalarDropdownDivider,
+  ScalarDropdownItem,
+  ScalarFloating,
   ScalarIcon,
   ScalarIconButton,
   ScalarLoading,
   ScalarModal,
+  ScalarPopover,
   ScalarSearchInput,
   ScalarSearchResultItem,
   ScalarSearchResultList,


### PR DESCRIPTION
Little followup PR to #1557 to add popovers and extend scalar floating a little bit for some future usage I foresee with middlewares.

Also I forgot to add the dropdown and floating components to the components export...

https://github.com/scalar/scalar/assets/6374090/18147245-1f6e-4c0f-88e4-12118e6ec8de

