### PR TITLE
chore: add bundle analyze scripts

### DIFF
--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -27,7 +27,9 @@
   "scripts": {
     "build": "pnpm build:default && pnpm build:standalone && pnpm types:build && tsc-alias -p tsconfig.build.json",
     "build:default": "vite build",
+    "analyze:default": "pnpm dlx vite-bundle-visualizer",
     "build:standalone": "vite build -c vite.standalone.config.ts",
+    "analyze:standalone": "pnpm dlx vite-bundle-visualizer -c vite.standalone.config.ts",
     "build:storybook": "storybook build",
     "dev": "vite",
     "dev:standalone": "vite -c vite.standalone.config.ts",


### PR DESCRIPTION
I use `vite-bundle-analyzer` way too often to understand what’s bundled. This PR adds `pnpm analyze:standalone` as a script for convenience. :)

The script makes a build, analyzes the bundle and opens this in your browser:

<img width="1502" alt="Screenshot 2024-05-15 at 12 00 19" src="https://github.com/scalar/scalar/assets/1577992/a3103b57-4574-400b-b6e3-27fa2bd8b51f">