### PR TITLE
fix: URL is not encoded when sent to the proxy

### DIFF
--- a/.changeset/lovely-monkeys-deny.md
+++ b/.changeset/lovely-monkeys-deny.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+'@scalar/client-app': patch
+'@scalar/oas-utils': patch
+---
+
+fix: URL is not encoded when sent to the proxy

--- a/packages/api-client/src/helpers/redirectToProxy.test.ts
+++ b/packages/api-client/src/helpers/redirectToProxy.test.ts
@@ -6,7 +6,9 @@ describe('redirectToProxy', () => {
   it('rewrites URLs', async () => {
     expect(
       redirectToProxy('https://proxy.scalar.com', 'https://example.com'),
-    ).toBe('https://proxy.scalar.com/?scalar_url=https%3A%2F%2Fexample.com')
+    ).toBe(
+      'https://proxy.scalar.com/?scalar_url=https%253A%252F%252Fexample.com',
+    )
   })
 
   it('keeps query parameters', async () => {
@@ -16,7 +18,7 @@ describe('redirectToProxy', () => {
         'https://example.com',
       ),
     ).toBe(
-      'https://proxy.scalar.com/?foo=bar&scalar_url=https%3A%2F%2Fexample.com',
+      'https://proxy.scalar.com/?foo=bar&scalar_url=https%253A%252F%252Fexample.com',
     )
   })
 })

--- a/packages/api-client/src/helpers/redirectToProxy.test.ts
+++ b/packages/api-client/src/helpers/redirectToProxy.test.ts
@@ -6,9 +6,7 @@ describe('redirectToProxy', () => {
   it('rewrites URLs', async () => {
     expect(
       redirectToProxy('https://proxy.scalar.com', 'https://example.com'),
-    ).toBe(
-      'https://proxy.scalar.com/?scalar_url=https%253A%252F%252Fexample.com',
-    )
+    ).toBe('https://proxy.scalar.com/?scalar_url=https%3A%2F%2Fexample.com')
   })
 
   it('keeps query parameters', async () => {
@@ -18,7 +16,7 @@ describe('redirectToProxy', () => {
         'https://example.com',
       ),
     ).toBe(
-      'https://proxy.scalar.com/?foo=bar&scalar_url=https%253A%252F%252Fexample.com',
+      'https://proxy.scalar.com/?foo=bar&scalar_url=https%3A%2F%2Fexample.com',
     )
   })
 })

--- a/packages/api-client/src/helpers/redirectToProxy.ts
+++ b/packages/api-client/src/helpers/redirectToProxy.ts
@@ -7,7 +7,7 @@ export function redirectToProxy(proxy: string, url: string): string {
   newUrl.href = proxy
 
   // Add the original URL as a query parameter
-  newUrl.searchParams.append('scalar_url', encodeURI(url))
+  newUrl.searchParams.append('scalar_url', encodeURIComponent(url))
 
   return newUrl.toString()
 }

--- a/packages/api-client/src/helpers/redirectToProxy.ts
+++ b/packages/api-client/src/helpers/redirectToProxy.ts
@@ -7,7 +7,7 @@ export function redirectToProxy(proxy: string, url: string): string {
   newUrl.href = proxy
 
   // Add the original URL as a query parameter
-  newUrl.searchParams.append('scalar_url', encodeURIComponent(url))
+  newUrl.searchParams.append('scalar_url', url)
 
   return newUrl.toString()
 }

--- a/packages/api-client/src/helpers/sendRequest.test.ts
+++ b/packages/api-client/src/helpers/sendRequest.test.ts
@@ -5,12 +5,6 @@ import { sendRequest } from './sendRequest'
 const PROXY_PORT = 5051
 const ECHO_PORT = 5052
 
-function createProxyRequest({ url }: { url?: string }) {
-  return {
-    url: `http://127.0.0.1:${PROXY_PORT}?scalar_url=${encodeURIComponent(url ?? '')}`,
-  }
-}
-
 describe('sendRequest', () => {
   it('shows a warning when scalar_url is missing', async () => {
     const request = {
@@ -39,11 +33,11 @@ describe('sendRequest', () => {
   })
 
   it('reaches the echo server *with* the proxy', async () => {
-    const request = createProxyRequest({
+    const request = {
       url: `http://localhost:${ECHO_PORT}`,
-    })
+    }
 
-    const result = await sendRequest(request)
+    const result = await sendRequest(request, 'http://127.0.0.1:${PROXY_PORT}')
 
     expect(result?.response.data).toMatchObject({
       method: 'GET',
@@ -213,8 +207,6 @@ describe('sendRequest', () => {
     }
 
     const result = await sendRequest(request, `http://127.0.0.1:${PROXY_PORT}`)
-
-    console.log(result?.response.data)
 
     expect(result?.response.data?.trim().toLowerCase()).toContain(
       'dial tcp: lookup does_not_exist',

--- a/packages/api-client/src/helpers/sendRequest.test.ts
+++ b/packages/api-client/src/helpers/sendRequest.test.ts
@@ -7,7 +7,7 @@ const ECHO_PORT = 5052
 
 function createProxyRequest({ url }: { url?: string }) {
   return {
-    url: `http://127.0.0.1:${PROXY_PORT}?scalar_url=${encodeURI(url ?? '')}`,
+    url: `http://127.0.0.1:${PROXY_PORT}?scalar_url=${encodeURIComponent(url ?? '')}`,
   }
 }
 

--- a/packages/client-app/src/libs/sendRequest.ts
+++ b/packages/client-app/src/libs/sendRequest.ts
@@ -129,7 +129,7 @@ export const sendRequest = async (
 
   const config: AxiosRequestConfig = {
     url: shouldUseProxy
-      ? `http://localhost:5051/?scalar_url=${encodeURI(url)}`
+      ? `http://localhost:5051/?scalar_url=${encodeURIComponent(url)}`
       : url,
     method: request.method,
     headers,

--- a/packages/oas-utils/src/helpers/fetchSpecFromUrl.ts
+++ b/packages/oas-utils/src/helpers/fetchSpecFromUrl.ts
@@ -7,7 +7,7 @@ const NEW_PROXY_URL = 'https://proxy.scalar.com'
 
 /** Redirects the request to a proxy server with a given URL. */
 function redirectToProxy(proxy: string, url: string): string {
-  return `${proxy}?scalar_url=${encodeURI(url)}`
+  return `${proxy}?scalar_url=${encodeURIComponent(url)}`
 }
 
 /** Fetches an OpenAPI/Swagger specification from a given URL. */


### PR DESCRIPTION
When sending multiple query parameters, only the first one is proxied to the target URL.

This is because we used `encodeURI` instead of `encodeURIComponent` in a few places.

```js
encodeURI('https://example.com/?color=red&size=large')
// 'https://example.com/?color=red&size=large'

encodeURIComponent('https://example.com/?color=red&size=large')
// 'https%3A%2F%2Fexample.com%2F%3Fcolor%3Dred%26size%3Dlarge'
```

We’re not encoding the URL (https://… is perfectly fine for an URL), but a parameter.

**❌ encodeURI**
https://proxy.scalar.com/?scalar_url=https://void.scalar.com?foo=bar&bar=foo

**✅ encodeURIComponent**
https://proxy.scalar.com/?scalar_url=https%3A%2F%2Fvoid.scalar.com%3Ffoo%3Dbar%26bar%3Dfoo%27