### PR TITLE
fix(components): tailwind specificity

### DIFF
--- a/.changeset/smart-papayas-compare.md
+++ b/.changeset/smart-papayas-compare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: components tailwind specificity

--- a/packages/components/src/tailwind/tailwind.css
+++ b/packages/components/src/tailwind/tailwind.css
@@ -1,14 +1,14 @@
 @import '@scalar/themes/style.css';
 @import 'tailwindcss/base' layer(scalar-base);
 
-.scalar-app {
+:where(.scalar-app) {
   @tailwind components;
   @tailwind utilities;
   @tailwind variants;
 
-  /** 
-   * Custom utilities to make life easier 
-   * For some reason it was bugging on apply so I just used css for now 
+  /**
+   * Custom utilities to make life easier
+   * For some reason it was bugging on apply so I just used css for now
    */
   @layer utilities {
     .row {


### PR DESCRIPTION
this pr adds the `:where` pseudo element to tailwind component stylesheet in order to maintain low specificity on component usages + fixes api reference style on new api client modal activation.

<img width="1460" alt="image" src="https://github.com/scalar/scalar/assets/14966155/aad9bfa0-29ea-46a4-b3db-eb122a45fb60">
