### PR TITLE
fix(themes): kepler theme dark mode

### DIFF
--- a/.changeset/silent-ears-play.md
+++ b/.changeset/silent-ears-play.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix: kepler theme darkmode

--- a/packages/themes/src/presets/kepler.css
+++ b/packages/themes/src/presets/kepler.css
@@ -21,8 +21,8 @@
   --scalar-color-accent: #828fff;
 
   --scalar-background-1: #000212;
-  --scalar-background-2: rgba(255, 255, 255, 0.05);
-  --scalar-background-3: rgba(255, 255, 255, 0.09);
+  --scalar-background-2: #0d0f1e;
+  --scalar-background-3: #232533;
   --scalar-background-accent: #8ab4f81f;
 
   --scalar-border-color: #242537;


### PR DESCRIPTION
**Problem**
using rgba with opacity on the kepler theme mode cause issue on css mask usage in the api client.

**Solution**
this pr fixes #2106 by favoring hex color over rgba in the kepler theme,