### PR TITLE
fix: change package name and dependencies for npm release

### DIFF
--- a/examples/proxy-server/package.json
+++ b/examples/proxy-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar-examples/proxy-server",
+  "name": "@scalar/proxy-server",
   "description": "Golang proxy for CORS requests",
   "license": "MIT",
   "author": "Scalar (https://github.com/scalar)",
@@ -28,18 +28,13 @@
     "types:check": "pnpm build"
   },
   "type": "module",
-  "main": "dist/index.js",
+  "main": "main",
   "exports": {
-    "import": "./dist/index.js"
+    "import": "./main"
   },
   "files": [
-    "dist",
+    "main",
     "CHANGELOG.md"
   ],
-  "module": "dist/index.js",
-  "devDependencies": {
-    "@scalar/build-tooling": "workspace:*",
-    "tsc-alias": "^1.8.8",
-    "vite": "^5.2.10"
-  }
+  "module": "main"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,17 +487,7 @@ importers:
         specifier: ^5.4.3
         version: 5.4.3
 
-  examples/proxy-server:
-    devDependencies:
-      '@scalar/build-tooling':
-        specifier: workspace:*
-        version: link:../../packages/build-tooling
-      tsc-alias:
-        specifier: ^1.8.8
-        version: 1.8.8
-      vite:
-        specifier: ^5.2.10
-        version: 5.2.10(@types/node@20.11.22)(terser@5.30.0)
+  examples/proxy-server: {}
 
   examples/react:
     dependencies:


### PR DESCRIPTION
**Problem**
Currently, there is an [error in CI](https://github.com/scalar/scalar/actions/runs/9019299978/job/24781866596) releasing `proxy-server` to `npm`. 

**Explanation**
This seems to be due to the package name. We should be releasing packages to `@scalar` not `@scalar-examples` because this is our npm org name. 
```
npm ERR! 404 Not Found - PUT https://registry.npmjs.org/@scalar-examples%2fproxy-server - Not found
npm ERR! 404 
npm ERR! 404  '@scalar-examples/proxy-server@0.0.1' is not in this registry.
```

**Solution**
Change the package name to `@scalar/proxy-server` and remove unnecessary dependencies from the package.json 
