### PR TITLE
fix: history toggle location

### DIFF
--- a/.changeset/late-dolphins-scream.md
+++ b/.changeset/late-dolphins-scream.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: history toggle location

--- a/packages/api-client/src/components/ApiClient/AddressBar.vue
+++ b/packages/api-client/src/components/ApiClient/AddressBar.vue
@@ -133,6 +133,35 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
           withVariables
           @change="onChange" />
       </div>
+      <div
+        v-if="requestHistoryOrder.length"
+        class="history">
+        <div
+          class="history-toggle"
+          @click="historyModal.show()">
+          <svg
+            fill="none"
+            height="48"
+            viewBox="0 0 14 14"
+            width="48"
+            xmlns="http://www.w3.org/2000/svg">
+            <g id="rewind-clock--back-return-clock-timer-countdown">
+              <path
+                id="Vector 1561 (Stroke)"
+                clip-rule="evenodd"
+                d="M6.99999 2.75C7.4142 2.75 7.74999 3.08579 7.74999 3.5V7.5C7.74999 7.76345 7.61177 8.00758 7.38586 8.14312L4.88586 9.64312C4.53068 9.85623 4.06998 9.74106 3.85687 9.38587C3.64376 9.03069 3.75893 8.56999 4.11412 8.35688L6.24999 7.07536V3.5C6.24999 3.08579 6.58578 2.75 6.99999 2.75Z"
+                fill="currentColor"
+                fill-rule="evenodd"></path>
+              <path
+                id="Union"
+                clip-rule="evenodd"
+                d="M12.5 7C12.5 3.96243 10.0376 1.5 7 1.5C5.24916 1.5 3.68853 2.31796 2.68066 3.59456L3.64645 4.56034C3.96143 4.87533 3.73835 5.4139 3.29289 5.4139H0.5C0.223857 5.4139 0 5.19004 0 4.9139V2.121C0 1.67555 0.53857 1.45247 0.853553 1.76745L1.61439 2.52829C2.89781 0.984301 4.83356 0 7 0C10.866 0 14 3.13401 14 7C14 10.866 10.866 14 7 14C3.68902 14 0.916591 11.702 0.187329 8.61473C0.0921059 8.21161 0.341704 7.80762 0.744824 7.7124C1.14794 7.61717 1.55193 7.86677 1.64715 8.26989C2.22013 10.6955 4.40025 12.5 7 12.5C10.0376 12.5 12.5 10.0376 12.5 7Z"
+                fill="currentColor"
+                fill-rule="evenodd"></path>
+            </g>
+          </svg>
+        </div>
+      </div>
       <button
         class="send-button"
         :disabled="!formattedUrl.trim().length"
@@ -168,37 +197,6 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
           :showHistory="showHistory"
           @toggle="showHistory = !showHistory" />
       </FlowModal>
-    </div>
-
-    <div
-      v-if="requestHistoryOrder.length"
-      class="history">
-      <div
-        class="history-toggle"
-        @click="historyModal.show()">
-        <svg
-          fill="none"
-          height="48"
-          viewBox="0 0 14 14"
-          width="48"
-          xmlns="http://www.w3.org/2000/svg">
-          <g id="rewind-clock--back-return-clock-timer-countdown">
-            <path
-              id="Vector 1561 (Stroke)"
-              clip-rule="evenodd"
-              d="M6.99999 2.75C7.4142 2.75 7.74999 3.08579 7.74999 3.5V7.5C7.74999 7.76345 7.61177 8.00758 7.38586 8.14312L4.88586 9.64312C4.53068 9.85623 4.06998 9.74106 3.85687 9.38587C3.64376 9.03069 3.75893 8.56999 4.11412 8.35688L6.24999 7.07536V3.5C6.24999 3.08579 6.58578 2.75 6.99999 2.75Z"
-              fill="currentColor"
-              fill-rule="evenodd"></path>
-            <path
-              id="Union"
-              clip-rule="evenodd"
-              d="M12.5 7C12.5 3.96243 10.0376 1.5 7 1.5C5.24916 1.5 3.68853 2.31796 2.68066 3.59456L3.64645 4.56034C3.96143 4.87533 3.73835 5.4139 3.29289 5.4139H0.5C0.223857 5.4139 0 5.19004 0 4.9139V2.121C0 1.67555 0.53857 1.45247 0.853553 1.76745L1.61439 2.52829C2.89781 0.984301 4.83356 0 7 0C10.866 0 14 3.13401 14 7C14 10.866 10.866 14 7 14C3.68902 14 0.916591 11.702 0.187329 8.61473C0.0921059 8.21161 0.341704 7.80762 0.744824 7.7124C1.14794 7.61717 1.55193 7.86677 1.64715 8.26989C2.22013 10.6955 4.40025 12.5 7 12.5C10.0376 12.5 12.5 10.0376 12.5 7Z"
-              fill="currentColor"
-              fill-rule="evenodd"></path>
-          </g>
-        </svg>
-        <span>{{ lastRequestTimestamp }}</span>
-      </div>
     </div>
   </div>
 </template>
@@ -275,7 +273,7 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   display: flex;
   align-items: center;
   border-radius: var(--scalar-radius);
-  height: 100%;
+  background: var(--scalar-background-2);
 }
 
 .send-button[type='submit'] {
@@ -340,19 +338,16 @@ const handleRequestMethodChanged = (requestMethod?: string) => {
   align-items: center;
   cursor: pointer;
   white-space: nowrap;
-  box-shadow: 0 0 0 1px var(--scalar-border-color);
-  margin-left: 12px;
   border-radius: var(--scalar-radius);
   user-select: none;
 }
 .history-toggle:hover {
-  background: var(--scalar-background-2);
+  color: var(--scalar-color-1);
 }
 .history-toggle svg {
   height: 13px;
   width: 13px;
-  margin-right: 6px;
-  color: var(--scalar-color-3);
+  color: currentColor;
 }
 .address-bar-content {
   width: 640px;


### PR DESCRIPTION
Fixes history toggle overlapping with close button. and puts it in it's new proper location:

<img width="838" alt="image" src="https://github.com/scalar/scalar/assets/6201407/ad8e1000-f591-423b-bd43-af1c7963884a">

This fixes:
https://github.com/scalar/scalar/issues/1687