### PR TITLE
fix(api-client): doesn’t render preview for mimetype variations like `application/foobar+json`

### DIFF
--- a/.changeset/selfish-ghosts-leave.md
+++ b/.changeset/selfish-ghosts-leave.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-client": patch
+"@scalar/oas-utils": patch
+---
+
+fix: doesn’t render preview for mimetype variations like application/foobar+json

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -52,7 +52,6 @@
     "@scalar/use-tooltip": "workspace:*",
     "@vueuse/core": "^10.9.0",
     "axios": "^1.6.8",
-    "content-type": "^1.0.5",
     "httpsnippet-lite": "^3.0.5",
     "nanoid": "^5.0.1",
     "pretty-bytes": "^6.1.1",

--- a/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
+++ b/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { ScalarCodeBlock } from '@scalar/components'
-import contentType from 'content-type'
+import { normalizeMimeType } from '@scalar/oas-utils'
 import { computed } from 'vue'
 
 import { CollapsibleSection } from '../../CollapsibleSection'
@@ -26,19 +26,12 @@ const mediaType = computed(() => {
     return null
   }
 
-  try {
-    return contentType.parse(contentTypeHeader.value).type
-  } catch {
-    return null
-  }
+  // application/foobar+json; charset=utf-8 -> application/json
+  return normalizeMimeType(contentTypeHeader?.value)
 })
 
 const codeMirrorLanguage = computed((): string | null => {
-  if (
-    mediaType.value === 'application/json' ||
-    mediaType.value === 'application/problem+json' ||
-    mediaType.value === 'application/vnd.api+json'
-  ) {
+  if (mediaType.value === 'application/json') {
     return 'json'
   }
 

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -25,11 +25,11 @@
     "node": ">=18"
   },
   "scripts": {
+    "analyze:default": "pnpm dlx vite-bundle-visualizer",
+    "analyze:standalone": "pnpm dlx vite-bundle-visualizer -c vite.standalone.config.ts",
     "build": "pnpm build:default && pnpm build:standalone && pnpm types:build && tsc-alias -p tsconfig.build.json",
     "build:default": "vite build",
-    "analyze:default": "pnpm dlx vite-bundle-visualizer",
     "build:standalone": "vite build -c vite.standalone.config.ts",
-    "analyze:standalone": "pnpm dlx vite-bundle-visualizer -c vite.standalone.config.ts",
     "build:storybook": "storybook build",
     "dev": "vite",
     "dev:standalone": "vite -c vite.standalone.config.ts",

--- a/packages/oas-utils/src/index.ts
+++ b/packages/oas-utils/src/index.ts
@@ -1,14 +1,18 @@
 export { createHash } from './createHash'
+export { defaultStateFactory, ssrState } from './ssrState'
 export { fetchSpecFromUrl } from './fetch-spec'
 export { getExampleFromSchema } from './getExampleFromSchema'
 export { getHarRequest } from './getHarRequest'
 export { getParametersFromOperation } from './getParametersFromOperation'
 export { getRequestBodyFromOperation } from './getRequestBodyFromOperation'
 export { getRequestFromOperation } from './getRequestFromOperation'
-export type { HttpStatusCode, HttpStatusCodes } from './httpStatusCodes'
 export { httpStatusCodes } from './httpStatusCodes'
-export { normalizeMimeTypeObject } from './normalizeMimeTypeObject'
 export { json2xml } from './json2xml'
+export { normalizeMimeTypeObject } from './normalizeMimeTypeObject'
+export { prettyPrintJson } from './prettyPrintJson'
+export * from './normalizeMimeType'
+export * from './types'
+export type { HttpStatusCode, HttpStatusCodes } from './httpStatusCodes'
 export {
   formatJsonOrYamlString,
   isJsonString,
@@ -17,6 +21,3 @@ export {
   transformToJson,
   yaml,
 } from './parse'
-export { prettyPrintJson } from './prettyPrintJson'
-export { defaultStateFactory, ssrState } from './ssrState'
-export * from './types'

--- a/packages/oas-utils/src/normalizeMimeType.test.ts
+++ b/packages/oas-utils/src/normalizeMimeType.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeMimeType } from './normalizeMimeType'
+
+describe('normalizeMimeType', () => {
+  it('removes charset', async () => {
+    const content = 'application/json; charset=utf-8'
+
+    expect(normalizeMimeType(content)).toBe('application/json')
+  })
+
+  it('removes semicolon', async () => {
+    const content = 'application/json;'
+
+    expect(normalizeMimeType(content)).toBe('application/json')
+  })
+
+  it('removes whitespace', async () => {
+    const content = ' application/json '
+
+    expect(normalizeMimeType(content)).toBe({
+      'application/json': {},
+    })
+  })
+
+  it('removes mimetype variants', async () => {
+    const content = 'application/problem+json'
+
+    expect(normalizeMimeType(content)).toBe({
+      'application/json': {},
+    })
+  })
+
+  it('removes mimetype variants with special characters', async () => {
+    const content = 'application/vnd.api+json'
+
+    expect(normalizeMimeType(content)).toBe({
+      'application/json': {},
+    })
+  })
+
+  it('removes all the clutter', async () => {
+    const content = 'application/problem-foobar+json; charset=utf-8'
+
+    expect(normalizeMimeType(content)).toBe({
+      'application/json': {},
+    })
+  })
+})

--- a/packages/oas-utils/src/normalizeMimeType.test.ts
+++ b/packages/oas-utils/src/normalizeMimeType.test.ts
@@ -18,32 +18,24 @@ describe('normalizeMimeType', () => {
   it('removes whitespace', async () => {
     const content = ' application/json '
 
-    expect(normalizeMimeType(content)).toBe({
-      'application/json': {},
-    })
+    expect(normalizeMimeType(content)).toBe('application/json')
   })
 
   it('removes mimetype variants', async () => {
     const content = 'application/problem+json'
 
-    expect(normalizeMimeType(content)).toBe({
-      'application/json': {},
-    })
+    expect(normalizeMimeType(content)).toBe('application/json')
   })
 
   it('removes mimetype variants with special characters', async () => {
     const content = 'application/vnd.api+json'
 
-    expect(normalizeMimeType(content)).toBe({
-      'application/json': {},
-    })
+    expect(normalizeMimeType(content)).toBe('application/json')
   })
 
   it('removes all the clutter', async () => {
     const content = 'application/problem-foobar+json; charset=utf-8'
 
-    expect(normalizeMimeType(content)).toBe({
-      'application/json': {},
-    })
+    expect(normalizeMimeType(content)).toBe('application/json')
   })
 })

--- a/packages/oas-utils/src/normalizeMimeType.ts
+++ b/packages/oas-utils/src/normalizeMimeType.ts
@@ -1,0 +1,13 @@
+import type { ContentType } from './types'
+
+export function normalizeMimeType(contentType: string) {
+  return (
+    contentType
+      // Remove '; charset=utf-8'
+      .replace(/;.*$/, '')
+      // Remove 'problem+'
+      .replace(/\/.+\+/, '/')
+      // Remove whitespace
+      .trim() as ContentType
+  )
+}

--- a/packages/oas-utils/src/normalizeMimeTypeObject.ts
+++ b/packages/oas-utils/src/normalizeMimeTypeObject.ts
@@ -1,3 +1,4 @@
+import { normalizeMimeType } from './normalizeMimeType'
 import type { ContentType } from './types'
 
 /**
@@ -18,13 +19,7 @@ export function normalizeMimeTypeObject(content?: Record<ContentType, any>) {
   Object.keys(newContent).forEach((key) => {
     // Example: 'application/problem+json; charset=utf-8'
 
-    const newKey = key
-      // Remove '; charset=utf-8'
-      .replace(/;.*$/, '')
-      // Remove 'problem+'
-      .replace(/\/.+\+/, '/')
-      // Remove whitespace
-      .trim() as ContentType
+    const newKey = normalizeMimeType(key)
 
     newContent[newKey] = newContent[key as ContentType]
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,9 +669,6 @@ importers:
       axios:
         specifier: ^1.6.8
         version: 1.6.8
-      content-type:
-        specifier: ^1.0.5
-        version: 1.0.5
       httpsnippet-lite:
         specifier: ^3.0.5
         version: 3.0.5
@@ -10233,7 +10230,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.21(typescript@5.4.3)
-      vue-component-type-helpers: 2.0.18
+      vue-component-type-helpers: 2.0.19
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -28364,8 +28361,8 @@ packages:
     resolution: {integrity: sha512-xNO5B7DstNWETnoYflLkVgh8dK8h2ZDgxY1M2O0zrqGeBNq5yAZ8a10yCS9+HnixouNGYNX+ggU9MQQq86HTpg==}
     dev: true
 
-  /vue-component-type-helpers@2.0.18:
-    resolution: {integrity: sha512-zi1QaDBhSb3oeHJh55aTCrosFNKEQsOL9j3XCAjpF9dwxDUUtd85RkJVzO+YpJqy1LNoCWLU8gwuZ7HW2iDN/A==}
+  /vue-component-type-helpers@2.0.19:
+    resolution: {integrity: sha512-cN3f1aTxxKo4lzNeQAkVopswuImUrb5Iurll9Gaw5cqpnbTAxtEMM1mgi6ou4X79OCyqYv1U1mzBHJkzmiK82w==}
     dev: true
 
   /vue-demi@0.14.7(vue@3.4.21):


### PR DESCRIPTION
Currently, we’re only showing a response body preview for `application/json` (and very few other types), but not for variants like `application/foobar+json`.

With this PR we’re using the recently introduced `normalizeMimeType` helper (and remove the package we used before) to decide whether to render a preview.

Related: https://github.com/scalar/scalar/discussions/1742#discussioncomment-9462321