### PR TITLE
fix: start page links broken

### DIFF
--- a/examples/web/src/pages/StartPage.vue
+++ b/examples/web/src/pages/StartPage.vue
@@ -66,7 +66,7 @@ import PageLink from '../components/PageLink.vue'
     </div>
     <h1>Examples</h1>
     <div class="page-links">
-      <PageLink href="http://localhost:5062/scalar">
+      <PageLink href="http://localhost:5062/galaxy">
         <template #title>Nuxt</template>
         <template #description>@scalar/nuxt</template>
       </PageLink>

--- a/examples/web/src/pages/StartPage.vue
+++ b/examples/web/src/pages/StartPage.vue
@@ -82,7 +82,7 @@ import PageLink from '../components/PageLink.vue'
         <template #title>React</template>
         <template #description>@scalar/api-reference</template>
       </PageLink>
-      <PageLink href="http://localhost:5053">
+      <PageLink href="http://localhost:5053/reference">
         <template #title>Fastify</template>
         <template #description>@scalar/fastify-api-reference</template>
       </PageLink>


### PR DESCRIPTION
Two example links are broken for the `examples/web` we’re using, this PR fixes them. ✨ 