### PR TITLE
style: no dropdown for a single server

### DIFF
--- a/.changeset/purple-lions-appear.md
+++ b/.changeset/purple-lions-appear.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+style: no dropdown for a single server

--- a/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
@@ -38,12 +38,14 @@ const selected = computed<ScalarListboxOption | undefined>({
       resize>
       <ScalarButton
         class="url-select"
+        :class="{ 'pointer-events-none': options.length <= 1 }"
         fullWidth
         variant="ghost">
         <span>
           <slot></slot>
         </span>
         <ScalarIcon
+          v-if="options.length > 1"
           icon="ChevronDown"
           size="xs" />
       </ScalarButton>


### PR DESCRIPTION
We don’t need to have a dropdown for a single server. :)

**Before**

<img width="582" alt="Screenshot 2024-06-27 at 17 55 53" src="https://github.com/scalar/scalar/assets/1577992/cae466ec-9dc5-4c9b-a84f-80e649291e16">

**After**

<img width="568" alt="Screenshot 2024-06-27 at 17 56 38" src="https://github.com/scalar/scalar/assets/1577992/994e21f2-832b-419a-a198-1dd2dbcf041c">
