### PR TITLE
fix(components): scalar button loading state

### DIFF
--- a/.changeset/modern-frogs-reply.md
+++ b/.changeset/modern-frogs-reply.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: scalar button loading state

--- a/packages/components/src/components/ScalarButton/ScalarButton.vue
+++ b/packages/components/src/components/ScalarButton/ScalarButton.vue
@@ -40,23 +40,29 @@ const attrs = computed(() => {
     :class="
       cx(
         variants({ fullWidth, disabled, size, variant }),
-        { 'pl-9 pr-3': loading },
+        { relative: loading?.isLoading },
         `${attrs.class}`,
       )
     "
     :type="type">
     <div
       v-if="$slots.icon"
-      class="mr-2 h-4 w-4">
+      class="mr-2 h-4 w-4"
+      :class="{ invisible: loading?.isLoading }">
       <slot name="icon" />
     </div>
-    <slot />
-    <div
+    <span
       v-if="loading"
-      class="ml-2">
+      :class="{ invisible: loading?.isLoading }">
+      <slot />
+    </span>
+    <slot v-else />
+    <div
+      v-if="loading?.isLoading"
+      class="centered-x absolute">
       <ScalarLoading
         :loadingState="loading"
-        size="20px" />
+        size="12px" />
     </div>
   </button>
 </template>


### PR DESCRIPTION
this pr updates the scalar button component in order to fix the loading state:

**before** (loading markup always shown)
<img width="788" alt="image" src="https://github.com/scalar/scalar/assets/14966155/edb6b731-ae52-423a-89dc-750e0fb83d25">

**after**
(is chilling)
<img width="788" alt="image" src="https://github.com/scalar/scalar/assets/14966155/07bd49c6-50ad-4265-a006-783857d14ca6">

(is loading)
<img width="788" alt="image" src="https://github.com/scalar/scalar/assets/14966155/683dd842-703e-472a-92d4-29ca9a3bad72">
