### PR TITLE
fix(api-reference): `x-displayName` is not used in the search modal and the tag component

### DIFF
--- a/.changeset/hot-needles-end.md
+++ b/.changeset/hot-needles-end.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: x-displayName is not used in the tag component

--- a/.changeset/ten-chicken-run.md
+++ b/.changeset/ten-chicken-run.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: x-displayName is not used in the search modal

--- a/packages/api-reference/src/components/Content/Tag/Endpoints.vue
+++ b/packages/api-reference/src/components/Content/Tag/Endpoints.vue
@@ -43,7 +43,7 @@ async function scrollHandler(operation: TransformedOperation) {
         <SectionColumn>
           <SectionHeader :level="2">
             <Anchor :id="getTagId(tag)">
-              {{ tag.name }}
+              {{ tag['x-displayName'] ?? tag.name }}
             </Anchor>
           </SectionHeader>
           <MarkdownRenderer

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -118,7 +118,7 @@ watch(
     // Tags
     props.parsedSpec.tags?.forEach((tag) => {
       const tagData: FuseData = {
-        title: tag.name,
+        title: tag['x-displayName'] ?? tag.name,
         href: `#${getTagId(tag)}`,
         description: tag.description,
         type: 'tag',


### PR DESCRIPTION
I struck me in the middle of the night: I forgot to add `x-displayName` to the search modal and the tag component.

This PR fixes both issues. :)

<img width="633" alt="Screenshot 2024-05-16 at 13 15 38" src="https://github.com/scalar/scalar/assets/1577992/ba880fa8-28f4-416b-84f3-974e70be6ef7">
