### PR TITLE
chore(cli): provide alternative name for the CLI

### DIFF
--- a/.changeset/poor-ghosts-matter.md
+++ b/.changeset/poor-ghosts-matter.md
@@ -1,0 +1,5 @@
+---
+"@scalar/cli": patch
+---
+
+chore: provide alternative name for the CLI (`scalar-cli`)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "@scalar/cli": "pnpm vite-node src/index.ts",
     "build": "rm -Rf dist/ && tsc && rollup -c",
-    "cli:link": "pnpm run build && npm unlink -g && npm link",
+    "link:cli": "pnpm run build && npm unlink -g @scalar/cli && npm link",
     "types:check": "tsc --noEmit --skipLibCheck"
   },
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,8 @@
     "./dist"
   ],
   "bin": {
-    "scalar": "./dist/index.js"
+    "scalar": "./dist/index.js",
+    "scalar-cli": "./dist/index.js"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",


### PR DESCRIPTION
Currently, users might run into conflicts with the existing `scalar` CLI that Microsoft built.

When installing, they can overwrite the other CLI and use ours as `scalar`. There’s also a note in the README on the matter. I’ve did a ton of reading, trying to find a good solution, here’s a short summary:

* We could just change the name to be something else, but I couldn’t come up with one that is as cool as `scalar`.
* We could ship executables with bun, which we’ll probably do at some point in the future, but it would require us to build/support/publish binaries for the various platforms in a convenient way, which adds a lot of complexity in multiple areas that I’d like to avoid at this point.
* We can’t hook into the install process to react to the error.

This PR suggests a pragmatic solution: We’ll just register the CLI under two names. If people run into a conflict and want to keep Microsoft’s `scalar`, they can just ignore the error and use `scalar-cli`.

This PR doesn’t change the docs, because I need to test it first, before we promote the solution. I couldn’t find a way to reproduce the issue when installing or linking the source files, so we need to publish to npm to test the solution.