### PR TITLE
ci: use local cli, instead of the one published on npm

### DIFF
--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -14,11 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
       - name: Format OpenAPI File
         run: pnpm @scalar/cli format ../../packages/galaxy/src/specifications/3.1.yaml
       - name: Validate OpenAPI File

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
       - name: Format OpenAPI File
         run: pnpm @scalar/cli format ../../packages/galaxy/src/specifications/3.1.yaml
       - name: Validate OpenAPI File

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -17,10 +17,13 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 8
-      - name: Use Node.js
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
       - name: Format OpenAPI File
         run: pnpm @scalar/cli format ../../packages/galaxy/src/specifications/3.1.yaml
       - name: Validate OpenAPI File

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -24,6 +24,10 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
+      - name: Turborepo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+      - name: Build
+        run: pnpm turbo build
       - name: Format OpenAPI File
         run: pnpm @scalar/cli format ../../packages/galaxy/src/specifications/3.1.yaml
       - name: Validate OpenAPI File

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           node-version: 20
       - name: Format OpenAPI File
-        run: npx @scalar/cli format ./packages/galaxy/src/specifications/3.1.yaml
+        run: pnpm @scalar/cli format ../../packages/galaxy/src/specifications/3.1.yaml
       - name: Validate OpenAPI File
-        run: npx @scalar/cli validate ./packages/galaxy/src/specifications/3.1.yaml
+        run: pnpm @scalar/cli validate ../../packages/galaxy/src/specifications/3.1.yaml
       - name: Update Scalar Sandbox (https://sandbox.scalar.com/e/MeCHQ)
         if: github.ref == 'refs/heads/main'
-        run: npx @scalar/cli share ./packages/galaxy/src/specifications/3.1.yaml --token=${{ secrets.SANDBOX_TOKEN }}
+        run: pnpm @scalar/cli share ../../packages/galaxy/src/specifications/3.1.yaml --token=${{ secrets.SANDBOX_TOKEN }}
         env:
           SANDBOX_TOKEN: ${{ secrets.SANDBOX_TOKEN }}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -189,9 +189,9 @@ jobs:
         with:
           node-version: 20
       - name: Validate OpenAPI File
-        # Replace `./my-openapi-file.json` with the correct path and filename for your project.
+        # Replace `./my-openapi-file.yaml` with the correct path and filename for your project.
         # Or: run `npx @scalar/cli init` and add the config file to your repository.
-        run: npx @scalar/cli validate ./my-openapi-file.json
+        run: npx @scalar/cli validate ./my-openapi-file.yaml
 ```
 
 ## Development


### PR DESCRIPTION
We’ve recently had an issue in CI, where we’ve added a new feature to the CLI workflow, but it wasn’t available - because it used the published version on npm and not the local version.

This PR changes the CLI CI workflow to use the local CLI. This should also help to detect bugs with the CLI earlier. :)