### PR TITLE
feat: new `@scalar/void-server`

### DIFF
--- a/.changeset/fuzzy-bags-smile.md
+++ b/.changeset/fuzzy-bags-smile.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': major
+---
+
+init

--- a/examples/cdn-api-reference/package.json
+++ b/examples/cdn-api-reference/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.8.4",
-    "nodemon": "^3.0.1",
+    "nodemon": "^3.1.3",
     "typescript": "^5.4.3",
     "vite": "^5.2.10",
     "vite-node": "^1.3.1"

--- a/examples/echo-server/package.json
+++ b/examples/echo-server/package.json
@@ -18,7 +18,7 @@
     "dotenv": "^16.3.1"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1",
+    "nodemon": "^3.1.3",
     "vite": "^5.2.10",
     "vite-node": "^1.3.1"
   }

--- a/examples/express-api-reference/package.json
+++ b/examples/express-api-reference/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/swagger-jsdoc": "^6.0.3",
-    "nodemon": "^3.0.1",
+    "nodemon": "^3.1.3",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",
     "vite-node": "^1.3.1"

--- a/examples/fastify-api-reference/package.json
+++ b/examples/fastify-api-reference/package.json
@@ -22,7 +22,7 @@
     "fastify": "^4.26.2"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1",
+    "nodemon": "^3.1.3",
     "tsc-alias": "^1.8.8",
     "typescript": "^5.4.3",
     "vite": "^5.2.10",

--- a/examples/hono-api-reference/package.json
+++ b/examples/hono-api-reference/package.json
@@ -22,7 +22,7 @@
     "hono": "^4.2.7"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1",
+    "nodemon": "^3.1.3",
     "tsc-alias": "^1.8.8",
     "vite": "^5.2.10",
     "vite-node": "^1.3.1"

--- a/packages/api-client-proxy/package.json
+++ b/packages/api-client-proxy/package.json
@@ -49,7 +49,7 @@
     "@types/express": "^4.17.21",
     "@types/node": "^20.8.4",
     "@vitest/coverage-v8": "^1.6.0",
-    "nodemon": "^3.0.1",
+    "nodemon": "^3.1.3",
     "tsc-alias": "^1.8.8",
     "typescript": "^5.4.3",
     "vite": "^5.2.10",

--- a/packages/echo-server/package.json
+++ b/packages/echo-server/package.json
@@ -49,7 +49,7 @@
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.21",
     "@vitest/coverage-v8": "^1.6.0",
-    "nodemon": "^3.0.1",
+    "nodemon": "^3.1.3",
     "tsc-alias": "^1.8.8",
     "typescript": "^5.4.3",
     "vite": "^5.2.10",

--- a/packages/void-server/README.md
+++ b/packages/void-server/README.md
@@ -1,0 +1,43 @@
+# Scalar Void Server
+
+[![Version](https://img.shields.io/npm/v/%40scalar/void-server)](https://www.npmjs.com/package/@scalar/void-server)
+[![Downloads](https://img.shields.io/npm/dm/%40scalar/void-server)](https://www.npmjs.com/package/@scalar/void-server)
+[![License](https://img.shields.io/npm/l/%40scalar%2Fvoid-server)](https://www.npmjs.com/package/@scalar/void-server)
+[![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
+
+An Hono server that responds with the request data. Kind of a mirror for HTTP requests.
+
+## Installation
+
+```
+npm add @scalar/void-server
+```
+
+## Usage
+
+```ts
+import { serve } from '@hono/node-server'
+import { createVoidServer } from '@scalar/void-server'
+
+// Create the server instance
+const app = await createVoidServer()
+
+// Start the server
+serve(
+  {
+    fetch: app.fetch,
+    port: 3000,
+  },
+  (info) => {
+    console.log(`Listening on http://localhost:${info.port}`)
+  },
+)
+```
+
+## Community
+
+We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/scalar>
+
+## License
+
+The source code in this repository is licensed under [MIT](https://github.com/scalar/void/blob/main/LICENSE).

--- a/packages/void-server/example/index.ts
+++ b/packages/void-server/example/index.ts
@@ -1,0 +1,21 @@
+import { serve } from '@hono/node-server'
+
+import { createVoidServer } from '../src/createVoidServer'
+
+const port = process.env.PORT || 5052
+
+// Create the server instance
+const app = await createVoidServer()
+
+// Start the server
+serve(
+  {
+    fetch: app.fetch,
+    port: Number(port),
+  },
+  (info) => {
+    console.log()
+    console.log(`Listening on http://localhost:${info.port}`)
+    console.log()
+  },
+)

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@scalar/void-server",
+  "description": "Mirror for HTTP requests",
+  "license": "MIT",
+  "author": "Scalar (https://github.com/scalar)",
+  "homepage": "https://github.com/scalar/scalar",
+  "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/void"
+  },
+  "keywords": [
+    "scalar",
+    "http testing",
+    "hono"
+  ],
+  "version": "1.0.0",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "rm -Rf dist/ && rollup -c",
+    "dev": "nodemon --exec \"vite-node example/index.ts\" --ext ts --quiet",
+    "test": "vitest",
+    "types:check": "tsc --noEmit --skipLibCheck"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.js"
+  },
+  "files": [
+    "./dist",
+    "CHANGELOG.md"
+  ],
+  "module": "dist/index.js",
+  "dependencies": {
+    "@hono/node-server": "^1.11.0",
+    "hono": "^4.2.7"
+  },
+  "devDependencies": {
+    "@scalar/build-tooling": "workspace:*",
+    "esbuild": "^0.21.1",
+    "nodemon": "^3.1.3",
+    "rollup": "^4.16.4",
+    "rollup-plugin-delete": "^2.0.0",
+    "rollup-plugin-dts": "^6.1.0",
+    "rollup-plugin-esbuild": "^6.1.1",
+    "tslib": "^2.6.2",
+    "typescript": "^5.4.3"
+  }
+}

--- a/packages/void-server/rollup.config.js
+++ b/packages/void-server/rollup.config.js
@@ -1,0 +1,41 @@
+import del from 'rollup-plugin-delete'
+import dts from 'rollup-plugin-dts'
+import esbuild from 'rollup-plugin-esbuild'
+
+const bundle = (config) => ({
+  ...config,
+  input: 'src/index.ts',
+  external: (id) => !/^[./]/.test(id),
+})
+
+export default [
+  bundle({
+    plugins: [esbuild()],
+    output: [
+      // ESM
+      {
+        file: `dist/index.js`,
+        format: 'es',
+        sourcemap: true,
+      },
+      // CommonJS
+      {
+        file: `dist/index.cjs`,
+        format: 'cjs',
+        sourcemap: true,
+      },
+    ],
+  }),
+  bundle({
+    plugins: [
+      dts(),
+      del({
+        targets: ['dist/tests', 'dist/**/*.test.*'],
+      }),
+    ],
+    output: {
+      file: `dist/index.d.ts`,
+      format: 'es',
+    },
+  }),
+]

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+
+import { createVoidServer } from './createVoidServer'
+
+describe('createVoidServer', () => {
+  it('GET /foobar', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      path: '/foobar',
+    })
+  })
+
+  it('GET /', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      path: '/',
+    })
+  })
+
+  it('returns the headers', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/', {
+      headers: {
+        'X-Custom-Header': 'foobar',
+      },
+    })
+
+    expect(await response.json()).toMatchObject({
+      headers: {
+        'x-custom-header': 'foobar',
+      },
+    })
+  })
+
+  it('returns the method', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/')
+
+    expect(await response.json()).toMatchObject({
+      method: 'GET',
+    })
+  })
+
+  it('returns the query parameters', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/?foo=bar')
+
+    expect(await response.json()).toMatchObject({
+      query: {
+        foo: 'bar',
+      },
+    })
+  })
+
+  it('returns the JSON body', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+      body: JSON.stringify({
+        foo: 'bar',
+      }),
+    })
+
+    expect((await response.json()).body).toMatchObject({
+      foo: 'bar',
+    })
+  })
+
+  it('returns plain text body', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: 'foobar',
+    })
+
+    expect((await response.json()).body).toBe('foobar')
+  })
+
+  it('returns the cookies', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/', {
+      method: 'POST',
+      headers: {
+        cookie: 'foo=bar;',
+      },
+      credentials: 'include',
+    })
+
+    expect((await response.json()).cookies).toMatchObject({
+      foo: 'bar',
+    })
+  })
+
+  it('returns 404', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/404')
+
+    expect(response.status).toBe(404)
+    expect(await response.text()).toBe('Not Found')
+  })
+
+  it('returns the authentication header bearer', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/', {
+      headers: {
+        Authorization: 'Bearer 123',
+      },
+    })
+
+    expect(await response.json()).toMatchObject({
+      authentication: {
+        type: 'http.bearer',
+        token: '123',
+      },
+    })
+  })
+
+  it('returns the authentication header basic', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/', {
+      headers: {
+        Authorization: 'Basic YmFy',
+      },
+    })
+
+    expect(await response.json()).toMatchObject({
+      authentication: {
+        type: 'http.basic',
+        token: 'YmFy',
+        value: 'bar',
+      },
+    })
+  })
+})

--- a/packages/void-server/src/createVoidServer.ts
+++ b/packages/void-server/src/createVoidServer.ts
@@ -1,0 +1,107 @@
+import { type Context, Hono } from 'hono'
+import { getCookie } from 'hono/cookie'
+import { cors } from 'hono/cors'
+
+/**
+ * Create a mock server instance
+ */
+export async function createVoidServer(options?: {
+  //
+}) {
+  const app = new Hono()
+
+  // CORS headers
+  app.use(cors())
+
+  // 404
+  app.all('/404', async (c: Context) => {
+    console.info(`${c.req.method} ${c.req.path}`)
+
+    c.status(404)
+
+    return c.text('Not Found')
+  })
+
+  // Return zip files for all requests ending with .zip
+  app.all('/:filename{.+\\.zip$}', async (c: Context) => {
+    console.info(`${c.req.method} ${c.req.path}`)
+
+    const blob = new Blob(
+      [
+        new Uint8Array([
+          80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]).buffer,
+      ],
+      {
+        type: 'application/zip',
+      },
+    )
+
+    c.header('Content-Type', 'application/zip')
+    return c.body(blob.toString())
+  })
+
+  // All other requests just respond with a JSON containing all the request data
+  app.all('/*', async (c: Context) => {
+    console.info(`${c.req.method} ${c.req.path}`)
+
+    let authentication = {}
+
+    const authorizationHeader = c.req.header('Authorization')
+
+    if (authorizationHeader) {
+      // if value starts with "Basic "
+      if (authorizationHeader.startsWith('Basic ')) {
+        const token = authorizationHeader.split(' ')[1]
+
+        authentication = {
+          authentication: {
+            type: 'http.basic',
+            token,
+            value: atob(token),
+          },
+        }
+      }
+
+      if (authorizationHeader.startsWith('Bearer ')) {
+        const token = authorizationHeader.split(' ')[1]
+
+        authentication = {
+          authentication: {
+            type: 'http.bearer',
+            token,
+          },
+        }
+      }
+    }
+
+    const headers = Object.fromEntries(c.req.raw.headers)
+
+    const body = await getBody(c)
+
+    const cookies = getCookie(c)
+
+    return c.json({
+      headers,
+      ...authentication,
+      cookies,
+      method: c.req.method,
+      path: c.req.path,
+      query: c.req.query(),
+      body: body,
+    })
+  })
+
+  return app
+}
+
+async function getBody(c: Context) {
+  const body = await c.req.text()
+
+  // Try to parse the body as JSON
+  try {
+    return JSON.parse(body)
+  } catch {
+    return body
+  }
+}

--- a/packages/void-server/src/index.ts
+++ b/packages/void-server/src/index.ts
@@ -1,0 +1,1 @@
+export * from './createVoidServer'

--- a/packages/void-server/tsconfig.build.json
+++ b/packages/void-server/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "package.json"],
+  "exclude": [
+    "dist",
+    "test",
+    "vite.config.ts",
+    "**/*.test.ts",
+    "**/*.test.json",
+    "**/*.test.md"
+  ],
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/"
+  }
+}

--- a/packages/void-server/tsconfig.json
+++ b/packages/void-server/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ importers:
         specifier: ^20.8.4
         version: 20.14.2
       nodemon:
-        specifier: ^3.0.1
+        specifier: ^3.1.3
         version: 3.1.3
       typescript:
         specifier: ^5.4.3
@@ -162,7 +162,7 @@ importers:
         version: 16.4.5
     devDependencies:
       nodemon:
-        specifier: ^3.0.1
+        specifier: ^3.1.3
         version: 3.1.3
       vite:
         specifier: ^5.2.10
@@ -206,7 +206,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.4
       nodemon:
-        specifier: ^3.0.1
+        specifier: ^3.1.3
         version: 3.1.3
       tsc-alias:
         specifier: ^1.8.8
@@ -231,7 +231,7 @@ importers:
         version: 4.28.0
     devDependencies:
       nodemon:
-        specifier: ^3.0.1
+        specifier: ^3.1.3
         version: 3.1.3
       tsc-alias:
         specifier: ^1.8.8
@@ -262,7 +262,7 @@ importers:
         version: 4.4.6
     devDependencies:
       nodemon:
-        specifier: ^3.0.1
+        specifier: ^3.1.3
         version: 3.1.3
       tsc-alias:
         specifier: ^1.8.8
@@ -793,7 +793,7 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(vitest@1.6.0(@types/node@20.14.2)(jsdom@24.1.0)(terser@5.31.1))
       nodemon:
-        specifier: ^3.0.1
+        specifier: ^3.1.3
         version: 3.1.3
       tsc-alias:
         specifier: ^1.8.8
@@ -1545,7 +1545,7 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(vitest@1.6.0(@types/node@20.14.2)(jsdom@24.1.0)(terser@5.31.1))
       nodemon:
-        specifier: ^3.0.1
+        specifier: ^3.1.3
         version: 3.1.3
       tsc-alias:
         specifier: ^1.8.8
@@ -2120,6 +2120,43 @@ importers:
       vue-tsc:
         specifier: ^2.0.13
         version: 2.0.21(typescript@5.4.5)
+
+  packages/void-server:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.11.0
+        version: 1.11.3
+      hono:
+        specifier: ^4.2.7
+        version: 4.4.6
+    devDependencies:
+      '@scalar/build-tooling':
+        specifier: workspace:*
+        version: link:../build-tooling
+      esbuild:
+        specifier: ^0.21.1
+        version: 0.21.5
+      nodemon:
+        specifier: ^3.1.3
+        version: 3.1.3
+      rollup:
+        specifier: ^4.16.4
+        version: 4.18.0
+      rollup-plugin-delete:
+        specifier: ^2.0.0
+        version: 2.0.0
+      rollup-plugin-dts:
+        specifier: ^6.1.0
+        version: 6.1.1(rollup@4.18.0)(typescript@5.4.5)
+      rollup-plugin-esbuild:
+        specifier: ^6.1.1
+        version: 6.1.1(esbuild@0.21.5)(rollup@4.18.0)
+      tslib:
+        specifier: ^2.6.2
+        version: 2.6.3
+      typescript:
+        specifier: ^5.4.3
+        version: 5.4.5
 
   playwright:
     devDependencies:


### PR DESCRIPTION
Hey, this PR comes with a rewrite of `@scalar/echo-server` under a new name.

`@scalar/void-server` is a HTTP request mirror. Whatever request you send, it’ll reply with all the request data. This is so, so great for testing the API client. :)

**New**

* Works with Hono, instead of Express
* New Name (will be released as `@scalar/void-server@2.0` and we’ll deprecate `@scalar/echo-server@1.x`)
* The example is in the package folder

**Special routes**

* /404 returns an error
* *.zip returns a Zip file

**Example response**

```json
{
  "headers": {
    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
    "accept-encoding": "gzip, deflate, br, zstd",
    "accept-language": "en-DE,en;q=0.9,de-DE;q=0.8,de;q=0.7,en-GB;q=0.6,en-US;q=0.5",
    "connection": "keep-alive",
    "dnt": "1",
    "host": "localhost:5052",
    "if-none-match": "W/\"2f4-KNqBSDacTTmD0cJwYm7CgTrB+UE\"",
    "sec-ch-ua": "\"Not/A)Brand\";v=\"8\", \"Chromium\";v=\"126\", \"Google Chrome\";v=\"126\"",
    "sec-ch-ua-mobile": "?0",
    "sec-ch-ua-platform": "\"macOS\"",
    "sec-fetch-dest": "document",
    "sec-fetch-mode": "navigate",
    "sec-fetch-site": "none",
    "sec-fetch-user": "?1",
    "upgrade-insecure-requests": "1",
    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
  },
  "cookies": {},
  "method": "GET",
  "path": "[/](http://localhost:5052/)",
  "query": {},
  "body": ""
}
```

