### PR TITLE
fix: add support for union types in getExampleFromSchema

### DIFF
--- a/.changeset/smooth-jeans-protect.md
+++ b/.changeset/smooth-jeans-protect.md
@@ -2,4 +2,4 @@
 "@scalar/oas-utils": patch
 ---
 
-fix: add support for union types in getExampleFromSchema
+feat: union types in getExampleFromSchema

--- a/.changeset/smooth-jeans-protect.md
+++ b/.changeset/smooth-jeans-protect.md
@@ -1,0 +1,5 @@
+---
+"@scalar/oas-utils": patch
+---
+
+fix: add support for union types in getExampleFromSchema

--- a/packages/oas-utils/src/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.test.ts
@@ -35,6 +35,22 @@ describe('getExampleFromSchema', () => {
     ).toMatchObject('')
   })
 
+  it('uses example value for first type in non-null union types', () => {
+    expect(
+      getExampleFromSchema({
+        type: ['string', 'number'],
+      }),
+    ).toMatchObject('')
+  })
+
+  it('uses null for nullable union types', () => {
+    expect(
+      getExampleFromSchema({
+        type: ['string', 'null'],
+      }),
+    ).toBeNull()
+  })
+
   it('sets example values', () => {
     expect(
       getExampleFromSchema({

--- a/packages/oas-utils/src/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.ts
@@ -258,6 +258,19 @@ export const getExampleFromSchema = (
     return example
   }
 
+  // Check if schema is a union type
+  if (Array.isArray(schema.type)) {
+    // Return null if the type is nullable
+    if (schema.type.includes('null')) {
+      return null
+    }
+    // Return an example for the first type in the union
+    const exampleValue = exampleValues[schema.type[0]]
+    if (exampleValue !== undefined) {
+      return exampleValue
+    }
+  }
+
   // Warn if the type is unknown …
   console.warn(`[getExampleFromSchema] Unknown property type "${schema.type}".`)
 


### PR DESCRIPTION
**Problem**
Currently, Scalar shows a warning like this when the spec declares union types:
```
[getExampleFromSchema] Unknown property type "string,null".
```

**Explanation**
This happens because there is no explicit support for union types in `getExampleFromSchema`. See section [7.6.1](https://json-schema.org/draft/2020-12/json-schema-core#section-7.6.1) of the JSON Schema spec for reference.

**Solution**
With this PR, `getExampleFromSchema` will understand union types and return null for nullable unions or an example for the first types otherwise. Let me know if this makes sense for you.
