### PR TITLE
ci: playwright cache

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
   lint:
-    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
       # https://github.com/marketplace/actions/semantic-pull-request

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -46,5 +46,7 @@ jobs:
             ${{ runner.os }}-playwright-
       - run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - name: Start HTML Server
+        run: pnpm --filter @scalar-examples/cdn-api-reference dev &
       - name: Run E2E tests (jsdelivr)
         run: CI=1 pnpm test:e2e:jsdelivr

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -24,14 +24,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: pnpm install
       - name: Build Packages
         uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Build packages
         run: pnpm build:packages
-      - name: Start HTML server
-        run: pnpm --filter @scalar-examples/cdn-api-reference dev &
       - name: Get Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -26,28 +26,23 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-node-
       - name: Build Packages
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+      - name: Build packages
         run: pnpm build:packages
-      - name: Start HTML Server
+      - name: Start HTML server
         run: pnpm --filter @scalar-examples/cdn-api-reference dev &
-      - name: Get installed Playwright version
-        id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")" >> $GITHUB_ENV
-      - name: Cache playwright binaries
-        uses: actions/cache@v4
+      - name: Get Playwright version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")" >> $GITHUB_ENV && echo $PLAYWRIGHT_VERSION
+      - name: Cache Playwright binaries
         id: playwright-cache
+        uses: actions/cache@v4
         with:
           path: '~/.cache/ms-playwright'
           key: '${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}'
           restore-keys: ${{ runner.os }}-playwright-
-      - name: Install Playwright browser binaries & OS dependencies
+      - name: Install Playwright binaries
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
-      - name: Run e2e tests (jsdelivr)
+      - name: Run E2E tests (jsdelivr)
         run: CI=1 pnpm test:e2e:jsdelivr

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -33,16 +33,19 @@ jobs:
       - name: Start HTML server
         run: pnpm --filter @scalar-examples/cdn-api-reference dev &
       - name: Get Playwright version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")" >> $GITHUB_ENV && echo $PLAYWRIGHT_VERSION
-      - name: Cache Playwright binaries
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
         id: playwright-cache
-        uses: actions/cache@v4
         with:
-          path: '~/.cache/ms-playwright'
-          key: '${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}'
-          restore-keys: ${{ runner.os }}-playwright-
-      - name: Install Playwright binaries
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+      - run: npm ci
+      - run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps
+      - run: npx playwright install-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Run E2E tests (jsdelivr)
         run: CI=1 pnpm test:e2e:jsdelivr

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -37,7 +37,7 @@ jobs:
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
       - name: Playwright binary cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: playwright-cache
         with:
           path: |

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -29,7 +29,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -34,17 +34,17 @@ jobs:
         run: pnpm --filter @scalar-examples/cdn-api-reference dev &
       - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
       - name: Cache playwright binaries
         uses: actions/cache@v3
         id: playwright-cache
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - run: npx playwright install --with-deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Run E2E tests (jsdelivr)
         run: CI=1 pnpm test:e2e:jsdelivr

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -49,5 +49,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
         run: npx playwright install-deps
+      - name: Start HTML Server
+        run: pnpm --filter @scalar-examples/cdn-api-reference dev &
       - name: Run E2E tests (jsdelivr)
         run: CI=1 pnpm test:e2e:jsdelivr

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
-      - name: Cache playwright binaries
+      - name: Playwright binary cache
         uses: actions/cache@v3
         id: playwright-cache
         with:
@@ -44,8 +44,11 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
           restore-keys: |
             ${{ runner.os }}-playwright-
-      - run: npx playwright install --with-deps
+      - name: Install Playwright browsers
+        run: npx playwright install
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - name: Install Playwright dependencies
+        run: npx playwright install-deps
       - name: Start HTML Server
         run: pnpm --filter @scalar-examples/cdn-api-reference dev &
       - name: Run E2E tests (jsdelivr)

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -49,7 +49,5 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
         run: npx playwright install-deps
-      - name: Start HTML Server
-        run: pnpm --filter @scalar-examples/cdn-api-reference dev &
       - name: Run E2E tests (jsdelivr)
         run: CI=1 pnpm test:e2e:jsdelivr

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
-      - name: Use pnpm
-        uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: pnpm install
       - name: Build Packages

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -20,8 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-      - name: Use pnpm
-        uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -29,7 +28,7 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Build Packages
+      - name: Turborepo cache
         uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Build packages
         run: pnpm build:packages

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -6,6 +6,7 @@ on:
     - cron: '0 * * * *'
   push:
     paths:
+      - 'playwright/tests/**'
       - 'examples/cdn-api-reference/**'
       - '.github/workflows/test-cdn-jsdelivr.yml'
 

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -42,7 +42,6 @@ jobs:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-      - run: npm ci
       - run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: npx playwright install-deps

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 * * * *'
   push:
     paths:
-      - 'packages/cdn-api-reference/**'
+      - 'examples/cdn-api-reference/**'
       - '.github/workflows/test-cdn-jsdelivr.yml'
 
 jobs:
@@ -40,7 +40,6 @@ jobs:
       - name: Get installed Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")" >> $GITHUB_ENV
-      # TODO doesn't work
       - name: Cache playwright binaries
         uses: actions/cache@v4
         id: playwright-cache

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -49,7 +49,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
         run: npx playwright install-deps
-      - name: Start HTML Server
+      - name: Start HTML server
         run: pnpm --filter @scalar-examples/cdn-api-reference dev &
       - name: Run E2E tests (jsdelivr)
         run: CI=1 pnpm test:e2e:jsdelivr

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -23,7 +23,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -36,7 +36,7 @@ jobs:
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
       - name: Playwright binary cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: playwright-cache
         with:
           path: |

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -14,8 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use pnpm
-        uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -14,13 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-node-
       - name: Use pnpm
         uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -30,6 +23,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
+      - name: Turborepo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -14,14 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
       - name: Turborepo cache
         uses: actions/cache@v4
         with:
@@ -29,22 +21,35 @@ jobs:
           key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
           restore-keys: |
             ${{ runner.os }}-turbo-node-
-      - name: Build Packages
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build packages
         run: pnpm build:packages
-      - name: Start HTML Server
-        run: pnpm --filter @scalar-examples/cdn-api-reference dev &
-      - name: Get installed Playwright version
+      - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")" >> $GITHUB_ENV
-      # TODO doesn't work
-      - name: Cache playwright binaries
-        uses: actions/cache@v4
+        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
+      - name: Playwright binary cache
+        uses: actions/cache@v3
         id: playwright-cache
         with:
-          path: '~/.cache/ms-playwright'
-          key: '${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}'
-          restore-keys: ${{ runner.os }}-playwright-
-      - name: Install Playwright browser binaries & OS dependencies
-        run: pnpm exec playwright install --with-deps
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+      - name: Install Playwright browsers
+        run: npx playwright install
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - name: Install Playwright dependencies
+        run: npx playwright install-deps
+      - name: Start HTML server
+        run: pnpm --filter @scalar-examples/cdn-api-reference dev &
       - name: Run e2e tests (local)
         run: CI=1 pnpm test:e2e:local

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -1,4 +1,4 @@
-name: Test Nuxt integration
+name: Test Nuxt Integration
 
 on:
   pull_request:

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -16,14 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm --filter nuxt install
       - name: Turborepo cache
         uses: actions/cache@v4
         with:
@@ -31,19 +23,35 @@ jobs:
           key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
           restore-keys: |
             ${{ runner.os }}-turbo-node-
-      - name: Start nuxt server
-        run: pnpm --filter nuxt dev --host &
-      - name: Get installed Playwright version
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build packages
+        run: pnpm build:packages
+      - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")" >> $GITHUB_ENV
-      - name: Cache playwright binaries
-        uses: actions/cache@v4
+        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
+      - name: Playwright binary cache
+        uses: actions/cache@v3
         id: playwright-cache
         with:
-          path: '~/.cache/ms-playwright'
-          key: '${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}'
-          restore-keys: ${{ runner.os }}-playwright-
-      - name: Install Playwright browser binaries & OS dependencies
-        run: pnpm exec playwright install --with-deps
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+      - name: Install Playwright browsers
+        run: npx playwright install
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - name: Install Playwright dependencies
+        run: npx playwright install-deps
+      - name: Start nuxt server
+        run: pnpm --filter nuxt dev --host &
       - name: Run e2e tests
         run: CI=1 pnpm -r --parallel test:e2e:nuxt

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -14,13 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -30,7 +23,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
-      - name: Install dependencies (Nuxt)
-        run: pnpm --filter nuxt install
+      - name: Install dependencies
+        run: pnpm install
       - name: Turborepo cache
         uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Build packages

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -36,7 +36,7 @@ jobs:
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
       - name: Playwright binary cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: playwright-cache
         with:
           path: |

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -1,11 +1,9 @@
-name: Test nuxt integration
+name: Test Nuxt integration
 
 on:
-  push:
-    paths:
-      - 'packages/**'
-      - '.github/workflows/test-nuxt-integration.yml'
-      - 'playwright/tests/**'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -21,8 +21,7 @@ jobs:
           key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
           restore-keys: |
             ${{ runner.os }}-turbo-node-
-      - name: Use pnpm
-        uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -28,8 +28,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
+      - name: Install dependencies (Nuxt)
+        run: pnpm --filter nuxt install
+      - name: Turborepo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/examples/cdn-api-reference/src/index.ts
+++ b/examples/cdn-api-reference/src/index.ts
@@ -7,7 +7,6 @@ import { join } from 'node:path'
 
 const app = await fastify({ logger: true })
 
-// serve all files in public/
 await app.register(fastifyStatic, {
   root: join(__dirname, 'public'),
   prefix: '/',

--- a/examples/cdn-api-reference/src/index.ts
+++ b/examples/cdn-api-reference/src/index.ts
@@ -13,6 +13,11 @@ await app.register(fastifyStatic, {
   cacheControl: false,
 })
 
+// health check
+app.get('/ping', (_request, reply) => {
+  reply.send('pong')
+})
+
 // @scalar/api-reference bundle
 
 app.get('/api-reference/standalone.js', (_request, reply) => {

--- a/examples/cdn-api-reference/src/index.ts
+++ b/examples/cdn-api-reference/src/index.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 
 const app = await fastify({ logger: true })
 
+// serve all files in public/
 await app.register(fastifyStatic, {
   root: join(__dirname, 'public'),
   prefix: '/',

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -71,7 +71,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'pnpm --filter @scalar-examples/cdn-api-reference dev',
-    url: 'http://127.0.0.1:3173',
+    url: 'http://127.0.0.1:3173/ping',
     reuseExistingServer: !process.env.CI,
   },
 })

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -69,9 +69,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'pnpm --filter @scalar-examples/cdn-api-reference dev',
+    url: 'http://127.0.0.1:3173',
+    reuseExistingServer: !process.env.CI,
+  },
 })

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -69,9 +69,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'pnpm --filter @scalar-examples/cdn-api-reference dev',
+    url: 'http://127.0.0.1:3173/ping',
+    reuseExistingServer: !process.env.CI,
+  },
 })

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -69,9 +69,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: 'pnpm --filter @scalar-examples/cdn-api-reference dev',
-    url: 'http://127.0.0.1:3173/ping',
-    reuseExistingServer: !process.env.CI,
-  },
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
 })


### PR DESCRIPTION
The playwright workflow has a comment that indicates the Playwright binary caching doesn’t work. Let’s fix this.

With this PR browsers aren’t installed if they are cached, but required system dependencies are installed always:

```yaml
      - name: Install Playwright browsers
        run: npx playwright install
        if: steps.playwright-cache.outputs.cache-hit != 'true'
      - name: Install Playwright dependencies
        run: npx playwright install-deps
```

This PR also changes the trigger for the Nuxt integration test. It’ll run on every PR now.