### PR TITLE
chore: do not run ci on node 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [18, 20, 21]
+        node-version: [18, 20]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**Problem**
Currently, our CI is taking a long time.

**Explanation**
This happens because we are testing on node 18, 20, and 21

**Solution**
With this PR we will only run testing in CI on node 18 (maintenance) and 20 (LTS) 
