### PR TITLE
fix: sidebar webhooks

### DIFF
--- a/.changeset/big-carrots-occur.md
+++ b/.changeset/big-carrots-occur.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: sidebar webhooks state

--- a/packages/api-reference/src/components/Section/Section.vue
+++ b/packages/api-reference/src/components/Section/Section.vue
@@ -28,8 +28,8 @@ function handleScroll() {
 
   window.history.replaceState({}, '', newUrl)
 
-  // Open models on scroll
-  if (props.id?.startsWith('model'))
+  // Open models and webhooks on scroll
+  if (props.id?.startsWith('model') || props.id?.startsWith('webhook'))
     setCollapsedSidebarItem(getSectionId(props.id), true)
 }
 </script>

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -67,10 +67,12 @@ const getTagId = ({ name }: Tag) => {
 
 // Grabs the sectionId of the hash to open the section before scrolling
 const getSectionId = (hashStr = hash.value) => {
+  console.log('hashStr', hash.value)
   const tagId = hashStr.match(/(tag\/[^/]+)/)?.[0]
   const modelId = hashStr.startsWith('model') ? 'models' : ''
+  const webhookId = hashStr.startsWith('webhook') ? 'webhooks' : ''
 
-  return tagId ?? modelId
+  return tagId || modelId || webhookId
 }
 
 // Update the reactive hash state


### PR DESCRIPTION
**Problem**
webhooks sidebar heading doesn't get toggled when navigating over a webhook section, nor when we navigate toward webhook section url.

https://github.com/scalar/scalar/assets/14966155/9e08e635-be30-4a40-9896-14021ec1fd2f

**Solution**
this pr is a proposal in order to open webhooks sidebar heading group on a webhook section scroll.
