### PR TITLE
fix(api-reference): server url with variable is prepended with current URL, fix #1755

### DIFF
--- a/.changeset/itchy-ants-talk.md
+++ b/.changeset/itchy-ants-talk.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: server url with variable is overwritten with current url

--- a/packages/api-reference/src/components/Content/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/components/Content/BaseUrl/BaseUrl.vue
@@ -51,6 +51,7 @@ watch(
     })
   },
   {
+    immediate: true,
     deep: true,
   },
 )

--- a/packages/api-reference/src/components/Content/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/components/Content/BaseUrl/BaseUrl.vue
@@ -5,7 +5,6 @@ import { ref, watch } from 'vue'
 
 import { useServerStore } from '../../../stores'
 import type { Variable } from '../../../types'
-import { Card, CardContent, CardHeader } from '../../Card'
 import { MarkdownRenderer } from '../../MarkdownRenderer'
 import ServerItem from './ServerItem.vue'
 import ServerVariables from './ServerVariables.vue'

--- a/packages/api-reference/src/components/Content/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/components/Content/BaseUrl/BaseUrl.vue
@@ -12,7 +12,7 @@ import ServerVariables from './ServerVariables.vue'
 const { server, setServer } = useServerStore()
 const selectedServerIndex = ref<number>(0)
 
-// TODO move this to a computed property in the store
+// TODO: Move this to the store
 watch(
   [selectedServerIndex, () => server.servers],
   () => {

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -26,8 +26,8 @@ const { setServer } = useServerStore()
 const { hideModels, collapsedSidebarItems } = useSidebar()
 
 const prependRelativePath = (server: Server) => {
-  // URLs that don't start with http[s]://
-  if (server.url.match(/^(?!(https?|file):\/\/).+/)) {
+  // URLs that don't start with http[s]:// or a variable
+  if (server.url.match(/^(?!(https?|file):\/\/|{).+/)) {
     let baseURL = props.baseServerURL ?? window.location.origin
 
     // Handle slashes


### PR DESCRIPTION
When a server URL starts with a variable e.g. `{protocol}`, the URL is prepended with the current URL.

We’ve got a check for http/https and even file in place, but not for variables.

This PR extends the check to work with variables.

See #1755