### PR TITLE
refactor: move `<HttpMethod />` component to `@scalar/api-reference`

### DIFF
--- a/.changeset/warm-lamps-wash.md
+++ b/.changeset/warm-lamps-wash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+refactor: add HttpMethod component

--- a/packages/api-reference/src/components/Content/Operation/CustomRequestExamples.vue
+++ b/packages/api-reference/src/components/Content/Operation/CustomRequestExamples.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { HttpMethod } from '@scalar/api-client'
 import { ScalarCodeBlock, ScalarIcon } from '@scalar/components'
 import type {
   CustomRequestExample,
@@ -7,6 +6,7 @@ import type {
 } from '@scalar/oas-utils'
 import { computed, ref, watch } from 'vue'
 
+import { HttpMethod } from '../../../components/HttpMethod'
 import { useClipboard } from '../../../hooks'
 import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
 import TextSelect from './TextSelect.vue'

--- a/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
+++ b/packages/api-reference/src/components/Content/Operation/ExampleRequest.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import {
-  HttpMethod,
   getRequestFromAuthentication,
   getSecretCredentialsFromAuthentication,
   getUrlFromServerState,
@@ -28,6 +27,7 @@ import {
 import { useClipboard } from '../../../hooks'
 import { useHttpClientStore } from '../../../stores'
 import { Card, CardContent, CardFooter, CardHeader } from '../../Card'
+import { HttpMethod } from '../../HttpMethod'
 import ExamplePicker from './ExamplePicker.vue'
 import TextSelect from './TextSelect.vue'
 

--- a/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
+++ b/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { HttpMethod } from '@scalar/api-client'
 import {
   ScalarIcon,
   ScalarIconButton,
@@ -9,6 +8,7 @@ import type { TransformedOperation } from '@scalar/oas-utils'
 
 import { useClipboard } from '../../../hooks'
 import { Anchor } from '../../Anchor'
+import { HttpMethod } from '../../HttpMethod'
 import { SectionAccordion } from '../../Section'
 import EndpointDetailsCard from './EndpointDetailsCard.vue'
 import EndpointPath from './EndpointPath.vue'

--- a/packages/api-reference/src/components/Content/Operation/TestRequestButton.vue
+++ b/packages/api-reference/src/components/Content/Operation/TestRequestButton.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { HttpMethod } from '@scalar/api-client'
 import { ScalarIcon } from '@scalar/components'
 import type { TransformedOperation } from '@scalar/oas-utils'
 import { inject } from 'vue'
@@ -15,8 +14,7 @@ defineProps<{
 const getGlobalSecurity = inject(GLOBAL_SECURITY_SYMBOL)
 </script>
 <template>
-  <HttpMethod
-    as="button"
+  <button
     class="show-api-client-button"
     :method="operation.httpVerb"
     type="button"
@@ -34,7 +32,7 @@ const getGlobalSecurity = inject(GLOBAL_SECURITY_SYMBOL)
     ">
     <ScalarIcon icon="PaperAirplane" />
     <span>Test Request</span>
-  </HttpMethod>
+  </button>
 </template>
 <style scoped>
 .show-api-client-button {

--- a/packages/api-reference/src/components/Content/Tag/Endpoints.vue
+++ b/packages/api-reference/src/components/Content/Tag/Endpoints.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { HttpMethod } from '@scalar/api-client'
 import { ScalarMarkdown } from '@scalar/components'
 import type { Tag, TransformedOperation } from '@scalar/oas-utils'
 
 import { useNavState, useSidebar } from '../../../hooks'
 import { Anchor } from '../../Anchor'
 import { Card, CardContent, CardHeader } from '../../Card'
+import { HttpMethod } from '../../HttpMethod'
 import {
   Section,
   SectionColumn,

--- a/packages/api-reference/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/api-reference/src/components/HttpMethod/HttpMethod.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { type Component, computed } from 'vue'
+
+import { requestMethodAbbreviations, requestMethodColors } from './constants'
+import { isRequestMethod } from './utils/isRequestMethod'
+
+const props = defineProps<{
+  /** The type of element to render as, defaults to `span` */
+  as?: Component | string
+  /** The css style property or variable that will be set to the request method color, defaults to `color` */
+  property?: string
+  /** Whether or not to abbreviated the slot content */
+  short?: boolean
+  /** The HTTP method to show */
+  method: string
+}>()
+
+/** A trimmed and uppercase version of the method */
+const normalized = computed(() => props.method.trim().toUpperCase())
+
+const abbreviated = computed<string>(() => {
+  if (isRequestMethod(normalized.value))
+    return requestMethodAbbreviations[normalized.value]
+  return normalized.value.slice(0, 4)
+})
+const color = computed<string>(() => {
+  if (isRequestMethod(normalized.value))
+    return requestMethodColors[normalized.value]
+  return 'var(--scalar-color-ghost)'
+})
+</script>
+<template>
+  <component
+    :is="as ?? 'span'"
+    :style="{ [property || 'color']: color }">
+    <slot v-bind="{ normalized, abbreviated, color }">{{
+      short ? abbreviated : normalized
+    }}</slot>
+  </component>
+</template>

--- a/packages/api-reference/src/components/HttpMethod/constants.ts
+++ b/packages/api-reference/src/components/HttpMethod/constants.ts
@@ -1,0 +1,37 @@
+export const validRequestMethods = [
+  'GET',
+  'POST',
+  'PUT',
+  'HEAD',
+  'DELETE',
+  'PATCH',
+  'OPTIONS',
+  'CONNECT',
+  'TRACE',
+] as const
+
+export type RequestMethod = (typeof validRequestMethods)[number]
+
+export const requestMethodColors: { [x in RequestMethod]: string } = {
+  POST: 'var(--scalar-color-green)',
+  DELETE: 'var(--scalar-color-red)',
+  PATCH: 'var(--scalar-color-yellow)',
+  GET: 'var(--scalar-color-blue)',
+  PUT: 'var(--scalar-color-orange)',
+  OPTIONS: 'var(--scalar-color-purple)',
+  HEAD: 'var(--scalar-color-2)',
+  CONNECT: 'var(--scalar-color-2)',
+  TRACE: 'var(--scalar-color-2)',
+}
+
+export const requestMethodAbbreviations: { [x in RequestMethod]: string } = {
+  POST: 'POST',
+  DELETE: 'DEL',
+  PATCH: 'PATCH',
+  GET: 'GET',
+  PUT: 'PUT',
+  OPTIONS: 'OPTS',
+  HEAD: 'HEAD',
+  CONNECT: 'CONN',
+  TRACE: 'TRACE',
+}

--- a/packages/api-reference/src/components/HttpMethod/index.ts
+++ b/packages/api-reference/src/components/HttpMethod/index.ts
@@ -1,0 +1,1 @@
+export { default as HttpMethod } from './HttpMethod.vue'

--- a/packages/api-reference/src/components/HttpMethod/utils/isRequestMethod.ts
+++ b/packages/api-reference/src/components/HttpMethod/utils/isRequestMethod.ts
@@ -1,0 +1,6 @@
+import { type RequestMethod, validRequestMethods } from '../constants'
+
+/** Checks whether a given request method is a valid request method */
+export function isRequestMethod(s: string): s is RequestMethod {
+  return validRequestMethods.includes(s as RequestMethod)
+}

--- a/packages/api-reference/src/components/Sidebar/SidebarHttpBadge.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarHttpBadge.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { HttpMethod } from '@scalar/api-client'
+import { HttpMethod } from '../HttpMethod'
 
 defineProps<{
   active?: boolean


### PR DESCRIPTION
As we’re about to say good bye to `@scalar/api-client` v1 it’s time to remove imports to it.

This PR moves the `<HttpMethod />`, which we use in a lot of places, to `@scalar/api-reference`.

⚠️ The `TestRequestButton` had a `HttpMethod` as a wrapper. I don't think we need this anymore, or do we have different colors for the button in other/older themes? @cameronrohani 