### PR TITLE
feat: support OAuth2 authorization code flow

### DIFF
--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeSelector.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeSelector.vue
@@ -92,6 +92,10 @@ const getAuthorizationTypeLabel = (item: any) => {
       return 'OAuth 2.0 Password'
     }
 
+    if (item.flows?.clientCredentials) {
+      return 'OAuth 2.0 Client Credentials'
+    }
+
     return 'OAuth 2.0'
   }
 

--- a/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeSelector.vue
+++ b/packages/api-client/src/components/ApiClient/Request/RequestAuthentication/SecuritySchemeSelector.vue
@@ -96,6 +96,10 @@ const getAuthorizationTypeLabel = (item: any) => {
       return 'OAuth 2.0 Client Credentials'
     }
 
+    if (item.flows?.authorizationCode) {
+      return 'OAuth 2.0 Authorization Code'
+    }
+
     return 'OAuth 2.0'
   }
 

--- a/packages/api-client/src/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-client/src/helpers/getRequestFromAuthentication.test.ts
@@ -202,6 +202,7 @@ describe('getRequestFromAuthentication', () => {
           username: '',
           password: '',
           clientSecret: '',
+          code: '',
         },
       },
       [

--- a/packages/api-client/src/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-client/src/helpers/getRequestFromAuthentication.test.ts
@@ -201,6 +201,7 @@ describe('getRequestFromAuthentication', () => {
           state: '',
           username: '',
           password: '',
+          clientSecret: '',
         },
       },
       [

--- a/packages/api-client/src/stores/useAuthenticationStore.ts
+++ b/packages/api-client/src/stores/useAuthenticationStore.ts
@@ -25,6 +25,7 @@ export const createEmptyAuthenticationState = (): AuthenticationState => ({
     accessToken: '',
     state: '',
     clientSecret: '',
+    code: '',
   },
 })
 

--- a/packages/api-client/src/stores/useAuthenticationStore.ts
+++ b/packages/api-client/src/stores/useAuthenticationStore.ts
@@ -24,6 +24,7 @@ export const createEmptyAuthenticationState = (): AuthenticationState => ({
     scopes: [],
     accessToken: '',
     state: '',
+    clientSecret: '',
   },
 })
 

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -56,7 +56,9 @@ security:
   - apiKeyQuery: []
   - apiKeyHeader: []
   - apiKeyCookie: []
-  - oauth2: []
+  - oauth2Implicit: []
+  - oauth2Password: []
+  - oauth2ClientCredentials: []
 tags:
   - name: Authentication
     description:
@@ -354,11 +356,27 @@ components:
       type: apiKey
       in: cookie
       name: api_key
-    oauth2:
+    oauth2Implicit:
       type: oauth2
       flows:
         implicit:
           authorizationUrl: https://galaxy.scalar.com/oauth/authorize
+          scopes:
+            write:planets: modify planets in your account
+            read:planets: read your planets
+    oauth2Password:
+      type: oauth2
+      flows:
+        password:
+          tokenUrl: https://galaxy.scalar.com/oauth/authorize
+          scopes:
+            write:planets: modify planets in your account
+            read:planets: read your planets
+    oauth2ClientCredentials:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://galaxy.scalar.com/oauth/token
           scopes:
             write:planets: modify planets in your account
             read:planets: read your planets

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -59,6 +59,7 @@ security:
   - oauth2Implicit: []
   - oauth2Password: []
   - oauth2ClientCredentials: []
+  - oauth2AuthorizationCode: []
 tags:
   - name: Authentication
     description:
@@ -377,6 +378,15 @@ components:
       flows:
         clientCredentials:
           tokenUrl: https://galaxy.scalar.com/oauth/token
+          scopes:
+            write:planets: modify planets in your account
+            read:planets: read your planets
+    oauth2AuthorizationCode:
+      type: oauth2
+      flows:
+        authorizationCode:
+          tokenUrl: https://galaxy.scalar.com/oauth/token
+          authorizationUrl: https://galaxy.scalar.com/oauth/authorize
           scopes:
             write:planets: modify planets in your account
             read:planets: read your planets

--- a/packages/oas-utils/src/types.ts
+++ b/packages/oas-utils/src/types.ts
@@ -160,6 +160,7 @@ export type AuthenticationState = {
     username: string
     password: string
     clientSecret: string
+    code: string
   }
 }
 

--- a/packages/oas-utils/src/types.ts
+++ b/packages/oas-utils/src/types.ts
@@ -159,6 +159,7 @@ export type AuthenticationState = {
     state: string
     username: string
     password: string
+    clientSecret: string
   }
 }
 


### PR DESCRIPTION
**Problem**
Currently, the authorization code flow for oauth is not supported.

**Explanation**
This happens because support has not yet been built out.

**Solution**
With this PR the authorization code flow is now supported.

**Note**
This was built on top of https://github.com/scalar/scalar/pull/1949, ignore the first commit when reviewing.