### PR TITLE
fix: CSS warning

### DIFF
--- a/packages/api-client/src/components/SimpleTable/SimpleCell.vue
+++ b/packages/api-client/src/components/SimpleTable/SimpleCell.vue
@@ -45,7 +45,6 @@ withDefaults(
 .simple-row:first-of-type .simple-cell:first-of-type {
   border-top-left-radius: var(--scalar-radius);
 }
-border-top-left-radius: var(--scalar-radius);
 .simple-cell a {
   color: var(--scalar-color-1) !important;
 }


### PR DESCRIPTION
> [WARNING] Unexpected "var(" [css-syntax-error]

```diff
.simple-row:first-of-type .simple-cell:first-of-type {
  border-top-left-radius: var(--scalar-radius);
}
-border-top-left-radius: var(--scalar-radius);
.simple-cell a {
  color: var(--scalar-color-1) !important;
}
```

👍 