### PR TITLE
fix(client-app):  request sidebar icon

### DIFF
--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -114,10 +114,12 @@ const showChildren = computed(
 <template>
   <div
     class="relative flex flex-row"
-    :class="
-      parentUids.length &&
-      `before:bg-b-3 pl-4 before:absolute before:left-[calc(.75rem_+_.5px)] before:top-0 before:z-10 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-px mb-[.5px] last:mb-0`
-    ">
+    :class="[
+      (workspace.isReadOnly && parentUids.length > 1) ||
+      (!workspace.isReadOnly && parentUids.length)
+        ? 'before:bg-b-3 pl-4 before:absolute before:left-[calc(.75rem_+_.5px)] before:top-0 before:z-10 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-px mb-[.5px] last:mb-0'
+        : '',
+    ]">
     <Draggable
       :id="item.uid"
       :ceiling="hasChildren ? 0.8 : 0.5"
@@ -161,7 +163,7 @@ const showChildren = computed(
 
       <!-- Collection/Folder -->
       <button
-        v-else
+        v-else-if="!workspace.isReadOnly || parentUids.length"
         class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5"
         :class="highlightClasses"
         type="button"


### PR DESCRIPTION
this pr updates request sidebar icon accordingly to workspace read only state:

`isReadOnly`
<img width="287" alt="image" src="https://github.com/scalar/scalar/assets/14966155/5841ceb0-02af-43af-a497-788b00ba8160">

`!isReadOnly`
<img width="287" alt="image" src="https://github.com/scalar/scalar/assets/14966155/baa18a9a-a890-4b2b-9e72-d03dd0e0d68d">
