### PR TITLE
feat(next): URL support

### DIFF
--- a/.changeset/gorgeous-sheep-check.md
+++ b/.changeset/gorgeous-sheep-check.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nextjs-api-reference': patch
+---
+
+feat: add URL support

--- a/examples/nextjs-api-reference/app/reference/route.ts
+++ b/examples/nextjs-api-reference/app/reference/route.ts
@@ -1,12 +1,8 @@
 import { ApiReference } from '@scalar/nextjs-api-reference'
 
-const response = await fetch(
-  'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-)
-
 const config = {
   spec: {
-    content: await response.text(),
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
   },
 }
 

--- a/packages/nextjs-api-reference/src/ApiReference.ts
+++ b/packages/nextjs-api-reference/src/ApiReference.ts
@@ -10,27 +10,37 @@ import { nextjsThemeCss } from './theme'
  * @params config - the Api Reference config object
  * @params options - reserved for future use to add customization to the response
  */
-export const ApiReference = (refConfig: ReferenceConfiguration) => {
-  const { spec, ...config } = refConfig
-
+export const ApiReference = (config: ReferenceConfiguration) => {
   // If no spec is passed, show a warning.
-  if (!spec?.content && !spec?.url) {
+  if (!config.spec?.content && !config.spec?.url) {
     throw new Error(
       '[@scalar/nextjs-api-reference] You didn’t provide a spec.content or spec.url. Please provide one of these options.',
     )
   }
 
-  const contentString = spec?.content
-    ? typeof spec.content === 'function'
-      ? JSON.stringify(spec.content())
-      : JSON.stringify(spec.content)
+  // Execute content function if it exists
+  if (typeof config.spec?.content === 'function') {
+    config.spec.content = config.spec.content()
+  }
+
+  // Convert the document to a string
+  const documentString = config?.spec?.content
+    ? typeof config?.spec?.content === 'string'
+      ? config.spec.content
+      : JSON.stringify(config.spec.content)
     : ''
+
+  // Delete content from configuration
+  if (config?.spec?.content) {
+    delete config.spec.content
+  }
 
   // Add the default CSS
   if (!config?.customCss && !config?.theme) {
     config.customCss = nextjsThemeCss
   }
 
+  // Convert the configuration to a string
   const configString = JSON.stringify(config ?? {})
     .split('"')
     .join('&quot;')
@@ -50,7 +60,7 @@ export const ApiReference = (refConfig: ReferenceConfiguration) => {
       id="api-reference"
       type="application/json"
       data-configuration="${configString}">
-      ${contentString}
+      ${documentString}
     </script>
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   </body>


### PR DESCRIPTION
I just found out that our Next.js integration doesn’t have support for URLs as promoted in the README:

```diff
import { ApiReference } from '@scalar/nextjs-api-reference'

const config = {
  spec: {
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
  },
}

export const GET = ApiReference(config)
```

This PR adds support for URLs.

Before, the plugin always passed `content`, but ignored `url`. 

This PR also adds support for YAML content, the CDN version doesn’t supports it yet though (not if it’s passed as content of the `script` tag, only if it’s in the configuration object).