### PR TITLE
chore: enable cache for dev command

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,6 @@
       "dependsOn": ["^build"]
     },
     "dev": {
-      "cache": false,
       "persistent": true,
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
With the switch from resolve aliases to builds, it’s necessary to restart `pnpm run dev` to see cross package changes. 

Currently, this takes close to a minute to restart, which makes me lose the focus every time I want to see a change in action.

Turns out, we disabled the cache for the `dev task` and everything is built again (even the packages that didn’t change). There might be a reason that I don’t know of, but if we’d use the cache, it would be faster. ⚡ 