### PR TITLE
fix: handle no tags spec import

### DIFF
--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -105,7 +105,10 @@ export const importSpecToWorkspace = async (spec: string | AnyObject) => {
     })
   })
 
-  const tags = schemaModel(schema?.tags, tagObjectSchema.array())
+  // todo workaround till we have createTags
+  const tags = schemaModel(schema?.tags, tagObjectSchema.array(), false) ?? [
+    { name: 'default' },
+  ]
 
   // If there are request tags that are only defined in
   requestTags.forEach((requestTag) => {


### PR DESCRIPTION
**Problem**
Currently, if a spec has no tags we fail

**Explanation**
This happens because although tags arent required, we dont have a createTags helper with a default

**Solution**
With this PR it creates a temporary default tag

<img width="951" alt="image" src="https://github.com/scalar/scalar/assets/6176314/17e61fe9-5661-4a11-a94f-d3a43d6231ce">

