### PR TITLE
feat: add events and tests to standalone references

### DIFF
--- a/.changeset/six-humans-visit.md
+++ b/.changeset/six-humans-visit.md
@@ -3,4 +3,4 @@
 "@scalar/use-toasts": patch
 ---
 
-feat: added two events to standalone build with tests
+feat: added two events to standalone references build with tests

--- a/.changeset/six-humans-visit.md
+++ b/.changeset/six-humans-visit.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/use-toasts": patch
+---
+
+feat: added two events to standalone build with tests

--- a/README.md
+++ b/README.md
@@ -111,6 +111,39 @@ If you’d like to add a request proxy for the API client (to avoid CORS issues)
 </script>
 ```
 
+#### Events [beta]
+
+We have recently added two events to the standalone CDN build only.
+
+##### scalar:reload-references
+
+Reload the references, this will re-mount the app in case you have switched pages or the dom
+elements have been removed.
+
+```ts
+document.dispatchEvent(new Event('scalar:reload-references'))
+```
+
+##### scalar:reload-references
+
+If you have updated the config or spec, you can trigger this event with the new payload to update
+the app. It should update reactively so you do not need to trigger the reload event above after.
+
+```ts
+import { type ReferenceProps } from './types'
+
+const ev = new CustomEvent('scalar:update-references-config', {
+  detail: {
+    configuration: {
+      spec: {
+        url: 'https://cdn.scalar.com/spec/openapi_petstore.json',
+      },
+    },
+  } satisfies ReferenProps,
+})
+document.dispatchEvent(ev)
+```
+
 ### With Nuxt
 
 You can easily run Scalar API References in Nuxt via the module:

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ elements have been removed.
 document.dispatchEvent(new Event('scalar:reload-references'))
 ```
 
-##### scalar:reload-references
+##### scalar:update-references-config
 
 If you have updated the config or spec, you can trigger this event with the new payload to update
 the app. It should update reactively so you do not need to trigger the reload event above after.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ const ev = new CustomEvent('scalar:update-references-config', {
         url: 'https://cdn.scalar.com/spec/openapi_petstore.json',
       },
     },
-  } satisfies ReferenProps,
+  } satisfies ReferenceProps,
 })
 document.dispatchEvent(ev)
 ```

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -70,8 +70,8 @@
     "@scalar/snippetz": "^0.1.6",
     "@scalar/themes": "workspace:*",
     "@scalar/use-modal": "workspace:*",
-    "@scalar/use-tooltip": "workspace:*",
     "@scalar/use-toasts": "workspace:*",
+    "@scalar/use-tooltip": "workspace:*",
     "@unhead/schema": "^1.9.5",
     "@vcarl/remark-headings": "^0.1.0",
     "@vueuse/core": "^10.9.0",
@@ -117,6 +117,7 @@
     "vite-plugin-css-injected-by-js": "^3.4.0",
     "vite-plugin-lib-inject-css": "^2.0.1",
     "vitest": "^1.5.0",
+    "vitest-matchmedia-mock": "^1.0.5",
     "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {

--- a/packages/api-reference/src/standalone.spec.ts
+++ b/packages/api-reference/src/standalone.spec.ts
@@ -1,0 +1,81 @@
+import galaxyContent from '@scalar/galaxy/latest.json'
+import { afterAll, describe, expect, it } from 'vitest'
+import MatchMediaMock from 'vitest-matchmedia-mock'
+
+import { sleep } from './helpers'
+import { type ReferenceProps } from './types'
+
+/**
+ * Tests for standalone
+ * A bit hacky as we are working with the dom without jsdom, but works for these tests
+ * as each test builds off the last
+ */
+describe('Standalone API References', () => {
+  const matchMediaMock = new MatchMediaMock()
+
+  afterAll(() => {
+    matchMediaMock.clear()
+  })
+
+  it('renders very basic references with standalone', async () => {
+    const script = document.createElement('script')
+    script.id = 'api-reference'
+    script.type = 'application/json'
+
+    const inlineCode = document.createTextNode(
+      `{ "openapi": "3.1.0", "info": { "title": "Example" }, "paths": {} }`,
+    )
+    script.appendChild(inlineCode)
+    document.body.appendChild(script)
+
+    await import('./standalone')
+    await sleep(10)
+
+    const rootElement = document.querySelector('[data-v-app]')
+    const reference = rootElement?.querySelector('.scalar-api-reference')
+    const h1 = reference?.querySelector('h1')
+
+    expect(rootElement?.contains(reference!)).toBeTruthy()
+    expect(h1?.innerHTML).toEqual('Example')
+  })
+
+  it('removes the app element and reloads', async () => {
+    // Remove the main element
+    let rootElement = document.querySelector('[data-v-app]')
+    rootElement?.parentNode?.removeChild(rootElement)
+
+    expect(document.body.contains(rootElement)).toBeFalsy()
+    expect(document.querySelector('[data-v-app]')).toBeNull()
+
+    // Now we use the event to re-load the app
+    document.dispatchEvent(new Event('scalar:reload-references'))
+    await sleep(10)
+
+    rootElement = document.querySelector('[data-v-app]')
+    const reference = rootElement?.querySelector('.scalar-api-reference')
+    const h1 = reference?.querySelector('h1')
+
+    expect(rootElement?.contains(reference!)).toBeTruthy()
+    expect(h1?.innerHTML).toEqual('Example')
+  })
+
+  it('updates the spec url, detect for changes', async () => {
+    // Update the config with the galaxy spec
+    const ev = new CustomEvent('scalar:update-references-config', {
+      detail: {
+        configuration: {
+          spec: {
+            content: galaxyContent,
+          },
+        },
+      } satisfies ReferenceProps,
+    })
+    document.dispatchEvent(ev)
+    await sleep(10)
+
+    const rootElement = document.querySelector('[data-v-app]')
+    const h1 = rootElement?.querySelector('h1')
+
+    expect(h1?.innerHTML).toEqual('Scalar Galaxy')
+  })
+})

--- a/packages/api-reference/src/standalone.spec.ts
+++ b/packages/api-reference/src/standalone.spec.ts
@@ -1,4 +1,4 @@
-import galaxyContent from '@scalar/galaxy/latest.json'
+import galaxyContent from '@scalar/galaxy/latest.json?raw'
 import { afterAll, describe, expect, it } from 'vitest'
 import MatchMediaMock from 'vitest-matchmedia-mock'
 

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -2,12 +2,12 @@
  * This file is the entry point for the CDN version of the API Reference.
  * It’s responsible for finding the spec and configuration in the HTML, and mounting the Vue.js app.
  */
-import { createApp } from 'vue'
+import { createApp, h, reactive } from 'vue'
 
 import { default as ApiReference } from './components/ApiReference.vue'
 import { type ReferenceConfiguration } from './types'
 
-const specScriptTag = document.querySelector('#api-reference')
+const specScriptTag = document.getElementById('api-reference')
 const specElement = document.querySelector('[data-spec]')
 const specUrlElement = document.querySelector('[data-spec-url]')
 const configurationScriptElement = document.querySelector(
@@ -96,6 +96,9 @@ const getProxyUrl = () => {
   return undefined
 }
 
+// Ensure Reference Props are reactive
+const props = reactive({})
+
 if (!specUrlElement && !specElement && !specScriptTag) {
   console.error(
     'Couldn’t find a [data-spec], [data-spec-url] or <script id="api-reference" /> element. Try adding it like this: %c<div data-spec-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml" />',
@@ -110,27 +113,65 @@ if (!specUrlElement && !specElement && !specScriptTag) {
         url: getSpecUrl(),
       }
 
-  document.querySelector('body')?.classList.add('light-mode')
-
-  // If it’s a script tag, we can’t mount the Vue.js app inside that tag.
-  // We need to add a new container div before the script tag.
-  let container: HTMLElement | string | null = null
-  if (specScriptTag) {
-    container = document.createElement('div')
-    specScriptTag?.parentNode?.insertBefore(container, specScriptTag)
-  } else {
-    container = specElement
-      ? '[data-spec]'
-      : specUrlElement
-        ? '[data-spec-url]'
-        : 'body'
-  }
-
-  createApp(ApiReference, {
+  Object.assign(props, {
     configuration: {
       ...getConfiguration(),
       spec: { ...specOrSpecUrl },
       proxy: getProxyUrl(),
     },
-  }).mount(container)
+  })
+
+  document.body?.classList.add('light-mode')
+
+  // If it’s a script tag, we can’t mount the Vue.js app inside that tag.
+  // We need to add a new container div before the script tag.
+  const createContainer = () => {
+    let _container: Element | null = null
+    if (specScriptTag) {
+      _container = document.createElement('div')
+      specScriptTag?.parentNode?.insertBefore(_container, specScriptTag)
+    } else {
+      _container = specElement || specUrlElement || document.body
+    }
+    return _container
+  }
+
+  const container = createContainer()
+
+  // Wrap create app in factory for re-loading
+  const createAppFactory = () => {
+    const _app = createApp(() => h(ApiReference, props))
+
+    if (container) {
+      _app.mount(container)
+    } else {
+      console.error('Could not find a mount point for API References')
+    }
+    return _app
+  }
+
+  let app = createAppFactory()
+
+  // Allow user to reload whole vue app
+  document.addEventListener(
+    'scalar:reload-references',
+    () => {
+      // Check if elemenet has been removed from dom, and re-add
+      if (container && !document.body.contains(container)) {
+        document.body.appendChild(container)
+      }
+      app.unmount()
+      app = createAppFactory()
+    },
+    false,
+  )
+
+  // Allow user to update config
+  document.addEventListener(
+    'scalar:update-references-config',
+    (ev) => {
+      if ('detail' in ev) Object.assign(props, ev.detail)
+    },
+    false,
+  )
 }

--- a/packages/use-toasts/package.json
+++ b/packages/use-toasts/package.json
@@ -39,13 +39,13 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
-    "@vitest/coverage-v8": "^1.2.2",
+    "@vitest/coverage-v8": "^1.5.0",
     "nanoid": "^5.0.1",
     "tsc-alias": "^1.8.8",
-    "vite": "^5.1.1",
+    "vite": "^5.2.10",
     "vite-plugin-css-injected-by-js": "^3.4.0",
-    "vitest": "^1.2.2",
-    "vue": "^3.3.0",
+    "vitest": "^1.5.0",
+    "vue": "^3.4.21",
     "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -946,6 +946,9 @@ importers:
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.22)(jsdom@22.1.0)
+      vitest-matchmedia-mock:
+        specifier: ^1.0.5
+        version: 1.0.5(@types/node@20.11.22)
       vue-tsc:
         specifier: ^1.8.19
         version: 1.8.27(typescript@5.4.3)
@@ -1739,7 +1742,7 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(vite@5.2.10)(vue@3.4.21)
       '@vitest/coverage-v8':
-        specifier: ^1.2.2
+        specifier: ^1.5.0
         version: 1.5.0(vitest@1.5.0)
       nanoid:
         specifier: ^5.0.1
@@ -1748,16 +1751,16 @@ importers:
         specifier: ^1.8.8
         version: 1.8.8
       vite:
-        specifier: ^5.1.1
+        specifier: ^5.2.10
         version: 5.2.10(@types/node@20.11.22)(terser@5.30.0)
       vite-plugin-css-injected-by-js:
         specifier: ^3.4.0
         version: 3.4.0(vite@5.2.10)
       vitest:
-        specifier: ^1.2.2
+        specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.22)(jsdom@22.1.0)
       vue:
-        specifier: ^3.3.0
+        specifier: ^3.4.21
         version: 3.4.21(typescript@5.4.3)
       vue-tsc:
         specifier: ^1.8.19
@@ -27698,6 +27701,26 @@ packages:
       - vitest
       - vue
       - vue-router
+    dev: true
+
+  /vitest-matchmedia-mock@1.0.5(@types/node@20.11.22):
+    resolution: {integrity: sha512-EqllUk4M7PckMIYZ9kMUygFJxwgPdONeden9UxHpM0Sum+ZZogx3G1pElw0/3FG6a+QOTk1gdGxEcbqV1mflIw==}
+    dependencies:
+      vitest: 1.5.0(@types/node@20.11.22)(jsdom@22.1.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/node'
+      - '@vitest/browser'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vitest@1.5.0(@types/node@20.11.22)(jsdom@22.1.0):


### PR DESCRIPTION
Added two user-requested events to the standalone app. 

Also added some tests to util, had to use sleep as we are outside of vue and flush promises didn't work. If the sleep becomes a problem I will remove and add a better solution.

Instructions can be found [here](https://github.com/scalar/scalar/blob/321485c913239e75a2466a5eaa3c29ea379b6d52/README.md#events-beta)

closes #1340