### PR TITLE
feat(cli): update existing sandboxes

### DIFF
--- a/.changeset/smooth-coins-search.md
+++ b/.changeset/smooth-coins-search.md
@@ -1,0 +1,5 @@
+---
+"@scalar/cli": patch
+---
+
+feat: update existing sandboxes

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -22,3 +22,8 @@ jobs:
         run: npx @scalar/cli format ./packages/galaxy/src/specifications/3.1.yaml
       - name: Validate OpenAPI File
         run: npx @scalar/cli validate ./packages/galaxy/src/specifications/3.1.yaml
+      - name: Update Scalar Sandbox (https://sandbox.scalar.com/e/MeCHQ)
+        if: github.ref == 'refs/heads/main'
+        run: npx @scalar/cli share ./packages/galaxy/src/specifications/3.1.yaml --token=${{ secrets.SANDBOX_TOKEN }}
+        env:
+          SANDBOX_TOKEN: ${{ secrets.SANDBOX_TOKEN }}

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './getFileOrUrl'
 export * from './getHtmlDocument'
 export * from './getMethodColor'
 export * from './getOperationByMethodAndPath'


### PR DESCRIPTION
Currently, you can use `scalar share` to quickly create a sandbox link.

If you’d like to update an existing sandbox, there wasn't anything you could do.

With this PR the share command outputs a token, that you can use to update an existing sandbox.

**Try it**

```bash
pnpm @scalar/cli share https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json
```

**Additional improvements**

* `scalar share` works with URLs (and not just local files) now, too :)
* It’s added to CI, to push the `@scalar/galaxy` example to a sandbox

**Preview**

<img width="723" alt="Screenshot 2024-05-17 at 17 09 46" src="https://github.com/scalar/scalar/assets/1577992/514f9558-c8dd-4f22-aeb8-cd31ca191a90">