### PR TITLE
fix(docusaurus): doesn’t support (relative) URLs

### DIFF
--- a/.changeset/silly-beds-retire.md
+++ b/.changeset/silly-beds-retire.md
@@ -1,0 +1,5 @@
+---
+'@scalar/docusaurus': patch
+---
+
+feat: add support for relative URLs

--- a/examples/docusaurus/docusaurus.config.ts
+++ b/examples/docusaurus/docusaurus.config.ts
@@ -58,11 +58,63 @@ const config: Config = {
     [
       '@scalar/docusaurus',
       {
-        label: 'Scalar',
-        route: '/scalar',
+        id: 'json-url',
+        label: 'json-url',
+        route: '/json-url',
         configuration: {
           spec: {
             url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+          },
+        },
+      } as ScalarOptions,
+    ],
+    [
+      '@scalar/docusaurus',
+      {
+        id: 'yaml-url',
+        label: 'yaml-url',
+        route: '/yaml-url',
+        configuration: {
+          spec: {
+            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+          },
+        },
+      } as ScalarOptions,
+    ],
+    [
+      '@scalar/docusaurus',
+      {
+        id: 'json-string',
+        label: 'json-string',
+        route: '/json-string',
+        configuration: {
+          spec: {
+            content: `{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Hello World",
+    "version": "1.0.0"
+  },
+  "paths": {}
+}`,
+          },
+        },
+      } as ScalarOptions,
+    ],
+    [
+      '@scalar/docusaurus',
+      {
+        id: 'yaml-string',
+        label: 'yaml-string',
+        route: '/yaml-string',
+        configuration: {
+          spec: {
+            content: `openapi: 3.1.0
+info:
+  title: Hello World
+  version: 1.0.0
+paths: {}
+`,
           },
         },
       } as ScalarOptions,

--- a/packages/docusaurus/src/ScalarDocusaurus.tsx
+++ b/packages/docusaurus/src/ScalarDocusaurus.tsx
@@ -10,17 +10,19 @@ type Props = {
   route: ReferenceProps
 }
 
-export const ScalarDocusaurus = ({ route }: Props) => (
-  <Layout>
-    <BrowserOnly>
-      {() => {
-        const ApiReferenceReact =
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          require('@scalar/api-reference-react').ApiReferenceReact
-        return <ApiReferenceReact configuration={route.configuration} />
-      }}
-    </BrowserOnly>
-  </Layout>
-)
+export const ScalarDocusaurus = ({ route }: Props) => {
+  return (
+    <Layout>
+      <BrowserOnly>
+        {() => {
+          const ApiReferenceReact =
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            require('@scalar/api-reference-react').ApiReferenceReact
+          return <ApiReferenceReact configuration={route.configuration} />
+        }}
+      </BrowserOnly>
+    </Layout>
+  )
+}
 
 export default ScalarDocusaurus

--- a/packages/docusaurus/src/ScalarDocusaurusCommonJS.tsx
+++ b/packages/docusaurus/src/ScalarDocusaurusCommonJS.tsx
@@ -36,24 +36,36 @@ class ScalarDocusaurusCommonJS extends Component<Props> {
           this.props.route.configuration &&
           !document.getElementById('api-reference')
         ) {
-          const { spec, ...config } = this.props.route.configuration
+          const config = this.props.route.configuration
 
-          const apiReferenceScript = document.createElement('script')
-          apiReferenceScript.id = 'api-reference'
-          apiReferenceScript.type = 'application/json'
+          // Execute content function if it exists
+          if (typeof config.spec?.content === 'function') {
+            config.spec.content = config.spec.content()
+          }
 
-          const contentString = spec?.content
-            ? typeof spec.content === 'function'
-              ? JSON.stringify(spec.content())
-              : JSON.stringify(spec.content)
+          // Convert the document to a string
+          const documentString = config?.spec?.content
+            ? typeof config?.spec?.content === 'string'
+              ? config.spec.content
+              : JSON.stringify(config.spec.content)
             : ''
 
+          // Delete content from configuration
+          if (config?.spec?.content) {
+            delete config.spec.content
+          }
+
+          // Convert the configuration to a string
           const configString = JSON.stringify(config ?? {})
             .split('"')
             .join('&quot;')
 
+          // Create and append a script element with the configuration and the content
+          const apiReferenceScript = document.createElement('script')
+          apiReferenceScript.id = 'api-reference'
+          apiReferenceScript.type = 'application/json'
           apiReferenceScript.dataset.configuration = configString
-          apiReferenceScript.innerHTML = contentString
+          apiReferenceScript.innerHTML = documentString
 
           container.appendChild(apiReferenceScript)
 

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -18,15 +18,6 @@ const ScalarDocusaurus = (
     name: '@scalar/docusaurus',
 
     async loadContent() {
-      // Check if we need to download a spec
-      if (options.configuration?.spec?.url) {
-        const resp = await fetch(options.configuration.spec.url)
-        const content = await resp.text()
-        return {
-          configuration: { ...options.configuration, spec: { content } },
-        }
-      }
-
       return options
     },
 


### PR DESCRIPTION
We brought back the CommonJS build for Docusaurus yesterday, but I think we broke URLs.

I’ve refactored the server side function to do the following:
* Execute a callback for the content, if provided
* Delete the `spec.content` attribute from the configuration and add it as content to the script tag (good, because we just use raw JSON/YAML here):
  * strings are just printed as they are
  * objects are JSON.stringified
* The remaining configuration is added as an attribute

Note: With this PR URLs are fetched in the frontend, which adds support for relative URLs (see https://github.com/scalar/scalar/discussions/2171). To fetch the document on the server side, just add your fetch call to the configuration and pass the result as `spec.content`. :)

This PR also comes with examples for the various ways to pass content to Docusaurus.

<img width="1501" alt="Screenshot 2024-06-19 at 14 16 08" src="https://github.com/scalar/scalar/assets/1577992/452b0a07-6e7d-49c8-a4bb-028c1562d6a5">
