### PR TITLE
feat: scalar button component type prop

### DIFF
--- a/.changeset/yellow-turkeys-wash.md
+++ b/.changeset/yellow-turkeys-wash.md
@@ -1,0 +1,5 @@
+---
+"@scalar/components": patch
+---
+
+feat: set type prop in scalar button component

--- a/packages/components/src/components/ScalarButton/ScalarButton.stories.ts
+++ b/packages/components/src/components/ScalarButton/ScalarButton.stories.ts
@@ -17,6 +17,10 @@ const meta = {
       control: 'select',
       options: ['solid', 'outlined', 'ghost', 'danger'],
     },
+    type: {
+      control: 'select',
+      options: ['button', 'submit', 'reset'],
+    },
   },
   render: (args) => ({
     components: { ScalarButton },

--- a/packages/components/src/components/ScalarButton/ScalarButton.vue
+++ b/packages/components/src/components/ScalarButton/ScalarButton.vue
@@ -15,11 +15,13 @@ withDefaults(
     loading?: LoadingState
     size?: Variants['size']
     variant?: Variants['variant']
+    type?: 'button' | 'submit' | 'reset'
   }>(),
   {
     fullWidth: false,
     size: 'md',
     variant: 'solid',
+    type: 'button',
   },
 )
 
@@ -42,7 +44,7 @@ const attrs = computed(() => {
         `${attrs.class}`,
       )
     "
-    type="button">
+    :type="type">
     <div
       v-if="$slots.icon"
       class="mr-2 h-4 w-4">


### PR DESCRIPTION
this pr adds a type prop to the scalar button component in order to be able to use it as a `submit` action within a form for instance, along the addition of the `reset` type
