### PR TITLE
fix: release build

### DIFF
--- a/.changeset/empty-terms-visit.md
+++ b/.changeset/empty-terms-visit.md
@@ -19,7 +19,6 @@
 "@scalar/use-toasts": minor
 "@scalar/draggable": minor
 "@scalar/oas-utils": minor
-"@scalar/use-modal": minor
 "@scalar/galaxy": minor
 "@scalar/themes": minor
 "@scalar/nuxt": minor


### PR DESCRIPTION
Currently our release build is broken due to this reference to the removed `use-modal` package. This should fix it