### PR TITLE
chore: switch from rehype-prism to @shikijs/rehype

### DIFF
--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -71,6 +71,7 @@
     "@scalar/use-modal": "workspace:*",
     "@scalar/use-toasts": "workspace:*",
     "@scalar/use-tooltip": "workspace:*",
+    "@shikijs/rehype": "^1.5.2",
     "@unhead/schema": "^1.9.5",
     "@vcarl/remark-headings": "^0.1.0",
     "@vueuse/core": "^10.9.0",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -90,6 +90,7 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.0",
     "remark-stringify": "^11.0.0",
+    "shiki": "^1.5.2",
     "unhead": "^1.8.3",
     "unified": "^11.0.4"
   },

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -82,7 +82,6 @@
     "prismjs": "^1.29.0",
     "rehype-external-links": "^3.0.0",
     "rehype-format": "^5.0.0",
-    "rehype-prism": "^2.3.2",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.0",

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import rehypeExternalLinks from 'rehype-external-links'
 import rehypeFormat from 'rehype-format'
-import rehypePrism from 'rehype-prism'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import rehypeStringify from 'rehype-stringify'
@@ -48,8 +47,6 @@ watch(
           (tag) => !disallowedTagNames.includes(tag),
         ),
       })
-      // Syntax highlighting
-      .use(rehypePrism)
       // Adds target="_blank" to external links
       .use(rehypeExternalLinks, { target: '_blank' })
       // Formats the HTML

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import rehypeShiki from '@shikijs/rehype'
 import rehypeExternalLinks from 'rehype-external-links'
 import rehypeFormat from 'rehype-format'
 import rehypeRaw from 'rehype-raw'
@@ -49,6 +50,14 @@ watch(
       })
       // Adds target="_blank" to external links
       .use(rehypeExternalLinks, { target: '_blank' })
+      // Syntax highlighting
+      .use(rehypeShiki, {
+        // or `theme` for a single theme
+        themes: {
+          light: 'vitesse-light',
+          dark: 'vitesse-dark',
+        },
+      })
       // Formats the HTML
       .use(rehypeFormat)
       // Converts the HTML AST to a string

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import rehypeShiki from '@shikijs/rehype'
+import rehypeShikiFromHighlighter from '@shikijs/rehype/core'
 import rehypeExternalLinks from 'rehype-external-links'
 import rehypeFormat from 'rehype-format'
 import rehypeRaw from 'rehype-raw'
@@ -8,6 +8,7 @@ import rehypeStringify from 'rehype-stringify'
 import remarkGfm from 'remark-gfm'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
+import { getHighlighterCore } from 'shiki/core'
 import { unified } from 'unified'
 import { onServerPrefetch, ref, watch } from 'vue'
 
@@ -30,6 +31,12 @@ const disallowedTagNames = props.withImages ? [] : ['img', 'picture']
 watch(
   () => props.value,
   async () => {
+    const highlighter = await getHighlighterCore({
+      themes: [import('shiki/themes/github-light.mjs')],
+      langs: [import('shiki/langs/html.mjs')],
+      loadWasm: import('shiki/wasm'),
+    })
+
     // Markdown pipeline
     const result = await unified()
       // Parses markdown
@@ -51,11 +58,10 @@ watch(
       // Adds target="_blank" to external links
       .use(rehypeExternalLinks, { target: '_blank' })
       // Syntax highlighting
-      .use(rehypeShiki, {
+      .use(rehypeShikiFromHighlighter, highlighter, {
         // or `theme` for a single theme
         themes: {
-          light: 'vitesse-light',
-          dark: 'vitesse-dark',
+          light: 'github-light',
         },
       })
       // Formats the HTML

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -51,7 +51,6 @@ export default defineNuxtModule<ModuleOptions>({
       'debug',
       'extend',
       'stringify-object',
-      'rehype-prismjs',
     )
 
     // Also check for Nitro OpenAPI auto generation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,6 +888,9 @@ importers:
       remark-stringify:
         specifier: ^11.0.0
         version: 11.0.0
+      shiki:
+        specifier: ^1.5.2
+        version: 1.5.2
       unhead:
         specifier: ^1.8.3
         version: 1.8.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -831,6 +831,9 @@ importers:
       '@scalar/use-tooltip':
         specifier: workspace:*
         version: link:../use-tooltip
+      '@shikijs/rehype':
+        specifier: ^1.5.2
+        version: 1.5.2
       '@unhead/schema':
         specifier: ^1.9.5
         version: 1.9.5
@@ -9272,6 +9275,27 @@ packages:
       '@scalar/snippetz-plugin-node-fetch': 0.1.2
       '@scalar/snippetz-plugin-node-ofetch': 0.1.1
       '@scalar/snippetz-plugin-node-undici': 0.1.6
+    dev: false
+
+  /@shikijs/core@1.5.2:
+    resolution: {integrity: sha512-wSAOgaz48GmhILFElMCeQypSZmj6Ru6DttOOtl3KNkdJ17ApQuGNCfzpk4cClasVrnIu45++2DBwG4LNMQAfaA==}
+    dev: false
+
+  /@shikijs/rehype@1.5.2:
+    resolution: {integrity: sha512-MlpLBEyLcV399AgV5ai7wD0F7E/5qTlfF3487bx5MkGZb+DMAvpF279OI0UYKXVrqKrTS1zJfZXyIJlFQ3JeTA==}
+    dependencies:
+      '@shikijs/transformers': 1.5.2
+      '@types/hast': 3.0.4
+      hast-util-to-string: 3.0.0
+      shiki: 1.5.2
+      unified: 11.0.4
+      unist-util-visit: 5.0.0
+    dev: false
+
+  /@shikijs/transformers@1.5.2:
+    resolution: {integrity: sha512-/Sh64rKOFGMQLCvtHeL1Y7EExdq8LLxcdVkvoGx2aMHsYMOn8DckYl2gYKMHRBu/YUt1C38/Amd1Jdh48tWHgw==}
+    dependencies:
+      shiki: 1.5.2
     dev: false
 
   /@sideway/address@4.1.5:
@@ -17791,7 +17815,6 @@ packages:
     resolution: {integrity: sha512-OGkAxX1Ua3cbcW6EJ5pT/tslVb90uViVkcJ4ZZIMW/R33DX/AkcJcRrPebPwJkHYwlDHXz4aIwvAAaAdtrACFA==}
     dependencies:
       '@types/hast': 3.0.4
-    dev: true
 
   /hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -25255,6 +25278,12 @@ packages:
       glob: 7.2.3
       interpret: 1.4.0
       rechoir: 0.6.2
+
+  /shiki@1.5.2:
+    resolution: {integrity: sha512-fpPbuSaatinmdGijE7VYUD3hxLozR3ZZ+iAx8Iy2X6REmJGyF5hQl94SgmiUNTospq346nXUVZx0035dyGvIVw==}
+    dependencies:
+      '@shikijs/core': 1.5.2
+    dev: false
 
   /side-channel@1.0.5:
     resolution: {integrity: sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -864,9 +864,6 @@ importers:
       rehype-format:
         specifier: ^5.0.0
         version: 5.0.0
-      rehype-prism:
-        specifier: ^2.3.2
-        version: 2.3.2(unified@11.0.4)
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
@@ -10238,7 +10235,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.21(typescript@5.4.3)
-      vue-component-type-helpers: 2.0.16
+      vue-component-type-helpers: 2.0.17
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -14671,10 +14668,6 @@ packages:
       domutils: 3.1.0
       nth-check: 2.1.1
 
-  /css-selector-parser@3.0.5:
-    resolution: {integrity: sha512-3itoDFbKUNx1eKmVpYMFyqKX04Ww9osZ+dLgrk6GEv6KMVeXUhUnp4I5X+evw+u3ZxVU6RFXSSRxlTeMh8bA+g==}
-    dev: false
-
   /css-tree@1.1.3:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
     engines: {node: '>=8.0.0'}
@@ -17642,17 +17635,6 @@ packages:
     dependencies:
       '@types/hast': 3.0.4
       hast-util-is-element: 3.0.0
-    dev: false
-
-  /hast-util-from-html@2.0.1:
-    resolution: {integrity: sha512-RXQBLMl9kjKVNkJTIO6bZyb2n+cUH8LFaSSzo82jiLT6Tfc+Pt7VQCS+/h3YwG4jaNE2TA2sdJisGWR+aJrp0g==}
-    dependencies:
-      '@types/hast': 3.0.4
-      devlop: 1.1.0
-      hast-util-from-parse5: 8.0.1
-      parse5: 7.1.2
-      vfile: 6.0.1
-      vfile-message: 4.0.2
     dev: false
 
   /hast-util-from-parse5@8.0.1:
@@ -24518,28 +24500,6 @@ packages:
       unist-util-is: 6.0.0
     dev: false
 
-  /rehype-parse@9.0.0:
-    resolution: {integrity: sha512-WG7nfvmWWkCR++KEkZevZb/uw41E8TsH4DsY9UxsTbIXCVGbAs4S+r8FrQ+OtH5EEQAs+5UxKC42VinkmpA1Yw==}
-    dependencies:
-      '@types/hast': 3.0.4
-      hast-util-from-html: 2.0.1
-      unified: 11.0.4
-    dev: false
-
-  /rehype-prism@2.3.2(unified@11.0.4):
-    resolution: {integrity: sha512-UvLT8kwsR7mPpAGtikypFTWV+Y8RkfoKCynLl+pa2MvrR6u4D72FZlVRkvxWa3ZkfMcWqAWekJ7s2J0GEp0v+Q==}
-    peerDependencies:
-      unified: ^10 || ^11
-    dependencies:
-      hastscript: 8.0.0
-      prismjs: 1.29.0
-      rehype-parse: 9.0.0
-      unified: 11.0.4
-      unist-util-is: 6.0.0
-      unist-util-select: 5.1.0
-      unist-util-visit: 5.0.0
-    dev: false
-
   /rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
     dependencies:
@@ -27196,16 +27156,6 @@ packages:
       '@types/unist': 3.0.2
       unist-util-visit: 5.0.0
 
-  /unist-util-select@5.1.0:
-    resolution: {integrity: sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==}
-    dependencies:
-      '@types/unist': 3.0.2
-      css-selector-parser: 3.0.5
-      devlop: 1.1.0
-      nth-check: 2.1.1
-      zwitch: 2.0.4
-    dev: false
-
   /unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
     dependencies:
@@ -28275,8 +28225,8 @@ packages:
     resolution: {integrity: sha512-xNO5B7DstNWETnoYflLkVgh8dK8h2ZDgxY1M2O0zrqGeBNq5yAZ8a10yCS9+HnixouNGYNX+ggU9MQQq86HTpg==}
     dev: true
 
-  /vue-component-type-helpers@2.0.16:
-    resolution: {integrity: sha512-qisL/iAfdO++7w+SsfYQJVPj6QKvxp4i1MMxvsNO41z/8zu3KuAw9LkhKUfP/kcOWGDxESp+pQObWppXusejCA==}
+  /vue-component-type-helpers@2.0.17:
+    resolution: {integrity: sha512-2car49m8ciqg/JjgMBkx7o/Fd2A7fHESxNqL/2vJYFLXm4VwYO4yH0rexOi4a35vwNgDyvt17B07Vj126l9rAQ==}
     dev: true
 
   /vue-demi@0.14.7(vue@3.4.21):


### PR DESCRIPTION
> ⚠️ Don’t merge yet. WIP

We run into problems with the two prismjs versions we have (see #1716).

Actually, I think [shiki is the most modern syntax highlighting package](https://github.com/shikijs/shiki) (ESM yay) and it would be great to use it. And there’s a shiki editor, which could replace CodeMirror for us: https://shikicode.vercel.app/

Last time I tried it, it added 8 megabytes to the CDN build. But I think we can do better, so let’s try it again.

EDIT: Results are in:

```
dist/browser/standalone.js       10,252.92 kB
```

Let’s see what we can do. :)