### PR TITLE
fix: uppercase required property

### DIFF
--- a/.changeset/plenty-mugs-do.md
+++ b/.changeset/plenty-mugs-do.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: uppercase required property

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -135,7 +135,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 }
 
 .property-required {
-  text-transform: uppercase;
+  text-transform: capitalize;
   color: var(--scalar-color-orange);
 }
 


### PR DESCRIPTION
Why was 'required' so AGGRESSIVE, let's fix that

Before:
<img width="334" alt="image" src="https://github.com/scalar/scalar/assets/6201407/e266e313-f7bd-4efc-8652-a73763b2edb1">

After:
<img width="225" alt="image" src="https://github.com/scalar/scalar/assets/6201407/a01956fb-d6a4-4565-a580-9182e158679b">
