### PR TITLE
fix: dont parse json from fetch just as text

### DIFF
--- a/.changeset/flat-grapes-bake.md
+++ b/.changeset/flat-grapes-bake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/docusaurus': patch
+---
+
+fix: dont parse json from fetch just as text

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -21,7 +21,7 @@ const ScalarDocusaurus = (
       // Check if we need to download a spec
       if (options.configuration?.spec?.url) {
         const resp = await fetch(options.configuration.spec.url)
-        const content = await resp.json()
+        const content = await resp.text()
         return {
           configuration: { ...options.configuration, spec: { content } },
         }


### PR DESCRIPTION
**Problem**
we .json() so we cant load yaml

**Explanation**
This happens because yaml cant be parsed as json

**Solution**
we just grab it as text :)
