### PR TITLE
feat: api client toggle sidebar

### DIFF
--- a/.changeset/young-tigers-tickle.md
+++ b/.changeset/young-tigers-tickle.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/api-client": patch
+---
+
+feat: api client toggle sidebar hotkey

--- a/packages/api-client/src/components/ApiClient/ApiClient.vue
+++ b/packages/api-client/src/components/ApiClient/ApiClient.vue
@@ -27,10 +27,12 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'escapeKeyPress'): void
+  (e: 'toggleSidebar'): void
 }>()
 
 const keys = useMagicKeys()
 whenever(keys.escape, () => emit('escapeKeyPress'))
+whenever(keys.meta_b, () => emit('toggleSidebar'))
 
 const { activeRequest, readOnly: stateReadOnly } = useRequestStore()
 

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -49,7 +49,8 @@ const showSideBar = ref(false)
           :showSideBar="showSideBar"
           :theme="theme ?? 'none'"
           :withDefaultFonts="false"
-          @escapeKeyPress="hideApiClient">
+          @escapeKeyPress="hideApiClient"
+          @toggleSidebar="showSideBar = !showSideBar">
           <template #address-bar-controls>
             <div class="scalar-api-client-states">
               <button


### PR DESCRIPTION
this pr is a proposal to use the `meta + b` shortcut to toggle the api client sidebar visibility.