### PR TITLE
fix: align show hide icons with icon standards

### DIFF
--- a/.changeset/tough-lizards-think.md
+++ b/.changeset/tough-lizards-think.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-client": patch
+"@scalar/components": patch
+---
+
+fix: align show hide icons with icon standards

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/CardFormTextInput.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/CardFormTextInput.vue
@@ -91,5 +91,6 @@ defineOptions({
   height: 24px;
   width: auto;
   align-self: center;
+  stroke-width: 0.75;
 }
 </style>

--- a/packages/components/src/components/ScalarIcon/icons/Hide.svg
+++ b/packages/components/src/components/ScalarIcon/icons/Hide.svg
@@ -1,1 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><desc>View Off Streamline Icon: https://streamlinehq.com</desc><g><path d="M2.78 21 21.53 3" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path><path d="M9 19.05a9.91 9.91 0 0 0 3 0.45c4.1 0.07 8.26 -2.81 10.82 -5.64a1.65 1.65 0 0 0 0 -2.22 20.06 20.06 0 0 0 -3.07 -2.76" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path><path d="M17.09 7.27A11.31 11.31 0 0 0 12 6c-4 -0.07 -8.2 2.75 -10.82 5.64a1.65 1.65 0 0 0 0 2.22 20 20 0 0 0 4.93 4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path><path d="M9 15.07a3.85 3.85 0 0 1 5.5 -5.28" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path><path d="M15.75 12.75h0A3.75 3.75 0 0 1 12 16.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="none">
+	<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+		d="M1.5 10l9.2-8.8M4.5 9.1c.5.1 1 .2 1.5.2 2 0 4-1.4 5.3-2.8.3-.3.3-.8 0-1.1-.5-.5-1-1-1.5-1.3M8.5 3.3c-.8-.4-1.6-.6-2.5-.6C4 2.7 2 4 .7 5.5c-.3.3-.3.8 0 1.1.7.8 1.5 1.4 2.4 2" />
+	<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+		d="M4.5 7.1c-.6-.8-.4-2 .5-2.6.6-.5 1.6-.5 2.2.1M7.8 6h0C7.8 7 7 7.8 6 7.8" />
+</svg>

--- a/packages/components/src/components/ScalarIcon/icons/Show.svg
+++ b/packages/components/src/components/ScalarIcon/icons/Show.svg
@@ -1,1 +1,6 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" ><path d="M12 5.251C7.969 5.183 3.8 8 1.179 10.885a1.663 1.663 0 0 0 0 2.226C3.743 15.935 7.9 18.817 12 18.748c4.1 0.069 8.258 -2.813 10.824 -5.637a1.663 1.663 0 0 0 0 -2.226C20.2 8 16.031 5.183 12 5.251Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path><path d="M15.75 12A3.75 3.75 0 1 1 12 8.249 3.749 3.749 0 0 1 15.75 12Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="none">
+	<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+		d="M6 2.7C4 2.7 2 4 .7 5.5c-.3.3-.3.8 0 1.1C2 7.9 4 9.3 6 9.3s4-1.4 5.3-2.8c.3-.3.3-.8 0-1.1C10 4 8 2.7 6 2.7z" />
+	<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
+		d="M7.8 6C7.8 7 7 7.8 6 7.8S4.2 7 4.2 6 5 4.2 6 4.2 7.8 5 7.8 6h0z" />
+</svg>


### PR DESCRIPTION
Fixes some icon shift for the show hide password field and updates the icon to align with our standards.

Before / After:

https://github.com/scalar/scalar/assets/6374090/6ddd8cbb-d8e8-4b84-8fb8-d1aa67fcddf6

