### PR TITLE
fix: export types from draggable

### DIFF
--- a/.changeset/tidy-wolves-complain.md
+++ b/.changeset/tidy-wolves-complain.md
@@ -1,0 +1,5 @@
+---
+"@scalar/draggable": patch
+---
+
+fix: export draggable types

--- a/packages/draggable/src/index.ts
+++ b/packages/draggable/src/index.ts
@@ -1,3 +1,5 @@
 import Draggable from './Draggable.vue'
 
+export type { DraggingItem, HoveredItem } from './store'
+
 export { Draggable }


### PR DESCRIPTION
Quickie, missed these types on the export