### PR TITLE
feat: support OAuth2 client credentials flow

### DIFF
--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeSelector.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeSelector.vue
@@ -92,6 +92,10 @@ const getAuthorizationTypeLabel = (item: any) => {
       return 'OAuth 2.0 Password'
     }
 
+    if (item.flows?.clientCredentials) {
+      return 'OAuth 2.0 Client Credentials'
+    }
+
     return 'OAuth 2.0'
   }
 

--- a/packages/api-client/src/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-client/src/helpers/getRequestFromAuthentication.test.ts
@@ -201,6 +201,7 @@ describe('getRequestFromAuthentication', () => {
           state: '',
           username: '',
           password: '',
+          clientSecret: '',
         },
       },
       [

--- a/packages/api-client/src/stores/useAuthenticationStore.ts
+++ b/packages/api-client/src/stores/useAuthenticationStore.ts
@@ -24,6 +24,7 @@ export const createEmptyAuthenticationState = (): AuthenticationState => ({
     scopes: [],
     accessToken: '',
     state: '',
+    clientSecret: '',
   },
 })
 

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -56,7 +56,9 @@ security:
   - apiKeyQuery: []
   - apiKeyHeader: []
   - apiKeyCookie: []
-  - oauth2: []
+  - oauth2Implicit: []
+  - oauth2Password: []
+  - oauth2ClientCredentials: []
 tags:
   - name: Authentication
     description:
@@ -354,11 +356,27 @@ components:
       type: apiKey
       in: cookie
       name: api_key
-    oauth2:
+    oauth2Implicit:
       type: oauth2
       flows:
         implicit:
           authorizationUrl: https://galaxy.scalar.com/oauth/authorize
+          scopes:
+            write:planets: modify planets in your account
+            read:planets: read your planets
+    oauth2Password:
+      type: oauth2
+      flows:
+        password:
+          tokenUrl: https://galaxy.scalar.com/oauth/authorize
+          scopes:
+            write:planets: modify planets in your account
+            read:planets: read your planets
+    oauth2ClientCredentials:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://galaxy.scalar.com/oauth/token
           scopes:
             write:planets: modify planets in your account
             read:planets: read your planets

--- a/packages/oas-utils/src/types.ts
+++ b/packages/oas-utils/src/types.ts
@@ -159,6 +159,7 @@ export type AuthenticationState = {
     state: string
     username: string
     password: string
+    clientSecret: string
   }
 }
 


### PR DESCRIPTION
**Problem**
Currently, the client credentials flow for oauth is not supported.

**Explanation**
This happens because support has not yet been built out.

**Solution**
With this PR the client credentials flow is supported.

***Sample in UI***
![image](https://github.com/scalar/scalar/assets/8587567/a13bf3a0-f09a-4588-a049-8a30004e7f0c)

***Sample in UI after successful auth***
![image](https://github.com/scalar/scalar/assets/8587567/bcf51030-d1ef-4305-a80a-0a11d0e2f182)
