### PR TITLE
fix(docusaurus): api client modal

### DIFF
--- a/.changeset/cyan-kiwis-warn.md
+++ b/.changeset/cyan-kiwis-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: scalar modal component padding reset

--- a/packages/client-app/src/components/Sidebar/Sidebar.vue
+++ b/packages/client-app/src/components/Sidebar/Sidebar.vue
@@ -6,7 +6,7 @@ import { themeClasses } from '@/constants'
     class="w-sidebar relative flex flex-col border-r bg-b-1"
     :class="[themeClasses.sidebar]">
     <div class="xl:min-h-header py-2.5 flex items-center border-b px-4 text-sm">
-      <h2 class="font-medium"><slot name="title" /></h2>
+      <h2 class="font-medium m-0 text-sm"><slot name="title" /></h2>
     </div>
     <div class="custom-scroll sidebar-height">
       <slot name="content" />

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -29,7 +29,7 @@ withDefaults(
 const modal = cva({
   base: [
     'scalar-modal',
-    'col relative mx-auto mb-0 mt-20 w-full rounded-lg bg-b-2 text-left leading-snug text-c-1 opacity-0',
+    'col relative mx-auto mb-0 mt-20 w-full rounded-lg bg-b-2 p-0 text-left leading-snug text-c-1 opacity-0',
   ].join(' '),
   variants: {
     size: {


### PR DESCRIPTION
this pr adds some base styles in order to fix new api client modal glitch with docusaurus:

**before**
<img width="618" alt="image" src="https://github.com/scalar/scalar/assets/14966155/202d5810-0f1b-4ddf-bc28-84d4e5c819a1">


**after**
<img width="618" alt="image" src="https://github.com/scalar/scalar/assets/14966155/49de8dce-767b-442e-9695-3703b631eab3">

