### PR TITLE
fix: zod url doesnt allow relative url for parsing

### DIFF
--- a/packages/oas-utils/src/entities/workspace/server/server.ts
+++ b/packages/oas-utils/src/entities/workspace/server/server.ts
@@ -32,7 +32,7 @@ const serverSchema = z.object({
    * the host location is relative to the location where the OpenAPI document is being served. Variable substitutions
    * will be made when a variable is named in {brackets}.
    */
-  url: z.string().url(),
+  url: z.string(),
   /**
    * An optional string describing the host designated by the URL. CommonMark syntax MAY be used for rich text
    * representation.

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -83,7 +83,10 @@ export const importSpecToWorkspace = async (payload: ImportSpecPayload) => {
       operation.parameters?.forEach((_param: any) => {
         const param = _param
 
-        if ('name' in param) {
+        if (
+          'name' in param &&
+          PARAM_DICTIONARY[param.in as keyof typeof PARAM_DICTIONARY]
+        ) {
           parameters[
             // Map cookie -> and header -> headers
             PARAM_DICTIONARY[param.in as keyof typeof PARAM_DICTIONARY]


### PR DESCRIPTION
**Problem**
openapi can have relative URLs for servers, which a good use case is for our integrations which are hosted docs on the api server

**Explanation**
zod url doesnt allow for relative url

**Solution**
we just make sure its a valid string now
