### PR TITLE
refactor: remove :where prefix in favor of cascade layers

### DIFF
--- a/.changeset/funny-snakes-kick.md
+++ b/.changeset/funny-snakes-kick.md
@@ -1,0 +1,5 @@
+---
+"@scalar/components": minor
+---
+
+refactor: remove :where prefix in favor of cascade layers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,7 @@ Here are all the prefixes you need to know:
 | ci       | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs) |
 | chore    | Other changes that don't modify src or test files                                                           |
 | revert   | Reverts a previous commit                                                                                   |
+
+## Styles and CSS Layers
+
+The Scalar packages use CSS cascade layers extensively to manage the priority of exported styles and to make it easy to override themes and component styles in projects consuming those packages. A load order for layers isn't specified by default because the contents layers have minimal overlap.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Most packages have a bunch of tests, mostly for all the helper functions we use.
 
 It’s worth to check the tests locally before sending contributions: `$ pnpm test`
 
-If you want to add a test and only run your test file, you can filter the test suite like this:  `$ pnpm test your-test`
+If you want to add a test and only run your test file, you can filter the test suite like this: `$ pnpm test your-test`
 
 ### Testing the CLI
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -113,9 +113,10 @@ export const extend = {
 } as const
 ```
 
-## Todo
+## CSS Layers
 
-- documentation
-- github actions for lint, types, tests, build, npm deployment
-- implementation (can remove more base style here)
-- host storybook
+This package exports its' tailwind styles in the following CSS cascade layers to make them easy to overwrite.
+
+- `scalar-base`: reset and normalize
+- `scalar-components`: complex component styles
+- `scalar-utilities`: utility styles like `flex`

--- a/packages/components/postcss.config.js
+++ b/packages/components/postcss.config.js
@@ -1,29 +1,8 @@
 /** Global prefix class used to scoped tailwind */
-const classPrefix = 'scalar-component'
-
-const globalRegx = /^\*|:root/
-const codeRegx = /^\.line-numbers/
-
-export default ({ env }) => ({
+export default () => ({
   plugins: {
     'tailwindcss/nesting': {},
     'tailwindcss': {},
-    'postcss-prefix-selector': {
-      prefix: `.${classPrefix}`,
-      /**
-       * Add the scoping prefix to all selectors and their children
-       * e.g. .flex -> .scalar-component.flex, .scalar-component .flex
-       */
-      transform: (prefix, selector) => {
-        if (env === 'development') return selector
-        if (selector.match(codeRegx)) return selector
-        return `${
-          selector.match(globalRegx) ? '' : selector
-        }:where(${prefix}), :where(${prefix}) ${selector}`
-      },
-    },
     'autoprefixer': {},
   },
 })
-
-export { classPrefix as prefix }

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -17,7 +17,7 @@ defineOptions({ inheritAttrs: false })
       </MenuButton>
       <template #floating="{ width }">
         <MenuItems
-          class="scalar-component relative flex w-56 flex-col p-0.75"
+          class="relative flex w-56 flex-col p-0.75"
           :style="{ width }"
           v-bind="$attrs">
           <slot name="items" />

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -69,12 +69,12 @@ const { floatingStyles, middlewareData } = useFloating(targetRef, floatingRef, {
 <template>
   <div
     ref="wrapperRef"
-    :class="['scalar-component', { contents: !!$slots.default }]">
+    :class="{ contents: !!$slots.default }">
     <slot />
   </div>
   <div
     ref="floatingRef"
-    class="scalar-component relative z-context"
+    class="relative z-context"
     :style="floatingStyles"
     v-bind="$attrs">
     <slot

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.vue
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.vue
@@ -16,7 +16,7 @@ defineOptions({ inheritAttrs: false })
       </PopoverButton>
       <template #floating="{ width, height }">
         <PopoverPanel
-          class="scalar-component relative flex flex-col p-0.75"
+          class="relative flex flex-col p-0.75"
           :style="{ width, height }"
           v-bind="$attrs">
           <slot name="popover" />

--- a/packages/components/src/components/ScalarTextField/ScalarTextField.vue
+++ b/packages/components/src/components/ScalarTextField/ScalarTextField.vue
@@ -101,7 +101,7 @@ onMounted(() => {
 })
 </script>
 <template>
-  <div class="scalar-component scalar-input-container relative">
+  <div class="scalar-input-container relative">
     <div :class="textField({ error, focus: isFocused })">
       <component
         :is="isMultiline ? 'textarea' : 'input'"

--- a/packages/components/src/cva.ts
+++ b/packages/components/src/cva.ts
@@ -1,8 +1,6 @@
 import { defineConfig } from 'cva'
 import { extendTailwindMerge } from 'tailwind-merge'
 
-import { prefix } from '../postcss.config'
-
 /**
  * Tailwind Merge Config
  *
@@ -12,12 +10,10 @@ import { prefix } from '../postcss.config'
  *
  * https://github.com/dcastil/tailwind-merge/blob/v2.0.0/docs/configuration.md#class-groups
  */
-const tw = extendTailwindMerge<typeof prefix>({
+const tw = extendTailwindMerge({
   extend: {
     classGroups: {
       'font-size': ['text-xxs'],
-      // Add the scalar class prefix as a custom class to be deduped by tailwind-merge
-      [prefix]: [prefix],
     },
   },
 })
@@ -29,7 +25,7 @@ const tw = extendTailwindMerge<typeof prefix>({
  */
 const { cva, cx, compose } = defineConfig({
   hooks: {
-    onComplete: (className) => `${tw(className, prefix)}`,
+    onComplete: (className) => tw(className),
   },
 })
 

--- a/packages/components/src/tailwind/tailwind.css
+++ b/packages/components/src/tailwind/tailwind.css
@@ -1,6 +1,11 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+/**
+ * Put the Tailwind output into our Scalar cascade layers
+ *
+ * @see https://emamoah.medium.com/using-native-css-cascade-layers-with-tailwindcss-cb11af266104
+ */
+@import 'tailwindcss/base' layer(scalar-base);
+@import 'tailwindcss/components' layer(scalar-components);
+@import 'tailwindcss/utilities' layer(scalar-utilities);
 
 /** 
  * Custom Reset - copied over from the tailwind reset
@@ -8,7 +13,7 @@
  *
  * @link https://tailwindcss.com/docs/preflight 
  */
-@layer base {
+@layer scalar-base {
   * {
     box-sizing: border-box;
     border-width: 0;
@@ -27,7 +32,7 @@
   }
 }
 
-@layer utilities {
+@layer scalar-utilities {
   .row {
     @apply flex flex-row;
   }


### PR DESCRIPTION
So this this will unscope our components tailwind classes in favor of just putting them in a layer that's super easy to override. This means we might technically have leaky component css **but** it should never override a consuming apps classes.
