### PR TITLE
fix(api-reference): sidebar font weight

### DIFF
--- a/.changeset/dull-peaches-greet.md
+++ b/.changeset/dull-peaches-greet.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: api reference sidebar method font weight

--- a/packages/api-reference/src/components/Sidebar/SidebarHttpBadge.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarHttpBadge.vue
@@ -29,7 +29,7 @@ defineProps<{
   );
   text-transform: uppercase;
   font-size: 10px;
-  font-weight: bold;
+  font-weight: var(--scalar-bold);
   text-align: right;
   position: relative;
   font-family: var(--scalar-font-code);


### PR DESCRIPTION
this pr sets the right font weight for the method in the api reference sidebar (700 -> 600):

<img width="290" alt="image" src="https://github.com/scalar/scalar/assets/14966155/0af0e30d-fa5b-4524-809c-9b764af13506">
