### PR TITLE
feat(mock-server): dynamic values for generated examples

### DIFF
--- a/.changeset/selfish-points-stare.md
+++ b/.changeset/selfish-points-stare.md
@@ -1,0 +1,7 @@
+---
+"@scalar/mock-server": patch
+"@scalar/oas-utils": patch
+"@scalar/galaxy": patch
+---
+
+feat: dynamic values for generated examples

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -487,6 +487,7 @@ components:
           format: int64
           examples:
             - 1
+          x-variable: planetId
         name:
           type: string
           examples:

--- a/packages/mock-server/src/createMockServer.test.ts
+++ b/packages/mock-server/src/createMockServer.test.ts
@@ -163,6 +163,52 @@ describe('createMockServer', () => {
     })
   })
 
+  it('POST /foobar/{id} -> uses dynamic ID', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar/{id}': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: {
+                          'type': 'number',
+                          'example': 'bar',
+                          'x-variable': 'id',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/foobar/123')
+
+    expect(await response.json()).toMatchObject({
+      id: 123,
+    })
+    expect(response.status).toBe(200)
+  })
+
   it('GET /foobar -> example from schema', async () => {
     const specification = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -73,7 +73,7 @@ export async function createMockServer(options?: {
 
         // Focus on JSON for now
         const jsonResponse = preferredResponseKey
-          ? operation.responses?.[preferredResponseKey]?.content[
+          ? operation.responses?.[preferredResponseKey]?.content?.[
               'application/json'
             ]
           : null
@@ -84,6 +84,7 @@ export async function createMockServer(options?: {
           : jsonResponse?.schema
             ? getExampleFromSchema(jsonResponse.schema, {
                 emptyString: '…',
+                variables: c.req.param(),
               })
             : null
 

--- a/packages/oas-utils/src/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.test.ts
@@ -135,6 +135,22 @@ describe('getExampleFromSchema', () => {
     ).toMatchObject('…')
   })
 
+  it('uses variables as an example value', () => {
+    expect(
+      getExampleFromSchema(
+        {
+          'type': 'string',
+          'x-variable': 'id',
+        },
+        {
+          variables: {
+            id: 'foobar',
+          },
+        },
+      ),
+    ).toBe('foobar')
+  })
+
   it('uses true as a fallback for booleans', () => {
     expect(
       getExampleFromSchema({

--- a/packages/oas-utils/src/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.ts
@@ -45,12 +45,15 @@ export const getExampleFromSchema = (
   if (schema['x-variable']) {
     const value = options?.variables?.[schema['x-variable']]
 
-    // Type-casting
-    if (schema.type === 'number' || schema.type === 'integer') {
-      return parseInt(value, 10)
-    }
+    // Return the value if it’s defined
+    if (value !== undefined) {
+      // Type-casting
+      if (schema.type === 'number' || schema.type === 'integer') {
+        return parseInt(value, 10)
+      }
 
-    return value
+      return value
+    }
   }
 
   // Use the first example, if there’s an array

--- a/packages/oas-utils/src/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.ts
@@ -19,6 +19,10 @@ export const getExampleFromSchema = (
      * @default undefined
      */
     mode?: 'read' | 'write'
+    /**
+     * Dynamic values to add to the example.
+     */
+    variables?: Record<string, any>
   },
   level: number = 0,
 ): any => {
@@ -35,6 +39,18 @@ export const getExampleFromSchema = (
   // Check if the property is write-only
   if (options?.mode === 'read' && schema.writeOnly) {
     return undefined
+  }
+
+  // Use given variables as values
+  if (schema['x-variable']) {
+    const value = options?.variables?.[schema['x-variable']]
+
+    // Type-casting
+    if (schema.type === 'number' || schema.type === 'integer') {
+      return parseInt(value, 10)
+    }
+
+    return value
   }
 
   // Use the first example, if there’s an array


### PR DESCRIPTION
Currently, the mock server just returns static JSON or a generated example (based on a given schema).

Requests to `/planets/{planetId}` are handled, but return a static value.

With this PR, `x-variable` is introduced as an extension to the specification, which tells the mock server to use a given variable for a property.

**Example Schema**

```yaml
    Planet:
      type: object
      properties:
        id:
          type: integer
          x-variable: planetId
```

**Example Response for `/planets/123`**

```json
{
  "id": 123,
}
```

I consider this an experimental feature for now, so documentation yet.