### PR TITLE
fix: docusaurus pre background

### DIFF
--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -43,5 +43,6 @@ const highlightedCode = computed(() => {
   margin: 0;
   padding: 0.5rem;
   overflow: auto;
+  background: transparent;
 }
 </style>


### PR DESCRIPTION
before:
<img width="624" alt="image" src="https://github.com/scalar/scalar/assets/6201407/20495678-a7d1-497e-a5a4-cbf2daa3348e">

after:
<img width="619" alt="image" src="https://github.com/scalar/scalar/assets/6201407/4c48bc31-9ad8-4979-ad09-df6511f9d446">
