### PR TITLE
chore: remove ESLint `max-len` for comments

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -97,7 +97,7 @@ module.exports = {
         ],
         '@typescript-eslint/prefer-optional-chain': 'warn',
         'camelcase': 'off',
-        'max-len': ['warn', { code: 120, comments: 120 }],
+        'max-len': ['warn', { code: 120, comments: null }],
         '@typescript-eslint/naming-convention': [
           'error',
           // {


### PR DESCRIPTION
We recently introduced a warning for code lines and comments longer than 120 characters. 

This highlights a lot of the existing comments, and I don't think it makes much sense to manually wrap them to fit into that length. It’s just one thing that I need to manually deal with and think about, especially when updating comments and adding content somewhere before the line break.

For some coments, it doesn’t make sense to wrap them:

<img width="1334" alt="Screenshot 2024-06-21 at 12 18 55" src="https://github.com/scalar/scalar/assets/1577992/28315ecf-7cd1-423c-9c62-9a11173699eb">

And if someone is annoyed by the long comments, there’s a setting in VS Code (and other editors) to automatically wrap lines.

Long code lines = complexity, long comments = valuable information.

I’d say, let’s keep the limit for the code, but not for the comments. :)