### PR TITLE
fix: code block broken

### DIFF
--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -183,7 +183,7 @@ To make authentication easier you can prefill the credentials for your users:
       },
     },
   } />
-``
+```
 
 For OpenAuth2 it’s more looking like this:
 
@@ -192,12 +192,12 @@ For OpenAuth2 it’s more looking like this:
   authentication: {
       // The OpenAPI file has keys for all security schemes
       // Which one should be used by default?
-      preferredSecurityScheme: 'petstore_auth',
+      preferredSecurityScheme: 'planets_auth',
       // The `petstore_auth` security scheme is of type `oAuth2`, so prefill the client id and the scopes:
       oAuth2: {
         clientId: 'foobar123',
         // optional:
-        scopes: ['read:pets', 'write:pets'],
+        scopes: ['read:planets', 'write:planets'],
       },
     },
   } />


### PR DESCRIPTION
Just adding a ` to fix this broken code block:

<img width="1053" alt="Screenshot 2024-05-07 at 13 15 11" src="https://github.com/scalar/scalar/assets/1577992/39dda213-da2f-4ba7-a733-01f3a8d7bade">

And while I’m on it, let’s remove the petstore stuff from the example. :)