### PR TITLE
chore: Remove nuxt prepare from install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "lint:fix": "pnpm -r lint:fix",
     "pack:packages": "./scripts/pack.sh",
     "playwright:install": "npx playwright install --with-deps",
-    "postinstall": "pnpm -r dev:prepare",
     "test": "vitest",
     "test:ci": "start-server-and-test 'pnpm dev:proxy-server & pnpm dev:echo-server' 'http://127.0.0.1:5051/ping|http://127.0.0.1:5052' 'CI=1 vitest --silent'",
     "test:e2e": "pnpm --filter playwright test:e2e",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -25,8 +25,8 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "nuxt-module-build build",
-    "dev": "nuxi dev playground",
+    "build": "pnpm dev:prepare nuxt-module-build build",
+    "dev": "pnpm dev:prepare && nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "lint:check": "eslint .",


### PR DESCRIPTION
This is really slowing down installs. Can just be run when working on nuxt