### PR TITLE
feat: copy server url with replaced variables

### DIFF
--- a/.changeset/neat-singers-cry.md
+++ b/.changeset/neat-singers-cry.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: copy server URL with replaced variables

--- a/packages/api-reference/src/components/Content/BaseUrl/ServerItem.vue
+++ b/packages/api-reference/src/components/Content/BaseUrl/ServerItem.vue
@@ -28,13 +28,26 @@ const formattedServerUrl = computed(() => {
     }</span>`
   })
 })
+
+/**
+ * We don’t want to just replace all variables, but keep variables without a value.
+ *
+ * Examples:
+ *  - `https://example.com/{foo}` (without foo) should return `https://example.com/{foo}`
+ *  - `https://example.com/{foo}` (with foo: 123) should return `https://example.com/123`
+ *
+ * So we just what we did above, but strip the HTML.
+ */
+const plainTextUrl = computed(() =>
+  formattedServerUrl.value.replace(/(<([^>]+)>)/gi, ''),
+)
 </script>
 <template>
   <template v-if="value">
     <a
       class="base-url"
       :title="value.description"
-      @click="copyToClipboard(value.url)"
+      @click="copyToClipboard(plainTextUrl)"
       v-html="formattedServerUrl" />
   </template>
 </template>


### PR DESCRIPTION
If you click on the server URL, it’s copied to the clipboard. Even if it has variables like `https://example.com/{version}`.

With this example, we try to replace the variables first, but keep the placeholders if the variables aren’t defined.

 *  `https://example.com/{foo}` (without foo) copies `https://example.com/{foo}`
 *  `https://example.com/{foo}` (with foo: 123) copies `https://example.com/123`
 
<img width="579" alt="Screenshot 2024-05-27 at 15 23 56" src="https://github.com/scalar/scalar/assets/1577992/1ef40850-a36d-4831-a6bd-06f1b98a68b3">
