### PR TITLE
fix: api client modal scroll fix

### DIFF
--- a/packages/api-client-modal/src/components/ApiClientModal.vue
+++ b/packages/api-client-modal/src/components/ApiClientModal.vue
@@ -12,7 +12,7 @@ defineProps<{
 
 <template>
   <ScalarModal
-    bodyClass="row flex-1"
+    bodyClass="h-full"
     size="full"
     :state="modalState">
     <RouterView key="$route.fullPath" />

--- a/packages/client-app/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/client-app/src/views/Request/ResponseSection/ResponseSection.vue
@@ -81,7 +81,7 @@ const activeSection = ref<ActiveSections>('All')
         <span class="text-c-3 pl-1">{{ response?.status }}</span>
       </div>
     </template>
-    <div class="xl:custom-scroll flex flex-1 flex-col px-2 xl:px-6 py-2.5">
+    <div class="custom-scroll flex flex-1 flex-col px-2 xl:px-6 py-2.5">
       <template v-if="!response">
         <ResponseEmpty />
       </template>


### PR DESCRIPTION
this pr fixes api client modal scroll from being stuck as of right now by giving it a height.