### PR TITLE
fix: doesn’t show webhooks when x-tagGroups are used, fix #2172

### DIFF
--- a/.changeset/cyan-knives-add.md
+++ b/.changeset/cyan-knives-add.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: doesn’t show webhooks when x-tagGroups is used

--- a/packages/api-reference/src/hooks/useSidebar.test.ts
+++ b/packages/api-reference/src/hooks/useSidebar.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it } from 'vitest'
+import { toValue } from 'vue'
+
+import { parse } from '../helpers'
+import { useSidebar } from './useSidebar'
+
+/**
+ * Parse the given OpenAPI definition and return the items for the sidebar.
+ */
+async function getItemsForDocument(definition: Record<string, any>) {
+  const parsedSpec = await parse(definition)
+
+  const { items } = useSidebar({
+    parsedSpec,
+  })
+
+  return toValue(items)
+}
+
+describe('useSidebar', async () => {
+  it('doesn’t return any entries for an empty specification', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {},
+      }),
+    ).toStrictEqual({
+      titles: {},
+      entries: [],
+    })
+  })
+
+  it('has a single entry for a single operation', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              operationId: 'helloWorld',
+              summary: 'Hello World',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [{ title: 'Hello World' }],
+    })
+  })
+
+  it('has two entries for a single operation and a webhook', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              operationId: 'helloWorld',
+              summary: 'Hello World',
+            },
+          },
+        },
+        webhooks: {
+          hello: {
+            post: {
+              operationId: 'helloWebhook',
+              summary: 'Hello Webhook',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        { title: 'Hello World' },
+        {
+          title: 'Webhook',
+          children: [
+            {
+              title: 'Hello Webhook',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('has a single entry for a single operation', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              operationId: 'helloWorld',
+              summary: 'Hello World',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [{ title: 'Hello World' }],
+    })
+  })
+
+  it('has a tag', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              operationId: 'helloWorld',
+              summary: 'Hello World',
+              tags: ['Foobar'],
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('has multiple tags', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              operationId: 'helloWorld',
+              summary: 'Hello World',
+              tags: ['Foobar', 'Barfoo'],
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+        {
+          title: 'Barfoo',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('adds to existing tags', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        tags: [
+          {
+            name: 'Foobar',
+            description: 'Foobar',
+          },
+        ],
+        paths: {
+          '/hello': {
+            get: {
+              operationId: 'helloWorld',
+              summary: 'Hello World',
+              tags: ['Foobar'],
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('creates a default tag', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        tags: [
+          {
+            name: 'Foobar',
+            description: 'Foobar',
+          },
+        ],
+        paths: {
+          '/hello': {
+            get: {
+              operationId: 'getHelloWorld',
+              summary: 'Get Hello World',
+              tags: ['foobar'],
+            },
+            post: {
+              operationId: 'postHelloWorld',
+              summary: 'Post Hello World',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'foobar',
+          children: [
+            {
+              title: 'Get Hello World',
+            },
+          ],
+        },
+        {
+          title: 'default',
+          children: [
+            {
+              title: 'Post Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('groups tags by x-tagGroups', async () => {
+    expect(
+      await getItemsForDocument({
+        'openapi': '3.1.0',
+        'info': {
+          title: 'Example',
+          version: '1.0',
+        },
+        'tags': [
+          {
+            name: 'planets',
+          },
+        ],
+        'x-tagGroups': [
+          {
+            name: 'galaxy',
+            tags: ['planets'],
+          },
+        ],
+        'paths': {
+          '/planets': {
+            get: {
+              summary: 'Get all planets',
+              tags: ['planets'],
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'galaxy',
+          children: [
+            {
+              title: 'planets',
+              children: [
+                {
+                  title: 'Get all planets',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it.todo('groups tags by x-tagGroups and shows webhooks', async () => {
+    expect(
+      await getItemsForDocument({
+        'openapi': '3.1.0',
+        'info': {
+          title: 'Example',
+          version: '1.0',
+        },
+        'tags': [
+          {
+            name: 'planets',
+          },
+        ],
+        'x-tagGroups': [
+          {
+            name: 'galaxy',
+            tags: ['planets'],
+          },
+        ],
+        'paths': {
+          '/planets': {
+            get: {
+              summary: 'Get all planets',
+              tags: ['planets'],
+            },
+          },
+        },
+        'webhooks': {
+          hello: {
+            post: {
+              operationId: 'helloWebhook',
+              summary: 'Hello Webhook',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'galaxy',
+          children: [
+            {
+              title: 'planets',
+              children: [
+                {
+                  title: 'Get all planets',
+                },
+              ],
+            },
+          ],
+        },
+
+        {
+          title: 'Webhook',
+          children: [
+            {
+              title: 'Hello Webhook',
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/packages/api-reference/src/hooks/useSidebar.test.ts
+++ b/packages/api-reference/src/hooks/useSidebar.test.ts
@@ -45,7 +45,6 @@ describe('useSidebar', async () => {
         paths: {
           '/hello': {
             get: {
-              operationId: 'helloWorld',
               summary: 'Hello World',
             },
           },
@@ -67,7 +66,6 @@ describe('useSidebar', async () => {
         paths: {
           '/hello': {
             get: {
-              operationId: 'helloWorld',
               summary: 'Hello World',
             },
           },
@@ -75,7 +73,6 @@ describe('useSidebar', async () => {
         webhooks: {
           hello: {
             post: {
-              operationId: 'helloWebhook',
               summary: 'Hello Webhook',
             },
           },
@@ -107,7 +104,6 @@ describe('useSidebar', async () => {
         paths: {
           '/hello': {
             get: {
-              operationId: 'helloWorld',
               summary: 'Hello World',
             },
           },
@@ -129,7 +125,6 @@ describe('useSidebar', async () => {
         paths: {
           '/hello': {
             get: {
-              operationId: 'helloWorld',
               summary: 'Hello World',
               tags: ['Foobar'],
             },
@@ -161,7 +156,6 @@ describe('useSidebar', async () => {
         paths: {
           '/hello': {
             get: {
-              operationId: 'helloWorld',
               summary: 'Hello World',
               tags: ['Foobar', 'Barfoo'],
             },
@@ -207,7 +201,6 @@ describe('useSidebar', async () => {
         paths: {
           '/hello': {
             get: {
-              operationId: 'helloWorld',
               summary: 'Hello World',
               tags: ['Foobar'],
             },
@@ -245,12 +238,10 @@ describe('useSidebar', async () => {
         paths: {
           '/hello': {
             get: {
-              operationId: 'getHelloWorld',
               summary: 'Get Hello World',
               tags: ['foobar'],
             },
             post: {
-              operationId: 'postHelloWorld',
               summary: 'Post Hello World',
             },
           },
@@ -325,7 +316,7 @@ describe('useSidebar', async () => {
     })
   })
 
-  it.todo('groups tags by x-tagGroups and shows webhooks', async () => {
+  it('groups tags by x-tagGroups and shows default webhook group', async () => {
     expect(
       await getItemsForDocument({
         'openapi': '3.1.0',
@@ -355,7 +346,7 @@ describe('useSidebar', async () => {
         'webhooks': {
           hello: {
             post: {
-              operationId: 'helloWebhook',
+              tags: ['planets'],
               summary: 'Hello Webhook',
             },
           },
@@ -376,12 +367,73 @@ describe('useSidebar', async () => {
             },
           ],
         },
-
         {
           title: 'Webhook',
           children: [
             {
               title: 'Hello Webhook',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('groups tags by x-tagGroups and adds the webhooks to one group', async () => {
+    expect(
+      await getItemsForDocument({
+        'openapi': '3.1.0',
+        'info': {
+          title: 'Example',
+          version: '1.0',
+        },
+        'tags': [
+          {
+            name: 'planets',
+          },
+        ],
+        'x-tagGroups': [
+          {
+            name: 'galaxy',
+            tags: ['planets', 'webhooks'],
+          },
+        ],
+        'paths': {
+          '/planets': {
+            get: {
+              summary: 'Get all planets',
+              tags: ['planets'],
+            },
+          },
+        },
+        'webhooks': {
+          hello: {
+            post: {
+              summary: 'Hello Webhook',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'galaxy',
+          children: [
+            {
+              title: 'planets',
+              children: [
+                {
+                  title: 'Get all planets',
+                },
+              ],
+            },
+            {
+              title: 'Webhook',
+              children: [
+                {
+                  title: 'Hello Webhook',
+                },
+              ],
             },
           ],
         },

--- a/packages/api-reference/src/hooks/useSidebar.test.ts
+++ b/packages/api-reference/src/hooks/useSidebar.test.ts
@@ -379,7 +379,7 @@ describe('useSidebar', async () => {
     })
   })
 
-  it('groups tags by x-tagGroups and adds the webhooks to one group', async () => {
+  it('groups tags by x-tagGroups and adds the webhooks to the tag group', async () => {
     expect(
       await getItemsForDocument({
         'openapi': '3.1.0',
@@ -434,6 +434,68 @@ describe('useSidebar', async () => {
                   title: 'Hello Webhook',
                 },
               ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('groups tags by x-tagGroups and keeps the webhook default entry', async () => {
+    expect(
+      await getItemsForDocument({
+        'openapi': '3.1.0',
+        'info': {
+          title: 'Example',
+          version: '1.0',
+        },
+        'tags': [
+          {
+            name: 'planets',
+          },
+        ],
+        'x-tagGroups': [
+          {
+            name: 'galaxy',
+            tags: ['planets'],
+          },
+        ],
+        'paths': {
+          '/planets': {
+            get: {
+              summary: 'Get all planets',
+              tags: ['planets'],
+            },
+          },
+        },
+        'webhooks': {
+          hello: {
+            post: {
+              summary: 'Hello Webhook',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'galaxy',
+          children: [
+            {
+              title: 'planets',
+              children: [
+                {
+                  title: 'Get all planets',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          title: 'Webhook',
+          children: [
+            {
+              title: 'Hello Webhook',
             },
           ],
         },


### PR DESCRIPTION
If x-tagGroups are used, the webhooks don’t show up anymore. See #2172 for more context.

This PR adds test for `useSidebar` (finally!) and fixes the bug.

**Example Definition**
https://gist.githubusercontent.com/hkosova/e1b6ce4d72a3ec722ad4802d77f7e3e4/raw/fa790231d345af0c4779b01f6e81a7937a229030/webhooks-tag-groups.json