### PR TITLE
fix(api-client): URL is not encoded when sent to the proxy

### DIFF
--- a/.changeset/brave-islands-explode.md
+++ b/.changeset/brave-islands-explode.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: URL is not encoded when sent to the proxy

--- a/packages/api-client/src/helpers/redirectToProxy.ts
+++ b/packages/api-client/src/helpers/redirectToProxy.ts
@@ -7,7 +7,7 @@ export function redirectToProxy(proxy: string, url: string): string {
   newUrl.href = proxy
 
   // Add the original URL as a query parameter
-  newUrl.searchParams.append('scalar_url', url)
+  newUrl.searchParams.append('scalar_url', encodeURI(url))
 
   return newUrl.toString()
 }

--- a/packages/client-app/src/libs/sendRequest.ts
+++ b/packages/client-app/src/libs/sendRequest.ts
@@ -76,7 +76,7 @@ export const sendRequest = async (
   }
 
   const config: AxiosRequestConfig = {
-    url: `https://proxy.scalar.com?scalar_url=${url}`,
+    url: `https://proxy.scalar.com/?scalar_url=${encodeURI(url)}`,
     method: request.method,
     headers,
     params: paramsReducer(example.parameters.query),


### PR DESCRIPTION
Currently, we just pass the request URL to the proxy (https://proxy.scalar.com?scalar_url=OUR_TARGET_URL_HERE) and this works for most cases.

It turns out, not in all cases. :) Actually we need to encode the target URL when adding it to the `scalar_url` parameter, otherwise we’ll get an error from the proxy:

**✅ Works (regular URL)**
https://proxy.scalar.com/?scalar_url=https://example.com/

**❌ Doesn’t work (has a whitespace)**
https://proxy.scalar.com/?scalar_url=https://example.com/?query=apple+banana

**✅ Works (encoded)**
https://proxy.scalar.com/?scalar_url=https%3A%2F%2Fexample.com%3Fquery%3Dapple%2Bbanana