### PR TITLE
fix(client-app): update input outline style

### DIFF
--- a/packages/client-app/src/components/ActionModal/ActionModalRequest.vue
+++ b/packages/client-app/src/components/ActionModal/ActionModalRequest.vue
@@ -82,6 +82,7 @@ function handleSubmit() {
         @change="handleChangeMethod" />
       <input
         v-model="requestName"
+        class="border-transparent outline-none w-full"
         label="Request Name"
         placeholder="Request Name" />
     </div>

--- a/packages/client-app/src/components/AddressBar/AddressBar.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBar.vue
@@ -250,7 +250,7 @@ const handlePaste = (event: ClipboardEvent) => {
 
             <!-- TODO wrap vars in spans for special effects like mouseOver descriptions -->
             <div
-              class="scroll-timeline-x-address font-code text-c-1 flex flex-1 items-center whitespace-nowrap lg:text-sm text-xs font-medium leading-[24.5px]"
+              class="scroll-timeline-x-address font-code text-c-1 flex flex-1 items-center whitespace-nowrap lg:text-sm text-xs font-medium leading-[24.5px] outline-none"
               :contenteditable="!workspace.isReadOnly"
               @input="(ev) => onUrlChange((ev.target as HTMLElement).innerText)"
               @keydown.enter.prevent="executeRequestBus.emit()"


### PR DESCRIPTION
this pr fixes some outline in the client-app package.

<img width="578" alt="image" src="https://github.com/scalar/scalar/assets/14966155/6ddaf625-a6e5-4b08-98cc-820197374e19">
