### PR TITLE
fix: text transform on all top level sidebar items

### DIFF
--- a/.changeset/plenty-poems-scream.md
+++ b/.changeset/plenty-poems-scream.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: text transform folder as option + remove transforms from top level items

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -137,9 +137,6 @@ const onAnchorClick = async (ev: Event) => {
   </li>
 </template>
 <style scoped>
-[data-sidebar-type] > .sidebar-heading {
-  text-transform: uppercase;
-}
 .sidebar-heading {
   display: flex;
   gap: 6px;
@@ -301,5 +298,6 @@ const onAnchorClick = async (ev: Event) => {
 }
 .sidebar-group-item__folder {
   color: var(--scalar-sidebar-color-1, var(--scalar-color-1));
+  text-transform: var(--scalar-tag-text-transform, initial);
 }
 </style>


### PR DESCRIPTION
Allow text transform of tags with 

new `--scalar-tag-text-transform` variable

remove text transform from all top level items 