### PR TITLE
fix(client-app): add data table cell checkbox style back

### DIFF
--- a/packages/client-app/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/client-app/src/views/Request/RequestSection/RequestBody.vue
@@ -371,7 +371,7 @@ watch(
             <RequestTable
               ref="tableWrapperRef"
               class="!m-0 rounded-t-none border-1/2 border-t-0 shadow-none"
-              :columns="['36px', '', '', '0.7fr']"
+              :columns="['32px', '', '', '0.7fr']"
               :items="formParams"
               showUploadButton
               @addRow="addRow"
@@ -384,7 +384,7 @@ watch(
             <RequestTable
               ref="tableWrapperRef"
               class="!m-0 rounded-t-none border-1/2 border-t-0 shadow-none"
-              :columns="['36px', '', '', '0.7fr']"
+              :columns="['32px', '', '', '0.7fr']"
               :items="formParams"
               showUploadButton
               @addRow="addRow"

--- a/packages/client-app/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/client-app/src/views/Request/RequestSection/RequestParams.vue
@@ -157,7 +157,7 @@ watch(
     <div ref="tableWrapperRef">
       <RequestTable
         class="flex-1"
-        :columns="['36px', '', '']"
+        :columns="['32px', '', '']"
         :items="params"
         @addRow="addRow"
         @toggleRow="toggleRow"


### PR DESCRIPTION
this pr adds back the checkbox style on data table cell component for the client app:

<img width="1284" alt="image" src="https://github.com/scalar/scalar/assets/14966155/511a2300-9fda-49fa-9efb-2167a836145d">
