### PR TITLE
fix: autoimport css in standalone

### DIFF
--- a/.changeset/great-news-grab.md
+++ b/.changeset/great-news-grab.md
@@ -1,0 +1,7 @@
+---
+"@scalar/api-reference": patch
+"@scalar/build-tooling": patch
+"@scalar/api-client": patch
+---
+
+fix: auto importing css backup

--- a/examples/web/src/App.vue
+++ b/examples/web/src/App.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import '@scalar/api-reference/style.css'
 import { RouterView } from 'vue-router'
 </script>
 <template>

--- a/examples/web/src/style.css
+++ b/examples/web/src/style.css
@@ -1,4 +1,5 @@
 @import '@scalar/api-client/style.css';
+@import '@scalar/api-reference/style.css';
 
 body {
   margin: 0;

--- a/packages/api-client/vite.config.ts
+++ b/packages/api-client/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     entry: ['src/index.ts'],
     options: {
       rollupOptions: {
-        plugins: [autoCSSInject],
+        plugins: [autoCSSInject('client')],
       },
     },
   }),

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       emptyOutDir: true,
       cssCodeSplit: false,
       rollupOptions: {
-        plugins: [autoCSSInject],
+        plugins: [autoCSSInject('references')],
       },
     },
   }),


### PR DESCRIPTION
This fixes the auto importing of css. The ID's were missing per app so it thought the style was already loaded. 

