### PR TITLE
feat(api-client): better error output for failed requests

### DIFF
--- a/.changeset/wet-lizards-brake.md
+++ b/.changeset/wet-lizards-brake.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+feat: better error output for failed requests

--- a/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
+++ b/packages/api-client/src/components/ApiClient/Response/ResponseBody.vue
@@ -64,7 +64,7 @@ const formattedResponseData = computed(() => {
       <ScalarCodeBlock
         v-if="codeMirrorLanguage || typeof response.data === 'string'"
         class="custom-scroll"
-        :content="formattedResponseData"
+        :content="formattedResponseData || response?.error?.message"
         :lang="codeMirrorLanguage" />
       <div
         v-else


### PR DESCRIPTION
If an request fails, we just show an empty request body. With this PR the Axios error message is shown.

As an alternative, we could also add some min-height or show a special component for empty response bodies. But I’m always staring at the response body and would love to see if something goes wrong right-away.

**Before**
<img width="688" alt="Screenshot 2024-06-07 at 12 38 38" src="https://github.com/scalar/scalar/assets/1577992/3f4578ff-5a8d-419d-8dde-b2f2aacdbeb1">

**After**
<img width="695" alt="Screenshot 2024-06-07 at 12 36 29" src="https://github.com/scalar/scalar/assets/1577992/1099c75a-f199-4af5-bf06-e6699da8378b">
