### PR TITLE
fix: galaxy latest JSON url wrong

### DIFF
--- a/packages/galaxy/README.md
+++ b/packages/galaxy/README.md
@@ -19,7 +19,7 @@ npm install @scalar/galaxy
 
 | Version     | Format | URL                                                          |
 | ----------- | ------ | ------------------------------------------------------------ |
-| Latest      | JSON   | https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml |
+| Latest      | JSON   | https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json |
 | Latest      | YAML   | https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml |
 | OpenAPI 3.1 | JSON   | https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/3.1.json    |
 | OpenAPI 3.1 | YAML   | https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/3.1.yaml    |


### PR DESCRIPTION
There’s a typo in the @scalar/galaxy JSON url. :)