### PR TITLE
ci: generate provenance statements

### DIFF
--- a/.changeset/poor-geckos-collect.md
+++ b/.changeset/poor-geckos-collect.md
@@ -1,0 +1,29 @@
+---
+"@scalar/api-client": patch
+"@scalar/api-client-proxy": patch
+"@scalar/api-client-react": patch
+"@scalar/api-reference": patch
+"@scalar/api-reference-react": patch
+"@scalar/build-tooling": patch
+"@scalar/cli": patch
+"@scalar/components": patch
+"@scalar/docusaurus": patch
+"@scalar/draggable": patch
+"@scalar/echo-server": patch
+"@scalar/express-api-reference": patch
+"@scalar/fastify-api-reference": patch
+"@scalar/galaxy": patch
+"@scalar/hono-api-reference": patch
+"@scalar/mock-server": patch
+"@scalar/nestjs-api-reference": patch
+"@scalar/nextjs-api-reference": patch
+"@scalar/nuxt": patch
+"@scalar/oas-utils": patch
+"@scalar/themes": patch
+"@scalar/use-codemirror": patch
+"@scalar/use-modal": patch
+"@scalar/use-toasts": patch
+"@scalar/use-tooltip": patch
+---
+
+chore: add provenance statement

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       matrix:
         node-version: [20]

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,9 @@
 # Needed to install npm version of our workspace packages
 # https://pnpm.io/npmrc#link-workspace-packages
 link-workspace-packages=false
+
+# You can generate provenance statements for the packages you publish.
+#
+# This allows you to publicly establish where a package was built and who published a package,
+# which can increase supply-chain security for your packages.
+provenance=true


### PR DESCRIPTION
Provenance statements give a proof that our published packages are what’s in this repository. This is a typical security concern users have. That’s why I suggest to enable it for this repository. :)

Note: It might not work on the first attempt, it’s hard to test without actually releasing. If you like, I can test this on a smaller repository first.

Read more:

> You can generate provenance statements for the packages you publish. This allows you to publicly establish where a package was built and who published a package, which can increase supply-chain security for your packages.

https://docs.npmjs.com/generating-provenance-statements