### PR TITLE
ci(update-contributors): add a comment about the token

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -15,4 +15,7 @@ jobs:
         with:
           use_username: true
         env:
+          # https://github.com/settings/tokens/new
+          # Expiration: No expiration
+          # Select: read:org
           GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
I just saw that our update-contributors workflow is broken for a while:

> Request failed due to following response errors:
> - Your token has not been granted the required scopes to execute this query. The 'name' field requires one of the following scopes: ['read:org'], but your token has only been granted the: ['repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.

I just created a new token and added a comment to the workflow for future us.