### PR TITLE
docs(cli): naming conflicts

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ Command-line interface to work with OpenAPI files
 - Upload your OpenAPI files to Scalar
 - Get a fully mocked API for testing purposes
 - Preview your API reference
-- Bundle multiple OpenAPI files
+- ~~Bundle multiple OpenAPI files~~ (work in progress)
 
 ## Quickstart
 
@@ -32,6 +32,24 @@ npm -g install @scalar/cli
 ```
 
 Otherwise just prefix all commands with `npx @scalar/cli` instead of `scalar`. That’s fine, too.
+
+### Conflict: EEXIST: file already exists
+
+There’s another `scalar` CLI, which is bundled with `git`. If you run into naming conflicts, but never use the other CLI anyway, you can replace it like this:
+
+```bash
+npm -g --force install @scalar/cli
+```
+
+Or, if you want to keep using the other `scalar` CLI, you can just stick to `npx` (or `pnpm dlx`):
+
+```bash
+# Execute without installation (npm)
+npx @scalar/cli help
+
+# Execute without installation (pnpm)
+pnpm dlx @scalar/cli help
+```
 
 ## Commands
 


### PR DESCRIPTION
Users might [run into issues when installing the CLI](https://github.com/scalar/scalar/issues/1786), this PR adds some information to the README to help them to find a workaround.