### PR TITLE
fix(proxy): cross-origin credentials are not allowed

### DIFF
--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -13,7 +13,14 @@ import (
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Headers", "*")
-		w.Header().Set("Access-Control-Allow-Origin", "*") // Allow all origins
+
+		allowOrigin := "*"
+		if r.Header.Get("Origin") != "" {
+			allowOrigin = r.Header.Get("Origin")
+		}
+		w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH")
 		w.Header().Set("Access-Control-Expose-Headers", "*")
 


### PR DESCRIPTION
Currently, when setting Axios to `withCredentials: true` the browser complains that credentials are not allowed (requires header `Access-Control-Allow-Credentials: true`), so I added this.

But then the browser complains `Access-Control-Allow-Origin` must not be `*`, so with this PR it’s set to the origin (if available).