### PR TITLE
fix: small images destroy the layout

### DIFF
--- a/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
+++ b/packages/api-reference/src/components/MarkdownRenderer/MarkdownRenderer.vue
@@ -145,6 +145,7 @@ onServerPrefetch(async () => await sleep(1))
   overflow: hidden;
   border-radius: var(--scalar-radius);
   max-width: 100%;
+  display: block;
 }
 /* Don't add margin to the first block */
 .markdown :deep(> :first-child) {


### PR DESCRIPTION
Small images are displayed as inline content. Maybe we could set them to `display: block`?

**Before**
<img width="417" alt="Screenshot 2024-05-28 at 11 23 02" src="https://github.com/scalar/scalar/assets/1577992/526a85b9-a41f-4d12-a5d1-bc7ee17e573d">

**After**
<img width="464" alt="Screenshot 2024-05-28 at 11 23 10" src="https://github.com/scalar/scalar/assets/1577992/e13bae3e-9516-4e50-97e7-7f14190d7c14">
