### PR TITLE
feat: include spec title in downloaded spec filename

### DIFF
--- a/.changeset/gentle-seas-know.md
+++ b/.changeset/gentle-seas-know.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: include spec title in downloaded spec filename

--- a/examples/web/src/pages/ApiReferenceTestPage.vue
+++ b/examples/web/src/pages/ApiReferenceTestPage.vue
@@ -4,7 +4,7 @@ import {
   type ReferenceConfiguration,
   type ReferenceLayoutType,
 } from '@scalar/api-reference'
-import content from '@scalar/galaxy/latest.json'
+import content from '@scalar/galaxy/latest.yaml?raw'
 import type { ThemeId } from '@scalar/themes'
 import { reactive } from 'vue'
 import { useRoute } from 'vue-router'

--- a/examples/web/src/pages/ClassicApiReferencePage.vue
+++ b/examples/web/src/pages/ClassicApiReferencePage.vue
@@ -3,7 +3,7 @@ import {
   ApiReference,
   type ReferenceConfiguration,
 } from '@scalar/api-reference'
-import content from '@scalar/galaxy/latest.json'
+import content from '@scalar/galaxy/latest.yaml?raw'
 import { reactive } from 'vue'
 
 const configuration = reactive<ReferenceConfiguration>({

--- a/examples/web/src/pages/EmbeddedApiReferencePage.vue
+++ b/examples/web/src/pages/EmbeddedApiReferencePage.vue
@@ -3,7 +3,7 @@ import {
   ApiReference,
   type ReferenceConfiguration,
 } from '@scalar/api-reference'
-import content from '@scalar/galaxy/latest.json'
+import content from '@scalar/galaxy/latest.yaml?raw'
 import { reactive } from 'vue'
 
 import SlotPlaceholder from '../components/SlotPlaceholder.vue'

--- a/examples/web/src/pages/StandaloneApiReferencePage.vue
+++ b/examples/web/src/pages/StandaloneApiReferencePage.vue
@@ -3,7 +3,7 @@ import {
   ApiReference,
   type ReferenceConfiguration,
 } from '@scalar/api-reference'
-import content from '@scalar/galaxy/latest.json'
+import content from '@scalar/galaxy/latest.yaml?raw'
 import { reactive } from 'vue'
 
 import SlotPlaceholder from '../components/SlotPlaceholder.vue'

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -105,7 +105,9 @@ const scrollToSection = async (id?: string) => {
 
 onMounted(() => {
   // Enable the spec download event bus
-  downloadSpecBus.on(() => downloadSpecFile(props.rawSpec))
+  downloadSpecBus.on(({ specTitle }) => {
+    downloadSpecFile(props.rawSpec, specTitle)
+  })
 
   // This is what updates the hash ref from hash changes
   window.onhashchange = () =>

--- a/packages/api-reference/src/components/Content/Introduction/DownloadSpec.vue
+++ b/packages/api-reference/src/components/Content/Introduction/DownloadSpec.vue
@@ -3,7 +3,16 @@ import { inject } from 'vue'
 
 import { HIDE_DOWNLOAD_BUTTON_SYMBOL, downloadSpecBus } from '../../../helpers'
 
+const props = defineProps<{
+  specTitle?: string
+}>()
+
 const getHideDownloadButtonSymbol = inject(HIDE_DOWNLOAD_BUTTON_SYMBOL)
+
+// id is retrieved at the layout level
+const handleDownloadClick = () => {
+  downloadSpecBus.emit({ id: '', specTitle: props.specTitle })
+}
 </script>
 <template>
   <div class="download">
@@ -12,7 +21,7 @@ const getHideDownloadButtonSymbol = inject(HIDE_DOWNLOAD_BUTTON_SYMBOL)
         v-if="!getHideDownloadButtonSymbol?.()"
         class="download-button"
         type="button"
-        @click="downloadSpecBus.emit()">
+        @click="handleDownloadClick">
         Download OpenAPI Spec
       </button>
     </div>

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
+import GithubSlugger from 'github-slugger'
 import { computed } from 'vue'
 
 import type { Spec } from '../../../types'
@@ -22,8 +23,14 @@ const props = defineProps<{
   parsedSpec: Spec
 }>()
 
+const slugger = new GithubSlugger()
+
 const specVersion = computed(() => {
   return props.parsedSpec.openapi ?? props.parsedSpec.swagger ?? ''
+})
+
+const formattedSpecTitle = computed(() => {
+  return slugger.slug(props.info.title ?? '')
 })
 </script>
 <template>
@@ -44,7 +51,7 @@ const specVersion = computed(() => {
               tight>
               {{ info.title }}
             </SectionHeader>
-            <DownloadSpec />
+            <DownloadSpec :specTitle="formattedSpecTitle" />
             <Description :value="info.description" />
           </SectionColumn>
           <SectionColumn v-if="$slots.aside">

--- a/packages/api-reference/src/helpers/specDownloads.ts
+++ b/packages/api-reference/src/helpers/specDownloads.ts
@@ -1,12 +1,12 @@
 import { isJsonString } from '@scalar/oas-utils'
 import { type EventBusKey, useEventBus } from '@vueuse/core'
 
-const downloadSpecEventBusKey: EventBusKey<{ id: string }> =
+const downloadSpecEventBusKey: EventBusKey<{ id: string; specTitle?: string }> =
   Symbol('downloadSpec')
 export const downloadSpecBus = useEventBus(downloadSpecEventBusKey)
 
 /** Download the OAS file string */
-export function downloadSpecFile(spec: string) {
+export function downloadSpecFile(spec: string, specTitle?: string) {
   const isJson = isJsonString(spec)
 
   const blob = isJson
@@ -14,11 +14,17 @@ export function downloadSpecFile(spec: string) {
     : new Blob([spec], { type: 'application/x-yaml' })
 
   const data = URL.createObjectURL(blob)
+  const fileExtension = isJson ? '.json' : '.yaml'
+
+  // Default filename based on the file type
+  const defaultFilename = 'spec' + fileExtension
+
+  // Spec title as filename or default
+  const specFilename = specTitle ? specTitle + fileExtension : defaultFilename
 
   const link = document.createElement('a')
   link.href = data
-  link.download = isJson ? 'spec.json' : 'spec.yaml'
-
+  link.download = specFilename
   // this is necessary as link.click() does not work on the latest firefox
   link.dispatchEvent(
     new MouseEvent('click', {

--- a/packages/api-reference/src/standalone.spec.ts
+++ b/packages/api-reference/src/standalone.spec.ts
@@ -1,4 +1,4 @@
-import galaxyContent from '@scalar/galaxy/latest.json?raw'
+import galaxyContent from '@scalar/galaxy/latest.yaml?raw'
 import { afterAll, describe, expect, it } from 'vitest'
 import MatchMediaMock from 'vitest-matchmedia-mock'
 


### PR DESCRIPTION
**Problem**
`spec` + extension is currently used as the file name when a spec is downloaded from the reference doc, which can make it difficult to find if using multiple APIs.

**Solution**
this pr is a proposal to include the spec title in the downloaded filename.