### PR TITLE
feat(galaxy): add void.scalar.com as an alternative server

### DIFF
--- a/.changeset/khaki-brooms-exist.md
+++ b/.changeset/khaki-brooms-exist.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat: add void.scalar.com as an alternative server

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -50,6 +50,8 @@ info:
     email: marc@scalar.com
 servers:
   - url: https://galaxy.scalar.com
+  - url: https://void.scalar.com
+    description: Responds with your request data
 security:
   - bearerAuth: []
   - basicAuth: []


### PR DESCRIPTION
This PR adds <https://void.scalar.com> as an alternative server URL to our OpenAPI Example.

This URL just responds with the request data and is great to play around, could be a great addition to the OpenAPI example.