### PR TITLE
chore: expand standarized build tooling

### DIFF
--- a/packages/build-tooling/README.md
+++ b/packages/build-tooling/README.md
@@ -1,0 +1,90 @@
+# @scalar/build-tooling
+
+Helpers for package management within the @scalar monorepo
+
+By default all dependencies are externalized and we don't bundle anything for internal modules.
+
+For deployed web apps alternative build methods should be used to provide a client bundle.
+
+In all cases package.json files should have:
+
+```json
+"scripts": {
+  "build": "scalar-build-rollup",
+  "types:check": "scalar-types-check",
+  "types:build": "scalar-types-build",
+  "format": "scalar-format-js",
+  "lint:check": "eslint .",
+  "lint:fix": "eslint . --fix",
+}
+```
+
+For Vue/Vite we need a different build command that leverages vite and vue-tsc:
+
+```json
+"scripts": {
+  "build": "scalar-build-vite",
+  "types:check": "scalar-types-check-vue",
+  "types:build": "scalar-types-build-vue",
+  "format": "scalar-format-js",
+  "lint:check": "eslint .",
+  "lint:fix": "eslint . --fix",
+}
+```
+
+## Rollup
+
+For non Vue projects we use Rollup for builds. Generally speaking rollup has better management of treeshaking.
+
+Our rollup config support json, yaml, and css import by default.
+Static files can be copied over by supplying entries to the `copy` parameter
+
+A basic `rollup.config.ts` file looks like:
+
+```typescript
+import type { RollupOptions } from 'rollup'
+
+import { createRollupConfig } from './src/rollup-options'
+
+const options: RollupOptions = {
+  input: ['./src/index.ts'],
+  // OR for nested exports with ts support
+  // input: await findEntryPoints({ allowCss: true }),
+  ...createRollupConfig({
+    // Needed to enable explicit typescript (which Vite does not need)
+    typescript: true,
+  }),
+}
+
+export default options
+```
+
+## Vite
+
+For Vue projects we use Vite to build production code. All the same rollup options can be passed through.
+
+A basic Vite implementation might look like:
+
+```typescript
+import {
+  alias,
+  createViteBuildOptions,
+  findEntryPoints,
+} from '@scalar/build-tooling'
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    // Provides @ -> './src' and @test -> './test' aliases
+    alias: alias(),
+  },
+  server: {
+    port: 5000,
+  },
+  build: createViteBuildOptions({
+    entry: await findEntryPoints({ allowCss: true }),
+  }),
+})
+```

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -16,13 +16,14 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.ts --configPlugin typescript && tsc -p tsconfig.build.json",
+    "build": "bash scripts/build-rollup.sh",
     "dev": "vite",
-    "format": "pnpm prettier --write --ignore-path=../../.prettierignore .",
+    "format": "bash scripts/format.sh",
     "lint:check": "eslint .",
     "lint:fix": "eslint . --fix",
     "preview": "dotenv -o -- vite preview",
-    "types:check": "tsc --noEmit"
+    "types:build": "bash scripts/types-build.sh",
+    "types:check": "bash scripts/types-check.sh"
   },
   "type": "module",
   "main": "dist/index.js",
@@ -32,20 +33,33 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "nx": {
-    "tags": [
-      "scope:package"
-    ]
+  "bin": {
+    "scalar-format-js": "scripts/format.sh",
+    "scalar-build-rollup": "scripts/build-rollup.sh",
+    "scalar-build-vite": "scripts/build-vite.sh",
+    "scalar-types-check": "scripts/types-check.sh",
+    "scalar-types-build": "scripts/types-build.sh",
+    "scalar-types-check-vue": "scripts/types-check-vue.sh",
+    "scalar-types-build-vue": "scripts/types-build-vue.sh"
   },
   "dependencies": {
+    "@rollup/plugin-alias": "^5.1.0",
+    "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-swc": "^0.3.1",
     "@rollup/plugin-typescript": "^11.1.6",
+    "@rollup/plugin-yaml": "^4.1.2",
     "@types/node": "^20.8.4",
     "glob": "^10.3.10",
     "rollup": "^4.16.4",
+    "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-dts": "^6.1.0",
+    "rollup-plugin-import-css": "^3.5.0",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.4.3",
     "vite": "^5.2.10",
     "vitest": "^1.6.0"
+  },
+  "devDependencies": {
+    "tsc-alias": "^1.8.8"
   }
 }

--- a/packages/build-tooling/rollup.config.ts
+++ b/packages/build-tooling/rollup.config.ts
@@ -1,10 +1,12 @@
-import type { RollupOptions } from 'rollup'
+import { addPackageFileExports, createRollupConfig } from './src'
 
-import { createRollupConfig } from './src/build-options'
+const entries = ['./src/index.ts']
 
-const options: RollupOptions = {
-  input: './src/index.ts',
-  ...createRollupConfig({ typescript: true }),
-}
+export default createRollupConfig({
+  options: {
+    input: entries,
+  },
+  typescript: true,
+})
 
-export default options
+await addPackageFileExports({ entries })

--- a/packages/build-tooling/scripts/build-rollup.sh
+++ b/packages/build-tooling/scripts/build-rollup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rollup -c rollup.config.ts --configPlugin typescript && pnpm types:build

--- a/packages/build-tooling/scripts/build-vite.sh
+++ b/packages/build-tooling/scripts/build-vite.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+vite build && pnpm types:build

--- a/packages/build-tooling/scripts/format.sh
+++ b/packages/build-tooling/scripts/format.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pnpm prettier --write --ignore-path=../../.prettierignore .

--- a/packages/build-tooling/scripts/types-build-vue.sh
+++ b/packages/build-tooling/scripts/types-build-vue.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json

--- a/packages/build-tooling/scripts/types-build.sh
+++ b/packages/build-tooling/scripts/types-build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json

--- a/packages/build-tooling/scripts/types-check-vue.sh
+++ b/packages/build-tooling/scripts/types-check-vue.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+vue-tsc --noEmit

--- a/packages/build-tooling/scripts/types-check.sh
+++ b/packages/build-tooling/scripts/types-check.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+tsc --noEmit

--- a/packages/build-tooling/src/index.ts
+++ b/packages/build-tooling/src/index.ts
@@ -1,6 +1,3 @@
-export { findEntryPoints } from './entry'
-export {
-  createRollupConfig,
-  createViteBuildOptions,
-  autoCSSInject,
-} from './build-options'
+export { findEntryPoints, addPackageFileExports } from './entry'
+export { createRollupConfig } from './rollup-options'
+export { alias, createViteBuildOptions, autoCSSInject } from './vite-options'

--- a/packages/build-tooling/src/rollup-options.ts
+++ b/packages/build-tooling/src/rollup-options.ts
@@ -1,0 +1,89 @@
+import alias from '@rollup/plugin-alias'
+import json from '@rollup/plugin-json'
+import typescript from '@rollup/plugin-typescript'
+import yaml from '@rollup/plugin-yaml'
+import { readFileSync } from 'fs'
+import type { InputPluginOption, RollupOptions } from 'rollup'
+import copy, { type Target } from 'rollup-plugin-copy'
+import css from 'rollup-plugin-import-css'
+
+export type StrictPluginOptions = RollupOptions & {
+  plugins?: InputPluginOption[]
+}
+
+/**
+ * Generate rollup options for a Scalar package build
+ *
+ * This should be used for packages and libraries NOT bundling
+ * projects to be served client-side (like web apps)
+ *
+ * Defaults:
+ * - Treeshaking enabled
+ * - Preserves modules
+ * - Externalizes ALL dependencies
+ */
+export function createRollupConfig(props: {
+  pkgFile?: Record<string, any>
+  /** Add the typescript plugin for non-vite builds */
+  typescript?: boolean
+  copy?: Target[]
+  options?: StrictPluginOptions
+}): RollupOptions {
+  /** Load the pkg file if not provided */
+  const pkgFile =
+    props.pkgFile ?? JSON.parse(readFileSync('./package.json', 'utf-8'))
+
+  const plugins = Array.isArray(props.options?.plugins)
+    ? [...props.options.plugins]
+    : []
+
+  // Optional list of files to copy over
+  if (props?.copy) plugins.push(copy({ targets: props.copy }))
+  // For vanilla rollup (not Vite) we need to enable transpilation
+  if (props.typescript) plugins.push(typescript())
+  plugins.push(json())
+  plugins.push(yaml())
+  plugins.push(css())
+  plugins.push(
+    alias({
+      entries: {
+        '@': './src',
+        '@test': './test',
+      },
+    }),
+  )
+
+  const external: string[] = []
+
+  if ('dependencies' in pkgFile)
+    external.push(...Object.keys(pkgFile.dependencies))
+  if ('devDependencies' in pkgFile)
+    external.push(...Object.keys(pkgFile.devDependencies))
+  if ('peerDependencies' in pkgFile)
+    external.push(...Object.keys(pkgFile.peerDependencies))
+  return {
+    treeshake: {
+      annotations: true,
+      preset: 'recommended',
+      /**
+       * We should never be importing modules for the side effects BUT
+       * CSS import are by definition side effects. These must be excluded
+       */
+      moduleSideEffects: (id) => {
+        return id.includes('.css')
+      },
+    },
+    output: {
+      format: 'esm',
+      preserveModules: true,
+      preserveModulesRoot: './src',
+      dir: './dist',
+    },
+    // Do not bundle any dependencies by default.
+    external: external.map(
+      (packageName) => new RegExp(`^${packageName}(/.*)?`),
+    ),
+    ...props.options,
+    plugins,
+  }
+}

--- a/packages/build-tooling/tsconfig.build.json
+++ b/packages/build-tooling/tsconfig.build.json
@@ -1,20 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": [
-    "dist",
-    "test",
-    "vite.config.ts",
-    "**/*.test.ts",
-    "**/*.test.json",
-    "**/*.test.md"
-  ],
   "compilerOptions": {
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
-    "outDir": "dist/",
-    "target": "ESNext"
+    "outDir": "dist/"
   }
 }

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -21,14 +21,14 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "vite build && pnpm types:build && tsc-alias -p tsconfig.build.json",
+    "build": "scalar-build-rollup",
     "dev": "vite",
+    "format": "scalar-format-js",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
-    "preview": "vite preview",
     "test": "vitest",
-    "types:build": "tsc -p tsconfig.build.json",
-    "types:check": "tsc --noEmit --skipLibCheck --composite false"
+    "types:build": "scalar-types-build",
+    "types:check": "scalar-types-check"
   },
   "type": "module",
   "main": "dist/index.js",
@@ -36,6 +36,18 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./rehype-highlight": {
+      "import": "./dist/rehype-highlight/index.js",
+      "types": "./dist/rehype-highlight/index.d.ts"
+    },
+    "./markdown": {
+      "import": "./dist/markdown/index.js",
+      "types": "./dist/markdown/index.d.ts"
+    },
+    "./code": {
+      "import": "./dist/code/index.js",
+      "types": "./dist/code/index.d.ts"
     },
     "./css/*.css": {
       "import": "./dist/css/*.css",

--- a/packages/code-highlight/rollup.config.ts
+++ b/packages/code-highlight/rollup.config.ts
@@ -1,0 +1,12 @@
+import { createRollupConfig, findEntryPoints } from '@scalar/build-tooling'
+import type { RollupOptions } from 'rollup'
+
+const options: RollupOptions = {
+  input: await findEntryPoints({ allowCss: true }),
+  ...createRollupConfig({
+    typescript: true,
+    copy: [{ src: './src/css', dest: 'dist' }],
+  }),
+}
+
+export default options

--- a/packages/code-highlight/src/code/highlight.ts
+++ b/packages/code-highlight/src/code/highlight.ts
@@ -1,0 +1,33 @@
+import { rehypeHighlight } from '@/rehype-highlight'
+import rehypeParse from 'rehype-parse'
+import rehypeStringify from 'rehype-stringify'
+import { type Plugin, unified } from 'unified'
+
+import { codeBlockLinesPlugin } from './line-numbers'
+
+export async function syntaxHighlight(
+  codeString: string,
+  options?: {
+    lang?: string
+    lineNumbers?: boolean
+  },
+) {
+  const className = options?.lang ? `language-${options?.lang}` : ''
+
+  const nullPlugin = (() => {}) satisfies Plugin
+
+  const html = await unified()
+    // Parses markdown
+    .use(rehypeParse, { fragment: true })
+    // Syntax highlighting
+    .use(rehypeHighlight, {
+      detect: options?.lang ? false : true,
+    })
+    .use(options?.lineNumbers ? codeBlockLinesPlugin : nullPlugin)
+    // Converts the HTML AST to a string
+    .use(rehypeStringify)
+    // Run the pipeline
+    .process(`<pre><code class="${className}">${codeString}</code></pre>`)
+
+  return html.toString()
+}

--- a/packages/code-highlight/src/code/index.ts
+++ b/packages/code-highlight/src/code/index.ts
@@ -1,0 +1,1 @@
+export { syntaxHighlight } from './highlight'

--- a/packages/code-highlight/src/code/line-numbers.ts
+++ b/packages/code-highlight/src/code/line-numbers.ts
@@ -1,37 +1,5 @@
 import type { Element, ElementContent, Root, Text } from 'hast'
-import rehypeParse from 'rehype-parse'
-import rehypeStringify from 'rehype-stringify'
-import { type Plugin, unified } from 'unified'
 import { visit } from 'unist-util-visit'
-
-import { rehypeHighlight } from './rehype-highlight'
-
-export async function syntaxHighlight(
-  codeString: string,
-  options?: {
-    lang?: string
-    lineNumbers?: boolean
-  },
-) {
-  const className = options?.lang ? `language-${options?.lang}` : ''
-
-  const nullPlugin = (() => {}) satisfies Plugin
-
-  const html = await unified()
-    // Parses markdown
-    .use(rehypeParse, { fragment: true })
-    // Syntax highlighting
-    .use(rehypeHighlight, {
-      detect: options?.lang ? false : true,
-    })
-    .use(options?.lineNumbers ? codeBlockLinesPlugin : nullPlugin)
-    // Converts the HTML AST to a string
-    .use(rehypeStringify)
-    // Run the pipeline
-    .process(`<pre><code class="${className}">${codeString}</code></pre>`)
-
-  return html.toString()
-}
 
 // ---------------------------------------------------------------------------
 // Line Numbering plugin

--- a/packages/code-highlight/src/index.ts
+++ b/packages/code-highlight/src/index.ts
@@ -1,3 +1,4 @@
 export { rehypeHighlight } from './rehype-highlight'
 export { lowlightLanguageMappings } from './constants'
 export { htmlFromMarkdown } from './markdown'
+export { syntaxHighlight } from './code'

--- a/packages/code-highlight/src/markdown/index.ts
+++ b/packages/code-highlight/src/markdown/index.ts
@@ -1,0 +1,1 @@
+export { htmlFromMarkdown } from './markdown'

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -1,3 +1,4 @@
+import { rehypeHighlight } from '@/rehype-highlight'
 import rehypeExternalLinks from 'rehype-external-links'
 import rehypeFormat from 'rehype-format'
 import rehypeRaw from 'rehype-raw'
@@ -7,8 +8,6 @@ import remarkGfm from 'remark-gfm'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
-
-import { rehypeHighlight } from './rehype-highlight'
 
 /** Take a markdown string and generate a raw HTML string */
 export async function htmlFromMarkdown(

--- a/packages/code-highlight/src/rehype-highlight/index.ts
+++ b/packages/code-highlight/src/rehype-highlight/index.ts
@@ -1,0 +1,1 @@
+export { rehypeHighlight } from './rehype-highlight'

--- a/packages/code-highlight/src/rehype-highlight/rehype-highlight.ts
+++ b/packages/code-highlight/src/rehype-highlight/rehype-highlight.ts
@@ -4,7 +4,7 @@ import { type LanguageFn, common, createLowlight } from 'lowlight'
 import { visit } from 'unist-util-visit'
 import type { VFile } from 'vfile'
 
-import { lowlightLanguageMappings } from './constants'
+import { lowlightLanguageMappings } from '../constants'
 
 type HighlightOptions = {
   /** Optional existing lowlight instance to use */

--- a/packages/code-highlight/test/preview.ts
+++ b/packages/code-highlight/test/preview.ts
@@ -9,7 +9,7 @@ import { syntaxHighlight } from '../src/code'
 import codeExampleLarge from '../src/constants.ts?raw'
 import '../src/css/code.css'
 import '../src/css/markdown.css'
-import { htmlFromMarkdown } from '../src/markdown'
+import { htmlFromMarkdown } from '../src/markdown/markdown'
 // @ts-expect-error vite not looking for raw types
 import markdownFile from './markdown-test.md?raw'
 

--- a/packages/code-highlight/tsconfig.json
+++ b/packages/code-highlight/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"],
+      "@test/*": ["./test/*"]
+    }
+  }
 }

--- a/packages/code-highlight/vite.config.ts
+++ b/packages/code-highlight/vite.config.ts
@@ -1,4 +1,4 @@
-import { findEntryPoints } from '@scalar/build-tooling'
+import { alias, findEntryPoints } from '@scalar/build-tooling'
 import { URL, fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 
@@ -7,33 +7,11 @@ import pkg from './package.json'
 export default defineConfig({
   plugins: [],
   resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
+    alias: alias(import.meta.url),
     dedupe: ['vue'],
   },
   server: {
     port: 9000,
   },
   publicDir: './src/css',
-  build: {
-    ssr: true,
-
-    minify: false,
-    target: 'esnext',
-    lib: {
-      entry: await findEntryPoints({ allowCss: true }),
-      formats: ['es'],
-    },
-    rollupOptions: {
-      external: [...Object.keys(pkg.dependencies)],
-      output: {
-        // Create a separate file for the dependency bundle
-        manualChunks: (id) =>
-          id.includes('node_modules') ? 'vendor' : undefined,
-        format: 'esm',
-      },
-      treeshake: true,
-    },
-  },
 })

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -21,15 +21,15 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "vite build && pnpm types:build && tsc-alias -p tsconfig.build.json",
+    "build": "scalar-build-rollup",
     "dev": "vite",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "preview": "vite preview",
     "test": "vitest",
     "test:unit": "vitest .",
-    "types:build": "tsc -p tsconfig.build.json",
-    "types:check": "tsc --noEmit --skipLibCheck --composite false"
+    "types:build": "scalar-types-build",
+    "types:check": "scalar-types-check"
   },
   "type": "module",
   "main": "dist/index.js",
@@ -85,14 +85,6 @@
     "./entities/workspace/collection": {
       "import": "./dist/entities/workspace/collection/index.js",
       "types": "./dist/entities/workspace/collection/index.d.ts"
-    },
-    "./css/*.css": {
-      "import": "./dist/css/*.css",
-      "require": "./dist/css/*.css"
-    },
-    "./*.css": {
-      "import": "./dist/*.css",
-      "require": "./dist/*.css"
     }
   },
   "files": [
@@ -111,6 +103,7 @@
     "axios": "^1.6.8",
     "httpsnippet-lite": "^3.0.5",
     "openapi-types": "^12.1.3",
+    "rollup": "^4.16.4",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",
     "vitest": "^1.6.0"

--- a/packages/oas-utils/rollup.config.ts
+++ b/packages/oas-utils/rollup.config.ts
@@ -1,0 +1,8 @@
+import { createRollupConfig, findEntryPoints } from '@scalar/build-tooling'
+
+export default createRollupConfig({
+  typescript: true,
+  options: {
+    input: await findEntryPoints({ allowCss: false }),
+  },
+})

--- a/packages/oas-utils/vite.config.ts
+++ b/packages/oas-utils/vite.config.ts
@@ -1,38 +1,13 @@
-import { findEntryPoints } from '@scalar/build-tooling'
-import { URL, fileURLToPath } from 'node:url'
+import { alias } from '@scalar/build-tooling'
 import { defineConfig } from 'vite'
-
-import pkg from './package.json'
 
 export default defineConfig({
   plugins: [],
   resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
+    alias: alias(import.meta.url),
     dedupe: ['vue'],
   },
   server: {
     port: 9000,
-  },
-  build: {
-    ssr: true,
-    minify: false,
-    target: 'esnext',
-    lib: {
-      entry: await findEntryPoints({ allowCss: true }),
-      formats: ['es'],
-    },
-    rollupOptions: {
-      external: [
-        ...Object.keys(pkg.peerDependencies),
-        ...Object.keys(pkg.dependencies),
-      ],
-      output: {
-        // Create a separate file for the dependency bundle
-        manualChunks: (id) =>
-          id.includes('node_modules') ? 'vendor' : undefined,
-      },
-    },
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1013,9 +1013,21 @@ importers:
 
   packages/build-tooling:
     dependencies:
+      '@rollup/plugin-alias':
+        specifier: ^5.1.0
+        version: 5.1.0(rollup@4.16.4)
+      '@rollup/plugin-json':
+        specifier: ^6.1.0
+        version: 6.1.0(rollup@4.16.4)
+      '@rollup/plugin-swc':
+        specifier: ^0.3.1
+        version: 0.3.1(@swc/core@1.4.2(@swc/helpers@0.5.2))(rollup@4.16.4)
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
         version: 11.1.6(rollup@4.16.4)(tslib@2.6.2)(typescript@5.4.3)
+      '@rollup/plugin-yaml':
+        specifier: ^4.1.2
+        version: 4.1.2(rollup@4.16.4)
       '@types/node':
         specifier: ^20.8.4
         version: 20.11.22
@@ -1025,9 +1037,15 @@ importers:
       rollup:
         specifier: ^4.16.4
         version: 4.16.4
+      rollup-plugin-copy:
+        specifier: ^3.5.0
+        version: 3.5.0
       rollup-plugin-dts:
         specifier: ^6.1.0
         version: 6.1.0(rollup@4.16.4)(typescript@5.4.3)
+      rollup-plugin-import-css:
+        specifier: ^3.5.0
+        version: 3.5.0(rollup@4.16.4)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1040,6 +1058,10 @@ importers:
       vitest:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.11.22)(jsdom@23.2.0)(terser@5.30.0)
+    devDependencies:
+      tsc-alias:
+        specifier: ^1.8.8
+        version: 1.8.8
 
   packages/cli:
     dependencies:
@@ -4865,6 +4887,16 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/plugin-swc@0.3.1':
+    resolution: {integrity: sha512-oqHt6W2J3CoIrdWpbLiRXdRkepEv+qwCgHMnSmh7waPFxaEeO3tocA1xy2p2qoJmk1zygDoxtPeP95z8bsJ+fA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@swc/core': ^1.3.0
+      rollup: ^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/plugin-terser@0.4.4':
     resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
     engines: {node: '>=14.0.0'}
@@ -4885,6 +4917,15 @@ packages:
       rollup:
         optional: true
       tslib:
+        optional: true
+
+  '@rollup/plugin-yaml@4.1.2':
+    resolution: {integrity: sha512-RpupciIeZMUqhgFE97ba0s98mOFS7CWzN3EJNhJkqSv9XLlWYtwVdtE6cDw6ASOF/sZVFS7kRJXftaqM2Vakdw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
         optional: true
 
   '@rollup/pluginutils@4.2.1':
@@ -5681,6 +5722,9 @@ packages:
 
   '@types/find-cache-dir@3.2.1':
     resolution: {integrity: sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==}
+
+  '@types/fs-extra@8.1.5':
+    resolution: {integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==}
 
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -7331,6 +7375,9 @@ packages:
 
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -9057,6 +9104,10 @@ packages:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
 
+  globby@10.0.1:
+    resolution: {integrity: sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==}
+    engines: {node: '>=8'}
+
   globby@10.0.2:
     resolution: {integrity: sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==}
     engines: {node: '>=8'}
@@ -9730,6 +9781,10 @@ packages:
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
+  is-plain-object@3.0.1:
+    resolution: {integrity: sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==}
     engines: {node: '>=0.10.0'}
 
   is-plain-object@5.0.0:
@@ -12657,6 +12712,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  rollup-plugin-copy@3.5.0:
+    resolution: {integrity: sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA==}
+    engines: {node: '>=8.3'}
+
   rollup-plugin-delete@2.0.0:
     resolution: {integrity: sha512-/VpLMtDy+8wwRlDANuYmDa9ss/knGsAgrDhM+tEwB1npHwNu4DYNmDfUL55csse/GHs9Q+SMT/rw9uiaZ3pnzA==}
     engines: {node: '>=10'}
@@ -12674,6 +12733,12 @@ packages:
     peerDependencies:
       esbuild: '>=0.18.0'
       rollup: ^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+
+  rollup-plugin-import-css@3.5.0:
+    resolution: {integrity: sha512-JOVow6n00qt2C/NnsqPmIjFOfxIAudwWqC5SaC84CodMGiMFaP1gPAdgnJ8g8hcG+P85TCYp2kI98grYCEt5pg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      rollup: ^2.x.x || ^3.x.x || ^4.x.x
 
   rollup-plugin-node-externals@7.1.2:
     resolution: {integrity: sha512-cVJFKs+ulZxpMmn/s+oi431d93Jq5+G7Sc5ixWDrL2k+Gj+MqXg0KMNWgKf8Mw5qpaG4jVDpsvuqFfiCvRcGeA==}
@@ -19178,6 +19243,14 @@ snapshots:
     optionalDependencies:
       rollup: 4.16.4
 
+  '@rollup/plugin-swc@0.3.1(@swc/core@1.4.2(@swc/helpers@0.5.2))(rollup@4.16.4)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.16.4)
+      '@swc/core': 1.4.2(@swc/helpers@0.5.2)
+      smob: 1.5.0
+    optionalDependencies:
+      rollup: 4.16.4
+
   '@rollup/plugin-terser@0.4.4(rollup@4.16.4)':
     dependencies:
       serialize-javascript: 6.0.2
@@ -19194,6 +19267,14 @@ snapshots:
     optionalDependencies:
       rollup: 4.16.4
       tslib: 2.6.2
+
+  '@rollup/plugin-yaml@4.1.2(rollup@4.16.4)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.16.4)
+      js-yaml: 4.1.0
+      tosource: 2.0.0-alpha.3
+    optionalDependencies:
+      rollup: 4.16.4
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
@@ -20675,6 +20756,10 @@ snapshots:
       '@types/serve-static': 1.15.5
 
   '@types/find-cache-dir@3.2.1': {}
+
+  '@types/fs-extra@8.1.5':
+    dependencies:
+      '@types/node': 20.11.26
 
   '@types/glob@7.2.0':
     dependencies:
@@ -22919,6 +23004,8 @@ snapshots:
 
   colord@2.9.3: {}
 
+  colorette@1.4.0: {}
+
   colorette@2.0.20: {}
 
   colors@1.2.5: {}
@@ -24974,6 +25061,17 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
 
+  globby@10.0.1:
+    dependencies:
+      '@types/glob': 7.2.0
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.2
+      glob: 7.2.3
+      ignore: 5.3.1
+      merge2: 1.4.1
+      slash: 3.0.0
+
   globby@10.0.2:
     dependencies:
       '@types/glob': 7.2.0
@@ -25807,6 +25905,8 @@ snapshots:
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  is-plain-object@3.0.1: {}
 
   is-plain-object@5.0.0: {}
 
@@ -29614,6 +29714,14 @@ snapshots:
     dependencies:
       glob: 9.3.5
 
+  rollup-plugin-copy@3.5.0:
+    dependencies:
+      '@types/fs-extra': 8.1.5
+      colorette: 1.4.0
+      fs-extra: 8.1.0
+      globby: 10.0.1
+      is-plain-object: 3.0.1
+
   rollup-plugin-delete@2.0.0:
     dependencies:
       del: 5.1.0
@@ -29644,6 +29752,11 @@ snapshots:
       rollup: 4.16.4
     transitivePeerDependencies:
       - supports-color
+
+  rollup-plugin-import-css@3.5.0(rollup@4.16.4):
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.16.4)
+      rollup: 4.16.4
 
   rollup-plugin-node-externals@7.1.2(rollup@4.16.4):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1817,6 +1817,9 @@ importers:
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
+      rollup:
+        specifier: ^4.16.4
+        version: 4.16.4
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12310,6 +12310,7 @@ packages:
   react-remove-scroll-bar@2.3.5:
     resolution: {integrity: sha512-3cqjOqg6s0XbOjWvmasmqHch+RLxIEk2r/70rzGXuz3iIGQsQheEQyqYCBb5EECoD01Vo2SIbDqW4paLeLTASw==}
     engines: {node: '>=10'}
+    deprecated: please update to the following version as this contains a bug (https://github.com/theKashey/react-remove-scroll-bar/issues/57)
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0


### PR DESCRIPTION
- Improves the rollup config with support for json, yaml, css, and automatic package exports updating
- Adds support for aliasing and a standard alias export function 
- Reorganized the code-highlight package a bit