### PR TITLE
fix: ensure trailing empty parameter item

### DIFF
--- a/packages/client-app/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/client-app/src/views/Request/RequestSection/RequestParams.vue
@@ -120,6 +120,12 @@ function defaultRow() {
   /** ensure one empty row by default */
   if (params.value.length === 0) {
     addRow()
+  } else if (params.value.length >= 1) {
+    /** ensure we always have a trailing empty row */
+    const lastParam = params.value[params.value.length - 1]
+    if (lastParam.key !== '' && lastParam.value !== '') {
+      addRow()
+    }
   }
 }
 


### PR DESCRIPTION
we would often end up with no ability to add an item! now if theres an item we check to see if we can add an empty row on mount :) 