### PR TITLE
fix: docusaurus README example

### DIFF
--- a/packages/docusaurus/README.md
+++ b/packages/docusaurus/README.md
@@ -23,7 +23,8 @@ import type { ScalarOptions } from '@scalar/docusaurus'
 
 plugins: [
   [
-    ['@scalar/docusaurus', {
+    '@scalar/docusaurus',
+    {
       label: 'Scalar',
       route: '/scalar',
       configuration: {
@@ -31,7 +32,7 @@ plugins: [
           url: 'https://petstore3.swagger.io/api/v3/openapi.json',
         },
       },
-    } as ScalarOptions],
+    } as ScalarOptions,
   ],
 ],
 ```


### PR DESCRIPTION
There were a couple of erraneous brackets in the docusaurus package README
