### PR TITLE
docs: trim down root README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Check build, types, and units tests are passing
+name: Check build, types, and units tests
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -71,12 +71,13 @@ We’re offering a free and paid managed hosting on the edge, too:
 
 - Write your API documentation and publish your API references (free)
 - Get SSL and a super cool `*.apidocumentation.com` subdomain (free)
+- Write free text documentation (paid)
 - Collaborate with your whole team (paid)
 - Use any domain (paid)
 
 Ready? [Create your account on scalar.com](https://scalar.com).
 
-## Tools
+## Projects
 
 | Project                                                            | Description            |
 | ------------------------------------------------------------------ | ---------------------- |
@@ -85,7 +86,7 @@ Ready? [Create your account on scalar.com](https://scalar.com).
 | [Scalar Galaxy](/packages/galaxy/README)                           | OpenAPI Example        |
 | [Scalar Play Button](/packages/play-button/README)                 | Quick API Client Embed |
 | [Scalar Mock Server](/packages/mock-server/README)                 | OpenAPI Mock Server    |
-| [Scalar Void Server](/packages/void-server/README)                 | HTTP Mirror            |
+| [Scalar Void Server](/packages/void-server/README)                 | HTTP Request Mirror    |
 | [Scalar Open API Parser](https://github.com/scalar/openapi-parser) | OpenAPI SDK            |
 | [Scalar Sandbox](https://sandbox.scalar.com/)                      | Online OpenAPI Editor  |
 

--- a/README.md
+++ b/README.md
@@ -6,60 +6,21 @@
 [![GitHub License](https://img.shields.io/github/license/scalar/scalar)](https://github.com/scalar/scalar/blob/main/LICENSE)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-Generate interactive API documentation from OpenAPI/Swagger files. [Try our Demo](https://docs.scalar.com/swagger-editor)
+Generate interactive API documentation from OpenAPI/Swagger documents. [Try our Demo](https://docs.scalar.com/swagger-editor)
 
 <img width="830" height="455" src="https://github.com/scalar/scalar/assets/6201407/046aaeca-f0fe-453d-a661-c747399c56ef">
 
 ## Features
 
-- Uses OpenAPI/Swagger specifications
-- Request examples for a ton of languages + frameworks
-- Has an integrated API client
-- Edit your OpenAPI/Swagger specification with a live preview
+- Uses OpenAPI/Swagger documents
+- Request examples for many favorite languages and frameworks
+- Comes with an integrated API client
+- Integrates with your favorite framework
 - Doesn’t look like it’s 2011
 
-> [!NOTE]\
-> [Scalar Townhall every 2nd Thursday in Discord](https://discord.gg/scalar?event=1219363385485824000)
->
-> Join us to see upcoming features, discuss the roadmap and chat about APIs. 💬
+## Quickstart
 
-## Table of Contents
-
-- [Getting Started](#getting-started)
-  - [CDN](#cdn)
-  - [Nuxt](#nuxt)
-  - [Vue.js](#vuejs)
-  - [React](#react)
-  - [Fastify](#fastify)
-  - [Platformatic](#platformatic)
-  - [.NET](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/README.md)
-  - [Hono](#hono)
-  - [ElysiaJS](#elysiajs)
-  - [Express](#express)
-  - [NestJS](#nestjs)
-  - [Docusaurus](#docusaurus)
-  - [Litestar](https://docs.litestar.dev/latest/usage/openapi/ui_plugins.html)
-  - [FastAPI](https://github.com/scalar/scalar/blob/main/packages/scalar_fastapi/README.md)
-  - [AdonisJS](#adonisjs)
-  - [Laravel](#laravel)
-  - [Rust](#rust)
-  - [Go](#go)
-  - [Free Hosting](#free-hosting)
-- [CLI](#cli)
-- [Markdown](#markdown)
-- [Configuration](#configuration)
-  - [Layouts](#layouts)
-  - [Themes](#themes)
-  - [Advanced: Styling](#advanced-styling)
-    - [Theme Prefix Changes](#theme-prefix-changes)
-- [Community](#community)
-- [Packages](#packages)
-- [Contributors](#contributors)
-- [License](#license)
-
-## Getting Started
-
-### CDN
+You’re just one HTML file away from having an awesome API reference:
 
 ```html
 <!doctype html>
@@ -72,714 +33,83 @@ Generate interactive API documentation from OpenAPI/Swagger files. [Try our Demo
       content="width=device-width, initial-scale=1" />
   </head>
   <body>
-    <!-- Add your own OpenAPI/Swagger specification URL here: -->
-    <!-- Note: The example is our public proxy (to avoid CORS issues). You can remove the `data-proxy-url` attribute if you don’t need it. -->
     <script
       id="api-reference"
-      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
-      data-proxy-url="https://proxy.scalar.com"></script>
-
-    <!-- Optional: You can set a full configuration object like this: -->
-    <script>
-      var configuration = {
-        theme: 'purple',
-      }
-
-      document.getElementById('api-reference').dataset.configuration =
-        JSON.stringify(configuration)
-    </script>
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"></script>
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   </body>
 </html>
 ```
 
-You can also use the following syntax to directly pass an OpenAPI specification:
-
-```html
-<script
-  id="api-reference"
-  type="application/json">
-  { … }
-</script>
-```
-
-If you’d like to add a request proxy for the API client (to avoid CORS issues):
-
-```html
-<script
-  id="api-reference"
-  type="application/json"
-  data-proxy-url="https://proxy.scalar.com">
-  { … }
-</script>
-```
-
-#### Events [beta]
-
-We have recently added two events to the standalone CDN build only.
-
-##### scalar:reload-references
-
-Reload the references, this will re-mount the app in case you have switched pages or the dom
-elements have been removed.
-
-```ts
-document.dispatchEvent(new Event('scalar:reload-references'))
-```
-
-##### scalar:update-references-config
-
-If you have updated the config or spec, you can trigger this event with the new payload to update
-the app. It should update reactively so you do not need to trigger the reload event above after.
-
-```ts
-import { type ReferenceProps } from './types'
-
-const ev = new CustomEvent('scalar:update-references-config', {
-  detail: {
-    configuration: {
-      spec: {
-        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-      },
-    },
-  } satisfies ReferenceProps,
-})
-document.dispatchEvent(ev)
-```
-
-### Nuxt
-
-You can easily run Scalar API References in Nuxt via the module:
-
-```bash
-npx nuxi module add @scalar/nuxt
-```
-
-If you are using Nuxt server routes, you can enable scalar simply by enabling `openAPI` in the nitro
-config in your `nuxt.config.ts`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ['@scalar/nuxt'],
-  nitro: {
-    experimental: {
-      openAPI: true,
-    },
-  },
-})
-```
-
-If you would like to add your own OpenAPI spec file, you can do so with the following minimal config:
-
-```ts
-export default defineNuxtConfig({
-  modules: ['@scalar/nuxt'],
-  scalar: {
-    spec: {
-      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-    },
-  },
-})
-```
-
-Read more: [@scalar/nuxt](/packages/nuxt)
-
-### Vue.js
-
-The API Reference is built in Vue.js. If you’re working in Vue.js, too, you can directly use our Vue components.
-Install them via `npm`:
-
-```bash
-npm install @scalar/api-reference
-```
-
-And import the `ApiReference` component and style to your app:
-
-```vue
-<script setup lang="ts">
-import { ApiReference } from '@scalar/api-reference'
-import '@scalar/api-reference/style.css'
-</script>
-
-<template>
-  <ApiReference
-    :configuration="{
-      spec: {
-        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-      },
-    }" />
-</template>
-```
-
-You can [pass props to customize the API reference](/packages/api-reference).
-
-### React
-
-The API Reference package is written in Vue, that shouldn’t stop you from using
-it in React though!
-We have created a client side wrapper in React:
-
-> [!WARNING]\
-> This is untested on SSR/SSG!
-
-```ts
-import { ApiReferenceReact } from '@scalar/api-reference-react'
-import '@scalar/api-reference-react/style.css'
-
-function App() {
-  return (
-    <ApiReferenceReact
-      configuration={{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-        },
-      }}
-    />
-  )
-}
-
-export default App
-```
-
-We wrote a [detailed integration guide for React](/documentation/react.md), too.
-
-### Next.js
-
-Our Next.js handler makes it easy to render a reference; just add it to an API
-route handler:
-
-```ts
-// app/reference/route.ts
-import { ApiReference } from '@scalar/nextjs-api-reference'
-
-const config = {
-  spec: {
-    url: '/openapi.json',
-  },
-}
-
-export const GET = ApiReference(config)
-```
-
-We wrote a [detailed integration guide for Next.js](/documentation/nextjs.md), too.
-
-Read more: [@scalar/nextjs-api-reference](/packages/nextjs-api-reference)
-
-### Fastify
-
-Our fastify plugin makes it so easy to render a reference, there’s no excuse to not have documentation for your API:
-
-```ts
-await fastify.register(require('@scalar/fastify-api-reference'), {
-  routePrefix: '/reference',
-  configuration: {
-    spec: () => fastify.swagger(),
-  },
-})
-```
-
-Actually, it’s executing the `fastify.swagger()` call by default (if available). So that’s all you need to add:
-
-```ts
-await fastify.register(require('@scalar/fastify-api-reference'), {
-  routePrefix: '/reference',
-})
-```
-
-We wrote a [detailed integration guide for Fastify](/documentation/fastify.md), too.
-
-Read more about the
-package: [@scalar/fastify-api-reference](/packages/fastify-api-reference)
-
-### Platformatic
-
-Good news: If you’re
-using [a recent version of Platformatic](https://github.com/platformatic/platformatic/releases/tag/v1.16.0), the Scalar
-API reference is installed and configured automatically.
-
-### Hono
-
-Our Hono middleware makes it so easy to render a reference:
-
-```ts
-import { apiReference } from '@scalar/hono-api-reference'
-
-app.get(
-  '/reference',
-  apiReference({
-    spec: {
-      url: '/openapi.json',
-    },
-  }),
-)
-```
-
-Read more: [@scalar/hono-api-reference](/packages/hono-api-reference)
-
-### ElysiaJS
-
-The `@elysiajs/swagger` plugin uses our API reference by default:
-
-```ts
-import { swagger } from '@elysiajs/swagger'
-import { Elysia } from 'elysia'
-
-new Elysia()
-  .use(swagger())
-  .get('/', () => 'hi')
-  .post('/hello', () => 'world')
-  .listen(8080)
-
-// open http://localhost:8080/swagger
-```
-
-[Read more about @elysiajs/swagger](https://elysiajs.com/plugins/swagger.html)
-
-### Express
-
-Our Express middleware makes it so easy to render a reference:
-
-```ts
-import { apiReference } from '@scalar/express-api-reference'
-
-app.use(
-  '/reference',
-  apiReference({
-    spec: {
-      content: OpenApiSpecification,
-    },
-  }),
-)
-```
-
-Read more: [@scalar/express-api-reference](/packages/express-api-reference)
-
-### NestJS
-
-Our NestJS middleware makes it so easy to render a reference:
-
-```ts
-import { apiReference } from '@scalar/nestjs-api-reference'
-
-app.use(
-  '/reference',
-  apiReference({
-    spec: {
-      url: '/openapi.json',
-    },
-  }),
-)
-```
-
-Read more: [@scalar/nestjs-api-reference](/packages/nestjs-api-reference)
-
-### Docusaurus
-
-Our Docusaurus plugin makes it easy to render API references. Simple add the
-following to your Docusaurus config:
-
-```ts
-import type { ScalarOptions } from '@scalar/docusaurus'
-
-plugins: [
-  [
-    '@scalar/docusaurus',
-    {
-      label: 'Scalar',
-      route: '/scalar',
-      configuration: {
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-        },
-      },
-    } as ScalarOptions,
-  ],
-],
-```
-
-We wrote a [detailed integration guide for Docusaurus](/documentation/docusaurus.md), too.
-
-For more information, check out
-the [Docusaurus package](/packages/docusaurus/README.md)
-
-### AdonisJS
-
-There’s [a community package to generate OpenAPI files in AdonisJS,](https://github.com/hanspagel/adonis-autoswagger)
-and it comes with support for the
-Scalar API reference already.
-
-We wrote a [detailed integration guide for AdonisJS](/documentation/adonisjs.md).
-
-### Laravel
-
-There’s [a wonderful package to generate OpenAPI files for Laravel](https://scribe.knuckles.wtf/laravel/) already.
-Set the `type` to `external_laravel` (for Blade) or `external_static` (for HTML) and `theme` to `scalar`:
-
-```php
-<?php
-// config/scribe.php
-
-return [
-  // …
-  'type' => 'external_laravel',
-  'theme' => 'scalar',
-  // …
-];
-```
-
-We wrote a [detailed integration guide for Laravel Scribe](/documentation/laravel-scribe.md),
-too.
-
-### Rust
-
-There’s [a wonderful package to generate OpenAPI files for Rust](https://github.com/tamasfe/aide) already.
-Set the `api_route` to use `Scalar` to get started:
-
-```rust
-use aide::{
-    axum::{
-        routing::{get_with},
-        ApiRouter, IntoApiResponse,
-    },
-    openapi::OpenApi,
-    scalar::Scalar,
-};
-...
-    let router: ApiRouter = ApiRouter::new()
-        .api_route_with(
-            "/",
-            get_with(
-                Scalar::new("/docs/private/api.json")
-                    .with_title("Aide Axum")
-                    .axum_handler(),
-                |op| op.description("This documentation page."),
-            ),
-            |p| p.security_requirement("ApiKey"),
-        )
-        ...
-```
-
-### Go
-
-`go-scalar-api-reference` by [@MarceloPetrucio](https://github.com/MarceloPetrucio/) offers a convenient way to generate
-API references in Go:
-
-<https://github.com/MarceloPetrucio/go-scalar-api-reference/>
-
-### Free Hosting
+And there’s an ever-growing list of plugins and integrations:
+
+## Integrations
+
+- [.NET](/packages/scalar.aspnetcore/README.md)
+- [AdonisJS](/documentation/adonisjs.md)
+- [Docusaurus](/packages/docusaurus/README.md)
+- [ElysiaJS](/documentation/elysiajs.md)
+- [Express](/packages/express-api-reference/README.md)
+- [FastAPI](/packages/scalar_fastapi/README.md)
+- [Fastify](/packages/fastify-api-reference/README.md)
+- [Go](/documentation/go.md)
+- [Hono](/packages/hono-api-reference/README.md)
+- [Laravel](/documentation/laravel.md)
+- [Litestar](https://docs.litestar.dev/latest/usage/openapi/ui_plugins.html)
+- [NestJS](/packages/nestjs-api-reference/README.md)
+- [Next.js](/packages/nextjs-api-reference/README.md)
+- [Nitro](/documentation/nitro.md)
+- [Nuxt](/packages/nuxt/README.md)
+- [Platformatic](/documentation/platformatic.md)
+- [React](/packages/api-reference-react/README.md)
+- [Rust](/documentation/rust.md)
+- [Vue.js](/packages/api-reference/README.md)
+
+## Managed Hosting
+
+We’re offering a free and paid managed hosting on the edge, too:
 
 - Write your API documentation and publish your API references (free)
-- Get SSL and a super cool \*.apidocumentation.com subdomain (free)
+- Get SSL and a super cool `*.apidocumentation.com` subdomain (free)
 - Collaborate with your whole team (paid)
 - Use any domain (paid)
 
-Ready? [Create an account on scalar.com](https://scalar.com).
-
-## CLI
-
-We’ve also got a nice command-line interface that you can use to play with OpenAPI files locally,
-integrate validation into your CI or share them easily (with us or anyone else).
-
-[CLI documentation](/packages/cli)
-
-Here are a few use cases:
-
-### Installation
-
-You can use [npx](https://docs.npmjs.com/cli/v8/commands/npx) to use the CLI without manually installing it:
-
-```bash
-npx @scalar/cli --version
-```
-
-If you want to install it locally, you can do it like this:
-
-```bash
-npm -g install @scalar/cli
-scalar --version
-```
-
-### Format
-
-Quickly bring your OpenAPI file (JSON or YAML) into shape:
-
-```bash
-scalar format openapi.json --output openapi.yaml
-```
-
-### Validate
-
-Validate your OpenAPI file to find errors
-quickly, [great for CI](https://github.com/scalar/scalar/blob/main/.github/workflows/validate-openapi-file.yml):
-
-```bash
-scalar validate openapi.json
-```
-
-Oh, and all commands work with hosted OpenAPI files, too:
-
-```bash
-scalar validate https://example.com/openapi.json
-```
-
-### Preview
-
-Preview the API reference for your OpenAPI file with just one command. It can even watch your file and reload the
-content on file changes:
-
-```bash
-scalar serve openapi.json --watch
-```
-
-### Mock server
-
-Designing an API, but don’t have a backend yet? Just quickly boot up a mock server like this:
-
-```bash
-scalar mock openapi.json --watch --port 8080
-```
-
-### Share
-
-Want to share your OpenAPI file? The following command will upload the given specification [to our sandbox](https://sandbox.scalar.com/):
-
-```bash
-scalar share openapi.json
-```
-
-Read [more about the CLI here](/packages/cli).
-
-## Markdown
-
-You can use Markdown in various places, for example in `info.description`, in your tag descriptions, in your operation
-descriptions, in your parameter descriptions and in a lot of other places. We’re using GitHub-flavored Markdown.
-What’s working here, is probably also working in the API reference:
-
-- bullet lists, numbered lists
-- _italic_, **bold**, ~~striked~~ text
-- accordions
-- links
-- tables
-- images
-- …
-
-[Have a look at our OpenAPI example specification](https://github.com/scalar/scalar/blob/main/packages/galaxy/src/specifications/3.1.yaml)
-to see more examples.
-
-> Note: Not everything is supported in all places. For example, you can use images in most places, but not in parameter
-> descriptions.
-
-## Configuration
-
-To customize the behavior of the API Reference, you can use the following configuration options:
-
-- `spec.content`: Directly pass an OpenAPI/Swagger specifcation.
-- `spec.url`: Pass the URL of a spec file (JSON or YAML).
-- `proxyUrl`: Use a proxy to send requests to other origins.
-- `darkMode`: Set dark mode on or off (light mode)
-- `layout`: The layout to use, either of `modern` or `classic` (see [#layouts](#layouts)).
-- `theme`: The theme to use (see [#themes](#themes)).
-- `showSidebar`: Whether the sidebar should be shown.
-- `customCss`: Pass custom CSS directly to the component.
-- `searchHotKey`: Key used with CTRL/CMD to open the search modal.
-- `servers`: Override the OpenAPI servers
-- `metaData`: Configure meta-information for the page.
-- `hiddenClients`: List of `httpsnippet` clients to hide from the client's menu, by default hides Unirest,
-  pass `[]` to show all clients.
-- `onSpecUpdate`: Listen to spec changes with a callback function.
-
-For detailed information on how to use these options, refer to
-the [Configuration Section](https://github.com/scalar/scalar/blob/main/packages/api-reference/README.md/#configuration).
-
-### Layouts
-
-We support two layouts at the moment, a `modern` layout (the default) and a Swagger UI inspired
-`classic` layout (we jazzed it up a bit though).
-
-![layouts](https://github.com/scalar/scalar/assets/6374090/a28b89e0-8d3b-477f-a02f-bcf39f7830f0)
-
-### Themes
-
-You don’t like the color scheme? We’ve prepared some themes for you:
-
-```vue
-/* theme?: 'alternate' | 'default' | 'moon' | 'purple' | 'solarized' |
-'bluePlanet' | 'saturn' | 'kepler' | 'mars' | 'deepSpace' | 'none' */
-<ApiReference :configuration="{ theme: 'moon' }" />
-```
-
-> [!NOTE]\
-> The `default` theme is … the default theme.
-> If you want to make sure **no** theme is applied, pass `none`.
-
-Wow, still nothing that fits your brand? Reach out to <marc@scalar.com> and we’ll make you a custom theme, just for you.
-
-### Advanced: Styling
-
-You can pretty much style everything you see.
-[Here’s an extreme example of what’s possible.](https://windows98.apidocumentation.com/)
-
-To get started, overwrite our CSS variables. We won’t judge.
-
-```html
-<style>
-  :root {
-    --scalar-font: 'Comic Sans MS', 'Comic Sans', cursive;
-  }
-</style>
-```
-
-> [!NOTE]\
-> By default, we’re using Inter and JetBrains Mono, served by our in-house CDN.
-
-If you want use a different font or want to use Google Fonts, pass `withDefaultFonts: false` to the configuration and overwrite the `--scalar-font` CSS variable. You will also need to provide the source of your new font which can be local or served over the network.
-
-Here is an example of how to use the `Roboto` font from Google Fonts with the CDN API reference.
-
-```html
-<!doctype html>
-<html>
-  <head>
-    <!-- Link to the font on Google -->
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto"
-      rel="stylesheet" />
-    <!-- Overwrite the scalar font variable -->
-    <style>
-      :root {
-        --scalar-font: 'Roboto', sans-serif;
-      }
-    </style>
-  </head>
-  <body>
-    <!-- Pass the custom configuration object -->
-    <script>
-      var configuration = {
-        theme: 'kepler',
-        // Do not use the default fonts from the Scalar CDN
-        withDefaultFonts: 'false',
-      }
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-  </body>
-</html>
-```
-
-You can [use all variables](https://github.com/scalar/scalar/blob/main/packages/themes/src/base.css) available in the
-base styles as well as overwrite the color theme.
-
-To build your own color themes, overwrite the night mode and day mode variables.
-Here are some basic variables to get you started:
-
-![basic-scalar-variables](https://github.com/scalar/scalar/assets/6374090/f49256c4-4623-4797-87a1-24bdbc9b17fd)
-
-```html
-<style>
-  .light-mode {
-    --scalar-color-1: #121212;
-    --scalar-color-2: rgba(0, 0, 0, 0.6);
-    --scalar-color-3: rgba(0, 0, 0, 0.4);
-    --scalar-color-accent: #0a85d1;
-    --scalar-background-1: #fff;
-    --scalar-background-2: #f6f5f4;
-    --scalar-background-3: #f1ede9;
-    --scalar-background-accent: #5369d20f;
-    --scalar-border-color: rgba(0, 0, 0, 0.08);
-  }
-  .dark-mode {
-    --scalar-color-1: rgba(255, 255, 255, 0.81);
-    --scalar-color-2: rgba(255, 255, 255, 0.443);
-    --scalar-color-3: rgba(255, 255, 255, 0.282);
-    --scalar-color-accent: #8ab4f8;
-    --scalar-background-1: #202020;
-    --scalar-background-2: #272727;
-    --scalar-background-3: #333333;
-    --scalar-background-accent: #8ab4f81f;
-  }
-</style>
-```
-
-Or get more advanced by styling our sidebar!
-
-![scalar-sidebar-variables](https://github.com/scalar/scalar/assets/6374090/5b1f0211-5c09-4092-a882-03d8241ad428)
-
-```html
-<style>
-  .light-mode .sidebar {
-    --scalar-sidebar-background-1: var(--scalar-background-1);
-    --scalar-sidebar-item-hover-color: currentColor;
-    --scalar-sidebar-item-hover-background: var(--scalar-background-2);
-    --scalar-sidebar-item-active-background: var(--scalar-background-2);
-    --scalar-sidebar-border-color: var(--scalar-border-color);
-    --scalar-sidebar-color-1: var(--scalar-color-1);
-    --scalar-sidebar-color-2: var(--scalar-color-2);
-    --scalar-sidebar-color-active: var(--scalar-color-2);
-    --scalar-sidebar-search-background: var(--scalar-background-2);
-    --scalar-sidebar-search-border-color: var(--scalar-border-color);
-    --scalar-sidebar-search-color: var(--scalar-color-3);
-  }
-  .dark-mode .sidebar {
-    --scalar-sidebar-background-1: var(--scalar-background-1);
-    --scalar-sidebar-item-hover-color: currentColor;
-    --scalar-sidebar-item-hover-background: var(--scalar-background-2);
-    --scalar-sidebar-item-active-background: var(--scalar-background-2);
-    --scalar-sidebar-border-color: var(--scalar-border-color);
-    --scalar-sidebar-color-1: var(--scalar-color-1);
-    --scalar-sidebar-color-2: var(--scalar-color-2);
-    --scalar-sidebar-color-active: var(--scalar-color-2);
-    --scalar-sidebar-search-background: var(--scalar-background-2);
-    --scalar-sidebar-search-border-color: var(--scalar-border-color);
-    --scalar-sidebar-search-color: var(--scalar-color-3);
-  }
-</style>
-```
-
-#### Theme Prefix Changes
-
-We've migrated our `--theme-*` CSS variables to `--scalar-*` to avoid conflicts with other CSS variables in
-applications consuming the Scalar references or themes.
-If you're injecting your custom CSS through the [`customCss`](#configuration) configuration option we will automatically
-migrate your variable prefixes but display a warning in the console.
-
-We recommend updating your theme variables as soon as possible:
-
-- `--theme-*` → `--scalar-*`
-- `--sidebar-*` → `--scalar-sidebar-*`
-
-For a before and after example of an updated theme
-see [`legacyTheme.css`](/packages/themes/src/fixtures/legacyTheme.css)
-and [`updatedTheme.css`](/packages/themes/src/fixtures/updatedTheme.css)
-in the [`@scalar/themes`](/packages/themes/) package.
+Ready? [Create your account on scalar.com](https://scalar.com).
+
+## Tools
+
+| Project                                                            | Description            |
+| ------------------------------------------------------------------ | ---------------------- |
+| [Scalar API Client](/packages/api-client/README)                   | API client             |
+| [Scalar CLI](/packages/cli/README)                                 | Command-line interface |
+| [Scalar Galaxy](/packages/galaxy/README)                           | OpenAPI Example        |
+| [Scalar Play Button](/packages/play-button/README)                 | Quick API Client Embed |
+| [Scalar Mock Server](/packages/mock-server/README)                 | OpenAPI Mock Server    |
+| [Scalar Void Server](/packages/void-server/README)                 | HTTP Mirror            |
+| [Scalar Open API Parser](https://github.com/scalar/openapi-parser) | OpenAPI SDK            |
+| [Scalar Sandbox](https://sandbox.scalar.com/)                      | Online OpenAPI Editor  |
+
+## Documentation
+
+| Topic                                            | Description                        |
+| ------------------------------------------------ | ---------------------------------- |
+| [Themes](/documentation/themes.md)               | Themes, layouts & styling          |
+| [Configuration](/documentation/configuration.md) | The universal configuration object |
+| [OpenAPI](/documentation/openapi.md)             | OpenAPI and our extensions to it   |
+| [Markdown](/documentation/markdown.md)           | Markdown syntax                    |
 
 ## Community
 
 We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/scalar>
 
-## Packages
-
-This repository contains all our open source projects, and there’s definitely more to discover.
-
-| Package                                                          | Description              |
-| ---------------------------------------------------------------- | ------------------------ |
-| [@scalar/api-client](/packages/api-client)                       | API client               |
-| [@scalar/api-reference-react](/packages/api-reference-react)     | React integration        |
-| [@scalar/api-reference](/packages/api-reference)                 | Beautiful API references |
-| [@scalar/cli](/packages/cli)                                     | OpenAPI CLI              |
-| [@scalar/docusaurus](/packages/docusaurus)                       | Docusaurus integration   |
-| [@scalar/echo-server](/packages/echo-server)                     | HTTP Mirror              |
-| [@scalar/express-api-reference](/packages/express-api-reference) | Express plugin           |
-| [@scalar/fastify-api-reference](/packages/fastify-api-reference) | Fastify plugin           |
-| [@scalar/galaxy](/packages/galaxy)                               | OpenAPI Example          |
-| [@scalar/hono-api-reference](/packages/hono-api-reference)       | Hono middleware          |
-| [@scalar/mock-server](/packages/mock-server)                     | OpenAPI Mock Server      |
-| [@scalar/nestjs-api-reference](/packages/nestjs-api-reference)   | NestJS middleware        |
-| [@scalar/nextjs-api-reference](/packages/nextjs-api-reference)   | Next.js adapter          |
-| [@scalar/nuxt](/packages/nuxt)                                   | Nuxt module              |
-| [@scalar/play-button](/packages/play-button)                     | Quick API Client Embed   |
+> [!NOTE]\
+> [Scalar Townhall every 2nd Thursday in Discord](https://discord.gg/scalar?event=1219363385485824000)
+>
+> Join us to see upcoming features, discuss the roadmap and chat about APIs. 💬
 
 ## Contributors
 
-Contributions are welcome! Read [`CONTRIBUTING`](https://github.com/scalar/scalar/blob/main/CONTRIBUTING).
+Contributions are welcome! Read the [`CONTRIBUTING`](https://github.com/scalar/scalar/blob/main/CONTRIBUTING) guide.
 
 <!-- readme: collaborators,contributors -start -->
 <table>
@@ -1199,7 +529,3 @@ Contributions are welcome! Read [`CONTRIBUTING`](https://github.com/scalar/scala
 	<tbody>
 </table>
 <!-- readme: collaborators,contributors -end -->
-
-## License
-
-The source code in this repository is licensed under [MIT](https://github.com/scalar/scalar/blob/main/LICENSE).

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -1,0 +1,237 @@
+# Configuration
+
+There’s a universal configuration object that can be used on all platforms.
+
+#### isEditable?: boolean
+
+Whether the Swagger editor should be shown.
+
+```js
+{
+  isEditable: true
+}
+```
+
+#### spec.content?: string
+
+Directly pass an OpenAPI/Swagger spec.
+
+```js
+{
+  spec: {
+    content: '{ … }'
+  }
+}
+```
+
+#### spec.url?: string
+
+Pass the URL of a spec file (JSON or Yaml).
+
+```js
+{
+  spec: {
+    url: '/openapi.json'
+  }
+}
+```
+
+#### proxyUrl?: string
+
+Making requests to other domains is restricted in the browser and requires [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS). It’s recommended to use a proxy to send requests to other origins.
+
+```js
+{
+  proxy: 'https://proxy.example.com'
+}
+```
+
+You can use our hosted proxy:
+
+```js
+{
+  proxy: 'https://proxy.scalar.com'
+}
+```
+
+If you like to run your own, check out our [example proxy written in Go](https://github.com/scalar/scalar/tree/main/examples/proxy-server).
+
+#### showSidebar?: boolean
+
+Whether the sidebar should be shown.
+
+```js
+{
+  showSidebar: true
+}
+```
+
+#### hideModels?: boolean
+
+Whether models (`components.schemas` or `definitions`) should be shown in the sidebar, search and content.
+
+`@default false`
+
+```js
+{
+  hideModels: true
+}
+```
+
+#### hideDownloadButton?: boolean
+
+Whether to show the "Download OpenAPI Specification" button
+
+`@default false`
+
+```js
+{
+  hideDownloadButton: true
+}
+```
+
+### customCss?: string
+
+You can pass custom CSS directly to the component. This is helpful for the integrations for Fastify, Express, Hono and others where you it’s easier to add CSS to the configuration.
+
+In Vue or React you’d probably use other ways to add custom CSS.
+
+```js
+{
+  customCss: `* { font-family: "Comic Sans MS", cursive, sans-serif; }`
+}
+```
+
+#### searchHotKey?: string
+
+Key used with CTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k)
+
+```js
+{
+  searchHotKey: 'l'
+}
+```
+
+#### servers?: Server[]
+
+List of servers to override the openapi spec servers
+
+@default undefined
+@example [{ url: 'https://api.scalar.com', description: 'Production server' }]
+
+```js
+{
+  servers: [
+    {
+      url: 'https://api.scalar.com',
+      description: 'Production server',
+    },
+  ]
+}
+```
+
+#### metaData?: object
+
+You can pass information to the config object to configure meta information out of the box.
+
+```js
+{
+  metaData: {
+    title: 'Page title',
+    description: 'My page page',
+    ogDescription: 'Still about my my page',
+    ogTitle: 'Page title',
+    ogImage: 'https://example.com/image.png',
+    twitterCard: 'summary_large_image',
+    // Add more...
+    }
+  }
+```
+
+#### hiddenClients?: array | true
+
+You can pass an array of [httpsnippet clients](https://github.com/Kong/httpsnippet/wiki/Targets) to hide from the clients menu.
+
+```js
+{
+  hiddenClients: ['fetch']
+}
+```
+
+By default hides Unirest, pass `[]` to **show** all clients or `true` to **hide** all clients:
+
+```js
+{
+  hiddenClients: true
+}
+```
+
+#### onSpecUpdate?: (spec: string) => void
+
+You can listen to spec changes with onSpecUpdate that runs on spec/swagger content change
+
+```js
+{
+  onSpecUpdate: (value: string) => {
+    console.log('Content updated:', value)
+  }
+}
+```
+
+#### authentication?: Partial<AuthenticationState>
+
+To make authentication easier you can prefill the credentials for your users:
+
+```js
+{
+  authentication: {
+    // The OpenAPI file has keys for all security schemes:
+    // Which one should be used by default?
+    preferredSecurityScheme: 'my_custom_security_scheme',
+    // The `my_custom_security_scheme` security scheme is of type `apiKey`, so prefill the token:
+    apiKey: {
+      token: 'super-secret-token',
+    },
+  },
+}
+```
+
+For OpenAuth2 it’s more looking like this:
+
+```js
+{
+  authentication: {
+    // The OpenAPI file has keys for all security schemes
+    // Which one should be used by default?
+    preferredSecurityScheme: 'oauth2',
+    // The `oauth2` security scheme is of type `oAuth2`, so prefill the client id and the scopes:
+    oAuth2: {
+    clientId: 'foobar123',
+    // optional:
+    scopes: ['read:planets', 'write:planets'],
+    },
+  },
+  }
+```
+
+#### withDefaultFonts?: boolean
+
+By default we’re using Inter and JetBrains Mono, served by Google Fonts. If you use a different font or just don’t want to use Google Fonts, pass `withDefaultFonts: false` to the configuration.
+
+```js
+{
+  withDefaultFonts: false
+}
+```
+
+#### theme?: string
+
+You don’t like the color scheme? We’ve prepared some themes for you:
+
+Can be one of: **alternate**, **default**, **moon**, **purple**, **solarized**, **bluePlanet**, **saturn**, **kepler**, **mars**, **deepSpace**, **none**
+
+```js
+{
+  theme: default
+}
+```

--- a/documentation/elysiajs.md
+++ b/documentation/elysiajs.md
@@ -1,0 +1,18 @@
+# ElysiaJS
+
+The `@elysiajs/swagger` plugin uses our API reference by default:
+
+```ts
+import { swagger } from '@elysiajs/swagger'
+import { Elysia } from 'elysia'
+
+new Elysia()
+  .use(swagger())
+  .get('/', () => 'hi')
+  .post('/hello', () => 'world')
+  .listen(8080)
+
+// open http://localhost:8080/swagger
+```
+
+[Read more about @elysiajs/swagger](https://elysiajs.com/plugins/swagger.html)

--- a/documentation/fastify.md
+++ b/documentation/fastify.md
@@ -237,12 +237,12 @@ await fastify.register(ScalarApiReference, {
   configuration: {
     layout: 'classic',
     // Learn more about configuration:
-    // https://github.com/scalar/scalar/tree/main/packages/api-reference#configuration
+    // https://github.com/scalar/scalar/tree/main/documentation/configuration.md
   },
 })
 ```
 
-TypeScript should give you a nice autocomplete for all options. If you’re more into reading an actual reference, you can read about all options here: <https://github.com/scalar/scalar/tree/main/packages/api-reference#configuration>
+TypeScript should give you a nice autocomplete for all options. If you’re more into reading an actual reference, you can read about all options here: <https://github.com/scalar/scalar/tree/main/documentation/configuration.md>
 
 ## Advanced: Handcrafted OpenAPI files
 

--- a/documentation/fastify.md
+++ b/documentation/fastify.md
@@ -199,7 +199,7 @@ Did it work? OMG, this is so cool! It didn’t? [Create a new issue](https://git
 
 Congratulations, you’ve come really far. And I have good news for you, you’re just a few lines of code away from a stunning API reference for your Fastify project. Time to pull our package:
 
-```
+```bash
 npm install @scalar/fastify-api-reference
 ```
 

--- a/documentation/go.md
+++ b/documentation/go.md
@@ -1,0 +1,6 @@
+# Go
+
+`go-scalar-api-reference` by [@MarceloPetrucio](https://github.com/MarceloPetrucio/) offers a convenient way to generate
+API references in Go:
+
+<https://github.com/MarceloPetrucio/go-scalar-api-reference/>

--- a/documentation/laravel-scribe.md
+++ b/documentation/laravel-scribe.md
@@ -56,13 +56,13 @@ cd my-new-app
 
 I’ve selected SQLite, so I need to create an empty database:
 
-```
+```bash
 touch database/database.sqlite
 ```
 
 If you’ve choosen another database driver, add the required credentials to your `.env` file. Once you’re done, you can use [Laravel Herd](https://herd.laravel.com/) or just spin up a tiny PHP server from the command-line:
 
-```
+```bash
 php artisan serve
 ```
 

--- a/documentation/laravel.md
+++ b/documentation/laravel.md
@@ -1,0 +1,19 @@
+# Laravel
+
+There’s [a wonderful package to generate OpenAPI files for Laravel](https://scribe.knuckles.wtf/laravel/) already.
+Set the `type` to `external_laravel` (for Blade) or `external_static` (for HTML) and `theme` to `scalar`:
+
+```php
+<?php
+// config/scribe.php
+
+return [
+  // …
+  'type' => 'external_laravel',
+  'theme' => 'scalar',
+  // …
+];
+```
+
+We wrote a [detailed integration guide for Laravel Scribe](/documentation/laravel-scribe.md),
+too.

--- a/documentation/markdown.md
+++ b/documentation/markdown.md
@@ -1,0 +1,19 @@
+# Markdown
+
+You can use Markdown in various places, for example in `info.description`, in your tag descriptions, in your operation
+descriptions, in your parameter descriptions and in a lot of other places. We’re using GitHub-flavored Markdown.
+What’s working here, is probably also working in the API reference:
+
+- bullet lists, numbered lists
+- _italic_, **bold**, ~~striked~~ text
+- accordions
+- links
+- tables
+- images
+- …
+
+[Have a look at our OpenAPI example specification](https://github.com/scalar/scalar/blob/main/packages/galaxy/src/specifications/3.1.yaml)
+to see more examples.
+
+> Note: Not everything is supported in all places. For example, you can use images in most places, but not in parameter
+> descriptions.

--- a/documentation/nitro.md
+++ b/documentation/nitro.md
@@ -1,0 +1,3 @@
+# Nitro
+
+Read more: https://nitro.unjs.io/config#openapi

--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -1,0 +1,66 @@
+# OpenAPI Specification
+
+We’re expecting the passed specification to adhere to [the Swagger 2.0, OpenAPI 3.0 or OpenAPI 3.1 specification](https://github.com/OAI/OpenAPI-Specification).
+
+On top of that, we’ve added a few things for your convenience:
+
+## x-displayName
+
+You can overwrite tag names with `x-displayName`.
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: "1.0"
+tags:
+  - name: pl4n3t5
++    x-displayName: planets
+paths:
+  '/planets':
+    get:
+      summary: Get all planets
+      tags:
+        - pl4n3t5
+```
+
+## x-tagGroup
+
+You can group your tags with `x-tagGroup`.
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: "1.0"
+tags:
+  - name: planets
++x-tagGroups:
++  - name: galaxy
++    tags:
++      - planets
+paths:
+  '/planets':
+    get:
+      summary: Get all planets
+      tags:
+        - planets
+```
+
+## x-internal
+
+You can hide operations from the reference with `x-internal`.
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: "1.0"
+paths:
+  '/planets':
+    get:
+      summary: Get all planets
+    post:
+      summary: Create a new planet
++      x-internal: true
+```

--- a/documentation/platformatic.md
+++ b/documentation/platformatic.md
@@ -1,0 +1,3 @@
+# Platformatic
+
+Good news: If you’re using [a recent version of Platformatic](https://github.com/platformatic/platformatic/releases/tag/v1.16.0), the Scalar API reference is installed and configured automatically.

--- a/documentation/rust.md
+++ b/documentation/rust.md
@@ -1,0 +1,31 @@
+# Rust
+
+There’s [a wonderful package to generate OpenAPI files for Rust](https://github.com/tamasfe/aide) already.
+Set the `api_route` to use `Scalar` to get started:
+
+```rust
+use aide::{
+    axum::{
+        routing::{get_with},
+        ApiRouter, IntoApiResponse,
+    },
+    openapi::OpenApi,
+    scalar::Scalar,
+};
+
+// …
+
+let router: ApiRouter = ApiRouter::new()
+    .api_route_with(
+        "/",
+        get_with(
+            Scalar::new("/docs/private/api.json")
+                .with_title("Aide Axum")
+                .axum_handler(),
+            |op| op.description("This documentation page."),
+        ),
+        |p| p.security_requirement("ApiKey"),
+    )
+
+// …
+```

--- a/documentation/themes.md
+++ b/documentation/themes.md
@@ -1,0 +1,159 @@
+# Themes
+
+You don’t like the color scheme? We’ve prepared some themes for you:
+
+```vue
+/* theme?: 'alternate' | 'default' | 'moon' | 'purple' | 'solarized' |
+'bluePlanet' | 'saturn' | 'kepler' | 'mars' | 'deepSpace' | 'none' */
+<ApiReference :configuration="{ theme: 'moon' }" />
+```
+
+> [!NOTE]\
+> The `default` theme is … the default theme.
+> If you want to make sure **no** theme is applied, pass `none`.
+
+Wow, still nothing that fits your brand? Reach out to <marc@scalar.com> and we’ll make you a custom theme, just for you.
+
+## Layouts
+
+We support two layouts at the moment, a `modern` layout (the default) and a Swagger UI inspired
+`classic` layout (we jazzed it up a bit though).
+
+![layouts](https://github.com/scalar/scalar/assets/6374090/a28b89e0-8d3b-477f-a02f-bcf39f7830f0)
+
+## Advanced: Styling
+
+You can pretty much style everything you see.
+[Here’s an extreme example of what’s possible.](https://windows98.apidocumentation.com/)
+
+To get started, overwrite our CSS variables. We won’t judge.
+
+```html
+<style>
+  :root {
+    --scalar-font: 'Comic Sans MS', 'Comic Sans', cursive;
+  }
+</style>
+```
+
+> [!NOTE]\
+> By default, we’re using Inter and JetBrains Mono, served by our in-house CDN.
+
+If you want use a different font or want to use Google Fonts, pass `withDefaultFonts: false` to the configuration and overwrite the `--scalar-font` CSS variable. You will also need to provide the source of your new font which can be local or served over the network.
+
+Here is an example of how to use the `Roboto` font from Google Fonts with the CDN API reference.
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <!-- Link to the font on Google -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto"
+      rel="stylesheet" />
+    <!-- Overwrite the scalar font variable -->
+    <style>
+      :root {
+        --scalar-font: 'Roboto', sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Pass the custom configuration object -->
+    <script>
+      var configuration = {
+        theme: 'kepler',
+        // Do not use the default fonts from the Scalar CDN
+        withDefaultFonts: 'false',
+      }
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>
+```
+
+You can [use all variables](https://github.com/scalar/scalar/blob/main/packages/themes/src/base.css) available in the
+base styles as well as overwrite the color theme.
+
+To build your own color themes, overwrite the night mode and day mode variables.
+Here are some basic variables to get you started:
+
+![basic-scalar-variables](https://github.com/scalar/scalar/assets/6374090/f49256c4-4623-4797-87a1-24bdbc9b17fd)
+
+```html
+<style>
+  .light-mode {
+    --scalar-color-1: #121212;
+    --scalar-color-2: rgba(0, 0, 0, 0.6);
+    --scalar-color-3: rgba(0, 0, 0, 0.4);
+    --scalar-color-accent: #0a85d1;
+    --scalar-background-1: #fff;
+    --scalar-background-2: #f6f5f4;
+    --scalar-background-3: #f1ede9;
+    --scalar-background-accent: #5369d20f;
+    --scalar-border-color: rgba(0, 0, 0, 0.08);
+  }
+  .dark-mode {
+    --scalar-color-1: rgba(255, 255, 255, 0.81);
+    --scalar-color-2: rgba(255, 255, 255, 0.443);
+    --scalar-color-3: rgba(255, 255, 255, 0.282);
+    --scalar-color-accent: #8ab4f8;
+    --scalar-background-1: #202020;
+    --scalar-background-2: #272727;
+    --scalar-background-3: #333333;
+    --scalar-background-accent: #8ab4f81f;
+  }
+</style>
+```
+
+Or get more advanced by styling our sidebar!
+
+![scalar-sidebar-variables](https://github.com/scalar/scalar/assets/6374090/5b1f0211-5c09-4092-a882-03d8241ad428)
+
+```html
+<style>
+  .light-mode .sidebar {
+    --scalar-sidebar-background-1: var(--scalar-background-1);
+    --scalar-sidebar-item-hover-color: currentColor;
+    --scalar-sidebar-item-hover-background: var(--scalar-background-2);
+    --scalar-sidebar-item-active-background: var(--scalar-background-2);
+    --scalar-sidebar-border-color: var(--scalar-border-color);
+    --scalar-sidebar-color-1: var(--scalar-color-1);
+    --scalar-sidebar-color-2: var(--scalar-color-2);
+    --scalar-sidebar-color-active: var(--scalar-color-2);
+    --scalar-sidebar-search-background: var(--scalar-background-2);
+    --scalar-sidebar-search-border-color: var(--scalar-border-color);
+    --scalar-sidebar-search-color: var(--scalar-color-3);
+  }
+  .dark-mode .sidebar {
+    --scalar-sidebar-background-1: var(--scalar-background-1);
+    --scalar-sidebar-item-hover-color: currentColor;
+    --scalar-sidebar-item-hover-background: var(--scalar-background-2);
+    --scalar-sidebar-item-active-background: var(--scalar-background-2);
+    --scalar-sidebar-border-color: var(--scalar-border-color);
+    --scalar-sidebar-color-1: var(--scalar-color-1);
+    --scalar-sidebar-color-2: var(--scalar-color-2);
+    --scalar-sidebar-color-active: var(--scalar-color-2);
+    --scalar-sidebar-search-background: var(--scalar-background-2);
+    --scalar-sidebar-search-border-color: var(--scalar-border-color);
+    --scalar-sidebar-search-color: var(--scalar-color-3);
+  }
+</style>
+```
+
+#### Theme Prefix Changes
+
+We've migrated our `--theme-*` CSS variables to `--scalar-*` to avoid conflicts with other CSS variables in
+applications consuming the Scalar references or themes.
+If you're injecting your custom CSS through the [`customCss`](/documentation/configuration.md) configuration option we will automatically
+migrate your variable prefixes but display a warning in the console.
+
+We recommend updating your theme variables as soon as possible:
+
+- `--theme-*` → `--scalar-*`
+- `--sidebar-*` → `--scalar-sidebar-*`
+
+For a before and after example of an updated theme
+see [`legacyTheme.css`](/packages/themes/src/fixtures/legacyTheme.css)
+and [`updatedTheme.css`](/packages/themes/src/fixtures/updatedTheme.css)
+in the [`@scalar/themes`](/packages/themes/) package.

--- a/examples/docusaurus/README.md
+++ b/examples/docusaurus/README.md
@@ -18,7 +18,7 @@ This command starts a local development server and opens up a browser window. Mo
 
 ### Build
 
-```
+```bash
 $ yarn build
 ```
 

--- a/examples/proxy-server/README.md
+++ b/examples/proxy-server/README.md
@@ -16,7 +16,7 @@ The Scalar Proxy redirects requests to another server to avoid CORS issues. Itâ€
 go run main.go
 ```
 
-```
+```bash
 2024/05/08 10:49:59 ðŸ¥¤ Proxy Server listening on http://localhost:1337
 ```
 
@@ -26,7 +26,7 @@ PORT=8080 go run main.go
 
 ### Example
 
-```
+```bash
 curl --request GET \
      --url 'localhost:1337?scalar_url=https%3A%2F%2Fgalaxy.scalar.com%2Fplanets'
 ```

--- a/packages/api-reference-react/README.md
+++ b/packages/api-reference-react/README.md
@@ -13,10 +13,14 @@ npm install @scalar/api-reference-react
 
 ## Usage
 
+The API Reference package is written in Vue. That shouldn’t stop you from using it in React, though. We have created a client side wrapper in React:
+
+> [!WARNING]\
+> This is untested on SSR/SSG!
+
 ```ts
 import { ApiReferenceReact } from '@scalar/api-reference-react'
 import '@scalar/api-reference-react/style.css'
-import React from 'react'
 
 function App() {
   return (
@@ -32,6 +36,8 @@ function App() {
 
 export default App
 ```
+
+We wrote a [detailed integration guide for React](https://github.com/scalar/scalar/tree/main/documentation/react.md), too.
 
 ### Example
 

--- a/packages/docusaurus/README.md
+++ b/packages/docusaurus/README.md
@@ -15,8 +15,7 @@ npm install @scalar/docusaurus
 
 ## Usage
 
-Simple add to the plugins section of your Docusaurus config. If you are using
-typescript you can import the type options type as well
+Simply add to the plugins section of your Docusaurus config. If you are using Typescript you can import the type options type as well.
 
 ```ts
 import type { ScalarOptions } from '@scalar/docusaurus'
@@ -37,9 +36,11 @@ plugins: [
 ],
 ```
 
+We wrote a [detailed integration guide for Docusaurus](https://github.com/scalar/scalar/tree/main/documentation/docusaurus.md).
+
 ### Multiple API descriptions
 
-Is it possible to add show multiple API descriptions? Yes, it is! :)
+Is it possible to show multiple API descriptions? Yes, it is! :)
 
 ```ts
 import type { ScalarOptions } from '@scalar/docusaurus'

--- a/packages/fastify-api-reference/README.md
+++ b/packages/fastify-api-reference/README.md
@@ -40,7 +40,7 @@ fastify.register(require('@scalar/fastify-api-reference'), {
 })
 ```
 
-With the [@fastify/swagger](https://github.com/fastify/fastify-swagger) you can even generate your Swagger spec from the registered routes and directly pass it to the plugin:
+With [@fastify/swagger](https://github.com/fastify/fastify-swagger) you can even generate your OpenAPI documents from the registered routes and directly pass it to the plugin:
 
 ```ts
 await fastify.register(require('@scalar/fastify-api-reference'), {
@@ -74,7 +74,9 @@ await fastify.register(require('@scalar/fastify-api-reference'), {
 })
 ```
 
-The fastify plugin takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/tree/main/packages/api-reference#configuration) in the core package README.
+We wrote a [detailed integration guide for Fastify](https://github.com/scalar/scalar/tree/main/documentation/fastify.md).
+
+The fastify plugin takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/tree/main/documentation/configuration.md) in the core package README.
 
 ## Themes
 

--- a/packages/nextjs-api-reference/README.md
+++ b/packages/nextjs-api-reference/README.md
@@ -46,7 +46,9 @@ const config = {
 }
 ```
 
-The Next.js handler takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/tree/main/packages/api-reference#configuration) in the core package README.
+We wrote a [detailed integration guide for Next.js](/documentation/nextjs.md).
+
+The Next.js handler takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/tree/main/documentation/configuration.md) in the core package README.
 
 ## Themes
 

--- a/packages/nextjs-api-reference/src/ApiReference.ts
+++ b/packages/nextjs-api-reference/src/ApiReference.ts
@@ -5,7 +5,7 @@ import { nextjsThemeCss } from './theme'
 /**
  * Next.js adapter for an Api Reference
  *
- * {@link https://github.com/scalar/scalar?tab=readme-ov-file#configuration Configuration}
+ * {@link https://github.com/scalar/scalar/tree/main/documentation/configuration.md Configuration}
  *
  * @params config - the Api Reference config object
  * @params options - reserved for future use to add customization to the response

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -116,6 +116,6 @@ we sort out what is causing the package issues.
 
 To do this, just create a `.npmrc` file in your project root and fill it with:
 
-```
+```bash
 shamefully-hoist=true
 ```

--- a/packages/play-button/README.md
+++ b/packages/play-button/README.md
@@ -6,20 +6,21 @@ Have your own custom docs and want API testing built in? Check out our new relea
 
 Add the Scalar Play Button to your page
 
-```
-    <script
-      id="scalar-play-button-script"
-      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/play-button"></script>
+```html
+<script
+  id="scalar-play-button-script"
+  data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"></script>
+<script src="https://cdn.jsdelivr.net/npm/@scalar/play-button"></script>
 ```
 
 then add a button with the class and optional scalar-operation-id
 
-```
-    <button
-      scalar-operation-id="getPetById"
-      class="scalar-play-button">Try it Out</button>
-
+```html
+<button
+  scalar-operation-id="getPetById"
+  class="scalar-play-button">
+  Try it Out
+</button>
 ```
 
 Now when that button is clicked the Scalar API Client will open up :)

--- a/packages/scalar_fastapi/README.md
+++ b/packages/scalar_fastapi/README.md
@@ -28,5 +28,4 @@ async def scalar_html():
         openapi_url=app.openapi_url,
         title=app.title,
     )
-
 ```

--- a/packages/void-server/README.md
+++ b/packages/void-server/README.md
@@ -9,7 +9,7 @@ An Hono server that responds with the request data. Kind of a mirror for HTTP re
 
 ## Installation
 
-```
+```bash
 npm add @scalar/void-server
 ```
 


### PR DESCRIPTION
Hot take: The root README is too long.

This PR moves most of the content to the package READMEs or separate Markdown files in the `documentation/` folder. The separate files need love, too, but let’s focus on the root README in this PR.

Other changes:
* I’ve updated the features list in the root README
* I’ve made the `ci.yml` name shorter, so the badge becomes smaller

Some links are broken now, because they point to `main` and the new files aren’t in `main` yet. But I think we have to use absolute URLs for Markdown files that are published on npmjs.com.

Preview: https://github.com/scalar/scalar/blob/de76754db35942c206858c2143428ceeaeb90d27/README.md