### PR TITLE
fix: support <sup> tag in markdown

### DIFF
--- a/.changeset/flat-dots-fry.md
+++ b/.changeset/flat-dots-fry.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: support markdown <sup> tag

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -198,6 +198,11 @@ onServerPrefetch(async () => await sleep(1))
 .markdown :deep(em) {
   font-style: italic;
 }
+.markdown :deep(sup) {
+  font-size: var(--scalar-micro);
+  vertical-align: super;
+  font-weight: 450;
+}
 .markdown :deep(del) {
   text-decoration: line-through;
 }


### PR DESCRIPTION
Add styling for <sup> tag in markdown
<img width="394" alt="image" src="https://github.com/scalar/scalar/assets/6201407/139774b0-86e9-4b1a-b374-7e4627bd1951">
