### PR TITLE
 feat: support <sub> tag in markdown

### DIFF
--- a/.changeset/spotty-kiwis-sort.md
+++ b/.changeset/spotty-kiwis-sort.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: support <sub> tag in markdown

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -203,6 +203,11 @@ onServerPrefetch(async () => await sleep(1))
   vertical-align: super;
   font-weight: 450;
 }
+.markdown :deep(sub) {
+  font-size: var(--scalar-micro);
+  vertical-align: sub;
+  font-weight: 450;
+}
 .markdown :deep(del) {
   text-decoration: line-through;
 }


### PR DESCRIPTION
We’ve added a styling for `<sup>` tags in Markdown in #1679.

This PR adds support for `<sub>` tags, too. 🤡 

<img width="260" alt="Screenshot 2024-05-13 at 13 11 35" src="https://github.com/scalar/scalar/assets/1577992/ff60af40-fc02-4786-b1e4-e1395cd0199c">
