### PR TITLE
feat: allow custom header & footers

### DIFF
--- a/.changeset/honest-geese-chew.md
+++ b/.changeset/honest-geese-chew.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/client-app': patch
+'@scalar/docusaurus': patch
+---
+
+feat: allow custom headers

--- a/examples/web/src/pages/EmbeddedApiReferencePage.vue
+++ b/examples/web/src/pages/EmbeddedApiReferencePage.vue
@@ -38,7 +38,7 @@ const configuration = reactive<ReferenceConfiguration>({
 }
 .container {
   flex: 1;
-  overflow: hidden;
+  overflow: auto;
   border: 1px solid #000;
   border-radius: 3px;
 }

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -80,6 +80,7 @@ const documentEl = ref<HTMLElement | null>(null)
 useResizeObserver(documentEl, (entries) => {
   elementHeight.value = entries[0].contentRect.height + 'px'
 })
+// Find scalar Y offset to support users who have tried to add their own headers
 const yPosition = ref(0)
 onMounted(() => {
   const pbcr = documentEl.value?.parentElement?.getBoundingClientRect()

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -80,6 +80,15 @@ const documentEl = ref<HTMLElement | null>(null)
 useResizeObserver(documentEl, (entries) => {
   elementHeight.value = entries[0].contentRect.height + 'px'
 })
+const yPosition = ref(0)
+onMounted(() => {
+  const pbcr = documentEl.value?.parentElement?.getBoundingClientRect()
+  const bcr = documentEl.value?.getBoundingClientRect()
+  if (pbcr && bcr) {
+    const difference = bcr.top - pbcr.top
+    yPosition.value = difference < 2 ? 0 : difference
+  }
+})
 
 const {
   breadcrumb,
@@ -265,7 +274,9 @@ useDeprecationWarnings(props.configuration)
       },
       $attrs.class,
     ]"
-    :style="{ '--full-height': elementHeight }"
+    :style="{
+      '--scalar-y-offset': `var(--scalar-custom-header-height, ${yPosition}px)`,
+    }"
     @scroll.passive="debouncedScroll">
     <!-- Header -->
     <div class="references-header">
@@ -378,7 +389,9 @@ useDeprecationWarnings(props.configuration)
 @layer scalar-config {
   .scalar-api-reference {
     --refs-sidebar-width: var(--scalar-sidebar-width, 0px);
-    --refs-header-height: var(--scalar-header-height, 0px);
+    --refs-header-height: calc(
+      var(--scalar-y-offset) + var(--scalar-header-height, 0px)
+    );
     --refs-content-max-width: var(--scalar-content-max-width, 1540px);
   }
 
@@ -394,16 +407,10 @@ useDeprecationWarnings(props.configuration)
 /* References Layout */
 .references-layout {
   /* Try to fill the container */
-  height: 100dvh;
-  max-height: 100%;
-  width: 100dvw;
+  min-height: 100dvh;
+  min-width: 100%;
   max-width: 100%;
   flex: 1;
-
-  /* Scroll vertically */
-  overflow-y: auto;
-  overflow-x: hidden;
-  scrollbar-gutter: stable;
 
   /*
   Calculated by a resize observer and set in the style attribute
@@ -413,7 +420,7 @@ useDeprecationWarnings(props.configuration)
 
   /* Grid layout */
   display: grid;
-  grid-template-rows: var(--refs-header-height) repeat(2, auto);
+  grid-template-rows: var(--scalar-header-height, 0px) repeat(2, auto);
   grid-template-columns: var(--refs-sidebar-width) 1fr;
   grid-template-areas:
     'header header'
@@ -426,10 +433,10 @@ useDeprecationWarnings(props.configuration)
 .references-header {
   grid-area: header;
   position: sticky;
-  top: 0;
+  top: var(--scalar-custom-header-height, 0px);
   z-index: 10;
 
-  height: var(--refs-header-height);
+  height: var(--scalar-header-height, 0px);
 }
 
 .references-editor {
@@ -459,7 +466,7 @@ useDeprecationWarnings(props.configuration)
 .references-navigation-list {
   position: sticky;
   top: var(--refs-header-height);
-  height: calc(var(--full-height) - var(--refs-header-height));
+  height: calc(100dvh - var(--refs-header-height));
   background: var(--scalar-sidebar-background-1 var(--scalar-background-1));
   overflow-y: auto;
   display: flex;
@@ -509,16 +516,13 @@ useDeprecationWarnings(props.configuration)
   /* Stack view on mobile */
   .references-layout {
     grid-template-columns: auto;
-    grid-template-rows: var(--refs-header-height) 0px auto auto;
+    grid-template-rows: var(--scalar-header-height, 0px) 0px auto auto;
 
     grid-template-areas:
       'header'
       'navigation'
       'rendered'
       'footer';
-  }
-  .references-sidebar.references-sidebar-mobile-open {
-    overflow-y: hidden;
   }
   .references-editable {
     grid-template-areas:
@@ -538,14 +542,15 @@ useDeprecationWarnings(props.configuration)
 
   .references-navigation {
     display: none;
-    position: sticky;
-    top: var(--refs-header-height);
-    height: 0px;
+    position: fixed;
     z-index: 10;
   }
 
   .references-sidebar-mobile-open .references-navigation {
     display: block;
+    top: var(--refs-header-height);
+    height: calc(100dvh - var(--refs-header-height));
+    width: 100%;
   }
 
   .references-navigation-list {

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -543,7 +543,6 @@ useDeprecationWarnings(props.configuration)
 
   .references-navigation {
     display: none;
-    position: fixed;
     z-index: 10;
   }
 
@@ -552,6 +551,7 @@ useDeprecationWarnings(props.configuration)
     top: var(--refs-header-height);
     height: calc(100dvh - var(--refs-header-height));
     width: 100%;
+    position: sticky;
   }
 
   .references-navigation-list {

--- a/packages/api-reference/src/components/MobileHeader.vue
+++ b/packages/api-reference/src/components/MobileHeader.vue
@@ -30,7 +30,6 @@ const { breadcrumb } = useSidebar()
 .references-mobile-header {
   display: none;
   align-items: center;
-  gap: 12px;
   height: 100%;
   width: 100%;
   padding: 0 8px;

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -197,6 +197,7 @@ onMounted(() => {
 @media (max-width: 1000px) {
   .sidebar {
     min-height: 0;
+    border-right: none;
   }
   .sidebar-pages {
     padding-top: 12px;

--- a/packages/client-app/src/App.vue
+++ b/packages/client-app/src/App.vue
@@ -57,7 +57,7 @@ onMounted(() => {
 @import './assets/tailwind.css';
 @import './assets/variables.css';
 
-#app {
+#app.scalar-client {
   display: flex;
   flex-direction: column;
   height: 100vh;

--- a/packages/docusaurus/src/theme.css
+++ b/packages/docusaurus/src/theme.css
@@ -214,8 +214,6 @@ html[data-theme='light'] body .api-client-drawer {
   position: relative !important;
 }
 .references-layout {
-  height: initial !important;
-  max-height: initial !important;
   overflow: initial !important;
   grid-template-rows: 0 repeat(2, auto) !important;
 }


### PR DESCRIPTION
This PR allows for users to easily add custom headers and footers by removing overflow:auto from `.api-reference` and instead relying on `<html>` for scrolling

We're already had to take this approach on Docusaurus so I think it will make sense to move forward with this approach for scalar

In order to support scalar users who have hacked adding a header I created `--scalar-y-offset` which applies the offset on how far scalar is pushed down on the page and assumes that is the desired header height. I imagine we'll remove this in a few months. 

Here's how a user will add a header (I'll add an example to the CDN as soon as this gets in 😄 )
<img width="803" alt="image" src="https://github.com/scalar/scalar/assets/6201407/430791bc-152b-499c-bcca-ab24c2743168">