### PR TITLE
feat(client-app): sidebar toggle hotkey

### DIFF
--- a/packages/client-app/src/views/Request/Request.vue
+++ b/packages/client-app/src/views/Request/Request.vue
@@ -17,7 +17,7 @@ import type { DraggingItem, HoveredItem } from '@scalar/draggable'
 import type { Collection } from '@scalar/oas-utils/entities/workspace/collection'
 import { REQUEST_METHODS, type RequestMethod } from '@scalar/oas-utils/helpers'
 import { isMacOS } from '@scalar/use-tooltip'
-import { useMagicKeys, whenever } from '@vueuse/core'
+import { useEventListener, useMagicKeys } from '@vueuse/core'
 import { type DeepReadonly, computed, ref } from 'vue'
 
 import RequestSidebarItem from './RequestSidebarItem.vue'
@@ -211,10 +211,12 @@ const getBackgroundColor = () => {
 }
 
 const keys = useMagicKeys()
-whenever(
-  isMacOS() ? keys.meta_b : keys.ctrl_b,
-  () => (showSideBar.value = !showSideBar.value),
-)
+
+useEventListener(document, 'keydown', (event) => {
+  if ((isMacOS() ? keys.meta.value : keys.ctrl.value) && event.key === 'b') {
+    showSideBar.value = !showSideBar.value
+  }
+})
 </script>
 <template>
   <div


### PR DESCRIPTION
currently we have to key up and key down both keys in order to toggle the sidebar, however sometimes we might keep the meta key down to have a glimpse on the navigation.

this pr is a proposal to favor useEventListener over whenever, i haven't been able to reach the same result otherwise.