### PR TITLE
fix: base docker builder hits memory limit or something

### DIFF
--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -12,5 +12,9 @@ COPY package.json .
 COPY tsconfig.json .
 COPY turbo.json .
 COPY packages ./packages
-RUN pnpm install 
-RUN pnpm build:packages
+RUN pnpm install
+RUN pnpm turbo \
+    run build \
+    --filter='./packages/*' \
+    # … don’t build too many in parallel, we don’t want to hit a memory limit.
+    --concurrency=2


### PR DESCRIPTION
CI is broken, the docker build complains about a list of strings and say it can’t analyse it.

![image](https://github.com/scalar/scalar/assets/1577992/48219094-7444-438d-a214-aac93e58dd51)

When I try it locally it bails at another point. I’m pretty confident we’re hitting a memory limit or something here.

With this PR we’re using turbo to build the packages in the Dockerfile and make sure it’s not running more than 2 processes in parallel.

Let’s try if that helps! It does locally.