### PR TITLE
fix(api-reference): servers are ignored

### DIFF
--- a/.changeset/brave-toes-relax.md
+++ b/.changeset/brave-toes-relax.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: configured servers list is ignored

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -144,8 +144,8 @@ You can pass information to the config object to configure meta information out 
     ogImage: 'https://example.com/image.png',
     twitterCard: 'summary_large_image',
     // Add more...
-    }
   }
+}
 ```
 
 #### hiddenClients?: array | true
@@ -211,7 +211,7 @@ For OpenAuth2 it’s more looking like this:
     scopes: ['read:planets', 'write:planets'],
     },
   },
-  }
+}
 ```
 
 #### withDefaultFonts?: boolean

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -313,7 +313,8 @@ useDeprecationWarnings(props.configuration)
           :baseServerURL="configuration.baseServerURL"
           :layout="configuration.layout === 'classic' ? 'accordion' : 'default'"
           :parsedSpec="parsedSpec"
-          :proxy="configuration.proxy">
+          :proxy="configuration.proxy"
+          :servers="configuration.servers">
           <template #start>
             <slot
               v-bind="referenceSlotProps"

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -2,7 +2,7 @@
 import type { Spec } from '@scalar/oas-utils'
 import { computed } from 'vue'
 
-import { BaseUrl } from '../../features/BaseUrl'
+import { BaseUrl, type Server } from '../../features/BaseUrl'
 import { getModels, hasModels } from '../../helpers'
 import { useNavState, useSidebar } from '../../hooks'
 import { Authentication } from './Authentication'
@@ -18,6 +18,7 @@ const props = defineProps<{
   parsedSpec: Spec
   layout?: 'default' | 'accordion'
   baseServerURL?: string
+  servers?: Server[]
   proxy?: string
 }>()
 
@@ -67,6 +68,7 @@ const isLazy = props.layout !== 'accordion' && !hash.value.startsWith('model')
           :class="{ 'introduction-card-row': layout === 'accordion' }">
           <BaseUrl
             :defaultServerUrl="baseServerURL"
+            :servers="props.servers"
             :specification="parsedSpec" />
           <Authentication
             :parsedSpec="parsedSpec"

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -3,9 +3,10 @@ import { type Server as ApiClientServer, useServerStore } from '#legacy'
 import type { Spec } from '@scalar/oas-utils'
 import { ref, watch } from 'vue'
 
+import { createEmptySpecification } from '../../helpers'
 import ServerForm from './ServerForm.vue'
 import type { Server } from './types'
-import { getServers } from './utils'
+import { getServers } from './utils/getServers'
 
 const props = defineProps<{
   /**
@@ -16,6 +17,10 @@ const props = defineProps<{
    * The fallback server URL to use if no servers are found in the specification
    */
   defaultServerUrl?: string
+  /**
+   * Overwrite the list of servers
+   */
+  servers?: Server[]
 }>()
 
 const { server: serverState, setServer } = useServerStore()
@@ -38,7 +43,16 @@ watch(
 watch(
   () => props.specification,
   () => {
-    const servers = getServers(props.specification, {
+    const specification =
+      // Use the specification
+      props.servers === undefined
+        ? props.specification
+        : // Or create an empty one with the specified servers list
+          createEmptySpecification({
+            servers: props.servers,
+          })
+
+    const servers = getServers(specification, {
       defaultServerUrl: props.defaultServerUrl,
     }) as ApiClientServer[]
 

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -116,13 +116,6 @@ export type ReferenceConfiguration = {
    * By default hides Unirest, pass `[]` to show all clients
    */
   hiddenClients?: HiddenClients
-  /**
-   * List of servers to override the openapi spec servers
-   *
-   * @default undefined
-   * @example [{ url: 'https://api.scalar.com', description: 'Production server' }]
-   */
-  servers?: Server[]
   /** Custom CSS to be added to the page */
   customCss?: string
   /** onSpecUpdate is fired on spec/swagger content change */
@@ -149,6 +142,13 @@ export type ReferenceConfiguration = {
    * @example 'http://localhost:3000'
    */
   baseServerURL?: string
+  /**
+   * List of servers to override the openapi spec servers
+   *
+   * @default undefined
+   * @example [{ url: 'https://api.scalar.com', description: 'Production server' }]
+   */
+  servers?: Server[]
   /**
    * We’re using Inter and JetBrains Mono as the default fonts. If you want to use your own fonts, set this to false.
    *


### PR DESCRIPTION
We somehow didn’t pass the list of servers (anymore). This passes the servers list down to the `<BaseUrl />` component as documented. :)

Based on #2272.