### PR TITLE
fix: different response examples for different status codes

### DIFF
--- a/.changeset/light-snails-bathe.md
+++ b/.changeset/light-snails-bathe.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": minor
+---
+
+fix: different response examples for different status codes

--- a/.changeset/light-snails-bathe.md
+++ b/.changeset/light-snails-bathe.md
@@ -1,5 +1,5 @@
 ---
-"@scalar/api-reference": minor
+"@scalar/api-reference": patch
 ---
 
 fix: different response examples for different status codes

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -71,17 +71,34 @@ const currentJsonResponse = computed(() => {
     currentResponse.value
   )
 })
+
+/**
+ * Gets the first example response if there are multiple example responses
+ * or the only example if there is only one example response.
+ */
+ const getFirstExampleResponse = () => {
+  if (!hasMultipleExamples.value)
+    return currentJsonResponse.value.example;
+  else if (Array.isArray(currentJsonResponse.value.examples))
+    return currentJsonResponse.value.examples[0]
+  else {
+    const firstProperty = Object.keys(currentJsonResponse.value.examples)[0];
+    return currentJsonResponse.value.examples[firstProperty];
+  }
+}
+
 const currentResponseWithExample = computed(() => ({
   ...currentJsonResponse.value,
   example:
     hasMultipleExamples.value && selectedExampleKey.value
       ? currentJsonResponse.value.examples[selectedExampleKey.value].value ??
         currentJsonResponse.value.examples[selectedExampleKey.value]
-      : currentJsonResponse.value.example,
+      : getFirstExampleResponse(),
 }))
 
 const changeTab = (index: number) => {
   selectedResponseIndex.value = index
+  selectedExampleKey.value = undefined;
 }
 
 const showSchema = ref(false)

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -76,14 +76,13 @@ const currentJsonResponse = computed(() => {
  * Gets the first example response if there are multiple example responses
  * or the only example if there is only one example response.
  */
- const getFirstExampleResponse = () => {
-  if (!hasMultipleExamples.value)
-    return currentJsonResponse.value.example;
+const getFirstExampleResponse = () => {
+  if (!hasMultipleExamples.value) return currentJsonResponse.value.example
   else if (Array.isArray(currentJsonResponse.value.examples))
     return currentJsonResponse.value.examples[0]
   else {
-    const firstProperty = Object.keys(currentJsonResponse.value.examples)[0];
-    return currentJsonResponse.value.examples[firstProperty];
+    const firstProperty = Object.keys(currentJsonResponse.value.examples)[0]
+    return currentJsonResponse.value.examples[firstProperty]
   }
 }
 
@@ -98,7 +97,7 @@ const currentResponseWithExample = computed(() => ({
 
 const changeTab = (index: number) => {
   selectedResponseIndex.value = index
-  selectedExampleKey.value = undefined;
+  selectedExampleKey.value = undefined
 }
 
 const showSchema = ref(false)


### PR DESCRIPTION
Fixing issue where status codes having different example responses would cause an error.

**Problem**
Currently, an error occurs when switching between response codes with different names for examples. This is issue #1624 

**Explanation**
This happens because the `selectedExampleKey` value isn't reset when switching tabs, which causes an error when attempting to find that value in the examples object

**Solution**
With this PR, the `selectedExampleKey` value is reset when changing tabs and the logic to determine the first example has been updated to account for a single example, a list of examples, and a object of examples (named examples).
