### PR TITLE
fix(client-app): path variable replacement in api client modal

### DIFF
--- a/packages/client-app/src/libs/sendRequest.test.ts
+++ b/packages/client-app/src/libs/sendRequest.test.ts
@@ -52,7 +52,7 @@ describe('sendRequest', () => {
       server?.url + request.path,
     )
 
-    expect(result?.response?.data).toContain(
+    expect(result?.response?.data ?? '').toContain(
       'The `scalar_url` query parameter is required.',
     )
   })
@@ -92,56 +92,29 @@ describe('sendRequest', () => {
     })
   })
 
-  // it('replaces variables', async () => {
-  //   const { request, example, server } = createRequestExampleServer({
-  //     serverPayload: { url: `http://localhost:${ECHO_PORT}` },
-  //     requestPayload: {
-  //       path: ':path',
-  //     },
-  //     requestExamplePayload: {
-  //       parameters: {
-  //         path: [
-  //           createRequestExampleParameter({
-  //             key: 'path',
-  //             value: 'example',
-  //             enabled: true,
-  //           }),
-  //         ],
-  //       },
-  //     },
-  //   })
+  it('replaces variables in urls', async () => {
+    const { request, example, server } = createRequestExampleServer({
+      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
+      requestExamplePayload: {
+        parameters: {
+          path: [
+            createRequestExampleParameter({
+              key: 'path',
+              value: 'example',
+              enabled: true,
+            }),
+          ],
+        },
+      },
+    })
 
-  //   const result = await sendRequest(
-  //     request,
-  //     example,
-  //     server?.url + request.path,
-  //   )
+    const result = await sendRequest(request, example, `${server?.url}/{path}`)
 
-  //   expect(result?.response?.data).toMatchObject({
-  //     method: 'GET',
-  //     path: '/example',
-  //   })
-  // })
-
-  // it('replaces variables in urls', async () => {
-  //   const request = {
-  //     url: `http://127.0.0.1:${ECHO_PORT}/{path}`,
-  //     variables: [
-  //       {
-  //         name: 'path',
-  //         value: 'example',
-  //         enabled: true,
-  //       },
-  //     ],
-  //   }
-
-  //   const result = await sendRequest(request)
-
-  //   expect(result?.response.data).toMatchObject({
-  //     method: 'GET',
-  //     path: '/example',
-  //   })
-  // })
+    expect(result?.response?.data).toMatchObject({
+      method: 'GET',
+      path: '/example',
+    })
+  })
 
   it('sends query parameters', async () => {
     const { request, example, server } = createRequestExampleServer({
@@ -262,19 +235,6 @@ describe('sendRequest', () => {
   //       foo: 'bar',
   //       another: 'cookie',
   //     },
-  //   })
-  // })
-
-  // it('sends requests through a proxy', async () => {
-  //   const request = {
-  //     url: `http://127.0.0.1:${ECHO_PORT}/v1`,
-  //   }
-
-  //   const result = await sendRequest(request, `http://127.0.0.1:${PROXY_PORT}`)
-
-  //   expect(result?.response.data).toMatchObject({
-  //     method: 'GET',
-  //     path: '/v1',
   //   })
   // })
 

--- a/packages/client-app/src/libs/sendRequest.ts
+++ b/packages/client-app/src/libs/sendRequest.ts
@@ -37,11 +37,15 @@ export const sendRequest = async (
 ) => {
   let url = rawUrl
 
-  // Replace path params
-  example.parameters.path.forEach((pathParam) => {
-    if (pathParam.key && pathParam.value) {
-      url = url.replace(`{${pathParam.key}}`, pathParam.value)
+  // Replace path variables
+  // Example: https://example.com/{path} -> https://example.com/example
+  // TODO: This replaces variables in the URL, not just in the path
+  example.parameters.path.forEach((parameter) => {
+    if (!parameter.key || !parameter.value) {
+      return
     }
+
+    url = url.replace(`{${parameter.key}}`, parameter.value)
   })
 
   const headers = paramsReducer(example.parameters.headers)
@@ -93,8 +97,6 @@ export const sendRequest = async (
   }
 
   const response = await axios(config).catch((error: AxiosError) => {
-    // TODO handle error
-    console.error(error)
     return error.response
   })
 

--- a/packages/client-app/src/libs/sendRequest.ts
+++ b/packages/client-app/src/libs/sendRequest.ts
@@ -40,7 +40,7 @@ export const sendRequest = async (
   // Replace path params
   example.parameters.path.forEach((pathParam) => {
     if (pathParam.key && pathParam.value) {
-      url = url.replace(`:${pathParam.key}`, pathParam.value)
+      url = url.replace(`{${pathParam.key}}`, pathParam.value)
     }
   })
 

--- a/packages/client-app/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/client-app/src/views/Request/RequestSection/RequestPathParams.vue
@@ -50,7 +50,6 @@ const updateRow = (rowIdx: number, field: 'key' | 'value', value: string) => {
     }
   }
 
-  console.log('iok')
   requestExampleMutators.edit(
     activeExample.value.uid,
     `parameters.${props.paramKey}.${rowIdx}.${field}`,

--- a/packages/client-app/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/client-app/src/views/Request/RequestSection/RequestPathParams.vue
@@ -74,8 +74,8 @@ const updateRow = (rowIdx: number, field: 'key' | 'value', value: string) => {
     <div
       v-else
       class="text-c-3 px-4 text-sm border rounded min-h-12 justify-center flex items-center bg-b-1 mx-1">
-      Add to address bar, i.e:
-      <code class="bg-b-2 ml-1 px-1 rounded">/path/:var</code>
+      You can use variables in your path:
+      <code class="bg-b-2 ml-1 px-1 rounded">/endpoint/{my_path_variable}</code>
     </div>
   </ViewLayoutCollapse>
 </template>

--- a/packages/client-app/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/client-app/src/views/Request/RequestSection/RequestPathParams.vue
@@ -10,7 +10,12 @@ const props = defineProps<{
   paramKey: keyof RequestExample['parameters']
 }>()
 
-const { activeRequest, activeExample } = useWorkspace()
+const {
+  activeRequest,
+  activeExample,
+  requestMutators,
+  requestExampleMutators,
+} = useWorkspace()
 
 const params = computed(
   () => activeExample.value?.parameters[props.paramKey] ?? [],
@@ -18,45 +23,39 @@ const params = computed(
 
 /** Update a field in a parameter row */
 const updateRow = (rowIdx: number, field: 'key' | 'value', value: string) => {
-  // if (!activeRequest.value || !activeExample.value) return
-  //
-  // const parameters = activeExample.value.parameters[props.paramKey]
-  // const oldKey = parameters[rowIdx]?.key
-  //
-  // /** Change variable in path as well */
-  // if (field === 'key') {
-  //   if (!value) {
-  //     /** Remove parameter if path params table key is empty */
-  //     parameters.splice(rowIdx, 1)
-  //     const regx = new RegExp(`/:${encodeURIComponent(oldKey)}(?=[/?#]|$)`, 'g')
-  //     const newPath = activeExample.value.url.replace(regx, '')
-  //     updateRequestExample(
-  //       activeRequest.value.uid,
-  //       activeExample.value.uid,
-  //       'url',
-  //       newPath,
-  //     )
-  //   } else {
-  //     /** Update URL with path params table key */
-  //     const encodedOldKey = encodeURIComponent(oldKey)
-  //     const encodedNewKey = encodeURIComponent(value)
-  //     const regx = new RegExp(`(?<=/):${encodedOldKey}(?=[/?#]|$)`, 'g')
-  //     const newPath = activeExample.value.url.replace(regx, `:${encodedNewKey}`)
-  //     updateRequestExample(
-  //       activeRequest.value.uid,
-  //       activeExampleIdx,
-  //       'url',
-  //       newPath,
-  //     )
-  //   }
-  // }
-  //
-  // updateRequestExample(
-  //   activeRequest.value.uid,
-  //   activeExampleIdx,
-  //   `parameters.${props.paramKey}.${rowIdx}.${field}`,
-  //   value,
-  // )
+  if (!activeRequest.value || !activeExample.value) return
+
+  const parameters = activeExample.value.parameters[props.paramKey]
+  const oldKey = parameters[rowIdx]?.key
+
+  /** Change variable in path as well */
+  if (field === 'key') {
+    if (!value) {
+      /** Remove parameter if path params table key is empty */
+      parameters.splice(rowIdx, 1)
+      const regx = new RegExp(`/:${encodeURIComponent(oldKey)}(?=[/?#]|$)`, 'g')
+      const newPath = activeRequest.value.path.replace(regx, '')
+
+      requestMutators.edit(activeRequest.value.uid, 'path', newPath)
+    } else {
+      /** Update URL with path params table key */
+      const encodedOldKey = encodeURIComponent(oldKey)
+      const encodedNewKey = encodeURIComponent(value)
+      const regx = new RegExp(`(?<=/):${encodedOldKey}(?=[/?#]|$)`, 'g')
+      const newPath = activeRequest.value.path.replace(
+        regx,
+        `:${encodedNewKey}`,
+      )
+      requestMutators.edit(activeRequest.value.uid, 'path', newPath)
+    }
+  }
+
+  console.log('iok')
+  requestExampleMutators.edit(
+    activeExample.value.uid,
+    `parameters.${props.paramKey}.${rowIdx}.${field}`,
+    value,
+  )
 }
 </script>
 <template>


### PR DESCRIPTION
things left

- [x] replace pattern matching to `{thing}`
- [x] remove path variables in read only mode if no param

<img width="1512" alt="image" src="https://github.com/scalar/scalar/assets/6176314/7184289c-549a-4ffd-a0aa-7bf8689bb37e">
