### PR TITLE
fix: client selector responsive

### DIFF
--- a/.changeset/breezy-roses-tap.md
+++ b/.changeset/breezy-roses-tap.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: api client selector responsive

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -157,6 +157,7 @@ const checkIfClientIsFeatured = (client: HttpClientState) =>
 </template>
 <style scoped>
 .client-libraries-content {
+  container: client-libraries-content / inline-size;
   display: flex;
   justify-content: center;
   overflow: hidden;
@@ -204,6 +205,23 @@ const checkIfClientIsFeatured = (client: HttpClientState) =>
 }
 .client-libraries-icon__more svg {
   height: initial;
+}
+@container client-libraries-content (width < 400px) {
+  .client-libraries__select {
+    width: fit-content;
+
+    .client-libraries-icon__more + span {
+      display: none;
+    }
+  }
+}
+@container client-libraries-content (width < 380px) {
+  .client-libraries {
+    width: 100%;
+  }
+  .client-libraries span {
+    display: none;
+  }
 }
 .client-libraries__active {
   background-color: var(--scalar-background-2);


### PR DESCRIPTION
**Problem**
responsive issue spotted in sandbox: 

<img width="700" alt="image" src="https://github.com/scalar/scalar/assets/14966155/3c05588f-d6af-4644-b374-5a30a2aa3a85">

**Solution**
this pr favor the ellipsis icon only according to the selector width:

<img width="700" alt="image" src="https://github.com/scalar/scalar/assets/14966155/1591bbfa-1861-4a4e-a1c1-06911d55ecf4">
 