### PR TITLE
fix(client-app): display hide icon in reference only

### DIFF
--- a/packages/client-app/src/views/Request/Request.vue
+++ b/packages/client-app/src/views/Request/Request.vue
@@ -250,6 +250,7 @@ whenever(
           Test Acctual Locally
         </button> -->
         <button
+          v-if="workspace.isReadOnly"
           class="request-text-color bg-mix-transparent hover:bg-mix-amount-95 p-2 rounded bg-mix-amount-100"
           :class="getBackgroundColor()"
           type="button"


### PR DESCRIPTION
this pr conditions the hide action icon from the client app in order for it to be displayed only when used within a reference as a client modal.

**before**
<img width="618" alt="image" src="https://github.com/scalar/scalar/assets/14966155/8619a318-8a18-4c78-96f1-e68842eec3fc">
