### PR TITLE
fix(express-api-reference): explicitly set content-type to text/html

### DIFF
--- a/.changeset/clever-mice-kick.md
+++ b/.changeset/clever-mice-kick.md
@@ -2,4 +2,4 @@
 '@scalar/express-api-reference': patch
 ---
 
-Fix missing content-type
+feat: add content-type text/html to the HTML response

--- a/.changeset/clever-mice-kick.md
+++ b/.changeset/clever-mice-kick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/express-api-reference': patch
+---
+
+Fix missing content-type

--- a/packages/express-api-reference/src/expressApiReference.ts
+++ b/packages/express-api-reference/src/expressApiReference.ts
@@ -130,7 +130,7 @@ export const ApiReference = (options: ApiReferenceOptions) => {
  */
 export function apiReference(options: ApiReferenceOptions) {
   return (req: Request, res: Response) => {
-    res.send(`
+    res.type('text/html').send(`
   <!DOCTYPE html>
   <html>
     <head>


### PR DESCRIPTION
**Problem**
When used together with security middlewares like [Helmet](https://helmetjs.github.io/) which disable content sniffing, or manually setting the header `X-Content-Type-Options` to `nosniff`, the API documentation is rendered as plain text.

**Explanation**
`@scalar/express-api-reference` doesn't set any content-type.

**Solution**
This PR explicitly sets the content-type of the initial HTML response to `text/html`. 