### PR TITLE
chore: do not expose `useApiClientStore` anymore

### DIFF
--- a/.changeset/tender-papayas-rule.md
+++ b/.changeset/tender-papayas-rule.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: don’t expose useApiClientStore anymore

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -18,5 +18,3 @@ export * from './stores'
 export * from './helpers'
 export * from './types'
 export * from './hooks'
-
-export { useApiClientStore } from '@scalar/api-client'


### PR DESCRIPTION
We probably had a reason at some point to expose the `useApiClientStore` from `@scalar/api-reference`, but that will break soon with the new API client. So let’s remove it already, with a proper changeset.