### PR TITLE
fix: hide default caret on <summary> on Safari

### DIFF
--- a/.changeset/yellow-zoos-study.md
+++ b/.changeset/yellow-zoos-study.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: hide default caret on <summary> on Safari

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -83,7 +83,7 @@ onServerPrefetch(async () => await sleep(1))
   all: unset;
   word-break: break-word;
 }
-/* all elements inside .markdown, but not <details> and <summary> */
+/* all elements inside .markdown */
 .markdown :deep(*) {
   all: unset;
   margin: 12px 0;
@@ -125,6 +125,12 @@ onServerPrefetch(async () => await sleep(1))
 .markdown :deep(details[open] summary::after) {
   transform: rotate(90deg);
 }
+
+/* Fix for Safari displaying default caret next to `<summary>` */
+.markdown :deep(summary::-webkit-details-marker) {
+  display: none;
+}
+
 .markdown :deep(img) {
   overflow: hidden;
   border-radius: var(--scalar-radius);


### PR DESCRIPTION
Before:

<img width="1461" alt="Safari-2024-05-07-15-54-51@2x" src="https://github.com/scalar/scalar/assets/6374090/d5f35e86-9376-4e37-b7df-dac0c6a08683">


After:

<img width="1461" alt="Safari-2024-05-07-15-54-53@2x" src="https://github.com/scalar/scalar/assets/6374090/757a8f97-f39d-4d78-bab2-605e6396a828">
