### PR TITLE
docs: add a detailed Next.js integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,7 @@ function App() {
 export default App
 ```
 
-We wrote
-a [detailed integration guide for React](https://github.com/scalar/scalar/tree/main/documentation/react.md), too.
+We wrote a [detailed integration guide for React](https://github.com/scalar/scalar/tree/main/documentation/react.md), too.
 
 ### Next.js
 
@@ -262,8 +261,7 @@ const config = {
 export const GET = ApiReference(config)
 ```
 
-We wrote
-a [detailed integration guide for Next.js](https://github.com/scalar/scalar/tree/main/documentation/nextjs.md), too.
+We wrote a [detailed integration guide for Next.js](https://github.com/scalar/scalar/tree/main/documentation/nextjs.md), too.
 
 Read more: [@scalar/nextjs-api-reference](https://github.com/scalar/scalar/tree/main/packages/nextjs-api-reference)
 
@@ -288,8 +286,7 @@ await fastify.register(require('@scalar/fastify-api-reference'), {
 })
 ```
 
-We wrote
-a [detailed integration guide for Fastify](https://github.com/scalar/scalar/tree/main/documentation/fastify.md), too.
+We wrote a [detailed integration guide for Fastify](https://github.com/scalar/scalar/tree/main/documentation/fastify.md), too.
 
 Read more about the
 package: [@scalar/fastify-api-reference](https://github.com/scalar/scalar/tree/main/packages/fastify-api-reference)
@@ -400,8 +397,7 @@ plugins: [
 ],
 ```
 
-We wrote
-a [detailed integration guide for Docusaurus](https://github.com/scalar/scalar/tree/main/documentation/docusaurus.md), too.
+We wrote a [detailed integration guide for Docusaurus](https://github.com/scalar/scalar/tree/main/documentation/docusaurus.md), too.
 
 For more information, check out
 the [Docusaurus package](https://github.com/scalar/scalar/tree/main/packages/docusaurus/README.md)
@@ -412,8 +408,7 @@ There’s [a community package to generate OpenAPI files in AdonisJS,](https://g
 and it comes with support for the
 Scalar API reference already.
 
-We wrote
-a [detailed integration guide for AdonisJS](https://github.com/scalar/scalar/tree/main/documentation/adonisjs.md).
+We wrote a [detailed integration guide for AdonisJS](https://github.com/scalar/scalar/tree/main/documentation/adonisjs.md).
 
 ### Laravel
 
@@ -432,8 +427,7 @@ return [
 ];
 ```
 
-We wrote
-a [detailed integration guide for Laravel Scribe](https://github.com/scalar/scalar/tree/main/documentation/laravel-scribe.md),
+We wrote a [detailed integration guide for Laravel Scribe](https://github.com/scalar/scalar/tree/main/documentation/laravel-scribe.md),
 too.
 
 ### Rust

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ const config = {
 export const GET = ApiReference(config)
 ```
 
+We wrote
+a [detailed integration guide for Next.js](https://github.com/scalar/scalar/tree/main/documentation/nextjs.md), too.
+
 Read more: [@scalar/nextjs-api-reference](https://github.com/scalar/scalar/tree/main/packages/nextjs-api-reference)
 
 ### Fastify

--- a/documentation/nextjs.md
+++ b/documentation/nextjs.md
@@ -34,10 +34,13 @@ Great! Open <http://localhost:3000> and see the default Next.js homepage. :)
 
 Ready to add your API reference? Cool, there are a few options to integrate your API reference. The recommended way is to use our Next.js integration for app routing:
 
+### App router
+
+Install the package:
+
 ```bash
 npm add @scalar/nextjs-api-reference
 ```
-### App router
 
 … and add a new app route:
 
@@ -56,9 +59,13 @@ export const GET = ApiReference(config)
 
 Open <http://localhost:3000/reference> and there it is: Your new API reference. :)
 
-### Page router
+### Pages router
 
 But you can also just use our React integration and add a page route:
+
+```bash
+npm add @scalar/api-reference-react
+```
 
 ```js
 import { ApiReferenceReact } from '@scalar/api-reference-react'

--- a/documentation/nextjs.md
+++ b/documentation/nextjs.md
@@ -34,7 +34,7 @@ Great! Open <http://localhost:3000> and see the default Next.js homepage. :)
 
 Ready to add your API reference? Cool, there are a few options to integrate your API reference. The recommended way is to use our Next.js integration for app routing:
 
-### App router
+### Recommended: App router
 
 Install the package:
 
@@ -59,13 +59,15 @@ export const GET = ApiReference(config)
 
 Open <http://localhost:3000/reference> and there it is: Your new API reference. :)
 
-### Pages router
+### Alternative: Pages router
 
 But you can also just use our React integration and add a page route:
 
 ```bash
 npm add @scalar/api-reference-react
 ```
+
+… and aa a new page route:
 
 ```js
 import { ApiReferenceReact } from '@scalar/api-reference-react'

--- a/documentation/nextjs.md
+++ b/documentation/nextjs.md
@@ -10,7 +10,7 @@ Sometimes, it’s great to start on a blank slate and set up a new project:
 npx create-next-app@latest my-awesome-app
 ```
 
-You’ll get some questions, you can leave all the recommended answer - or pick what you prefer:
+You’ll get some questions, you can leave all the default answers – or pick what you prefer:
 
 ```bash
 ? Would you like to use TypeScript? › No
@@ -21,7 +21,7 @@ You’ll get some questions, you can leave all the recommended answer - or pick 
 ? Would you like to customize the default import alias (@/*)? … No
 ```
 
-That should be it! Jump into the folder and start the development server:
+That should be it. Jump into the folder and start the development server:
 
 ```bash
 cd my-awesome-app
@@ -32,7 +32,7 @@ Great! Open <http://localhost:3000> and see the default Next.js homepage. :)
 
 ## Render your OpenAPI reference with Scalar
 
-Ready to add your API reference? Cool, there are a few options to integrate your API reference. The reommended way is to use our Next.js integration for app routing:
+Ready to add your API reference? Cool, there are a few options to integrate your API reference. The recommended way is to use our Next.js integration for app routing:
 
 ```bash
 npm add @scalar/nextjs-api-reference

--- a/documentation/nextjs.md
+++ b/documentation/nextjs.md
@@ -1,0 +1,75 @@
+# Scalar API Reference for Next.js
+
+Next.js enables you to create high-quality web applications with the power of React components. And Scalar enables you to create high-quality API references. What a match, isn’t it?
+
+## Create a new Next.js project (optional)
+
+Sometimes, it’s great to start on a blank slate and set up a new project:
+
+```bash
+npx create-next-app@latest my-awesome-app
+```
+
+You’ll get some questions, you can leave all the recommended answer - or pick what you prefer:
+
+```bash
+? Would you like to use TypeScript? › No
+? Would you like to use ESLint? › No
+? Would you like to use Tailwind CSS? … No
+? Would you like to use `src/` directory? › No
+? Would you like to use App Router? (recommended) › Yes
+? Would you like to customize the default import alias (@/*)? … No
+```
+
+That should be it! Jump into the folder and start the development server:
+
+```bash
+cd my-awesome-app
+npm run dev
+```
+
+Great! Open <http://localhost:3000> and see the default Next.js homepage. :)
+
+## Render your OpenAPI reference with Scalar
+
+Ready to add your API reference? Cool, there are a few options to integrate your API reference. The reommended way is to use our Next.js integration for app routing:
+
+```bash
+npm add @scalar/nextjs-api-reference
+```
+
+… and add a new app route:
+
+```js
+// app/reference/route.js
+import { ApiReference } from '@scalar/nextjs-api-reference'
+
+const config = {
+  spec: {
+    content: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+  },
+}
+
+export const GET = ApiReference(config)
+```
+
+Open <http://localhost:3000/reference> and there it is: Your new API reference. :)
+
+But you can also just use our React integration and add a page route:
+
+```js
+import { ApiReferenceReact } from '@scalar/api-reference-react'
+import '@scalar/api-reference-react/style.css'
+
+export default function References() {
+  return (
+    <ApiReferenceReact
+      configuration={{
+        spec: {
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+        },
+      }}
+    />
+  )
+}
+```

--- a/documentation/nextjs.md
+++ b/documentation/nextjs.md
@@ -55,6 +55,8 @@ export const GET = ApiReference(config)
 
 Open <http://localhost:3000/reference> and there it is: Your new API reference. :)
 
+### Page router
+
 But you can also just use our React integration and add a page route:
 
 ```js

--- a/documentation/nextjs.md
+++ b/documentation/nextjs.md
@@ -37,6 +37,7 @@ Ready to add your API reference? Cool, there are a few options to integrate your
 ```bash
 npm add @scalar/nextjs-api-reference
 ```
+### App router
 
 … and add a new app route:
 


### PR DESCRIPTION
I was testing the Next.js integration today and used the opportunity to write a detailed integration guide.

@amritk I’m not really sure I did a good job describing what to use when, would you mind to check it’s not completely off?