### PR TITLE
chore(client-app): switch server form fields

### DIFF
--- a/packages/client-app/src/views/Servers/ServerForm.vue
+++ b/packages/client-app/src/views/Servers/ServerForm.vue
@@ -10,7 +10,7 @@ const { activeCollection, servers, serverMutators } = useWorkspace()
 const options = [
   { label: 'URL', key: 'url', placeholder: 'https://galaxy.scalar.com/api/v1' },
   {
-    label: 'Title',
+    label: 'Label',
     key: 'description',
     placeholder: 'Production',
   },

--- a/packages/client-app/src/views/Servers/ServerForm.vue
+++ b/packages/client-app/src/views/Servers/ServerForm.vue
@@ -8,12 +8,12 @@ import { useRoute } from 'vue-router'
 const { activeCollection, servers, serverMutators } = useWorkspace()
 
 const options = [
-  {
-    label: 'Description',
-    key: 'description',
-    placeholder: 'The Scalar Galaxy is an example OpenAPI...',
-  },
   { label: 'URL', key: 'url', placeholder: 'https://galaxy.scalar.com/api/v1' },
+  {
+    label: 'Title',
+    key: 'description',
+    placeholder: 'Production',
+  },
 ]
 
 const route = useRoute()


### PR DESCRIPTION
It’s bugging me, that the optional field is coming first. And I don’t think it’s a description, it’s more a label or something. And the placeholder wasn’t really a good fit.

**Before**
<img width="602" alt="Screenshot 2024-06-14 at 12 22 32" src="https://github.com/scalar/scalar/assets/1577992/8be4eda1-7b8e-4695-bc04-8b58f433c9a7">

**After**
![image](https://github.com/scalar/scalar/assets/1577992/89153e62-bf1d-4eae-931a-968ceccce5aa)
 