### PR TITLE
chore: fix all linter errors

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,6 +28,7 @@ module.exports = {
     '**/tailwind.config.ts',
     '**/vite.standalone.config.ts',
     '**/cdn/**',
+    '**/hydrateClient.d.ts',
   ],
   rules: {
     // ---------------------------------------------------------------------------

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeScopes.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeScopes.vue
@@ -10,7 +10,6 @@ import { ScalarIcon } from '@scalar/components'
 import { ResetStyles } from '@scalar/themes'
 import { computed, ref } from 'vue'
 
-import { Badge } from '../../../Badge'
 import CardFormButton from './CardFormButton.vue'
 
 const props = defineProps<{

--- a/packages/api-client/src/components/ApiClient/Response/Response.vue
+++ b/packages/api-client/src/components/ApiClient/Response/Response.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { isJsonString } from '@scalar/oas-utils'
-import { computed, toRaw } from 'vue'
+import { computed } from 'vue'
 
 import Computer from '../../../assets/computer.ascii?raw'
 import { useRequestStore } from '../../../stores'

--- a/packages/api-client/src/components/CollapsibleSection/CollapsibleSection.vue
+++ b/packages/api-client/src/components/CollapsibleSection/CollapsibleSection.vue
@@ -43,14 +43,14 @@ watch(
           <div class="scalar-api-client__toggle-container">
             <svg
               class="scalar-api-client__toggle__icon"
-              xmlns="http://www.w3.org/2000/svg"
               fill="none"
-              viewBox="0 0 12 12">
+              viewBox="0 0 12 12"
+              xmlns="http://www.w3.org/2000/svg">
               <path
+                d="M2.2 4.1 6 7.9l3.8-3.8"
                 stroke="currentColor"
                 stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M2.2 4.1 6 7.9l3.8-3.8"></path>
+                stroke-linejoin="round"></path>
             </svg>
             <span class="scalar-api-client__item__title">
               {{ title }}

--- a/packages/api-client/src/components/Grid/GridHeader.vue
+++ b/packages/api-client/src/components/Grid/GridHeader.vue
@@ -28,10 +28,10 @@ defineEmits<{
         variant="text"
         @click="$emit('update:showDescription', !showDescription)">
         <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="18"
+          fill="currentColor"
           height="12"
-          fill="currentColor">
+          width="18"
+          xmlns="http://www.w3.org/2000/svg">
           <path d="M0 11h9v-1H0v1ZM0 0v1h18V0H0Zm0 6h18V5H0v1Z" />
         </svg>
       </ScalarButton>

--- a/packages/api-client/src/components/Grid/GridRowEditable.vue
+++ b/packages/api-client/src/components/Grid/GridRowEditable.vue
@@ -71,8 +71,8 @@ const enabledProxy = computed<boolean>({
       <button
         v-if="!required"
         class="meta-delete"
-        type="button"
         tabindex="-1"
+        type="button"
         @click="$emit('delete')">
         <svg
           fill="none"

--- a/packages/api-client/src/components/ScalarAsciiArt.vue
+++ b/packages/api-client/src/components/ScalarAsciiArt.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type StyleValue, computed } from 'vue'
+import { computed } from 'vue'
 
 const props = defineProps<{ art: string }>()
 

--- a/packages/api-client/src/helpers/sendRequest.test.ts
+++ b/packages/api-client/src/helpers/sendRequest.test.ts
@@ -1,4 +1,3 @@
-import { encode } from 'punycode'
 import { describe, expect, it } from 'vitest'
 
 import { sendRequest } from './sendRequest'

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -14,7 +14,7 @@ import {
 
 import { createEmptySpecification } from '../helpers'
 // AnyStringOrObject
-import type { Spec, Tag } from '../types'
+import type { Spec } from '../types'
 
 export const parse = (specification: any): Promise<Spec> => {
   // eslint-disable-next-line no-async-promise-executor

--- a/packages/play-button/src/index.ts
+++ b/packages/play-button/src/index.ts
@@ -35,22 +35,6 @@ const getSpecUrl = () => {
   return undefined
 }
 
-const getProxyUrl = () => {
-  // <script id="api-reference" data-proxy-url="https://proxy.scalar.com">…</script>
-  if (specScriptTag) {
-    const proxyUrl = specScriptTag.getAttribute('data-proxy-url')
-
-    if (proxyUrl) {
-      return proxyUrl.trim()
-    }
-  }
-
-  return undefined
-}
-
-// Ensure Reference Props are reactive
-const props = reactive({})
-
 if (!specUrlElement && !specElement && !specScriptTag) {
   console.error(
     'Couldn’t find a [data-spec], [data-spec-url] or <script id="api-reference" /> element. Try adding it like this: %c<div data-spec-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml" />',


### PR DESCRIPTION
I just found out we removed ESLint from CI, I’m not even sure if this was intentional. Anyway, I think it’s good this way. It would have added some extra work in some PRs, without really preventing any bad errors.

That said, I feel better if we go through the errors and warnings every now and then, though. This PR fixes all ESLint errors and some of the warnings (mostly unused code or imports).

Note: It seems the play button doesn’t support the `data-proxy-url` API, because the relevant code isn’t used. I think it’s fine to remove it. It’s not mentioned in the README (for the play button), no one complained and you can always pass the proxy with the configuration object anyway.