### PR TITLE
fix(proxy-server): only some headers are shown

### DIFF
--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -15,6 +15,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Headers", "*")
 		w.Header().Set("Access-Control-Allow-Origin", "*") // Allow all origins
 		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH")
+		w.Header().Set("Access-Control-Expose-Headers", "*")
 
 		// Handle pre-flight requests
 		if r.Method == "OPTIONS" {

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -81,6 +81,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		res.Header.Del("Access-Control-Allow-Headers")
 		res.Header.Del("Access-Control-Allow-Origin")
 		res.Header.Del("Access-Control-Allow-Methods")
+		res.Header.Del("Access-Control-Expose-Headers")
 
 		return nil
 	}


### PR DESCRIPTION
Since we switched to the new proxy, only some headers are shown. By default, only some headers can be accessed for cross-origin requests.

This PR adds the `Access-Control-Expose-Header` with a `*` wildcard value to allow JS to access all headers.

Read more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#access-control-expose-headers

**Preview**
<img width="683" alt="Screenshot 2024-06-14 at 13 32 49" src="https://github.com/scalar/scalar/assets/1577992/543adb34-8fd6-44e1-b78e-f381deda4b23">


EDIT: This must be a flaky test? Can you take a look @geoffgscott?

>  FAIL  |@scalar/object-utils| src/mutator-record/mutations.test.ts > Handles history rolling > Rolls history back to initial then forward to modified state
AssertionError: expected { storage: [ { …(3) }, …(2) ], …(2) } to not deeply equal { storage: [ { …(3) }, …(2) ], …(2) }
