### PR TITLE
fix(api-reference): allof items merge objects

### DIFF
--- a/.changeset/long-radios-punch.md
+++ b/.changeset/long-radios-punch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: api reference allof items merge objects

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/ExampleResponse.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/ExampleResponse.vue
@@ -30,18 +30,6 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
       lang="json" />
   </div>
   <div v-else-if="response?.schema">
-    <!-- Single Schema -->
-    <ScalarCodeBlock
-      v-if="response?.schema.type"
-      :content="
-        prettyPrintJson(
-          getExampleFromSchema(response?.schema, {
-            emptyString: '…',
-            mode: 'read',
-          }),
-        )
-      "
-      lang="json" />
     <!-- oneOf, anyOf, not … -->
     <template
       v-for="rule in rules"
@@ -94,6 +82,31 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
               mode: 'read',
             }),
           ),
+        )
+      "
+      lang="json" />
+    <ScalarCodeBlock
+      v-if="response?.schema['items']?.['allOf']"
+      :content="
+        mergeAllObjects(
+          response?.schema['items']['allOf'].map((schema: any) =>
+            getExampleFromSchema(schema, {
+              emptyString: '…',
+              mode: 'read',
+            }),
+          ),
+        )
+      "
+      lang="json" />
+    <!-- Single Schema -->
+    <ScalarCodeBlock
+      v-else
+      :content="
+        prettyPrintJson(
+          getExampleFromSchema(response?.schema, {
+            emptyString: '…',
+            mode: 'read',
+          }),
         )
       "
       lang="json" />

--- a/packages/api-reference/src/helpers/mergeAllObjects.test.ts
+++ b/packages/api-reference/src/helpers/mergeAllObjects.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeAllObjects } from './mergeAllObjects'
+
+describe('mergeAllObjects', () => {
+  it('merges two objects', () => {
+    expect(mergeAllObjects([{ foo: 'bar' }, { bar: 'foo' }])).toStrictEqual({
+      foo: 'bar',
+      bar: 'foo',
+    })
+  })
+
+  it('overwrites first object', () => {
+    expect(mergeAllObjects([{ foo: 'bar' }, { foo: 'foo' }])).toStrictEqual({
+      foo: 'foo',
+    })
+  })
+
+  it('merges objects with circular references', () => {
+    const foobar: Record<string, any> = { foo: 'bar' }
+    foobar.foo = foobar
+
+    expect(mergeAllObjects([{ foo: 'bar' }, foobar])).toStrictEqual(foobar)
+  })
+})


### PR DESCRIPTION
this pr is a proposal to fix #2137 in order to merge objects in response example for allof items.

<img width="797" alt="image" src="https://github.com/scalar/scalar/assets/14966155/6337a3ba-8876-40b6-845e-c8e022876087">
 
