### PR TITLE
chore(cli): remove openapi-types

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "@scalar/cli": "pnpm vite-node src/index.ts",
     "build": "rm -Rf dist/ && tsc && rollup -c",
-    "cli:link": "pnpm run build && npm unlink -g && npm link",
+    "link:cli": "pnpm run build && npm unlink -g @scalar/cli && npm link",
     "types:check": "tsc --noEmit --skipLibCheck"
   },
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,6 @@
     "glob": "^10.3.10",
     "hono": "^4.2.7",
     "kleur": "^4.1.5",
-    "openapi-types": "^12.1.3",
     "prettyjson": "^1.2.5"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/bundle/BundleCommand.ts
+++ b/packages/cli/src/commands/bundle/BundleCommand.ts
@@ -1,7 +1,6 @@
 import { Command } from 'commander'
 import kleur from 'kleur'
 import fs from 'node:fs'
-import type { OpenAPI } from 'openapi-types'
 
 import { loadOpenApiFile, useGivenFileOrConfiguration } from '../../utils'
 

--- a/packages/cli/src/commands/mock/MockCommand.ts
+++ b/packages/cli/src/commands/mock/MockCommand.ts
@@ -1,9 +1,9 @@
 import { serve } from '@hono/node-server'
 import { createMockServer } from '@scalar/mock-server'
+import type { OpenAPI } from '@scalar/openapi-parser'
 import { Command } from 'commander'
 import type { Context } from 'hono'
 import kleur from 'kleur'
-import type { OpenAPI } from 'openapi-types'
 
 import {
   getMethodColor,

--- a/packages/cli/src/commands/validate/ValidateCommand.ts
+++ b/packages/cli/src/commands/validate/ValidateCommand.ts
@@ -1,7 +1,6 @@
 import { openapi } from '@scalar/openapi-parser'
 import { Command } from 'commander'
 import kleur from 'kleur'
-import fs from 'node:fs'
 import prettyjson from 'prettyjson'
 
 import { useGivenFileOrConfiguration } from '../../utils'

--- a/packages/cli/src/utils/getHtmlDocument.ts
+++ b/packages/cli/src/utils/getHtmlDocument.ts
@@ -1,4 +1,4 @@
-import type { OpenAPI } from 'openapi-types'
+import type { OpenAPI } from '@scalar/openapi-parser'
 
 export function getHtmlDocument(
   specification: OpenAPI.Document,

--- a/packages/cli/src/utils/getOperationByMethodAndPath.test.ts
+++ b/packages/cli/src/utils/getOperationByMethodAndPath.test.ts
@@ -1,4 +1,4 @@
-import type { OpenAPI } from 'openapi-types'
+import type { OpenAPI } from '@scalar/openapi-parser'
 import { describe, expect, it } from 'vitest'
 
 import { getOperationByMethodAndPath } from './getOperationByMethodAndPath'

--- a/packages/cli/src/utils/getOperationByMethodAndPath.ts
+++ b/packages/cli/src/utils/getOperationByMethodAndPath.ts
@@ -1,4 +1,4 @@
-import type { OpenAPI } from 'openapi-types'
+import type { OpenAPI } from '@scalar/openapi-parser'
 
 export function getOperationByMethodAndPath(
   schema: OpenAPI.Document,
@@ -14,9 +14,8 @@ export function getOperationByMethodAndPath(
 
   // Create a Regex for all paths with variables
   const pathRegex = Object.keys(schema.paths ?? {})
-    .filter((path) => {
-      return path.includes('{')
-    })
+    // Has variables?
+    .filter((item) => item.includes('{'))
     .map((operationPath) => {
       return {
         path: operationPath,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,9 +1077,6 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
-      openapi-types:
-        specifier: ^12.1.3
-        version: 12.1.3
       prettyjson:
         specifier: ^1.2.5
         version: 1.2.5


### PR DESCRIPTION
I was trying to resolve the CLI alias issue and saw a few minor things I’d like to clean up.

* Remove `openapi-types` as a dependency (we can use the `@scalar/openapi-parser` types instead)
* Fix the `cli:link` script for local development
* Remove an unused import