### PR TITLE
chore: optimize standalone build

### DIFF
--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
     emptyOutDir: false,
     outDir: 'dist/browser',
     commonjsOptions: {
-      include: [/@scalar\/swagger-editor/, /node_modules/],
+      include: [/node_modules/],
     },
     cssCodeSplit: false,
     minify: 'terser',
@@ -58,7 +58,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(openapi-parser|snippetz|galaxy|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(openapi-parser|snippetz\b))(.+)/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],


### PR DESCRIPTION
I’ve had a few ideas to optimize the CDN build, but it turns out only one helped to decrease the build size by a bit:

Adding an alias for the packages that live in the same repository (components + galaxy) helps to tree shake or something and reduce the bundle size by 20kb:

**Before**
```
dist/browser/standalone.js       2,155.70 kB │ gzip: 634.53 kB
```

**After**
```
dist/browser/standalone.js       2,135.14 kB │ gzip: 631.41 kB
```