### PR TITLE
fix: api client modal search

### DIFF
--- a/packages/api-client-modal/src/api-client-modal.ts
+++ b/packages/api-client-modal/src/api-client-modal.ts
@@ -93,5 +93,6 @@ export const createScalarApiClient = async (
     },
     /** Mount the references to a given element */
     mount,
+    modalState,
   }
 }

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -2,6 +2,7 @@
 import type { SpecConfiguration } from '@scalar/oas-utils'
 import { onMounted, ref } from 'vue'
 
+import { modalStateBus } from './api-client-bus'
 import { apiClientBus } from './api-client-bus'
 
 const props = defineProps<{
@@ -16,10 +17,12 @@ onMounted(async () => {
 
   const { createScalarApiClient } = await import('@scalar/api-client-modal')
 
-  const { open } = await createScalarApiClient(el.value, {
+  const { open, modalState: state } = await createScalarApiClient(el.value, {
     spec: props.spec ?? {},
     proxyUrl: props.proxyUrl,
   })
+
+  modalStateBus.emit(state)
 
   // Event bus to listen to apiClient events
   apiClientBus.on(open)

--- a/packages/api-reference/src/components/SearchButton.vue
+++ b/packages/api-reference/src/components/SearchButton.vue
@@ -3,8 +3,10 @@ import { ScalarIcon, useModal } from '@scalar/components'
 import type { Spec } from '@scalar/oas-utils'
 import { isMacOS } from '@scalar/use-tooltip'
 import { useMagicKeys, whenever } from '@vueuse/core'
+import { onMounted, ref } from 'vue'
 
 import SearchModal from './SearchModal.vue'
+import { modalStateBus } from './api-client-bus'
 
 const props = withDefaults(
   defineProps<{
@@ -17,6 +19,7 @@ const props = withDefaults(
 )
 
 const modalState = useModal()
+const apiClientModalState = ref<{ open: boolean } | null>(null)
 
 const keys = useMagicKeys({
   passive: false,
@@ -29,8 +32,19 @@ const keys = useMagicKeys({
   },
 })
 
-whenever(keys[`${isMacOS() ? 'meta' : 'control'}_${props.searchHotKey}`], () =>
-  modalState.open ? modalState.hide() : modalState.show(),
+onMounted(() => {
+  modalStateBus.on((state: unknown) => {
+    apiClientModalState.value = state as { open: boolean } | null
+  })
+})
+
+whenever(
+  keys[`${isMacOS() ? 'meta' : 'control'}_${props.searchHotKey}`],
+  () => {
+    if (!apiClientModalState.value?.open) {
+      modalState.open ? modalState.hide() : modalState.show()
+    }
+  },
 )
 </script>
 <template>

--- a/packages/api-reference/src/components/api-client-bus.ts
+++ b/packages/api-reference/src/components/api-client-bus.ts
@@ -5,3 +5,4 @@ const apiClientBusKey: EventBusKey<OpenClientPayload> = Symbol()
 
 /** Event bus to open the API Client */
 export const apiClientBus = useEventBus(apiClientBusKey)
+export const modalStateBus = useEventBus('modalState')

--- a/packages/client-app/src/components/ScalarHotkey.vue
+++ b/packages/client-app/src/components/ScalarHotkey.vue
@@ -29,12 +29,9 @@ const keys = useMagicKeys({
   },
 })
 
-whenever(
-  keys[`${isMacOS() ? 'meta' : 'control'}_${resolvedHotkey.value}`],
-  () => {
-    emit('hotkeyPressed', resolvedHotkey.value || '')
-  },
-)
+whenever(keys[`${isMacOS() ? 'meta' : 'control'}_${props.hotkey}`], () => {
+  emit('hotkeyPressed', resolvedHotkey.value || '')
+})
 </script>
 <template>
   <div

--- a/packages/client-app/src/components/Search/SearchButton.vue
+++ b/packages/client-app/src/components/Search/SearchButton.vue
@@ -21,7 +21,9 @@ const modalState = useModal()
       <div
         class="sidebar-search-input ml-1.5 flex w-full items-center justify-between text-sm font-medium">
         <span class="sidebar-search-placeholder">Search</span>
-        <ScalarHotkey hotkey="k" />
+        <ScalarHotkey
+          hotkey="k"
+          @hotkeyPressed="modalState.show()" />
       </div>
     </button>
   </div>


### PR DESCRIPTION
this pr fixes the api reference search being display on hotkey pressed while api client modal is open in order to displays its own.