### PR TITLE
fix: make custom scroll :global again

### DIFF
--- a/packages/themes/src/components/ScrollbarStyles.vue
+++ b/packages/themes/src/components/ScrollbarStyles.vue
@@ -13,62 +13,62 @@ useApplyClasses('#headlessui-portal-root', scrollbars)
 </template>
 <style lang="postcss" module>
 @layer scalar-utilities {
-  .scrollbars :global {
-    .cm-scroller,
-    .custom-scroll {
+  .scrollbars {
+    :global(.cm-scroller),
+    :global(.custom-scroll) {
       overflow-y: auto;
       scrollbar-color: transparent transparent;
       scrollbar-width: thin;
       -webkit-overflow-scrolling: touch;
     }
-    .custom-scroll-self-contain-overflow {
+    :global(.custom-scroll-self-contain-overflow) {
       overscroll-behavior: contain;
     }
     @supports (-moz-appearance: none) {
-      .cm-scroller,
-      .custom-scroll {
+      :global(.cm-scroller),
+      :global(.custom-scroll) {
         padding-right: 12px;
       }
     }
-    .cm-scroller:hover,
-    .custom-scroll:hover {
+    :global(.cm-scroller:hover),
+    :global(.custom-scroll:hover) {
       scrollbar-color: var(--scalar-scrollbar-color) transparent;
     }
-    .cm-scroller:hover::-webkit-scrollbar-thumb,
-    .custom-scroll:hover::-webkit-scrollbar-thumb {
+    :global(.cm-scroller:hover::-webkit-scrollbar-thumb),
+    :global(.custom-scroll:hover::-webkit-scrollbar-thumb) {
       background: var(--scalar-scrollbar-color);
       background-clip: content-box;
       border: 3px solid transparent;
     }
-    .cm-scroller::-webkit-scrollbar-thumb:active,
-    .custom-scroll::-webkit-scrollbar-thumb:active {
+    :global(.cm-scroller::-webkit-scrollbar-thumb:active),
+    :global(.custom-scroll::-webkit-scrollbar-thumb:active) {
       background: var(--scalar-scrollbar-color-active);
       background-clip: content-box;
       border: 3px solid transparent;
     }
-    .cm-scroller::-webkit-scrollbar-corner,
-    .custom-scroll::-webkit-scrollbar-corner {
+    :global(.cm-scroller::-webkit-scrollbar-corner),
+    :global(.custom-scroll::-webkit-scrollbar-corner) {
       background: transparent;
     }
-    .cm-scroller::-webkit-scrollbar,
-    .custom-scroll::-webkit-scrollbar {
+    :global(.cm-scroller::-webkit-scrollbar),
+    :global(.custom-scroll::-webkit-scrollbar) {
       height: 12px;
       width: 12px;
     }
-    .cm-scroller::-webkit-scrollbar-track,
-    .custom-scroll::-webkit-scrollbar-track {
+    :global(.cm-scroller::-webkit-scrollbar-track),
+    :global(.custom-scroll::-webkit-scrollbar-track) {
       background: transparent;
     }
-    .cm-scroller::-webkit-scrollbar-thumb,
-    .custom-scroll::-webkit-scrollbar-thumb {
+    :global(.cm-scroller::-webkit-scrollbar-thumb),
+    :global(.custom-scroll::-webkit-scrollbar-thumb) {
       border-radius: 20px;
       background: transparent;
       background-clip: content-box;
       border: 3px solid transparent;
     }
     @media (pointer: coarse) {
-      .cm-scroller,
-      .custom-scroll {
+      :global(.cm-scroller),
+      :global(.custom-scroll) {
         padding-right: 12px;
       }
     }


### PR DESCRIPTION
Looks like something with our changes in build tooling changed how we're parsing CSS modules and we can't use `:global` the way we were before.

We can probably change how we're doing this in the future but for now this PR fixes the regression.

## Before / After

https://github.com/scalar/scalar/assets/6374090/30c5ca0e-da47-46be-a75a-7744e16cf887


