### PR TITLE
feat(client-app): add scalar-client class to teleported dropdowns

### DIFF
--- a/.changeset/six-planets-buy.md
+++ b/.changeset/six-planets-buy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/client-app': patch
+---
+
+feat(client-app): add scalar-client class to teleported dropdowns

--- a/.changeset/six-planets-buy.md
+++ b/.changeset/six-planets-buy.md
@@ -2,4 +2,4 @@
 '@scalar/client-app': patch
 ---
 
-feat(client-app): add scalar-client class to teleported dropdowns
+feat(client-app): teleport dropdowns to #scalar-client instead of <body> 

--- a/packages/client-app/index.html
+++ b/packages/client-app/index.html
@@ -25,7 +25,7 @@
 
   <body>
     <div
-      id="app"
+      id="scalar-client"
       class="scalar-app scalar-client"></div>
     <script
       type="module"

--- a/packages/client-app/src/App.vue
+++ b/packages/client-app/src/App.vue
@@ -57,7 +57,7 @@ onMounted(() => {
 @import './assets/tailwind.css';
 @import './assets/variables.css';
 
-#app.scalar-client {
+#scalar-client {
   display: flex;
   flex-direction: column;
   height: 100vh;

--- a/packages/client-app/src/components/AddressBar/AddressBar.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBar.vue
@@ -194,9 +194,8 @@ const handlePaste = (event: ClipboardEvent) => {
                 (serverOptions.length > 1 || !workspace.isReadOnly)
               ">
               <ScalarDropdown
-                class="scalar-client"
                 :options="serverOptions"
-                teleport
+                teleport="#scalar-client"
                 :value="activeCollection?.selectedServerUid">
                 <button
                   class="font-code lg:text-sm text-xs whitespace-nowrap border border-b-3 border-solid rounded px-1.5 text-c-2"

--- a/packages/client-app/src/components/AddressBar/AddressBar.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBar.vue
@@ -194,7 +194,9 @@ const handlePaste = (event: ClipboardEvent) => {
                 (serverOptions.length > 1 || !workspace.isReadOnly)
               ">
               <ScalarDropdown
+                class="scalar-client"
                 :options="serverOptions"
+                teleport
                 :value="activeCollection?.selectedServerUid">
                 <button
                   class="font-code lg:text-sm text-xs whitespace-nowrap border border-b-3 border-solid rounded px-1.5 text-c-2"

--- a/packages/client-app/src/main.ts
+++ b/packages/client-app/src/main.ts
@@ -6,4 +6,4 @@ import App from './App.vue'
 const app = createApp(App)
 
 app.use(router)
-app.mount('#app')
+app.mount('#scalar-client')

--- a/packages/client-app/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/client-app/src/views/Request/RequestSidebarItemMenu.vue
@@ -48,7 +48,9 @@ const isRequest = computed(() => 'summary' in props.item)
 </script>
 
 <template>
-  <ScalarDropdown teleport>
+  <ScalarDropdown
+    class="scalar-client"
+    teleport>
     <ScalarButton
       class="z-10 hover:bg-b-3 transition-none p-1 group-hover:flex ui-open:flex absolute left-0 hidden -translate-x-full -ml-1"
       size="sm"

--- a/packages/client-app/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/client-app/src/views/Request/RequestSidebarItemMenu.vue
@@ -48,9 +48,7 @@ const isRequest = computed(() => 'summary' in props.item)
 </script>
 
 <template>
-  <ScalarDropdown
-    class="scalar-client"
-    teleport>
+  <ScalarDropdown teleport="#scalar-client">
     <ScalarButton
       class="z-10 hover:bg-b-3 transition-none p-1 group-hover:flex ui-open:flex absolute left-0 hidden -translate-x-full -ml-1"
       size="sm"

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -75,7 +75,7 @@ const { floatingStyles, middlewareData } = useFloating(targetRef, floatingRef, {
   <Teleport
     v-if="isOpen"
     :disabled="!teleport"
-    to="body">
+    :to="typeof teleport === 'string' ? teleport : 'body'">
     <div class="scalar-app">
       <div
         ref="floatingRef"

--- a/packages/components/src/components/ScalarFloating/types.ts
+++ b/packages/components/src/components/ScalarFloating/types.ts
@@ -22,8 +22,9 @@ export type FloatingOptions = {
    */
   isOpen?: boolean
   /**
-   * Whether to teleport the floating element to the end of the document body.
+   * Whether to teleport the floating element.
+   * Can be an `id` to teleport to or `true` to teleport to the `<body>`.
    * @default false
    */
-  teleport?: boolean
+  teleport?: boolean | string
 }


### PR DESCRIPTION
ScalarDropdown [merges the class onto the dropdown](https://github.com/scalar/scalar/blob/main/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue#L24) so we can just add the class directly to the dropdown component.

## Before:

<img width="395" alt="Google Chrome-2024-06-21-09-25-08@2x" src="https://github.com/scalar/scalar/assets/6374090/bf9eecae-80eb-4180-85b5-e51542402ae9">

## After:

<img width="392" alt="Google Chrome-2024-06-21-09-24-15@2x" src="https://github.com/scalar/scalar/assets/6374090/ca18b5ce-00a1-4023-bc53-7c03f439848f">
