### PR TITLE
fix: icon button sizes

### DIFF
--- a/.changeset/wicked-shoes-switch.md
+++ b/.changeset/wicked-shoes-switch.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/components": patch
+---
+
+style: updated icon button size

--- a/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
+++ b/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
@@ -59,7 +59,7 @@ const { copyToClipboard } = useClipboard()
         class="endpoint-copy"
         icon="Clipboard"
         label="Copy endpoint URL"
-        size="sm"
+        size="xs"
         variant="ghost"
         @click.stop="copyToClipboard(operation.path)" />
     </template>

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -103,7 +103,7 @@ const onAnchorClick = async (ev: Event) => {
           class="toggle-nested-icon"
           :icon="open ? 'ChevronDown' : 'ChevronRight'"
           label="Toggle group"
-          size="sm"
+          size="xs"
           @click.stop="handleClick" />
         &hairsp;
       </p>

--- a/packages/components/src/components/ScalarIconButton/ScalarIconButton.stories.ts
+++ b/packages/components/src/components/ScalarIconButton/ScalarIconButton.stories.ts
@@ -8,7 +8,7 @@ const meta = {
   tags: ['autodocs'],
   argTypes: {
     icon: { control: 'select', options: ICONS },
-    size: { control: 'select', options: ['xs', 'sm', 'md'] },
+    size: { control: 'select', options: ['xxs', 'xs', 'sm', 'md'] },
     label: { control: 'string' },
     variant: {
       control: 'select',

--- a/packages/components/src/components/ScalarIconButton/ScalarIconButton.vue
+++ b/packages/components/src/components/ScalarIconButton/ScalarIconButton.vue
@@ -26,7 +26,8 @@ const variants = cva({
   base: 'scalar-icon-button grid aspect-square cursor-pointer rounded',
   variants: {
     size: {
-      xs: 'size-3.5 p-0.5',
+      xxs: 'size-3.5 p-0.5',
+      xs: 'size-5 p-1',
       sm: 'size-6 p-1',
       md: 'size-10 p-3',
       full: 'h-full w-full',


### PR DESCRIPTION
In a previous PR I missed two instances of `sm` IconButtons. This PR adds another size instead of changing `sm`