### PR TITLE
fix: wrong repository url

### DIFF
--- a/.changeset/lovely-pears-reflect.md
+++ b/.changeset/lovely-pears-reflect.md
@@ -1,0 +1,6 @@
+---
+"@scalar/mock-server": patch
+"@scalar/cli": patch
+---
+
+fix: wrong repository URL in the package.json

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/cli.git",
+    "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/cli"
   },
   "keywords": [

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/cli.git",
+    "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/mock-server"
   },
   "keywords": [


### PR DESCRIPTION
Can't generate the provenance statement for packages without a wrong repository URL. 😬 