### PR TITLE
style: client library select dark theme fix

### DIFF
--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -245,6 +245,8 @@ const checkIfClientIsFeatured = (client: HttpClientState) =>
   color: var(--scalar-color-1);
 }
 .client-libraries__select select {
+  background: var(--scalar-background-3);
+  color: var(--scalar-color-2);
   opacity: 0;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
**Problem**
Not visible client libraries select with dark theme
![image](https://github.com/scalar/scalar/assets/55696268/49800bc1-7e3a-4ca6-aa25-c4000f9f0ed7)

**Explanation**
Bad styling for select

**Solution**
After
![image](https://github.com/scalar/scalar/assets/55696268/d875549f-217d-41c7-8712-7058eadc1796)
