### PR TITLE
fix(client app): address bar server dropdown

### DIFF
--- a/.changeset/lazy-pumpkins-chew.md
+++ b/.changeset/lazy-pumpkins-chew.md
@@ -1,0 +1,5 @@
+---
+'@scalar/client-app': patch
+---
+
+fix: resize client app address bar server dropdown

--- a/packages/client-app/src/components/AddressBar/AddressBar.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBar.vue
@@ -195,6 +195,7 @@ const handlePaste = (event: ClipboardEvent) => {
               ">
               <ScalarDropdown
                 :options="serverOptions"
+                resize
                 teleport="#scalar-client"
                 :value="activeCollection?.selectedServerUid">
                 <button


### PR DESCRIPTION
this pr sets resize to the address bar server dropdown in the client app to make it wider:

**current state**
![image](https://github.com/scalar/scalar/assets/14966155/b0cb6a4c-f601-485f-ba24-6e0d87f07e72)
