### PR TITLE
feat: client credentials flow

### DIFF
--- a/packages/client-app/src/App.vue
+++ b/packages/client-app/src/App.vue
@@ -36,8 +36,9 @@ onBeforeMount(() => {
 
 onMounted(() => {
   importSpecFromUrl(
-    'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
-    'https://proxy.scalar.com',
+    'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+    // 'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
+    // 'https://proxy.scalar.com',
   )
 })
 </script>

--- a/packages/client-app/src/App.vue
+++ b/packages/client-app/src/App.vue
@@ -36,7 +36,8 @@ onBeforeMount(() => {
 
 onMounted(() => {
   importSpecFromUrl(
-    'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+    'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
+    'https://proxy.scalar.com',
   )
 })
 </script>

--- a/packages/client-app/src/store/workspace.ts
+++ b/packages/client-app/src/store/workspace.ts
@@ -555,32 +555,32 @@ async function importSpecFile(spec: string | AnyObject) {
       string,
       SecurityScheme
     >,
-    // ).forEach(([key, securityScheme]) =>
-    //   securitySchemeMutators.add(
-    //     createSecurityScheme({ ...securityScheme, uid: key }),
-    //   ),
-    // )
-    // TODOtest remove Temp for testing
   ).forEach(([key, securityScheme]) =>
     securitySchemeMutators.add(
-      createSecurityScheme({
-        ...securityScheme,
-        type: 'oauth2',
-        flows: {
-          authorizationCode: {
-            authorizationUrl: 'https://accounts.spotify.com/authorize',
-            tokenUrl: 'https://accounts.spotify.com/api/token',
-            scopes: securityScheme.flows.authorizationCode.scopes,
-          },
-          clientCredentials: {
-            tokenUrl: 'https://accounts.spotify.com/api/token',
-            scopes: securityScheme.flows.authorizationCode.scopes,
-          },
-        },
-        uid: key,
-      }),
+      createSecurityScheme({ ...securityScheme, uid: key }),
     ),
   )
+  // TODOtest remove Temp for testing
+  // ).forEach(([key, securityScheme]) =>
+  //   securitySchemeMutators.add(
+  //     createSecurityScheme({
+  //       ...securityScheme,
+  //       type: 'oauth2',
+  //       flows: {
+  //         authorizationCode: {
+  //           authorizationUrl: 'https://accounts.spotify.com/authorize',
+  //           tokenUrl: 'https://accounts.spotify.com/api/token',
+  //           scopes: securityScheme.flows.authorizationCode.scopes,
+  //         },
+  //         clientCredentials: {
+  //           tokenUrl: 'https://accounts.spotify.com/api/token',
+  //           scopes: securityScheme.flows.authorizationCode.scopes,
+  //         },
+  //       },
+  //       uid: key,
+  //     }),
+  //   ),
+  // )
 }
 
 // Function to fetch and import a spec from a URL

--- a/packages/client-app/src/store/workspace.ts
+++ b/packages/client-app/src/store/workspace.ts
@@ -597,7 +597,7 @@ async function importSpecFromUrl(url: string, proxy?: string) {
 const modalState = useModal()
 
 /**
- * Global hool which contains the store for the whole app
+ * Global hook which contains the store for the whole app
  * We may want to break this up at some point due to the massive file size
  */
 export const useWorkspace = () => ({

--- a/packages/client-app/src/store/workspace.ts
+++ b/packages/client-app/src/store/workspace.ts
@@ -48,7 +48,6 @@ import {
   setNestedValue,
 } from '@scalar/object-utils/nested'
 import type { AnyObject, OpenAPIV3_1 } from '@scalar/openapi-parser'
-import { log } from 'console'
 import { computed, reactive, readonly } from 'vue'
 
 const { setCollapsedSidebarFolder } = useSidebar()
@@ -568,10 +567,9 @@ async function importSpecFile(spec: string | AnyObject) {
         ...securityScheme,
         type: 'oauth2',
         flows: {
-          implicit: {
-            scopes: securityScheme.flows.authorizationCode.scopes,
-          },
           authorizationCode: {
+            authorizationUrl: 'https://accounts.spotify.com/authorize',
+            tokenUrl: 'https://accounts.spotify.com/api/token',
             scopes: securityScheme.flows.authorizationCode.scopes,
           },
           clientCredentials: {

--- a/packages/client-app/src/views/Request/RequestSection/RequestAuth.vue
+++ b/packages/client-app/src/views/Request/RequestSection/RequestAuth.vue
@@ -35,7 +35,7 @@ const columnLayout = computed(() => {
   ) {
     if (schemeModel.value.flowKey === 'implicit') {
       return ['', 'auto']
-    } else return ['']
+    } else return ['', 'auto']
   } else return ['']
 })
 

--- a/packages/client-app/src/views/Request/components/OAuth2.vue
+++ b/packages/client-app/src/views/Request/components/OAuth2.vue
@@ -43,7 +43,7 @@ const handleAuthorize = async () => {
       :modelValue="activeScheme.flow.token"
       type="password"
       @update:modelValue="
-        (v) => updateScheme(`flows.${props.schemeModel.flowKey}.token`, v)
+        (v) => updateScheme(`flows.${schemeModel.flowKey}.token`, v)
       ">
       Access Token
     </RequestAuthDataTableInput>
@@ -51,14 +51,16 @@ const handleAuthorize = async () => {
       <ScalarButton
         size="sm"
         variant="ghost"
-        @click="updateScheme(`flows.${props.schemeModel.flowKey}.token`, '')">
+        @click="updateScheme(`flows.${schemeModel.flowKey}.token`, '')">
         Clear
       </ScalarButton>
     </DataTableCell>
   </DataTableRow>
 
   <template v-else>
-    <DataTableRow class="border-r-transparent">
+    <DataTableRow
+      v-if="schemeModel.flowKey !== 'clientCredentials'"
+      class="border-r-transparent">
       <!-- Redirect URI -->
       <RequestAuthDataTableInput
         id="oauth2-redirect-uri"
@@ -74,13 +76,18 @@ const handleAuthorize = async () => {
     <DataTableRow class="border-r-transparent">
       <RequestAuthDataTableInput
         id="oauth2-client-id"
+        :containerClass="
+          schemeModel.flowKey !== 'implicit' ? 'col-start-1 col-end-3' : ''
+        "
         :modelValue="activeScheme.scheme.clientId"
         placeholder="12345"
         @update:modelValue="(v) => props.updateScheme('clientId', v)">
         Client ID
       </RequestAuthDataTableInput>
 
-      <DataTableCell class="flex items-center p-0.5">
+      <DataTableCell
+        v-if="schemeModel.flowKey === 'implicit'"
+        class="flex items-center p-0.5">
         <ScopesDropdown
           :activeFlow="activeScheme.flow"
           :schemeModel="schemeModel"
@@ -88,7 +95,6 @@ const handleAuthorize = async () => {
 
         <!-- Authorize button only for implicit here -->
         <ScalarButton
-          v-if="schemeModel.flowKey === 'implicit'"
           :loading="loadingState"
           size="sm"
           @click="handleAuthorize">
@@ -117,6 +123,11 @@ const handleAuthorize = async () => {
       </RequestAuthDataTableInput>
 
       <DataTableCell class="flex items-center p-0.5">
+        <ScopesDropdown
+          :activeFlow="activeScheme.flow"
+          :schemeModel="schemeModel"
+          :updateScheme="updateScheme" />
+
         <ScalarButton
           :loading="loadingState"
           size="sm"
@@ -140,22 +151,6 @@ const handleAuthorize = async () => {
     <!--     <ScalarButton size="sm">Authorize</ScalarButton> -->
     <!--   </DataTableCell> -->
     <!-- </DataTableRow> -->
-
-    <!-- Client Credentials -->
-    <DataTableRow
-      v-if="schemeModel.flowKey === 'clientCredentials'"
-      class="border-r-transparent">
-      <RequestAuthDataTableInput
-        id="oauth2-client-credentials"
-        :modelValue="activeScheme.scheme.clientId"
-        placeholder="12345"
-        @update:modelValue="(v) => updateScheme('clientId', v)">
-        Client ID
-      </RequestAuthDataTableInput>
-      <DataTableCell class="flex items-center p-0.5">
-        <ScalarButton size="sm">Authorize</ScalarButton>
-      </DataTableCell>
-    </DataTableRow>
 
     <!-- Open ID Connect -->
     <!-- <DataTableRow -->

--- a/packages/oas-utils/src/entities/workspace/security/security-schemes.ts
+++ b/packages/oas-utils/src/entities/workspace/security/security-schemes.ts
@@ -176,5 +176,5 @@ export type SecuritySchemePayload = z.input<typeof securityScheme>
 
 /** Create Security Scheme with defaults */
 export const createSecurityScheme = (payload: SecuritySchemePayload) =>
-  // deepMerge(securityScheme.parse({ type: payload.type }), payload)
-  securityScheme.parse(payload)
+  deepMerge(securityScheme.parse({ type: payload.type }), payload)
+// securityScheme.parse(payload)

--- a/packages/oas-utils/src/entities/workspace/security/security-schemes.ts
+++ b/packages/oas-utils/src/entities/workspace/security/security-schemes.ts
@@ -176,4 +176,5 @@ export type SecuritySchemePayload = z.input<typeof securityScheme>
 
 /** Create Security Scheme with defaults */
 export const createSecurityScheme = (payload: SecuritySchemePayload) =>
-  deepMerge(securityScheme.parse({ type: payload.type }), payload)
+  // deepMerge(securityScheme.parse({ type: payload.type }), payload)
+  securityScheme.parse(payload)


### PR DESCRIPTION
This PR adds the client credentials oauth 2 flow. 

Test data IS enabled so you can test both authorization code flow as well as client credentials (they use the same server method now) to make sure there's no regressions

sorry @cameronrohani I ended up doing some front end... I tried to resist. We can work out any conflicts