### PR TITLE
fix(api-client): set param example value

### DIFF
--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -178,7 +178,13 @@ const createParamInstance = (param: OpenAPIV3_1.ParameterObject) =>
   createRequestExampleParameter({
     key: param.name,
     value:
-      param.schema && 'default' in param.schema ? param.schema.default : '',
+      param.schema && 'default' in param.schema
+        ? param.schema.default
+        : param.schema &&
+            'examples' in param.schema &&
+            param.schema.examples.length > 0
+          ? param.schema.examples[0]
+          : '',
     description: param.description,
   })
 


### PR DESCRIPTION
this pr sets back param example values, which displays the first occurence:

<img width="567" alt="image" src="https://github.com/scalar/scalar/assets/14966155/6eaccc8f-cff2-46f4-9c08-4458291af062">

