### PR TITLE
feat: support for `<abbr />` tags, fix #1850

### DIFF
--- a/.changeset/lazy-poems-study.md
+++ b/.changeset/lazy-poems-study.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: support abbr html tag

--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -27,6 +27,22 @@ const html = ref<string>('')
 
 const disallowedTagNames = props.withImages ? [] : ['img', 'picture']
 
+const extendedSchema = {
+  ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames || []).filter(
+      // Removes disallowed tags
+      (tag) => !disallowedTagNames.includes(tag),
+    ),
+    // Adds support for <abbr>
+    'abbr',
+  ],
+  attributes: {
+    ...defaultSchema.attributes,
+    abbr: ['title'],
+  },
+}
+
 watch(
   () => props.value,
   async () => {
@@ -40,14 +56,8 @@ watch(
       .use(remarkRehype, { allowDangerousHtml: true })
       // Creates a HTML AST
       .use(rehypeRaw)
-      // Removes disallowed tags
-      .use(rehypeSanitize, {
-        ...defaultSchema,
-        // Makes it even more strict
-        tagNames: defaultSchema.tagNames?.filter(
-          (tag) => !disallowedTagNames.includes(tag),
-        ),
-      })
+      // Extends capabilities
+      .use(rehypeSanitize, extendedSchema)
       // Syntax highlighting
       .use(rehypeHighlight, {
         detect: true,
@@ -212,6 +222,9 @@ onServerPrefetch(async () => await sleep(1))
 }
 .markdown :deep(del) {
   text-decoration: line-through;
+}
+.markdown :deep(abbr[title]) {
+  text-decoration: underline dotted;
 }
 .markdown :deep(code) {
   font-family: var(--scalar-font-code);


### PR DESCRIPTION
this pr adds the support of `abbr` HTML tag in api reference, as seen below:

<img width="594" alt="image" src="https://github.com/scalar/scalar/assets/14966155/703feadf-2808-406c-9ed2-90efa52b40f1">

