### PR TITLE
chore: use prism instead of highlightjs

### DIFF
--- a/.changeset/eight-penguins-cough.md
+++ b/.changeset/eight-penguins-cough.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+refactor: use prismjs instead of highlightjs in the markdown component

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -48,6 +48,7 @@
     "character-entities": "^2.0.2",
     "decode-named-character-reference": "^1.0.2",
     "path": "^0.12.7",
+    "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "vite": "^5.2.10",
     "vite-plugin-dts": "^3.6.3",
@@ -55,7 +56,6 @@
     "vue": "^3.4.21"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "vue": "^3.3.0"
+    "react": "^18.0.0"
   }
 }

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -79,6 +79,7 @@
     "github-slugger": "^2.0.0",
     "httpsnippet-lite": "^3.0.5",
     "postcss-nested": "^6.0.1",
+    "prismjs": "^1.29.0",
     "rehype-external-links": "^3.0.0",
     "rehype-format": "^5.0.0",
     "rehype-highlight": "^7.0.0",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -82,7 +82,6 @@
     "prismjs": "^1.29.0",
     "rehype-external-links": "^3.0.0",
     "rehype-format": "^5.0.0",
-    "rehype-highlight": "^7.0.0",
     "rehype-prism": "^2.3.2",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -82,6 +82,7 @@
     "rehype-external-links": "^3.0.0",
     "rehype-format": "^5.0.0",
     "rehype-highlight": "^7.0.0",
+    "rehype-prism": "^2.3.2",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.0",

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import rehypeExternalLinks from 'rehype-external-links'
 import rehypeFormat from 'rehype-format'
-import rehypeHighlight from 'rehype-highlight'
+// @ts-expect-error comes without types
+import rehypePrism from 'rehype-prism'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import rehypeStringify from 'rehype-stringify'
@@ -49,9 +50,7 @@ watch(
         ),
       })
       // Syntax highlighting
-      .use(rehypeHighlight, {
-        detect: true,
-      })
+      .use(rehypePrism)
       // Adds target="_blank" to external links
       .use(rehypeExternalLinks, { target: '_blank' })
       // Formats the HTML
@@ -314,7 +313,7 @@ onServerPrefetch(async () => await sleep(1))
 
 <style lang="postcss">
 .markdown {
-  pre code.hljs {
+  pre code[class*='language-'] {
     display: block;
     overflow-x: auto;
     padding: 12px;
@@ -323,71 +322,91 @@ onServerPrefetch(async () => await sleep(1))
     font-size: var(--scalar-small) !important;
     font-family: var(--scalar-font-code) !important;
   }
-  code.hljs {
+  code[class*='language-'] {
     padding: 3px 5px;
   }
-  .hljs {
-    background: var(--scalar-background-4);
-    color: var(--scalar-color-1);
+  pre[class*='language-']::-moz-selection,
+  pre[class*='language-'] ::-moz-selection,
+  code[class*='language-']::-moz-selection,
+  code[class*='language-'] ::-moz-selection {
+    background: var(--scalar-background-3);
   }
-  .hljs-comment,
-  .hljs-quote {
-    color: var(--scalar-color-3);
+
+  pre[class*='language-']::selection,
+  pre[class*='language-'] ::selection,
+  code[class*='language-']::selection,
+  code[class*='language-'] ::selection {
+    background: var(--scalar-background-3);
+  }
+
+  /* Code blocks */
+  pre[class*='language-'] {
+    padding: 1em;
+    margin: 0.5em 0;
+    overflow: auto;
+    background-color: var(--scalar-background-4);
+  }
+
+  .token.comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata {
+    color: var(--scalar-color-2);
     font-style: italic;
   }
-  .hljs-addition,
-  .hljs-keyword,
-  .hljs-literal,
-  .hljs-selector-tag,
-  .hljs-type {
+
+  .token.namespace {
+    opacity: 0.7;
+  }
+
+  .token.string,
+  .token.attr-value {
+    color: var(--scalar-color-blue);
+  }
+
+  .token.punctuation,
+  .token.operator {
+    color: var(--scalar-color-1); /* no highlight */
+  }
+
+  .token.entity,
+  .token.url,
+  .token.symbol,
+  .token.number,
+  .token.boolean,
+  .token.variable,
+  .token.constant,
+  .token.property,
+  .token.regex,
+  .token.inserted {
+    color: var(--scalar-color-1);
+  }
+
+  .token.atrule,
+  .token.keyword,
+  .token.attr-name,
+  .language-autohotkey .token.selector {
     color: var(--scalar-color-green);
   }
-  .hljs-number,
-  .hljs-selector-attr,
-  .hljs-selector-pseudo {
-    color: var(--scalar-color-orange);
+
+  .token.function,
+  .token.deleted,
+  .language-autohotkey .token.tag {
+    color: var(--scalar-color-1);
   }
-  .hljs-doctag,
-  .hljs-regexp,
-  .hljs-string {
+
+  .token.tag,
+  .token.selector,
+  .language-autohotkey .token.keyword {
     color: var(--scalar-color-blue);
   }
-  .hljs-built_in,
-  .hljs-name,
-  .hljs-section,
-  .hljs-title {
-    color: var(--scalar-color-1);
+
+  .token.important,
+  .token.bold {
+    font-weight: bold;
   }
-  .hljs-class .hljs-title,
-  .hljs-selector-id,
-  .hljs-template-variable,
-  .hljs-title.class_,
-  .hljs-variable {
-    color: var(--scalar-color-1);
-  }
-  .hljs-name,
-  .hljs-section,
-  .hljs-strong {
-    font-weight: var(--scalar-semibold);
-  }
-  .hljs-bullet,
-  .hljs-link,
-  .hljs-meta,
-  .hljs-subst,
-  .hljs-symbol {
-    color: var(--scalar-color-blue);
-  }
-  .hljs-deletion {
-    color: var(--scalar-color-red);
-  }
-  .hljs-formula {
-    background: var(--scalar-color-1);
-  }
-  .hljs-attr,
-  .hljs-attribute {
-    color: var(--scalar-color-1);
-  }
-  .hljs-emphasis {
+
+  .token.italic {
     font-style: italic;
   }
 }

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import rehypeExternalLinks from 'rehype-external-links'
 import rehypeFormat from 'rehype-format'
-// @ts-expect-error comes without types
 import rehypePrism from 'rehype-prism'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     rollupOptions: {
       external: [
         'vue',
+        'prismjs',
         ...Object.keys(pkg.dependencies || {}).filter(
           (item) => !item.startsWith('@scalar'),
         ),

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -51,7 +51,7 @@ export default defineNuxtModule<ModuleOptions>({
       'debug',
       'extend',
       'stringify-object',
-      'rehype-highlight',
+      'rehype-prismjs',
     )
 
     // Also check for Nitro OpenAPI auto generation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,9 +852,6 @@ importers:
       rehype-format:
         specifier: ^5.0.0
         version: 5.0.0
-      rehype-highlight:
-        specifier: ^7.0.0
-        version: 7.0.0
       rehype-prism:
         specifier: ^2.3.2
         version: 2.3.2(unified@11.0.4)
@@ -17520,15 +17517,6 @@ packages:
       '@types/hast': 3.0.4
     dev: true
 
-  /hast-util-to-text@4.0.2:
-    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.2
-      hast-util-is-element: 3.0.0
-      unist-util-find-after: 5.0.0
-    dev: false
-
   /hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
     dependencies:
@@ -17552,11 +17540,6 @@ packages:
     resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}
     engines: {node: '>=8'}
     dev: true
-
-  /highlight.js@11.9.0:
-    resolution: {integrity: sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==}
-    engines: {node: '>=12.0.0'}
-    dev: false
 
   /history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
@@ -19740,14 +19723,6 @@ packages:
   /lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: false
-
-  /lowlight@3.1.0:
-    resolution: {integrity: sha512-CEbNVoSikAxwDMDPjXlqlFYiZLkDJHwyGu/MfOsJnF3d7f3tds5J3z8s/l9TMXhzfsJCCJEAsD78842mwmg0PQ==}
-    dependencies:
-      '@types/hast': 3.0.4
-      devlop: 1.1.0
-      highlight.js: 11.9.0
     dev: false
 
   /lru-cache@10.2.0:
@@ -24247,16 +24222,6 @@ packages:
       unist-util-visit-parents: 6.0.1
     dev: false
 
-  /rehype-highlight@7.0.0:
-    resolution: {integrity: sha512-QtobgRgYoQaK6p1eSr2SD1i61f7bjF2kZHAQHxeCHAuJf7ZUDMvQ7owDq9YTkmar5m5TSUol+2D3bp3KfJf/oA==}
-    dependencies:
-      '@types/hast': 3.0.4
-      hast-util-to-text: 4.0.2
-      lowlight: 3.1.0
-      unist-util-visit: 5.0.0
-      vfile: 6.0.1
-    dev: false
-
   /rehype-minify-whitespace@6.0.0:
     resolution: {integrity: sha512-i9It4YHR0Sf3GsnlR5jFUKXRr9oayvEk9GKQUkwZv6hs70OH9q3OCZrq9PpLvIGKt3W+JxBOxCidNVpH/6rWdA==}
     dependencies:
@@ -26900,13 +26865,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       crypto-random-string: 4.0.0
-    dev: false
-
-  /unist-util-find-after@5.0.0:
-    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
-    dependencies:
-      '@types/unist': 3.0.2
-      unist-util-is: 6.0.0
     dev: false
 
   /unist-util-is@5.2.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,6 +843,9 @@ importers:
       postcss-nested:
         specifier: ^6.0.1
         version: 6.0.1(postcss@8.4.38)
+      prismjs:
+        specifier: ^1.29.0
+        version: 1.29.0
       rehype-external-links:
         specifier: ^3.0.0
         version: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,6 +852,9 @@ importers:
       rehype-highlight:
         specifier: ^7.0.0
         version: 7.0.0
+      rehype-prism:
+        specifier: ^2.3.2
+        version: 2.3.2(unified@11.0.4)
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
@@ -14405,6 +14408,10 @@ packages:
       domutils: 3.1.0
       nth-check: 2.1.1
 
+  /css-selector-parser@3.0.5:
+    resolution: {integrity: sha512-3itoDFbKUNx1eKmVpYMFyqKX04Ww9osZ+dLgrk6GEv6KMVeXUhUnp4I5X+evw+u3ZxVU6RFXSSRxlTeMh8bA+g==}
+    dev: false
+
   /css-tree@1.1.3:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
     engines: {node: '>=8.0.0'}
@@ -17343,6 +17350,17 @@ packages:
       hast-util-is-element: 3.0.0
     dev: false
 
+  /hast-util-from-html@2.0.1:
+    resolution: {integrity: sha512-RXQBLMl9kjKVNkJTIO6bZyb2n+cUH8LFaSSzo82jiLT6Tfc+Pt7VQCS+/h3YwG4jaNE2TA2sdJisGWR+aJrp0g==}
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.1
+      parse5: 7.1.2
+      vfile: 6.0.1
+      vfile-message: 4.0.2
+    dev: false
+
   /hast-util-from-parse5@8.0.1:
     resolution: {integrity: sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==}
     dependencies:
@@ -17499,8 +17517,8 @@ packages:
       '@types/hast': 3.0.4
     dev: true
 
-  /hast-util-to-text@4.0.0:
-    resolution: {integrity: sha512-EWiE1FSArNBPUo1cKWtzqgnuRQwEeQbQtnFJRYV1hb1BWDgrAlBU0ExptvZMM/KSA82cDpm2sFGf3Dmc5Mza3w==}
+  /hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
     dependencies:
       '@types/hast': 3.0.4
       '@types/unist': 3.0.2
@@ -24230,7 +24248,7 @@ packages:
     resolution: {integrity: sha512-QtobgRgYoQaK6p1eSr2SD1i61f7bjF2kZHAQHxeCHAuJf7ZUDMvQ7owDq9YTkmar5m5TSUol+2D3bp3KfJf/oA==}
     dependencies:
       '@types/hast': 3.0.4
-      hast-util-to-text: 4.0.0
+      hast-util-to-text: 4.0.2
       lowlight: 3.1.0
       unist-util-visit: 5.0.0
       vfile: 6.0.1
@@ -24244,6 +24262,28 @@ packages:
       hast-util-is-element: 3.0.0
       hast-util-whitespace: 3.0.0
       unist-util-is: 6.0.0
+    dev: false
+
+  /rehype-parse@9.0.0:
+    resolution: {integrity: sha512-WG7nfvmWWkCR++KEkZevZb/uw41E8TsH4DsY9UxsTbIXCVGbAs4S+r8FrQ+OtH5EEQAs+5UxKC42VinkmpA1Yw==}
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.1
+      unified: 11.0.4
+    dev: false
+
+  /rehype-prism@2.3.2(unified@11.0.4):
+    resolution: {integrity: sha512-UvLT8kwsR7mPpAGtikypFTWV+Y8RkfoKCynLl+pa2MvrR6u4D72FZlVRkvxWa3ZkfMcWqAWekJ7s2J0GEp0v+Q==}
+    peerDependencies:
+      unified: ^10 || ^11
+    dependencies:
+      hastscript: 8.0.0
+      prismjs: 1.29.0
+      rehype-parse: 9.0.0
+      unified: 11.0.4
+      unist-util-is: 6.0.0
+      unist-util-select: 5.1.0
+      unist-util-visit: 5.0.0
     dev: false
 
   /rehype-raw@7.0.0:
@@ -25942,7 +25982,7 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.23
       '@swc/core': 1.4.2
       jest-worker: 27.5.1
       schema-utils: 3.3.0
@@ -25967,7 +26007,7 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.23
       '@swc/core': 1.4.2
       jest-worker: 27.5.1
       schema-utils: 3.3.0
@@ -26892,6 +26932,16 @@ packages:
     dependencies:
       '@types/unist': 3.0.2
       unist-util-visit: 5.0.0
+
+  /unist-util-select@5.1.0:
+    resolution: {integrity: sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==}
+    dependencies:
+      '@types/unist': 3.0.2
+      css-selector-parser: 3.0.5
+      devlop: 1.1.0
+      nth-check: 2.1.1
+      zwitch: 2.0.4
+    dev: false
 
   /unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -989,6 +989,9 @@ importers:
       path:
         specifier: ^0.12.7
         version: 0.12.7
+      prismjs:
+        specifier: ^1.29.0
+        version: 1.29.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -23413,7 +23416,6 @@ packages:
   /prismjs@1.29.0:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
-    dev: false
 
   /proc-log@3.0.0:
     resolution: {integrity: sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==}


### PR DESCRIPTION
Look what I found! We’re using highlight.js for the syntax highlighting in Markdown and it’s huge!

| Package          | Size      |
|----------------- | --------- |
| rehype-highlight | 3.54KiB   |
| highlight.js	   | 354.87KiB |

But we’re also using prismjs for code blocks. What if … we replace highlight.js with prismjs … 🤔 

EDIT: Results are in: 💥 1.77MiB (-6.4%) 💥