### PR TITLE
feat: Adds new unified package for code highlight and markdown rendering

### DIFF
--- a/packages/code-highlight/index.html
+++ b/packages/code-highlight/index.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Scalar Code Highlighting Demo</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        --scalar-font: 'Inter';
+      }
+      /* basic theme */
+      .light-mode {
+        --scalar-background-1: #fff;
+        --scalar-background-2: #f5f6f8;
+        --scalar-background-3: #eceef1;
+
+        --scalar-color-1: #2a2f45;
+        --scalar-color-2: #757575;
+        --scalar-color-3: #8e8e8e;
+
+        --scalar-color-accent: #5469d4;
+        --scalar-background-accent: #5469d41f;
+
+        --scalar-border-color: rgba(215, 215, 206, 0.5);
+      }
+      .dark-mode {
+        --scalar-background-1: #15171c;
+        --scalar-background-2: #1c1e24;
+        --scalar-background-3: #22252b;
+
+        --scalar-color-1: #fafafa;
+        --scalar-color-2: #c9ced8;
+        --scalar-color-3: #8c99ad;
+
+        --scalar-color-accent: #5469d4;
+        --scalar-background-accent: #5469d41f;
+
+        --scalar-border-color: rgba(255, 255, 255, 0.12);
+      }
+      /* Document header */
+      .light-mode .t-doc__header,
+      .dark-mode .t-doc__header {
+        --header-background-1: var(--scalar-background-1);
+        --header-border-color: var(--scalar-border-color);
+        --header-color-1: var(--scalar-color-1);
+        --header-color-2: var(--scalar-color-2);
+        --header-call-to-action-color: var(--scalar-color-accent);
+      }
+      /* Document Sidebar */
+      .light-mode .t-doc__sidebar,
+      .dark-mode .t-doc__sidebar {
+        --scalar-sidebar-background-1: var(--scalar-background-1);
+        --scalar-sidebar-color-1: var(--scalar-color-1);
+        --scalar-sidebar-color-2: var(--scalar-color-2);
+        --scalar-sidebar-border-color: var(--scalar-border-color);
+
+        --scalar-sidebar-item-hover-background: var(--scalar-background-3);
+        --scalar-sidebar-item-hover-color: currentColor;
+
+        --scalar-sidebar-item-active-background: var(
+          --scalar-background-accent
+        );
+        --scalar-sidebar-color-active: var(--scalar-color-accent);
+
+        --scalar-sidebar-search-background: var(--scalar-background-1);
+        --scalar-sidebar-search-color: var(--scalar-color-3);
+        --scalar-sidebar-search-border-color: var(--scalar-border-color);
+      }
+
+      /* advanced */
+      .light-mode {
+        --scalar-color-green: #17803d;
+        --scalar-color-red: #e10909;
+        --scalar-color-yellow: #edbe20;
+        --scalar-color-blue: #1763a6;
+        --scalar-color-orange: #e25b09;
+        --scalar-color-purple: #5c3993;
+      }
+      .dark-mode {
+        --scalar-color-green: #30a159;
+        --scalar-color-red: #dc1b19;
+        --scalar-color-yellow: #eec644;
+        --scalar-color-blue: #2b7abf;
+        --scalar-color-orange: #f07528;
+        --scalar-color-purple: #7a59b1;
+      }
+
+      body {
+        background-color: var(--scalar-background-1);
+        color: var(--scalar-color-1);
+      }
+
+      .section-header {
+        font-size: 40px;
+        display: block;
+        border: 1px dotted var(--scalar-color-1);
+        padding: 12px;
+      }
+    </style>
+  </head>
+  <body class="dark-mode">
+    <div id="code"></div>
+    <script
+      src="test/preview.ts"
+      type="module"></script>
+  </body>
+</html>

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "@scalar/use-code-highlight",
+  "description": "Central methods and themes for code highlighting in Scalar projects",
+  "license": "MIT",
+  "author": "Scalar (https://github.com/scalar)",
+  "homepage": "https://github.com/scalar/scalar",
+  "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/code-highlight"
+  },
+  "keywords": [
+    "syntax",
+    "highlight",
+    "lowlight",
+    "highlightjs"
+  ],
+  "version": "0.0.1",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "vite build && pnpm types:build && tsc-alias -p tsconfig.build.json",
+    "dev": "vite",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
+    "preview": "vite preview",
+    "test": "vitest",
+    "types:build": "tsc -p tsconfig.build.json",
+    "types:check": "tsc --noEmit --skipLibCheck --composite false"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./css/*.css": {
+      "import": "./dist/css/*.css",
+      "require": "./dist/css/*.css"
+    },
+    "./*.css": {
+      "import": "./dist/*.css",
+      "require": "./dist/*.css"
+    }
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "module": "dist/index.js",
+  "sideEffects": false,
+  "dependencies": {
+    "hast-util-to-text": "^4.0.2",
+    "highlight.js": "^11.9.0",
+    "lowlight": "^3.1.0",
+    "rehype-external-links": "^3.0.0",
+    "rehype-format": "^5.0.0",
+    "rehype-highlight": "^7.0.0",
+    "rehype-parse": "^9.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
+    "rehype-stringify": "^10.0.0",
+    "remark-gfm": "^4.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.0",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^11.1.6",
+    "@scalar/build-tooling": "workspace:*",
+    "@scalar/themes": "workspace:*",
+    "@types/hast": "^3.0.4",
+    "rollup": "^4.16.4",
+    "tsc-alias": "^1.8.8",
+    "vfile": "^6.0.1",
+    "vite": "^5.2.10"
+  }
+}

--- a/packages/code-highlight/src/code.ts
+++ b/packages/code-highlight/src/code.ts
@@ -1,0 +1,164 @@
+import type { Element, ElementContent, Root, Text } from 'hast'
+import rehypeParse from 'rehype-parse'
+import rehypeStringify from 'rehype-stringify'
+import { type Plugin, unified } from 'unified'
+import { visit } from 'unist-util-visit'
+
+import { rehypeHighlight } from './rehype-highlight'
+
+export async function syntaxHighlight(
+  codeString: string,
+  options?: {
+    lang?: string
+    lineNumbers?: boolean
+  },
+) {
+  const className = options?.lang ? `language-${options?.lang}` : ''
+
+  const nullPlugin = (() => {}) satisfies Plugin
+
+  const html = await unified()
+    // Parses markdown
+    .use(rehypeParse, { fragment: true })
+    // Syntax highlighting
+    .use(rehypeHighlight, {
+      detect: options?.lang ? false : true,
+    })
+    .use(options?.lineNumbers ? codeBlockLinesPlugin : nullPlugin)
+    // Converts the HTML AST to a string
+    .use(rehypeStringify)
+    // Run the pipeline
+    .process(`<pre><code class="${className}">${codeString}</code></pre>`)
+
+  return html.toString()
+}
+
+// ---------------------------------------------------------------------------
+// Line Numbering plugin
+
+export function isText(element?: ElementContent): element is Text {
+  return element?.type === 'text'
+}
+
+export function isElement(node?: ElementContent): node is Element {
+  return node?.type === 'element'
+}
+
+export function textElement(value: string): Text {
+  return { type: 'text', value }
+}
+
+export function lineBreak(): Text {
+  return { type: 'text', value: '\n' }
+}
+
+/**
+ * Adds lines to code blocks
+ */
+export function codeBlockLinesPlugin() {
+  return (tree: Root) => {
+    visit(
+      tree,
+      'element',
+      (node: Element, _i, parent: Root | Element | null) => {
+        if (
+          parent?.type === 'element' &&
+          parent.tagName === 'pre' &&
+          node.tagName === 'code'
+        ) {
+          let numLines = 0
+
+          // Wraps each line in a span
+          node.children = addLines(node)
+          console.log(node)
+          // Adds a line break to the end of each line
+          node.children.forEach((child: ElementContent) => {
+            if (child.type === 'element' && child.tagName === 'span') {
+              const lastChild: ElementContent =
+                child.children[child.children.length - 1]
+
+              if (
+                !isText(lastChild) ||
+                (isText(lastChild) && !hasLineBreak(lastChild))
+              ) {
+                child.children.push(lineBreak())
+                numLines++
+              }
+            }
+          })
+
+          // We need to maintain a count of the total lines to allow space for the labels
+          node.properties.style = [
+            `--line-count: ${numLines};`,
+            `--line-digits: ${numLines.toString().length};`,
+          ]
+        }
+      },
+    )
+
+    // console.log('NUMBER OF LINES IS: ', numLines)
+  }
+}
+
+/**
+ * Adds lines to a node recursively and returns them
+ *
+ * @param node - The node to add lines to
+ * @param lines - The current lines
+ * @param copyParent - Whether to copy the parent node to save the original node styles
+ */
+function addLines(
+  node: Element,
+  lines: Element[] = [],
+  copyParent?: boolean,
+): Element[] {
+  const line = () =>
+    lines[lines.length - 1] ??
+    (lines.push(createLine()) && lines[lines.length - 1])
+
+  node.children.forEach((child: ElementContent) => {
+    if (isText(child) && hasLineBreak(child)) {
+      const split: string[] = child.value.split(/\n/)
+
+      split.forEach((content: string, i: number) => {
+        copyParent
+          ? line().children.push({ ...node, children: [textElement(content)] })
+          : line().children.push(textElement(content))
+
+        i !== split.length - 1 && lines.push(createLine())
+      })
+    } else if (isElement(child) && child.children.some(hasLineBreak)) {
+      addLines(child, lines, true)
+    } else {
+      line().children.push(child)
+    }
+  })
+
+  return lines
+}
+
+/**
+ * Creates a new line element
+ *
+ * @param children - The children the line should have initially
+ */
+function createLine(...children: ElementContent[]): Element {
+  return {
+    type: 'element',
+    tagName: 'span',
+    properties: { class: ['line'] },
+    children,
+  }
+}
+
+/**
+ * Checks if a node has a line break
+ *
+ * @param node - The node to check
+ */
+function hasLineBreak(node: ElementContent): boolean {
+  return (
+    (isText(node) && /\r?\n/.test(node.value)) ||
+    (isElement(node) && node.children.some(hasLineBreak))
+  )
+}

--- a/packages/code-highlight/src/constants.ts
+++ b/packages/code-highlight/src/constants.ts
@@ -1,0 +1,11 @@
+/** Map common markdown language shortcuts to lowlight languages */
+export const lowlightLanguageMappings: Record<string, string> = {
+  'ts': 'typescript',
+  'js': 'javascript',
+  'py': 'python',
+  'c#': 'csharp',
+  'c++': 'cpp',
+  'node': 'javascript',
+}
+
+//

--- a/packages/code-highlight/src/css/code.css
+++ b/packages/code-highlight/src/css/code.css
@@ -1,0 +1,86 @@
+@layer scalar-base {
+  pre * {
+    font-size: var(--scalar-small) !important;
+    font-family: var(--scalar-font-code) !important;
+  }
+  code.hljs {
+    display: inline-block;
+    padding: 3px 5px;
+    counter-reset: linenumber;
+  }
+  .hljs {
+    background: var(--scalar-background-4, var(--scalar-background-3));
+    color: var(--scalar-color-1);
+  }
+
+  .hljs .line::before {
+    display: inline-block;
+    counter-increment: linenumber;
+    content: counter(linenumber);
+    padding-right: 1em;
+    /* Variable is set on the code element by the plugin when line numbers are used */
+    width: calc(var(--line-digits) * 0.6em);
+    text-align: right;
+  }
+
+  .hljs-comment,
+  .hljs-quote {
+    color: var(--scalar-color-3);
+    font-style: italic;
+  }
+  .hljs-addition,
+  .hljs-keyword,
+  .hljs-literal,
+  .hljs-selector-tag,
+  .hljs-type {
+    color: var(--scalar-color-green);
+  }
+  .hljs-number,
+  .hljs-selector-attr,
+  .hljs-selector-pseudo {
+    color: var(--scalar-color-orange);
+  }
+  .hljs-doctag,
+  .hljs-regexp,
+  .hljs-string {
+    color: var(--scalar-color-blue);
+  }
+  .hljs-built_in,
+  .hljs-name,
+  .hljs-section,
+  .hljs-title {
+    color: var(--scalar-color-blue);
+  }
+  .hljs-class .hljs-title,
+  .hljs-selector-id,
+  .hljs-template-variable,
+  .hljs-title.class_,
+  .hljs-variable {
+    color: var(--scalar-color-1);
+  }
+  .hljs-name,
+  .hljs-section,
+  .hljs-strong {
+    font-weight: var(--scalar-semibold);
+  }
+  .hljs-bullet,
+  .hljs-link,
+  .hljs-meta,
+  .hljs-subst,
+  .hljs-symbol {
+    color: var(--scalar-color-blue);
+  }
+  .hljs-deletion {
+    color: var(--scalar-color-red);
+  }
+  .hljs-formula {
+    background: var(--scalar-color-1);
+  }
+  .hljs-attr,
+  .hljs-attribute {
+    color: var(--scalar-color-1);
+  }
+  .hljs-emphasis {
+    font-style: italic;
+  }
+}

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -1,0 +1,272 @@
+.markdown {
+  color: var(--scalar-color-1);
+  all: unset;
+  word-break: break-word;
+}
+/* all elements inside .markdown */
+.markdown {
+  /* all: unset; */
+  margin: 12px 0;
+  font-family: var(--scalar-font);
+  color: var(--scalar-color-1);
+}
+.markdown details {
+  margin: 12px 0;
+  color: var(--scalar-color-1);
+}
+.markdown summary {
+  margin: 12px 0;
+  padding-left: 20px;
+  position: relative;
+  font-weight: var(--scalar-semibold);
+  cursor: pointer;
+  user-select: none;
+}
+
+.markdown summary::after {
+  display: block;
+  content: '';
+
+  position: absolute;
+  top: 1px;
+  left: 1px;
+
+  width: 16px;
+  height: 16px;
+
+  background-color: var(--scalar-color-3);
+  mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.25 19.5L15.75 12L8.25 4.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+}
+
+.markdown summary:hover::after {
+  background-color: var(--scalar-color-1);
+}
+
+.markdown details[open] summary::after {
+  transform: rotate(90deg);
+}
+
+/* Fix for Safari displaying default caret next to `<summary>` */
+.markdown summary::-webkit-details-marker {
+  display: none;
+}
+
+.markdown img {
+  overflow: hidden;
+  border-radius: var(--scalar-radius);
+  max-width: 100%;
+}
+/* Don't add margin to the first block */
+.markdown > :first-child {
+  margin-top: 0;
+}
+
+.markdown h1 {
+  --font-size: 1.4em;
+}
+
+.markdown h2 {
+  --font-size: 1.25em;
+}
+
+.markdown h3 {
+  --font-size: 1.1em;
+}
+
+.markdown h4 {
+  --font-size: 1em;
+}
+
+.markdown h6 {
+  --font-size: 1em;
+}
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4,
+.markdown h5,
+.markdown h6 {
+  font-size: var(--font-size);
+  margin: 18px 0 6px;
+  font-weight: var(--scalar-bold);
+  display: block;
+  line-height: 1.45;
+}
+.markdown b,
+.markdown strong {
+  font-weight: var(--scalar-bold);
+}
+.markdown p {
+  color: var(--scalar-color-1);
+  font-weight: var(--font-weight, var(--scalar-regular));
+  line-height: 1.5;
+  margin-bottom: 0;
+  display: block;
+}
+
+.markdown ul,
+.markdown ol {
+  padding-left: 24px;
+  line-height: 1.5;
+  margin: 12px 0;
+  display: block;
+}
+
+.markdown ul {
+  list-style: disc;
+}
+
+.markdown ol {
+  list-style: decimal;
+}
+
+.markdown ul.contains-task-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.markdown li {
+  margin: 6px 0;
+  display: list-item;
+}
+.markdown a {
+  color: var(--scalar-color-accent);
+  text-decoration: var(--scalar-text-decoration);
+  cursor: pointer;
+}
+.markdown a:hover {
+  text-decoration: var(--scalar-text-decoration-hover);
+}
+.markdown em {
+  font-style: italic;
+}
+.markdown sup {
+  font-size: var(--scalar-micro);
+  vertical-align: super;
+  font-weight: 450;
+}
+.markdown sub {
+  font-size: var(--scalar-micro);
+  vertical-align: sub;
+  font-weight: 450;
+}
+.markdown del {
+  text-decoration: line-through;
+}
+.markdown code {
+  font-family: var(--scalar-font-code);
+  background-color: var(--scalar-background-2);
+  box-shadow: 0 0 0 1px var(--scalar-border-color);
+  font-size: var(--scalar-micro);
+  border-radius: 2px;
+  padding: 0 3px;
+}
+
+.markdown pre code {
+  display: block;
+  white-space: pre;
+  padding: 12px;
+  line-height: 1.5;
+  margin: 12px 0;
+  -webkit-overflow-scrolling: touch;
+  overflow-x: auto;
+  max-width: 100%;
+  min-width: 100px;
+}
+
+.markdown hr {
+  border: none;
+  border-bottom: 1px solid var(--scalar-border-color);
+}
+
+.markdown img {
+  max-height: 150px;
+  border-radius: var(--scalar-radius);
+}
+
+.markdown blockquote {
+  border-left: 3px solid var(--scalar-border-color);
+  padding-left: 12px;
+  margin: 0;
+  display: block;
+}
+
+.markdown table {
+  display: block;
+  overflow-x: auto;
+  position: relative;
+  border-collapse: collapse;
+  width: max-content;
+  max-width: 100%;
+  margin: 1em 0;
+  box-shadow: 0 0 0 1px var(--scalar-border-color);
+  border-radius: var(--scalar-radius-lg);
+}
+.markdown tbody {
+  display: table-row-group;
+  vertical-align: middle;
+}
+.markdown thead {
+  display: table-header-group;
+  vertical-align: middle;
+}
+
+.markdown tr {
+  display: table-row;
+  border-color: inherit;
+  vertical-align: inherit;
+}
+.markdown td,
+.markdown th {
+  display: table-cell;
+  vertical-align: inherit;
+  min-width: 1em;
+  padding: 6px 9px;
+  vertical-align: top;
+  line-height: 1.5;
+  position: relative;
+  word-break: initial;
+  font-size: var(--scalar-small);
+  color: var(--scalar-color-1);
+  font-weight: var(--font-weight, var(--scalar-regular));
+  border-right: 1px solid var(--scalar-border-color);
+  border-bottom: 1px solid var(--scalar-border-color);
+}
+
+.markdown td > *,
+.markdown th > * {
+  margin-bottom: 0;
+}
+.markdown th:empty {
+  display: none;
+}
+.markdown td:first-of-type,
+.markdown th:first-of-type {
+  border-left: none;
+}
+
+.markdown td:last-of-type,
+.markdown th:last-of-type {
+  border-right: none;
+}
+
+.markdown tr:last-of-type td {
+  border-bottom: none;
+}
+
+.markdown th {
+  font-weight: var(--scalar-semibold) !important;
+  text-align: left;
+  border-left-color: transparent;
+  background: var(--scalar-background-2);
+}
+
+.markdown tr > [align='left'] {
+  text-align: left;
+}
+.markdown tr > [align='right'] {
+  text-align: right;
+}
+.markdown tr > [align='center'] {
+  text-align: center;
+}

--- a/packages/code-highlight/src/index.ts
+++ b/packages/code-highlight/src/index.ts
@@ -1,0 +1,3 @@
+export { rehypeHighlight } from './rehype-highlight'
+export { lowlightLanguageMappings } from './constants'
+export { htmlFromMarkdown } from './markdown'

--- a/packages/code-highlight/src/markdown.ts
+++ b/packages/code-highlight/src/markdown.ts
@@ -1,0 +1,51 @@
+import rehypeExternalLinks from 'rehype-external-links'
+import rehypeFormat from 'rehype-format'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
+import rehypeStringify from 'rehype-stringify'
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import { unified } from 'unified'
+
+import { rehypeHighlight } from './rehype-highlight'
+
+/** Take a markdown string and generate a raw HTML string */
+export async function htmlFromMarkdown(
+  markdownString: string,
+  options?: {
+    removeTags?: string[]
+  },
+) {
+  const html = await unified()
+    // Parses markdown
+    .use(remarkParse)
+    // Support autolink literals, footnotes, strikethrough, tables and tasklists
+    .use(remarkGfm)
+    // Allows any HTML tags
+    .use(remarkRehype, { allowDangerousHtml: true })
+    // Creates a HTML AST
+    .use(rehypeRaw)
+    // Removes disallowed tags
+    .use(rehypeSanitize, {
+      ...defaultSchema,
+      // Makes it even more strict
+      tagNames: defaultSchema.tagNames?.filter(
+        (tag) => !(options?.removeTags ?? []).includes(tag),
+      ),
+    })
+    // Syntax highlighting
+    .use(rehypeHighlight, {
+      detect: true,
+    })
+    // Adds target="_blank" to external links
+    .use(rehypeExternalLinks, { target: '_blank' })
+    // Formats the HTML
+    .use(rehypeFormat)
+    // Converts the HTML AST to a string
+    .use(rehypeStringify)
+    // Run the pipeline
+    .process(markdownString)
+
+  return html.toString()
+}

--- a/packages/code-highlight/src/rehype-highlight.ts
+++ b/packages/code-highlight/src/rehype-highlight.ts
@@ -1,0 +1,145 @@
+import type { Element, ElementContent, Root } from 'hast'
+import { toText } from 'hast-util-to-text'
+import { type LanguageFn, common, createLowlight } from 'lowlight'
+import { visit } from 'unist-util-visit'
+import type { VFile } from 'vfile'
+
+import { lowlightLanguageMappings } from './constants'
+
+type HighlightOptions = {
+  /** Optional existing lowlight instance to use */
+  lowlight?: ReturnType<typeof createLowlight> | undefined
+  /** Register more aliases (optional); passed to `lowlight.registerAlias` */
+  aliases?:
+    | Readonly<Record<string, ReadonlyArray<string> | string>>
+    | null
+    | undefined
+  /** Highlight code without language classes by guessing the language (default: `false`). */
+  detect?: boolean | null | undefined
+  /** Register languages (default: `common`) passed to `lowlight.register` */
+  languages?: Readonly<Record<string, LanguageFn>> | null | undefined
+  /** List of language names to not highlight (optional). Note: you can also add `no-highlight` classes. */
+  plainText?: ReadonlyArray<string> | null | undefined
+  /** Class prefix (default: `'hljs-'`) */
+  prefix?: string | null | undefined
+  /** Names of languages to check when detecting (default: all registered languages) */
+  subset?: ReadonlyArray<string> | null | undefined
+}
+
+const emptyOptions: HighlightOptions = {}
+
+/**
+ * Lowlight syntax highlighting plugin for rehype pipelines
+ *
+ * Derived from: @url https://github.com/rehypejs/rehype-highlight/blob/main/lib/index.js
+ */
+export function rehypeHighlight(
+  options?: Readonly<HighlightOptions> | null | undefined,
+) {
+  const settings = options || emptyOptions
+  const aliases = settings.aliases
+  const detect = settings.detect || false
+  const languages = settings.languages || common
+  const plainText = settings.plainText
+  const prefix = settings.prefix
+  const subset = settings.subset
+  let name = 'hljs'
+
+  // Create a lowlight instance if not provided
+  const lowlight = options?.lowlight ?? createLowlight(languages)
+
+  if (aliases) lowlight.registerAlias(aliases)
+
+  if (prefix) {
+    const pos = prefix.indexOf('-')
+    name = pos > -1 ? prefix.slice(0, pos) : prefix
+  }
+
+  /** Transform.*/
+  return function (tree: Root, file: VFile) {
+    visit(tree, 'element', function (node, _, parent) {
+      if (
+        node.tagName !== 'code' ||
+        !parent ||
+        parent.type !== 'element' ||
+        parent.tagName !== 'pre'
+      ) {
+        return
+      }
+
+      const lang = language(node)
+
+      if (
+        lang === 'no-highlight' ||
+        (!lang && !detect) ||
+        (lang && plainText?.includes(lang))
+      ) {
+        return
+      }
+
+      if (!Array.isArray(node.properties.className)) {
+        node.properties.className = []
+      }
+
+      if (!node.properties.className.includes(name)) {
+        node.properties.className.unshift(name)
+      }
+
+      let result: Root | undefined
+
+      try {
+        result = lang
+          ? lowlight.highlight(lang, toText(parent), { prefix })
+          : lowlight.highlightAuto(toText(parent), { prefix, subset })
+      } catch (error) {
+        const cause = error as Error
+
+        if (lang && /Unknown language/.test(cause.message)) {
+          file.message(
+            'Cannot highlight as `' + lang + '`, it’s not registered',
+            {
+              ancestors: [parent, node],
+              cause,
+              place: node.position,
+              ruleId: 'missing-language',
+              source: 'rehype-highlight',
+            },
+          )
+
+          /* c8 ignore next 5 -- throw arbitrary hljs errors */
+          return
+        }
+
+        throw cause
+      }
+
+      if (!lang && result.data?.language) {
+        node.properties.className.push('language-' + result.data.language)
+      }
+
+      if (result.children.length > 0) {
+        node.children = result.children as Array<ElementContent>
+      }
+    })
+  }
+}
+
+/** Get the programming language of `node` or an empty string */
+function language(node: Element) {
+  const list = node.properties.className
+
+  if (!Array.isArray(list)) return ''
+
+  const name: string = list.reduce<string>((result, _item) => {
+    if (result) return result
+    const item = String(_item)
+
+    if (item === 'no-highlight' || item === 'nohighlight') return 'no-highlight'
+    if (item.slice(0, 5) === 'lang-') return item.slice(5)
+    if (item.slice(0, 9) === 'language-') return item.slice(9)
+
+    return result
+  }, '')
+
+  return lowlightLanguageMappings[name || ''] || name
+}

--- a/packages/code-highlight/test/markdown-test.md
+++ b/packages/code-highlight/test/markdown-test.md
@@ -1,0 +1,228 @@
+---
+__Advertisement :)__
+
+- __[pica](https://nodeca.github.io/pica/demo/)__ - high quality and fast image
+resize in browser.
+- __[babelfish](https://github.com/nodeca/babelfish/)__ - developer friendly
+i18n with plurals support and easy syntax.
+
+You will like those projects!
+---
+
+# h1 Heading 8-)
+
+## h2 Heading
+
+### h3 Heading
+
+#### h4 Heading
+
+##### h5 Heading
+
+###### h6 Heading
+
+## Horizontal Rules
+
+---
+
+## Typographic replacements
+
+Enable typographer option to see result.
+
+(c) (C) (r) (R) (tm) (TM) (p) (P) +-
+
+test.. test... test..... test?..... test!....
+
+!!!!!! ???? ,, -- ---
+
+"Smartypants, double quotes" and 'single quotes'
+
+## Emphasis
+
+**This is bold text**
+
+**This is bold text**
+
+_This is italic text_
+
+_This is italic text_
+
+~~Strikethrough~~
+
+## Blockquotes
+
+> Blockquotes can also be nested...
+>
+> > ...by using additional greater-than signs right next to each other...
+> >
+> > > ...or with spaces between arrows.
+
+## Lists
+
+Unordered
+
+- Create a list by starting a line with `+`, `-`, or `*`
+- Sub-lists are made by indenting 2 spaces:
+  - Marker character change forces new list start:
+    - Ac tristique libero volutpat at
+    * Facilisis in pretium nisl aliquet
+    - Nulla volutpat aliquam velit
+- Very easy!
+
+Ordered
+
+1. Lorem ipsum dolor sit amet
+2. Consectetur adipiscing elit
+3. Integer molestie lorem at massa
+
+4. You can use sequential numbers...
+5. ...or keep all the numbers as `1.`
+
+Start numbering with offset:
+
+57. foo
+1. bar
+
+## Code
+
+Inline `code`
+
+Indented code
+
+    // Some comments
+    line 1 of code
+    line 2 of code
+    line 3 of code
+
+Block code "fences"
+
+```
+Sample text here...
+```
+
+Syntax highlighting
+
+```javascript
+var foo = function (bar) {
+  return bar++
+}
+
+console.log(foo(5))
+```
+
+## Tables
+
+| Option | Description                                                               |
+| ------ | ------------------------------------------------------------------------- |
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default.    |
+| ext    | extension to be used for dest files.                                      |
+
+Right aligned columns
+
+| Option |                                                               Description |
+| -----: | ------------------------------------------------------------------------: |
+|   data | path to data files to supply the data that will be passed into templates. |
+| engine |    engine to be used for processing templates. Handlebars is the default. |
+|    ext |                                      extension to be used for dest files. |
+
+## Links
+
+[link text](http://dev.nodeca.com)
+
+[link with title](http://nodeca.github.io/pica/demo/ 'title text!')
+
+Autoconverted link https://github.com/nodeca/pica (enable linkify to see)
+
+## Images
+
+![Minion](https://octodex.github.com/images/minion.png)
+![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg 'The Stormtroopocat')
+
+Like links, Images also have a footnote style syntax
+
+![Alt text][id]
+
+With a reference later in the document defining the URL location:
+
+[id]: https://octodex.github.com/images/dojocat.jpg 'The Dojocat'
+
+## Plugins
+
+The killer feature of `markdown-it` is very effective support of
+[syntax plugins](https://www.npmjs.org/browse/keyword/markdown-it-plugin).
+
+### [Emojies](https://github.com/markdown-it/markdown-it-emoji)
+
+> Classic markup: :wink: :cry: :laughing: :yum:
+>
+> Shortcuts (emoticons): :-) :-( 8-) ;)
+
+see [how to change output](https://github.com/markdown-it/markdown-it-emoji#change-output) with twemoji.
+
+### [Subscript](https://github.com/markdown-it/markdown-it-sub) / [Superscript](https://github.com/markdown-it/markdown-it-sup)
+
+- 19^th^
+- H~2~O
+
+### [\<ins>](https://github.com/markdown-it/markdown-it-ins)
+
+++Inserted text++
+
+### [\<mark>](https://github.com/markdown-it/markdown-it-mark)
+
+==Marked text==
+
+### [Footnotes](https://github.com/markdown-it/markdown-it-footnote)
+
+Footnote 1 link[^first].
+
+Footnote 2 link[^second].
+
+Inline footnote^[Text of inline footnote] definition.
+
+Duplicated footnote reference[^second].
+
+[^first]: Footnote **can have markup**
+
+    and multiple paragraphs.
+
+[^second]: Footnote text.
+
+### [Definition lists](https://github.com/markdown-it/markdown-it-deflist)
+
+Term 1
+
+: Definition 1
+with lazy continuation.
+
+Term 2 with _inline markup_
+
+: Definition 2
+
+        { some code, part of Definition 2 }
+
+    Third paragraph of definition 2.
+
+_Compact style:_
+
+Term 1
+~ Definition 1
+
+Term 2
+~ Definition 2a
+~ Definition 2b
+
+### [Abbreviations](https://github.com/markdown-it/markdown-it-abbr)
+
+This is HTML abbreviation example.
+
+It converts "HTML", but keep intact partial entries like "xxxHTMLyyy" and so on.
+
+\*[HTML]: Hyper Text Markup Language
+
+### [Custom containers](https://github.com/markdown-it/markdown-it-container)
+
+::: warning
+_here be dragons_
+:::

--- a/packages/code-highlight/test/preview.ts
+++ b/packages/code-highlight/test/preview.ts
@@ -1,0 +1,53 @@
+/**
+ * Simple demo page for all Scalar code highlighting functions
+ */
+import '@scalar/themes/base.css'
+import '@scalar/themes/fonts.css'
+
+import { syntaxHighlight } from '../src/code'
+// @ts-expect-error vite not looking for raw types
+import codeExampleLarge from '../src/constants.ts?raw'
+import '../src/css/code.css'
+import '../src/css/markdown.css'
+import { htmlFromMarkdown } from '../src/markdown'
+// @ts-expect-error vite not looking for raw types
+import markdownFile from './markdown-test.md?raw'
+
+/** Create a section break header */
+function createHeader(text: string) {
+  const header = document.createElement('h2')
+  header.classList.add('section-header')
+  header.innerHTML = text
+  document.body.appendChild(header)
+}
+
+// ---------------------------------------------------------------------------
+// Codeblock example
+
+createHeader('Basic Codeblock')
+const code = document.createElement('div')
+code.innerHTML = await syntaxHighlight(
+  `const boo = 'booooooo'
+function scare() {
+    console.log(boo)
+}
+`,
+)
+document.body.appendChild(code)
+
+createHeader('Longer Codeblock')
+const codeLong = document.createElement('div')
+codeLong.innerHTML = await syntaxHighlight(codeExampleLarge, {
+  lang: 'ts',
+  lineNumbers: true,
+})
+document.body.appendChild(codeLong)
+
+// ---------------------------------------------------------------------------
+// Markdown render example
+
+createHeader('Markdown')
+const markdown = document.createElement('div')
+markdown.classList.add('markdown')
+markdown.innerHTML = await htmlFromMarkdown(markdownFile)
+document.body.appendChild(markdown)

--- a/packages/code-highlight/tsconfig.build.json
+++ b/packages/code-highlight/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["dist", "test", "vite.config.ts", "**/*.test.ts"],
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/"
+  }
+}

--- a/packages/code-highlight/tsconfig.json
+++ b/packages/code-highlight/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/code-highlight/vite.config.ts
+++ b/packages/code-highlight/vite.config.ts
@@ -1,0 +1,39 @@
+import { findEntryPoints } from '@scalar/build-tooling'
+import { URL, fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+
+import pkg from './package.json'
+
+export default defineConfig({
+  plugins: [],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+    dedupe: ['vue'],
+  },
+  server: {
+    port: 9000,
+  },
+  publicDir: './src/css',
+  build: {
+    ssr: true,
+
+    minify: false,
+    target: 'esnext',
+    lib: {
+      entry: await findEntryPoints({ allowCss: true }),
+      formats: ['es'],
+    },
+    rollupOptions: {
+      external: [...Object.keys((pkg as any).peerDependencies || {})],
+      output: {
+        // Create a separate file for the dependency bundle
+        manualChunks: (id) =>
+          id.includes('node_modules') ? 'vendor' : undefined,
+        format: 'esm',
+      },
+      treeshake: true,
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1118,6 +1118,79 @@ importers:
         specifier: ^1.3.1
         version: 1.5.0(@types/node@20.11.26)
 
+  packages/code-highlight:
+    dependencies:
+      hast-util-to-text:
+        specifier: ^4.0.2
+        version: 4.0.2
+      highlight.js:
+        specifier: ^11.9.0
+        version: 11.9.0
+      lowlight:
+        specifier: ^3.1.0
+        version: 3.1.0
+      rehype-external-links:
+        specifier: ^3.0.0
+        version: 3.0.0
+      rehype-format:
+        specifier: ^5.0.0
+        version: 5.0.0
+      rehype-highlight:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-parse:
+        specifier: ^9.0.0
+        version: 9.0.0
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
+      rehype-stringify:
+        specifier: ^10.0.0
+        version: 10.0.0
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.0
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: ^11.1.0
+        version: 11.1.0
+      unified:
+        specifier: ^11.0.4
+        version: 11.0.4
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^11.1.6
+        version: 11.1.6(rollup@4.16.4)(tslib@2.6.2)(typescript@5.4.3)
+      '@scalar/build-tooling':
+        specifier: workspace:*
+        version: link:../build-tooling
+      '@scalar/themes':
+        specifier: workspace:*
+        version: link:../themes
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
+      rollup:
+        specifier: ^4.16.4
+        version: 4.16.4
+      tsc-alias:
+        specifier: ^1.8.8
+        version: 1.8.8
+      vfile:
+        specifier: ^6.0.1
+        version: 6.0.1
+      vite:
+        specifier: ^5.2.10
+        version: 5.2.10(@types/node@20.11.22)(terser@5.30.0)
+
   packages/components:
     dependencies:
       '@floating-ui/utils':
@@ -17759,6 +17832,17 @@ packages:
       hast-util-is-element: 3.0.0
     dev: false
 
+  /hast-util-from-html@2.0.1:
+    resolution: {integrity: sha512-RXQBLMl9kjKVNkJTIO6bZyb2n+cUH8LFaSSzo82jiLT6Tfc+Pt7VQCS+/h3YwG4jaNE2TA2sdJisGWR+aJrp0g==}
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.1
+      parse5: 7.1.2
+      vfile: 6.0.1
+      vfile-message: 4.0.2
+    dev: false
+
   /hast-util-from-parse5@8.0.1:
     resolution: {integrity: sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==}
     dependencies:
@@ -24643,6 +24727,14 @@ packages:
       hast-util-is-element: 3.0.0
       hast-util-whitespace: 3.0.0
       unist-util-is: 6.0.0
+    dev: false
+
+  /rehype-parse@9.0.0:
+    resolution: {integrity: sha512-WG7nfvmWWkCR++KEkZevZb/uw41E8TsH4DsY9UxsTbIXCVGbAs4S+r8FrQ+OtH5EEQAs+5UxKC42VinkmpA1Yw==}
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.1
+      unified: 11.0.4
     dev: false
 
   /rehype-raw@7.0.0:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "strict": true,
     "strictNullChecks": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "checkJs": true
   },
   "types": ["vite/client"],
   "exclude": ["dist", "node_modules", "**/dist", "**/node_modules"],


### PR DESCRIPTION
This package will be used as the basis for all remark/rehype pipelines where we are rendering code and markdown. 

Provides a common place for transforms and themes. 

Testing:
```
pnpm dev
```