### PR TITLE
feat: do not include properties with unknown values in generated examples, fix #933

### DIFF
--- a/.changeset/small-zoos-sell.md
+++ b/.changeset/small-zoos-sell.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/oas-utils": patch
+---
+
+feat: omit empty and not required properties from the generated request body

--- a/packages/api-reference/src/components/Content/Models/ModelsAccordion.vue
+++ b/packages/api-reference/src/components/Content/Models/ModelsAccordion.vue
@@ -63,9 +63,8 @@ const { getModelId } = useNavState()
           :key="property"
           :name="property"
           :required="
-            schema.required &&
-            !!schema.required.length &&
-            schema.required.includes(property)
+            schema.required?.includes(property) ||
+            schema.properties?.[property]?.required === true
           "
           :value="value as OpenAPIV3_1.SchemaObject['properties']" />
       </div>

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -102,9 +102,8 @@ const handleClick = (e: MouseEvent) =>
                 :level="level"
                 :name="property"
                 :required="
-                  value.required &&
-                  value.required.length &&
-                  value.required.includes(property)
+                  value.required?.includes(property) ||
+                  value.properties[property].required
                 "
                 :value="value.properties?.[property]" />
             </template>

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -103,7 +103,7 @@ const handleClick = (e: MouseEvent) =>
                 :name="property"
                 :required="
                   value.required?.includes(property) ||
-                  value.properties[property].required
+                  value.properties?.[property]?.required === true
                 "
                 :value="value.properties?.[property]" />
             </template>

--- a/packages/oas-utils/src/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.test.ts
@@ -808,6 +808,7 @@ describe('getExampleFromSchema', () => {
     expect(
       getExampleFromSchema(
         {
+          type: 'object',
           properties: {
             myProperty: {
               additionalProperties: {
@@ -818,7 +819,6 @@ describe('getExampleFromSchema', () => {
               title: 'MyProperty',
             },
           },
-          type: 'object',
         },
         {
           omitEmptyAndOptionalProperties: true,

--- a/packages/oas-utils/src/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.test.ts
@@ -37,30 +37,35 @@ describe('getExampleFromSchema', () => {
 
   it('only includes required attributes and attributes with example values', () => {
     expect(
-      getExampleFromSchema({
-        type: 'object',
-        required: ['first_name'],
-        properties: {
-          first_name: {
-            type: 'string',
-          },
-          last_name: {
-            type: 'string',
-            required: true,
-          },
-          position: {
-            type: 'string',
-            examples: ['Developer'],
-          },
-          description: {
-            type: 'string',
-            example: 'A developer',
-          },
-          age: {
-            type: 'number',
+      getExampleFromSchema(
+        {
+          type: 'object',
+          required: ['first_name'],
+          properties: {
+            first_name: {
+              type: 'string',
+            },
+            last_name: {
+              type: 'string',
+              required: true,
+            },
+            position: {
+              type: 'string',
+              examples: ['Developer'],
+            },
+            description: {
+              type: 'string',
+              example: 'A developer',
+            },
+            age: {
+              type: 'number',
+            },
           },
         },
-      }),
+        {
+          omitEmptyAndOptionalProperties: true,
+        },
+      ),
     ).toStrictEqual({
       first_name: '',
       last_name: '',

--- a/packages/oas-utils/src/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.test.ts
@@ -799,7 +799,34 @@ describe('getExampleFromSchema', () => {
       }),
     ).toMatchObject({
       myProperty: {
-        someKey: '',
+        '{{key}}': '',
+      },
+    })
+  })
+
+  it('adds a key-value pair example with the schema additionalProperties (omitEmptyAndOptionalProperties: true)', () => {
+    expect(
+      getExampleFromSchema(
+        {
+          properties: {
+            myProperty: {
+              additionalProperties: {
+                type: 'string',
+                title: 'Message',
+              },
+              type: 'object',
+              title: 'MyProperty',
+            },
+          },
+          type: 'object',
+        },
+        {
+          omitEmptyAndOptionalProperties: true,
+        },
+      ),
+    ).toMatchObject({
+      myProperty: {
+        '{{key}}': '',
       },
     })
   })

--- a/packages/oas-utils/src/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.test.ts
@@ -35,6 +35,40 @@ describe('getExampleFromSchema', () => {
     ).toMatchObject('')
   })
 
+  it('only includes required attributes and attributes with example values', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        required: ['first_name'],
+        properties: {
+          first_name: {
+            type: 'string',
+          },
+          last_name: {
+            type: 'string',
+            required: true,
+          },
+          position: {
+            type: 'string',
+            examples: ['Developer'],
+          },
+          description: {
+            type: 'string',
+            example: 'A developer',
+          },
+          age: {
+            type: 'number',
+          },
+        },
+      }),
+    ).toStrictEqual({
+      first_name: '',
+      last_name: '',
+      position: 'Developer',
+      description: 'A developer',
+    })
+  })
+
   it('uses example value for first type in non-null union types', () => {
     expect(
       getExampleFromSchema({

--- a/packages/oas-utils/src/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.ts
@@ -124,6 +124,19 @@ export const getExampleFromSchema = (
     return schema.enum[0]
   }
 
+  // Check if the property is required
+  const isObjectOrArray = schema.type === 'object' || schema.type === 'array'
+  if (!isObjectOrArray && options?.omitEmptyAndOptionalProperties === true) {
+    const isRequired =
+      schema.required === true ||
+      parentSchema?.required === true ||
+      parentSchema?.required?.includes(name ?? schema.name)
+
+    if (!isRequired) {
+      return undefined
+    }
+  }
+
   // Object
   if (schema.type === 'object' || schema.properties !== undefined) {
     const response: Record<string, any> = {}
@@ -218,9 +231,9 @@ export const getExampleFromSchema = (
 
       return {
         ...response,
-        ...(additionalProperties !== undefined
-          ? { '{{key}}': additionalProperties }
-          : {}),
+        ...(additionalProperties === undefined
+          ? {}
+          : { '{{key}}': additionalProperties }),
       }
     }
 
@@ -292,16 +305,6 @@ export const getExampleFromSchema = (
   }
 
   if (schema.type !== undefined && exampleValues[schema.type] !== undefined) {
-    if (options?.omitEmptyAndOptionalProperties === true) {
-      const isRequired =
-        schema.required === true ||
-        parentSchema?.required?.includes(name ?? schema.name)
-
-      if (!isRequired) {
-        return undefined
-      }
-    }
-
     return exampleValues[schema.type]
   }
 

--- a/packages/oas-utils/src/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/getExampleFromSchema.ts
@@ -206,15 +206,21 @@ export const getExampleFromSchema = (
         return null
       }
       // Otherwise, add an example of key-value pair
-      const someKey = getExampleFromSchema(
+      const additionalProperties = getExampleFromSchema(
         schema.additionalProperties,
-        options,
+        {
+          ...options,
+          // Let’s just add the additionalProperties, even if they are optional.
+          omitEmptyAndOptionalProperties: false,
+        },
         level + 1,
       )
 
       return {
         ...response,
-        ...(someKey !== undefined ? { someKey } : {}),
+        ...(additionalProperties !== undefined
+          ? { '{{key}}': additionalProperties }
+          : {}),
       }
     }
 

--- a/packages/oas-utils/src/getRequestBodyFromOperation.test.ts
+++ b/packages/oas-utils/src/getRequestBodyFromOperation.test.ts
@@ -248,16 +248,16 @@ describe('getRequestBodyFromOperation', () => {
 
     const expectedResult = {
       recordString: {
-        someKey: '',
+        '{{key}}': '',
       },
       recordInteger: {
-        someKey: 1,
+        '{{key}}': 1,
       },
       recordArray: {
-        someKey: [],
+        '{{key}}': [],
       },
       recordBoolean: {
-        someKey: true,
+        '{{key}}': true,
       },
       recordNullable: null,
       recordObject: {},

--- a/packages/oas-utils/src/getRequestBodyFromOperation.test.ts
+++ b/packages/oas-utils/src/getRequestBodyFromOperation.test.ts
@@ -192,6 +192,15 @@ describe('getRequestBodyFromOperation', () => {
             'application/json': {
               schema: {
                 type: 'object',
+                required: [
+                  'recordString',
+                  'recordInteger',
+                  'recordArray',
+                  'recordBoolean',
+                  'recordNullable',
+                  'recordObject',
+                  'recordWithoutAdditionalProperties',
+                ],
                 properties: {
                   recordString: {
                     type: 'object',

--- a/packages/oas-utils/src/getRequestBodyFromOperation.test.ts
+++ b/packages/oas-utils/src/getRequestBodyFromOperation.test.ts
@@ -259,7 +259,9 @@ describe('getRequestBodyFromOperation', () => {
       recordBoolean: {
         '{{key}}': true,
       },
-      recordNullable: null,
+      recordNullable: {
+        '{{key}}': null,
+      },
       recordObject: {},
       recordWithoutAdditionalProperties: {},
     }

--- a/packages/oas-utils/src/getRequestBodyFromOperation.ts
+++ b/packages/oas-utils/src/getRequestBodyFromOperation.ts
@@ -128,7 +128,10 @@ export function getRequestBodyFromOperation(
   // JSON
   if (mimeType === 'application/json') {
     const exampleFromSchema = requestBodyObject?.schema
-      ? getExampleFromSchema(requestBodyObject?.schema, { mode: 'write' })
+      ? getExampleFromSchema(requestBodyObject?.schema, {
+          mode: 'write',
+          omitEmptyAndOptionalProperties: true,
+        })
       : null
 
     const body = example ?? exampleFromSchema
@@ -148,6 +151,7 @@ export function getRequestBodyFromOperation(
       ? getExampleFromSchema(requestBodyObject?.schema, {
           xml: true,
           mode: 'write',
+          omitEmptyAndOptionalProperties: true,
         })
       : null
 
@@ -177,6 +181,7 @@ export function getRequestBodyFromOperation(
       ? getExampleFromSchema(requestBodyObject?.schema, {
           xml: true,
           mode: 'write',
+          omitEmptyAndOptionalProperties: true,
         })
       : null
 


### PR DESCRIPTION
Currently, we’re generating empty request bodies from the schema, which always includes all properties. Sometimes, we can prefill the fields with values, but mostly we can’t. This can be annoying when there’s a ton of optional properties (with invalid values).

With this PR only required properties and properties with an example value are added to the request body, others are omitted, as suggested in #933.

**Other changes**
* The request body didn’t show properties that have `required: true` as required (only if they were in `required: […]` one level above).
* With `additionalProperties` you can define arbitrary properties. We used to pick `someKey` as an example. I changed it to `{{key}}` because I think it’s more clear. It’s the variable syntax we use in other places already.

**Example**
```yaml
openapi: 3.1.0
info:
  title: Example
  version: 1.0.0
paths:
  '/planets':
    post:
      tags:
        - Planets
      summary: Create a planet
      requestBody:
        description: Planet
        content:
          application/json:
            schema:
              '$ref': '#/components/schemas/Planet'
      responses:
        '201':
          description: Created
          content:
            application/json:
              schema:
                '$ref': '#/components/schemas/Planet'
components:
  schemas:
    Planet:
      type: object
      required:
        - id
      properties:
        # example + required
        id:
          type: integer
          examples:
            - 1
        # example + required
        name:
          type: string
          examples:
            - Mars
          required: true
        # example + not required
        description:
          type:
            - string
            - 'null'
          examples:
            - The red planet
        # empty + not required
        size:
          type:
            - string

```

**Preview**

Note: There’s no `size` in the example request.

<img width="587" alt="Screenshot 2024-05-30 at 18 03 30" src="https://github.com/scalar/scalar/assets/1577992/322f5cea-6786-4069-9701-3ac6178215e8">
