### PR TITLE
chore(galaxy): remove headings from details tag

### DIFF
--- a/.changeset/perfect-bags-swim.md
+++ b/.changeset/perfect-bags-swim.md
@@ -1,0 +1,5 @@
+---
+"@scalar/galaxy": patch
+---
+
+chore: remove headings from inside the details tag

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -17,17 +17,17 @@ info:
     <details>
       <summary>Examples</summary>
 
-      ### Blockquotes
+      **Blockquotes**
 
       > I love OpenAPI. <3
 
-      ### Tables
+      **Tables**
 
       | Feature          | Availability |
       | ---------------- | ------------ |
       | Markdown Support | ✓            |
 
-      ### Accordion
+      **Accordion**
 
       ```html
       <details>
@@ -36,7 +36,7 @@ info:
       </details>
       ```
 
-      ### Images
+      **Images**
 
       Yes, there’s support for images, too!
 


### PR DESCRIPTION
We’ve had a special case in our example: Headings inside an `<details>` tag. Which isn’t really compatible with our way to split the Markdown content in sections. Fixing it (for example adding ids to the headings, not splitting the content in sections) would make it harder to show an accurate active state in the sidebar.

This PR just removes the headings from inside the `<details>` tag. Looks the same, but isn’t anymore in the sidebar, which is actually better IMHO.