### PR TITLE
fix: do not use new proxy in cdn api reference example yet

### DIFF
--- a/examples/cdn-api-reference/src/public/api-reference-cdn-live.html
+++ b/examples/cdn-api-reference/src/public/api-reference-cdn-live.html
@@ -13,8 +13,7 @@
     <!-- data-proxy-url="https://proxy.scalar.com" -->
     <script
       id="api-reference"
-      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
-      data-proxy-url="https://proxy.scalar.com"></script>
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"></script>
     <!-- You can also set a full configuration object like this -->
     <!-- easier for nested objects -->
     <script>


### PR DESCRIPTION
Currently, the live CDN e2e tests are failing. Do not use the proxy to pass the tests while we fix proxy bugs and examples. 