### PR TITLE
fix: add dotnet9 package feed and preivew.4 version

### DIFF
--- a/examples/DotNet/DotNet.csproj
+++ b/examples/DotNet/DotNet.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-preview.3.24172.13" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-preview.4.24260.3" />
   </ItemGroup>
 
 </Project>

--- a/examples/DotNet/Program.cs
+++ b/examples/DotNet/Program.cs
@@ -10,6 +10,8 @@ builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
+app.MapOpenApi();
+
 app.MapGet("/", () => "Hello world!");
 
 app.Run();

--- a/examples/DotNet/nuget.config
+++ b/examples/DotNet/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This PR adds a NuGet config file with a pointer to the public feed and the nightly dotnet9 feed to support resolving the required preview4 version of the Microsoft.AspNetCore.OpenApi package.

Once preview4 officially ships, we can remove the nightly feed and use the public preview.

I've also updated the sample to add the OpenAPI endpoint so now the following works:

```
$ dotnet run
...
$ curl http://localhost:5296/openapi/v1.json
{
  "openapi": "3.0.1",
  "info": {
    "title": "DotNet | v1",
    "version": "1.0.0"
  },
  "paths": {
    "/": {
      "get": {
        "tags": [
          "DotNet"
        ],
        "responses": {
          "200": {
            "description": "OK",
            "content": {
              "text/plain": {
                "schema": {
                  "type": "string"
                }
              }
            }
          }
        },
        "x-aspnetcore-id": "c8e87a4f-38a7-4e29-b7f7-a40dacbb5380"
      }
    }
  },
  "tags": [
    {
      "name": "DotNet"
    }
  ]
}
```