### PR TITLE
fix: vertical alignment of client response empty state

### DIFF
--- a/.changeset/stale-trees-own.md
+++ b/.changeset/stale-trees-own.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: vertical alignment of client response empty state

--- a/packages/api-client/src/components/ApiClient/Response/Response.vue
+++ b/packages/api-client/src/components/ApiClient/Response/Response.vue
@@ -115,7 +115,7 @@ const responseData = computed(() => {
   display: flex;
   flex-direction: column;
   gap: 20px;
-  height: 100%;
+  height: calc(100% - 50px);
   justify-content: center;
 }
 .scalar-api-client__main__content .empty-state p {


### PR DESCRIPTION
v e r t i c a l y aligned
<img width="707" alt="image" src="https://github.com/scalar/scalar/assets/6201407/8848c4aa-05b3-4e7f-99a7-349a85a8d68f">
