### PR TITLE
chore: fetch example specification from jsdelivr

### DIFF
--- a/.changeset/five-weeks-shave.md
+++ b/.changeset/five-weeks-shave.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+chore: fetch scalar galaxy example from jsdelivr

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -64,7 +64,6 @@
     "@headlessui/vue": "^1.7.20",
     "@scalar/api-client": "workspace:*",
     "@scalar/components": "workspace:*",
-    "@scalar/galaxy": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
     "@scalar/openapi-parser": "^0.3.2",
     "@scalar/snippetz": "^0.1.6",
@@ -118,7 +117,8 @@
     "vite-plugin-lib-inject-css": "^2.0.1",
     "vitest": "^1.5.0",
     "vitest-matchmedia-mock": "^1.0.5",
-    "vue-tsc": "^1.8.19"
+    "vue-tsc": "^1.8.19",
+    "@scalar/galaxy": "workspace:*"
   },
   "peerDependencies": {
     "unified": "^11.0.0",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@etchteam/storybook-addon-css-variables-theme": "^1.5.1",
+    "@scalar/galaxy": "workspace:*",
     "@storybook/addon-essentials": "^8.0.8",
     "@storybook/addon-interactions": "^8.0.8",
     "@storybook/addon-links": "^8.0.8",
@@ -117,8 +118,7 @@
     "vite-plugin-lib-inject-css": "^2.0.1",
     "vitest": "^1.5.0",
     "vitest-matchmedia-mock": "^1.0.5",
-    "vue-tsc": "^1.8.19",
-    "@scalar/galaxy": "workspace:*"
+    "vue-tsc": "^1.8.19"
   },
   "peerDependencies": {
     "unified": "^11.0.0",

--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ScalarButton } from '@scalar/components'
-import exampleSpecification from '@scalar/galaxy/latest.yaml?raw'
 import { type ThemeId, themeLabels } from '@scalar/themes'
 
 defineProps<{
@@ -26,8 +25,12 @@ const themeIds: ThemeId[] = [
   'deepSpace',
 ]
 
-function handleEmitPetstore() {
-  emits('updateContent', exampleSpecification)
+async function fetchExampleSpecification() {
+  const response = await fetch(
+    'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+  )
+
+  emits('updateContent', await response.text())
 }
 </script>
 <template>
@@ -54,7 +57,7 @@ function handleEmitPetstore() {
       <div class="start-cta">
         <ScalarButton
           fullWidth
-          @click="handleEmitPetstore">
+          @click="fetchExampleSpecification">
           Show Example
         </ScalarButton>
         <ScalarButton

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -798,9 +798,6 @@ importers:
       '@scalar/components':
         specifier: workspace:*
         version: link:../components
-      '@scalar/galaxy':
-        specifier: workspace:*
-        version: link:../galaxy
       '@scalar/oas-utils':
         specifier: workspace:*
         version: link:../oas-utils
@@ -889,6 +886,9 @@ importers:
       '@etchteam/storybook-addon-css-variables-theme':
         specifier: ^1.5.1
         version: 1.6.0(@types/react@18.2.60)(react-dom@18.2.0)(react@18.2.0)
+      '@scalar/galaxy':
+        specifier: workspace:*
+        version: link:../galaxy
       '@storybook/addon-essentials':
         specifier: ^8.0.8
         version: 8.0.8(@types/react@18.2.60)(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
What if we don’t bundle the @scalar/galaxy example, but fetch it from jsdelivr? This should decrease the bundle size. 🤔 