### PR TITLE
feat(client-app): client app reponse meta infos

### DIFF
--- a/packages/client-app/package.json
+++ b/packages/client-app/package.json
@@ -99,6 +99,8 @@
     "cva": "1.0.0-beta.1",
     "nanoid": "^5.0.7",
     "vue": "^3.4.22",
+    "pretty-bytes": "^6.1.1",
+    "pretty-ms": "^8.0.0",
     "vue-router": "^4.3.0",
     "zod": "^3.22.4"
   },

--- a/packages/client-app/src/components/HelpfulLink.vue
+++ b/packages/client-app/src/components/HelpfulLink.vue
@@ -1,0 +1,12 @@
+<script lang="ts" setup>
+defineProps<{ href: string }>()
+</script>
+<template>
+  <a
+    class="cursor-help decoration-c-3 underline underline-offset-2"
+    :href="href"
+    rel="noopener noreferrer"
+    target="_blank">
+    <slot />
+  </a>
+</template>

--- a/packages/client-app/src/libs/sendRequest.ts
+++ b/packages/client-app/src/libs/sendRequest.ts
@@ -34,7 +34,11 @@ export const sendRequest = async (
   request: Request,
   example: RequestExample,
   rawUrl: string,
-) => {
+): Promise<{
+  sentTime?: number
+  request?: RequestExample
+  response?: ResponseInstance
+}> => {
   let url = rawUrl
 
   // Replace path params

--- a/packages/client-app/src/libs/sendRequest.ts
+++ b/packages/client-app/src/libs/sendRequest.ts
@@ -95,6 +95,9 @@ export const sendRequest = async (
     data,
   }
 
+  /** start time to get response duration */
+  const startTime = Date.now()
+
   const response = await axios(config).catch((error: AxiosError) => {
     // TODO handle error
     console.error(error)
@@ -117,8 +120,12 @@ export const sendRequest = async (
     }
 
     return {
+      sentTime: Date.now(),
       request: example,
-      response: response,
+      response: {
+        ...response,
+        duration: Date.now() - startTime,
+      },
     }
   } else {
     return {}

--- a/packages/client-app/src/views/Request/ResponseSection/ResponseMetaInformation.vue
+++ b/packages/client-app/src/views/Request/ResponseSection/ResponseMetaInformation.vue
@@ -1,0 +1,49 @@
+<script lang="ts" setup>
+import HelpfulLink from '@/components/HelpfulLink.vue'
+import type { ResponseInstance } from '@scalar/oas-utils/entities/workspace/spec'
+import { type HttpStatusCode, httpStatusCodes } from '@scalar/oas-utils/helpers'
+import prettyBytes from 'pretty-bytes'
+import prettyMilliseconds from 'pretty-ms'
+import { computed } from 'vue'
+
+const props = defineProps<{ response: ResponseInstance }>()
+
+/** Size of the response */
+const getContentLength = (response: ResponseInstance) => {
+  const contentLength = parseInt(
+    response.headers?.['content-length'] || '0',
+    10,
+  )
+
+  return contentLength ? prettyBytes(contentLength) : undefined
+}
+
+/** Status text for the response */
+const statusCodeInformation = computed((): HttpStatusCode | undefined => {
+  const responseStatusCode = props.response.status
+
+  if (!responseStatusCode) {
+    return undefined
+  }
+
+  return httpStatusCodes[responseStatusCode] ?? undefined
+})
+</script>
+<template>
+  <div class="flex gap-1.5 text-c-3 pl-1">
+    <span>{{ prettyMilliseconds(response.duration) }}</span>
+    <span v-if="getContentLength(response)">{{
+      getContentLength(response)
+    }}</span>
+    <template v-if="statusCodeInformation">
+      <HelpfulLink
+        v-if="statusCodeInformation.url"
+        :href="statusCodeInformation.url">
+        {{ response.status }} {{ statusCodeInformation.name }}
+      </HelpfulLink>
+      <span v-else>
+        {{ response.status }} {{ statusCodeInformation.name }}
+      </span>
+    </template>
+  </div>
+</template>

--- a/packages/client-app/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/client-app/src/views/Request/ResponseSection/ResponseSection.vue
@@ -3,6 +3,7 @@ import ContextBar from '@/components/ContextBar.vue'
 import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
 import ResponseBody from '@/views/Request/ResponseSection/ResponseBody.vue'
 import ResponseEmpty from '@/views/Request/ResponseSection/ResponseEmpty.vue'
+import ResponseMetaInformation from '@/views/Request/ResponseSection/ResponseMetaInformation.vue'
 import { ScalarIcon } from '@scalar/components'
 import type { ResponseInstance } from '@scalar/oas-utils/entities/workspace/spec'
 import { isJsonString } from '@scalar/oas-utils/helpers'
@@ -76,9 +77,11 @@ const activeSection = ref<ActiveSections>('All')
         class="text-c-3 mr-1.5 rotate-180"
         icon="ExternalLink"
         size="sm" />
-      <div class="flex-1">
+      <div class="flex items-center flex-1">
         Response
-        <span class="text-c-3 pl-1">{{ response?.status }}</span>
+        <ResponseMetaInformation
+          v-if="response"
+          :response="response" />
       </div>
     </template>
     <div class="custom-scroll flex flex-1 flex-col px-2 xl:px-6 py-2.5">

--- a/packages/oas-utils/src/entities/workspace/spec/requests.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/requests.ts
@@ -8,7 +8,12 @@ import { $refSchema } from './refs'
 import type { RequestExample } from './request-examples'
 
 /** A single set of populated values for a sent request */
-export type ResponseInstance = AxiosResponse
+export type ResponseInstance = AxiosResponse & {
+  /**
+   * Time in ms the request took
+   **/
+  duration: number
+}
 
 /** A single request/response set to save to the history stack */
 export type RequestEvent = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1175,6 +1175,12 @@ importers:
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7
+      pretty-bytes:
+        specifier: ^6.1.1
+        version: 6.1.1
+      pretty-ms:
+        specifier: ^8.0.0
+        version: 8.0.0
       vue:
         specifier: ^3.4.22
         version: 3.4.29(typescript@5.4.5)


### PR DESCRIPTION
this pr adds response meta informations in the client app:

<img width="766" alt="image" src="https://github.com/scalar/scalar/assets/14966155/113afac3-c135-4fa5-b1a2-d8770df72b51">

