### PR TITLE
fix: empty html response show theme background + color + app polish

### DIFF
--- a/.changeset/wet-paws-lie.md
+++ b/.changeset/wet-paws-lie.md
@@ -1,0 +1,6 @@
+---
+'@scalar/client-app': patch
+'@scalar/themes': patch
+---
+
+fix: empty html response show theme background

--- a/packages/client-app/src/Modal/api-client-modal.ts
+++ b/packages/client-app/src/Modal/api-client-modal.ts
@@ -15,6 +15,8 @@ export type ClientConfiguration = {
   spec: SpecConfiguration
   /** Pass in a proxy to the API client */
   proxyUrl?: string
+  /** Pass in a theme API client */
+  themeId?: string
   /** Whether to show the sidebar */
   showSidebar?: boolean
   /** Whether dark mode is on or off initially (light mode) */
@@ -111,6 +113,10 @@ export const createScalarApiClient = async (
 
   if (config.proxyUrl) {
     workspaceMutators.edit('proxyUrl', config.proxyUrl)
+  }
+
+  if (config.themeId) {
+    workspaceMutators.edit('themeId', config.themeId)
   }
 
   return {

--- a/packages/client-app/src/components/ActionModal/ActionModal.vue
+++ b/packages/client-app/src/components/ActionModal/ActionModal.vue
@@ -51,9 +51,9 @@ const changeTab = (index: number) => {
     :open="state.open"
     @close="state.hide()">
     <div
-      class="animate-modal-fade bg-backdrop fixed left-0 top-0 z-[1001] h-screen w-screen p-[20px] opacity-0">
+      class="animate-modal-fade bg-backdrop fixed left-0 top-0 z-[1001] h-screen w-screen p-[20px] opacity-0 cursor-pointer">
       <DialogPanel
-        class="animate-modal-pop before:bg-b-1 relative mx-auto mt-20 w-full max-w-[480px] scale-[0.98] rounded-lg opacity-0 before:absolute before:z-0 before:block before:h-full before:w-full before:rounded-lg before:content-['']">
+        class="animate-modal-pop before:bg-b-1 relative mx-auto mt-20 w-full max-w-[480px] scale-[0.98] rounded-lg opacity-0 before:absolute before:z-0 before:block before:h-full before:w-full before:rounded-lg before:content-[''] cursor-auto">
         <DialogDescription
           class="bg-b-1 custom-scroll relative overflow-visible rounded-lg">
           <TabGroup

--- a/packages/client-app/src/views/Request/Request.vue
+++ b/packages/client-app/src/views/Request/Request.vue
@@ -225,11 +225,6 @@ const onDragEnd = (
 const addItemHandler = () => {
   actionModalState.show()
 }
-const getBackgroundColor = () => {
-  if (!activeRequest.value) return ''
-  const { method } = activeRequest.value
-  return REQUEST_METHODS[method as RequestMethod].backgroundColor
-}
 
 const keys = useMagicKeys()
 
@@ -241,21 +236,13 @@ useEventListener(document, 'keydown', (event) => {
 </script>
 <template>
   <div
-    class="bg-mix-transparent bg-mix-amount-95 flex flex-1 flex-col rounded-lg rounded-b-none rounded-r-none pt-0 h-full"
-    :class="getBackgroundColor()"
-    style="
-      background: linear-gradient(
-        color-mix(in srgb, var(--tw-bg-base) 6%, transparent) 1%,
-        var(--scalar-background-2) 9%
-      );
-    ">
+    class="bg-b-2 flex flex-1 flex-col rounded-lg rounded-b-none rounded-r-none pt-0 h-full">
     <div
       class="lg:min-h-header flex items-center w-full justify-center p-1 flex-wrap t-app__top-container">
       <div
         class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-0.5 lg:flex-1 w-6/12">
         <button
-          class="request-text-color bg-mix-transparent hover:bg-mix-amount-95 p-2 rounded bg-mix-amount-100"
-          :class="getBackgroundColor()"
+          class="request-text-color bg-mix-transparent hover:bg-mix-amount-95 p-2 rounded"
           type="button"
           @click="showSideBar = !showSideBar">
           <ScalarIcon
@@ -268,14 +255,12 @@ useEventListener(document, 'keydown', (event) => {
         class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-0.5 lg:flex-1 justify-end w-6/12">
         <!-- <button
           class="request-text-color-text bg-mix-transparent hover:bg-mix-amount-95 px-2 py-1.5 rounded bg-mix-amount-90 font-medium text-sm"
-          :class="getBackgroundColor()"
           type="button">
           Test Acctual Locally
         </button> -->
         <button
           v-if="workspace.isReadOnly"
           class="request-text-color bg-mix-transparent hover:bg-mix-amount-95 p-2 rounded bg-mix-amount-100"
-          :class="getBackgroundColor()"
           type="button"
           @click="modalState.hide()">
           <ScalarIcon
@@ -352,10 +337,18 @@ useEventListener(document, 'keydown', (event) => {
 </template>
 <style scoped>
 .request-text-color {
-  color: color-mix(in srgb, var(--tw-bg-base) 15%, var(--scalar-color-3));
+  color: var(--scalar-color-3);
+}
+.request-text-color:hover {
+  color: var(--scalar-color-2);
 }
 .request-text-color-text {
-  color: color-mix(in srgb, var(--tw-bg-base) 25%, var(--scalar-color-1));
+  color: var(--scalar-color-1);
+  background: linear-gradient(
+    var(--scalar-background-1),
+    var(--scalar-background-3)
+  );
+  box-shadow: 0 0 0 1px var(--scalar-border-color);
 }
 .request-text-color-text:active,
 .request-text-color:active {

--- a/packages/client-app/src/views/Request/Request.vue
+++ b/packages/client-app/src/views/Request/Request.vue
@@ -340,7 +340,7 @@ useEventListener(document, 'keydown', (event) => {
   color: var(--scalar-color-3);
 }
 .request-text-color:hover {
-  color: var(--scalar-color-2);
+  background: var(--scalar-background-2);
 }
 .request-text-color-text {
   color: var(--scalar-color-1);

--- a/packages/client-app/src/views/Request/Request.vue
+++ b/packages/client-app/src/views/Request/Request.vue
@@ -242,7 +242,7 @@ useEventListener(document, 'keydown', (event) => {
       <div
         class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-0.5 lg:flex-1 w-6/12">
         <button
-          class="request-text-color bg-mix-transparent hover:bg-mix-amount-95 p-2 rounded"
+          class="text-c-3 hover:bg-b-3 active:text-c-1 p-2 rounded"
           type="button"
           @click="showSideBar = !showSideBar">
           <ScalarIcon
@@ -260,7 +260,7 @@ useEventListener(document, 'keydown', (event) => {
         </button> -->
         <button
           v-if="workspace.isReadOnly"
-          class="request-text-color bg-mix-transparent hover:bg-mix-amount-95 p-2 rounded bg-mix-amount-100"
+          class="text-c-3 hover:bg-b-3 active:text-c-1 p-2 rounded"
           type="button"
           @click="modalState.hide()">
           <ScalarIcon
@@ -336,12 +336,6 @@ useEventListener(document, 'keydown', (event) => {
   </div>
 </template>
 <style scoped>
-.request-text-color {
-  color: var(--scalar-color-3);
-}
-.request-text-color:hover {
-  background: var(--scalar-background-2);
-}
 .request-text-color-text {
   color: var(--scalar-color-1);
   background: linear-gradient(
@@ -349,10 +343,6 @@ useEventListener(document, 'keydown', (event) => {
     var(--scalar-background-3)
   );
   box-shadow: 0 0 0 1px var(--scalar-border-color);
-}
-.request-text-color-text:active,
-.request-text-color:active {
-  color: var(--scalar-color-1);
 }
 @media screen and (max-width: 780px) {
   .sidebar-active-hide-layout {

--- a/packages/client-app/src/views/Request/RequestSidebarItem.vue
+++ b/packages/client-app/src/views/Request/RequestSidebarItem.vue
@@ -146,7 +146,7 @@ const showChildren = computed(
             <span class="flex">
               &hairsp;
               <HttpMethod
-                class="font-[550]"
+                class="font-bold"
                 :method="method" />
             </span>
           </div>

--- a/packages/client-app/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/client-app/src/views/Request/ResponseSection/ResponseBody.vue
@@ -4,6 +4,7 @@ import DataTableHeader from '@/components/DataTable/DataTableHeader.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useDarkModeState } from '@/hooks'
+import { useWorkspace } from '@/store/workspace'
 import { ScalarCodeBlock, ScalarIcon } from '@scalar/components'
 import { type ThemeId, getThemeStyles } from '@scalar/themes'
 import { computed, nextTick, ref, watch } from 'vue'
@@ -20,6 +21,8 @@ const props = withDefaults(
     data: null,
   },
 )
+
+const { workspace } = useWorkspace()
 
 const codeLanguage = computed(() => {
   const contentTypeHeader =
@@ -84,8 +87,9 @@ watch(
         doc.write(
           '<style>body,html {body:not(:has(* + style + style)) {font-family: var(--scalar-font-code); font-size: 12px; font-weight: 400;background:var(--scalar-background-1); color: var(--scalar-color-2)}</style>',
         )
-        doc.write(`<style>${getThemeStyles('default')}</style>`)
-        console.log(getThemeStyles('default'))
+        doc.write(
+          `<style>${getThemeStyles(workspace.themeId as ThemeId)}</style>`,
+        )
         doc.close()
       }
     }

--- a/packages/client-app/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/client-app/src/views/Request/ResponseSection/ResponseBody.vue
@@ -3,7 +3,9 @@ import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableHeader from '@/components/DataTable/DataTableHeader.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
+import { useDarkModeState } from '@/hooks'
 import { ScalarCodeBlock, ScalarIcon } from '@scalar/components'
+import { type ThemeId, getThemeStyles } from '@scalar/themes'
 import { computed, nextTick, ref, watch } from 'vue'
 
 const props = withDefaults(
@@ -34,6 +36,7 @@ const iframe = ref<HTMLIFrameElement | null>(null)
 const activePreview = ref('raw')
 const previewOptions = ['raw', 'preview']
 
+const { isDark } = useDarkModeState()
 watch(
   () => activePreview.value,
   async (newValue) => {
@@ -45,6 +48,44 @@ watch(
         if (!doc) return
         doc.open()
         doc.write(props.data)
+        doc.close()
+      }
+    }
+  },
+)
+
+watch(
+  () => isDark.value,
+  async (newValue) => {
+    await nextTick()
+    if (iframe.value) {
+      const doc =
+        iframe.value.contentDocument || iframe.value.contentWindow?.document
+      if (!doc) return
+      doc.body.classList.toggle('dark-mode', isDark.value)
+      doc.body.classList.toggle('light-mode', !isDark.value)
+    }
+  },
+)
+
+watch(
+  () => activePreview.value,
+  async (newValue) => {
+    if (newValue === 'preview') {
+      await nextTick()
+      if (iframe.value) {
+        const doc =
+          iframe.value.contentDocument || iframe.value.contentWindow?.document
+        if (!doc) return
+        doc.open()
+        doc.write(props.data)
+        doc.body.classList.toggle('dark-mode', isDark.value)
+        doc.body.classList.toggle('light-mode', !isDark.value)
+        doc.write(
+          '<style>body,html {body:not(:has(* + style + style)) {font-family: var(--scalar-font-code); font-size: 12px; font-weight: 400;background:var(--scalar-background-1); color: var(--scalar-color-2)}</style>',
+        )
+        doc.write(`<style>${getThemeStyles('default')}</style>`)
+        console.log(getThemeStyles('default'))
         doc.close()
       }
     }
@@ -91,6 +132,7 @@ watch(
             <iframe
               ref="iframe"
               allowfullscreen
+              allowtransparency="true"
               class="w-full aspect-video"
               frameborder="0"></iframe>
           </template>
@@ -102,5 +144,8 @@ watch(
 <style scoped>
 .force-text-sm {
   --scalar-small: 13px;
+}
+iframe {
+  background-color: transparent;
 }
 </style>

--- a/packages/client-app/src/views/Request/components/OAuthScopesInput.vue
+++ b/packages/client-app/src/views/Request/components/OAuthScopesInput.vue
@@ -57,7 +57,7 @@ function setScope(id: string, checked: boolean) {
         <DisclosureButton
           v-slot="{ open }"
           class="group/scopes-accordion flex items-center text-left min-h-8 gap-1.5 h-auto pl-2 hover:bg-b-2 pr-2.5 cursor-pointer">
-          <div class="flex-1">
+          <div class="flex-1 text-c-3">
             Selected
             {{ activeFlow?.selectedScopes?.length || 0 }} /
             {{ Object.keys(activeFlow?.scopes ?? {}).length || 0 }}

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -17,6 +17,8 @@ const workspaceSchema = z.object({
   cookieUids: z.array(z.string()).default([]),
   /** Workspace level proxy for all requests to be sent through */
   proxyUrl: z.string().optional(),
+  /** Workspace level theme, we might move this to user level later */
+  themeId: z.string().optional().default('default'),
 })
 
 /** The base scalar workspace */

--- a/packages/themes/src/tailwind.ts
+++ b/packages/themes/src/tailwind.ts
@@ -76,7 +76,7 @@ export default {
       },
 
       // Utility Colors
-      backdrop: 'rgba(0, 0, 0, 0.44)', // Overlay Backdrops
+      backdrop: 'rgba(0, 0, 0, 0.22)', // Overlay Backdrops
       border: 'var(--scalar-border-color)',
       brand: 'var(--scalar-brand)',
 


### PR DESCRIPTION
if no html was rendered the preview would always have a white background now we take the current theme background if there's no html within the preview

before:
<img width="823" alt="image" src="https://github.com/scalar/scalar/assets/6201407/724dcfbb-071e-4ef5-940c-88ad18a3bb6a">

after:
<img width="759" alt="image" src="https://github.com/scalar/scalar/assets/6201407/60dda68e-3c58-49bb-ba68-0077153309b3">

+ some app polish