### PR TITLE
fix: wrapped code blocks

### DIFF
--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -44,5 +44,7 @@ const highlightedCode = computed(() => {
   padding: 0.5rem;
   overflow: auto;
   background: transparent;
+  text-wrap: nowrap;
+  white-space-collapse: preserve;
 }
 </style>


### PR DESCRIPTION
before:
<img width="580" alt="image" src="https://github.com/scalar/scalar/assets/6176314/c90040ea-c596-4e19-9e2f-32f3c9385c5e">

after:
<img width="557" alt="image" src="https://github.com/scalar/scalar/assets/6176314/dd7f399f-116f-4b78-a85e-06c2246825c5">

