### PR TITLE
fix(components): scalar icon ref

### DIFF
--- a/.changeset/sharp-drinks-deny.md
+++ b/.changeset/sharp-drinks-deny.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: shalow ref over ref in scalar icon

--- a/packages/components/src/components/ScalarIcon/ScalarIcon.vue
+++ b/packages/components/src/components/ScalarIcon/ScalarIcon.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { VariantProps } from 'cva'
-import { ref, watch } from 'vue'
+import { ref, shallowRef, watch } from 'vue'
 
 import { cva, cx } from '../../cva'
 import { type Icon, getIcon } from './icons/'
@@ -33,7 +33,7 @@ const iconProps = cva({
   },
 })
 
-const iconComp = ref<SVGElement | null>(null)
+const iconComp = shallowRef<SVGElement | null>(null)
 const isLoading = ref(true)
 
 watch(


### PR DESCRIPTION
this pr favors shallow ref over ref usage in scalar icon component and ensures that only the reference to the icon component is reactive + fix log errors.