### PR TITLE
chore: re-enable tests

### DIFF
--- a/packages/themes/src/index.test.ts
+++ b/packages/themes/src/index.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest'
 import { getThemeById } from './'
 
 // TODO: re-enable this test - it's failing because of an issue with the vitest snapshot
-describe.skip('Get Theme by ID', () => {
+describe('Get Theme by ID', () => {
   it('Should provide the default theme if no ThemeId is provided', () => {
     const res = getThemeById()
     expect(res).toMatchFileSnapshot('./presets/default.css')

--- a/packages/themes/src/utilities/legacy.test.ts
+++ b/packages/themes/src/utilities/legacy.test.ts
@@ -7,7 +7,7 @@ import legacyTheme from '../fixtures/legacyTheme.css?inline'
 import { migrateThemeVariables } from './legacy'
 
 // TODO: re-enable this test - it's failing because of an issue with the vitest snapshot
-describe.skip('Legacy Utils', () => {
+describe('Legacy Utils', () => {
   it('Changes a legacy theme variable', () => {
     const res = migrateThemeVariables('--theme-color-1')
     expect(res).toBe('--scalar-color-1')


### PR DESCRIPTION
**Problem**
Currently, we are skipping the tests in `/packages/themes` because they are throwing errors related to `environment` in vitest snapshot. 

Unsure why this is the case but I have tried setting the test environment to `jsdom` both in the vitest config and as a docstring at the top of the test files. 

I have noticed that this error only occurs when running the tests from the root of the repo with `pnpm test` but the error is not thrown if you first cd into the package and then run the test. 

I have also tried upgrading vite and vitest packages to latest versions. I did notice that vitest has [an open PR for upgrading to pnpm 9](https://github.com/vitest-dev/vitest/pull/5581) but I'm skeptical this is related. We could also try downgrading to see if that helps.  

To reproduce, run the proxy and the echo server 
`pnpm dev:proxy-server`
`pnpm dev:echo-server` 
`pnpm test` 


