### PR TITLE
fix: add important to response header tabs

### DIFF
--- a/packages/api-reference/src/components/Card/CardTabHeader.vue
+++ b/packages/api-reference/src/components/Card/CardTabHeader.vue
@@ -33,6 +33,6 @@ const changeTab = (index: number) => {
   overflow: auto;
 }
 .scalar-card-header-tabs {
-  padding: 0;
+  padding: 0 !important;
 }
 </style>


### PR DESCRIPTION
before:
<img width="557" alt="image" src="https://github.com/scalar/scalar/assets/6176314/2d9937fd-1add-49bc-9686-2a0adbd41669">


after:
<img width="559" alt="image" src="https://github.com/scalar/scalar/assets/6176314/72adda9f-60a8-4772-a79d-ed5db0c333c2">
