### PR TITLE
fix: disable scroll observer on sidebar click

### DIFF
--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -37,8 +37,8 @@ const handleClick = async () => {
   // If the section was open, wait for a short delay before enabling intersection observer
   if (props.open) {
     isIntersectionEnabled.value = false
-    await sleep(100)
   }
+  await sleep(100)
   isIntersectionEnabled.value = true
 }
 

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -37,9 +37,9 @@ const handleClick = async () => {
   // If the section was open, wait for a short delay before enabling intersection observer
   if (props.open) {
     isIntersectionEnabled.value = false
+    await sleep(100)
+    isIntersectionEnabled.value = true
   }
-  await sleep(100)
-  isIntersectionEnabled.value = true
 }
 
 // Build relative URL and add hash


### PR DESCRIPTION
Because handleclick wraps the whole sidebar section, `isIntersectionEnabled` was getting enabled early and was bugging out the scroll, causing the wrong sidebar elements to get selected. This PR fixes that.