### PR TITLE
fix(api-reference): default example response is always the first example

### DIFF
--- a/.changeset/silly-beds-call.md
+++ b/.changeset/silly-beds-call.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix: default example response is moved to the first position

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -29,17 +29,9 @@ const { copyToClipboard } = useClipboard()
 const selectedExampleKey = ref<string>()
 
 // Bring the status codes in the right order.
-const orderedStatusCodes = computed(() => {
-  return Object.keys(props?.operation?.information?.responses ?? {}).sort(
-    (x) => {
-      if (x === 'default') {
-        return -1
-      }
-
-      return 0
-    },
-  )
-})
+const orderedStatusCodes = computed(() =>
+  Object.keys(props?.operation?.information?.responses ?? {}).sort(),
+)
 
 const hasMultipleExamples = computed<boolean>(
   () => !!currentJsonResponse.value.examples,


### PR DESCRIPTION
Currently, we’re always moving the `default` example response to the first position. Turns out, most people use `default` as a fallback and it doesn’t really make sense to have it as the first example response.

With this PR, all example responses are ordered alphabetically (new!) and default just comes after all numbers (new!).

Wdyt @marclave?

More context: https://github.com/scalar/scalar/discussions/1148