### PR TITLE
fix: x-displayName & x-tagGroups cancel eachother out, fix #1719

### DIFF
--- a/.changeset/cool-tomatoes-cheer.md
+++ b/.changeset/cool-tomatoes-cheer.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: x-displayName & x-tagGroups cancel eachother out

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -75,7 +75,9 @@ onMounted(() => {
           v-for="item in items.entries"
           :key="item.id">
           <template v-if="item.isGroup">
-            <li class="sidebar-group-title">{{ item.title }}</li>
+            <li class="sidebar-group-title">
+              {{ item.displayTitle ?? item.title }}
+            </li>
             <template
               v-for="group in item.children"
               :key="group.id">
@@ -86,7 +88,7 @@ onMounted(() => {
                 :isActive="hash === group.id"
                 :item="{
                   id: group.id,
-                  title: group.title,
+                  title: group.displayTitle ?? group.title,
                   select: group.select,
                   httpVerb: group.httpVerb,
                   deprecated: group.deprecated ?? false,
@@ -111,7 +113,7 @@ onMounted(() => {
                         :isActive="hash === child.id"
                         :item="{
                           id: child.id,
-                          title: child.title,
+                          title: child.displayTitle ?? child.title,
                           select: child.select,
                           httpVerb: child.httpVerb,
                           deprecated: child.deprecated ?? false,
@@ -131,7 +133,7 @@ onMounted(() => {
               :isActive="hash === item.id"
               :item="{
                 id: item.id,
-                title: item.title,
+                title: item.displayTitle ?? item.title,
                 select: item.select,
                 httpVerb: item.httpVerb,
                 deprecated: item.deprecated ?? false,
@@ -156,7 +158,7 @@ onMounted(() => {
                       :isActive="hash === child.id"
                       :item="{
                         id: child.id,
-                        title: child.title,
+                        title: child.displayTitle ?? child.title,
                         select: child.select,
                         httpVerb: child.httpVerb,
                         deprecated: child.deprecated ?? false,

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -227,15 +227,6 @@ const transformResult = (originalSchema: ResolvedOpenAPI.Document): Spec => {
     })
   })
 
-  // handle x-displayName extension
-  schema.tags.forEach((tag: Tag, tagIndex: number) => {
-    const xDisplayName = tag['x-displayName']
-
-    if (xDisplayName && schema.tags?.[tagIndex]) {
-      schema.tags[tagIndex].name = xDisplayName
-    }
-  })
-
   const returnedResult = {
     ...schema,
     webhooks: newWebhooks,

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -17,6 +17,7 @@ import { useNavState } from './useNavState'
 export type SidebarEntry = {
   id: string
   title: string
+  displayTitle?: string
   children?: SidebarEntry[]
   select?: () => void
   httpVerb?: string
@@ -129,6 +130,7 @@ const items = computed(() => {
             return {
               id: getTagId(tag),
               title: tag.name.toUpperCase(),
+              displayTitle: (tag['x-displayName'] ?? tag.name).toUpperCase(),
               show: true,
               children: tag.operations?.map(
                 (operation: TransformedOperation) => {


### PR DESCRIPTION
Currently, `x-displayName` and `x-tagGroups` don’t play well with each other, see #1719.

This PR fixes it. Instead of overwriting the name, and breaking the logic of what belongs to which tag, we’ll just keep an optional `displayTitle` which is used to overwrite `title` (if needed).

**Example**
```yaml
openapi: 3.1.0
info:
  title: Tag groups example
x-tagGroups:
  - name: fruits
    tags:
      - fruitPrice
  - name: vegetables
    tags:
      - vegetablePrice
tags:
  - name: fruitPrice
    x-displayName: price
  - name: vegetablePrice
    x-displayName: price
paths:
  '/fruit/price':
    get:
      tags:
        - fruitPrice
      summary: Get fruit price

  '/vegetable/price':
    get:
      tags:
        - vegetablePrice
      summary: Get vegatable price
```

**Result**

<img width="274" alt="Screenshot 2024-05-14 at 12 03 42" src="https://github.com/scalar/scalar/assets/1577992/330c3b6a-6e4c-433e-91f7-131bf785e489">