### PR TITLE
feat(api-reference): show text/plain example responses, fix #1758

### DIFF
--- a/.changeset/smart-eels-work.md
+++ b/.changeset/smart-eels-work.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: show text/plain example responses, too

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -66,6 +66,7 @@ const currentJsonResponse = computed(() => {
   return (
     // OpenAPI 3.x
     normalizedContent?.['application/json'] ??
+    normalizedContent?.['text/plain'] ??
     // Swagger 2.0
     currentResponse.value
   )


### PR DESCRIPTION
We’re only showing json example responses, this PR adds support for text/plain responses, too.

See #1758