### PR TITLE
fix(mock-server): openapi.json returns yaml string

### DIFF
--- a/.changeset/few-wombats-sort.md
+++ b/.changeset/few-wombats-sort.md
@@ -1,0 +1,5 @@
+---
+"@scalar/mock-server": patch
+---
+
+fix: openapi.json returns yaml string

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -16,13 +16,22 @@ export async function createMockServer(options?: {
   // Resolve references
   const result = await openapi().load(options.specification).resolve()
 
-  // OpenAPI file
+  // OpenAPI JSON file
   app.get('/openapi.json', (c) => {
     if (!options?.specification) {
       return c.text('Not found', 404)
     }
 
-    return c.json(options.specification)
+    return c.json(openapi().load(options.specification).get())
+  })
+
+  // OpenAPI YAML file
+  app.get('/openapi.yaml', (c) => {
+    if (!options?.specification) {
+      return c.text('Not found', 404)
+    }
+
+    return c.text(openapi().load(options.specification).toYaml())
   })
 
   // Paths

--- a/packages/mock-server/tests/openapi.test.ts
+++ b/packages/mock-server/tests/openapi.test.ts
@@ -1,9 +1,10 @@
+import { normalize, toYaml } from '@scalar/openapi-parser'
 import { describe, expect, it } from 'vitest'
 
 import { createMockServer } from '../src/createMockServer'
 
 describe('openapi.{json|yaml}', () => {
-  it('GET /openapi.json (object)', async () => {
+  it('GET /openapi.json (from object)', async () => {
     const specification = {
       openapi: '3.1.0',
       info: {
@@ -23,7 +24,7 @@ describe('openapi.{json|yaml}', () => {
     expect(await response.json()).toMatchObject(specification)
   })
 
-  it('GET /openapi.json (JSON string)', async () => {
+  it('GET /openapi.json (from JSON string)', async () => {
     const specification = {
       openapi: '3.1.0',
       info: {
@@ -34,7 +35,7 @@ describe('openapi.{json|yaml}', () => {
     }
 
     const server = await createMockServer({
-      specification,
+      specification: JSON.stringify(specification),
     })
 
     const response = await server.request('/openapi.json')
@@ -43,7 +44,7 @@ describe('openapi.{json|yaml}', () => {
     expect(await response.json()).toMatchObject(specification)
   })
 
-  it.skip('GET /openapi.json (YAML string)', async () => {
+  it('GET /openapi.json (YAML string)', async () => {
     const specification = {
       openapi: '3.1.0',
       info: {
@@ -54,7 +55,7 @@ describe('openapi.{json|yaml}', () => {
     }
 
     const server = await createMockServer({
-      specification,
+      specification: toYaml(specification),
     })
 
     const response = await server.request('/openapi.json')
@@ -63,7 +64,7 @@ describe('openapi.{json|yaml}', () => {
     expect(await response.json()).toMatchObject(specification)
   })
 
-  it.skip('GET /openapi.yaml (object)', async () => {
+  it('GET /openapi.yaml (object)', async () => {
     const specification = {
       openapi: '3.1.0',
       info: {
@@ -80,10 +81,10 @@ describe('openapi.{json|yaml}', () => {
     const response = await server.request('/openapi.yaml')
 
     expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject(specification)
+    expect(normalize(await response.text())).toMatchObject(specification)
   })
 
-  it.skip('GET /openapi.yaml (YAML string)', async () => {
+  it('GET /openapi.yaml (YAML string)', async () => {
     const specification = {
       openapi: '3.1.0',
       info: {
@@ -94,16 +95,16 @@ describe('openapi.{json|yaml}', () => {
     }
 
     const server = await createMockServer({
-      specification,
+      specification: toYaml(specification),
     })
 
     const response = await server.request('/openapi.yaml')
 
     expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject(specification)
+    expect(normalize(await response.text())).toMatchObject(specification)
   })
 
-  it.skip('GET /openapi.yaml (JSON string)', async () => {
+  it('GET /openapi.yaml (JSON string)', async () => {
     const specification = {
       openapi: '3.1.0',
       info: {
@@ -114,12 +115,12 @@ describe('openapi.{json|yaml}', () => {
     }
 
     const server = await createMockServer({
-      specification,
+      specification: JSON.stringify(specification),
     })
 
     const response = await server.request('/openapi.yaml')
 
     expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject(specification)
+    expect(normalize(await response.text())).toMatchObject(specification)
   })
 })


### PR DESCRIPTION
The mock server has an `/openapi.json` endpoint, which isn’t working very well.

[If you pass YAML, /openapi.json returns the YAML string …](https://galaxy.scalar.com/openapi.json)

Anyway, this PR makes it all awesome and even adds an `openapi.yaml` endpoint. :)