### PR TITLE
fix: remove hardcoded dark-mode class from ExampleRequest

### DIFF
--- a/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
@@ -159,7 +159,7 @@ computed(() => {
 })
 </script>
 <template>
-  <Card class="dark-mode">
+  <Card>
     <CardHeader muted>
       <div class="request-header">
         <HttpMethod


### PR DESCRIPTION
**Problem**
Currently, the example request section renders as dark mode regardless of whether dark mode is enabled.

**Explanation**
This happens because a `dark-mode` class has been hardcoded on the `Card` component.

**Solution**
With this PR the dark mode setting is respected and the card renders properly in both light and dark mode.

***Example Before***
![image](https://github.com/scalar/scalar/assets/8587567/6dc32007-b751-4711-8d53-dcfc22a1f7ae)

***Example After Light***
![image](https://github.com/scalar/scalar/assets/8587567/296ddead-1efb-4461-ba92-bc64fbdc56da)

***Example After Dark***
![image](https://github.com/scalar/scalar/assets/8587567/1c0f7120-26d3-4c3f-b004-5cb10563588a)

