### PR TITLE
feat(api-reference): support for constants in schemas, fix #1846

### DIFF
--- a/.changeset/beige-timers-report.md
+++ b/.changeset/beige-timers-report.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: support for constants in schemas

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -64,8 +64,8 @@ const generatePropertyDescription = function (property?: Record<string, any>) {
   return descriptions[property.type][property.format || '_default']
 }
 
-const getEnumFromValue = function (value?: Record<string, any>): any[] | null {
-  return value?.enum || value?.items?.enum || null
+const getEnumFromValue = function (value?: Record<string, any>): any[] | [] {
+  return value?.enum || value?.items?.enum || []
 }
 
 const rules = ['oneOf', 'anyOf', 'allOf', 'not']
@@ -82,7 +82,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     ]">
     <SchemaPropertyHeading
       :additional="additional"
-      :enum="!!getEnumFromValue(value)"
+      :enum="getEnumFromValue(value).length > 1"
       :required="required"
       :value="value">
       <template
@@ -113,7 +113,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     </div>
     <!-- Enum -->
     <div
-      v-if="getEnumFromValue(value)"
+      v-if="getEnumFromValue(value)?.length > 1"
       class="property-enum">
       <ul class="property-enum-values">
         <li

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -43,7 +43,15 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
       required
     </div>
     <div
-      v-if="value?.type"
+      v-if="value?.const || (value?.enum && value.enum.length === 1)"
+      class="property-const">
+      <SchemaPropertyDetail truncate>
+        <template #prefix>const:</template>
+        {{ value.const ?? value.enum[0] }}
+      </SchemaPropertyDetail>
+    </div>
+    <div
+      v-else-if="value?.type"
       class="property-details">
       <SchemaPropertyDetail v-if="additional">
         <template #prefix>key:</template>
@@ -156,5 +164,9 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
   align-items: center;
 
   min-width: 0;
+}
+
+.property-const {
+  color: var(--scalar-color-1);
 }
 </style>


### PR DESCRIPTION
Currently, we don't support constants

This PR adds support for constants, and if an enum with just one possible value is given, we treat it like a const (because that’s what people where using it for).

More context in #1846

**Preview**

<img width="583" alt="Screenshot 2024-05-27 at 15 43 00" src="https://github.com/scalar/scalar/assets/1577992/1e96481f-4a69-4560-9eb9-db325aa494dd">

**Example**

```yaml
openapi: 3.1.0
info:
  title: Scalar Galaxy
  version: 1.0.0
components:
  schemas:
    Planet:
      type: object
      properties:
        exists: 
          type: string
          enum: ['yes']
          default: 'yes'
        size: 
          type: string
          enum: ['huge', 'extra huge']
          default: 'huge' 
        shape: 
          const: 'flat'

```