### PR TITLE
fix: remove click events from http verb + adding server in address bar

### DIFF
--- a/packages/client-app/src/components/AddressBar/AddressBar.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBar.vue
@@ -33,7 +33,6 @@ const {
   activeCollection,
   collectionMutators,
   servers,
-  workspace,
   requestMutators,
 } = useWorkspace()
 
@@ -242,8 +241,8 @@ const handlePaste = (event: ClipboardEvent) => {
                     {{ server.label }}
                   </span>
                 </ScalarDropdownItem>
-                <ScalarDropdownDivider v-if="!workspace.isReadOnly" />
-                <ScalarDropdownItem v-if="!workspace.isReadOnly">
+                <ScalarDropdownDivider />
+                <ScalarDropdownItem>
                   <RouterLink
                     class="font-code text-xxs flex items-center gap-1.5"
                     to="/servers">

--- a/packages/client-app/src/components/AddressBar/AddressBar.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBar.vue
@@ -33,6 +33,7 @@ const {
   activeCollection,
   collectionMutators,
   servers,
+  workspace,
   requestMutators,
 } = useWorkspace()
 
@@ -241,8 +242,8 @@ const handlePaste = (event: ClipboardEvent) => {
                     {{ server.label }}
                   </span>
                 </ScalarDropdownItem>
-                <ScalarDropdownDivider />
-                <ScalarDropdownItem>
+                <ScalarDropdownDivider v-if="!workspace.isReadOnly" />
+                <ScalarDropdownItem v-if="!workspace.isReadOnly">
                   <RouterLink
                     class="font-code text-xxs flex items-center gap-1.5"
                     to="/servers">

--- a/packages/client-app/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/client-app/src/components/HttpMethod/HttpMethod.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useWorkspace } from '@/store/workspace'
 import { ScalarIcon, ScalarListbox } from '@scalar/components'
 import {
   REQUEST_METHODS,
@@ -20,6 +21,8 @@ const props = withDefaults(
 const emit = defineEmits<{
   (e: 'change', value: RequestMethod): void
 }>()
+
+const { workspace } = useWorkspace()
 
 const method = computed(() => getRequest(props.method))
 
@@ -52,22 +55,27 @@ const httpLabel = computed(() => method.value.short)
     v-if="isEditable"
     v-model="selectedMethod"
     :options="methodOptions">
-    <button
-      class="relative h-full cursor-pointer gap-1"
-      :class="
-        cx(
-          variants({ isSquare, isEditable }),
-          method.color,
-          isSquare && method.backgroundColor,
-        )
-      "
-      type="button">
-      <span>{{ httpLabel }}</span>
-      <ScalarIcon
-        :class="method.color"
-        icon="ChevronDown"
-        size="xs" />
-    </button>
+    <div
+      class="h-full"
+      :class="{ 'pointer-events-none': workspace.isReadOnly }">
+      <button
+        class="relative h-full cursor-pointer gap-1"
+        :class="
+          cx(
+            variants({ isSquare, isEditable }),
+            method.color,
+            isSquare && method.backgroundColor,
+          )
+        "
+        type="button">
+        <span>{{ httpLabel }}</span>
+        <ScalarIcon
+          v-if="!workspace.isReadOnly"
+          :class="method.color"
+          icon="ChevronDown"
+          size="xs" />
+      </button>
+    </div>
   </ScalarListbox>
   <!-- Display only -->
   <div

--- a/packages/client-app/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/client-app/src/components/HttpMethod/HttpMethod.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useWorkspace } from '@/store/workspace'
 import { ScalarIcon, ScalarListbox } from '@scalar/components'
 import {
   REQUEST_METHODS,
@@ -21,8 +20,6 @@ const props = withDefaults(
 const emit = defineEmits<{
   (e: 'change', value: RequestMethod): void
 }>()
-
-const { workspace } = useWorkspace()
 
 const method = computed(() => getRequest(props.method))
 
@@ -57,7 +54,7 @@ const httpLabel = computed(() => method.value.short)
     :options="methodOptions">
     <div
       class="h-full"
-      :class="{ 'pointer-events-none': workspace.isReadOnly }">
+      :class="{ 'pointer-events-none': isEditable }">
       <button
         class="relative h-full cursor-pointer gap-1"
         :class="
@@ -70,7 +67,7 @@ const httpLabel = computed(() => method.value.short)
         type="button">
         <span>{{ httpLabel }}</span>
         <ScalarIcon
-          v-if="!workspace.isReadOnly"
+          v-if="isEditable"
           :class="method.color"
           icon="ChevronDown"
           size="xs" />


### PR DESCRIPTION
Removed click events and chevron from HTTP verb
<img width="345" alt="image" src="https://github.com/scalar/scalar/assets/6201407/a8e187ca-9beb-4eba-a5ab-f246913afe38">

and removed the add server
<img width="376" alt="image" src="https://github.com/scalar/scalar/assets/6201407/54347bf6-c957-4925-9e80-8bb1bbf82eec">
