### PR TITLE
fix: remove reliance of ifm colour system for docusaurus sidebar heading type

### DIFF
--- a/.changeset/little-lies-prove.md
+++ b/.changeset/little-lies-prove.md
@@ -1,0 +1,5 @@
+---
+"@scalar/docusaurus": patch
+---
+
+fix: remove ifm colour system from sidebar hea

--- a/packages/docusaurus/src/theme.css
+++ b/packages/docusaurus/src/theme.css
@@ -87,10 +87,10 @@ html[data-theme='dark'] .t-doc__sidebar {
 }
 /* advanced */
 html[data-theme='light'] {
-  --scalar-color-green: var(--ifm-color-success, #00a400);
-  --scalar-color-red: var(--ifm-color-danger, #fa383e);
-  --scalar-color-yellow: var(--ifm-color-warning, #ffba00);
-  --scalar-color-blue: var(--ifm-color-info-darkest, #2554a0);
+  --scalar-color-green: #00a400;
+  --scalar-color-red: #fa383e;
+  --scalar-color-yellow: #ffba00;
+  --scalar-color-blue: #0082d0;
   --scalar-color-orange: #fb892c;
   --scalar-color-purple: #5203d1;
   --scalar-docsearch-key: var(
@@ -105,10 +105,10 @@ html[data-theme='light'] {
   );
 }
 html[data-theme='dark'] {
-  --scalar-color-green: var(--ifm-color-success, #00a400);
-  --scalar-color-red: var(--ifm-color-danger, #fa383e);
-  --scalar-color-yellow: var(--ifm-color-warning, #ffba00);
-  --scalar-color-blue: var(--ifm-color-info-light, #3578e5);
+  --scalar-color-green: #00a400;
+  --scalar-color-red: #fa383e;
+  --scalar-color-yellow: #ffba00;
+  --scalar-color-blue: #3578e5;
   --scalar-color-orange: #ff8d4d;
   --scalar-color-purple: #b191f9;
   --scalar-docsearch-key: var(
@@ -124,22 +124,6 @@ html[data-theme='dark'] {
 }
 .references-rendered .section-header {
   color: var(--ifm-heading-color, var(--scalar-color-1));
-}
-.sidebar-heading-type {
-  font-size: 10px !important;
-  line-height: 16px !important;
-  padding: 1px 3px !important;
-}
-html[data-theme='light'] .sidebar-heading.active_page .sidebar-heading-type {
-  background: white !important;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-html[data-theme='dark'] .sidebar-heading.active_page .sidebar-heading-type {
-  background: rgba(255, 255, 255, 0.14) !important;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-.sidebar-heading.active_page .sidebar-heading-type:after {
-  display: none;
 }
 .references-rendered .section-container:nth-of-type(2) {
   border-top: none !important;


### PR DESCRIPTION
fixes https://github.com/scalar/scalar/issues/1808

unfortunately pulling in colours from Docusaurus themes doesn't work _perfectly_ so we need to rely on our own variables for sidebar heading types 