### PR TITLE
fix: update package.json so go proxy is not published to npm

### DIFF
--- a/examples/proxy-server/package.json
+++ b/examples/proxy-server/package.json
@@ -28,15 +28,6 @@
     "types:check": "pnpm build"
   },
   "type": "module",
-  "main": "dist/index.js",
-  "exports": {
-    "import": "./dist/index.js"
-  },
-  "files": [
-    "dist",
-    "CHANGELOG.md"
-  ],
-  "module": "dist/index.js",
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
     "tsc-alias": "^1.8.8",


### PR DESCRIPTION
Remove fields from package.json so the proxy is not published to npm
