### PR TITLE
fix: received NaN as the port

### DIFF
--- a/examples/nestjs-api-reference-express/src/main.ts
+++ b/examples/nestjs-api-reference-express/src/main.ts
@@ -4,7 +4,7 @@ import { AppModule } from './app.module';
 
 import { apiReference } from '@scalar/nestjs-api-reference';
 
-const PORT = Number(process.env.PORT);
+const PORT = Number(process.env.PORT || 5056);
 const HOST = process.env.HOST || '0.0.0.0';
 
 async function bootstrap() {


### PR DESCRIPTION
I think we’ve remove the default port for the NestJS (with Express) example. Locally, this throws an error for me:

>  RangeError: options.port should be >= 0 and < 65536. Received type number (NaN).

This PR adds a default port (again) and should fix the error. ✌️ 