### PR TITLE
fix(galaxy): tsconfig does not include scripts

### DIFF
--- a/packages/galaxy/tsconfig.json
+++ b/packages/galaxy/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["vitest/globals", "@modyfi/vite-plugin-yaml/modules"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
When I run `pnpm lint` I get:

> ESLint was configured to run on `<tsconfigRootDir>/scripts/format.ts` 
> However, that TSConfig does not include this file.

This PR adds it to the `tsconfig.json`. :)