### PR TITLE
feat: add support for x-additionalPropertiesName

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -27,7 +27,10 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     <div
       v-if="additional"
       class="property-additional">
-      additional properties
+      <template v-if="value?.['x-additionalPropertiesName']">
+        {{ value['x-additionalPropertiesName'] }}
+      </template>
+      <template v-else> additional properties </template>
     </div>
     <div
       v-if="value?.deprecated"


### PR DESCRIPTION
**Problem**
Currently, scalar does not have support for the [x-additionalPropertiesName extension](https://redocly.com/docs/api-reference-docs/specification-extensions/x-additional-properties-name/) which redocly uses to support displaying a more descriptive property name for `additionalProperties`.

**Explanation**
This happens because there is currently no logic for this and scalar instead defaults to `additional properties` for the property heading.

**Solution**
With this PR `x-additionalPropertiesName` is supported and overrides the default `additional properties` heading if provided.

***Example Using x-additionalPropertiesName***
![image](https://github.com/scalar/scalar/assets/8587567/7b92324a-4e79-411e-ab3a-b294a0f7c543)

