### PR TITLE
chore: update `@scalar/openapi-parser`

### DIFF
--- a/.changeset/young-spies-sort.md
+++ b/.changeset/young-spies-sort.md
@@ -1,0 +1,13 @@
+---
+"@scalar/api-reference": patch
+"@scalar/mock-server": patch
+"@scalar/play-button": patch
+"@scalar/api-client": patch
+"@scalar/client-app": patch
+"@scalar/oas-utils": patch
+"@scalar/galaxy": patch
+"@scalar/nuxt": patch
+"@scalar/cli": patch
+---
+
+chore: upgrade to new @scalar/openapi-parser version

--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,4 @@ fixtures
 .next
 
 examples/docusaurus/**/*.mdx
+packages/nuxt/src/runtime/plugins/hydrateClient.d.mts

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -49,7 +49,7 @@
     "@headlessui/vue": "^1.7.20",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.1",
+    "@scalar/openapi-parser": "^0.5.0",
     "@scalar/themes": "workspace:*",
     "@scalar/use-codemirror": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -49,7 +49,7 @@
     "@headlessui/vue": "^1.7.20",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.5.0",
+    "@scalar/openapi-parser": "^0.6.0",
     "@scalar/themes": "workspace:*",
     "@scalar/use-codemirror": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -49,7 +49,7 @@
     "@headlessui/vue": "^1.7.20",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.0",
+    "@scalar/openapi-parser": "^0.4.1",
     "@scalar/themes": "workspace:*",
     "@scalar/use-codemirror": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -49,7 +49,7 @@
     "@headlessui/vue": "^1.7.20",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.3.2",
+    "@scalar/openapi-parser": "^0.4.0",
     "@scalar/themes": "workspace:*",
     "@scalar/use-codemirror": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -49,7 +49,7 @@
     "@headlessui/vue": "^1.7.20",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.6.0",
+    "@scalar/openapi-parser": "^0.7.1",
     "@scalar/themes": "workspace:*",
     "@scalar/use-codemirror": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecurityScheme.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecurityScheme.vue
@@ -236,7 +236,10 @@ const startAuthentication = (url: string) => {
       type="password"
       :value="authentication.apiKey.token"
       @input="handleApiKeyTokenInput">
-      {{ value.in.charAt(0).toUpperCase() + value.in.slice(1) }} API
+      {{
+        value.in ? value.in?.charAt(0).toUpperCase() + value.in?.slice(1) : ''
+      }}
+      API
     </CardFormTextInput>
 
     <!-- HTTP Basic Auth -->
@@ -311,7 +314,7 @@ const startAuthentication = (url: string) => {
             <CardFormTextInput
               id="oAuth2.username"
               placeholder="Username"
-              :value="authentication.oAuth2.username"
+              :value="(authentication.oAuth2 as any).username"
               @input="handleOAuth2UsernameInput">
               Username
             </CardFormTextInput>
@@ -319,7 +322,7 @@ const startAuthentication = (url: string) => {
               id="oAuth2.password"
               placeholder="Password"
               type="password"
-              :value="authentication.oAuth2.password"
+              :value="(authentication.oAuth2 as any).password"
               @input="handleOAuth2PasswordInput">
               Password
             </CardFormTextInput>
@@ -370,6 +373,7 @@ const startAuthentication = (url: string) => {
       </template>
       <!-- Other Flows -->
       <template v-else>
+        <<<<<<< HEAD
         <CardFormRows>
           <CardFormGroup>
             <CardFormTextInput
@@ -412,6 +416,34 @@ const startAuthentication = (url: string) => {
             </button>
           </CardFormGroup>
         </CardFormRows>
+        =======
+        <CardFormTextInput
+          id="oAuth2.clientId"
+          placeholder="12345"
+          type="text"
+          :value="authentication.oAuth2.clientId"
+          @input="handleOpenAuth2ClientIdInput">
+          Client ID
+        </CardFormTextInput>
+        <SecuritySchemeScopes
+          v-if="value !== undefined"
+          v-model:selected="oauth2SelectedScopes"
+          :scopes="(value as Record<string, any>).flows.implicit!.scopes" />
+        <button
+          class="cardform-auth-button"
+          type="button"
+          @click="
+            () =>
+              startAuthentication(
+                getOpenAuth2AuthorizationUrl(
+                  //@ts-ignore
+                  value?.flows.implicit,
+                ),
+              )
+          ">
+          Authorize
+        </button>
+        >>>>>>> ab402bb1c (fix: some TS issues)
       </template>
     </CardFormGroup>
   </CardForm>

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecurityScheme.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecurityScheme.vue
@@ -236,9 +236,9 @@ const startAuthentication = (url: string) => {
       type="password"
       :value="authentication.apiKey.token"
       @input="handleApiKeyTokenInput">
-      {{
-        value.in ? value.in?.charAt(0).toUpperCase() + value.in?.slice(1) : ''
-      }}
+      <template v-if="value.in">
+        {{ value.in?.charAt(0)?.toUpperCase() + value.in?.slice(1) }}
+      </template>
       API
     </CardFormTextInput>
 
@@ -283,7 +283,7 @@ const startAuthentication = (url: string) => {
         (value as OpenAPIV3.OAuth2SecurityScheme).flows
       ">
       <!-- Implicit Flow -->
-      <template v-if="(value as OpenAPIV3.OAuth2SecurityScheme).flows.implicit">
+      <template v-if="(value as any).flows.implicit">
         <template v-if="authentication.oAuth2.accessToken">
           <CardFormTextInput
             id="oAuth2.accessToken"
@@ -308,13 +308,13 @@ const startAuthentication = (url: string) => {
         </template>
       </template>
       <!-- Password Flow -->
-      <template v-if="(value as OpenAPIV3.OAuth2SecurityScheme).flows.password">
+      <template v-if="(value as any).flows.password">
         <CardFormRows>
           <CardFormGroup>
             <CardFormTextInput
               id="oAuth2.username"
               placeholder="Username"
-              :value="(authentication.oAuth2 as any).username"
+              :value="authentication.oAuth2.username"
               @input="handleOAuth2UsernameInput">
               Username
             </CardFormTextInput>
@@ -322,7 +322,7 @@ const startAuthentication = (url: string) => {
               id="oAuth2.password"
               placeholder="Password"
               type="password"
-              :value="(authentication.oAuth2 as any).password"
+              :value="authentication.oAuth2.password"
               @input="handleOAuth2PasswordInput">
               Password
             </CardFormTextInput>
@@ -340,17 +340,14 @@ const startAuthentication = (url: string) => {
               v-if="
                 value !== undefined &&
                 Object.entries(
-                  (value as OpenAPIV3.OAuth2SecurityScheme).flows.implicit
-                    ?.scopes ??
-                    (value as OpenAPIV3.OAuth2SecurityScheme).flows.password!
-                      .scopes,
+                  (value as any).flows.implicit?.scopes ??
+                    (value as any).flows.password!.scopes,
                 ).length > 0
               "
               v-model:selected="oauth2SelectedScopes"
               :scopes="
-                (value as OpenAPIV3.OAuth2SecurityScheme).flows.implicit
-                  ?.scopes ??
-                (value as OpenAPIV3.OAuth2SecurityScheme).flows.password!.scopes
+                (value as any).flows.implicit?.scopes ??
+                (value as any).flows.password!.scopes
               " />
             <button
               class="cardform-auth-button"
@@ -373,7 +370,6 @@ const startAuthentication = (url: string) => {
       </template>
       <!-- Other Flows -->
       <template v-else>
-        <<<<<<< HEAD
         <CardFormRows>
           <CardFormGroup>
             <CardFormTextInput
@@ -388,17 +384,14 @@ const startAuthentication = (url: string) => {
               v-if="
                 value !== undefined &&
                 Object.entries(
-                  (value as OpenAPIV3.OAuth2SecurityScheme).flows.implicit
-                    ?.scopes ??
-                    (value as OpenAPIV3.OAuth2SecurityScheme).flows.password!
-                      .scopes,
+                  (value as any).flows.implicit?.scopes ??
+                    (value as any).flows.password!.scopes,
                 ).length > 0
               "
               v-model:selected="oauth2SelectedScopes"
               :scopes="
-                (value as OpenAPIV3.OAuth2SecurityScheme).flows.implicit
-                  ?.scopes ??
-                (value as OpenAPIV3.OAuth2SecurityScheme).flows.password!.scopes
+                (value as any).flows.implicit?.scopes ??
+                (value as any).flows.password!.scopes
               " />
             <button
               class="cardform-auth-button"
@@ -416,34 +409,6 @@ const startAuthentication = (url: string) => {
             </button>
           </CardFormGroup>
         </CardFormRows>
-        =======
-        <CardFormTextInput
-          id="oAuth2.clientId"
-          placeholder="12345"
-          type="text"
-          :value="authentication.oAuth2.clientId"
-          @input="handleOpenAuth2ClientIdInput">
-          Client ID
-        </CardFormTextInput>
-        <SecuritySchemeScopes
-          v-if="value !== undefined"
-          v-model:selected="oauth2SelectedScopes"
-          :scopes="(value as Record<string, any>).flows.implicit!.scopes" />
-        <button
-          class="cardform-auth-button"
-          type="button"
-          @click="
-            () =>
-              startAuthentication(
-                getOpenAuth2AuthorizationUrl(
-                  //@ts-ignore
-                  value?.flows.implicit,
-                ),
-              )
-          ">
-          Authorize
-        </button>
-        >>>>>>> ab402bb1c (fix: some TS issues)
       </template>
     </CardFormGroup>
   </CardForm>

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecurityScheme.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecurityScheme.vue
@@ -318,7 +318,7 @@ const startAuthentication = (url: string) => {
             value as
               | OpenAPIV3.OAuth2SecurityScheme
               | OpenAPIV3_1.OAuth2SecurityScheme
-          ).flows.password
+          )?.flows?.password
         ">
         <CardFormRows>
           <CardFormGroup>
@@ -355,12 +355,13 @@ const startAuthentication = (url: string) => {
                     value as
                       | OpenAPIV3.OAuth2SecurityScheme
                       | OpenAPIV3_1.OAuth2SecurityScheme
-                  ).flows.implicit?.scopes ??
+                  )?.flows?.implicit?.scopes ??
                     (
                       value as
                         | OpenAPIV3.OAuth2SecurityScheme
                         | OpenAPIV3_1.OAuth2SecurityScheme
-                    ).flows.password!.scopes,
+                    )?.flows?.password?.scopes ??
+                    {},
                 ).length > 0
               "
               v-model:selected="oauth2SelectedScopes"
@@ -369,12 +370,12 @@ const startAuthentication = (url: string) => {
                   value as
                     | OpenAPIV3.OAuth2SecurityScheme
                     | OpenAPIV3_1.OAuth2SecurityScheme
-                ).flows.implicit?.scopes ??
+                )?.flows?.implicit?.scopes ??
                 (
                   value as
                     | OpenAPIV3.OAuth2SecurityScheme
                     | OpenAPIV3_1.OAuth2SecurityScheme
-                ).flows.password!.scopes
+                )?.flows?.password!.scopes
               " />
             <button
               class="cardform-auth-button"

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecurityScheme.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecurityScheme.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import { useToasts } from '@scalar/use-toasts'
 import { computed } from 'vue'
 
@@ -18,7 +18,10 @@ import CardFormTextInput from './CardFormTextInput.vue'
 import SecuritySchemeScopes from './SecuritySchemeScopes.vue'
 
 defineProps<{
-  value?: OpenAPIV3.SecuritySchemeObject | OpenAPIV3_1.SecuritySchemeObject
+  value?:
+    | OpenAPIV2.SecuritySchemeObject
+    | OpenAPIV3.SecuritySchemeObject
+    | OpenAPIV3_1.SecuritySchemeObject
   proxy?: string
 }>()
 
@@ -243,10 +246,7 @@ const startAuthentication = (url: string) => {
     </CardFormTextInput>
 
     <!-- HTTP Basic Auth -->
-    <template
-      v-else-if="
-        value.type === 'http' || (value as unknown as any).type === 'basic'
-      ">
+    <template v-else-if="value.type === 'http' || value.type === 'basic'">
       <!-- @vue-ignore -->
       <CardFormGroup v-if="value.type === 'basic' || value.scheme === 'basic'">
         <CardFormTextInput
@@ -280,7 +280,11 @@ const startAuthentication = (url: string) => {
     <CardFormGroup
       v-else-if="
         value.type.toLowerCase() === 'oauth2' &&
-        (value as OpenAPIV3.OAuth2SecurityScheme).flows
+        (
+          value as
+            | OpenAPIV3.OAuth2SecurityScheme
+            | OpenAPIV3_1.OAuth2SecurityScheme
+        ).flows
       ">
       <!-- Implicit Flow -->
       <template v-if="(value as any).flows.implicit">
@@ -308,7 +312,14 @@ const startAuthentication = (url: string) => {
         </template>
       </template>
       <!-- Password Flow -->
-      <template v-if="(value as any).flows.password">
+      <template
+        v-if="
+          (
+            value as
+              | OpenAPIV3.OAuth2SecurityScheme
+              | OpenAPIV3_1.OAuth2SecurityScheme
+          ).flows.password
+        ">
         <CardFormRows>
           <CardFormGroup>
             <CardFormTextInput
@@ -340,14 +351,30 @@ const startAuthentication = (url: string) => {
               v-if="
                 value !== undefined &&
                 Object.entries(
-                  (value as any).flows.implicit?.scopes ??
-                    (value as any).flows.password!.scopes,
+                  (
+                    value as
+                      | OpenAPIV3.OAuth2SecurityScheme
+                      | OpenAPIV3_1.OAuth2SecurityScheme
+                  ).flows.implicit?.scopes ??
+                    (
+                      value as
+                        | OpenAPIV3.OAuth2SecurityScheme
+                        | OpenAPIV3_1.OAuth2SecurityScheme
+                    ).flows.password!.scopes,
                 ).length > 0
               "
               v-model:selected="oauth2SelectedScopes"
               :scopes="
-                (value as any).flows.implicit?.scopes ??
-                (value as any).flows.password!.scopes
+                (
+                  value as
+                    | OpenAPIV3.OAuth2SecurityScheme
+                    | OpenAPIV3_1.OAuth2SecurityScheme
+                ).flows.implicit?.scopes ??
+                (
+                  value as
+                    | OpenAPIV3.OAuth2SecurityScheme
+                    | OpenAPIV3_1.OAuth2SecurityScheme
+                ).flows.password!.scopes
               " />
             <button
               class="cardform-auth-button"
@@ -355,8 +382,11 @@ const startAuthentication = (url: string) => {
               @click="
                 () =>
                   authorizeWithPassword(
-                    (value as OpenAPIV3.OAuth2SecurityScheme).flows?.password
-                      ?.tokenUrl,
+                    (
+                      value as
+                        | OpenAPIV3.OAuth2SecurityScheme
+                        | OpenAPIV3_1.OAuth2SecurityScheme
+                    ).flows?.password?.tokenUrl,
                     {
                       baseUrl: getUrlFromServerState(server),
                       proxy,
@@ -400,8 +430,16 @@ const startAuthentication = (url: string) => {
                 () =>
                   startAuthentication(
                     getOpenAuth2AuthorizationUrl(
-                      //@ts-ignore
-                      value?.flows.implicit ?? value?.flows.password,
+                      (
+                        value as
+                          | OpenAPIV3.OAuth2SecurityScheme
+                          | OpenAPIV3_1.OAuth2SecurityScheme
+                      )?.flows?.implicit ??
+                        (
+                          value as
+                            | OpenAPIV3.OAuth2SecurityScheme
+                            | OpenAPIV3_1.OAuth2SecurityScheme
+                        )?.flows?.password,
                     ),
                   )
               ">

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeScopes.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeScopes.vue
@@ -13,7 +13,7 @@ import { computed, ref } from 'vue'
 import CardFormButton from './CardFormButton.vue'
 
 const props = defineProps<{
-  scopes: { [scope: string]: string }
+  scopes?: { [scope: string]: string }
   selected: string[]
 }>()
 
@@ -37,6 +37,7 @@ const model = computed({
 </script>
 <template>
   <Listbox
+    v-if="Object.keys(scopes ?? {}).length"
     v-slot="{ open }"
     v-model="model"
     multiple>
@@ -47,7 +48,7 @@ const model = computed({
       <ListboxButton :as="CardFormButton">
         <div class="scopes-label">
           Scopes
-          {{ model.length }}<em>/</em>{{ Object.entries(scopes).length }}
+          {{ model.length }}<em>/</em>{{ Object.entries(scopes ?? {}).length }}
           <ScalarIcon
             :icon="open ? 'ChevronUp' : 'ChevronDown'"
             size="sm" />
@@ -65,7 +66,7 @@ const model = computed({
             as="dl"
             class="dropdown">
             <ListboxOption
-              v-for="[key, description] in Object.entries(scopes)"
+              v-for="[key, description] in Object.entries(scopes ?? {})"
               :key="key"
               v-slot="{ selected: s }"
               as="div"

--- a/packages/api-client/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-client/src/helpers/getRequestFromAuthentication.ts
@@ -123,6 +123,7 @@ export function getRequestFromAuthentication(
         'type' in securityScheme &&
         // @ts-ignore
         (securityScheme.type === 'basic' ||
+          // @ts-ignore
           (securityScheme.type === 'http' && securityScheme.scheme === 'basic'))
       ) {
         const { username, password } = authentication.http.basic
@@ -138,6 +139,7 @@ export function getRequestFromAuthentication(
       else if (
         'type' in securityScheme &&
         securityScheme.type === 'http' &&
+        // @ts-ignore
         securityScheme.scheme === 'bearer'
       ) {
         const token = authentication.http.bearer.token.length

--- a/packages/api-client/src/helpers/getRequestFromAuthentication.ts
+++ b/packages/api-client/src/helpers/getRequestFromAuthentication.ts
@@ -1,5 +1,5 @@
 import type { AuthenticationState } from '@scalar/oas-utils'
-import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import type { HarRequest } from 'httpsnippet-lite'
 
 import { encodeStringAsBase64 } from './encodeStringAsBase64'
@@ -65,7 +65,10 @@ export function getRequestFromAuthentication(
       ),
   )
 
-  // If the (globally) selected security scheme is not allowed for the operation, use the first available security scheme.
+  /**
+   * If the (globally) selected security scheme is not allowed for the operation,
+   * use the first available security scheme.
+   */
   const operationSecurityKey =
     operationAllowsSelectedSecurityScheme || authentication.customSecurity
       ? authentication.preferredSecurityScheme
@@ -115,16 +118,18 @@ export function getRequestFromAuthentication(
     // HTTP Header Auth
     else if (
       'type' in securityScheme &&
-      // @ts-ignore
       (securityScheme.type === 'http' || securityScheme.type === 'basic')
     ) {
       // Basic Auth
       if (
         'type' in securityScheme &&
-        // @ts-ignore
         (securityScheme.type === 'basic' ||
-          // @ts-ignore
-          (securityScheme.type === 'http' && securityScheme.scheme === 'basic'))
+          (securityScheme.type === 'http' &&
+            (
+              securityScheme as
+                | OpenAPIV3.HttpSecurityScheme
+                | OpenAPIV3_1.HttpSecurityScheme
+            ).scheme === 'basic'))
       ) {
         const { username, password } = authentication.http.basic
 
@@ -139,8 +144,11 @@ export function getRequestFromAuthentication(
       else if (
         'type' in securityScheme &&
         securityScheme.type === 'http' &&
-        // @ts-ignore
-        securityScheme.scheme === 'bearer'
+        (
+          securityScheme as
+            | OpenAPIV3.HttpSecurityScheme
+            | OpenAPIV3_1.HttpSecurityScheme
+        ).scheme === 'bearer'
       ) {
         const token = authentication.http.bearer.token.length
           ? authentication.http.bearer.token

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -64,7 +64,7 @@
     "@scalar/api-client-modal": "workspace:*",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.5.0",
+    "@scalar/openapi-parser": "^0.6.0",
     "@scalar/snippetz": "^0.1.6",
     "@scalar/themes": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -64,7 +64,7 @@
     "@scalar/api-client-modal": "workspace:*",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.6.0",
+    "@scalar/openapi-parser": "^0.7.1",
     "@scalar/snippetz": "^0.1.6",
     "@scalar/themes": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -64,7 +64,7 @@
     "@scalar/api-client-modal": "workspace:*",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.0",
+    "@scalar/openapi-parser": "^0.4.1",
     "@scalar/snippetz": "^0.1.6",
     "@scalar/themes": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -64,7 +64,7 @@
     "@scalar/api-client-modal": "workspace:*",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.1",
+    "@scalar/openapi-parser": "^0.5.0",
     "@scalar/snippetz": "^0.1.6",
     "@scalar/themes": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -64,7 +64,7 @@
     "@scalar/api-client-modal": "workspace:*",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.3.2",
+    "@scalar/openapi-parser": "^0.4.0",
     "@scalar/snippetz": "^0.1.6",
     "@scalar/themes": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -103,7 +103,7 @@ const isLazy = props.layout !== 'accordion' && !hash.value.startsWith('model')
       :parsedSpec="parsedSpec" />
 
     <Introduction
-      v-if="parsedSpec.info.title || parsedSpec.info.description"
+      v-if="parsedSpec?.info?.title || parsedSpec?.info?.description"
       :info="parsedSpec.info"
       :parsedSpec="parsedSpec">
       <template #[introCardsSlot]>

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -4,6 +4,7 @@ import type {
   Tag as TagType,
   TransformedOperation,
 } from '@scalar/oas-utils'
+import type { OpenAPIV3 } from '@scalar/openapi-parser'
 import { onMounted, ref, watch } from 'vue'
 
 import { getModels, scrollToId } from '../../../helpers'
@@ -176,7 +177,10 @@ onMounted(() => {
           <SectionContent>
             <SectionHeader :level="2">
               <Anchor :id="getModelId(name)">
-                {{ (getModels(parsedSpec)?.[name]).title ?? name }}
+                {{
+                  (getModels(parsedSpec)?.[name] as OpenAPIV3.SchemaObject)
+                    .title ?? name
+                }}
               </Anchor>
             </SectionHeader>
             <Schema

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -176,13 +176,13 @@ onMounted(() => {
           <SectionContent>
             <SectionHeader :level="2">
               <Anchor :id="getModelId(name)">
-                {{ (getModels(parsedSpec)?.[name] as any).title ?? name }}
+                {{ (getModels(parsedSpec)?.[name]).title ?? name }}
               </Anchor>
             </SectionHeader>
             <Schema
               :name="name"
               noncollapsible
-              :value="getModels(parsedSpec)?.[name] as Record<string, any>" />
+              :value="getModels(parsedSpec)?.[name]" />
           </SectionContent>
         </template>
       </Section>

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -182,7 +182,7 @@ onMounted(() => {
             <Schema
               :name="name"
               noncollapsible
-              :value="getModels(parsedSpec)?.[name]" />
+              :value="getModels(parsedSpec)?.[name] as Record<string, any>" />
           </SectionContent>
         </template>
       </Section>

--- a/packages/api-reference/src/components/Content/Models/ModelsAccordion.vue
+++ b/packages/api-reference/src/components/Content/Models/ModelsAccordion.vue
@@ -66,7 +66,7 @@ const { getModelId } = useNavState()
             schema.required?.includes(property) ||
             schema.properties?.[property]?.required === true
           "
-          :value="value as OpenAPIV3_1.SchemaObject['properties']" />
+          :value="value as Record<string, any>" />
       </div>
       <div v-else>
         <SchemaProperty :value="schema" />

--- a/packages/api-reference/src/components/Content/Schema/Schema.stories.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.stories.ts
@@ -1,3 +1,4 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-parser'
 import type { Meta, StoryObj } from '@storybook/vue3'
 
 import Schema from './Schema.vue'
@@ -107,6 +108,6 @@ export const Default: Story = {
     `,
   }),
   args: {
-    value: schema,
+    value: schema as OpenAPIV3_1.SchemaObject,
   },
 }

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -50,9 +50,9 @@ const handleClick = (e: MouseEvent) =>
         { 'schema-card--compact': compact, 'schema-card--open': open },
       ]">
       <div
-        v-if="value?.description"
+        v-if="value?.description && typeof value.description === 'string'"
         class="schema-card-description">
-        <ScalarMarkdown :value="value.description as string" />
+        <ScalarMarkdown :value="value.description" />
       </div>
       <div
         class="schema-properties"

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -52,7 +52,7 @@ const handleClick = (e: MouseEvent) =>
       <div
         v-if="value?.description"
         class="schema-card-description">
-        <ScalarMarkdown :value="value.description" />
+        <ScalarMarkdown :value="value.description as string" />
       </div>
       <div
         class="schema-properties"

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon } from '@scalar/components'
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import { computed } from 'vue'
 
 import SchemaHeading from './SchemaHeading.vue'
@@ -9,7 +9,14 @@ import SchemaProperty from './SchemaProperty.vue'
 
 const props = withDefaults(
   defineProps<{
-    value?: Record<string, any> | string
+    value?:
+      | OpenAPIV2.DefinitionsObject
+      | OpenAPIV3.SchemaObject
+      | OpenAPIV3.ArraySchemaObject
+      | OpenAPIV3.NonArraySchemaObject
+      | OpenAPIV3_1.SchemaObject
+      | OpenAPIV3_1.ArraySchemaObject
+      | OpenAPIV3_1.NonArraySchemaObject
     /** Track how deep we’ve gone */
     level?: number
     /* Show as a heading */
@@ -88,7 +95,7 @@ const handleClick = (e: MouseEvent) =>
               icon="ChevronRight"
               size="md" />
             <SchemaHeading
-              :name="value?.title ?? name"
+              :name="(value?.title ?? name) as string"
               :value="value" />
           </template>
         </DisclosureButton>
@@ -122,7 +129,12 @@ const handleClick = (e: MouseEvent) =>
                 :compact="compact"
                 :level="level"
                 noncollapsible
-                :value="{ type: 'any', ...value.additionalProperties }" />
+                :value="{
+                  type: 'any',
+                  ...(typeof value.additionalProperties === 'object'
+                    ? value.additionalProperties
+                    : {}),
+                }" />
               <!-- Allows a specific type of additional property value -->
               <SchemaProperty
                 v-else
@@ -137,7 +149,7 @@ const handleClick = (e: MouseEvent) =>
             <SchemaProperty
               :compact="compact"
               :level="level"
-              :name="value.name"
+              :name="(value as OpenAPIV2.SchemaObject).name"
               :value="value" />
           </template>
         </DisclosurePanel>

--- a/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
@@ -1,13 +1,22 @@
 <script lang="ts" setup>
-import type { OpenAPIV2 } from '@scalar/openapi-parser'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 
 defineProps<{
-  value: OpenAPIV2.SchemaObject
+  value:
+    | OpenAPIV2.DefinitionsObject
+    | OpenAPIV3.SchemaObject
+    | OpenAPIV3.ArraySchemaObject
+    | OpenAPIV3.NonArraySchemaObject
+    | OpenAPIV3_1.SchemaObject
+    | OpenAPIV3_1.ArraySchemaObject
+    | OpenAPIV3_1.NonArraySchemaObject
   name?: string
 }>()
 </script>
 <template>
-  <span class="schema-type">
+  <span
+    v-if="typeof value === 'object'"
+    class="schema-type">
     <span
       class="schema-type-icon"
       :title="

--- a/packages/api-reference/src/helpers/getModels.ts
+++ b/packages/api-reference/src/helpers/getModels.ts
@@ -3,7 +3,7 @@ import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 
 export function getModels(spec?: Spec) {
   if (!spec) {
-    return {}
+    return {} as Record<string, OpenAPIV3_1.SchemaObject>
   }
 
   return (

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -2,12 +2,7 @@
  * Unfortunately, this file is very messy. I think we should get rid of it entirely. :)
  * TODO: Slowly remove all the transformed properties and use the raw output of @scalar/openapi-parser instead.
  */
-import {
-  type RequestMethod,
-  normalizeRequestMethod,
-  validRequestMethods,
-} from '@scalar/api-client'
-// AnyStringOrObject
+import { type RequestMethod, validRequestMethods } from '@scalar/api-client'
 import type { Spec } from '@scalar/oas-utils'
 import {
   type AnyObject,
@@ -16,9 +11,9 @@ import {
   type OpenAPIV3,
   type OpenAPIV3_1,
   dereference,
-  fetchUrlsPlugin,
   load,
 } from '@scalar/openapi-parser'
+import { fetchUrls } from '@scalar/openapi-parser/plugins/fetch-urls'
 
 import { createEmptySpecification } from '../helpers'
 
@@ -36,7 +31,11 @@ export const parse = (specification: any): Promise<Spec> => {
       const start = performance.now()
 
       const { filesystem } = await load(specification, {
-        plugins: [fetchUrlsPlugin()],
+        plugins: [
+          fetchUrls({
+            // TODO: Use proxy here
+          }),
+        ],
       })
 
       const { schema, errors } = await dereference(filesystem)

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -53,7 +53,7 @@ export const parse = (specification: any): Promise<Spec> => {
       }
 
       if (schema === undefined) {
-        reject(errors?.[0]?.error ?? 'Failed to parse the OpenAPI file.')
+        reject(errors?.[0]?.message ?? 'Failed to parse the OpenAPI file.')
 
         return resolve(
           transformResult(createEmptySpecification() as OpenAPI.Document),
@@ -181,7 +181,6 @@ const transformResult = (originalSchema: OpenAPI.Document): Spec => {
         if (
           !schema.tags?.find(
             (tag: OpenAPIV2.TagObject | OpenAPIV3.TagObject) =>
-              // @ts-expect-error upstream issue
               tag.name === 'default',
           )
         ) {
@@ -195,7 +194,6 @@ const transformResult = (originalSchema: OpenAPI.Document): Spec => {
         // find the index of the default tag
         const indexOfDefaultTag = schema.tags?.findIndex(
           (tag: OpenAPIV2.TagObject | OpenAPIV3.TagObject) =>
-            // @ts-expect-error upstream issue
             tag.name === 'default',
         )
 

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -5,6 +5,7 @@
 import {
   type RequestMethod,
   normalizeRequestMethod,
+  redirectToProxy,
   validRequestMethods,
 } from '@scalar/api-client'
 import type { Spec } from '@scalar/oas-utils'
@@ -21,7 +22,14 @@ import { fetchUrls } from '@scalar/openapi-parser/plugins/fetch-urls'
 
 import { createEmptySpecification } from '../helpers'
 
-export const parse = (specification: any): Promise<Spec> => {
+export const parse = (
+  specification: any,
+  {
+    proxy,
+  }: {
+    proxy?: string
+  } = {},
+): Promise<Spec> => {
   // eslint-disable-next-line no-async-promise-executor
   return new Promise(async (resolve, reject) => {
     try {
@@ -37,7 +45,12 @@ export const parse = (specification: any): Promise<Spec> => {
       const { filesystem } = await load(specification, {
         plugins: [
           fetchUrls({
-            // TODO: Use proxy here
+            fetch: (url) => {
+              console.log('FETCH')
+              console.log('url', url)
+              console.log('proxy', proxy)
+              return fetch(proxy ? redirectToProxy(proxy, url) : url)
+            },
           }),
         ],
       })

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -15,6 +15,7 @@ import {
   type OpenAPIV3,
   type OpenAPIV3_1,
   type ResolvedOpenAPI,
+  fetchUrlsPlugin,
   openapi,
 } from '@scalar/openapi-parser'
 
@@ -33,7 +34,12 @@ export const parse = (specification: any): Promise<Spec> => {
         )
       }
 
-      const { schema, errors } = await openapi().load(specification).resolve()
+      const { schema, errors } = await openapi()
+        .load(specification, {
+          plugins: [fetchUrlsPlugin],
+        })
+        .dereference()
+        .get()
 
       if (errors?.length) {
         console.warn(

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -35,11 +35,11 @@ export const parse = (specification: any): Promise<Spec> => {
 
       const start = performance.now()
 
-      const content = await load(specification, {
+      const { filesystem } = await load(specification, {
         plugins: [fetchUrlsPlugin()],
       })
 
-      const { schema, errors } = await dereference(content)
+      const { schema, errors } = await dereference(filesystem)
 
       const end = performance.now()
       console.log(`dereference: ${Math.round(end - start)} ms`)

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -2,7 +2,11 @@
  * Unfortunately, this file is very messy. I think we should get rid of it entirely. :)
  * TODO: Slowly remove all the transformed properties and use the raw output of @scalar/openapi-parser instead.
  */
-import { type RequestMethod, validRequestMethods } from '@scalar/api-client'
+import {
+  type RequestMethod,
+  normalizeRequestMethod,
+  validRequestMethods,
+} from '@scalar/api-client'
 import type { Spec } from '@scalar/oas-utils'
 import {
   type AnyObject,

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -15,8 +15,9 @@ import {
   type OpenAPIV2,
   type OpenAPIV3,
   type OpenAPIV3_1,
+  dereference,
   fetchUrlsPlugin,
-  openapi,
+  load,
 } from '@scalar/openapi-parser'
 
 import { createEmptySpecification } from '../helpers'
@@ -34,12 +35,11 @@ export const parse = (specification: any): Promise<Spec> => {
 
       const start = performance.now()
 
-      const { schema, errors } = await openapi()
-        .load(specification, {
-          plugins: [fetchUrlsPlugin()],
-        })
-        .dereference()
-        .get()
+      const content = await load(specification, {
+        plugins: [fetchUrlsPlugin()],
+      })
+
+      const { schema, errors } = await dereference(content)
 
       const end = performance.now()
       console.log(`dereference: ${Math.round(end - start)} ms`)

--- a/packages/api-reference/src/hooks/useReactiveSpec.test.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.test.ts
@@ -201,7 +201,7 @@ describe('useParser', () => {
     // Sleep for 10ms to wait for the parser to finish
     await new Promise((resolve) => setTimeout(resolve, 50))
 
-    expect(parsedSpec.info.title).toBe('Example')
+    expect(parsedSpec.info?.title).toBe('Example')
   })
 
   test('works with refs', async () => {
@@ -216,7 +216,7 @@ describe('useParser', () => {
     // Sleep for 300ms to wait for the debouncer and the parser
     await new Promise((resolve) => setTimeout(resolve, 300))
 
-    expect(parsedSpec.info.title).toBe('Example')
+    expect(parsedSpec.info?.title).toBe('Example')
   })
 
   test('watches the ref', async () => {
@@ -231,7 +231,7 @@ describe('useParser', () => {
     // Sleep for 300ms to wait for the debouncer and the parser
     await new Promise((resolve) => setTimeout(resolve, 300))
 
-    expect(parsedSpec.info.title).toBe('Example')
+    expect(parsedSpec.info?.title).toBe('Example')
 
     rawSpecConfig.value = {
       content: JSON.stringify(basicSpecString.replace('Example', 'Foobar')),
@@ -240,7 +240,7 @@ describe('useParser', () => {
     // Sleep for 300ms to wait for the debouncer and the parser
     await new Promise((resolve) => setTimeout(resolve, 300))
 
-    expect(parsedSpec.info.title).toBe('Foobar')
+    expect(parsedSpec.info?.title).toBe('Foobar')
   })
 
   test('deals with undefined input', async () => {
@@ -249,7 +249,7 @@ describe('useParser', () => {
     // Sleep for 10ms to wait for the parser to finish
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(parsedSpec.info.title).toBe('')
+    expect(parsedSpec.info?.title).toBe('')
   })
 
   test('deals with empty input', async () => {
@@ -262,7 +262,7 @@ describe('useParser', () => {
     // Sleep for 10ms to wait for the parser to finish
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(parsedSpec.info.title).toBe('')
+    expect(parsedSpec.info?.title).toBe('')
   })
 
   test('returns errors', async () => {

--- a/packages/api-reference/src/hooks/useReactiveSpec.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.ts
@@ -70,7 +70,9 @@ export function useReactiveSpec({
   function parseInput(value?: string) {
     if (!value) return Object.assign(parsedSpec, createEmptySpecification())
 
-    return parse(value)
+    return parse(value, {
+      proxy,
+    })
       .then((validSpec) => {
         specErrors.value = null
 

--- a/packages/api-reference/src/hooks/useReactiveSpec.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.ts
@@ -71,7 +71,7 @@ export function useReactiveSpec({
     if (!value) return Object.assign(parsedSpec, createEmptySpecification())
 
     return parse(value, {
-      proxy,
+      proxy: proxy ? toValue(proxy) : undefined,
     })
       .then((validSpec) => {
         specErrors.value = null

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "@scalar/api-reference": "workspace:*",
     "@scalar/mock-server": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.5.0",
+    "@scalar/openapi-parser": "^0.6.0",
     "commander": "^12.0.0",
     "glob": "^10.3.10",
     "hono": "^4.2.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "@scalar/api-reference": "workspace:*",
     "@scalar/mock-server": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.0",
+    "@scalar/openapi-parser": "^0.4.1",
     "commander": "^12.0.0",
     "glob": "^10.3.10",
     "hono": "^4.2.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "@scalar/api-reference": "workspace:*",
     "@scalar/mock-server": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.3.2",
+    "@scalar/openapi-parser": "^0.4.0",
     "commander": "^12.0.0",
     "glob": "^10.3.10",
     "hono": "^4.2.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "@scalar/api-reference": "workspace:*",
     "@scalar/mock-server": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.1",
+    "@scalar/openapi-parser": "^0.5.0",
     "commander": "^12.0.0",
     "glob": "^10.3.10",
     "hono": "^4.2.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "@scalar/api-reference": "workspace:*",
     "@scalar/mock-server": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.6.0",
+    "@scalar/openapi-parser": "^0.7.1",
     "commander": "^12.0.0",
     "glob": "^10.3.10",
     "hono": "^4.2.7",

--- a/packages/cli/src/commands/format/FormatCommand.ts
+++ b/packages/cli/src/commands/format/FormatCommand.ts
@@ -29,8 +29,8 @@ export function FormatCommand() {
     }
 
     const newContent = isYamlFileName(output || input)
-      ? openapi().load(specification).toYaml()
-      : openapi().load(specification).toJson()
+      ? await openapi().load(specification).toYaml()
+      : await openapi().load(specification).toJson()
 
     // Replace file content with newContent
     if (output) {

--- a/packages/cli/src/commands/validate/ValidateCommand.ts
+++ b/packages/cli/src/commands/validate/ValidateCommand.ts
@@ -19,7 +19,7 @@ export function ValidateCommand() {
     const specification = await getFileOrUrl(input)
 
     // Validate
-    const result = await openapi().load(specification).validate()
+    const result = await openapi().load(specification).validate().get()
 
     if (result.valid) {
       console.log(

--- a/packages/cli/src/utils/loadOpenApiFile.ts
+++ b/packages/cli/src/utils/loadOpenApiFile.ts
@@ -1,4 +1,4 @@
-import { openapi } from '@scalar/openapi-parser'
+import { load, validate } from '@scalar/openapi-parser'
 import kleur from 'kleur'
 
 import { getFileOrUrl } from './getFileOrUrl'
@@ -7,11 +7,11 @@ export async function loadOpenApiFile(input: string) {
   const specification = await getFileOrUrl(input)
 
   try {
-    const result = await openapi().load(specification).resolve()
-    const { valid } = result
+    const { filesystem } = await load(specification)
+    const result = await validate(filesystem)
 
     // Invalid specification
-    if (!valid) {
+    if (!result.valid) {
       console.warn(
         kleur.bold().yellow('[WARN]'),
         kleur.bold().yellow('File doesn’t match the OpenAPI specification.'),

--- a/packages/cli/src/utils/loadOpenApiFile.ts
+++ b/packages/cli/src/utils/loadOpenApiFile.ts
@@ -1,4 +1,6 @@
 import { load, validate } from '@scalar/openapi-parser'
+import { fetchUrls } from '@scalar/openapi-parser/plugins/fetch-urls'
+import { readFiles } from '@scalar/openapi-parser/plugins/read-urls'
 import kleur from 'kleur'
 
 import { getFileOrUrl } from './getFileOrUrl'
@@ -7,7 +9,9 @@ export async function loadOpenApiFile(input: string) {
   const specification = await getFileOrUrl(input)
 
   try {
-    const { filesystem } = await load(specification)
+    const { filesystem } = await load(specification, {
+      plugins: [fetchUrls(), readFiles()],
+    })
     const result = await validate(filesystem)
 
     // Invalid specification

--- a/packages/cli/src/utils/loadOpenApiFile.ts
+++ b/packages/cli/src/utils/loadOpenApiFile.ts
@@ -1,6 +1,4 @@
 import { load, validate } from '@scalar/openapi-parser'
-import { fetchUrls } from '@scalar/openapi-parser/plugins/fetch-urls'
-import { readFiles } from '@scalar/openapi-parser/plugins/read-urls'
 import kleur from 'kleur'
 
 import { getFileOrUrl } from './getFileOrUrl'
@@ -9,9 +7,7 @@ export async function loadOpenApiFile(input: string) {
   const specification = await getFileOrUrl(input)
 
   try {
-    const { filesystem } = await load(specification, {
-      plugins: [fetchUrls(), readFiles()],
-    })
+    const { filesystem } = await load(specification)
     const result = await validate(filesystem)
 
     // Invalid specification

--- a/packages/cli/src/utils/printSpecificationBanner.ts
+++ b/packages/cli/src/utils/printSpecificationBanner.ts
@@ -1,9 +1,9 @@
-import type { ResolvedOpenAPI } from '@scalar/openapi-parser'
+import type { OpenAPI } from '@scalar/openapi-parser'
 import kleur from 'kleur'
 
 export function printSpecificationBanner(result: {
   version: string
-  schema: ResolvedOpenAPI.Document
+  schema: OpenAPI.Document
 }) {
   const { version, schema } = result
 
@@ -19,7 +19,7 @@ export function printSpecificationBanner(result: {
 
   // Count number of operations
   const operationsCount = Object.values(schema.paths).reduce(
-    (acc, path) => acc + Object.keys(path).length,
+    (acc: number, path) => acc + Object.keys(path).length,
     0,
   )
 

--- a/packages/client-app/package.json
+++ b/packages/client-app/package.json
@@ -92,6 +92,7 @@
     "@scalar/draggable": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
     "@scalar/object-utils": "workspace:*",
+    "@scalar/openapi-parser": "^0.7.1",
     "@scalar/use-toasts": "workspace:*",
     "@scalar/use-tooltip": "workspace:*",
     "@vueuse/core": "^10.10.0",

--- a/packages/client-app/package.json
+++ b/packages/client-app/package.json
@@ -92,7 +92,6 @@
     "@scalar/draggable": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
     "@scalar/object-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.3.2",
     "@scalar/use-toasts": "workspace:*",
     "@scalar/use-tooltip": "workspace:*",
     "@vueuse/core": "^10.10.0",

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@scalar/build-tooling": "workspace:*",
-    "@scalar/openapi-parser": "^0.3.2",
     "@vitest/coverage-v8": "^1.6.0",
+    "@scalar/openapi-parser": "^0.4.0",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",
     "vite-plugin-static-copy": "^1.0.2",

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@scalar/build-tooling": "workspace:*",
+    "@scalar/openapi-parser": "^0.7.1",
     "@vitest/coverage-v8": "^1.6.0",
-    "@scalar/openapi-parser": "^0.6.0",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",
     "vite-plugin-static-copy": "^1.0.2",

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -51,7 +51,7 @@
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@scalar/build-tooling": "workspace:*",
     "@vitest/coverage-v8": "^1.6.0",
-    "@scalar/openapi-parser": "^0.5.0",
+    "@scalar/openapi-parser": "^0.6.0",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",
     "vite-plugin-static-copy": "^1.0.2",

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -51,7 +51,7 @@
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@scalar/build-tooling": "workspace:*",
     "@vitest/coverage-v8": "^1.6.0",
-    "@scalar/openapi-parser": "^0.4.0",
+    "@scalar/openapi-parser": "^0.5.0",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",
     "vite-plugin-static-copy": "^1.0.2",

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.1",
+    "@scalar/openapi-parser": "^0.5.0",
     "hono": "^4.2.7"
   },
   "devDependencies": {

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.3.2",
+    "@scalar/openapi-parser": "^0.4.0",
     "hono": "^4.2.7"
   },
   "devDependencies": {

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.6.0",
+    "@scalar/openapi-parser": "^0.7.1",
     "hono": "^4.2.7"
   },
   "devDependencies": {

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.0",
+    "@scalar/openapi-parser": "^0.4.1",
     "hono": "^4.2.7"
   },
   "devDependencies": {

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.5.0",
+    "@scalar/openapi-parser": "^0.6.0",
     "hono": "^4.2.7"
   },
   "devDependencies": {

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -31,12 +31,14 @@ export async function createMockServer(options?: {
   app.use(cors())
 
   // OpenAPI JSON file
-  app.get('/openapi.json', (c) => {
+  app.get('/openapi.json', async (c) => {
     if (!options?.specification) {
       return c.text('Not found', 404)
     }
 
-    return c.json(openapi().load(options.specification).get())
+    const { specification } = await openapi().load(options.specification).get()
+
+    return c.json(specification)
   })
 
   // OpenAPI YAML file
@@ -45,7 +47,9 @@ export async function createMockServer(options?: {
       return c.text('Not found', 404)
     }
 
-    return c.text(await openapi().load(options.specification).toYaml())
+    const specification = await openapi().load(options.specification).toYaml()
+
+    return c.text(specification)
   })
 
   // Paths

--- a/packages/mock-server/src/utils/isBasicAuthenticationRequired.ts
+++ b/packages/mock-server/src/utils/isBasicAuthenticationRequired.ts
@@ -1,12 +1,8 @@
-import type {
-  OpenAPI,
-  OpenAPIV3_1,
-  ResolvedOpenAPI,
-} from '@scalar/openapi-parser'
+import type { OpenAPI, OpenAPIV3_1 } from '@scalar/openapi-parser'
 
 export function isBasicAuthenticationRequired(
   operation: OpenAPI.Operation,
-  schema?: ResolvedOpenAPI.Document,
+  schema?: OpenAPI.Document,
 ) {
   const allowedSecuritySchemes = operation.security?.map(
     (securityScheme: OpenAPIV3_1.SecurityRequirementObject) => {

--- a/packages/nuxt/src/runtime/plugins/hydrateClient.d.mts
+++ b/packages/nuxt/src/runtime/plugins/hydrateClient.d.mts
@@ -1,0 +1,2 @@
+declare const _default: any;
+export default _default;

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -103,7 +103,7 @@
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
-    "@scalar/openapi-parser": "^0.6.0",
+    "@scalar/openapi-parser": "^0.7.1",
     "axios": "^1.6.8",
     "httpsnippet-lite": "^3.0.5",
     "openapi-types": "^12.1.3",

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -103,7 +103,7 @@
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
-    "@scalar/openapi-parser": "^0.3.2",
+    "@scalar/openapi-parser": "^0.4.0",
     "axios": "^1.6.8",
     "httpsnippet-lite": "^3.0.5",
     "openapi-types": "^12.1.3",

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -103,7 +103,7 @@
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.1",
+    "@scalar/openapi-parser": "^0.5.0",
     "axios": "^1.6.8",
     "httpsnippet-lite": "^3.0.5",
     "openapi-types": "^12.1.3",

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -98,7 +98,7 @@
   "module": "dist/index.js",
   "dependencies": {
     "nanoid": "^5.0.7",
-    "yaml": "^2.4.1",
+    "yaml": "^2.4.5",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -103,7 +103,7 @@
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
-    "@scalar/openapi-parser": "^0.5.0",
+    "@scalar/openapi-parser": "^0.6.0",
     "axios": "^1.6.8",
     "httpsnippet-lite": "^3.0.5",
     "openapi-types": "^12.1.3",

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -103,7 +103,7 @@
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.0",
+    "@scalar/openapi-parser": "^0.4.1",
     "axios": "^1.6.8",
     "httpsnippet-lite": "^3.0.5",
     "openapi-types": "^12.1.3",

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -145,9 +145,7 @@ export const importSpecToWorkspace = async (spec: string | AnyObject) => {
   const collection = createCollection({
     spec: {
       openapi: parsedSpec.openapi,
-      // @ts-expect-error For some reason the types don't match
       info: schema?.info,
-      // @ts-expect-error For some reason the types don't match
       externalDocs: schema?.externalDocs,
       serverUids: servers.map(({ uid }) => uid),
       tags,

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -145,7 +145,9 @@ export const importSpecToWorkspace = async (spec: string | AnyObject) => {
   const collection = createCollection({
     spec: {
       openapi: parsedSpec.openapi,
+      // @ts-expect-error For some reason the types don't match
       info: schema?.info,
+      // @ts-expect-error For some reason the types don't match
       externalDocs: schema?.externalDocs,
       serverUids: servers.map(({ uid }) => uid),
       tags,

--- a/packages/play-button/package.json
+++ b/packages/play-button/package.json
@@ -53,7 +53,7 @@
     "@scalar/api-client": "workspace:*",
     "@scalar/api-reference": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.1",
+    "@scalar/openapi-parser": "^0.5.0",
     "@scalar/themes": "workspace:*",
     "@vueuse/core": "^10.10.0"
   },

--- a/packages/play-button/package.json
+++ b/packages/play-button/package.json
@@ -53,7 +53,7 @@
     "@scalar/api-client": "workspace:*",
     "@scalar/api-reference": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.6.0",
+    "@scalar/openapi-parser": "^0.7.1",
     "@scalar/themes": "workspace:*",
     "@vueuse/core": "^10.10.0"
   },

--- a/packages/play-button/package.json
+++ b/packages/play-button/package.json
@@ -53,7 +53,7 @@
     "@scalar/api-client": "workspace:*",
     "@scalar/api-reference": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.3.2",
+    "@scalar/openapi-parser": "^0.4.0",
     "@scalar/themes": "workspace:*",
     "@vueuse/core": "^10.10.0"
   },

--- a/packages/play-button/package.json
+++ b/packages/play-button/package.json
@@ -53,7 +53,7 @@
     "@scalar/api-client": "workspace:*",
     "@scalar/api-reference": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.5.0",
+    "@scalar/openapi-parser": "^0.6.0",
     "@scalar/themes": "workspace:*",
     "@vueuse/core": "^10.10.0"
   },

--- a/packages/play-button/package.json
+++ b/packages/play-button/package.json
@@ -53,7 +53,7 @@
     "@scalar/api-client": "workspace:*",
     "@scalar/api-reference": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
-    "@scalar/openapi-parser": "^0.4.0",
+    "@scalar/openapi-parser": "^0.4.1",
     "@scalar/themes": "workspace:*",
     "@vueuse/core": "^10.10.0"
   },

--- a/packages/use-codemirror/src/index.ts
+++ b/packages/use-codemirror/src/index.ts
@@ -1,4 +1,5 @@
 export { type Extension } from '@codemirror/state'
+// @ts-expect-error y-codemirror is not exporting types correctly
 export { yCollab } from 'y-codemirror.next'
 export { colorPicker } from '@replit/codemirror-css-color-picker'
 

--- a/packages/use-codemirror/src/index.ts
+++ b/packages/use-codemirror/src/index.ts
@@ -1,5 +1,4 @@
 export { type Extension } from '@codemirror/state'
-// @ts-expect-error y-codemirror is not exporting types correctly
 export { yCollab } from 'y-codemirror.next'
 export { colorPicker } from '@replit/codemirror-css-color-picker'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -658,8 +658,8 @@ importers:
         specifier: workspace:*
         version: link:../oas-utils
       '@scalar/openapi-parser':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       '@scalar/themes':
         specifier: workspace:*
         version: link:../themes
@@ -854,8 +854,8 @@ importers:
         specifier: workspace:*
         version: link:../oas-utils
       '@scalar/openapi-parser':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       '@scalar/snippetz':
         specifier: ^0.1.6
         version: 0.1.6
@@ -1085,8 +1085,8 @@ importers:
         specifier: workspace:*
         version: link:../oas-utils
       '@scalar/openapi-parser':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       commander:
         specifier: ^12.0.0
         version: 12.0.0
@@ -1154,6 +1154,9 @@ importers:
       '@scalar/object-utils':
         specifier: workspace:*
         version: link:../object-utils
+      '@scalar/openapi-parser':
+        specifier: ^0.7.1
+        version: 0.7.1
       '@scalar/use-toasts':
         specifier: workspace:*
         version: link:../use-toasts
@@ -1609,8 +1612,8 @@ importers:
         specifier: workspace:*
         version: link:../build-tooling
       '@scalar/openapi-parser':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       '@vitest/coverage-v8':
         specifier: ^1.6.0
         version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
@@ -1655,8 +1658,8 @@ importers:
         specifier: workspace:*
         version: link:../oas-utils
       '@scalar/openapi-parser':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       hono:
         specifier: ^4.2.7
         version: 4.2.8
@@ -1803,8 +1806,8 @@ importers:
         specifier: ^5.0.7
         version: 5.0.7
       yaml:
-        specifier: ^2.4.1
-        version: 2.4.1
+        specifier: ^2.4.5
+        version: 2.4.5
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1813,8 +1816,8 @@ importers:
         specifier: workspace:*
         version: link:../build-tooling
       '@scalar/openapi-parser':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       axios:
         specifier: ^1.6.8
         version: 1.6.8(debug@4.3.4)
@@ -1868,8 +1871,8 @@ importers:
         specifier: workspace:*
         version: link:../oas-utils
       '@scalar/openapi-parser':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       '@scalar/themes':
         specifier: workspace:*
         version: link:../themes
@@ -5050,8 +5053,8 @@ packages:
   '@rushstack/ts-command-line@4.17.1':
     resolution: {integrity: sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==}
 
-  '@scalar/openapi-parser@0.6.0':
-    resolution: {integrity: sha512-m01gvKxOnjvRSLhw2wIPpgF5hJlpGCpe+ROVnnxhHaHVlmrKeaTNteYYCrEoTxLT5eMJLmXW1T5cxZA47ltz0Q==}
+  '@scalar/openapi-parser@0.7.1':
+    resolution: {integrity: sha512-FR2ezONBF0OOe5w5fa8uBInWvlGjC2+hEEmRZnJn/n1VMII8gg88VmBpE1wD2TqE4d6KIPCp/yxr5h10a8D1vw==}
     engines: {node: '>=18'}
 
   '@scalar/snippetz-core@0.1.4':
@@ -19406,7 +19409,7 @@ snapshots:
       colors: 1.2.5
       string-argv: 0.3.2
 
-  '@scalar/openapi-parser@0.6.0':
+  '@scalar/openapi-parser@0.7.1':
     dependencies:
       ajv: 8.16.0
       ajv-draft-04: 1.0.0(ajv@8.16.0)
@@ -22066,6 +22069,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.12.0
 
+  ajv-formats@2.1.1(ajv@8.16.0):
+    optionalDependencies:
+      ajv: 8.16.0
+
   ajv-formats@3.0.1(ajv@8.16.0):
     optionalDependencies:
       ajv: 8.16.0
@@ -22074,9 +22081,9 @@ snapshots:
     dependencies:
       ajv: 6.12.6
 
-  ajv-keywords@5.1.0(ajv@8.12.0):
+  ajv-keywords@5.1.0(ajv@8.16.0):
     dependencies:
-      ajv: 8.12.0
+      ajv: 8.16.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -28295,7 +28302,7 @@ snapshots:
 
   openapi3-ts@4.2.2:
     dependencies:
-      yaml: 2.4.1
+      yaml: 2.4.5
 
   opener@1.5.2: {}
 
@@ -28700,7 +28707,7 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)):
     dependencies:
       lilconfig: 3.1.1
-      yaml: 2.4.1
+      yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.38
       ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)
@@ -28708,7 +28715,7 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.26)(typescript@5.4.3)):
     dependencies:
       lilconfig: 3.1.1
-      yaml: 2.4.1
+      yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.38
       ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@20.11.26)(typescript@5.4.3)
@@ -29900,9 +29907,9 @@ snapshots:
   schema-utils@4.2.0:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
-      ajv-keywords: 5.1.0(ajv@8.12.0)
+      ajv: 8.16.0
+      ajv-formats: 2.1.1(ajv@8.16.0)
+      ajv-keywords: 5.1.0(ajv@8.16.0)
 
   scule@1.3.0: {}
 
@@ -31423,7 +31430,7 @@ snapshots:
       pathe: 1.1.2
       scule: 1.3.0
       unplugin: 1.10.1
-      yaml: 2.4.1
+      yaml: 2.4.5
     optionalDependencies:
       vue-router: 4.3.2(vue@3.4.27(typescript@5.4.3))
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -658,8 +658,8 @@ importers:
         specifier: workspace:*
         version: link:../oas-utils
       '@scalar/openapi-parser':
-        specifier: ^0.3.2
-        version: 0.3.2(terser@5.30.0)
+        specifier: ^0.6.0
+        version: 0.6.0
       '@scalar/themes':
         specifier: workspace:*
         version: link:../themes
@@ -854,8 +854,8 @@ importers:
         specifier: workspace:*
         version: link:../oas-utils
       '@scalar/openapi-parser':
-        specifier: ^0.3.2
-        version: 0.3.2(terser@5.30.0)
+        specifier: ^0.6.0
+        version: 0.6.0
       '@scalar/snippetz':
         specifier: ^0.1.6
         version: 0.1.6
@@ -1085,8 +1085,8 @@ importers:
         specifier: workspace:*
         version: link:../oas-utils
       '@scalar/openapi-parser':
-        specifier: ^0.3.2
-        version: 0.3.2(terser@5.30.0)
+        specifier: ^0.6.0
+        version: 0.6.0
       commander:
         specifier: ^12.0.0
         version: 12.0.0
@@ -1154,9 +1154,6 @@ importers:
       '@scalar/object-utils':
         specifier: workspace:*
         version: link:../object-utils
-      '@scalar/openapi-parser':
-        specifier: ^0.3.2
-        version: 0.3.2(terser@5.30.0)
       '@scalar/use-toasts':
         specifier: workspace:*
         version: link:../use-toasts
@@ -1612,8 +1609,8 @@ importers:
         specifier: workspace:*
         version: link:../build-tooling
       '@scalar/openapi-parser':
-        specifier: ^0.3.2
-        version: 0.3.2(terser@5.30.0)
+        specifier: ^0.6.0
+        version: 0.6.0
       '@vitest/coverage-v8':
         specifier: ^1.6.0
         version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
@@ -1658,8 +1655,8 @@ importers:
         specifier: workspace:*
         version: link:../oas-utils
       '@scalar/openapi-parser':
-        specifier: ^0.3.2
-        version: 0.3.2(terser@5.30.0)
+        specifier: ^0.6.0
+        version: 0.6.0
       hono:
         specifier: ^4.2.7
         version: 4.2.8
@@ -1816,8 +1813,8 @@ importers:
         specifier: workspace:*
         version: link:../build-tooling
       '@scalar/openapi-parser':
-        specifier: ^0.3.2
-        version: 0.3.2(terser@5.30.0)
+        specifier: ^0.6.0
+        version: 0.6.0
       axios:
         specifier: ^1.6.8
         version: 1.6.8(debug@4.3.4)
@@ -1871,8 +1868,8 @@ importers:
         specifier: workspace:*
         version: link:../oas-utils
       '@scalar/openapi-parser':
-        specifier: ^0.3.2
-        version: 0.3.2(terser@5.30.0)
+        specifier: ^0.6.0
+        version: 0.6.0
       '@scalar/themes':
         specifier: workspace:*
         version: link:../themes
@@ -3861,10 +3858,6 @@ packages:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
 
-  '@humanwhocodes/momoa@3.0.1':
-    resolution: {integrity: sha512-Yj2GOwIDb77+A5p4oV2x27edQ7NX86+vKBGWySnfwjKesxn8JCa90Q0Z0eyBBy2G1FulTDrRtfIdmPpIOGhCmQ==}
-    engines: {node: '>=18'}
-
   '@humanwhocodes/object-schema@2.0.2':
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
 
@@ -5057,8 +5050,8 @@ packages:
   '@rushstack/ts-command-line@4.17.1':
     resolution: {integrity: sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==}
 
-  '@scalar/openapi-parser@0.3.2':
-    resolution: {integrity: sha512-o38wF1rKqCc7R0zFMta5rPTiY4cWwVcZPJkV1OCcnPsF2eE79uPkhYU2j/kdocJXVwMqqAe9a6+0o4R8YjgPVw==}
+  '@scalar/openapi-parser@0.6.0':
+    resolution: {integrity: sha512-m01gvKxOnjvRSLhw2wIPpgF5hJlpGCpe+ROVnnxhHaHVlmrKeaTNteYYCrEoTxLT5eMJLmXW1T5cxZA47ltz0Q==}
     engines: {node: '>=18'}
 
   '@scalar/snippetz-core@0.1.4':
@@ -6651,6 +6644,14 @@ packages:
       ajv:
         optional: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
@@ -6666,6 +6667,9 @@ packages:
 
   ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+
+  ajv@8.16.0:
+    resolution: {integrity: sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==}
 
   algoliasearch-helper@3.16.3:
     resolution: {integrity: sha512-1OuJT6sONAa9PxcOmWo5WCAT3jQSpCR9/m5Azujja7nhUQwAUDvaaAYrcmUySsrvHh74usZHbE3jFfGnWtZj8w==}
@@ -14871,6 +14875,11 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
 
+  yaml@2.4.5:
+    resolution: {integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -17752,8 +17761,6 @@ snapshots:
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
-  '@humanwhocodes/momoa@3.0.1': {}
-
   '@humanwhocodes/object-schema@2.0.2': {}
 
   '@iconify/types@2.0.0': {}
@@ -19399,26 +19406,14 @@ snapshots:
       colors: 1.2.5
       string-argv: 0.3.2
 
-  '@scalar/openapi-parser@0.3.2(terser@5.30.0)':
+  '@scalar/openapi-parser@0.6.0':
     dependencies:
-      '@humanwhocodes/momoa': 3.0.1
-      '@types/node': 20.11.26
-      ajv: 8.12.0
-      ajv-draft-04: 1.0.0(ajv@8.12.0)
-      ajv-formats: 2.1.1(ajv@8.12.0)
-      js-yaml: 4.1.0
+      ajv: 8.16.0
+      ajv-draft-04: 1.0.0(ajv@8.16.0)
+      ajv-formats: 3.0.1(ajv@8.16.0)
       jsonpointer: 5.0.1
       leven: 4.0.0
-      openapi-types: 12.1.3
-      vite: 5.2.10(@types/node@20.11.26)(terser@5.30.0)
-      yaml: 2.4.1
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - terser
+      yaml: 2.4.5
 
   '@scalar/snippetz-core@0.1.4':
     dependencies:
@@ -22063,13 +22058,17 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-draft-04@1.0.0(ajv@8.12.0):
+  ajv-draft-04@1.0.0(ajv@8.16.0):
     optionalDependencies:
-      ajv: 8.12.0
+      ajv: 8.16.0
 
   ajv-formats@2.1.1(ajv@8.12.0):
     optionalDependencies:
       ajv: 8.12.0
+
+  ajv-formats@3.0.1(ajv@8.16.0):
+    optionalDependencies:
+      ajv: 8.16.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
@@ -22088,6 +22087,13 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.12.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
+  ajv@8.16.0:
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -32576,6 +32582,8 @@ snapshots:
   yaml@2.0.0-1: {}
 
   yaml@2.4.1: {}
+
+  yaml@2.4.5: {}
 
   yargs-parser@18.1.3:
     dependencies:


### PR DESCRIPTION
This PR integrates some big updates to `@scalar/openapi-parser`. Here is what we’ll get from it:

**Fetch referenced files from URLs**

Let’s say you’d like to import the `Planet` schema from our Scalar Galaxy example:

```json
{
  "$ref": "https://galaxy.scalar.com/openapi.json#/components/schemas/Planet"
}
```

You can test this here: https://openapi-parser.pages.dev/

**Smaller bundle size**

We updated the build process of `@scalar/openapi-parser` and did a handful of optimizations, so we can eventually shave off ~200kb.

**Way faster**

The parser is just way, way faster now. It has more features, but is smarter than ever.

Note: Currently, when dereferencing the document is validated first, which is a pretty heavy process (takes ages, adds 200kb to the bundle). But we didn’t do anything with the results of the validation anyway, we only did a `console.log`. With that PR this step is skipped. The new `dereference` function is just derefencing, without any validation.