### PR TITLE
chore: add missing repository urls to package.json

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@scalar-examples/*"]
+  "ignore": ["@scalar-examples/*", "playwright"]
 }

--- a/.changeset/silly-bugs-nail.md
+++ b/.changeset/silly-bugs-nail.md
@@ -1,0 +1,29 @@
+---
+"@scalar/express-api-reference": patch
+"@scalar/fastify-api-reference": patch
+"@scalar/nestjs-api-reference": patch
+"@scalar/nextjs-api-reference": patch
+"@scalar/api-reference-react": patch
+"@scalar/hono-api-reference": patch
+"@scalar/api-client-proxy": patch
+"@scalar/api-client-react": patch
+"@scalar/use-codemirror": patch
+"@scalar/api-reference": patch
+"@scalar/build-tooling": patch
+"@scalar/echo-server": patch
+"@scalar/mock-server": patch
+"@scalar/use-tooltip": patch
+"@scalar/api-client": patch
+"@scalar/components": patch
+"@scalar/docusaurus": patch
+"@scalar/use-toasts": patch
+"@scalar/draggable": patch
+"@scalar/oas-utils": patch
+"@scalar/use-modal": patch
+"@scalar/galaxy": patch
+"@scalar/themes": patch
+"@scalar/nuxt": patch
+"@scalar/cli": patch
+---
+
+fix: can’t release packages

--- a/examples/express-api-reference/package.json
+++ b/examples/express-api-reference/package.json
@@ -4,6 +4,7 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "version": "0.1.0",
   "private": true,
   "engines": {
     "node": ">=18"

--- a/examples/hono-api-reference/package.json
+++ b/examples/hono-api-reference/package.json
@@ -4,6 +4,7 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "version": "0.1.0",
   "private": true,
   "engines": {
     "node": ">=18"

--- a/packages/api-client-proxy/package.json
+++ b/packages/api-client-proxy/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/api-client-proxy"
+  },
   "keywords": [
     "api",
     "express",
@@ -34,11 +39,6 @@
     "CHANGELOG.md"
   ],
   "module": "./dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/api-client-proxy"
-  },
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.19.2"

--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/api-client-react"
+  },
   "keywords": [
     "api",
     "client",
@@ -34,11 +39,6 @@
     "CHANGELOG.md"
   ],
   "module": "./dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/api-client-react"
-  },
   "dependencies": {
     "@scalar/api-client": "workspace:*"
   },

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/api-client"
+  },
   "keywords": [
     "api",
     "client",
@@ -36,11 +41,6 @@
     "CHANGELOG.md"
   ],
   "module": "./dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/api-client"
-  },
   "dependencies": {
     "@floating-ui/vue": "^1.0.2",
     "@headlessui/vue": "^1.7.20",

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/api-reference-react"
+  },
   "keywords": [
     "api",
     "client",
@@ -33,11 +38,6 @@
     "CHANGELOG.md"
   ],
   "module": "./dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/docusaurus"
-  },
   "dependencies": {
     "@scalar/api-reference": "workspace:*"
   },

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/api-reference"
+  },
   "keywords": [
     "component",
     "documentation",
@@ -55,11 +60,6 @@
   ],
   "browser": "./dist/browser/standalone.js",
   "module": "./dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/api-reference"
-  },
   "dependencies": {
     "@headlessui/vue": "^1.7.20",
     "@scalar/api-client": "workspace:*",

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/build-tooling"
+  },
   "keywords": [],
   "version": "0.1.3",
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/cli.git",
+    "directory": "packages/cli"
+  },
   "keywords": [
     "scalar",
     "openapi",
@@ -25,11 +30,6 @@
   "files": [
     "./dist"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/cli.git",
-    "directory": "packages/cli"
-  },
   "bin": {
     "scalar": "./dist/index.js"
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/components"
+  },
   "version": "0.7.2",
   "engines": {
     "node": ">=18"

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/docusaurus"
+  },
   "keywords": [
     "api",
     "client",
@@ -29,11 +34,6 @@
     "dist",
     "CHANGELOG.md"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/docusaurus"
-  },
   "dependencies": {
     "@scalar/api-reference-react": "workspace:*"
   },

--- a/packages/draggable/package.json
+++ b/packages/draggable/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/draggable"
+  },
   "keywords": [
     "vue drag and drop draggable html"
   ],
@@ -37,11 +42,6 @@
     "CHANGELOG.md"
   ],
   "module": "dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/draggable"
-  },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
     "tsc-alias": "^1.8.8",

--- a/packages/echo-server/package.json
+++ b/packages/echo-server/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/echo-server"
+  },
   "keywords": [
     "express",
     "server",
@@ -34,11 +39,6 @@
     "CHANGELOG.md"
   ],
   "module": "./dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/echo-server"
-  },
   "dependencies": {
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",

--- a/packages/express-api-reference/package.json
+++ b/packages/express-api-reference/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/express-api-reference"
+  },
   "version": "0.4.23",
   "engines": {
     "node": ">=18"
@@ -32,11 +37,6 @@
     "dist"
   ],
   "module": "dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/express-api-reference"
-  },
   "dependencies": {
     "@scalar/api-reference": "workspace:*",
     "express": "^4.19.2"

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/fastify-api-reference"
+  },
   "keywords": [
     "api",
     "documentation",
@@ -35,11 +40,6 @@
     "dist",
     "CHANGELOG.md"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/fastify-api-reference"
-  },
   "module": "./dist/index.js",
   "dependencies": {
     "fastify-plugin": "^4.5.1"

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/galaxy"
+  },
   "keywords": [
     "openapi",
     "example",
@@ -37,11 +42,6 @@
     "CHANGELOG.md"
   ],
   "module": "./dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/galaxy"
-  },
   "devDependencies": {
     "@scalar/openapi-parser": "^0.3.2",
     "@vitest/coverage-v8": "^1.5.0",

--- a/packages/hono-api-reference/package.json
+++ b/packages/hono-api-reference/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/hono-api-reference"
+  },
   "version": "0.5.23",
   "engines": {
     "node": ">=18"
@@ -32,11 +37,6 @@
     "dist"
   ],
   "module": "dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/hono-api-reference"
-  },
   "dependencies": {
     "@scalar/api-reference": "workspace:*"
   },

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/cli.git",
+    "directory": "packages/mock-server"
+  },
   "keywords": [
     "scalar",
     "openapi",
@@ -30,11 +35,6 @@
   "files": [
     "./dist"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/cli.git",
-    "directory": "packages/mock-server"
-  },
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "@scalar/api-reference": "workspace:*",

--- a/packages/nestjs-api-reference/package.json
+++ b/packages/nestjs-api-reference/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/nestjs-api-reference"
+  },
   "version": "0.3.23",
   "engines": {
     "node": ">=18"
@@ -32,11 +37,6 @@
     "dist"
   ],
   "module": "dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/nestjs-api-reference"
-  },
   "dependencies": {
     "@scalar/api-reference": "workspace:*",
     "express": "^4.19.2"

--- a/packages/nextjs-api-reference/package.json
+++ b/packages/nextjs-api-reference/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/nextjs-api-reference"
+  },
   "keywords": [
     "api",
     "documentation",
@@ -36,11 +41,6 @@
     "CHANGELOG.md"
   ],
   "module": "./dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/nextjs-api-reference"
-  },
   "dependencies": {
     "@scalar/api-reference": "workspace:*"
   },

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/nuxt"
+  },
   "keywords": [
     "api",
     "references",

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/oas-utils"
+  },
   "keywords": [
     "oas",
     "fetching",
@@ -47,11 +52,6 @@
     "CHANGELOG.md"
   ],
   "module": "dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/oas-utils"
-  },
   "dependencies": {
     "yaml": "^2.4.1"
   },

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/themes"
+  },
   "keywords": [
     "css",
     "css-variables",
@@ -38,11 +43,6 @@
     "CHANGELOG.md"
   ],
   "module": "./dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/default-theme"
-  },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
     "@vitest/coverage-v8": "^1.5.0",

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/use-codemirror"
+  },
   "keywords": [
     "codemirror",
     "composable",
@@ -35,11 +40,6 @@
     "CHANGELOG.md"
   ],
   "module": "dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/use-codemirror"
-  },
   "optionalDependencies": {
     "y-codemirror.next": "^0.3.2"
   },

--- a/packages/use-modal/package.json
+++ b/packages/use-modal/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/use-modal"
+  },
   "keywords": [
     "composable",
     "modals",
@@ -35,11 +40,6 @@
     "CHANGELOG.md"
   ],
   "module": "dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/use-modal"
-  },
   "devDependencies": {
     "@headlessui/vue": "^1.7.20",
     "@vitejs/plugin-vue": "^5.0.4",

--- a/packages/use-toasts/package.json
+++ b/packages/use-toasts/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/use-toasts"
+  },
   "keywords": [
     "composable",
     "notifcation",
@@ -32,11 +37,6 @@
     "dist",
     "CHANGELOG.md"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/use-toasts"
-  },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
     "@vitest/coverage-v8": "^1.5.0",

--- a/packages/use-tooltip/package.json
+++ b/packages/use-tooltip/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/use-tooltip"
+  },
   "keywords": [
     "composable",
     "tootltips",
@@ -35,11 +40,6 @@
     "CHANGELOG.md"
   ],
   "module": "dist/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/use-tooltip"
-  },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
     "@vitest/coverage-v8": "^1.5.0",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,5 +1,6 @@
 {
   "name": "playwright",
+  "version": "0.1.0",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -26,6 +26,7 @@ const restrictedKeys = [
   'author',
   'homepage',
   'bugs',
+  'repository',
   'keywords',
   'version',
   'private',


### PR DESCRIPTION
To generate provenance statements (#1621) the repository URL has to be set. This PR adds the repository URL where it’s missing.