### PR TITLE
fix: add scalar component scope to missing components

### DIFF
--- a/.changeset/serious-carrots-beam.md
+++ b/.changeset/serious-carrots-beam.md
@@ -1,0 +1,5 @@
+---
+"@scalar/components": patch
+---
+
+fix: add scalar component scope to missing components

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -17,7 +17,7 @@ defineOptions({ inheritAttrs: false })
       </MenuButton>
       <template #floating="{ width }">
         <MenuItems
-          class="relative flex w-56 flex-col p-0.75"
+          class="scalar-component relative flex w-56 flex-col p-0.75"
           :style="{ width }"
           v-bind="$attrs">
           <slot name="items" />

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -69,12 +69,12 @@ const { floatingStyles, middlewareData } = useFloating(targetRef, floatingRef, {
 <template>
   <div
     ref="wrapperRef"
-    :class="{ contents: !!$slots.default }">
+    :class="['scalar-component', { contents: !!$slots.default }]">
     <slot />
   </div>
   <div
     ref="floatingRef"
-    class="relative z-context"
+    class="scalar-component relative z-context"
     :style="floatingStyles"
     v-bind="$attrs">
     <slot

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.vue
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.vue
@@ -16,7 +16,7 @@ defineOptions({ inheritAttrs: false })
       </PopoverButton>
       <template #floating="{ width, height }">
         <PopoverPanel
-          class="relative flex flex-col p-0.75"
+          class="scalar-component relative flex flex-col p-0.75"
           :style="{ width, height }"
           v-bind="$attrs">
           <slot name="popover" />

--- a/packages/components/src/components/ScalarTextField/ScalarTextField.vue
+++ b/packages/components/src/components/ScalarTextField/ScalarTextField.vue
@@ -101,7 +101,7 @@ onMounted(() => {
 })
 </script>
 <template>
-  <div class="scalar-input-container relative">
+  <div class="scalar-component scalar-input-container relative">
     <div :class="textField({ error, focus: isFocused })">
       <component
         :is="isMultiline ? 'textarea' : 'input'"


### PR DESCRIPTION
Because we scope our tailwind CSS coming out of the components library all scalar components need to have the `scalar-component` class on their root element (which I forgot to do for the dropdown).

@amritk we might want to rethink at some point how were handling scoping here or if we even need to handle it anymore.