### PR TITLE
feat: Add vite plugin to restart dev server when workspace files change

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,16 +1,3 @@
-# EXAMPLE USAGE:
-#
-#   Refer for explanation to following link:
-#   https://github.com/evilmartians/lefthook/blob/master/docs/configuration.md
-#
-post-checkout:
-  commands:
-    conditional-pnpm-install:
-      # Run pnpm install if pnpm-lock changed between the commits we checked out.
-      # {1} is old-hash, {2} is current-head, {3} is 1 for a branch checkout, 0 for a file checkout
-      # See https://git-scm.com/docs/githooks#_post_checkout
-      run: 'if [ ! -z "$(git diff {1}..{2} --name-only pnpm-lock.yaml)" ]; then pnpm install -r; fi'
-
 pre-commit:
   commands:
     package_format:

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -48,8 +48,8 @@
     "@rollup/plugin-swc": "^0.3.1",
     "@rollup/plugin-typescript": "^11.1.6",
     "@rollup/plugin-yaml": "^4.1.2",
-    "@types/node": "^20.8.4",
     "glob": "^10.3.10",
+    "picomatch": "^4.0.2",
     "rollup": "^4.16.4",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-dts": "^6.1.0",
@@ -60,6 +60,8 @@
     "vitest": "^1.6.0"
   },
   "devDependencies": {
+    "@types/node": "^20.8.4",
+    "@types/picomatch": "^2.3.3",
     "tsc-alias": "^1.8.8"
   }
 }

--- a/packages/build-tooling/rollup.config.ts
+++ b/packages/build-tooling/rollup.config.ts
@@ -5,6 +5,7 @@ const entries = ['./src/index.ts']
 export default createRollupConfig({
   options: {
     input: entries,
+    external: ['url', 'fs/promises'],
   },
   typescript: true,
 })

--- a/packages/build-tooling/src/index.ts
+++ b/packages/build-tooling/src/index.ts
@@ -1,3 +1,4 @@
 export { findEntryPoints, addPackageFileExports } from './entry'
 export { createRollupConfig } from './rollup-options'
 export { alias, createViteBuildOptions, autoCSSInject } from './vite-options'
+export { ViteWatchWorkspace } from './workspace-reload'

--- a/packages/build-tooling/src/rollup-options.ts
+++ b/packages/build-tooling/src/rollup-options.ts
@@ -53,7 +53,9 @@ export function createRollupConfig(props: {
     }),
   )
 
-  const external: string[] = []
+  const external = Array.isArray(props.options?.external)
+    ? props.options.external
+    : []
 
   if ('dependencies' in pkgFile)
     external.push(...Object.keys(pkgFile.dependencies))
@@ -79,11 +81,11 @@ export function createRollupConfig(props: {
       preserveModulesRoot: './src',
       dir: './dist',
     },
+    ...props.options,
     // Do not bundle any dependencies by default.
     external: external.map(
       (packageName) => new RegExp(`^${packageName}(/.*)?`),
     ),
-    ...props.options,
     plugins,
   }
 }

--- a/packages/build-tooling/src/workspace-reload.ts
+++ b/packages/build-tooling/src/workspace-reload.ts
@@ -1,0 +1,35 @@
+import pm from 'picomatch'
+import type { Plugin } from 'vite'
+
+export function ViteWatchWorkspace(): Plugin {
+  const currentDir = process.cwd().split('/').at(-1)
+
+  const timer = {
+    instance: null as ReturnType<typeof setTimeout> | null,
+    /** Run a function after a certain delay */
+    run: (callback: () => void, delay = 500) => {
+      // Clear any existing callbacks to debounce
+      timer.clear()
+      // Set the new delay
+      timer.instance = setTimeout(callback, delay)
+    },
+    /** Cancel any pending actions */
+    clear: () => timer.instance && clearTimeout(timer.instance),
+  }
+
+  // We match any workspace package dist that are not the current one
+  const matcher = pm(`**/scalar/packages/!(${currentDir})/dist/**`)
+  return {
+    name: `vite-plugin-workspace-watch`,
+    apply: 'serve',
+    handleHotUpdate({ file, server }) {
+      if (matcher(file)) {
+        timer.run(() => {
+          console.log('Reloading the mothership...')
+          server.restart()
+        })
+        return []
+      }
+    },
+  }
+}

--- a/packages/client-app/vite.config.ts
+++ b/packages/client-app/vite.config.ts
@@ -1,16 +1,23 @@
-import { createViteBuildOptions, findEntryPoints } from '@scalar/build-tooling'
+import {
+  ViteWatchWorkspace,
+  createViteBuildOptions,
+  findEntryPoints,
+} from '@scalar/build-tooling'
 import vue from '@vitejs/plugin-vue'
 import { URL, fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import svgLoader from 'vite-svg-loader'
 
 export default defineConfig({
-  plugins: [vue(), svgLoader()],
+  plugins: [vue(), svgLoader(), ViteWatchWorkspace()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
     dedupe: ['vue'],
+  },
+  optimizeDeps: {
+    exclude: ['@scalar/*'],
   },
   server: {
     port: 5065,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1029,12 +1029,12 @@ importers:
       '@rollup/plugin-yaml':
         specifier: ^4.1.2
         version: 4.1.2(rollup@4.18.0)
-      '@types/node':
-        specifier: ^20.8.4
-        version: 20.14.2
       glob:
         specifier: ^10.3.10
         version: 10.4.1
+      picomatch:
+        specifier: ^4.0.2
+        version: 4.0.2
       rollup:
         specifier: ^4.16.4
         version: 4.18.0
@@ -1060,6 +1060,12 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.14.2)(jsdom@24.1.0)(terser@5.31.1)
     devDependencies:
+      '@types/node':
+        specifier: ^20.8.4
+        version: 20.14.2
+      '@types/picomatch':
+        specifier: ^2.3.3
+        version: 2.3.3
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.10
@@ -5951,6 +5957,9 @@ packages:
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+
+  '@types/picomatch@2.3.3':
+    resolution: {integrity: sha512-Yll76ZHikRFCyz/pffKGjrCwe/le2CDwOP5F210KQo27kpRE46U2rDnzikNlVn6/ezH3Mhn46bJMTfeVTtcYMg==}
 
   '@types/pretty-hrtime@1.0.3':
     resolution: {integrity: sha512-nj39q0wAIdhwn7DGUyT9irmsKK1tV0bd5WFEhgpqNTMFZ8cE+jieuTphCW0tfdm47S2zVT5mr09B28b1chmQMA==}
@@ -20955,6 +20964,8 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
+
+  '@types/picomatch@2.3.3': {}
 
   '@types/pretty-hrtime@1.0.3': {}
 


### PR DESCRIPTION
Adds a vite plugin to watch for workspace file changes. When files in package `dist` folders change we restart the vite server automatically. 

