### PR TITLE
feat: add base server override

### DIFF
--- a/.changeset/fifty-gorillas-smoke.md
+++ b/.changeset/fifty-gorillas-smoke.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+feat: add base server override

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ To customize the behavior of the API Reference, you can use the following config
 - `showSidebar`: Whether the sidebar should be shown.
 - `customCss`: Pass custom CSS directly to the component.
 - `searchHotKey`: Key used with CTRL/CMD to open the search modal.
+- `servers`: Override the OpenAPI servers
 - `metaData`: Configure meta-information for the page.
 - `hiddenClients`: List of `httpsnippet` clients to hide from the client's menu, by default hides Unirest,
   pass `[]` to show all clients.

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -194,6 +194,17 @@ Key used with CTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k)
 <ApiReference :configuration="{ searchHotKey: 'l'} />
 ```
 
+#### servers?: Server[]
+
+List of servers to override the openapi spec servers
+
+@default undefined
+@example [{ url: 'https://api.scalar.com', description: 'Production server' }]
+
+```vue
+<ApiReference :configuration="{ servers: [{ url: 'https://api.scalar.com', description: 'Production server' }] } />
+```
+
 #### metaData?: object
 
 You can pass information to the config object to configure meta information out of the box.

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -298,7 +298,8 @@ useDeprecationWarnings(props.configuration)
                 configuration.layout === 'classic' ? 'accordion' : 'default'
               "
               :parsedSpec="parsedSpec"
-              :proxy="configuration.proxy">
+              :proxy="configuration.proxy"
+              :servers="configuration.servers">
               <template #start>
                 <slot
                   v-bind="referenceSlotProps"

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
   layout?: 'default' | 'accordion'
   baseServerURL?: string
   proxy?: string
+  servers?: Server[]
 }>()
 
 const { getOperationId, getTagId, hash } = useNavState()
@@ -47,7 +48,9 @@ watch(
       { url: typeof window !== 'undefined' ? window.location.origin : '/' },
     ]
 
-    if (parsedSpec.servers && parsedSpec.servers.length > 0) {
+    if (props.servers) {
+      servers = props.servers
+    } else if (parsedSpec.servers && parsedSpec.servers.length > 0) {
       servers = parsedSpec.servers
     } else if (props.parsedSpec.host) {
       // Use the first scheme if available, otherwise default to http

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -17,6 +17,11 @@ type ClientInfo = {
   link: string
   description: string
 }
+export type Server = {
+  url: string
+  description?: string
+}
+
 export type TargetInfo = {
   key: TargetId
   title: string
@@ -113,6 +118,13 @@ export type ReferenceConfiguration = {
    * By default hides Unirest, pass `[]` to show all clients
    */
   hiddenClients?: HiddenClients
+  /**
+   * List of servers to override the openapi spec servers
+   *
+   * @default undefined
+   * @example [{ url: 'https://api.scalar.com', description: 'Production server' }]
+   */
+  servers?: Server[]
   /** Custom CSS to be added to the page */
   customCss?: string
   /** onSpecUpdate is fired on spec/swagger content change */


### PR DESCRIPTION
if you dont have servers in your spec, and you cant update them due to build pipeline we allow you to override it :) like so


```vue
<ApiReference :configuration="{ servers: [{ url: 'https://api.scalar.com', description: 'Production server' }] } />
```