### PR TITLE
chore: add deprecation warnings (still disabled)

### DIFF
--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -28,7 +28,7 @@ import {
   scrollToId,
   sleep,
 } from '../helpers'
-import { useNavState, useSidebar } from '../hooks'
+import { useDeprecationWarnings, useNavState, useSidebar } from '../hooks'
 import type {
   ReferenceLayoutProps,
   ReferenceLayoutSlot,
@@ -202,6 +202,8 @@ provide(
 )
 
 hideModels.value = props.configuration.hideModels ?? false
+
+useDeprecationWarnings(props.configuration)
 </script>
 <template>
   <ThemeStyles

--- a/packages/api-reference/src/hooks/index.ts
+++ b/packages/api-reference/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useClipboard'
 export * from './useDarkModeState'
+export * from './useDeprecationWarnings'
 export * from './useHttpClients'
 export * from './useNavState'
 export * from './useOperation'

--- a/packages/api-reference/src/hooks/useDeprecationWarnings.ts
+++ b/packages/api-reference/src/hooks/useDeprecationWarnings.ts
@@ -1,0 +1,36 @@
+// import { type ComputedRef, watch } from 'vue'
+import type { ReferenceConfiguration } from '../types'
+
+// const OLD_PROXY_URL = 'https://api.scalar.com/request-proxy'
+// const NEW_PROXY_URL = 'https://proxy.scalar.com'
+
+export function useDeprecationWarnings(configuration: ReferenceConfiguration) {
+  // TODO: Enable once the new proxy is ready
+  // watch(
+  //   () => configuration,
+  //   () => {
+  //     if (configuration.proxy === OLD_PROXY_URL) {
+  //       console.warn(
+  //         `[DEPRECATED] Warning: configuration.proxy points to our old proxy (${OLD_PROXY_URL}). We’re using the new proxy URL instead.`,
+  //       )
+  //       configuration.proxy = NEW_PROXY_URL
+  //       console.warn(
+  //         `[DEPRECATED] Action Required: You should manually update your configuration to use the new URL (${NEW_PROXY_URL}). Read more: https://github.com/scalar/scalar`,
+  //       )
+  //     } else if (
+  //       configuration.proxy?.length &&
+  //       configuration.proxy !== NEW_PROXY_URL
+  //     ) {
+  //       console.warn(
+  //         `[DEPRECATED] Warning: configuration.proxy points to a custom proxy (${configuration?.proxy}).`,
+  //       )
+  //       console.warn(
+  //         `[DEPRECATED] Action Required: You need to use our new proxy (written in Go). Read more: https://github.com/scalar/scalar/tree/main/examples/proxy-server`,
+  //       )
+  //     }
+  //   },
+  //   {
+  //     immediate: true,
+  //   },
+  // )
+}


### PR DESCRIPTION
Once we switch to the new proxy, we need to overwrite the old proxy URL (https://api.scalar.com/request-proxy) with the new URL (https://proxy.scalar.com) and warn users about it (affects probably everyone).

And we want to warn if a custom proxy URL is used (shouldn’t affect many people).

This PR adds the code already, but disables the messages until the proxy is ready.

<img width="1070" alt="Screenshot 2024-05-08 at 11 37 16" src="https://github.com/scalar/scalar/assets/1577992/bc07883c-0349-49f2-90dc-ac233918add3">
<img width="1048" alt="Screenshot 2024-05-08 at 11 34 31" src="https://github.com/scalar/scalar/assets/1577992/e0065d65-052a-4a08-a1cc-85ae455dc169">
