### PR TITLE
chore(galaxy): add a preview script

### DIFF
--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -26,7 +26,7 @@
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "test": "vitest",
-    "dev": "pnpm dlx @scalar/cli serve ./src/specifications/3.1.yaml",
+    "dev": "pnpm dlx @scalar/cli serve ./src/specifications/3.1.yaml --watch",
     "types:build": "tsc -p tsconfig.build.json",
     "types:check": "tsc --noEmit --skipLibCheck"
   },

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -26,6 +26,7 @@
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "test": "vitest",
+    "dev": "pnpm dlx @scalar/cli serve ./src/specifications/3.1.yaml",
     "types:build": "tsc -p tsconfig.build.json",
     "types:check": "tsc --noEmit --skipLibCheck"
   },


### PR DESCRIPTION
This PR adds a script to preview the `@scalar/galaxy` example and watch for changes. Great to see the results right-away while editing the example specification.