### PR TITLE
fix: docusaurus border radius

### DIFF
--- a/.changeset/young-students-add.md
+++ b/.changeset/young-students-add.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: docusaurus scalar codeblock border radius

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -46,5 +46,6 @@ const highlightedCode = computed(() => {
   background: transparent;
   text-wrap: nowrap;
   white-space-collapse: preserve;
+  border-radius: 0;
 }
 </style>


### PR DESCRIPTION
before:
<img width="104" alt="image" src="https://github.com/scalar/scalar/assets/6201407/7285a564-f24f-4838-87d2-1faf51a22d93">

after:
<img width="146" alt="image" src="https://github.com/scalar/scalar/assets/6201407/35de03be-21ee-4e01-bfb8-d2a8dca837b4">
