### PR TITLE
fix: mimetypes with charsets and variants are ignored, see #920

### DIFF
--- a/.changeset/small-dancers-call.md
+++ b/.changeset/small-dancers-call.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/oas-utils": patch
+---
+
+fix: mimetypes with charsets and variants are ignored

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -59,11 +59,13 @@ const currentResponse = computed(() => {
 })
 
 const currentJsonResponse = computed(() => {
-  normalizeMimeTypeObject(currentResponse.value?.content)
+  const normalizedContent = normalizeMimeTypeObject(
+    currentResponse.value?.content,
+  )
 
   return (
     // OpenAPI 3.x
-    currentResponse.value?.content?.['application/json'] ??
+    normalizedContent?.['application/json'] ??
     // Swagger 2.0
     currentResponse.value
   )

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -1,6 +1,9 @@
 <script lang="ts" setup>
 import { ScalarCodeBlock, ScalarIcon } from '@scalar/components'
-import type { TransformedOperation } from '@scalar/oas-utils'
+import {
+  type TransformedOperation,
+  removeCharsetFromContentTypes,
+} from '@scalar/oas-utils'
 import { computed, ref } from 'vue'
 
 import { useClipboard } from '../../../../hooks'
@@ -55,16 +58,18 @@ const currentResponse = computed(() => {
   return props.operation.information?.responses?.[currentStatusCode]
 })
 
-const currentJsonResponse = computed(
-  () =>
+const currentJsonResponse = computed(() => {
+  removeCharsetFromContentTypes(currentResponse.value?.content)
+
+  return (
     // OpenAPI 3.x
     currentResponse.value?.content?.['application/json'] ??
-    currentResponse.value?.content?.['application/json; charset=utf-8'] ??
     currentResponse.value?.content?.['application/problem+json'] ??
     currentResponse.value?.content?.['application/vnd.api+json'] ??
     // Swagger 2.0
-    currentResponse.value,
-)
+    currentResponse.value
+  )
+})
 const currentResponseWithExample = computed(() => ({
   ...currentJsonResponse.value,
   example:

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -2,7 +2,7 @@
 import { ScalarCodeBlock, ScalarIcon } from '@scalar/components'
 import {
   type TransformedOperation,
-  removeCharsetFromContentTypes,
+  normalizeMimeTypeObject,
 } from '@scalar/oas-utils'
 import { computed, ref } from 'vue'
 
@@ -59,13 +59,11 @@ const currentResponse = computed(() => {
 })
 
 const currentJsonResponse = computed(() => {
-  removeCharsetFromContentTypes(currentResponse.value?.content)
+  normalizeMimeTypeObject(currentResponse.value?.content)
 
   return (
     // OpenAPI 3.x
     currentResponse.value?.content?.['application/json'] ??
-    currentResponse.value?.content?.['application/problem+json'] ??
-    currentResponse.value?.content?.['application/vnd.api+json'] ??
     // Swagger 2.0
     currentResponse.value
   )

--- a/packages/oas-utils/src/getRequestBodyFromOperation.test.ts
+++ b/packages/oas-utils/src/getRequestBodyFromOperation.test.ts
@@ -36,6 +36,39 @@ describe('getRequestBodyFromOperation', () => {
     })
   })
 
+  it('ignores charset in mimetypes', () => {
+    const request = getRequestBodyFromOperation({
+      httpVerb: 'POST',
+      path: '/foobar',
+      information: {
+        requestBody: {
+          content: {
+            'application/json; charset=utf-8': {
+              schema: {
+                type: 'object',
+                properties: {
+                  id: {
+                    type: 'integer',
+                    example: 1,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const expectedResult = {
+      id: 1,
+    }
+
+    expect(request?.postData).toMatchObject({
+      mimeType: 'application/json',
+      text: JSON.stringify(expectedResult, null, 2),
+    })
+  })
+
   it('creates a JSON body from body parameters', () => {
     const request = getRequestBodyFromOperation({
       httpVerb: 'POST',

--- a/packages/oas-utils/src/getRequestBodyFromOperation.ts
+++ b/packages/oas-utils/src/getRequestBodyFromOperation.ts
@@ -23,11 +23,8 @@ export function getRequestBodyFromOperation(
   ]
 
   // Get the content object from the operation
-  const content = operation.information?.requestBody?.content
-
-  normalizeMimeTypeObject(content)
-
-  console.log('CONTENT', content)
+  const originalContent = operation.information?.requestBody?.content
+  const content = normalizeMimeTypeObject(originalContent)
 
   // Find the first mime type that is supported
   const mimeType: ContentType | undefined = mimeTypes.find(

--- a/packages/oas-utils/src/getRequestBodyFromOperation.ts
+++ b/packages/oas-utils/src/getRequestBodyFromOperation.ts
@@ -1,8 +1,8 @@
 import { getExampleFromSchema } from './getExampleFromSchema'
 import { getParametersFromOperation } from './getParametersFromOperation'
 import { json2xml } from './json2xml'
+import { normalizeMimeTypeObject } from './normalizeMimeTypeObject'
 import { prettyPrintJson } from './prettyPrintJson'
-import { removeCharsetFromContentTypes } from './removeCharsetFromContentTypes'
 import type { ContentType, TransformedOperation } from './types'
 
 /**
@@ -25,7 +25,9 @@ export function getRequestBodyFromOperation(
   // Get the content object from the operation
   const content = operation.information?.requestBody?.content
 
-  removeCharsetFromContentTypes(content)
+  normalizeMimeTypeObject(content)
+
+  console.log('CONTENT', content)
 
   // Find the first mime type that is supported
   const mimeType: ContentType | undefined = mimeTypes.find(

--- a/packages/oas-utils/src/getRequestBodyFromOperation.ts
+++ b/packages/oas-utils/src/getRequestBodyFromOperation.ts
@@ -2,6 +2,7 @@ import { getExampleFromSchema } from './getExampleFromSchema'
 import { getParametersFromOperation } from './getParametersFromOperation'
 import { json2xml } from './json2xml'
 import { prettyPrintJson } from './prettyPrintJson'
+import { removeCharsetFromContentTypes } from './removeCharsetFromContentTypes'
 import type { ContentType, TransformedOperation } from './types'
 
 /**
@@ -21,15 +22,18 @@ export function getRequestBodyFromOperation(
     'text/plain',
   ]
 
+  // Get the content object from the operation
+  const content = operation.information?.requestBody?.content
+
+  removeCharsetFromContentTypes(content)
+
   // Find the first mime type that is supported
   const mimeType: ContentType | undefined = mimeTypes.find(
-    (currentMimeType: ContentType) =>
-      !!operation.information?.requestBody?.content?.[currentMimeType],
+    (currentMimeType: ContentType) => !!content?.[currentMimeType],
   )
 
   /** Examples */
-  const examples =
-    operation.information?.requestBody?.content?.['application/json']?.examples
+  const examples = content?.['application/json']?.examples
 
   // Let’s use the first example
   const selectedExample = (examples ?? {})?.[
@@ -107,8 +111,7 @@ export function getRequestBodyFromOperation(
   }
 
   // Get the request body object for the mime type
-  const requestBodyObject =
-    operation.information?.requestBody?.content?.[mimeType]
+  const requestBodyObject = content?.[mimeType]
 
   // Define the appropriate Content-Type headers
   const headers = [

--- a/packages/oas-utils/src/index.ts
+++ b/packages/oas-utils/src/index.ts
@@ -5,7 +5,7 @@ export { getHarRequest } from './getHarRequest'
 export { getParametersFromOperation } from './getParametersFromOperation'
 export { getRequestBodyFromOperation } from './getRequestBodyFromOperation'
 export { getRequestFromOperation } from './getRequestFromOperation'
-export { removeCharsetFromContentTypes } from './normalizeMimeTypeObject'
+export { normalizeMimeTypeObject } from './normalizeMimeTypeObject'
 export { json2xml } from './json2xml'
 export {
   formatJsonOrYamlString,

--- a/packages/oas-utils/src/index.ts
+++ b/packages/oas-utils/src/index.ts
@@ -5,6 +5,7 @@ export { getHarRequest } from './getHarRequest'
 export { getParametersFromOperation } from './getParametersFromOperation'
 export { getRequestBodyFromOperation } from './getRequestBodyFromOperation'
 export { getRequestFromOperation } from './getRequestFromOperation'
+export { removeCharsetFromContentTypes } from './removeCharsetFromContentTypes'
 export { json2xml } from './json2xml'
 export {
   formatJsonOrYamlString,

--- a/packages/oas-utils/src/index.ts
+++ b/packages/oas-utils/src/index.ts
@@ -5,7 +5,7 @@ export { getHarRequest } from './getHarRequest'
 export { getParametersFromOperation } from './getParametersFromOperation'
 export { getRequestBodyFromOperation } from './getRequestBodyFromOperation'
 export { getRequestFromOperation } from './getRequestFromOperation'
-export { removeCharsetFromContentTypes } from './removeCharsetFromContentTypes'
+export { removeCharsetFromContentTypes } from './normalizeMimeTypeObject'
 export { json2xml } from './json2xml'
 export {
   formatJsonOrYamlString,

--- a/packages/oas-utils/src/normalizeMimeTypeObject.test.ts
+++ b/packages/oas-utils/src/normalizeMimeTypeObject.test.ts
@@ -8,9 +8,7 @@ describe('normalizeMimeTypeObject', () => {
       'application/json; charset=utf-8': {},
     }
 
-    normalizeMimeTypeObject(content)
-
-    expect(content).toMatchObject({
+    expect(normalizeMimeTypeObject(content)).toMatchObject({
       'application/json': {},
     })
   })
@@ -20,9 +18,7 @@ describe('normalizeMimeTypeObject', () => {
       'application/json;': {},
     }
 
-    normalizeMimeTypeObject(content)
-
-    expect(content).toMatchObject({
+    expect(normalizeMimeTypeObject(content)).toMatchObject({
       'application/json': {},
     })
   })
@@ -32,9 +28,7 @@ describe('normalizeMimeTypeObject', () => {
       ' application/json ': {},
     }
 
-    normalizeMimeTypeObject(content)
-
-    expect(content).toMatchObject({
+    expect(normalizeMimeTypeObject(content)).toMatchObject({
       'application/json': {},
     })
   })
@@ -44,9 +38,7 @@ describe('normalizeMimeTypeObject', () => {
       'application/problem+json': {},
     }
 
-    normalizeMimeTypeObject(content)
-
-    expect(content).toMatchObject({
+    expect(normalizeMimeTypeObject(content)).toMatchObject({
       'application/json': {},
     })
   })
@@ -56,9 +48,7 @@ describe('normalizeMimeTypeObject', () => {
       'application/vnd.api+json': {},
     }
 
-    normalizeMimeTypeObject(content)
-
-    expect(content).toMatchObject({
+    expect(normalizeMimeTypeObject(content)).toMatchObject({
       'application/json': {},
     })
   })
@@ -68,9 +58,7 @@ describe('normalizeMimeTypeObject', () => {
       'application/problem-foobar+json; charset=utf-8': {},
     }
 
-    normalizeMimeTypeObject(content)
-
-    expect(content).toMatchObject({
+    expect(normalizeMimeTypeObject(content)).toMatchObject({
       'application/json': {},
     })
   })

--- a/packages/oas-utils/src/normalizeMimeTypeObject.test.ts
+++ b/packages/oas-utils/src/normalizeMimeTypeObject.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeMimeTypeObject } from './normalizeMimeTypeObject'
+
+describe('normalizeMimeTypeObject', () => {
+  it('removes charset', async () => {
+    const content = {
+      'application/json; charset=utf-8': {},
+    }
+
+    normalizeMimeTypeObject(content)
+
+    expect(content).toMatchObject({
+      'application/json': {},
+    })
+  })
+
+  it('removes semicolon', async () => {
+    const content = {
+      'application/json;': {},
+    }
+
+    normalizeMimeTypeObject(content)
+
+    expect(content).toMatchObject({
+      'application/json': {},
+    })
+  })
+
+  it('removes whitespace', async () => {
+    const content = {
+      ' application/json ': {},
+    }
+
+    normalizeMimeTypeObject(content)
+
+    expect(content).toMatchObject({
+      'application/json': {},
+    })
+  })
+
+  it('removes mimetype variants', async () => {
+    const content = {
+      'application/problem+json': {},
+    }
+
+    normalizeMimeTypeObject(content)
+
+    expect(content).toMatchObject({
+      'application/json': {},
+    })
+  })
+
+  it('removes mimetype variants with special characters', async () => {
+    const content = {
+      'application/vnd.api+json': {},
+    }
+
+    normalizeMimeTypeObject(content)
+
+    expect(content).toMatchObject({
+      'application/json': {},
+    })
+  })
+
+  it('removes all the clutter', async () => {
+    const content = {
+      'application/problem-foobar+json; charset=utf-8': {},
+    }
+
+    normalizeMimeTypeObject(content)
+
+    expect(content).toMatchObject({
+      'application/json': {},
+    })
+  })
+})

--- a/packages/oas-utils/src/normalizeMimeTypeObject.ts
+++ b/packages/oas-utils/src/normalizeMimeTypeObject.ts
@@ -7,15 +7,21 @@ import type { ContentType } from './types'
  *
  * Example: `application/json; charset=utf-8` -> `application/json`
  */
-export function removeCharsetFromContentTypes(
-  content?: Record<ContentType, any>,
-) {
+export function normalizeMimeTypeObject(content?: Record<ContentType, any>) {
   if (!content) {
     return
   }
 
   Object.keys(content).forEach((key) => {
-    const newKey = key.split(';')[0] as ContentType
+    // Example: 'application/problem+json; charset=utf-8'
+
+    const newKey = key
+      // Remove '; charset=utf-8'
+      .replace(/;.*$/, '')
+      // Remove 'problem+'
+      .replace(/\/.+\+/, '/')
+      // Remove whitespace
+      .trim() as ContentType
 
     content[newKey] = content[key as ContentType]
 

--- a/packages/oas-utils/src/normalizeMimeTypeObject.ts
+++ b/packages/oas-utils/src/normalizeMimeTypeObject.ts
@@ -3,16 +3,17 @@ import type { ContentType } from './types'
 /**
  * Remove charset from content types
  *
- * Warning: This modifies the given object!
- *
  * Example: `application/json; charset=utf-8` -> `application/json`
  */
 export function normalizeMimeTypeObject(content?: Record<ContentType, any>) {
   if (!content) {
-    return
+    return content
   }
 
-  Object.keys(content).forEach((key) => {
+  // Clone the object
+  const newContent = structuredClone(content)
+
+  Object.keys(newContent).forEach((key) => {
     // Example: 'application/problem+json; charset=utf-8'
 
     const newKey = key
@@ -23,10 +24,12 @@ export function normalizeMimeTypeObject(content?: Record<ContentType, any>) {
       // Remove whitespace
       .trim() as ContentType
 
-    content[newKey] = content[key as ContentType]
+    newContent[newKey] = newContent[key as ContentType]
 
     if (key !== newKey) {
-      delete content[key as ContentType]
+      delete newContent[key as ContentType]
     }
   })
+
+  return newContent
 }

--- a/packages/oas-utils/src/removeCharsetFromContentTypes.ts
+++ b/packages/oas-utils/src/removeCharsetFromContentTypes.ts
@@ -1,0 +1,26 @@
+import type { ContentType } from './types'
+
+/**
+ * Remove charset from content types
+ *
+ * Warning: This modifies the given object!
+ *
+ * Example: `application/json; charset=utf-8` -> `application/json`
+ */
+export function removeCharsetFromContentTypes(
+  content?: Record<ContentType, any>,
+) {
+  if (!content) {
+    return
+  }
+
+  Object.keys(content).forEach((key) => {
+    const newKey = key.split(';')[0] as ContentType
+
+    content[newKey] = content[key as ContentType]
+
+    if (key !== newKey) {
+      delete content[key as ContentType]
+    }
+  })
+}

--- a/packages/oas-utils/src/types.ts
+++ b/packages/oas-utils/src/types.ts
@@ -13,14 +13,16 @@ export type BaseParameter = {
   enabled: boolean
 }
 
+type OptionalCharset = string | null
+
 export type ContentType =
-  | 'application/json'
-  | 'application/xml'
-  | 'text/plain'
-  | 'text/html'
-  | 'application/octet-stream'
-  | 'application/x-www-form-urlencoded'
-  | 'multipart/form-data'
+  | `application/json${OptionalCharset}`
+  | `application/xml${OptionalCharset}`
+  | `text/plain${OptionalCharset}`
+  | `text/html${OptionalCharset}`
+  | `application/octet-stream${OptionalCharset}`
+  | `application/x-www-form-urlencoded${OptionalCharset}`
+  | `multipart/form-data${OptionalCharset}`
 
 export type Cookie = {
   name: string


### PR DESCRIPTION
Currently, we expect request bodies and example responses to be in `application/json`, variants like `application/json; charset=utf-8` or `application/vnd.api+json` (which are totally valid) are ignored.

That’s why we’re just looking for that string. I’ve added a normalize function, that transforms all those variants to simple mime types like `application/json`.

See #920