### PR TITLE
chore: upgrade vitest coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/node": "^20.8.4",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "@vue/eslint-config-typescript": "^12.0.0",
     "concurrently": "^8.2.2",
     "eslint": "^8.56.0",

--- a/packages/api-client-modal/package.json
+++ b/packages/api-client-modal/package.json
@@ -5,7 +5,6 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/scalar/scalar.git",
@@ -15,6 +14,7 @@
     "vue api client modal"
   ],
   "version": "0.0.1",
+  "private": true,
   "engines": {
     "node": ">=18"
   },

--- a/packages/api-client-proxy/package.json
+++ b/packages/api-client-proxy/package.json
@@ -48,7 +48,7 @@
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.21",
     "@types/node": "^20.8.4",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "nodemon": "^3.0.1",
     "tsc-alias": "^1.8.8",
     "typescript": "^5.4.3",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -68,7 +68,7 @@
     "@scalar/oas-utils": "workspace:*",
     "@types/content-type": "^1.1.8",
     "@vitejs/plugin-vue": "^5.0.4",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",
     "vitest": "^1.6.0",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -102,7 +102,7 @@
     "@storybook/vue3": "^8.0.8",
     "@storybook/vue3-vite": "^8.0.8",
     "@vitejs/plugin-vue": "^5.0.4",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "@vue/test-utils": "^2.4.1",
     "eslint": "^8.56.0",
     "postcss": "^8.4.38",

--- a/packages/echo-server/package.json
+++ b/packages/echo-server/package.json
@@ -48,7 +48,7 @@
     "@types/cookie-parser": "^1.4.3",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.21",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "nodemon": "^3.0.1",
     "tsc-alias": "^1.8.8",
     "typescript": "^5.4.3",

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@scalar/api-reference": "workspace:*",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "fastify": "^4.26.2",
     "magic-string": "^0.30.8",
     "rollup-plugin-node-externals": "^7.1.2",

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -51,7 +51,7 @@
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@scalar/build-tooling": "workspace:*",
     "@scalar/openapi-parser": "^0.3.2",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",
     "vite-plugin-static-copy": "^1.0.2",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -50,7 +50,7 @@
     "@rise8/tailwind-pixel-perfect-preset": "^1.0.1",
     "@scalar/build-tooling": "workspace:*",
     "@vitejs/plugin-vue": "^5.0.4",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "tailwindcss": "^3.4.3",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",

--- a/packages/themes/src/index.test.ts
+++ b/packages/themes/src/index.test.ts
@@ -1,6 +1,3 @@
-/**
- * @vitest-environment happy-dom
- */
 import { describe, expect, it } from 'vitest'
 
 import { getThemeById } from './'

--- a/packages/themes/src/index.test.ts
+++ b/packages/themes/src/index.test.ts
@@ -1,13 +1,12 @@
 /**
- * @vitest-environment jsdom
+ * @vitest-environment happy-dom
  */
 import { describe, expect, it } from 'vitest'
 
 import { getThemeById } from './'
 
-// TODO: re-enable this test - it's failing because of an issue with the vitest snapshot
-describe.skip('Get Theme by ID', () => {
-  it('Should provide the default theme if no ThemeId is provided', () => {
+describe('Get Theme by ID', () => {
+  it.skip('Should provide the default theme if no ThemeId is provided', () => {
     const res = getThemeById()
     expect(res).toMatchFileSnapshot('./presets/default.css')
   })

--- a/packages/themes/src/utilities/legacy.test.ts
+++ b/packages/themes/src/utilities/legacy.test.ts
@@ -1,6 +1,3 @@
-/**
- * @vitest-environment happy-dom
- */
 import { describe, expect, it, vi } from 'vitest'
 
 import legacyTheme from '../fixtures/legacyTheme.css?inline'

--- a/packages/themes/src/utilities/legacy.test.ts
+++ b/packages/themes/src/utilities/legacy.test.ts
@@ -1,13 +1,12 @@
 /**
- * @vitest-environment jsdom
+ * @vitest-environment happy-dom
  */
 import { describe, expect, it, vi } from 'vitest'
 
 import legacyTheme from '../fixtures/legacyTheme.css?inline'
 import { migrateThemeVariables } from './legacy'
 
-// TODO: re-enable this test - it's failing because of an issue with the vitest snapshot
-describe.skip('Legacy Utils', () => {
+describe('Legacy Utils', () => {
   it('Changes a legacy theme variable', () => {
     const res = migrateThemeVariables('--theme-color-1')
     expect(res).toBe('--scalar-color-1')
@@ -28,7 +27,7 @@ describe.skip('Legacy Utils', () => {
     expect(res).toBe('--scalar-sidebar-color-1')
   })
 
-  it('Can migrate a long style string', () => {
+  it.skip('Can migrate a long style string', () => {
     const res = migrateThemeVariables(legacyTheme)
     expect(res).toMatchFileSnapshot('../fixtures/updatedTheme.css')
   })

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
     "@vitejs/plugin-vue": "^5.0.4",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",
     "vitest": "^1.6.0",

--- a/packages/use-toasts/package.json
+++ b/packages/use-toasts/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
     "@vitejs/plugin-vue": "^5.0.4",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "nanoid": "^5.0.7",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",

--- a/packages/use-tooltip/package.json
+++ b/packages/use-tooltip/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
     "@vitejs/plugin-vue": "^5.0.4",
-    "@vitest/coverage-v8": "^1.5.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "tippy.js": "^6.3.7",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",

--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^6.21.0
         version: 6.21.0(eslint@8.57.0)(typescript@5.4.3)
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.22)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       '@vue/eslint-config-typescript':
         specifier: ^12.0.0
         version: 12.0.0(eslint-plugin-vue@9.22.0(eslint@8.57.0))(eslint@8.57.0)(typescript@5.4.3)
@@ -79,7 +79,7 @@ importers:
         version: 1.5.0(@types/node@20.11.22)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.22)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
       vue-eslint-parser:
         specifier: ^9.4.2
         version: 9.4.2(eslint@8.57.0)
@@ -707,8 +707,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vue@3.4.27(typescript@5.4.3))
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
@@ -717,7 +717,7 @@ importers:
         version: 5.2.10(@types/node@20.11.26)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
       vue:
         specifier: ^3.4.22
         version: 3.4.27(typescript@5.4.3)
@@ -784,8 +784,8 @@ importers:
         specifier: ^20.8.4
         version: 20.11.22
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.22)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       nodemon:
         specifier: ^3.0.1
         version: 3.1.0
@@ -803,7 +803,7 @@ importers:
         version: 1.5.0(@types/node@20.11.22)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.22)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
 
   packages/api-client-react:
     dependencies:
@@ -943,7 +943,7 @@ importers:
         version: 8.0.8(@types/react@18.2.60)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-interactions':
         specifier: ^8.0.8
-        version: 8.0.8(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+        version: 8.0.8(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       '@storybook/addon-links':
         specifier: ^8.0.8
         version: 8.0.8(react@18.3.1)
@@ -963,8 +963,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vue@3.4.27(typescript@5.4.3))
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       '@vue/test-utils':
         specifier: ^2.4.1
         version: 2.4.4(@vue/server-renderer@3.4.27(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3))
@@ -997,10 +997,10 @@ importers:
         version: 3.4.0(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
       vitest-matchmedia-mock:
         specifier: ^1.0.5
-        version: 1.0.5(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.0.5(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
       vue:
         specifier: ^3.4.22
         version: 3.4.27(typescript@5.4.3)
@@ -1094,7 +1094,7 @@ importers:
         version: 5.2.10(@types/node@20.11.22)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.22)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
     devDependencies:
       tsc-alias:
         specifier: ^1.8.8
@@ -1353,7 +1353,7 @@ importers:
         version: link:../oas-utils
       '@storybook/test':
         specifier: ^8.0.8
-        version: 8.0.8(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(jsdom@22.1.0)(terser@5.30.0))
+        version: 8.0.8(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@22.1.0)(terser@5.30.0))
       '@vueuse/core':
         specifier: ^10.10.0
         version: 10.10.0(vue@3.4.27(typescript@5.4.3))
@@ -1384,7 +1384,7 @@ importers:
         version: 8.0.8(@types/react@18.2.60)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-interactions':
         specifier: ^8.0.8
-        version: 8.0.8(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(jsdom@22.1.0)(terser@5.30.0))
+        version: 8.0.8(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@22.1.0)(terser@5.30.0))
       '@storybook/addon-links':
         specifier: ^8.0.8
         version: 8.0.8(react@18.3.1)
@@ -1468,7 +1468,7 @@ importers:
         version: 5.1.0(vue@3.4.27(typescript@5.4.3))
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.22)(jsdom@22.1.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@22.1.0)(terser@5.30.0)
       vue:
         specifier: ^3.4.22
         version: 3.4.27(typescript@5.4.3)
@@ -1544,8 +1544,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       nodemon:
         specifier: ^3.0.1
         version: 3.1.0
@@ -1563,7 +1563,7 @@ importers:
         version: 1.5.0(@types/node@20.11.26)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
 
   packages/express-api-reference:
     dependencies:
@@ -1585,7 +1585,7 @@ importers:
         version: 5.2.10(@types/node@20.11.26)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
 
   packages/fastify-api-reference:
     dependencies:
@@ -1597,8 +1597,8 @@ importers:
         specifier: workspace:*
         version: link:../api-reference
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       fastify:
         specifier: ^4.26.2
         version: 4.26.2
@@ -1625,7 +1625,7 @@ importers:
         version: 1.0.2(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
       vue:
         specifier: ^3.4.22
         version: 3.4.27(typescript@5.4.3)
@@ -1642,8 +1642,8 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2(terser@5.30.0)
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
@@ -1655,7 +1655,7 @@ importers:
         version: 1.0.2(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
 
   packages/hono-api-reference:
     dependencies:
@@ -1674,7 +1674,7 @@ importers:
         version: 5.2.10(@types/node@20.11.26)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
 
   packages/mock-server:
     dependencies:
@@ -1748,7 +1748,7 @@ importers:
         version: 5.2.10(@types/node@20.11.26)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
 
   packages/nextjs-api-reference:
     dependencies:
@@ -1810,7 +1810,7 @@ importers:
         version: 3.11.2(rollup@4.16.4)
       '@nuxt/test-utils':
         specifier: ^3.12.0
-        version: 3.12.0(@jest/globals@29.7.0)(@playwright/test@1.42.0)(@vue/test-utils@2.4.4(vue@3.4.27(typescript@5.4.3)))(h3@1.11.1)(jsdom@23.2.0)(playwright-core@1.42.0)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3))
+        version: 3.12.0(@jest/globals@29.7.0)(@playwright/test@1.42.0)(@vue/test-utils@2.4.4(vue@3.4.27(typescript@5.4.3)))(h3@1.11.1)(happy-dom@14.12.0)(jsdom@23.2.0)(playwright-core@1.42.0)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3))
       '@types/node':
         specifier: ^20.8.4
         version: 20.11.26
@@ -1825,7 +1825,7 @@ importers:
         version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.26)(@unocss/reset@0.59.2)(axios@1.6.8)(encoding@0.1.13)(eslint@8.57.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.16.4))(vue@3.4.27(typescript@5.4.3)))(fuse.js@7.0.0)(ioredis@5.3.2)(nprogress@0.2.0)(optionator@0.9.3)(rollup@4.16.4)(terser@5.30.0)(typescript@5.4.3)(unocss@0.59.2(postcss@8.4.38)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0)))(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vue-tsc@2.0.19(typescript@5.4.3))
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
 
   packages/oas-utils:
     dependencies:
@@ -1865,7 +1865,7 @@ importers:
         version: 5.2.10(@types/node@20.11.26)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
 
   packages/object-utils:
     dependencies:
@@ -1944,8 +1944,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vue@3.4.27(typescript@5.4.3))
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       tailwindcss:
         specifier: ^3.4.3
         version: 3.4.3(ts-node@10.9.2(@types/node@20.11.26)(typescript@5.4.3))
@@ -1960,7 +1960,7 @@ importers:
         version: 1.0.2(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
       vue:
         specifier: ^3.4.22
         version: 3.4.27(typescript@5.4.3)
@@ -2027,8 +2027,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vue@3.4.27(typescript@5.4.3))
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
@@ -2037,7 +2037,7 @@ importers:
         version: 5.2.10(@types/node@20.11.26)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
       vue:
         specifier: ^3.4.22
         version: 3.4.27(typescript@5.4.3)
@@ -2061,8 +2061,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vue@3.4.27(typescript@5.4.3))
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7
@@ -2077,7 +2077,7 @@ importers:
         version: 3.4.0(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
       vue:
         specifier: ^3.4.22
         version: 3.4.27(typescript@5.4.3)
@@ -2094,8 +2094,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vue@3.4.27(typescript@5.4.3))
       '@vitest/coverage-v8':
-        specifier: ^1.5.0
-        version: 1.5.0(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       tippy.js:
         specifier: ^6.3.7
         version: 6.3.7
@@ -2107,7 +2107,7 @@ importers:
         version: 5.2.10(@types/node@20.11.26)(terser@5.30.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+        version: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
       vue:
         specifier: ^3.4.22
         version: 3.4.27(typescript@5.4.3)
@@ -6268,10 +6268,10 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
 
-  '@vitest/coverage-v8@1.5.0':
-    resolution: {integrity: sha512-1igVwlcqw1QUMdfcMlzzY4coikSIBN944pkueGi0pawrX5I5Z+9hxdTR+w3Sg6Q3eZhvdMAs8ZaF9JuTG1uYOQ==}
+  '@vitest/coverage-v8@1.6.0':
+    resolution: {integrity: sha512-KvapcbMY/8GYIG0rlwwOKCVNRc0OL20rrhFkg/CHNzncV03TE2XWvO5w9uZYoxNiMEBacAJt3unSOiZ7svePew==}
     peerDependencies:
-      vitest: 1.5.0
+      vitest: 1.6.0
 
   '@vitest/expect@1.3.1':
     resolution: {integrity: sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==}
@@ -9213,6 +9213,10 @@ packages:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
+
+  happy-dom@14.12.0:
+    resolution: {integrity: sha512-dHcnlGFY2o2CdxfuYpqwSrBrpj/Kuzv4u4f3TU5yHW1GL24dKij4pv1BRjXnXc3uWo8qsCbToF9weaDsm/He8A==}
+    engines: {node: '>=16.0.0'}
 
   hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -18679,7 +18683,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/test-utils@3.12.0(@jest/globals@29.7.0)(@playwright/test@1.42.0)(@vue/test-utils@2.4.4(vue@3.4.27(typescript@5.4.3)))(h3@1.11.1)(jsdom@23.2.0)(playwright-core@1.42.0)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3))':
+  '@nuxt/test-utils@3.12.0(@jest/globals@29.7.0)(@playwright/test@1.42.0)(@vue/test-utils@2.4.4(vue@3.4.27(typescript@5.4.3)))(h3@1.11.1)(happy-dom@14.12.0)(jsdom@23.2.0)(playwright-core@1.42.0)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3))':
     dependencies:
       '@nuxt/kit': 3.11.2(rollup@4.16.4)
       '@nuxt/schema': 3.11.2(rollup@4.16.4)
@@ -18705,16 +18709,17 @@ snapshots:
       unenv: 1.9.0
       unplugin: 1.10.1
       vite: 5.2.10(@types/node@20.11.26)(terser@5.30.0)
-      vitest-environment-nuxt: 1.0.0(@jest/globals@29.7.0)(@playwright/test@1.42.0)(@vue/test-utils@2.4.4(vue@3.4.27(typescript@5.4.3)))(h3@1.11.1)(jsdom@23.2.0)(playwright-core@1.42.0)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3))
+      vitest-environment-nuxt: 1.0.0(@jest/globals@29.7.0)(@playwright/test@1.42.0)(@vue/test-utils@2.4.4(vue@3.4.27(typescript@5.4.3)))(h3@1.11.1)(happy-dom@14.12.0)(jsdom@23.2.0)(playwright-core@1.42.0)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3))
       vue: 3.4.27(typescript@5.4.3)
       vue-router: 4.3.2(vue@3.4.27(typescript@5.4.3))
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@playwright/test': 1.42.0
       '@vue/test-utils': 2.4.4(@vue/server-renderer@3.4.27(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3))
+      happy-dom: 14.12.0
       jsdom: 23.2.0
       playwright-core: 1.42.0
-      vitest: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+      vitest: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -19617,11 +19622,11 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
 
-  '@storybook/addon-interactions@8.0.8(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(jsdom@22.1.0)(terser@5.30.0))':
+  '@storybook/addon-interactions@8.0.8(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@22.1.0)(terser@5.30.0))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/instrumenter': 8.0.8
-      '@storybook/test': 8.0.8(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(jsdom@22.1.0)(terser@5.30.0))
+      '@storybook/test': 8.0.8(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@22.1.0)(terser@5.30.0))
       '@storybook/types': 8.0.8
       polished: 4.3.1
       ts-dedent: 2.2.0
@@ -19632,11 +19637,11 @@ snapshots:
       - jest
       - vitest
 
-  '@storybook/addon-interactions@8.0.8(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))':
+  '@storybook/addon-interactions@8.0.8(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/instrumenter': 8.0.8
-      '@storybook/test': 8.0.8(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+      '@storybook/test': 8.0.8(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       '@storybook/types': 8.0.8
       polished: 4.3.1
       ts-dedent: 2.2.0
@@ -20235,14 +20240,14 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/test@8.0.8(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(jsdom@22.1.0)(terser@5.30.0))':
+  '@storybook/test@8.0.8(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@22.1.0)(terser@5.30.0))':
     dependencies:
       '@storybook/client-logger': 8.0.8
       '@storybook/core-events': 8.0.8
       '@storybook/instrumenter': 8.0.8
       '@storybook/preview-api': 8.0.8
       '@testing-library/dom': 9.3.4
-      '@testing-library/jest-dom': 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(jsdom@22.1.0)(terser@5.30.0))
+      '@testing-library/jest-dom': 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@22.1.0)(terser@5.30.0))
       '@testing-library/user-event': 14.5.2(@testing-library/dom@9.3.4)
       '@vitest/expect': 1.3.1
       '@vitest/spy': 1.5.0
@@ -20255,14 +20260,14 @@ snapshots:
       - jest
       - vitest
 
-  '@storybook/test@8.0.8(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))':
+  '@storybook/test@8.0.8(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))':
     dependencies:
       '@storybook/client-logger': 8.0.8
       '@storybook/core-events': 8.0.8
       '@storybook/instrumenter': 8.0.8
       '@storybook/preview-api': 8.0.8
       '@testing-library/dom': 9.3.4
-      '@testing-library/jest-dom': 6.4.2(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))
+      '@testing-library/jest-dom': 6.4.2(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))
       '@testing-library/user-event': 14.5.2(@testing-library/dom@9.3.4)
       '@vitest/expect': 1.3.1
       '@vitest/spy': 1.5.0
@@ -20608,7 +20613,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(jsdom@22.1.0)(terser@5.30.0))':
+  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3)))(vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@22.1.0)(terser@5.30.0))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.24.5
@@ -20622,9 +20627,9 @@ snapshots:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.12
       jest: 29.7.0(@types/node@20.11.22)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@20.11.22)(typescript@5.4.3))
-      vitest: 1.6.0(@types/node@20.11.22)(jsdom@22.1.0)(terser@5.30.0)
+      vitest: 1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@22.1.0)(terser@5.30.0)
 
-  '@testing-library/jest-dom@6.4.2(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))':
+  '@testing-library/jest-dom@6.4.2(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.24.5
@@ -20635,7 +20640,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
     optionalDependencies:
-      vitest: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+      vitest: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
 
   '@testing-library/user-event@14.5.2(@testing-library/dom@9.3.4)':
     dependencies:
@@ -21501,7 +21506,7 @@ snapshots:
       vite: 5.2.10(@types/node@20.11.26)(terser@5.30.0)
       vue: 3.4.27(typescript@5.4.3)
 
-  '@vitest/coverage-v8@1.5.0(vitest@1.6.0(@types/node@20.11.22)(jsdom@23.2.0)(terser@5.30.0))':
+  '@vitest/coverage-v8@1.6.0(vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -21510,17 +21515,17 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.4
       istanbul-reports: 3.1.7
-      magic-string: 0.30.9
+      magic-string: 0.30.10
       magicast: 0.3.3
       picocolors: 1.0.0
       std-env: 3.7.0
       strip-literal: 2.1.0
       test-exclude: 6.0.0
-      vitest: 1.6.0(@types/node@20.11.22)(jsdom@23.2.0)(terser@5.30.0)
+      vitest: 1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.5.0(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))':
+  '@vitest/coverage-v8@1.6.0(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -21529,13 +21534,13 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.4
       istanbul-reports: 3.1.7
-      magic-string: 0.30.9
+      magic-string: 0.30.10
       magicast: 0.3.3
       picocolors: 1.0.0
       std-env: 3.7.0
       strip-literal: 2.1.0
       test-exclude: 6.0.0
-      vitest: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+      vitest: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25238,6 +25243,13 @@ snapshots:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.17.4
+
+  happy-dom@14.12.0:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
+    optional: true
 
   hard-rejection@2.1.0: {}
 
@@ -31885,9 +31897,9 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.30.0
 
-  vitest-environment-nuxt@1.0.0(@jest/globals@29.7.0)(@playwright/test@1.42.0)(@vue/test-utils@2.4.4(vue@3.4.27(typescript@5.4.3)))(h3@1.11.1)(jsdom@23.2.0)(playwright-core@1.42.0)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3)):
+  vitest-environment-nuxt@1.0.0(@jest/globals@29.7.0)(@playwright/test@1.42.0)(@vue/test-utils@2.4.4(vue@3.4.27(typescript@5.4.3)))(h3@1.11.1)(happy-dom@14.12.0)(jsdom@23.2.0)(playwright-core@1.42.0)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3)):
     dependencies:
-      '@nuxt/test-utils': 3.12.0(@jest/globals@29.7.0)(@playwright/test@1.42.0)(@vue/test-utils@2.4.4(vue@3.4.27(typescript@5.4.3)))(h3@1.11.1)(jsdom@23.2.0)(playwright-core@1.42.0)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3))
+      '@nuxt/test-utils': 3.12.0(@jest/globals@29.7.0)(@playwright/test@1.42.0)(@vue/test-utils@2.4.4(vue@3.4.27(typescript@5.4.3)))(h3@1.11.1)(happy-dom@14.12.0)(jsdom@23.2.0)(playwright-core@1.42.0)(rollup@4.16.4)(vite@5.2.10(@types/node@20.11.26)(terser@5.30.0))(vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.3)))(vue@3.4.27(typescript@5.4.3))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -31906,9 +31918,9 @@ snapshots:
       - vue
       - vue-router
 
-  vitest-matchmedia-mock@1.0.5(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0):
+  vitest-matchmedia-mock@1.0.5(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0):
     dependencies:
-      vitest: 1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0)
+      vitest: 1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@types/node'
@@ -31924,7 +31936,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.0(@types/node@20.11.22)(jsdom@22.1.0)(terser@5.30.0):
+  vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@22.1.0)(terser@5.30.0):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
@@ -31948,6 +31960,7 @@ snapshots:
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.11.22
+      happy-dom: 14.12.0
       jsdom: 22.1.0
     transitivePeerDependencies:
       - less
@@ -31958,7 +31971,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.0(@types/node@20.11.22)(jsdom@23.2.0)(terser@5.30.0):
+  vitest@1.6.0(@types/node@20.11.22)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
@@ -31982,6 +31995,7 @@ snapshots:
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.11.22
+      happy-dom: 14.12.0
       jsdom: 23.2.0
     transitivePeerDependencies:
       - less
@@ -31992,7 +32006,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.0(@types/node@20.11.26)(jsdom@23.2.0)(terser@5.30.0):
+  vitest@1.6.0(@types/node@20.11.26)(happy-dom@14.12.0)(jsdom@23.2.0)(terser@5.30.0):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
@@ -32016,6 +32030,7 @@ snapshots:
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.11.26
+      happy-dom: 14.12.0
       jsdom: 23.2.0
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Breaking out some work that I did while down the rabbit hole trying to fix the the `themes` snapshot testing. 

This PR re-enables most of the themes testing except for two tests that using `toMatchFileSnapshot()` which still requires some work to fix our environment. 

Also fixes the tsconfig path in the playwright package and upgrades `@vitest/coverage-v8` to `1.6.0` fixing some peer dependency warnings.  
