### PR TITLE
fix: support commonjs docusaurus builds

### DIFF
--- a/.changeset/sour-feet-applaud.md
+++ b/.changeset/sour-feet-applaud.md
@@ -1,0 +1,5 @@
+---
+'@scalar/docusaurus': patch
+---
+
+fix: support commonjs docusaurus builds

--- a/packages/docusaurus/src/ScalarDocusaurusCommonJS.tsx
+++ b/packages/docusaurus/src/ScalarDocusaurusCommonJS.tsx
@@ -1,0 +1,61 @@
+// Workaround to handle commonjs failing with older react version
+import type { ReferenceProps } from '@scalar/api-reference-react'
+import Layout from '@theme/Layout'
+import React, { useEffect } from 'react'
+
+import './theme.css'
+
+type Props = {
+  route: ReferenceProps
+}
+
+const ScalarDocusaurusCommonJS = ({ route }: Props) => {
+  useEffect(() => {
+    const container = document.getElementById('api-reference-container')
+
+    if (container && route.configuration) {
+      const { spec, ...config } = route.configuration
+
+      const apiReferenceScript = document.createElement('script')
+      apiReferenceScript.id = 'api-reference'
+      apiReferenceScript.type = 'application/json'
+
+      const contentString = spec?.content
+        ? typeof spec.content === 'function'
+          ? JSON.stringify(spec.content())
+          : JSON.stringify(spec.content)
+        : ''
+
+      const configString = JSON.stringify(config ?? {})
+        .split('"')
+        .join('&quot;')
+
+      apiReferenceScript.dataset.configuration = configString
+      apiReferenceScript.innerHTML = contentString
+
+      container.appendChild(apiReferenceScript)
+
+      // Creating and appending the script element
+      const script = document.createElement('script')
+      script.src = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+      script.async = true
+      script.onload = () => {
+        console.log('Script loaded successfully')
+      }
+      script.onerror = (error) => {
+        console.error('Error loading script:', error)
+      }
+      container.appendChild(script)
+    } else {
+      console.error('#api-reference-container not found')
+    }
+  }, [])
+
+  return (
+    <Layout>
+      <div id="api-reference-container"></div>
+    </Layout>
+  )
+}
+
+export default ScalarDocusaurusCommonJS

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -44,13 +44,23 @@ const ScalarDocusaurus = (
         position: 'left',
       })
 
-      addRoute({
-        path: options.route,
-        component: path.resolve(__dirname, './ScalarDocusaurus'),
-        // Provide the path to the loaded spec as a prop to your component
-        exact: true,
-        ...content,
-      })
+      if (typeof require === 'function') {
+        addRoute({
+          path: options.route,
+          component: path.resolve(__dirname, './ScalarDocusaurusCommonJS'),
+          // Provide the path to the loaded spec as a prop to your component
+          exact: true,
+          ...content,
+        })
+      } else {
+        addRoute({
+          path: options.route,
+          component: path.resolve(__dirname, './ScalarDocusaurus'),
+          // Provide the path to the loaded spec as a prop to your component
+          exact: true,
+          ...content,
+        })
+      }
     },
   }
 }


### PR DESCRIPTION
**Problem**
If you are using an older version of docusaurus it breaks our api reference react package

**Explanation**
because we dont handle commonjs

**Solution**
we load the standalone versions since we arent doing ssr anyways :) 
