### PR TITLE
feat(client-app): hide header in read only mode

### DIFF
--- a/packages/client-app/src/components/Sidebar/Sidebar.vue
+++ b/packages/client-app/src/components/Sidebar/Sidebar.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 import { themeClasses } from '@/constants'
+import { useWorkspace } from '@/store/workspace'
+
+const { workspace } = useWorkspace()
 </script>
 <template>
   <aside
     class="w-sidebar relative flex flex-col border-r bg-b-1"
     :class="[themeClasses.sidebar]">
-    <div class="xl:min-h-header py-2.5 flex items-center border-b px-4 text-sm">
+    <div
+      v-if="!workspace.isReadOnly"
+      class="xl:min-h-header py-2.5 flex items-center border-b px-4 text-sm">
       <h2 class="font-medium m-0 text-sm"><slot name="title" /></h2>
     </div>
     <div class="custom-scroll sidebar-height">


### PR DESCRIPTION
this pr is a proposal to hide the client modal header in read only mode as it could be misleading:

<img width="1460" alt="image" src="https://github.com/scalar/scalar/assets/14966155/cd0dd676-b771-42c9-ad1b-13313d345730">
