### PR TITLE
feat(mock-server): http basic auth

### DIFF
--- a/.changeset/spicy-dodos-remain.md
+++ b/.changeset/spicy-dodos-remain.md
@@ -1,0 +1,5 @@
+---
+"@scalar/mock-server": patch
+---
+
+feat: http basic auth middleware

--- a/packages/api-client/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-client/src/helpers/getRequestFromAuthentication.ts
@@ -71,7 +71,6 @@ export function getRequestFromAuthentication(
       ? authentication.preferredSecurityScheme
       : Object.keys(operationSecurity?.[0] ?? {}).pop()
 
-  // We’re using a parsed OpenAPI file here, so let’s get rid of the `ReferenceObject` type
   const securityScheme =
     authentication.securitySchemes?.[operationSecurityKey ?? '']
 

--- a/packages/mock-server/src/utils/anyBasicAuthentication.ts
+++ b/packages/mock-server/src/utils/anyBasicAuthentication.ts
@@ -1,0 +1,25 @@
+import type { Context } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+
+/**
+ * Middleware to check for any basic authentication header
+ */
+export function anyBasicAuthentication() {
+  return async function (ctx: Context, next: () => Promise<void>) {
+    // Check if the request has an Authorization header
+    // Note: We don’t care *what* credentials are sent, though.
+    if (ctx.req.header('Authorization')?.startsWith('Basic ')) {
+      return await next()
+    }
+
+    // Unauthorized
+    throw new HTTPException(401, {
+      res: new Response('Unauthorized', {
+        status: 401,
+        headers: {
+          'WWW-Authenticate': 'Basic realm="Authentication Required"',
+        },
+      }),
+    })
+  }
+}

--- a/packages/mock-server/src/utils/authenticationRequired.ts
+++ b/packages/mock-server/src/utils/authenticationRequired.ts
@@ -1,0 +1,29 @@
+import type { OpenAPIV3 } from '@scalar/openapi-parser'
+
+/**
+ * Check whether the given security scheme key is in the `security` configuration for this operation.
+ **/
+export function authenticationRequired(
+  security?: OpenAPIV3.SecurityRequirementObject[],
+): boolean {
+  // If security is not defined, auth is not required.
+  if (!security) {
+    return false
+  }
+
+  // Don’t require auth if security is just an empty array []
+  if (Array.isArray(security) && !security.length) {
+    return false
+  }
+
+  // Includes empty object = auth is not required
+  if (
+    (security ?? []).some(
+      (securityRequirement) => !Object.keys(securityRequirement).length,
+    )
+  ) {
+    return false
+  }
+
+  return true
+}

--- a/packages/mock-server/src/utils/index.ts
+++ b/packages/mock-server/src/utils/index.ts
@@ -1,3 +1,3 @@
 export * from './findPreferredResponseKey'
 export * from './routeFromPath'
-export * from './authenticationRequired'
+export * from './isAuthenticationRequired'

--- a/packages/mock-server/src/utils/index.ts
+++ b/packages/mock-server/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './findPreferredResponseKey'
 export * from './routeFromPath'
+export * from './authenticationRequired'

--- a/packages/mock-server/src/utils/isAuthenticationRequired.ts
+++ b/packages/mock-server/src/utils/isAuthenticationRequired.ts
@@ -3,7 +3,7 @@ import type { OpenAPIV3 } from '@scalar/openapi-parser'
 /**
  * Check whether the given security scheme key is in the `security` configuration for this operation.
  **/
-export function authenticationRequired(
+export function isAuthenticationRequired(
   security?: OpenAPIV3.SecurityRequirementObject[],
 ): boolean {
   // If security is not defined, auth is not required.

--- a/packages/mock-server/src/utils/isBasicAuthenticationRequired.ts
+++ b/packages/mock-server/src/utils/isBasicAuthenticationRequired.ts
@@ -1,0 +1,27 @@
+import type {
+  OpenAPI,
+  OpenAPIV3_1,
+  ResolvedOpenAPI,
+} from '@scalar/openapi-parser'
+
+export function isBasicAuthenticationRequired(
+  operation: OpenAPI.Operation,
+  schema?: ResolvedOpenAPI.Document,
+) {
+  const allowedSecuritySchemes = operation.security?.map(
+    (securityScheme: OpenAPIV3_1.SecurityRequirementObject) => {
+      return Object.keys(securityScheme)[0]
+    },
+  )
+  // Check if one of them is HTTP Basic Auth
+  const httpBasicAuthIsRequired =
+    allowedSecuritySchemes?.findIndex((securitySchemeKey: string) => {
+      const securityScheme =
+        schema?.components?.securitySchemes?.[securitySchemeKey]
+
+      return (
+        securityScheme?.type === 'http' && securityScheme?.scheme === 'basic'
+      )
+    }) !== undefined
+  return httpBasicAuthIsRequired
+}

--- a/packages/mock-server/tests/authentication.test.ts
+++ b/packages/mock-server/tests/authentication.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMockServer } from '../src/createMockServer'
+
+describe('authentication', () => {
+  it('fails without credentials', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      security: [
+        {
+          basicAuth: [],
+        },
+      ],
+      paths: {
+        '/secret': {
+          get: {
+            security: [
+              {
+                basicAuth: [],
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          basicAuth: {
+            type: 'http',
+            schema: 'basic',
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/secret')
+
+    expect(response.status).toBe(401)
+  })
+
+  it('succeeds with credentials', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      security: [
+        {
+          basicAuth: [],
+        },
+      ],
+      paths: {
+        '/secret': {
+          get: {
+            security: [
+              {
+                basicAuth: [],
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          basicAuth: {
+            type: 'http',
+            schema: 'basic',
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/secret', {
+      headers: {
+        Authorization: `Basic ${btoa(`demo:secret`)}`,
+      },
+    })
+
+    expect(response.status).toBe(200)
+  })
+})

--- a/packages/mock-server/tests/authentication.test.ts
+++ b/packages/mock-server/tests/authentication.test.ts
@@ -3,6 +3,35 @@ import { describe, expect, it } from 'vitest'
 import { createMockServer } from '../src/createMockServer'
 
 describe('authentication', () => {
+  it('doesn’t require authentication', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/public': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/public')
+
+    expect(response.status).toBe(200)
+  })
+
   it('fails without credentials', async () => {
     const specification = {
       openapi: '3.1.0',
@@ -10,11 +39,6 @@ describe('authentication', () => {
         title: 'Hello World',
         version: '1.0.0',
       },
-      security: [
-        {
-          basicAuth: [],
-        },
-      ],
       paths: {
         '/secret': {
           get: {
@@ -35,7 +59,7 @@ describe('authentication', () => {
         securitySchemes: {
           basicAuth: {
             type: 'http',
-            schema: 'basic',
+            scheme: 'basic',
           },
         },
       },
@@ -57,11 +81,6 @@ describe('authentication', () => {
         title: 'Hello World',
         version: '1.0.0',
       },
-      security: [
-        {
-          basicAuth: [],
-        },
-      ],
       paths: {
         '/secret': {
           get: {
@@ -82,7 +101,7 @@ describe('authentication', () => {
         securitySchemes: {
           basicAuth: {
             type: 'http',
-            schema: 'basic',
+            scheme: 'basic',
           },
         },
       },

--- a/packages/mock-server/tests/authentication.test.ts
+++ b/packages/mock-server/tests/authentication.test.ts
@@ -113,7 +113,7 @@ describe('authentication', () => {
 
     const response = await server.request('/secret', {
       headers: {
-        Authorization: `Basic ${btoa(`demo:secret`)}`,
+        Authorization: `Basic ${Buffer.from(`demo:secret`).toString('base64')}`,
       },
     })
 


### PR DESCRIPTION
I missed a way to test authentication with our mock server today.

So, I’ve had to do a little midnight hack session and … add HTTP basic authentication to the mock server. :)