### PR TITLE
fix: HMR doesn’t work in examples/web

### DIFF
--- a/examples/web/vite.config.ts
+++ b/examples/web/vite.config.ts
@@ -1,4 +1,5 @@
 import vue from '@vitejs/plugin-vue'
+import path from 'node:path'
 import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
@@ -7,5 +8,19 @@ export default defineConfig({
   server: {
     port: 5050,
     open: true,
+  },
+  resolve: {
+    alias: [
+      // Resolve the uncompiled source code for all @scalar packages
+      // It’s working with the alias, too. It’s just required to enable HMR.
+      // It also does not match components since we want the built version
+      {
+        // Resolve the uncompiled source code for all @scalar packages
+        // @scalar/* -> packages/*/
+        // (not @scalar/*/style.css)
+        find: /^@scalar\/(?!(openapi-parser|snippetz|galaxy|components))([^\/]+)(?<!\/[^\/]+\.css)$/,
+        replacement: path.resolve(__dirname, '../../packages/$2/src/index.ts'),
+      },
+    ],
   },
 })

--- a/packages/api-client/vite.config.ts
+++ b/packages/api-client/vite.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
                     return
 
                   setTimeout(() => {
-                    if (getComputedStyle(document.body).getPropertyValue('${STYLE_LOADED_VAR}') === 'true') return 
+                    if (getComputedStyle(document.body).getPropertyValue('${STYLE_LOADED_VAR}') === 'true') return
 
                     const elementStyle = document.createElement('style')
                     elementStyle.setAttribute('id', '${STYLE_ID}')
@@ -82,7 +82,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(openapi-parser|snippetz|galaxy|themes\/style.css|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(openapi-parser|snippetz|galaxy|components))([^\/]+)(?<!\/[^\/]+\.css)$/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -54,7 +54,7 @@ export default defineConfig({
                     return
 
                   setTimeout(() => {
-                    if (getComputedStyle(document.body).getPropertyValue('${STYLE_LOADED_VAR}') === 'true') return 
+                    if (getComputedStyle(document.body).getPropertyValue('${STYLE_LOADED_VAR}') === 'true') return
 
                     const elementStyle = document.createElement('style')
                     elementStyle.setAttribute('id', '${STYLE_ID}')
@@ -86,7 +86,7 @@ export default defineConfig({
         // Resolve the uncompiled source code for all @scalar packages
         // @scalar/* -> packages/*/
         // (not @scalar/*/style.css)
-        find: /^@scalar\/(?!(openapi-parser|snippetz|galaxy|themes\/style.css|components\/style\.css|components\b))(.+)/,
+        find: /^@scalar\/(?!(openapi-parser|snippetz|galaxy|components))([^\/]+)(?<!\/[^\/]+\.css)$/,
         replacement: path.resolve(__dirname, '../$2/src/index.ts'),
       },
     ],


### PR DESCRIPTION
With #1765 the resolve alias was removed from `examples/web`, this broke HMR. I think it was removed because the aliases broke for @scalar/api-reference/style.css and @scalar/api-client/style.css (we only had an exemption for @scalar/components/style.css)

This PR re-introduces the aliases and changes them to *not* match `@scalar/${anything}/style.css`.

Let’s test the deploy preview to see if the CSS is still fine and all.