### PR TITLE
feat: create esm javascript build docs

### DIFF
--- a/examples/esm-api-reference/index.html
+++ b/examples/esm-api-reference/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/favicon.svg" />
+    <link
+      rel="icon alternate"
+      type="image/png"
+      href="/favicon.png" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0" />
+    <title>Scalar API Reference</title>
+  </head>
+  <style>
+    body {
+      max-height: 100dvh;
+      overflow: hidden;
+      display: flex;
+      margin: 0;
+      flex-direction: column;
+    }
+  </style>
+  <body>
+    <div id="root"></div>
+    <script
+      type="module"
+      src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/esm-api-reference/package.json
+++ b/examples/esm-api-reference/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@scalar-examples/esm-api-reference",
+  "description": "ESM example for Scalar References",
+  "license": "MIT",
+  "author": "Scalar (https://github.com/scalar)",
+  "homepage": "https://github.com/scalar/scalar",
+  "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/esm-api-reference"
+  },
+  "keywords": [
+    ""
+  ],
+  "version": "0.0.1",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "vite build && pnpm types:build && tsc-alias -p tsconfig.build.json",
+    "dev": "vite",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
+    "preview": "vite preview",
+    "test": "vitest",
+    "types:build": "tsc -p tsconfig.build.json",
+    "types:check": "tsc --noEmit --skipLibCheck --composite false"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    "import": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "module": "dist/index.js",
+  "dependencies": {
+    "@scalar/api-reference": "workspace:*",
+    "@scalar/galaxy": "workspace:*"
+  },
+  "devDependencies": {
+    "tsc-alias": "^1.8.8",
+    "vite": "^5.2.10"
+  }
+}

--- a/examples/esm-api-reference/src/main.ts
+++ b/examples/esm-api-reference/src/main.ts
@@ -1,0 +1,30 @@
+import { createScalarReferences } from '@scalar/api-reference'
+import content from '@scalar/galaxy/latest.yaml?raw'
+
+const el = document.getElementById('root')
+console.log(el)
+
+const references = createScalarReferences(el, {
+  spec: { content },
+})
+
+/** Change the title to show dynamic updates */
+const galaxy: string = content
+const universe = content.replace(
+  'title: Scalar Galaxy',
+  'title: Scalar Universe',
+)
+let activeContent = galaxy
+
+setInterval(() => {
+  activeContent = activeContent === galaxy ? universe : galaxy
+  references.updateSpec({
+    content: activeContent,
+  })
+}, 1500)
+
+let isDark = false
+setInterval(() => {
+  isDark = !isDark
+  references.updateConfig({ darkMode: isDark })
+}, 3000)

--- a/examples/esm-api-reference/tsconfig.build.json
+++ b/examples/esm-api-reference/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["dist", "test", "vite.config.ts", "**/*.test.ts"],
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/"
+  }
+}

--- a/examples/esm-api-reference/tsconfig.json
+++ b/examples/esm-api-reference/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["vite/client"]
+  }
+}

--- a/examples/esm-api-reference/vite.config.ts
+++ b/examples/esm-api-reference/vite.config.ts
@@ -1,0 +1,16 @@
+import { URL, fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+
+import pkg from './package.json'
+
+export default defineConfig({
+  plugins: [],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  server: {
+    port: 5041,
+  },
+})

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -2,7 +2,7 @@
 import { useAuthenticationStore } from '@scalar/api-client'
 import { migrateThemeVariables } from '@scalar/themes'
 import { createHead, useSeoMeta } from 'unhead'
-import { computed, toRef, watch } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 
 import { useDarkModeState, useHttpClients, useReactiveSpec } from '../hooks'
 import type { ReferenceConfiguration, ReferenceProps } from '../types'
@@ -26,6 +26,16 @@ const customCss = computed(() => {
 
 watch(customCss, () => console.log(customCss.value))
 
+// For non-vue integrations we expose an api to update the props dynamically
+const localConfig = ref<ReferenceConfiguration>(props.configuration ?? {})
+watch(
+  () => props.configuration,
+  () => {
+    localConfig.value = props.configuration ?? {}
+  },
+  { deep: true },
+)
+
 // Set defaults as needed on the provided configuration
 const configuration = computed<ReferenceConfiguration>(() => ({
   spec: {
@@ -37,7 +47,7 @@ const configuration = computed<ReferenceConfiguration>(() => ({
   theme: 'default',
   showSidebar: true,
   isEditable: false,
-  ...props.configuration,
+  ...localConfig.value,
   customCss: customCss.value,
 }))
 

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -2,7 +2,7 @@
 import { useAuthenticationStore } from '@scalar/api-client'
 import { migrateThemeVariables } from '@scalar/themes'
 import { createHead, useSeoMeta } from 'unhead'
-import { computed, ref, toRef, watch } from 'vue'
+import { computed, toRef, watch } from 'vue'
 
 import { useDarkModeState, useHttpClients, useReactiveSpec } from '../hooks'
 import type { ReferenceConfiguration, ReferenceProps } from '../types'
@@ -19,22 +19,20 @@ const { toggleDarkMode, isDark } = useDarkModeState(
   props.configuration?.darkMode,
 )
 
+/** Update the dark mode state when props change */
+watch(
+  () => props.configuration?.darkMode,
+  (_isDark) => {
+    if (_isDark !== isDark.value) toggleDarkMode()
+  },
+)
+
 const customCss = computed(() => {
   if (!props.configuration?.customCss) return undefined
   return migrateThemeVariables(props.configuration?.customCss)
 })
 
 watch(customCss, () => console.log(customCss.value))
-
-// For non-vue integrations we expose an api to update the props dynamically
-const localConfig = ref<ReferenceConfiguration>(props.configuration ?? {})
-watch(
-  () => props.configuration,
-  () => {
-    localConfig.value = props.configuration ?? {}
-  },
-  { deep: true },
-)
 
 // Set defaults as needed on the provided configuration
 const configuration = computed<ReferenceConfiguration>(() => ({
@@ -47,7 +45,7 @@ const configuration = computed<ReferenceConfiguration>(() => ({
   theme: 'default',
   showSidebar: true,
   isEditable: false,
-  ...localConfig.value,
+  ...props.configuration,
   customCss: customCss.value,
 }))
 

--- a/packages/api-reference/src/esm.ts
+++ b/packages/api-reference/src/esm.ts
@@ -5,29 +5,29 @@ import { objectMerge } from './helpers'
 import type { ReferenceConfiguration, SpecConfiguration } from './types'
 
 /** Initialize Scalar References and  */
-export function ScalarReferences(
+export function createScalarReferences(
   /** Element to mount the references to */
-  el: HTMLElement,
+  el: HTMLElement | null,
   /** Configuration object for Scalar References */
   initialConfig: ReferenceConfiguration,
   /**
    * Will attempt to mount the references immediately
    * For SSR this may need to be blocked and done client side
    */
-  mountOnInitialize: true,
+  mountOnInitialize = true,
 ) {
-  const config = reactive(initialConfig)
+  const configuration = reactive(initialConfig)
 
-  const app = createApp(ApiReference, config)
+  const app = createApp(ApiReference, { configuration })
 
-  function mount(mountLocation = el) {
-    if (!el) {
+  function mount(mountingEl = el) {
+    if (!mountingEl) {
       console.warn(
         'Invalid HTML element provided. Cannot mount Scalar References',
       )
       return
     }
-    app.mount(mountLocation)
+    app.mount(mountingEl)
   }
 
   if (mountOnInitialize) mount()
@@ -36,13 +36,13 @@ export function ScalarReferences(
     /** Update the configuration for a mounted reference */
     updateConfig(newConfig: ReferenceConfiguration, mergeConfigs = true) {
       if (mergeConfigs) {
-        Object.assign(config, newConfig)
+        Object.assign(configuration, newConfig)
       } else {
-        objectMerge(config, newConfig)
+        objectMerge(configuration, newConfig)
       }
     },
     updateSpec(spec: SpecConfiguration) {
-      config.spec = spec
+      configuration.spec = spec
     },
     /** Mount the references to a given element */
     mount,

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -6,7 +6,7 @@ export { default as RenderedReference } from './components/Content/Content.vue'
 export { default as SearchModal } from './components/SearchModal.vue'
 export { default as SearchButton } from './components/SearchButton.vue'
 export { default as GettingStarted } from './components/GettingStarted.vue'
-export { ScalarReferences } from './integration'
+export { createScalarReferences } from './esm'
 export { useReactiveSpec } from './hooks/useReactiveSpec'
 
 export * from './components/DarkModeToggle'

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -6,7 +6,7 @@ export { default as RenderedReference } from './components/Content/Content.vue'
 export { default as SearchModal } from './components/SearchModal.vue'
 export { default as SearchButton } from './components/SearchButton.vue'
 export { default as GettingStarted } from './components/GettingStarted.vue'
-
+export { ScalarReferences } from './integration'
 export { useReactiveSpec } from './hooks/useReactiveSpec'
 
 export * from './components/DarkModeToggle'

--- a/packages/api-reference/src/integration.ts
+++ b/packages/api-reference/src/integration.ts
@@ -1,0 +1,50 @@
+import { createApp, reactive } from 'vue'
+
+import ApiReference from './components/ApiReference.vue'
+import { objectMerge } from './helpers'
+import type { ReferenceConfiguration, SpecConfiguration } from './types'
+
+/** Initialize Scalar References and  */
+export function ScalarReferences(
+  /** Element to mount the references to */
+  el: HTMLElement,
+  /** Configuration object for Scalar References */
+  initialConfig: ReferenceConfiguration,
+  /**
+   * Will attempt to mount the references immediately
+   * For SSR this may need to be blocked and done client side
+   */
+  mountOnInitialize: true,
+) {
+  const config = reactive(initialConfig)
+
+  const app = createApp(ApiReference, config)
+
+  function mount(mountLocation = el) {
+    if (!el) {
+      console.warn(
+        'Invalid HTML element provided. Cannot mount Scalar References',
+      )
+      return
+    }
+    app.mount(mountLocation)
+  }
+
+  if (mountOnInitialize) mount()
+
+  return {
+    /** Update the configuration for a mounted reference */
+    updateConfig(newConfig: ReferenceConfiguration, mergeConfigs = true) {
+      if (mergeConfigs) {
+        Object.assign(config, newConfig)
+      } else {
+        objectMerge(config, newConfig)
+      }
+    },
+    updateSpec(spec: SpecConfiguration) {
+      config.spec = spec
+    },
+    /** Mount the references to a given element */
+    mount,
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,22 @@ importers:
         specifier: ^1.3.1
         version: 1.5.0(@types/node@20.11.22)(terser@5.30.0)
 
+  examples/esm-api-reference:
+    dependencies:
+      '@scalar/api-reference':
+        specifier: workspace:*
+        version: link:../../packages/api-reference
+      '@scalar/galaxy':
+        specifier: workspace:*
+        version: link:../../packages/galaxy
+    devDependencies:
+      tsc-alias:
+        specifier: ^1.8.8
+        version: 1.8.8
+      vite:
+        specifier: ^5.2.10
+        version: 5.2.10(@types/node@20.11.22)(terser@5.30.0)
+
   examples/express-api-reference:
     dependencies:
       '@scalar/express-api-reference':

--- a/scripts/bootstrap-package/bootstrap-package.ts
+++ b/scripts/bootstrap-package/bootstrap-package.ts
@@ -76,7 +76,7 @@ if (dirs.includes(name)) {
     JSON.stringify(newPackageFile, null, 2),
   )
 
-  await fs.writeFile(`${newDirName}/index.ts`, '')
+  await fs.writeFile(`${newDirName}/src/index.ts`, '')
 
   console.log(`\x1b[33m Package created! Checkout ./packages/${name} \x1b[0m`)
 }


### PR DESCRIPTION
Adds an ESM integration for references. 

Improvements and Future Work:
- The mounted references are always 100% viewport height. Ideally it should be flex and just fill its parent container
- Other integrations should likely use the exported function as their main entrypoint. Standalone should only be used for the script tag integrations (and not in bundled code). 
