### PR TITLE
feat: hide operations with `x-internal: true`

### DIFF
--- a/.changeset/fuzzy-baboons-yell.md
+++ b/.changeset/fuzzy-baboons-yell.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: hide operations with x-internal: true

--- a/examples/web/src/fixtures/emptySpec.ts
+++ b/examples/web/src/fixtures/emptySpec.ts
@@ -1,7 +1,7 @@
-import { type Spec } from "@scalar/api-reference";
+import type { Spec } from "@scalar/api-reference";
 
 // Generate a new empty spec instance
-export const emptySpecGenerator = (): Spec => ({
+export const createEmptySpecification = (): Spec => ({
     info: {
       title: '',
       description: '',

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -3,6 +3,7 @@ import {
   ApiReferenceLayout,
   type ReferenceConfiguration,
   type Spec,
+  createEmptySpecification,
   parse,
 } from '@scalar/api-reference'
 import { asyncComputed } from '@vueuse/core'
@@ -12,7 +13,6 @@ import DevReferencesOptions from '../components/DevReferencesOptions.vue'
 import DevToolbar from '../components/DevToolbar.vue'
 import MonacoEditor from '../components/MonacoEditor.vue'
 import SlotPlaceholder from '../components/SlotPlaceholder.vue'
-import { createEmptySpecification } from '../fixtures/emptySpec'
 
 const content = ref('')
 

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -12,7 +12,7 @@ import DevReferencesOptions from '../components/DevReferencesOptions.vue'
 import DevToolbar from '../components/DevToolbar.vue'
 import MonacoEditor from '../components/MonacoEditor.vue'
 import SlotPlaceholder from '../components/SlotPlaceholder.vue'
-import { emptySpecGenerator } from '../fixtures/emptySpec'
+import { createEmptySpecification } from '../fixtures/emptySpec'
 
 const content = ref('')
 
@@ -71,9 +71,9 @@ const parsedSpec = asyncComputed(
       })
       .catch((error) => {
         console.warn(error)
-        return emptySpecGenerator()
+        return createEmptySpecification()
       }),
-  emptySpecGenerator(),
+  createEmptySpecification(),
 )
 </script>
 <template>

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -30,6 +30,73 @@ import { ApiReference } from '@scalar/api-reference'
 
 You can even [mount the component in React](https://github.com/scalar/scalar/blob/main/examples/react/src/App.tsx).
 
+## OpenAPI Specification
+
+We’re expecting the passed specification to adhere to [the Swagger 2.0, OpenAPI 3.0 or OpenAPI 3.1 specification](https://github.com/OAI/OpenAPI-Specification).
+
+On top of that, we’ve added a few things for your convenience:
+
+### x-displayName
+
+You can overwrite tag names with `x-displayName`.
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: "1.0"
+tags:
+  - name: pl4n3t5
++    x-displayName: planets
+paths:
+  '/planets':
+    get:
+      summary: Get all planets
+      tags:
+        - pl4n3t5
+```
+
+### x-tagGroup
+
+You can group your tags with `x-tagGroup`.
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: "1.0"
+tags:
+  - name: planets
++x-tagGroups:
++  - name: galaxy
++    tags:
++      - planets
+paths:
+  '/planets':
+    get:
+      summary: Get all planets
+      tags:
+        - planets
+```
+
+### x-internal
+
+You can hide operations from the reference with `x-internal`.
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: "1.0"
+paths:
+  '/planets':
+    get:
+      summary: Get all planets
+    post:
+      summary: Create a new planet
++      x-internal: true
+```
+
 ## Configuration
 
 There’s a configuration object that can be used on all platforms. In Vue.js, you use it like this:

--- a/packages/api-reference/src/helpers/createEmptySpecification.ts
+++ b/packages/api-reference/src/helpers/createEmptySpecification.ts
@@ -1,7 +1,7 @@
-import type { Spec } from "@scalar/api-reference";
+import type { Spec } from '../types'
 
-// Generate a new empty spec instance
-export const createEmptySpecification = (): Spec => ({
+export function createEmptySpecification(): Spec {
+  return {
     info: {
       title: '',
       description: '',
@@ -19,10 +19,7 @@ export const createEmptySpecification = (): Spec => ({
       description: '',
       url: '',
     },
-    components: {
-      schemas: {},
-      securitySchemes: {},
-    },
     servers: [],
     tags: [],
-  })
+  }
+}

--- a/packages/api-reference/src/helpers/index.ts
+++ b/packages/api-reference/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './createEmptySpecification'
 export * from './deepMerge'
 export * from './getApiClientRequest'
 export * from './getHeadingsFromMarkdown'

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -12,7 +12,7 @@ import {
   openapi,
 } from '@scalar/openapi-parser'
 
-import { createEmptySpecification } from '../hooks'
+import { createEmptySpecification } from '../helpers'
 // AnyStringOrObject
 import type { Spec, Tag } from '../types'
 

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -20,6 +20,15 @@ export const parse = (specification: any): Promise<Spec> => {
   // eslint-disable-next-line no-async-promise-executor
   return new Promise(async (resolve, reject) => {
     try {
+      // Return an empty resolved specification if the given specification is empty
+      if (!specification) {
+        return resolve(
+          transformResult(
+            createEmptySpecification() as ResolvedOpenAPI.Document,
+          ),
+        )
+      }
+
       const { schema, errors } = await openapi().load(specification).resolve()
 
       if (errors?.length) {

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -14,7 +14,7 @@ import {
 
 import { createEmptySpecification } from '../hooks'
 // AnyStringOrObject
-import type { Spec } from '../types'
+import type { Spec, Tag } from '../types'
 
 export const parse = (specification: any): Promise<Spec> => {
   // eslint-disable-next-line no-async-promise-executor
@@ -228,7 +228,7 @@ const transformResult = (originalSchema: ResolvedOpenAPI.Document): Spec => {
   })
 
   // handle x-displayName extension
-  schema.tags.forEach((tag, tagIndex) => {
+  schema.tags.forEach((tag: Tag, tagIndex: number) => {
     const xDisplayName = tag['x-displayName']
 
     if (xDisplayName && schema.tags?.[tagIndex]) {

--- a/packages/api-reference/src/hooks/useReactiveSpec.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.ts
@@ -1,36 +1,9 @@
 import { fetchSpecFromUrl } from '@scalar/oas-utils'
 import { type MaybeRefOrGetter, reactive, ref, toValue, watch } from 'vue'
 
-import { isValidUrl } from '../helpers'
+import { createEmptySpecification, isValidUrl } from '../helpers'
 import { parse } from '../helpers/parse'
-import type { Spec, SpecConfiguration } from '../types'
-
-// Generate a new empty spec instance
-export const createEmptySpecification = (): Spec => ({
-  info: {
-    title: '',
-    description: '',
-    termsOfService: '',
-    version: '',
-    license: {
-      name: '',
-      url: '',
-    },
-    contact: {
-      email: '',
-    },
-  },
-  externalDocs: {
-    description: '',
-    url: '',
-  },
-  components: {
-    schemas: {},
-    securitySchemes: {},
-  },
-  servers: [],
-  tags: [],
-})
+import type { SpecConfiguration } from '../types'
 
 /**
  * Get the spec content from the provided configuration:

--- a/packages/api-reference/src/hooks/useReactiveSpec.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.ts
@@ -6,7 +6,7 @@ import { parse } from '../helpers/parse'
 import type { Spec, SpecConfiguration } from '../types'
 
 // Generate a new empty spec instance
-export const emptySpecGenerator = (): Spec => ({
+export const createEmptySpecification = (): Spec => ({
   info: {
     title: '',
     description: '',
@@ -75,7 +75,7 @@ export function useReactiveSpec({
   /** OAS spec as a string */
   const rawSpec = ref('')
   /** Fully parsed and resolved OAS object */
-  const parsedSpec = reactive(emptySpecGenerator())
+  const parsedSpec = reactive(createEmptySpecification())
   /** Parser error messages when parsing fails */
   const specErrors = ref<string | null>(null)
 
@@ -85,7 +85,7 @@ export function useReactiveSpec({
    * If there are errors continue to show the previous valid spec
    */
   function parseInput(value?: string) {
-    if (!value) return Object.assign(parsedSpec, emptySpecGenerator())
+    if (!value) return Object.assign(parsedSpec, createEmptySpecification())
 
     return parse(value)
       .then((validSpec) => {

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -146,9 +146,10 @@ export type ExampleResponseHeaders = Record<
 >
 
 export type Tag = {
-  name: string
-  description: string
-  operations: TransformedOperation[]
+  'name': string
+  'description': string
+  'operations': TransformedOperation[]
+  'x-displayName'?: string
 }
 export type Parameter = {
   name: string

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -234,7 +234,12 @@ export type Definitions = OpenAPIV2.DefinitionsObject
 
 export type Webhooks = Record<
   string,
-  Record<OpenAPIV3_1.HttpMethods, TransformedOperation>
+  Record<
+    OpenAPIV3_1.HttpMethods,
+    TransformedOperation & {
+      'x-internal'?: boolean
+    }
+  >
 >
 
 export type Spec = {

--- a/packages/nuxt/playwright.config.ts
+++ b/packages/nuxt/playwright.config.ts
@@ -1,0 +1,12 @@
+import type { ConfigOptions } from '@nuxt/test-utils/playwright'
+import { defineConfig, devices } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig<ConfigOptions>({
+  use: {
+    nuxt: {
+      rootDir: fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+  // ...
+})


### PR DESCRIPTION
As requested in https://github.com/scalar/scalar/discussions/1728, this PR adds the ability to hide some operations with `x-internal: true`.

I’ve added an example to the `@scalar/api-reference` README. While I was on it, I’ve added examples for `x-displayName` and `x-tagGroup` aswell.

I was also able to remove handful of `@ts-expect error` comments.