### PR TITLE
fix: api client request body display

### DIFF
--- a/.changeset/tender-masks-eat.md
+++ b/.changeset/tender-masks-eat.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: request body display

--- a/packages/api-client/src/components/ApiClient/Request/Request.vue
+++ b/packages/api-client/src/components/ApiClient/Request/Request.vue
@@ -27,6 +27,13 @@ const authenticationRequest = computed(() =>
   ),
 )
 
+const showRequestBody = computed(() => {
+  const requestType = activeRequest.type.toLowerCase()
+  return (
+    requestType === 'put' || requestType === 'post' || requestType === 'patch'
+  )
+})
+
 /**
  * TODO: This is a workaround to make the address bar editable, but not the rest. If we’d really like to have an
  * API client where everything can be edited, we need to invest more time.
@@ -61,6 +68,7 @@ const readOnly = true
         :generatedQueries="authenticationRequest.queryString"
         :queries="activeRequest.query" />
       <RequestBody
+        v-if="showRequestBody"
         :body="activeRequest.body"
         :formData="activeRequest.formData"
         :requestBody="activeRequest.body" />


### PR DESCRIPTION
**Problem**
request body is displayed for each http method in the api client, even though it is not useful for each of them.

**Solution**
this pr is a proposal to introduce a condition on the request body display on selected http methods.