### PR TITLE
feat: pass auth into client modal

### DIFF
--- a/packages/api-client-modal/package.json
+++ b/packages/api-client-modal/package.json
@@ -59,6 +59,7 @@
     "@scalar/client-app": "workspace:*",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
+    "@scalar/object-utils": "workspace:*",
     "vue": "^3.4.22",
     "vue-router": "^4.3.0"
   },

--- a/packages/api-client-modal/src/api-client-modal.ts
+++ b/packages/api-client-modal/src/api-client-modal.ts
@@ -82,7 +82,7 @@ export const createScalarApiClient = async (
 
       // ApiKey
       if (auth.apiKey.token?.length) {
-        // schemes.gcc
+        // schemes.filter(scheme => scheme.type === 'apiKey' && !scheme.value.length).forEach(scheme => scheme.)
       }
 
       //selected scopes

--- a/packages/api-client-modal/src/api-client-modal.ts
+++ b/packages/api-client-modal/src/api-client-modal.ts
@@ -1,7 +1,7 @@
 import { ApiClientModal } from '@/components'
 import type { ClientConfiguration, OpenClientPayload } from '@/types'
 import { clientRouter, useWorkspace } from '@scalar/client-app'
-import type { SpecConfiguration } from '@scalar/oas-utils'
+import type { AuthenticationState, SpecConfiguration } from '@scalar/oas-utils'
 import { objectMerge } from '@scalar/oas-utils/helpers'
 import { createApp, reactive } from 'vue'
 
@@ -21,9 +21,11 @@ export const createScalarApiClient = async (
 
   const {
     importSpecFile,
-    requests,
     importSpecFromUrl,
     modalState,
+    requests,
+    securitySchemeMutators,
+    securitySchemes,
     workspaceMutators,
   } = useWorkspace()
 
@@ -69,10 +71,29 @@ export const createScalarApiClient = async (
       }
       if (newConfig.spec) importSpecFile(newConfig.spec)
     },
-    /** Update the spec file, this will re-parse it */
-    updateSpec(spec: SpecConfiguration) {
-      importSpecFile(spec)
+    /**
+     * Update the security schemes
+     * maps the references useAuthenticationStore to the client auth
+     */
+    updateAuth: (auth: AuthenticationState) => {
+      console.log('securitySchemes')
+      console.log(securitySchemes)
+      const schemes = Object.values(securitySchemes)
+
+      // ApiKey
+      if (auth.apiKey.token?.length) {
+        // schemes.gcc
+      }
+
+      //selected scopes
+      //     securitySchemeMutators.edit(
+      // activeSecurityScheme.value?.scheme.uid ?? '',
+      // path,
+      // value,
+      // )
     },
+    /** Update the spec file, this will re-parse it and clear your store */
+    updateSpec: (spec: SpecConfiguration) => importSpecFile(spec),
     /** Open the  API client modal */
     open: (payload?: OpenClientPayload) => {
       // Find the request from path + method

--- a/packages/api-client-modal/src/api-client-modal.ts
+++ b/packages/api-client-modal/src/api-client-modal.ts
@@ -2,7 +2,10 @@ import { ApiClientModal } from '@/components'
 import type { ClientConfiguration, OpenClientPayload } from '@/types'
 import { clientRouter, useWorkspace } from '@scalar/client-app'
 import type { AuthenticationState, SpecConfiguration } from '@scalar/oas-utils'
+import type { SecurityScheme } from '@scalar/oas-utils/entities/workspace/security'
 import { objectMerge } from '@scalar/oas-utils/helpers'
+import { getNestedValue } from '@scalar/object-utils/nested'
+import type { Paths } from 'type-fest'
 import { createApp, reactive } from 'vue'
 
 /** Initialize Scalar API Client Modal */
@@ -76,28 +79,54 @@ export const createScalarApiClient = async (
      * maps the references useAuthenticationStore to the client auth
      */
     updateAuth: (auth: AuthenticationState) => {
-      console.log('securitySchemes')
-      console.log(securitySchemes)
       const schemes = Object.values(securitySchemes)
 
-      // ApiKey
-      if (auth.apiKey.token?.length) {
-        // schemes.filter(scheme => scheme.type === 'apiKey' && !scheme.value.length).forEach(scheme => scheme.)
-      }
+      // Loop on all schemes from client to see which types we have
+      schemes.forEach((scheme) => {
+        /**
+         * Edit helper to reduce some boilerplate in the switch statements
+         * Ensures the passed in value exists and one does not exist already
+         */
+        const edit = (
+          value: string | string[],
+          path: Paths<SecurityScheme> = 'value',
+        ) =>
+          value.length &&
+          !getNestedValue(scheme, path).length &&
+          securitySchemeMutators.edit(scheme.uid, path, value)
 
-      //selected scopes
-      //     securitySchemeMutators.edit(
-      // activeSecurityScheme.value?.scheme.uid ?? '',
-      // path,
-      // value,
-      // )
+        switch (scheme.type) {
+          case 'apiKey':
+            edit(auth.apiKey.token)
+            break
+
+          case 'http':
+            if (scheme.scheme === 'bearer') edit(auth.http.bearer.token)
+            else if (scheme.scheme === 'basic') {
+              edit(auth.http.basic.username)
+              edit(auth.http.basic.password, 'secondValue')
+            }
+            break
+
+          // Currently we only support implicit + password on the references side
+          case 'oauth2':
+            edit(auth.oAuth2.clientId, 'clientId')
+
+            // Implicit
+            if (scheme.flows.implicit) {
+              edit(auth.oAuth2.accessToken, 'flows.implicit.token')
+              edit(auth.oAuth2.scopes, 'flows.implicit.selectedScopes')
+            }
+            break
+          // TODO password
+        }
+      })
     },
     /** Update the spec file, this will re-parse it and clear your store */
     updateSpec: (spec: SpecConfiguration) => importSpecFile(spec),
     /** Open the  API client modal */
     open: (payload?: OpenClientPayload) => {
       // Find the request from path + method
-
       const request = Object.values(requests).find(({ path, method }) =>
         payload
           ? // The given operation
@@ -105,10 +134,7 @@ export const createScalarApiClient = async (
           : // Or the first request
             true,
       )
-
-      if (request) {
-        clientRouter.push(`/request/${request.uid}`)
-      }
+      if (request) clientRouter.push(`/request/${request.uid}`)
 
       modalState.open = true
     },

--- a/packages/api-client-modal/src/api-client-modal.ts
+++ b/packages/api-client-modal/src/api-client-modal.ts
@@ -117,8 +117,15 @@ export const createScalarApiClient = async (
               edit(auth.oAuth2.accessToken, 'flows.implicit.token')
               edit(auth.oAuth2.scopes, 'flows.implicit.selectedScopes')
             }
+
+            // Password
+            else if (scheme.flows.password) {
+              edit(auth.oAuth2.accessToken, 'flows.password.token')
+              edit(auth.oAuth2.scopes, 'flows.password.selectedScopes')
+              edit(auth.oAuth2.username, 'flows.password.value')
+              edit(auth.oAuth2.password, 'flows.password.secondValue')
+            }
             break
-          // TODO password
         }
       })
     },

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -102,6 +102,7 @@
     "storybook": "^8.0.8",
     "storybook-dark-mode": "^4.0.1",
     "tsc-alias": "^1.8.8",
+    "type-fest": "^4.20.0",
     "vite": "^5.2.10",
     "vite-plugin-banner": "^0.7.1",
     "vite-plugin-css-injected-by-js": "^3.4.0",

--- a/packages/api-reference/src/components/Content/Operation/TestRequestButton.vue
+++ b/packages/api-reference/src/components/Content/Operation/TestRequestButton.vue
@@ -24,8 +24,10 @@ const getGlobalSecurity = inject(GLOBAL_SECURITY_SYMBOL)
       NEW_API_MODAL
         ? // @scalar/api-client@2.0
           apiClientBus.emit({
-            path: operation.path,
-            method: operation.httpVerb,
+            open: {
+              path: operation.path,
+              method: operation.httpVerb,
+            },
           })
         : // @scalar/api-client@1.x
           openClientFor(operation, getGlobalSecurity?.())

--- a/packages/api-reference/src/components/api-client-bus.ts
+++ b/packages/api-reference/src/components/api-client-bus.ts
@@ -1,10 +1,21 @@
 import type { OpenClientPayload } from '@scalar/api-client-modal'
 import type { ModalState } from '@scalar/components'
+import type { AuthenticationState } from '@scalar/oas-utils'
 import { type EventBusKey, useEventBus } from '@vueuse/core'
+import type { RequireAtLeastOne } from 'type-fest'
 
-const apiClientBusKey: EventBusKey<OpenClientPayload> = Symbol()
+type ApiClientEvents = RequireAtLeastOne<{
+  open?: OpenClientPayload
+  updateAuth?: AuthenticationState
+}>
+const apiClientBusKey: EventBusKey<ApiClientEvents> = Symbol()
 const apiClientModalStateBusKey: EventBusKey<ModalState> = Symbol()
 
-/** Event bus to open the API Client */
+/**
+ * Event bus for controlling the Api Client
+ *
+ * There is a limitation in useEventBus with mapping the event with the payload type. This is a workaround, however
+ * doing it this way allows us to "fire" multiple events at the same time which is actually kind of nice
+ */
 export const apiClientBus = useEventBus(apiClientBusKey)
 export const modalStateBus = useEventBus(apiClientModalStateBusKey)

--- a/packages/oas-utils/src/entities/workspace/security/security-schemes.ts
+++ b/packages/oas-utils/src/entities/workspace/security/security-schemes.ts
@@ -40,7 +40,9 @@ const securitySchemeHttp = z.object({
     .optional()
     .default('JWT'),
 
+  /** Username */
   value,
+  /** Password */
   secondValue: value,
 })
 
@@ -97,7 +99,9 @@ const oauthFlowSchema = z
         refreshUrl,
         scopes,
 
+        /** Username */
         value: value,
+        /** Password */
         secondValue: value,
         selectedScopes,
         clientSecret: value,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -754,6 +754,9 @@ importers:
       '@scalar/oas-utils':
         specifier: workspace:*
         version: link:../oas-utils
+      '@scalar/object-utils':
+        specifier: workspace:*
+        version: link:../object-utils
       vue:
         specifier: ^3.4.22
         version: 3.4.29(typescript@5.4.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -977,6 +977,9 @@ importers:
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.10
+      type-fest:
+        specifier: ^4.20.0
+        version: 4.20.0
       vite:
         specifier: ^5.2.10
         version: 5.3.1(@types/node@20.14.2)(terser@5.31.1)


### PR DESCRIPTION
Currently `useAuthStore` and the `client-app` don't match 1:1 since `useAuthStore` can only support one of each type of auth. What we do here is set every type on the `client-app` as long as value does not already exist

I would hold off on this one and merge https://github.com/scalar/scalar/pull/2258 first, then I can add password to this one and were g2g