### PR TITLE
chore: lazy load API client

### DIFF
--- a/.changeset/healthy-pears-build.md
+++ b/.changeset/healthy-pears-build.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+chore: lazy load api client

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ApiClient, useApiClientStore } from '@scalar/api-client'
+import {  useApiClientStore } from '@scalar/api-client'
 import { ScalarIcon } from '@scalar/components'
 import type { ThemeId } from '@scalar/themes'
 import { useMediaQuery } from '@vueuse/core'
 import { ref } from 'vue'
+import { defineAsyncComponent } from 'vue'
 
 import type { Spec } from '../types'
 import { Sidebar } from './Sidebar'
@@ -18,6 +19,10 @@ defineProps<{
 defineEmits<{
   (e: 'toggleDarkMode'): void
 }>()
+
+const LazyLoadedApiClient = defineAsyncComponent(() =>
+  import('@scalar/api-client').then((m) => m.ApiClient),
+)
 
 const { hideApiClient, state } = useApiClientStore()
 
@@ -40,7 +45,7 @@ const showSideBar = ref(false)
         </div> -->
       <div class="scalar-api-client-height">
         <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withDefaultFonts: false` -->
-        <ApiClient
+        <LazyLoadedApiClient
           :proxyUrl="proxyUrl"
           :showSideBar="showSideBar"
           :theme="theme ?? 'none'"

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import {  useApiClientStore } from '@scalar/api-client'
+import { useApiClientStore } from '@scalar/api-client'
 import { ScalarIcon } from '@scalar/components'
 import type { ThemeId } from '@scalar/themes'
 import { useMediaQuery } from '@vueuse/core'
-import { ref } from 'vue'
-import { defineAsyncComponent } from 'vue'
+import { defineAsyncComponent, ref } from 'vue'
 
 import type { Spec } from '../types'
 import { Sidebar } from './Sidebar'
@@ -83,7 +82,7 @@ const showSideBar = ref(false)
               </Sidebar>
             </div>
           </template>
-        </ApiClient>
+        </LazyLoadedApiClient>
       </div>
     </div>
   </div>


### PR DESCRIPTION
`@scalar/api-client` is pretty heavy. It’s the only reason we still have CodeMirror (for the request body and the address bar).

@amritk had the wonderful idea to lazy load the API client. This PR does exactly this, and the ESM build improves:

```diff
-dist/index.js 1,650.72 kB
+dist/index.js 1.60 kB
+dist/index-Bw-GQvDT.js 1,314.59 kB
```

This means:
1. The first file that needs to be loaded in ESM envs is 1kB instead of 1,600kB.
2. The biggest chunk is 1,300 kB instead of 1,600 kB.
3. Users that never open the API client, will never load the ~1,500 kB (only applies to ESM envs, like our app).

CDN users don’t benefit from the change yet, because it’s still bundling everything in one file. But at some point (once the ESM CDN build works), they'll experience the same benefits. :)