### PR TITLE
fix: sidebar is empty locally

### DIFF
--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -18,6 +18,7 @@ import {
   provide,
   ref,
   useSSRContext,
+  watch,
 } from 'vue'
 
 import {
@@ -72,6 +73,7 @@ const {
   isSidebarOpen,
   setCollapsedSidebarItem,
   hideModels,
+  setParsedSpec,
 } = useSidebar()
 
 const {
@@ -137,6 +139,9 @@ const referenceSlotProps = computed<ReferenceSlotProps>(() => ({
   breadcrumb: breadcrumb.value,
   spec: props.parsedSpec,
 }))
+
+// Keep the parsed spec up to date
+watch(() => props.parsedSpec, setParsedSpec, { deep: true })
 
 // Initialize the server state
 onServerPrefetch(() => {

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -38,6 +38,10 @@ const {
 // Track the parsed spec
 const parsedSpec = ref<Spec | undefined>(undefined)
 
+function setParsedSpec(spec: Spec) {
+  return (parsedSpec.value = spec)
+}
+
 const hideModels = ref(false)
 
 // Track which sidebar items are collapsed
@@ -308,5 +312,6 @@ export function useSidebar(options?: { parsedSpec: Spec }) {
     toggleCollapsedSidebarItem,
     setCollapsedSidebarItem,
     hideModels,
+    setParsedSpec,
   }
 }


### PR DESCRIPTION
Since we removed the editor from @scalar/api-reference the local demo was broken. We’ve re-added Monaco a while ago, but the sidebar was empty. I’m using this a lot to play around with specifications, so I’m eager to finally fix this again. :)

This PR makes the sidebar reactive again, which fixes the local demo (the one with the editor):

http://localhost:5050/api-reference