### PR TITLE
fix(client-app): data table cell checkbox width

### DIFF
--- a/packages/client-app/src/components/DataTable/DataTableCell.vue
+++ b/packages/client-app/src/components/DataTable/DataTableCell.vue
@@ -11,7 +11,7 @@ withDefaults(
 <template>
   <component
     :is="is"
-    class="h-8 min-w-0 border-b-1/2 border-r-1/2 border-r-[inherit] text-sm last:border-r-0 group-last:border-b-transparent w-fit min-w-full"
+    class="h-8 min-w-0 border-b-1/2 border-r-1/2 border-r-[inherit] text-sm last:border-r-0 group-last:border-b-transparent w-fit min-w-full has-[input[type=checkbox]]:w-8 has-[input[type=checkbox]]:min-w-8"
     role="cell">
     <slot />
   </component>


### PR DESCRIPTION
this pr sets data table width based on its type in order to enhance style alignment on checkbox hover:

<img width="618" alt="image" src="https://github.com/scalar/scalar/assets/14966155/fb1e3407-7a1c-4515-834e-a9540aa30a17">
