### PR TITLE
feat(cli): add more attributes to `scalar init`

### DIFF
--- a/.changeset/pretty-rats-melt.md
+++ b/.changeset/pretty-rats-melt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/cli': patch
+---
+
+feat: add a subdomain to the configuration file

--- a/.changeset/wild-mangos-invent.md
+++ b/.changeset/wild-mangos-invent.md
@@ -1,0 +1,5 @@
+---
+'@scalar/cli': patch
+---
+
+feat: add --force flag to overwrite existing files

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
     "@scalar/openapi-parser": "^0.7.1",
     "@scalar/void-server": "workspace:*",
     "commander": "^12.0.0",
+    "github-slugger": "^2.0.0",
     "glob": "^10.3.10",
     "hono": "^4.2.7",
     "kleur": "^4.1.5",

--- a/packages/cli/src/commands/init/InitCommand.ts
+++ b/packages/cli/src/commands/init/InitCommand.ts
@@ -105,6 +105,7 @@ export function InitCommand() {
         message: `Where is your OpenAPI file? ${kleur.reset().grey('(Add a path to the file)')}`,
         validate(value) {
           if (value.length === 0) return `Value is required!`
+          return null
         },
       })
 

--- a/packages/cli/src/commands/init/InitCommand.ts
+++ b/packages/cli/src/commands/init/InitCommand.ts
@@ -134,16 +134,14 @@ export function InitCommand() {
     // Create `scalar.config.json` file
     s.start('Creating Scalar configuration file...')
 
-    setTimeout(() => {
-      fs.writeFileSync(configFile, content)
-      s.stop(
-        `Scalar configuration file created: ${kleur.reset().green(`${CONFIG_FILE}`)}`,
-      )
-      console.log()
-      nextSteps()
-      console.log()
-      console.log()
-    }, 1000)
+    fs.writeFileSync(configFile, content)
+    s.stop(
+      `Scalar configuration file created: ${kleur.reset().green(`${CONFIG_FILE}`)}`,
+    )
+    console.log()
+    nextSteps()
+    console.log()
+    console.log()
   })
 
   return cmd

--- a/packages/cli/src/commands/init/init.test.ts
+++ b/packages/cli/src/commands/init/init.test.ts
@@ -29,7 +29,10 @@ describe('init', () => {
       ])
 
     // Output
-    logs.should.contain('Scalar configuration file created: scalar.config.json')
+    logs.should.contain(`"subdomain": "foobar.apidocumentation.com"`)
+    logs.should.contain(
+      `"path": "./packages/cli/src/commands/validate/valid.json"`,
+    )
 
     // File exists
     expect(fs.existsSync(configFile)).toBe(true)

--- a/packages/cli/src/commands/init/init.test.ts
+++ b/packages/cli/src/commands/init/init.test.ts
@@ -23,6 +23,9 @@ describe('init', () => {
         'init',
         '--file',
         './packages/cli/src/commands/validate/valid.json',
+        '--force',
+        '--subdomain',
+        'foobar.apidocumentation.com',
       ])
 
     // Output

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,7 +558,7 @@ importers:
         version: 8.4.38
       tailwindcss:
         specifier: ^3.4.4
-        version: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+        version: 3.4.4(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5))
       typescript:
         specifier: ^5.4.3
         version: 5.4.5
@@ -1108,6 +1108,9 @@ importers:
       commander:
         specifier: ^12.0.0
         version: 12.1.0
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       glob:
         specifier: ^10.3.10
         version: 10.4.1
@@ -1156,7 +1159,7 @@ importers:
     dependencies:
       '@headlessui/tailwindcss':
         specifier: ^0.2.0
-        version: 0.2.1(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)))
+        version: 0.2.1(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5)))
       '@headlessui/vue':
         specifier: ^1.7.20
         version: 1.7.22(vue@3.4.29(typescript@5.4.5))
@@ -1238,10 +1241,10 @@ importers:
         version: 8.4.38
       tailwindcss:
         specifier: ^3.4.4
-        version: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+        version: 3.4.4(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5))
       tailwindcss-color-mix:
         specifier: ^0.0.8
-        version: 0.0.8(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)))
+        version: 0.0.8(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5)))
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.10
@@ -1965,7 +1968,7 @@ importers:
         version: 1.6.0(vitest@1.6.0(@types/node@20.14.2)(jsdom@24.1.0)(terser@5.31.1))
       tailwindcss:
         specifier: ^3.4.4
-        version: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+        version: 3.4.4(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5))
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.10
@@ -14877,6 +14880,9 @@ packages:
   vue-component-type-helpers@2.0.21:
     resolution: {integrity: sha512-3NaicyZ7N4B6cft4bfb7dOnPbE9CjLcx+6wZWAg5zwszfO4qXRh+U52dN5r5ZZfc6iMaxKCEcoH9CmxxoFZHLg==}
 
+  vue-component-type-helpers@2.0.22:
+    resolution: {integrity: sha512-gPr2Ba7efUwy/Vfbuf735bHSVdN4ycoZUCHfypkI33M9DUH+ieRblLLVM2eImccFYaWNWwEzURx02EgoXDBmaQ==}
+
   vue-demi@0.14.8:
     resolution: {integrity: sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==}
     engines: {node: '>=12'}
@@ -17797,10 +17803,6 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5))
 
-  '@headlessui/tailwindcss@0.2.1(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)))':
-    dependencies:
-      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
-
   '@headlessui/vue@1.7.22(vue@3.4.29(typescript@5.4.5))':
     dependencies:
       '@tanstack/vue-virtual': 3.5.1(vue@3.4.29(typescript@5.4.5))
@@ -19404,7 +19406,7 @@ snapshots:
 
   '@rise8/tailwind-pixel-perfect-preset@1.0.1(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)))':
     dependencies:
-      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5))
 
   '@rollup/plugin-alias@5.1.0(rollup@3.29.4)':
     dependencies:
@@ -20530,7 +20532,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.29(typescript@5.4.5)
-      vue-component-type-helpers: 2.0.21
+      vue-component-type-helpers: 2.0.22
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -28926,14 +28928,6 @@ snapshots:
       postcss: 8.4.38
       ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5)
 
-  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)):
-    dependencies:
-      lilconfig: 3.1.2
-      yaml: 2.4.5
-    optionalDependencies:
-      postcss: 8.4.38
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.2)(typescript@5.4.5)
-
   postcss-loader@7.3.4(postcss@8.4.38)(typescript@5.4.5)(webpack@5.92.0):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -30990,10 +30984,6 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5))
 
-  tailwindcss-color-mix@0.0.8(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))):
-    dependencies:
-      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
-
   tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -31014,33 +31004,6 @@ snapshots:
       postcss-import: 15.1.0(postcss@8.4.38)
       postcss-js: 4.0.1(postcss@8.4.38)
       postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.2)(typescript@5.4.5))
-      postcss-nested: 6.0.1(postcss@8.4.38)
-      postcss-selector-parser: 6.1.0
-      resolve: 1.22.8
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
-
-  tailwindcss@3.4.4(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.2
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.6
-      lilconfig: 2.1.0
-      micromatch: 4.0.7
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.1
-      postcss: 8.4.38
-      postcss-import: 15.1.0(postcss@8.4.38)
-      postcss-js: 4.0.1(postcss@8.4.38)
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
       postcss-nested: 6.0.1(postcss@8.4.38)
       postcss-selector-parser: 6.1.0
       resolve: 1.22.8
@@ -32236,6 +32199,8 @@ snapshots:
       typescript: 5.4.5
 
   vue-component-type-helpers@2.0.21: {}
+
+  vue-component-type-helpers@2.0.22: {}
 
   vue-demi@0.14.8(vue@3.4.29(typescript@5.4.5)):
     dependencies:


### PR DESCRIPTION
The `scalar init` command generates a `scalar.config.json`.  This PR extends the `scalar init` command to add the required attributes `subdomain`, an empty `guides` array and adds a `--force` flag to overwrite existing configurations without further interaction.

It’s not perfect, but one step closer to connect the CLI to docs.scalar.com.

<img width="933" alt="Screenshot 2024-06-24 at 15 21 38" src="https://github.com/scalar/scalar/assets/1577992/10912d47-1880-4034-9d4a-49e12a0daa15">
