### PR TITLE
ci: use turborepo cache again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -22,8 +29,6 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - if: matrix.node-version == 20
         name: Check code style
         run: pnpm format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -29,6 +22,13 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - if: matrix.node-version == 20
         name: Check code style
         run: pnpm format:check

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -17,13 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -36,6 +29,13 @@ jobs:
         run: echo "DEPLOY_ID=$(uuidgen)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Install dependencies
         run: pnpm --filter web install
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - name: Build
         run: cd examples/web && pnpm turbo run build
         env:

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -17,6 +17,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -29,8 +36,6 @@ jobs:
         run: echo "DEPLOY_ID=$(uuidgen)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Install dependencies
         run: pnpm --filter web install
-      - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Build
         run: cd examples/web && pnpm turbo run build
         env:

--- a/.github/workflows/deploy-preview-examples.yml
+++ b/.github/workflows/deploy-preview-examples.yml
@@ -34,6 +34,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
       - name: Turborepo cache
         uses: actions/cache@v4
         with:
@@ -41,12 +47,6 @@ jobs:
           key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
           restore-keys: |
             ${{ runner.os }}-turbo-node-
-      - uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
       - name: Install netlify
         run: pnpm install -g netlify
       - name: Generate Run UUID

--- a/.github/workflows/deploy-preview-examples.yml
+++ b/.github/workflows/deploy-preview-examples.yml
@@ -40,6 +40,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+      - name: Install netlify
+        run: pnpm install -g netlify
+      - name: Generate Run UUID
+        run: echo "DEPLOY_ID=$(uuidgen)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
+      - name: Install dependencies
+        run: pnpm --filter web install
       - name: Turborepo cache
         uses: actions/cache@v4
         with:
@@ -47,12 +53,6 @@ jobs:
           key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
           restore-keys: |
             ${{ runner.os }}-turbo-node-
-      - name: Install netlify
-        run: pnpm install -g netlify
-      - name: Generate Run UUID
-        run: echo "DEPLOY_ID=$(uuidgen)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
-      - name: Install dependencies
-        run: pnpm --filter web install
       - name: Build
         run: cd examples/web && pnpm turbo run build
         env:

--- a/.github/workflows/deploy-preview-examples.yml
+++ b/.github/workflows/deploy-preview-examples.yml
@@ -34,6 +34,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -46,8 +53,6 @@ jobs:
         run: echo "DEPLOY_ID=$(uuidgen)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Install dependencies
         run: pnpm --filter web install
-      - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Build
         run: cd examples/web && pnpm turbo run build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - name: Build
         run: pnpm turbo build
       - name: Git Status

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -18,13 +18,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -33,6 +26,13 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - name: Build Packages
         run: pnpm build:packages
       - name: Start HTML Server

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -18,6 +18,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -26,8 +33,6 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Build Packages
         run: pnpm build:packages
       - name: Start HTML Server

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -14,6 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -22,8 +29,6 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Build Packages
         run: pnpm build:packages
       - name: Start HTML Server

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -14,13 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -29,6 +22,13 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - name: Build Packages
         run: pnpm build:packages
       - name: Start HTML Server

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -16,6 +16,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -24,8 +31,6 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm --filter nuxt install
-      - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Start nuxt server
         run: pnpm --filter nuxt dev --host &
       - name: Get installed Playwright version

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -16,13 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -31,6 +24,13 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm --filter nuxt install
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - name: Start nuxt server
         run: pnpm --filter nuxt dev --host &
       - name: Get installed Playwright version

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -17,13 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -32,6 +25,13 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - name: Build packages
         run: pnpm build:packages
       - name: Format OpenAPI File

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -11,23 +11,29 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20]
 
     steps:
       - uses: actions/checkout@v4
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - uses: pnpm/action-setup@v4
-        # with:
-        #   version: 9.2.0
-      - name: Use Node.js 20
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Turborepo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
-      - name: Build
-        run: pnpm turbo build
+      - name: Build packages
+        run: pnpm build:packages
       - name: Format OpenAPI File
         run: pnpm @scalar/cli format ../../packages/galaxy/src/specifications/3.1.yaml
       - name: Validate OpenAPI File


### PR DESCRIPTION
Looks like the Cache for Turborepo isn’t used anymore (since we switched to Turborepo 2?).

This PR brings it back to speed up CI. :)

It’s also nice because we’re using the official `actions/cache@v4` now.