### PR TITLE
chore: add some missing JSDoc comments

### DIFF
--- a/packages/api-reference/src/helpers/createEmptySpecification.ts
+++ b/packages/api-reference/src/helpers/createEmptySpecification.ts
@@ -1,5 +1,9 @@
 import type { Spec } from '@scalar/oas-utils'
 
+/**
+ * Creates an empty specification object.
+ * The returning object has the same structure as a valid OpenAPI specification, but everything is empty.
+ */
 export function createEmptySpecification(): Spec {
   return {
     info: {

--- a/packages/api-reference/src/helpers/getHeadingsFromMarkdown.ts
+++ b/packages/api-reference/src/helpers/getHeadingsFromMarkdown.ts
@@ -9,6 +9,9 @@ const withSlugs = (headings: Heading[], slugger: GithubSlugger): Heading[] =>
     }
   })
 
+/**
+ * Extracts all headings from a Markdown string.
+ */
 export function getHeadingsFromMarkdown(input: string): Heading[] {
   const slugger = new GithubSlugger()
 

--- a/packages/api-reference/src/helpers/getModels.ts
+++ b/packages/api-reference/src/helpers/getModels.ts
@@ -1,6 +1,9 @@
 import type { Spec } from '@scalar/oas-utils'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 
+/**
+ * Returns all models from the specification, no matter if it’s Swagger 2.0 or OpenAPI 3.x.
+ */
 export function getModels(spec?: Spec) {
   if (!spec) {
     return {} as Record<string, OpenAPIV3_1.SchemaObject>

--- a/packages/api-reference/src/helpers/isValidUrl.ts
+++ b/packages/api-reference/src/helpers/isValidUrl.ts
@@ -1,8 +1,10 @@
-// checks to see if a given url is valid
+/**
+ * Checks if the given string is a valid URL
+ */
 export function isValidUrl(url: string) {
   try {
     return Boolean(new URL(url))
-  } catch (e) {
+  } catch {
     return false
   }
 }

--- a/packages/api-reference/src/helpers/openClientFor.ts
+++ b/packages/api-reference/src/helpers/openClientFor.ts
@@ -16,6 +16,9 @@ const { toggleApiClient } = useApiClientStore()
 
 const { setActiveRequest, resetActiveResponse } = useRequestStore()
 
+/**
+ * Prepares all the data to open the API client for a specific operation.
+ */
 export function openClientFor(
   operation: TransformedOperation,
   globalSecurity?: OpenAPIV3.SecurityRequirementObject[],

--- a/packages/api-reference/src/hooks/useDeprecationWarnings.ts
+++ b/packages/api-reference/src/hooks/useDeprecationWarnings.ts
@@ -6,6 +6,9 @@ const OLD_PROXY_URL = 'https://api.scalar.com/request-proxy'
 const NEW_PROXY_URL = 'https://proxy.scalar.com'
 const LOCAL_PROXY_URL = 'http://localhost:5051'
 
+/**
+ * Warns the user about deprecated configurations in the browser console.
+ */
 export function useDeprecationWarnings(configuration: ReferenceConfiguration) {
   watch(
     () => configuration,

--- a/packages/api-reference/src/hooks/useRefOnMount.ts
+++ b/packages/api-reference/src/hooks/useRefOnMount.ts
@@ -1,6 +1,8 @@
 import { type Ref, onMounted, ref } from 'vue'
 
-// Set a ref value on mount when needed to access properties that are not SSR friendly
+/**
+ * Set a ref value on mount when needed to access properties that are not SSR-friendly.
+ */
 export function useRefOnMount<T>(setter: () => T) {
   const value: Ref<T | null> = ref(null)
 

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -276,12 +276,17 @@ const items = computed(() => {
   }
 })
 
-// Controls whether or not the sidebar is open on MOBILE only
-// Desktop uses the standard showSidebar prop which supercedes this one
+/**
+ * Controls whether or not the sidebar is open on mobile-only.
+ * Desktop uses the standard showSidebar prop which supercedes this one.
+ */
 const isSidebarOpen = ref(false)
 
 const breadcrumb = computed(() => items.value?.titles?.[hash.value] ?? '')
 
+/**
+ * Provides the sidebar state and methods to control it.
+ */
 export function useSidebar(options?: { parsedSpec: Spec }) {
   if (options?.parsedSpec) {
     parsedSpec.value = options.parsedSpec

--- a/packages/api-reference/src/stores/useHttpClientStore.ts
+++ b/packages/api-reference/src/stores/useHttpClientStore.ts
@@ -32,6 +32,9 @@ const httpClientTitle = computed(() => {
   return getClientTitle(httpClient)
 })
 
+/**
+ * Filters out hidden clients from the available targets (based on the given configuration).
+ */
 export function filterHiddenClients(
   targets: AvailableTarget[],
   exclude: Ref<HiddenClients>,


### PR DESCRIPTION
This PR adds some of the missing JSDoc comments for exported functions in `@scalar/api-reference`. 🌟 