### PR TITLE
fix: api reference auth form style

### DIFF
--- a/.changeset/rare-lies-wink.md
+++ b/.changeset/rare-lies-wink.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: authentication card form style

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/CardFormGroup.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/CardFormGroup.vue
@@ -4,7 +4,7 @@
   </div>
 </template>
 <style scoped>
-:where(.card-form-group) {
+.card-form-group {
   display: flex;
 }
 </style>

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/CardFormTextInput.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/CardFormTextInput.vue
@@ -42,7 +42,7 @@ defineOptions({
   </div>
 </template>
 <style scoped>
-:where(.card-form-input) {
+.card-form-input {
   background: transparent;
   position: relative;
   width: 100%;

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeScopes.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeScopes.vue
@@ -87,7 +87,7 @@ const model = computed({
   </Listbox>
 </template>
 <style scoped>
-:where(.wrapper) {
+.wrapper {
   display: grid;
   border-color: inherit;
 }


### PR DESCRIPTION
**Problem**
authentication block style is broken as seen below:
<img width="785" alt="image" src="https://github.com/scalar/scalar/assets/14966155/c9eab336-ca3f-4d2a-8a0c-631867fc0154">

**Explanation**
lack of specificity using `where` is not maintaining style one reference is published. this pr is a proposal to remove `where` usage in order to ensure higher style specificity.
