### PR TITLE
fix: webhook operation parsing

### DIFF
--- a/.changeset/poor-tips-develop.md
+++ b/.changeset/poor-tips-develop.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: webhook operation parsing

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -89,7 +89,7 @@ const transformResult = (originalSchema: ResolvedOpenAPI.Document): Spec => {
       Object.keys(schema.webhooks?.[name] ?? {}) as OpenAPIV3_1.HttpMethods[]
     ).forEach((httpVerb) => {
       const originalWebhook =
-        (schema.webhooks?.[name] as (OpenAPIV3_1.PathItemObject[typeof httpVerb]) & {
+        (schema.webhooks?.[name][httpVerb] as (OpenAPIV3_1.PathItemObject[typeof httpVerb]) & {
           'x-internal'?: boolean
         })
 


### PR DESCRIPTION
**Problem**
Currently, OpenAPI 3.1 webhooks do not render correctly. See issue https://github.com/scalar/scalar/issues/1811

**Explanation**
This happens because when transforming webhooks in the `parse` function from `@scalar/api-reference`, the originalWebhook variable is assigned to the `PathItem` object instead of the `Operation`, as implied by [this cast](https://github.com/scalar/scalar/blob/22bb58f97660b28a797d0d52f21c33e68fd079ab/packages/api-reference/src/helpers/parse.ts#L91-L94).

**Solution**
With this PR, the originalWebhook variable is correctly assigned to the Operation.

**Note:** the PathItem also has summary and description fields. It might be useful to fall back to them if they are missing in the operation.
