### PR TITLE
chore: deploy preview changes to main

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -2,9 +2,6 @@ name: Deploy Scalar examples
 
 on:
   push:
-    paths:
-      - 'examples/web/**'
-      - '.github/workflows/deploy-examples.yml'
     branches:
       - 'main'
 


### PR DESCRIPTION
Remove filters from the workflow trigger to ensure the example page is deployed when changes are pushed to main
