### PR TITLE
fix(client-app): teleport fixtures

### DIFF
--- a/.changeset/sixty-dots-do.md
+++ b/.changeset/sixty-dots-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: scalar-client in scalar floating component

--- a/packages/client-app/src/components/AddressBar/AddressBar.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBar.vue
@@ -191,6 +191,7 @@ const handlePaste = (event: ClipboardEvent) => {
               ">
               <ScalarDropdown
                 :options="serverOptions"
+                teleport
                 :value="activeCollection?.selectedServerUid">
                 <button
                   class="font-code lg:text-sm text-xs whitespace-nowrap border border-b-3 border-solid rounded px-1.5 text-c-2"

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -76,7 +76,7 @@ const { floatingStyles, middlewareData } = useFloating(targetRef, floatingRef, {
     v-if="isOpen"
     :disabled="!teleport"
     to="body">
-    <div class="scalar-app">
+    <div class="scalar-app scalar-client">
       <div
         ref="floatingRef"
         class="relative z-overlay"


### PR DESCRIPTION
this pr fixes broken styles in teleported components as seen below:

<img width="687" alt="image" src="https://github.com/scalar/scalar/assets/14966155/e6984223-d0f6-44d7-85fe-0d6af16ed189">
