### PR TITLE
fix: response body does not show a preview when the content-type is undefined, fix #1818

### DIFF
--- a/.changeset/gold-peas-report.md
+++ b/.changeset/gold-peas-report.md
@@ -1,0 +1,5 @@
+---
+"@scalar/oas-utils": patch
+---
+
+fix: response body does not show a preview when the content-type is undefined

--- a/packages/oas-utils/src/normalizeMimeType.ts
+++ b/packages/oas-utils/src/normalizeMimeType.ts
@@ -1,6 +1,16 @@
 import type { ContentType } from './types'
 
-export function normalizeMimeType(contentType: string) {
+/**
+ * Normalizes a MIME type to a standard format.
+ *
+ * Input: application/problem+json; charset=utf-8
+ * Output: application/json
+ */
+export function normalizeMimeType(contentType?: string) {
+  if (typeof contentType !== 'string') {
+    return undefined
+  }
+
   return (
     contentType
       // Remove '; charset=utf-8'

--- a/packages/oas-utils/src/normalizeMimeTypeObject.ts
+++ b/packages/oas-utils/src/normalizeMimeTypeObject.ts
@@ -17,12 +17,19 @@ export function normalizeMimeTypeObject(content?: Record<ContentType, any>) {
   }
 
   Object.keys(newContent).forEach((key) => {
-    // Example: 'application/problem+json; charset=utf-8'
-
+    // Input: 'application/problem+json; charset=utf-8'
+    // Output: 'application/json'
     const newKey = normalizeMimeType(key)
 
+    // We need a new key to replace the old one
+    if (newKey === undefined) {
+      return
+    }
+
+    // Move the content
     newContent[newKey] = newContent[key as ContentType]
 
+    // Remove the old key
     if (key !== newKey) {
       delete newContent[key as ContentType]
     }


### PR DESCRIPTION
Currently, the response body preview doesn’t show up when the content-type header isn’t set. That’s bad.

This PR makes sure it’ll still work even if the content-type header isn’t set.

See #1818