### PR TITLE
fix: client selector style

### DIFF
--- a/.changeset/flat-eggs-sing.md
+++ b/.changeset/flat-eggs-sing.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: client selector style

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -172,7 +172,7 @@ const checkIfClientIsFeatured = (client: HttpClientState) =>
   position: relative;
   cursor: pointer;
   white-space: nowrap;
-  padding: 5px 0;
+  padding: 5px;
   gap: 6px;
   color: var(--scalar-color-3);
   border-radius: var(--scalar-radius);
@@ -192,6 +192,7 @@ const checkIfClientIsFeatured = (client: HttpClientState) =>
 .client-libraries-icon {
   max-width: 14px;
   max-height: 14px;
+  min-width: 14px;
   width: 100%;
   aspect-ratio: 1;
   display: flex;


### PR DESCRIPTION
**problem**
client selector icon depending on display size do not keep their width.

**solution**
this pr add padding and min-width on icons.

<img width="691" alt="image" src="https://github.com/scalar/scalar/assets/14966155/4024af31-c071-4ad3-99fc-aa57501ad3fe">
