### PR TITLE
fix: allow nullable in servers as per openapi spec

### DIFF
--- a/packages/oas-utils/src/entities/workspace/server/server.ts
+++ b/packages/oas-utils/src/entities/workspace/server/server.ts
@@ -39,7 +39,7 @@ const serverSchema = z.object({
    */
   description: z.string().optional(),
   /** A map between a variable name and its value. The value is used for substitution in the server’s URL template. */
-  variables: z.record(z.string(), serverVariableSchema).optional(),
+  variables: z.record(z.string(), serverVariableSchema).nullable().optional(),
 })
 
 /**


### PR DESCRIPTION
variables can be nullable inside of servers :) 

https://swagger.io/docs/specification/api-host-and-base-path/