### PR TITLE
chore(galaxy): use Node script instead of bash script

### DIFF
--- a/.changeset/clean-readers-unite.md
+++ b/.changeset/clean-readers-unite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+chore: use Node script to format specifications

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "vite build && pnpm build:format && pnpm types:build && tsc-alias -p tsconfig.build.json",
-    "build:format": "./scripts/format.sh",
+    "build:format": "vite-node ./scripts/format.ts",
     "dev": "pnpm dlx @scalar/cli serve ./src/specifications/3.1.yaml --watch",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",

--- a/packages/galaxy/scripts/format.sh
+++ b/packages/galaxy/scripts/format.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# The source file is just YAML. We transform it to JSON to have both formats available.
-
-pnpm dlx @scalar/cli format ./dist/3.1.yaml --output ./dist/3.1.json
-pnpm dlx @scalar/cli format ./dist/latest.yaml --output ./dist/latest.json
-

--- a/packages/galaxy/scripts/format.ts
+++ b/packages/galaxy/scripts/format.ts
@@ -1,5 +1,5 @@
 import { openapi } from '@scalar/openapi-parser'
-import fs from 'fs'
+import fs from 'node:fs'
 
 const base = fs.readFileSync('dist/3.1.yaml', 'utf-8')
 const latest = fs.readFileSync('dist/latest.yaml', 'utf-8')

--- a/packages/galaxy/scripts/format.ts
+++ b/packages/galaxy/scripts/format.ts
@@ -4,8 +4,8 @@ import fs from 'node:fs'
 const base = fs.readFileSync('dist/3.1.yaml', 'utf-8')
 const latest = fs.readFileSync('dist/latest.yaml', 'utf-8')
 
-const baseOut = openapi().load(base).toJson()
-const latestOut = openapi().load(latest).toJson()
+const baseOut = await openapi().load(base).toJson()
+const latestOut = await openapi().load(latest).toJson()
 
 fs.writeFileSync('./dist/3.1.json', baseOut)
 fs.writeFileSync('./dist/latest.json', latestOut)

--- a/packages/galaxy/scripts/format.ts
+++ b/packages/galaxy/scripts/format.ts
@@ -1,0 +1,11 @@
+import { openapi } from '@scalar/openapi-parser'
+import fs from 'fs'
+
+const base = fs.readFileSync('dist/3.1.yaml', 'utf-8')
+const latest = fs.readFileSync('dist/latest.yaml', 'utf-8')
+
+const baseOut = openapi().load(base).toJson()
+const latestOut = openapi().load(latest).toJson()
+
+fs.writeFileSync('./dist/3.1.json', baseOut)
+fs.writeFileSync('./dist/latest.json', latestOut)


### PR DESCRIPTION
Currently, we use a bash script and the CLI to build/format the `@scalar/galaxy` package. If this breaks, for some reason, it’s hard to fix and blocks CI.

This PR uses a Node script instead. If that breaks and blocks CI, it’s easy to modify.

Note: This is extracted from #2091.