### PR TITLE
fix: standalone always defaults to light mode

### DIFF
--- a/.changeset/hungry-guests-arrive.md
+++ b/.changeset/hungry-guests-arrive.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: standalone always defaults to light mode

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -121,8 +121,6 @@ if (!specUrlElement && !specElement && !specScriptTag) {
     },
   })
 
-  console.log('marc', getConfiguration())
-
   if (getConfiguration().darkMode) {
     document.body?.classList.add('dark-mode')
   } else {

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -121,7 +121,13 @@ if (!specUrlElement && !specElement && !specScriptTag) {
     },
   })
 
-  document.body?.classList.add('light-mode')
+  console.log('marc', getConfiguration())
+
+  if (getConfiguration().darkMode) {
+    document.body?.classList.add('dark-mode')
+  } else {
+    document.body?.classList.add('light-mode')
+  }
 
   // If it’s a script tag, we can’t mount the Vue.js app inside that tag.
   // We need to add a new container div before the script tag.


### PR DESCRIPTION
**Problem**
you could not force initial dark mode

**Explanation**
because lightmode was always added

**Solution**
With this PR we check config on initial set
