### PR TITLE
feat: use example values for path variables

### DIFF
--- a/.changeset/proud-pots-work.md
+++ b/.changeset/proud-pots-work.md
@@ -1,0 +1,6 @@
+---
+"@scalar/oas-utils": patch
+"@scalar/api-reference": patch
+---
+
+feat: use example values for path variables

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -2,12 +2,8 @@
 import {
   ApiReferenceLayout,
   type ReferenceConfiguration,
-  type Spec,
-  createEmptySpecification,
-  parse,
   useReactiveSpec,
 } from '@scalar/api-reference'
-import { asyncComputed } from '@vueuse/core'
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 
 import DevReferencesOptions from '../components/DevReferencesOptions.vue'
@@ -80,7 +76,9 @@ const { parsedSpec } = useReactiveSpec({
     <template #sidebar-start>
       <SlotPlaceholder>sidebar-start</SlotPlaceholder>
     </template>
-    <template #sidebar-end>value </template>
+    <template #sidebar-end>
+      <SlotPlaceholder>sidebar-end</SlotPlaceholder>
+    </template>
     <template #editor>
       <MonacoEditor
         v-model="content"

--- a/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
@@ -32,7 +32,7 @@ import {
   getHarRequest,
   sleep,
 } from '../../../helpers'
-import { useClipboard } from '../../../hooks'
+import { useClipboard, useOperation } from '../../../hooks'
 import { useHttpClientStore } from '../../../stores'
 import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
 import ExamplePicker from './ExamplePicker.vue'
@@ -76,6 +76,8 @@ const hasMultipleExamples = computed<boolean>(
 const getGlobalSecurity = inject(GLOBAL_SECURITY_SYMBOL)
 
 const generateSnippet = async (): Promise<string> => {
+  const { parameterMap } = useOperation(props)
+
   // Generate a request object
   const request = getHarRequest(
     {
@@ -85,6 +87,7 @@ const generateSnippet = async (): Promise<string> => {
       props.operation,
       {
         replaceVariables: true,
+        parameters: parameterMap,
       },
       selectedExampleKey.value,
     ),

--- a/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
@@ -32,7 +32,7 @@ import {
   getHarRequest,
   sleep,
 } from '../../../helpers'
-import { useClipboard, useOperation } from '../../../hooks'
+import { useClipboard } from '../../../hooks'
 import { useHttpClientStore } from '../../../stores'
 import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
 import ExamplePicker from './ExamplePicker.vue'
@@ -76,8 +76,6 @@ const hasMultipleExamples = computed<boolean>(
 const getGlobalSecurity = inject(GLOBAL_SECURITY_SYMBOL)
 
 const generateSnippet = async (): Promise<string> => {
-  const { parameterMap } = useOperation(props)
-
   // Generate a request object
   const request = getHarRequest(
     {
@@ -87,7 +85,6 @@ const generateSnippet = async (): Promise<string> => {
       props.operation,
       {
         replaceVariables: true,
-        parameters: parameterMap,
       },
       selectedExampleKey.value,
     ),

--- a/packages/oas-utils/src/spec-getters/getRequestFromOperation.test.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestFromOperation.test.ts
@@ -235,4 +235,61 @@ describe('getRequestFromOperation', () => {
 
     expect(request.postData?.text).toBe('BINARY')
   })
+
+  it('doesn’t replace path variables with underscore syntax', () => {
+    const request = getRequestFromOperation({
+      httpVerb: 'POST',
+      path: '/foobar/{id}',
+    } as TransformedOperation)
+
+    expect(request).toMatchObject({
+      method: 'POST',
+      path: '/foobar/{id}',
+    })
+  })
+
+  it('replaces path variables with underscore syntax when replaceVariables: true', () => {
+    const request = getRequestFromOperation(
+      {
+        httpVerb: 'POST',
+        path: '/foobar/{id}',
+      } as TransformedOperation,
+      {
+        replaceVariables: true,
+      },
+    )
+
+    expect(request).toMatchObject({
+      method: 'POST',
+      path: '/foobar/__ID__',
+    })
+  })
+
+  it('uses example values for path variables', () => {
+    const request = getRequestFromOperation(
+      {
+        httpVerb: 'POST',
+        path: '/foobar/{id}',
+      } as TransformedOperation,
+      {
+        parameters: {
+          path: [
+            {
+              name: 'id',
+              example: 123,
+            },
+          ],
+          query: [],
+          header: [],
+          body: [],
+          formData: [],
+        },
+      },
+    )
+
+    expect(request).toMatchObject({
+      method: 'POST',
+      path: '/foobar/123',
+    })
+  })
 })

--- a/packages/oas-utils/src/spec-getters/getRequestFromOperation.test.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestFromOperation.test.ts
@@ -285,4 +285,29 @@ describe('getRequestFromOperation', () => {
       path: '/foobar/123',
     })
   })
+
+  it('still replaces variables if an example value isn’t available', () => {
+    const request = getRequestFromOperation(
+      {
+        httpVerb: 'POST',
+        path: '/foobar/{id}',
+        information: {
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+            },
+          ],
+        },
+      } as TransformedOperation,
+      {
+        replaceVariables: true,
+      },
+    )
+
+    expect(request).toMatchObject({
+      method: 'POST',
+      path: '/foobar/__ID__',
+    })
+  })
 })

--- a/packages/oas-utils/src/spec-getters/getRequestFromOperation.test.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestFromOperation.test.ts
@@ -266,26 +266,19 @@ describe('getRequestFromOperation', () => {
   })
 
   it('uses example values for path variables', () => {
-    const request = getRequestFromOperation(
-      {
-        httpVerb: 'POST',
-        path: '/foobar/{id}',
-      } as TransformedOperation,
-      {
-        parameters: {
-          path: [
-            {
-              name: 'id',
-              example: 123,
-            },
-          ],
-          query: [],
-          header: [],
-          body: [],
-          formData: [],
-        },
+    const request = getRequestFromOperation({
+      httpVerb: 'POST',
+      path: '/foobar/{id}',
+      information: {
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            example: 123,
+          },
+        ],
       },
-    )
+    } as TransformedOperation)
 
     expect(request).toMatchObject({
       method: 'POST',

--- a/packages/oas-utils/src/spec-getters/getRequestFromOperation.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestFromOperation.ts
@@ -8,26 +8,15 @@ import type {
 import { getParametersFromOperation } from './getParametersFromOperation'
 import { getRequestBodyFromOperation } from './getRequestBodyFromOperation'
 
-export type Parameters = {
-  name: string
-  example?: any
-  examples?: Map<string, any>
-}
-
-type ParamMap = {
-  path: Parameters[]
-  query: Parameters[]
-  header: Parameters[]
-  body: Parameters[]
-  formData: Parameters[]
-}
-
 export const getRequestFromOperation = (
   operation: TransformedOperation,
   options?: {
+    /**
+     * If the path will be URL encoded, you may want to replace {curlyBrackets} with __UNDERSCORES__ to indicate an
+     * variable.
+     */
     replaceVariables?: boolean
     requiredOnly?: boolean
-    parameters?: ParamMap
   },
   selectedExampleKey?: string | number,
 ): Partial<HarRequestWithPath> => {
@@ -35,20 +24,22 @@ export const getRequestFromOperation = (
   let path = operation.path
 
   // {id} -> 123
-  if (options?.parameters?.path) {
+  const pathParameters = getParametersFromOperation(operation, 'path', false)
+
+  if (pathParameters.length) {
     const pathVariables = path.match(/{(.*?)}/g)
 
     if (pathVariables) {
       pathVariables.forEach((variable) => {
         const variableName = variable.replace(/{|}/g, '')
 
-        if (options.parameters?.path) {
-          const parameter = options.parameters.path.find(
+        if (pathParameters) {
+          const parameter = pathParameters.find(
             (param) => param.name === variableName,
           )
 
           if (parameter) {
-            path = path.replace(variable, parameter.example.toString() ?? '')
+            path = path.replace(variable, parameter.value?.toString())
           }
         }
       })

--- a/packages/oas-utils/src/spec-getters/getRequestFromOperation.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestFromOperation.ts
@@ -38,8 +38,8 @@ export const getRequestFromOperation = (
             (param) => param.name === variableName,
           )
 
-          if (parameter) {
-            path = path.replace(variable, parameter.value?.toString())
+          if (parameter?.value) {
+            path = path.replace(variable, parameter.value.toString())
           }
         }
       })


### PR DESCRIPTION
For the example requests, variables are replaced from `{curlyBrackets}` to `__UNDERSCORES__`, because curly brackets would be URL encoded.

Anyway, if we an example value is provided, we could actually use the example value instead. 🤔 

**Preview**

Note the `planets/123` in the example request:

<img width="602" alt="Screenshot 2024-06-07 at 12 14 52" src="https://github.com/scalar/scalar/assets/1577992/2f544836-c824-4b29-bafd-10c61fdd9f45">

**Example**

```yaml
openapi: 3.1.0
info:
  title: Scalar Galaxy
  version: 1.0.0
paths:
  '/planets/{planetId}':
    get:
      summary: Get a planet
      parameters:
        - name: planetId
          in: path
          schema:
            examples:
              - 123
```