### PR TITLE
fix: search results empty state shows empty string

### DIFF
--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultList.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultList.vue
@@ -24,10 +24,7 @@ const attrs = computed(() => {
       name="noResults">
       <div class="flex flex-col items-center gap-2 px-3 py-4">
         <div class="rotate-90 text-lg font-bold">:(</div>
-        <div class="text-sm font-medium text-fore-2">
-          No results found
-          <template v-if="$slots.query">for "<slot name="query" />"</template>
-        </div>
+        <div class="text-sm font-medium text-fore-2">No results found</div>
       </div>
     </slot>
     <slot />


### PR DESCRIPTION
The new empty state for the search results shows an empty string "" when there’s nothing loaded.

Actually, I think it’s nicer to not repeat the search string anyway.

Feel free to close the PR if you disagree @cameronrohani.

**Before**
<img width="625" alt="Screenshot 2024-05-22 at 11 39 39" src="https://github.com/scalar/scalar/assets/1577992/e94d2d8a-8f1f-40b6-b46f-c2249ae7be3b">

**After**
<img width="596" alt="Screenshot 2024-05-22 at 11 40 29" src="https://github.com/scalar/scalar/assets/1577992/1380c2d9-66cc-4eeb-a9e3-2454938ddba8">