### PR TITLE
fix: indentation bug on groups

### DIFF
--- a/.changeset/breezy-apples-rhyme.md
+++ b/.changeset/breezy-apples-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: indentation bug on groups

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -103,7 +103,7 @@ onMounted(() => {
                   }
                 ">
                 <template v-if="group.children && group.children?.length > 0">
-                  <SidebarGroup :level="2">
+                  <SidebarGroup :level="1">
                     <template
                       v-for="child in group.children"
                       :key="child.id">


### PR DESCRIPTION
before:

<img width="276" alt="image" src="https://github.com/scalar/scalar/assets/6176314/7d410956-8130-4988-8082-c0f5a1f5eb7f">


after:
<img width="288" alt="image" src="https://github.com/scalar/scalar/assets/6176314/27c0f0b8-2fb8-4b11-9e3d-04b0cf48cf33">
