### PR TITLE
feat(docusaurus): add yaml support

### DIFF
--- a/.changeset/old-knives-smell.md
+++ b/.changeset/old-knives-smell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/docusaurus': patch
+---
+
+feat: add Yaml support

--- a/examples/docusaurus/docusaurus.config.ts
+++ b/examples/docusaurus/docusaurus.config.ts
@@ -62,7 +62,7 @@ const config: Config = {
         route: '/scalar',
         configuration: {
           spec: {
-            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
           },
         },
       } as ScalarOptions,

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -18,15 +18,6 @@ const ScalarDocusaurus = (
     name: '@scalar/docusaurus',
 
     async loadContent() {
-      // Check if we need to download a spec
-      if (options.configuration?.spec?.url) {
-        const resp = await fetch(options.configuration.spec.url)
-        const content = await resp.json()
-        return {
-          configuration: { ...options.configuration, spec: { content } },
-        }
-      }
-
       return options
     },
 


### PR DESCRIPTION
Currently, the docusaurus plugin fetches the OpenAPI document, but supports JSON only. If someone tried to add a YAML url, this exception was thrown:

```
> docusaurus start --port=5063 --no-open

[INFO] Starting the development server...

[ERROR] SyntaxError: Unexpected token 'o', "openapi: 3"... is not valid JSON
    at JSON.parse (<anonymous>)
```

With this PR we’re removing the code to fetch the OpenAPI document, so `@scalar/api-reference` can fetch the document and we all get YAML support for free. :)

