### PR TITLE
feat(mock-server): add wildcard CORS headers

### DIFF
--- a/.changeset/funny-taxis-deliver.md
+++ b/.changeset/funny-taxis-deliver.md
@@ -1,0 +1,5 @@
+---
+"@scalar/mock-server": patch
+---
+
+feat: add wildcard CORS headers

--- a/packages/mock-server/src/createMockServer.test.ts
+++ b/packages/mock-server/src/createMockServer.test.ts
@@ -211,4 +211,70 @@ describe('createMockServer', () => {
       foo: 'bar',
     })
   })
+
+  it('has CORS headers', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    example: {
+                      foo: 'bar',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    // Options request
+    let response = await server.request('/foobar', {
+      method: 'OPTIONS',
+      headers: {
+        origin: 'https://example.com',
+      },
+    })
+
+    expect(response.status).toBe(204)
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
+
+    const allowMethodsHeader = response.headers.get(
+      'Access-Control-Allow-Methods',
+    )
+    expect(allowMethodsHeader).toBeTypeOf('string')
+    expect(allowMethodsHeader?.split(',').sort()).toStrictEqual(
+      ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH'].sort(),
+    )
+
+    // Get request
+    response = await server.request('/foobar', {
+      headers: {
+        origin: 'https://example.com',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
+
+    expect(await response.json()).toMatchObject({
+      foo: 'bar',
+    })
+  })
 })

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -1,6 +1,7 @@
 import { type Operation, getExampleFromSchema } from '@scalar/oas-utils'
 import { openapi } from '@scalar/openapi-parser'
 import { type Context, Hono } from 'hono'
+import { cors } from 'hono/cors'
 
 import { routeFromPath } from './utils'
 
@@ -17,6 +18,9 @@ export async function createMockServer(options?: {
   const result = await openapi()
     .load(options?.specification ?? {})
     .resolve()
+
+  // CORS headers
+  app.use(cors())
 
   // OpenAPI JSON file
   app.get('/openapi.json', (c) => {


### PR DESCRIPTION
Currently, the `@scalar/mock-server` doesn’t allow cross origin requests.

This PR adds loose CORS headers to make development (that’s what a mock server is for) easier.