### PR TITLE
fix: bring back request history for client app

### DIFF
--- a/packages/client-app/src/components/AddressBar/AddressBar.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBar.vue
@@ -16,8 +16,7 @@ import { useMagicKeys, whenever } from '@vueuse/core'
 import { computed, ref } from 'vue'
 
 import HttpMethod from '../HttpMethod/HttpMethod.vue'
-
-// import AddressBarHistory from './AddressBarHistory.vue'
+import AddressBarHistory from './AddressBarHistory.vue'
 
 const {
   activeRequest,
@@ -260,8 +259,7 @@ const handlePaste = (event: ClipboardEvent) => {
             <div class="fade-right"></div>
           </div>
 
-          <!-- commenting out history for now -->
-          <!-- <AddressBarHistory :open="open" /> -->
+          <AddressBarHistory :open="open" />
           <ScalarButton
             class="relative h-auto shrink-0 gap-1.5 overflow-hidden px-2.5 py-1"
             @click="executeRequestBus.emit()">

--- a/packages/client-app/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBarHistory.vue
@@ -105,6 +105,7 @@ function handleHistoryClick(index: number) {
             {{ httpStatusCodes[response.status]?.name }}
           </span>
           <HttpMethod
+            v-if="response.config.method"
             class="lg:text-sm text-xs"
             :method="response.config.method" />
         </div>

--- a/packages/client-app/src/store/workspace.ts
+++ b/packages/client-app/src/store/workspace.ts
@@ -27,6 +27,7 @@ import {
 } from '@scalar/oas-utils/entities/workspace/server'
 import {
   type Request,
+  type RequestEvent,
   type RequestExample,
   type RequestPayload,
   createRequest,
@@ -277,7 +278,7 @@ const activeExample = computed(
 // ---------------------------------------------------------------------------
 // REQUEST HISTORY
 
-const requestsHistory = computed(() => {
+const requestsHistory = computed<RequestEvent[]>(() => {
   return Object.values(requests).flatMap((request) => request.history)
 })
 

--- a/packages/object-utils/src/mutator-record/handlers.ts
+++ b/packages/object-utils/src/mutator-record/handlers.ts
@@ -31,6 +31,11 @@ export function mutationFactory<
       delete entityMap[uid]
       delete mutationMap[uid]
     },
+    /** Destructive, overwrites a record to a new item and creates a new mutation tracking instance */
+    set: (item: T) => {
+      entityMap[item.uid] = item
+      mutationMap[item.uid] = new Mutation(item, maxNumberRecords)
+    },
     /** Update a nested property and track the mutation */
     edit: <P extends Path<T>>(uid: string, path: P, value: PathValue<T, P>) => {
       const mutator = getMutator(uid)


### PR DESCRIPTION
I think we can make this better... but here for feedback!

some ideas:

- [ ] we move the request history off of activeRequest for storing responses and link it to each example
- [ ] do we replace the example or enter a sort of draft state (replace response + request)

we can also think about this post modal integration

https://github.com/scalar/scalar/assets/6176314/6e77a32f-35db-4cca-980e-790befb9fdf9

