### PR TITLE
docs: switch from docs.scalar.com to app.scalar.com

### DIFF
--- a/.changeset/tiny-dogs-run.md
+++ b/.changeset/tiny-dogs-run.md
@@ -1,0 +1,7 @@
+---
+"@scalar/fastify-api-reference": patch
+"@scalar/api-reference": patch
+"@scalar/nuxt": patch
+---
+
+docs: switch from docs.scalar.com to app.scalar.com

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub License](https://img.shields.io/github/license/scalar/scalar)](https://github.com/scalar/scalar/blob/main/LICENSE)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-Generate interactive API documentation from OpenAPI/Swagger files. [Try our Demo](https://docs.scalar.com/swagger-editor)
+Generate interactive API documentation from OpenAPI/Swagger files. [Try our Demo](https://app.scalar.com/swagger-editor)
 
 <img width="830" height="455" src="https://github.com/scalar/scalar/assets/6201407/046aaeca-f0fe-453d-a661-c747399c56ef">
 

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -6,9 +6,9 @@
 [![License](https://img.shields.io/npm/l/%40scalar%2Fapi-reference)](https://www.npmjs.com/package/@scalar/api-reference)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-Generate interactive API documentations from Swagger files. [Try our Demo](https://docs.scalar.com/swagger-editor)
+Generate interactive API documentations from Swagger files. [Try our Demo](https://app.scalar.com/swagger-editor)
 
-[![Screenshot of an API Reference](https://github.com/scalar/scalar/assets/6201407/d8beb5e1-bf64-4589-8cb0-992ba79215a8)](https://docs.scalar.com/swagger-editor)
+[![Screenshot of an API Reference](https://github.com/scalar/scalar/assets/6201407/d8beb5e1-bf64-4589-8cb0-992ba79215a8)](https://app.scalar.com/swagger-editor)
 
 ## Installation
 

--- a/packages/fastify-api-reference/README.md
+++ b/packages/fastify-api-reference/README.md
@@ -7,7 +7,7 @@
 
 This plugin provides an easy way to render a beautiful API reference based on a OpenAPI/Swagger file with Fastify.
 
-[![Screenshot of an API Reference](https://github.com/scalar/scalar/assets/6201407/d8beb5e1-bf64-4589-8cb0-992ba79215a8)](https://docs.scalar.com/swagger-editor)
+[![Screenshot of an API Reference](https://github.com/scalar/scalar/assets/6201407/d8beb5e1-bf64-4589-8cb0-992ba79215a8)](https://app.scalar.com/swagger-editor)
 
 ## Installation
 

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -7,7 +7,7 @@
 
 This plugin provides an easy way to render a beautiful API reference based on a OpenAPI/Swagger file with Nuxt.
 
-[![Screenshot of an API Reference](https://github.com/scalar/scalar/assets/6176314/178f4e4c-afdf-4c6a-bc72-128ea1786350)](https://docs.scalar.com/swagger-editor)
+[![Screenshot of an API Reference](https://github.com/scalar/scalar/assets/6176314/178f4e4c-afdf-4c6a-bc72-128ea1786350)](https://app.scalar.com/swagger-editor)
 
 ## Quick Setup
 


### PR DESCRIPTION
⚠️ Don’t merge it yet, the domain isn’t working.

Currently, we’re using `docs.scalar.com` as the main domain for our app. But we might need this domain for something else soon. 👀 That’s why we’re going to switch to `app.scalar.com` sooner or later.

This PR is a preparation.