### PR TITLE
ci: type check only once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
         run: pnpm format:check
       - name: Build
         run: pnpm turbo build
-      - name: Check types
+      - if: matrix.node-version == 20
+        name: Check types
         run: pnpm turbo types:check
       - name: Run tests
         run: pnpm test:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm format:check
       - name: Build
         run: pnpm turbo build
-      - if: matrix.node-version == 20
+      - if: matrix.node-version == 20 || github.head_ref == 'changeset-release/main'
         name: Check types
         run: pnpm turbo types:check
       - name: Run tests


### PR DESCRIPTION
Some tasks don’t need to be run in Node 18 and 20, I think `types:check` is one of them.

With this PR it’s only executed for Node 20, not for Node 18.

As this takes ~1m it should speed up CI a little bit.