### PR TITLE
chore(cdn-api-reference): simplify cdn server

### DIFF
--- a/examples/cdn-api-reference/src/index.ts
+++ b/examples/cdn-api-reference/src/index.ts
@@ -10,6 +10,7 @@ const app = await fastify({ logger: true })
 await app.register(fastifyStatic, {
   root: join(__dirname, 'public'),
   prefix: '/',
+  cacheControl: false,
 })
 
 // @scalar/api-reference bundle

--- a/examples/cdn-api-reference/src/index.ts
+++ b/examples/cdn-api-reference/src/index.ts
@@ -2,6 +2,7 @@ import fastifyStatic from '@fastify/static'
 import apiReferenceBundle from '@scalar/api-reference/browser/standalone.js?raw'
 import playButtonBundle from '@scalar/play-button?raw'
 import fastify from 'fastify'
+import { readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
 const app = await fastify({ logger: true })
@@ -11,34 +12,18 @@ await app.register(fastifyStatic, {
   prefix: '/',
 })
 
-// @scalar/api-reference
+// @scalar/api-reference bundle
 
-app.get('/api-reference/jsdelivr', (_request, reply) => {
-  reply.sendFile('api-reference-jsdelivr.html', { cacheControl: false })
-})
-
-app.get('/api-reference/local', (_request, reply) => {
-  reply.sendFile('api-reference-local.html', { cacheControl: false })
-})
-
-app.get('/api-reference/local/standalone.js', (_request, reply) => {
+app.get('/api-reference/standalone.js', (_request, reply) => {
   reply
     .code(200)
     .header('Content-Type', 'text/javascript; charset=utf-8')
     .send(apiReferenceBundle)
 })
 
-// @scalar/play-button
+// @scalar/play-button bundle
 
-app.get('/play-button/jsdelivr', (_request, reply) => {
-  reply.sendFile('play-button-jsdelivr.html', { cacheControl: false })
-})
-
-app.get('/play-button/local', (_request, reply) => {
-  reply.sendFile('play-button-local.html', { cacheControl: false })
-})
-
-app.get('/play-button/local/standalone.js', (_request, reply) => {
+app.get('/play-button/standalone.js', (_request, reply) => {
   reply
     .code(200)
     .header('Content-Type', 'text/javascript; charset=utf-8')
@@ -51,11 +36,10 @@ try {
     console.log()
     console.info(`📦 CDN Example listening on http://127.0.0.1:3173`)
     console.log()
-    console.info('  ➜ http://127.0.0.1:3173/api-reference/jsdelivr')
-    console.info('  ➜ http://127.0.0.1:3173/api-reference/local')
-    console.log()
-    console.info('  ➜ http://127.0.0.1:3173/play-button/jsdelivr')
-    console.info('  ➜ http://127.0.0.1:3173/play-button/local')
+    // List all files in the public directory
+    readdirSync(join(__dirname, 'public')).forEach((file) => {
+      console.info(`  ➜ http://127.0.0.1:3173/${file}`)
+    })
     console.log()
   })
 } catch (err) {

--- a/examples/cdn-api-reference/src/public/api-reference-local.html
+++ b/examples/cdn-api-reference/src/public/api-reference-local.html
@@ -24,6 +24,6 @@
       var apiReference = document.getElementById('api-reference')
       apiReference.dataset.configuration = JSON.stringify(configuration)
     </script>
-    <script src="/api-reference/local/standalone.js"></script>
+    <script src="/api-reference/standalone.js"></script>
   </body>
 </html>

--- a/examples/cdn-api-reference/src/public/play-button-local.html
+++ b/examples/cdn-api-reference/src/public/play-button-local.html
@@ -11,7 +11,7 @@
     <script
       id="scalar-play-button-script"
       data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json"></script>
-    <script src="/play-button/local/standalone.js"></script>
+    <script src="/play-button/standalone.js"></script>
     <button
       scalar-operation-id="getPetById"
       class="scalar-play-button">

--- a/playwright/tests/jsdelivr.spec.ts
+++ b/playwright/tests/jsdelivr.spec.ts
@@ -6,7 +6,7 @@ import { playButton } from './play-button-ui-test'
 const HOST = process.env.HOST || 'localhost'
 
 test('@scalar/api-reference jsdelivr build', async ({ page, isMobile }) => {
-  await page.goto(`http://${HOST}:3173/api-reference/jsdelivr`)
+  await page.goto(`http://${HOST}:3173/api-reference-jsdelivr.html`)
 
   await apiReference(page, isMobile)
 
@@ -31,7 +31,7 @@ test('@scalar/api-reference jsdelivr build', async ({ page, isMobile }) => {
 
 // TODO: The package is just broken and needs to be fixed.
 test.skip('@scalar/play-button jsdelivr build', async ({ page, isMobile }) => {
-  await page.goto(`http://${HOST}:3173/play-button/jsdelivr`)
+  await page.goto(`http://${HOST}:3173/play-button-jsdelivr.html`)
 
   await playButton(page, isMobile)
 })

--- a/playwright/tests/local.spec.ts
+++ b/playwright/tests/local.spec.ts
@@ -6,7 +6,7 @@ import { playButton } from './play-button-ui-test'
 const HOST = process.env.HOST || 'localhost'
 
 test('@scalar/api-reference local build', async ({ page, isMobile }) => {
-  await page.goto(`http://${HOST}:3173/api-reference/local`)
+  await page.goto(`http://${HOST}:3173/api-reference-local.html`)
 
   await apiReference(page, isMobile)
 
@@ -31,7 +31,7 @@ test('@scalar/api-reference local build', async ({ page, isMobile }) => {
 
 // TODO: The package is just broken and needs to be fixed.
 test.skip('@scalar/play-button local build', async ({ page, isMobile }) => {
-  await page.goto(`http://${HOST}:3173/play-button/local`)
+  await page.goto(`http://${HOST}:3173/play-button-local.html`)
 
   await playButton(page, isMobile)
 })


### PR DESCRIPTION
I saw the CDN example had code to serve all static files already, so there’s no need to register all routes individually.
