### PR TITLE
fix: handle extrict minimum and maximum properties

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -86,11 +86,23 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
       <SchemaPropertyDetail v-if="value.format">{{
         value.format
       }}</SchemaPropertyDetail>
-      <SchemaPropertyDetail v-if="value.minimum">
+      <SchemaPropertyDetail
+        v-if="value.minimum !== undefined && value.exclusiveMinimum">
+        <template #prefix>greater than:</template>
+        {{ value.minimum }}
+      </SchemaPropertyDetail>
+      <SchemaPropertyDetail
+        v-if="value.minimum !== undefined && !value.exclusiveMinimum">
         <template #prefix>min:</template>
         {{ value.minimum }}
       </SchemaPropertyDetail>
-      <SchemaPropertyDetail v-if="value.maximum">
+      <SchemaPropertyDetail
+        v-if="value.maximum !== undefined && value.exclusiveMaximum">
+        <template #prefix>less than:</template>
+        {{ value.maximum }}
+      </SchemaPropertyDetail>
+      <SchemaPropertyDetail
+        v-if="value.maximum !== undefined && !value.exclusiveMaximum">
         <template #prefix>max:</template>
         {{ value.maximum }}
       </SchemaPropertyDetail>


### PR DESCRIPTION
Fix https://github.com/scalar/scalar/discussions/1956

## Problem
Currently, `min` and `max` equal to 0 restrictions are not rendered, also the `extrictMinimum`and `extrictMaximum`properties are not handled. 

![image](https://github.com/scalar/scalar/assets/42624869/1a4eeb5e-12f1-4f3b-9651-a24af25a6fee)

## Explanation

This happens because `0` is falsy in Javascript, so the condition isn't satisfied and the min|max property is not rendered.
Also components for "extrictMinimum" and "extrictMaximum" are missing.

**Solution**
With this PR the condition to check if `value.minimum`or `value.maximum` are defined were refactored to check if the values are different from `undefined`, so "min=0" satisfies the condition.
"greater than" and "less then" schema property details were added to handle extrict minimum and maximum.

![image](https://github.com/scalar/scalar/assets/42624869/eaa5f7ca-7a7b-42ab-8d60-659426bd1236)

> ⚠️ "greater than" and "less than" were chose to avoid breaking changes, but it would be also possible to follow the Redoc's solution.
![image](https://github.com/scalar/scalar/assets/42624869/b258d349-e272-4f25-ae48-45b393dd529d)

## OpenAPI Properties

```json
"balance": {
  "type": "integer",
  "minimum": 0,
  "exclusiveMinimum": true,
  "description": "Saldo devedor em centavos."
},
"remainingTerm": {
  "type": "integer",
  "minimum": 0,
  "description": "Prazo remanescente em meses."
},
```

## Reference
https://swagger.io/docs/specification/data-models/data-types/