### PR TITLE
feat: Adding Options to Scalar.AspNetCore

### DIFF
--- a/packages/scalar.aspnetcore/Scalar.AspNetCore.cs
+++ b/packages/scalar.aspnetcore/Scalar.AspNetCore.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,28 +11,52 @@ namespace Scalar.AspNetCore
     {
         public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints)
         {
-            return endpoints.MapGet("/scalar/{documentName}", (string documentName) => Results.Content($$"""
-            <!doctype html>
-            <html>
-            <head>
-                <title>Scalar API Reference -- {{documentName}}</title>
-                <meta charset="utf-8" />
-                <meta name="viewport" content="width=device-width, initial-scale=1" />
-            </head>
-            <body>
-                <script id="api-reference" data-url="/openapi/{{documentName}}.json"></script>
-                <script>
-                var configuration = {
-                    theme: 'purple',
-                }
+              return endpoints.MapScalarApiReference(_ => { });   
+        }
 
-                document.getElementById('api-reference').dataset.configuration =
-                    JSON.stringify(configuration)
-                </script>
-                <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-            </body>
-            </html>
-            """, "text/html")).ExcludeFromDescription();
+        private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints,
+            Action<ScalarOptions> configureOptions)
+        {
+            var options = new ScalarOptions();
+            configureOptions(options);
+
+            var configurationJson = JsonSerializer.Serialize(options, JsonSerializerOptions);
+            
+            return endpoints.MapGet(options.EndpointPathPrefix + "/{documentName}", (string documentName) =>
+                {
+                    var title = options.Title ?? $"Scalar API Reference -- {documentName}";
+                    return Results.Content(
+                        $$"""
+                          <!doctype html>
+                          <html>
+                          <head>
+                              <title>{{title}}</title>
+                              <meta charset="utf-8" />
+                              <meta name="viewport" content="width=device-width, initial-scale=1" />
+                          </head>
+                          <body>
+                              <script id="api-reference" data-url="/openapi/{{documentName}}.json"></script>
+                              <script>
+                              var configuration = {
+                                  {{configurationJson}}
+                              }
+                          
+                              document.getElementById('api-reference').dataset.configuration =
+                                  JSON.stringify(configuration)
+                              </script>
+                              <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+                          </body>
+                          </html>
+                          """, "text/html");
+                })
+                .ExcludeFromDescription();
         }
     }
 }

--- a/packages/scalar.aspnetcore/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/ScalarOptions.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Scalar.AspNetCore;
+
+public class ScalarOptions
+{
+    [JsonIgnore]
+    public string EndpointPathPrefix { get; set; } = "/scalar";
+
+    [JsonIgnore] 
+    public string? Title { get; set; }
+
+    public string Theme { get; set; } = "purple";
+
+    public bool? DarkMode { get; set; }
+    public bool? HideDownloadButton { get; set; }
+    public bool? ShowSideBar { get; set; }
+
+    public bool? WithDefaultFonts { get; set; }
+
+    public string? Layout { get; set; }
+
+    public string? CustomCss { get; set; }
+
+    public string? SearchHotkey { get; set; }
+
+    public Dictionary<string, string>? Metadata { get; set; }
+
+    public ScalarAuthenticationOptions? Authentication { get; set; }
+}
+
+public class ScalarAuthenticationOptions
+{
+    public string? PreferredSecurityScheme { get; set; }
+
+    public ScalarAuthenticationApiKey? ApiKey { get; set; }
+}
+
+public class ScalarAuthenticationoAuth2
+{
+    public string? ClientId { get; set; }
+
+    public List<string>? Scopes { get; set; }
+}
+
+public class ScalarAuthenticationApiKey
+{
+    public string? Token { get; set; }
+}


### PR DESCRIPTION
**Problem**
Currently, there is no way to configure any of the configuration options using Scalar.AspNetCore nuget package

**Solution**
I added a new `MapScalarApiReference` extension which accepts an `Action<ScalarOptions>` which you can use to configure the options, i might have not added all the configuration but i added all of those i could find in the documentation.

There is also the `MapScalarApiReference` extension without any arguments with sensible default options

Please tell me if the code requires more features or "massaging" to get this PR merged as i would really like to use these features with the official nuget package and i think some folks as well.
