### PR TITLE
feat: api client modal size

### DIFF
--- a/.changeset/twenty-houses-study.md
+++ b/.changeset/twenty-houses-study.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: api client modal size

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -154,9 +154,8 @@ const showSideBar = ref(false)
 }
 .api-client-drawer {
   background: var(--scalar-background-1);
-  height: calc(100% - 180px);
-  width: calc(100% - 8px);
-  max-width: 1280px;
+  height: calc(100% - 2dvw);
+  width: calc(100% - 2dvw);
   left: 50%;
   top: 50%;
   transform: translate3d(-50%, -50%, 0);
@@ -265,12 +264,6 @@ const showSideBar = ref(false)
 .scalar-api-client-states-button:focus {
   background: var(--scalar-background-2);
   box-shadow: 0 0 0 1px var(--scalar-border-color);
-}
-@media (max-width: 1280px) {
-  .api-client-drawer {
-    height: calc(100% - 56px);
-    top: calc(50% + 26px);
-  }
 }
 @media (max-width: 820px) {
   .scalar-api-client-states-button__endpoints {


### PR DESCRIPTION
**Problem**
the recent update of the api client has reduced the size of the modal in an api reference which may lack covered space, especially in the case where the sidebar is open :

<img width="1469" alt="image" src="https://github.com/scalar/scalar/assets/14966155/b00691de-f6b6-45ce-9856-cb238467218d">
 

**Solution**
this pr is a proposal to increase the size of the api client modal, as seen below:

<img width="1469" alt="image" src="https://github.com/scalar/scalar/assets/14966155/18e91e39-f34f-4903-b125-4423cd23aab0">