### PR TITLE
fix(client-app): preview and raw are swapped

### DIFF
--- a/packages/client-app/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/client-app/src/views/Request/ResponseSection/ResponseBody.vue
@@ -19,6 +19,12 @@ const props = withDefaults(
   },
 )
 
+// Preview options
+const previewOptions = ['preview', 'raw'] as const
+type PreviewOption = (typeof previewOptions)[number]
+const selectedPreview = ref<PreviewOption>('preview')
+
+// Code language based on the Content-Type header
 const codeLanguage = computed(() => {
   const contentTypeHeader =
     props.headers.find((header) => header.name.toLowerCase() === 'content-type')
@@ -26,13 +32,13 @@ const codeLanguage = computed(() => {
 
   if (contentTypeHeader.includes('json')) return 'json'
   if (contentTypeHeader.includes('html')) return 'html'
+
+  // Default
   return 'plaintext'
 })
 
+// Update the iframe content
 const iframe = ref<HTMLIFrameElement | null>(null)
-
-const previewOptions = ['preview', 'raw'] as const
-const selectedPreview = ref<(typeof previewOptions)[number]>('preview')
 
 watch(
   () => selectedPreview.value,
@@ -56,7 +62,7 @@ watch(
   <ViewLayoutCollapse>
     <template #title>{{ title }}</template>
     <template v-if="active">
-      <DataTable :columns="['']">
+      <DataTable :columns="[]">
         <DataTableRow>
           <DataTableHeader
             class="relative col-span-full flex h-8 cursor-pointer items-center px-[2.25px] py-[2.25px]">
@@ -84,12 +90,14 @@ watch(
           </DataTableHeader>
         </DataTableRow>
         <DataTableRow>
+          <!-- Preview -->
           <template v-if="selectedPreview === 'preview'">
             <ScalarCodeBlock
               class="force-text-sm rounded-b border-t-0"
               :content="data"
               :lang="codeLanguage" />
           </template>
+          <!-- Raw -->
           <template v-else>
             <iframe
               ref="iframe"

--- a/packages/client-app/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/client-app/src/views/Request/ResponseSection/ResponseBody.vue
@@ -31,14 +31,15 @@ const codeLanguage = computed(() => {
 
 const iframe = ref<HTMLIFrameElement | null>(null)
 
-const activePreview = ref('raw')
-const previewOptions = ['raw', 'preview']
+const previewOptions = ['preview', 'raw'] as const
+const selectedPreview = ref<(typeof previewOptions)[number]>('preview')
 
 watch(
-  () => activePreview.value,
+  () => selectedPreview.value,
   async (newValue) => {
-    if (newValue === 'preview') {
+    if (newValue === 'raw') {
       await nextTick()
+
       if (iframe.value) {
         const doc =
           iframe.value.contentDocument || iframe.value.contentWindow?.document
@@ -61,15 +62,17 @@ watch(
             class="relative col-span-full flex h-8 cursor-pointer items-center px-[2.25px] py-[2.25px]">
             <div
               class="text-c-2 group-hover:text-c-1 flex h-full w-full items-center justify-start rounded px-1.5">
-              <span class="capitalize">{{ activePreview }}</span>
+              <span class="capitalize">
+                {{ selectedPreview }}
+              </span>
               <ScalarIcon
                 class="text-c-3 ml-1 mt-px"
                 icon="ChevronDown"
                 size="xs" />
             </div>
             <select
-              v-model="activePreview"
-              class="absolute inset-0 w-auto opacity-0"
+              v-model="selectedPreview"
+              class="absolute inset-0 w-auto opacity-0 capitalize"
               @click.prevent>
               <option
                 v-for="value in previewOptions"
@@ -81,7 +84,7 @@ watch(
           </DataTableHeader>
         </DataTableRow>
         <DataTableRow>
-          <template v-if="activePreview === 'raw'">
+          <template v-if="selectedPreview === 'preview'">
             <ScalarCodeBlock
               class="force-text-sm rounded-b border-t-0"
               :content="data"


### PR DESCRIPTION
“Preview” shows the raw data and “Raw” shows the formatted and highlighted code, let’s fix this:

**Before**
<img width="702" alt="Screenshot 2024-06-14 at 12 30 25" src="https://github.com/scalar/scalar/assets/1577992/68f42386-9ca1-47e7-acd1-15d5333ef62f">

**After**
<img width="695" alt="Screenshot 2024-06-14 at 12 38 49" src="https://github.com/scalar/scalar/assets/1577992/67612895-98b5-4a99-8eec-8092f7895e2b">
<img width="698" alt="Screenshot 2024-06-14 at 12 38 45" src="https://github.com/scalar/scalar/assets/1577992/06a5e9be-c90f-4516-a400-a5fb8908b7da">
