### PR TITLE
feat(client-app): server variables

### DIFF
--- a/.changeset/chilly-meals-boil.md
+++ b/.changeset/chilly-meals-boil.md
@@ -1,0 +1,5 @@
+---
+'@scalar/client-app': patch
+---
+
+feat: variables in server urls

--- a/.changeset/fluffy-dolls-juggle.md
+++ b/.changeset/fluffy-dolls-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: add a value to the server variables

--- a/packages/client-app/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBarServer.vue
@@ -36,6 +36,20 @@ const updateSelectedServer = (serverUid: string) => {
 const isSelectedServer = (serverId: string) => {
   return activeCollection.value?.selectedServerUid === serverId
 }
+
+// Replace variables in URL
+const serverUrl = computed(() => {
+  const server = servers[activeCollection.value?.selectedServerUid ?? '']
+  const url = server?.url
+
+  // TODO: use `replaceVariables` from `@scalar/oas-utils/helpers`
+  // Note: Currently, it’s in @scalar/api-client, but that’s about to change.
+  const singleCurlyBrackets = /{\s*([\w.-]+)\s*}/g
+  return url.replace(singleCurlyBrackets, (match, key) => {
+    const variable = server?.variables?.[key]
+    return variable?.value || variable?.default || variable?.enum?.[0] || match
+  })
+})
 </script>
 <template>
   <template v-if="serverOptions && !workspace.isReadOnly">
@@ -48,7 +62,7 @@ const isSelectedServer = (serverId: string) => {
         class="font-code lg:text-sm text-xs whitespace-nowrap border border-b-3 border-solid rounded px-1.5 text-c-2"
         type="button"
         @click.stop>
-        {{ servers[activeCollection?.selectedServerUid ?? '']?.url }}
+        {{ serverUrl }}
       </button>
       <template #items>
         <ScalarDropdownItem
@@ -93,7 +107,7 @@ const isSelectedServer = (serverId: string) => {
   <template v-else>
     <div
       class="flex whitespace-nowrap items-center font-code lg:text-sm text-xs">
-      {{ servers[activeCollection?.selectedServerUid ?? '']?.url }}
+      {{ serverUrl }}
     </div>
   </template>
 </template>

--- a/packages/client-app/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBarServer.vue
@@ -40,12 +40,13 @@ const isSelectedServer = (serverId: string) => {
 // Replace variables in URL
 const serverUrl = computed(() => {
   const server = servers[activeCollection.value?.selectedServerUid ?? '']
-  const url = server?.url
+  const url = server?.url as string | undefined
 
   // TODO: use `replaceVariables` from `@scalar/oas-utils/helpers`
   // Note: Currently, it’s in @scalar/api-client, but that’s about to change.
   const singleCurlyBrackets = /{\s*([\w.-]+)\s*}/g
-  return url.replace(singleCurlyBrackets, (match, key) => {
+
+  return url?.replace(singleCurlyBrackets, (match, key) => {
     const variable = server?.variables?.[key]
     return variable?.value || variable?.default || variable?.enum?.[0] || match
   })

--- a/packages/client-app/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBarServer.vue
@@ -37,7 +37,7 @@ const isSelectedServer = (serverId: string) => {
   return activeCollection.value?.selectedServerUid === serverId
 }
 
-// Replace variables in URL
+/** Server URL with variables replaced */
 const serverUrl = computed(() => {
   const server = servers[activeCollection.value?.selectedServerUid ?? '']
   const url = server?.url as string | undefined

--- a/packages/client-app/src/views/Request/Request.vue
+++ b/packages/client-app/src/views/Request/Request.vue
@@ -50,11 +50,26 @@ executeRequestBus.on(async () => {
     return
   }
 
+  let url = activeServer.value?.url + activeRequest.value.path
+
+  // Replace vraible
+  // TODO: use `replaceVariables` from `@scalar/oas-utils/helpers`
+  // Note: Currently, it’s in @scalar/api-client, but that’s about to change.
+  // TODO: This is not really the best place. I to replace variables. It should probably happen in sendRequest? Let me think about that.
+  if (activeServer.value?.variables) {
+    const singleCurlyBrackets = /{\s*([\w.-]+)\s*}/g
+    url = url.replace(singleCurlyBrackets, (match, key) => {
+      const variable = activeServer.value?.variables?.[key]
+      return (
+        variable?.value || variable?.default || variable?.enum?.[0] || match
+      )
+    })
+  }
+
   const { request, response } = await sendRequest(
     activeRequest.value,
     activeExample.value,
-    /** to be added as a fullUrl?  */
-    activeServer.value?.url + activeRequest.value.path,
+    url,
     activeSecurityScheme.value,
   )
 

--- a/packages/client-app/src/views/Servers/ServerForm.vue
+++ b/packages/client-app/src/views/Servers/ServerForm.vue
@@ -39,20 +39,23 @@ const updateVariable = (key: string, value: any) => {
   serverMutators.edit(activeServer.value.uid, `variables.${key}.value`, value)
 }
 
+/** Fields for the table */
 const variableOptions = computed(() =>
-  Object.entries(activeServer.value?.variables ?? {}).map(([key, val]) => ({
-    key,
-    label: key,
-    placeholder: val ?? '',
-  })),
+  Object.entries(activeServer.value?.variables ?? {}).map(
+    ([key, variable]) => ({
+      key,
+      label: key,
+      placeholder: variable.default ?? variable?.enum?.[0] ?? '',
+    }),
+  ),
 )
 
-/** Get values from the workspace, use `default` or `enum[0]` as fallback */
+/** Values from the workspace, use `default` or `enum[0]` as fallback */
 const variablesData = computed(() =>
   Object.entries(activeServer.value.variables ?? {}).reduce<
     Record<string, string>
-  >((acc, [key, entry]) => {
-    acc[key] = entry.value ?? entry.default ?? entry?.enum?.[0] ?? ''
+  >((acc, [key, variable]) => {
+    acc[key] = variable.value ?? variable.default ?? variable?.enum?.[0] ?? ''
     return acc
   }, {}),
 )

--- a/packages/client-app/src/views/Servers/ServerForm.vue
+++ b/packages/client-app/src/views/Servers/ServerForm.vue
@@ -39,17 +39,13 @@ const updateVariable = (key: string, value: any) => {
   serverMutators.edit(activeServer.value.uid, `variables.${key}.value`, value)
 }
 
-const variableOptions = computed(() => {
-  const variables = activeServer.value?.variables ?? {}
-
-  const keys = Object.keys(variables)
-
-  return keys.map((key: string) => ({
+const variableOptions = computed(() =>
+  Object.entries(activeServer.value?.variables ?? {}).map(([key, val]) => ({
     key,
     label: key,
-    placeholder: variables?.[key]?.default ?? '',
-  }))
-})
+    placeholder: val ?? '',
+  })),
+)
 
 /**
  * Get values from the workspace, use `default` as fallback

--- a/packages/client-app/src/views/Servers/ServerForm.vue
+++ b/packages/client-app/src/views/Servers/ServerForm.vue
@@ -47,21 +47,15 @@ const variableOptions = computed(() =>
   })),
 )
 
-/**
- * Get values from the workspace, use `default` as fallback
- */
-const variablesData = computed(() => {
-  return Object.keys(activeServer.value.variables ?? {}).reduce(
-    (acc, variable) => ({
-      ...acc,
-      [variable]:
-        activeServer.value.variables?.[variable].value ??
-        activeServer.value.variables?.[variable].default ??
-        '',
-    }),
-    {},
-  )
-})
+/** Get values from the workspace, use `default` or `enum[0]` as fallback */
+const variablesData = computed(() =>
+  Object.entries(activeServer.value.variables ?? {}).reduce<
+    Record<string, string>
+  >((acc, [key, entry]) => {
+    acc[key] = entry.value ?? entry.default ?? entry?.enum?.[0] ?? ''
+    return acc
+  }, {}),
+)
 </script>
 <template>
   <div class="w-full">

--- a/packages/client-app/src/views/Servers/ServerForm.vue
+++ b/packages/client-app/src/views/Servers/ServerForm.vue
@@ -8,7 +8,7 @@ import { useRoute } from 'vue-router'
 const { activeCollection, servers, serverMutators } = useWorkspace()
 
 const options = [
-  { label: 'URL', key: 'url', placeholder: 'https://galaxy.scalar.com/api/v1' },
+  { label: 'URL', key: 'url', placeholder: 'https://void.scalar.com/api' },
   {
     label: 'Label',
     key: 'description',

--- a/packages/client-app/src/views/Servers/ServerForm.vue
+++ b/packages/client-app/src/views/Servers/ServerForm.vue
@@ -34,15 +34,9 @@ const updateServer = (key: string, value: string) => {
   serverMutators.edit(activeServer.value.uid, key as keyof Server, value)
 }
 
-const updateVariable = (key: string, value: string) => {
+const updateVariable = (key: string, value: any) => {
   if (!activeCollection.value) return
-
-  serverMutators.edit(activeServer.value.uid, `variables.${key}`, {
-    uid: 'foobar',
-    default: '',
-    ...activeServer.value.variables?.[key],
-    value,
-  })
+  serverMutators.edit(activeServer.value.uid, `variables.${key}.value`, value)
 }
 
 const variableOptions = computed(() => {

--- a/packages/client-app/src/views/Servers/ServerForm.vue
+++ b/packages/client-app/src/views/Servers/ServerForm.vue
@@ -82,8 +82,8 @@ const variablesData = computed(() => {
         :options="options"
         title="Server" />
 
-      <!-- TODO: Only if we have variables -->
       <Form
+        v-if="Object.keys(variablesData).length"
         :data="variablesData"
         :onUpdate="updateVariable"
         :options="variableOptions"

--- a/packages/client-app/src/views/Servers/ServerForm.vue
+++ b/packages/client-app/src/views/Servers/ServerForm.vue
@@ -35,8 +35,14 @@ const updateServer = (key: string, value: string) => {
 }
 
 const updateVariable = (key: string, value: string) => {
-  // TODO: Hook that up to the workspace
-  console.log('updateVariable', key, value)
+  if (!activeCollection.value) return
+
+  serverMutators.edit(activeServer.value.uid, `variables.${key}`, {
+    uid: 'foobar',
+    default: '',
+    ...activeServer.value.variables?.[key],
+    value,
+  })
 }
 
 const variableOptions = computed(() => {
@@ -51,10 +57,21 @@ const variableOptions = computed(() => {
   }))
 })
 
-// TODO: Get data from the workspace, use `default` as the default value
-const variablesData = {
-  basePath: '/api/v1',
-}
+/**
+ * Get values from the workspace, use `default` as fallback
+ */
+const variablesData = computed(() => {
+  return Object.keys(activeServer.value.variables ?? {}).reduce(
+    (acc, variable) => ({
+      ...acc,
+      [variable]:
+        activeServer.value.variables?.[variable].value ??
+        activeServer.value.variables?.[variable].default ??
+        '',
+    }),
+    {},
+  )
+})
 </script>
 <template>
   <div class="w-full">

--- a/packages/client-app/src/views/Servers/ServerForm.vue
+++ b/packages/client-app/src/views/Servers/ServerForm.vue
@@ -33,12 +33,44 @@ const updateServer = (key: string, value: string) => {
   if (!activeCollection.value) return
   serverMutators.edit(activeServer.value.uid, key as keyof Server, value)
 }
+
+const updateVariable = (key: string, value: string) => {
+  // TODO: Hook that up to the workspace
+  console.log('updateVariable', key, value)
+}
+
+const variableOptions = computed(() => {
+  const variables = activeServer.value?.variables ?? {}
+
+  const keys = Object.keys(variables)
+
+  return keys.map((key: string) => ({
+    key,
+    label: key,
+    placeholder: variables?.[key]?.default ?? '',
+  }))
+})
+
+// TODO: Get data from the workspace, use `default` as the default value
+const variablesData = {
+  basePath: '/api/v1',
+}
 </script>
 <template>
-  <Form
-    v-if="activeServer"
-    :data="activeServer"
-    :onUpdate="updateServer"
-    :options="options"
-    title="Server" />
+  <div class="w-full">
+    <template v-if="activeServer">
+      <Form
+        :data="activeServer"
+        :onUpdate="updateServer"
+        :options="options"
+        title="Server" />
+
+      <!-- TODO: Only if we have variables -->
+      <Form
+        :data="variablesData"
+        :onUpdate="updateVariable"
+        :options="variableOptions"
+        title="Variables" />
+    </template>
+  </div>
 </template>

--- a/packages/oas-utils/src/entities/workspace/server/server.ts
+++ b/packages/oas-utils/src/entities/workspace/server/server.ts
@@ -24,6 +24,8 @@ const serverVariableSchema = z.object({
   default: z.string().optional().default('default'),
   /** An optional description for the server variable. CommonMark syntax MAY be used for rich text representation. */
   description: z.string().optional(),
+  /** An optional value for the server variable */
+  value: z.string().optional(),
 })
 
 const serverSchema = z.object({


### PR DESCRIPTION
This PR adds support for server variables to `@scalar/client-app`:

<img width="1499" alt="Screenshot 2024-06-25 at 13 16 50" src="https://github.com/scalar/scalar/assets/1577992/faace6c9-88aa-4280-a929-02999616283d">

```js
{
  "openapi": "3.1.0",
  "info": {
    "title": "Servers with Variables",
    "version": "1.0.0"
  },
  "servers": [
    {
      "url": "https://{username}.gigantic-server.com:{port}/{basePath}",
      "description": "The production API server",
      "variables": {
        "username": {
          "default": "demo",
          "description": "this value is assigned by the service provider, in this example `gigantic-server.com`"
        },
        "port": {
          "enum": [
            "8443",
            "443"
          ],
          "default": "8443"
        },
        "basePath": {
          "default": "v2"
        }
      }
    }
  ],
  "paths": {}
}
```