### PR TITLE
chore: bring back local urls for development

### DIFF
--- a/examples/web/src/pages/StartPage.vue
+++ b/examples/web/src/pages/StartPage.vue
@@ -2,6 +2,8 @@
 import { ThemeStyles } from '@scalar/themes'
 
 import PageLink from '../components/PageLink.vue'
+
+const inDevelopment = import.meta.env.DEV
 </script>
 <template>
   <ThemeStyles id="default" />
@@ -74,33 +76,66 @@ import PageLink from '../components/PageLink.vue'
         <template #title>Docusaurus</template>
         <template #description>@scalar/docusaurus</template>
       </PageLink>
-      <PageLink href="https://scalar-example-next-js-p6gnzjpyuq-uc.a.run.app">
+      <PageLink
+        :href="
+          inDevelopment
+            ? 'http://localhost:5058'
+            : 'https://scalar-example-next-js-p6gnzjpyuq-uc.a.run.app'
+        ">
         <template #title>Next.js</template>
         <template #description>@scalar/nextjs-api-reference</template>
       </PageLink>
-      <PageLink href="https://scalar-example-react-p6gnzjpyuq-uc.a.run.app">
+      <PageLink
+        :href="
+          inDevelopment
+            ? 'http://localhost:5059'
+            : 'https://scalar-example-react-p6gnzjpyuq-uc.a.run.app'
+        ">
         <template #title>React</template>
         <template #description>@scalar/api-reference</template>
       </PageLink>
       <PageLink
-        href="https://scalar-example-fastify-p6gnzjpyuq-uc.a.run.app/reference">
+        :href="
+          inDevelopment
+            ? 'http://localhost:5053/reference'
+            : 'https://scalar-example-fastify-p6gnzjpyuq-uc.a.run.app/reference'
+        ">
         <template #title>Fastify</template>
         <template #description>@scalar/fastify-api-reference</template>
       </PageLink>
-      <PageLink href="https://scalar-example-hono-p6gnzjpyuq-uc.a.run.app">
+      <PageLink
+        :href="
+          inDevelopment
+            ? 'http://localhost:5054'
+            : 'https://scalar-example-hono-p6gnzjpyuq-uc.a.run.app'
+        ">
         <template #title>Hono</template>
         <template #description>@scalar/hono-api-reference</template>
       </PageLink>
-      <PageLink href="https://scalar-example-express-p6gnzjpyuq-uc.a.run.app">
+      <PageLink
+        :href="
+          inDevelopment
+            ? 'http://localhost:5055'
+            : 'https://scalar-example-express-p6gnzjpyuq-uc.a.run.app'
+        ">
         <template #title>Express</template>
         <template #description>@scalar/express-api-reference</template>
       </PageLink>
-      <PageLink href="https://scalar-example-nest-js-p6gnzjpyuq-uc.a.run.app">
+      <PageLink
+        :href="
+          inDevelopment
+            ? 'http://localhost:5056'
+            : 'https://scalar-example-nest-js-p6gnzjpyuq-uc.a.run.app'
+        ">
         <template #title>NestJS (Express)</template>
         <template #description>@scalar/nestjs-api-reference</template>
       </PageLink>
       <PageLink
-        href="https://scalar-example-nest-js-fastify-p6gnzjpyuq-uc.a.run.app">
+        :href="
+          inDevelopment
+            ? 'http://localhost:5057'
+            : 'https://scalar-example-nest-js-fastify-p6gnzjpyuq-uc.a.run.app'
+        ">
         <template #title>NestJS (Fastify)</template>
         <template #description>@scalar/nestjs-api-reference</template>
       </PageLink>


### PR DESCRIPTION
In #659 we’ve added the URLs of the deployed examples, but I’m missing the local URLs. I love how convenient it is to open a locally running example. 

So why don’t we add both? 😊 