### PR TITLE
fix: remove yellow/blue autofill indicator

### DIFF
--- a/.changeset/honest-eyes-wonder.md
+++ b/.changeset/honest-eyes-wonder.md
@@ -1,0 +1,5 @@
+---
+"@scalar/themes": patch
+---
+
+fix: remove yellow/blue autofill indicator

--- a/packages/themes/src/components/ResetStyles.vue
+++ b/packages/themes/src/components/ResetStyles.vue
@@ -75,5 +75,9 @@ useApplyClasses('#headlessui-portal-root', reset)
     color: var(--scalar-color-3);
     font-family: var(--scalar-font);
   }
+  /** Remove yellow/blue autofill indicator */
+  input:-webkit-autofill {
+    background-clip: text !important;
+  }
 }
 </style>


### PR DESCRIPTION
Discussed in #1762 

**Solution**

Apply `background-clip: text !important` (`!important` is required) on `input:-webkit-autofill`, so that browser indicator color is not visible.

Actually there are more solutions:
1. Use `transition: background-color 5000000s ease-in-out 0s` to delay color rendering, but it delays all background color transitions, which can introduce unnecessary headaches in the future.
2. Apply `box-shadow`, but there is no way to "clear" background color, only to replace it with another (`inherit` didn't work for me for some reason).

Tested on Mozilla Firefox 125.0 and Google Chrome 124.0.6367.118.
