### PR TITLE
fix(client-app): address bar request history items

### DIFF
--- a/.changeset/thick-rivers-punch.md
+++ b/.changeset/thick-rivers-punch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/client-app': patch
+---
+
+fix: address bar request history item style

--- a/packages/client-app/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/client-app/src/components/AddressBar/AddressBarHistory.vue
@@ -32,7 +32,7 @@ function getUrlPart(request: XMLHttpRequest, part: keyof URL) {
   const scalarUrlParsed = new URL(scalarUrl)
   const baseUrl = scalarUrlParsed[part]
 
-  return baseUrl
+  return baseUrl.toString()
 }
 
 const { addNavItem, setNavItemIdx, topNavItems } = useTopNav()
@@ -66,7 +66,7 @@ function handleHistoryClick(index: number) {
   <!-- History shadow and placement-->
   <div
     :class="[
-      'absolute left-0 top-[31px] w-full rounded before:pointer-events-none before:absolute before:left-0 before:top-[-31.5px] before:h-[calc(100%+31.5px)] before:w-full before:rounded z-50',
+      'absolute left-0 top-[33px] w-full rounded before:pointer-events-none before:absolute before:left-0 before:top-[-33px] before:h-[calc(100%+33px)] before:w-full before:rounded z-50',
       { 'before:shadow-lg': open },
     ]">
     <!-- History Item -->
@@ -85,10 +85,10 @@ function handleHistoryClick(index: number) {
             {{ response.status }}
           </span>
           <span class="text-c-2 gap-0">
-            {{ getUrlPart(response.request, 'origin') }}
-            <em class="text-c-1 ml-[-8px]">{{
+            {{
+              getUrlPart(response.request, 'origin') +
               getUrlPart(response.request, 'pathname')
-            }}</em>
+            }}
           </span>
         </div>
 


### PR DESCRIPTION
this pr updates the request history item style and removes italic on pathname:

**before**
<img width="1464" alt="image" src="https://github.com/scalar/scalar/assets/14966155/0122299c-4a2f-48cd-b560-f87921a2039e">


**after**
<img width="1464" alt="image" src="https://github.com/scalar/scalar/assets/14966155/baf1df2f-5aef-4a19-b765-260946c485c7">
