### PR TITLE
fix: always return html vs error rendering

### DIFF
--- a/.changeset/gentle-ducks-itch.md
+++ b/.changeset/gentle-ducks-itch.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: always return html vs error rendering

--- a/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
+++ b/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
@@ -28,7 +28,6 @@ const mediaType = computed(() => {
 
 // Determine the CodeMirror language based on the media type
 const codeMirrorLanguage = computed((): string | undefined => {
-  console.log(mediaType.value)
   if (mediaType.value === 'application/json') {
     return 'json'
   }

--- a/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
+++ b/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
@@ -28,6 +28,7 @@ const mediaType = computed(() => {
 
 // Determine the CodeMirror language based on the media type
 const codeMirrorLanguage = computed((): string | undefined => {
+  console.log(mediaType.value)
   if (mediaType.value === 'application/json') {
     return 'json'
   }
@@ -40,7 +41,8 @@ const codeMirrorLanguage = computed((): string | undefined => {
     return 'html'
   }
 
-  return undefined
+  // let's just always return html vs not rendering anything
+  return 'html'
 })
 
 // Pretty print JSON


### PR DESCRIPTION
before:
<img width="1437" alt="image" src="https://github.com/scalar/scalar/assets/6176314/63a02878-2e0c-4eca-9c57-6d3ea64b1781">


after:

<img width="701" alt="image" src="https://github.com/scalar/scalar/assets/6176314/360e59de-aeba-4080-a512-c8e577ab3c3e">
