### PR TITLE
feat(api-reference): support x-enumDescriptions

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -1,5 +1,11 @@
 <script lang="ts" setup>
 import { MarkdownRenderer } from '../../MarkdownRenderer'
+import {
+  SimpleCell,
+  SimpleHeader,
+  SimpleRow,
+  SimpleTable,
+} from '../../SimpleTable'
 import Schema from './Schema.vue'
 import SchemaPropertyHeading from './SchemaPropertyHeading.vue'
 
@@ -115,14 +121,35 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     <div
       v-if="getEnumFromValue(value)?.length > 1"
       class="property-enum">
-      <ul class="property-enum-values">
-        <li
-          v-for="enumValue in getEnumFromValue(value)"
-          :key="enumValue"
-          class="property-enum-value">
-          {{ enumValue }}
-        </li>
-      </ul>
+      <template v-if="value?.['x-enumDescriptions']">
+        <SimpleTable>
+          <SimpleRow>
+            <SimpleHeader>Value</SimpleHeader>
+            <SimpleHeader>Description</SimpleHeader>
+          </SimpleRow>
+          <SimpleRow
+            v-for="enumValue in getEnumFromValue(value)"
+            :key="enumValue">
+            <SimpleCell>
+              {{ enumValue }}
+            </SimpleCell>
+            <SimpleCell>
+              <MarkdownRenderer
+                :value="value['x-enumDescriptions'][enumValue]" />
+            </SimpleCell>
+          </SimpleRow>
+        </SimpleTable>
+      </template>
+      <template v-else>
+        <ul class="property-enum-values">
+          <li
+            v-for="enumValue in getEnumFromValue(value)"
+            :key="enumValue"
+            class="property-enum-value">
+            {{ enumValue }}
+          </li>
+        </ul>
+      </template>
     </div>
     <!-- Object -->
     <div


### PR DESCRIPTION
**Problem**
Currently, scalar does not have support for the [x-enumDescriptions extension](https://redocly.com/docs/api-reference-docs/specification-extensions/x-enum-descriptions/) which redocly uses to support displaying a table with individual descriptions for enum values.

**Explanation**
This happens because there is currently no support in scalar for this extension.

**Solution**
With this PR `x-enumDescriptions` is supported and displays a table with enum value -> description mappings when populated for an enum.

***Sample***
![image](https://github.com/scalar/scalar/assets/8587567/d3178582-97ca-423a-b9e6-e29e6f9c7218)

***Example OpenAPI***
```yaml
openapi: 3.1.0
info:
  title: Scalar Galaxy
  version: 1.0.0
components:
  schemas:
    User:
      type: object
      properties:
        status:
          type: string
          enum:
            - ACTIVE
            - INACTIVE
        role:
          type: string
          enum:
            - ADMIN
            - MEMBER
          x-enumDescriptions:
            ADMIN: Can do **all** of the things!
            MEMBER: Can do ~all~ _some_ things
```
