### PR TITLE
ci: use GitHub bot to create PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,7 @@ jobs:
           # The command to use to build and publish packages
           publish: 'pnpm -r publish --access public'
         env:
-          # https://github.com/settings/tokens/new
-          # Expiration: No expiration
-          # Select: repo.*
-          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # https://www.npmjs.com/settings/YOUR_ACCOUNT_HANDLE/tokens/granular-access-tokens/new
           # Custom Expiration: 01-01-2100
           # Permissions: Read and Write


### PR DESCRIPTION
Currently, the created PRs are automatically created, but through my account. That was necessary to auto approve them, which we removed in #2087.

I think we can use the default GITHUB_TOKEN now and the PRs should be created by the GitHub bot.

Note: There’s no way to test this other than merging it. If it breaks the release workflow for some reason (I can’t think of one), just revert the PR.