### PR TITLE
docs: move contributing guide up

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,8 @@ This repository contains all our open source projects, and there’s definitely 
 
 ## Contributors
 
+Contributions are welcome! Read [`CONTRIBUTING`](https://github.com/scalar/scalar/blob/main/CONTRIBUTING).
+
 <!-- readme: collaborators,contributors -start -->
 <table>
 <tr>
@@ -973,8 +975,6 @@ This repository contains all our open source projects, and there’s definitely 
     </td></tr>
 </table>
 <!-- readme: collaborators,contributors -end -->
-
-Contributions are welcome! Read [`CONTRIBUTING`](https://github.com/scalar/scalar/blob/main/CONTRIBUTING).
 
 ## License
 


### PR DESCRIPTION
Currently, the CONTRIBUTING guide is below the avatar wall. Maybe it’s a little bit too hidden there, let’s move it above avatar wall.

**Before**
<img width="956" alt="Screenshot 2024-06-17 at 10 52 35" src="https://github.com/scalar/scalar/assets/1577992/ec44aa2f-c97b-4fc7-ae2e-8c55f4a76145">
