### PR TITLE
ci(release): start proxy in release workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build": "turbo build",
     "build:packages": "turbo --filter './packages/**' build",
     "build:standalone": "pnpm --filter api-reference play-button build:standalone",
-    "bump": "CI=true pnpm run test && pnpm changeset version",
+    "bump": "pnpm test:ci && pnpm changeset version",
     "clean": "pnpm clean:nodeModules; pnpm clean:dist; pnpm clean:turbo; pnpm clean:nuxt",
     "clean:build": "pnpm clean ; pnpm i && pnpm build:packages",
     "clean:nodeModules": "find . -name node_modules -type d -exec rm -rf {} \\;",


### PR DESCRIPTION
Currently, the tests fail in the release workflow. That’s because the proxy isn’t running there.

There’s a tiny difference in the scripts now:

* `pnpm test` run the tests locally, assumes the proxy is already running
* `pnpm test:ci` runs the tests in CI, starts the proxy and waits until it’s ready

We had `test:ci` already, but I’ve added to it in #1090.