### PR TITLE
feat(client-app): section navigation

### DIFF
--- a/packages/client-app/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/client-app/src/views/Request/RequestSection/RequestSection.vue
@@ -11,7 +11,7 @@ import { computed, ref, watch } from 'vue'
 
 const { activeRequest, activeExample } = useWorkspace()
 
-const bodyMethods = ['POST', 'PUT', 'PATCH']
+const bodyMethods = ['POST', 'PUT', 'PATCH', 'DELETE']
 
 const sections = computed(() => {
   const allSections = [

--- a/packages/client-app/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/client-app/src/views/Request/RequestSection/RequestSection.vue
@@ -7,7 +7,7 @@ import RequestBody from '@/views/Request/RequestSection/RequestBody.vue'
 import RequestParams from '@/views/Request/RequestSection/RequestParams.vue'
 import RequestPathParams from '@/views/Request/RequestSection/RequestPathParams.vue'
 import { ScalarIcon } from '@scalar/components'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 const { activeRequest, activeExample } = useWorkspace()
 
@@ -37,6 +37,15 @@ const sections = computed(() => {
 type ActiveSections = (typeof sections.value)[number]
 
 const activeSection = ref<ActiveSections>('All')
+
+watch(activeRequest, (newRequest) => {
+  if (
+    activeSection.value === 'Body' &&
+    !bodyMethods.includes(newRequest.method)
+  ) {
+    activeSection.value = 'All'
+  }
+})
 </script>
 <template>
   <ViewLayoutSection>


### PR DESCRIPTION
this pr fallbacks on 'all' section when navigating to an endpoint without body if the latter is active + displays body on delete http method.
