### PR TITLE
feat(void): XML and HTML response

### DIFF
--- a/.changeset/tame-pumpkins-judge.md
+++ b/.changeset/tame-pumpkins-judge.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+feat: html and xml responses

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -38,7 +38,8 @@
   "module": "dist/index.js",
   "dependencies": {
     "@hono/node-server": "^1.11.0",
-    "hono": "^4.2.7"
+    "hono": "^4.2.7",
+    "object-to-xml": "^2.0.0"
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -155,7 +155,7 @@ describe('createVoidServer', () => {
     })
   })
 
-  it('returns xml', async () => {
+  it('returns XML', async () => {
     const server = await createVoidServer()
 
     const response = await server.request('/', {
@@ -165,5 +165,17 @@ describe('createVoidServer', () => {
     })
 
     expect(await response.text()).toContain('<method>GET</method>')
+  })
+
+  it('returns HTML', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/', {
+      headers: {
+        Accept: 'text/html',
+      },
+    })
+
+    expect(await response.text()).toContain('<strong>method:</strong> GET</li>')
   })
 })

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -154,4 +154,16 @@ describe('createVoidServer', () => {
       },
     })
   })
+
+  it('returns xml', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/', {
+      headers: {
+        Accept: 'application/xml',
+      },
+    })
+
+    expect(await response.text()).toContain('<method>GET</method>')
+  })
 })

--- a/packages/void-server/src/createVoidServer.ts
+++ b/packages/void-server/src/createVoidServer.ts
@@ -54,11 +54,11 @@ export async function createVoidServer() {
 
     const acceptedContentType = accepts(c, {
       header: 'Accept',
-      supports: ['application/json', 'application/xml', 'application/zip'],
+      supports: ['text/html', 'application/xml', 'application/zip'],
       default: 'application/json',
     })
 
-    if (acceptedContentType === 'application/html') {
+    if (acceptedContentType === 'text/html') {
       return createHtmlResponse(c, requestData)
     }
 

--- a/packages/void-server/src/createVoidServer.ts
+++ b/packages/void-server/src/createVoidServer.ts
@@ -1,13 +1,19 @@
 import { type Context, Hono } from 'hono'
-import { getCookie } from 'hono/cookie'
+import { accepts } from 'hono/accepts'
 import { cors } from 'hono/cors'
+
+import {
+  createHtmlResponse,
+  createJsonResponse,
+  createXmlResponse,
+  createZipFileResponse,
+  getRequestData,
+} from './utils'
 
 /**
  * Create a mock server instance
  */
-export async function createVoidServer(options?: {
-  //
-}) {
+export async function createVoidServer() {
   const app = new Hono()
 
   // CORS headers
@@ -26,82 +32,46 @@ export async function createVoidServer(options?: {
   app.all('/:filename{.+\\.zip$}', async (c: Context) => {
     console.info(`${c.req.method} ${c.req.path}`)
 
-    const blob = new Blob(
-      [
-        new Uint8Array([
-          80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ]).buffer,
-      ],
-      {
-        type: 'application/zip',
-      },
-    )
+    return createZipFileResponse(c)
+  })
 
-    c.header('Content-Type', 'application/zip')
-    return c.body(blob.toString())
+  // Return HTML files for all requests ending with .html
+  app.all('/:filename{.+\\.html$}', async (c: Context) => {
+    console.info(`${c.req.method} ${c.req.path}`)
+
+    // make sure to not execute another route
+
+    const requestData = await getRequestData(c)
+
+    return createHtmlResponse(c, requestData)
   })
 
   // All other requests just respond with a JSON containing all the request data
   app.all('/*', async (c: Context) => {
     console.info(`${c.req.method} ${c.req.path}`)
 
-    let authentication = {}
+    const requestData = await getRequestData(c)
 
-    const authorizationHeader = c.req.header('Authorization')
+    const acceptedContentType = accepts(c, {
+      header: 'Accept',
+      supports: ['application/json', 'application/xml', 'application/zip'],
+      default: 'application/json',
+    })
 
-    if (authorizationHeader) {
-      // if value starts with "Basic "
-      if (authorizationHeader.startsWith('Basic ')) {
-        const token = authorizationHeader.split(' ')[1]
-
-        authentication = {
-          authentication: {
-            type: 'http.basic',
-            token,
-            value: atob(token),
-          },
-        }
-      }
-
-      if (authorizationHeader.startsWith('Bearer ')) {
-        const token = authorizationHeader.split(' ')[1]
-
-        authentication = {
-          authentication: {
-            type: 'http.bearer',
-            token,
-          },
-        }
-      }
+    if (acceptedContentType === 'application/html') {
+      return createHtmlResponse(c, requestData)
     }
 
-    const headers = Object.fromEntries(c.req.raw.headers)
+    if (acceptedContentType === 'application/xml') {
+      return createXmlResponse(c, requestData)
+    }
 
-    const body = await getBody(c)
+    if (acceptedContentType === 'application/zip') {
+      return createZipFileResponse(c)
+    }
 
-    const cookies = getCookie(c)
-
-    return c.json({
-      headers,
-      ...authentication,
-      cookies,
-      method: c.req.method,
-      path: c.req.path,
-      query: c.req.query(),
-      body: body,
-    })
+    return createJsonResponse(c, requestData)
   })
 
   return app
-}
-
-async function getBody(c: Context) {
-  const body = await c.req.text()
-
-  // Try to parse the body as JSON
-  try {
-    return JSON.parse(body)
-  } catch {
-    return body
-  }
 }

--- a/packages/void-server/src/utils/createHtmlResponse.ts
+++ b/packages/void-server/src/utils/createHtmlResponse.ts
@@ -1,0 +1,72 @@
+import type { Context } from 'hono'
+
+/**
+ * Transform an object into an XML response
+ */
+export function createHtmlResponse(c: Context, data: Record<string, any>) {
+  c.header('Content-Type', 'text/html')
+
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0" />
+    <title>Void</title>
+    <style>
+      body {
+        margin: 2rem;
+      }
+
+      * {
+        font-family: monospace;
+        line-height: 1.4;
+        color: #868e96;
+      }
+
+      strong {
+        color: #495057;
+      }
+
+      li {
+        list-style-type: none;
+        margin: 0.3rem 0;
+      }
+
+      ul {
+        padding-left: 1rem;
+        margin: 0;
+        margin-bottom: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    ${createObjectTree(data)}
+  </body>
+</html>
+`
+
+  return c.html(html)
+}
+
+/**
+ * Loop through object recursively and create a JSON string as formatted HTML
+ */
+function createObjectTree(data: Record<string, any>) {
+  let html = ''
+
+  for (const key in data) {
+    if (Object.hasOwn(data, key)) {
+      const value = data[key]
+
+      if (typeof value === 'object') {
+        html += `<li><strong>${key}:</strong> <ul>${createObjectTree(value)}</ul></li>`
+      } else {
+        html += `<li><strong>${key}:</strong> ${value}</li>`
+      }
+    }
+  }
+
+  return html
+}

--- a/packages/void-server/src/utils/createJsonResponse.ts
+++ b/packages/void-server/src/utils/createJsonResponse.ts
@@ -1,0 +1,8 @@
+import type { Context } from 'hono'
+
+/**
+ * Transform an object into a JSON response
+ */
+export function createJsonResponse(c: Context, data: Record<string, any>) {
+  return c.json(data)
+}

--- a/packages/void-server/src/utils/createXmlResponse.ts
+++ b/packages/void-server/src/utils/createXmlResponse.ts
@@ -1,0 +1,17 @@
+import type { Context } from 'hono'
+// @ts-expect-error Doesn’t come with types
+import objectToXML from 'object-to-xml'
+
+/**
+ * Transform an object into an XML response
+ */
+export function createXmlResponse(c: Context, data: Record<string, any>) {
+  c.header('Content-Type', 'application/xml')
+
+  const obj = {
+    '?xml version="1.0" encoding="UTF-8"?': null,
+    ...data,
+  }
+
+  return c.text(objectToXML(obj))
+}

--- a/packages/void-server/src/utils/createZipFileResponse.ts
+++ b/packages/void-server/src/utils/createZipFileResponse.ts
@@ -1,0 +1,21 @@
+import type { Context } from 'hono'
+
+/**
+ * Creates an empty Zip file response
+ */
+export function createZipFileResponse(c: Context) {
+  c.header('Content-Type', 'application/zip')
+
+  const blob = new Blob(
+    [
+      new Uint8Array([
+        80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      ]).buffer,
+    ],
+    {
+      type: 'application/zip',
+    },
+  )
+
+  return c.body(blob.toString())
+}

--- a/packages/void-server/src/utils/getBody.ts
+++ b/packages/void-server/src/utils/getBody.ts
@@ -1,0 +1,15 @@
+import type { Context } from 'hono'
+
+/**
+ * Get the body of a request, no matter if it’s JSON or text
+ */
+export async function getBody(c: Context) {
+  const body = await c.req.text()
+
+  // Try to parse the body as JSON
+  try {
+    return JSON.parse(body)
+  } catch {
+    return body
+  }
+}

--- a/packages/void-server/src/utils/getRequestData.ts
+++ b/packages/void-server/src/utils/getRequestData.ts
@@ -1,0 +1,55 @@
+import type { Context } from 'hono'
+import { getCookie } from 'hono/cookie'
+
+import { getBody } from './getBody'
+
+/**
+ * Collect all the data from a request
+ */
+export async function getRequestData(c: Context) {
+  let authentication = {}
+
+  const authorizationHeader = c.req.header('Authorization')
+
+  if (authorizationHeader) {
+    // if value starts with "Basic "
+    if (authorizationHeader.startsWith('Basic ')) {
+      const token = authorizationHeader.split(' ')[1]
+
+      authentication = {
+        authentication: {
+          type: 'http.basic',
+          token,
+          value: atob(token),
+        },
+      }
+    }
+
+    if (authorizationHeader.startsWith('Bearer ')) {
+      const token = authorizationHeader.split(' ')[1]
+
+      authentication = {
+        authentication: {
+          type: 'http.bearer',
+          token,
+        },
+      }
+    }
+  }
+
+  const headers = Object.fromEntries(c.req.raw.headers)
+
+  const body = await getBody(c)
+
+  const cookies = getCookie(c)
+
+  return {
+    method: c.req.method,
+    path: c.req.path,
+    headers,
+    ...authentication,
+    cookies,
+    query: c.req.query(),
+    body: body,
+  }
+}

--- a/packages/void-server/src/utils/index.ts
+++ b/packages/void-server/src/utils/index.ts
@@ -1,0 +1,6 @@
+export * from './createHtmlResponse'
+export * from './createJsonResponse'
+export * from './createXmlResponse'
+export * from './createZipFileResponse'
+export * from './getBody'
+export * from './getRequestData'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2129,6 +2129,9 @@ importers:
       hono:
         specifier: ^4.2.7
         version: 4.4.6
+      object-to-xml:
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -7946,6 +7949,12 @@ packages:
       typescript:
         optional: true
 
+  dank-each@1.0.0:
+    resolution: {integrity: sha512-gMDy24y+3LlnAaHq4WFwRKliMZRkGp41Gy9JVsD1BO5tprb/lEh4afJlkankcTqRoppSaHRwgFQX61QjJ5ClfQ==}
+
+  dank-map@0.1.0:
+    resolution: {integrity: sha512-mQoLySkWc5bQM8XKXz0rIuISX/+12rSSfPojYlTVT6KPj3LsvfLURtrv0w+QEt1gRIKwp9mxnwOcL5nsOTkk2Q==}
+
   data-urls@4.0.0:
     resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
     engines: {node: '>=14'}
@@ -11512,6 +11521,9 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
+  object-to-xml@2.0.0:
+    resolution: {integrity: sha512-bArXy7WCF1V9R88/zF9adSZSeFQnFmmKhMqNuNLAxqrbkvzcWP8HgnaRCcVJsfvIgvpdHiYd0qzJi7LM7QFfcQ==}
+
   object.assign@4.1.5:
     resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
     engines: {node: '>= 0.4'}
@@ -13218,6 +13230,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitizer@0.1.3:
+    resolution: {integrity: sha512-j05vL56tR90rsYqm9ZD05v6K4HI7t4yMDEvvU0x4f+IADXM9Jx1x9mzatxOs5drJq6dGhugxDW99mcPvXVLl+Q==}
 
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
@@ -23505,6 +23520,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.4.5
 
+  dank-each@1.0.0: {}
+
+  dank-map@0.1.0: {}
+
   data-urls@4.0.0:
     dependencies:
       abab: 2.0.6
@@ -28340,6 +28359,12 @@ snapshots:
 
   object-keys@1.1.1: {}
 
+  object-to-xml@2.0.0:
+    dependencies:
+      dank-each: 1.0.0
+      dank-map: 0.1.0
+      sanitizer: 0.1.3
+
   object.assign@4.1.5:
     dependencies:
       call-bind: 1.0.7
@@ -30173,6 +30198,8 @@ snapshots:
   safe-stable-stringify@2.4.3: {}
 
   safer-buffer@2.1.2: {}
+
+  sanitizer@0.1.3: {}
 
   sax@1.4.1: {}
 


### PR DESCRIPTION
This PR adds HTML and XML responses to the `@scalar/void-server`, they come up when you request an URL that ends with `.html` or `.xml` or send an `Accept: application/xml` or `Accept: text/html` header.

<img width="636" alt="Screenshot 2024-06-21 at 16 02 40" src="https://github.com/scalar/scalar/assets/1577992/eb73662f-7d5c-4675-8306-e0ddea275ffe">
