### PR TITLE
fix: color single security scheme

### DIFF
--- a/.changeset/proud-boxes-punch.md
+++ b/.changeset/proud-boxes-punch.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: color single security scheme

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeSelector.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeSelector.vue
@@ -96,13 +96,16 @@ const keys = computed(() => Object.keys(props.value ?? {}))
 <template>
   <!-- Single security scheme -->
   <template v-if="keys.length === 1">
-    {{ getLabelForScheme(value?.[keys[0]], keys[0]) }}
+    <!-- Use <div> to avoid unnecessary styles added by `CollapsibleSection` -->
+    <div class="security-scheme-label">
+      {{ getLabelForScheme(value?.[keys[0]], keys[0]) }}
+    </div>
   </template>
 
   <!-- Multiple security schemes -->
   <template v-else-if="keys.length > 1">
     <div class="security-scheme-selector">
-      <span>
+      <span class="security-scheme-label">
         {{
           authentication.preferredSecurityScheme
             ? getLabelForScheme(
@@ -144,7 +147,8 @@ const keys = computed(() => Object.keys(props.value ?? {}))
 .security-scheme-selector:hover {
   color: var(--scalar-color-1);
 }
-.security-scheme-selector span {
+.security-scheme-label {
+  color: var(--scalar-color-2);
   font-size: var(--scalar-mini);
   font-weight: var(--scalar-semibold);
 }


### PR DESCRIPTION
**Problem**
Currently, if `securitySchemes` is defined with a single scheme, uncolored security scheme will be displayed in the API client.

Before:
![1(1)](https://github.com/scalar/scalar/assets/49305219/dd77753e-7db5-4fe7-b4b0-405b806d4a2a)

After:
![2(1)](https://github.com/scalar/scalar/assets/49305219/40dde0da-2022-4665-85b4-c8d81ef1d5c3)

**Explanation**
The issue is... the needed styles weren't applied to text if a single scheme is provided.

**Solution**
Put `.security-scheme-selector span` into a separate class, and use it for scheme labels.

