### PR TITLE
ci: publish packages on Stackblitz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,3 @@ jobs:
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
           webpackStatsFile: ./packages/api-reference/dist/browser/webpack-stats.json
-      - if: matrix.node-version == 20 && github.head_ref == 'changeset-release/main'
-        name: Publish on Stackblitz
-        # TODO: Fails on non-npm packages (see: https://github.com/stackblitz-labs/pkg.pr.new/issues/116)
-        # run: npx pkg-pr-new publish ./packages/*
-        # TODO: We can’t pass multiple lines (see: https://github.com/stackblitz-labs/pkg.pr.new/issues/117)
-        run: npx pkg-pr-new publish ./packages/api-client ./packages/api-reference ./packages/api-reference-editor ./packages/api-reference-react ./packages/build-tooling ./packages/cli ./packages/code-highlight ./packages/components ./packages/docusaurus ./packages/draggable ./packages/echo-server ./packages/express-api-reference ./packages/fastify-api-reference ./packages/galaxy ./packages/hono-api-reference ./packages/mock-server ./packages/nestjs-api-reference ./packages/nextjs-api-reference ./packages/nuxt ./packages/oas-utils ./packages/object-utils ./packages/play-button ./packages/themes ./packages/use-codemirror ./packages/use-toasts ./packages/use-tooltip ./packages/void-server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,7 @@ jobs:
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
           webpackStatsFile: ./packages/api-reference/dist/browser/webpack-stats.json
-      #- if: matrix.node-version == 20 && github.head_ref == 'changeset-release/main'
-      - if: matrix.node-version == 20
+      - if: matrix.node-version == 20 && github.head_ref == 'changeset-release/main'
         name: Publish on Stackblitz
         # TODO: Fails on non-npm packages (see: https://github.com/stackblitz-labs/pkg.pr.new/issues/116)
         # run: npx pkg-pr-new publish ./packages/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,6 @@ jobs:
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
           webpackStatsFile: ./packages/api-reference/dist/browser/webpack-stats.json
+      - if: matrix.node-version == 20 && github.head_ref == 'changeset-release/main'
+        name: Publish on Stackblitz
+        run: npx pkg-pr-new publish ./packages/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,33 @@ jobs:
       #- if: matrix.node-version == 20 && github.head_ref == 'changeset-release/main'
       - if: matrix.node-version == 20
         name: Publish on Stackblitz
-        run: npx pkg-pr-new publish ./packages/*
+        # TODO: Fails on non-npm packages (see: https://github.com/stackblitz-labs/pkg.pr.new/issues/116)
+        # run: npx pkg-pr-new publish ./packages/*
+        run: npx pkg-pr-new publish \
+          ./packages/api-client \
+          ./packages/api-reference \
+          ./packages/api-reference-editor \
+          ./packages/api-reference-react \
+          ./packages/build-tooling \
+          ./packages/cli \
+          ./packages/code-highlight \
+          ./packages/components \
+          ./packages/docusaurus \
+          ./packages/draggable \
+          ./packages/echo-server \
+          ./packages/express-api-reference \
+          ./packages/fastify-api-reference \
+          ./packages/galaxy \
+          ./packages/hono-api-reference \
+          ./packages/mock-server \
+          ./packages/nestjs-api-reference \
+          ./packages/nextjs-api-reference \
+          ./packages/nuxt \
+          ./packages/oas-utils \
+          ./packages/object-utils \
+          ./packages/play-button \
+          ./packages/themes \
+          ./packages/use-codemirror \
+          ./packages/use-toasts \
+          ./packages/use-tooltip \
+          ./packages/void-server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
           webpackStatsFile: ./packages/api-reference/dist/browser/webpack-stats.json
-      - if: matrix.node-version == 20 && github.head_ref == 'changeset-release/main'
+      #- if: matrix.node-version == 20 && github.head_ref == 'changeset-release/main'
+      - if: matrix.node-version == 20
         name: Publish on Stackblitz
         run: npx pkg-pr-new publish ./packages/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,31 +51,5 @@ jobs:
         name: Publish on Stackblitz
         # TODO: Fails on non-npm packages (see: https://github.com/stackblitz-labs/pkg.pr.new/issues/116)
         # run: npx pkg-pr-new publish ./packages/*
-        run: npx pkg-pr-new publish \
-          ./packages/api-client \
-          ./packages/api-reference \
-          ./packages/api-reference-editor \
-          ./packages/api-reference-react \
-          ./packages/build-tooling \
-          ./packages/cli \
-          ./packages/code-highlight \
-          ./packages/components \
-          ./packages/docusaurus \
-          ./packages/draggable \
-          ./packages/echo-server \
-          ./packages/express-api-reference \
-          ./packages/fastify-api-reference \
-          ./packages/galaxy \
-          ./packages/hono-api-reference \
-          ./packages/mock-server \
-          ./packages/nestjs-api-reference \
-          ./packages/nextjs-api-reference \
-          ./packages/nuxt \
-          ./packages/oas-utils \
-          ./packages/object-utils \
-          ./packages/play-button \
-          ./packages/themes \
-          ./packages/use-codemirror \
-          ./packages/use-toasts \
-          ./packages/use-tooltip \
-          ./packages/void-server
+        # TODO: We can’t pass multiple lines (see: https://github.com/stackblitz-labs/pkg.pr.new/issues/117)
+        run: npx pkg-pr-new publish ./packages/api-client ./packages/api-reference ./packages/api-reference-editor ./packages/api-reference-react ./packages/build-tooling ./packages/cli ./packages/code-highlight ./packages/components ./packages/docusaurus ./packages/draggable ./packages/echo-server ./packages/express-api-reference ./packages/fastify-api-reference ./packages/galaxy ./packages/hono-api-reference ./packages/mock-server ./packages/nestjs-api-reference ./packages/nextjs-api-reference ./packages/nuxt ./packages/oas-utils ./packages/object-utils ./packages/play-button ./packages/themes ./packages/use-codemirror ./packages/use-toasts ./packages/use-tooltip ./packages/void-server

--- a/.github/workflows/publish-on-stackblitz.yml
+++ b/.github/workflows/publish-on-stackblitz.yml
@@ -1,0 +1,36 @@
+name: Publish on Stackblitz
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-20.04
+    if: github.head_ref == 'changeset-release/main'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-20
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
+      - name: Build packages
+        run: pnpm build:packages
+      - name: Publish on Stackblitz
+        # TODO: Fails on non-npm packages (see: https://github.com/stackblitz-labs/pkg.pr.new/issues/116)
+        # run: npx pkg-pr-new publish ./packages/*
+        # TODO: We can’t pass multiple lines (see: https://github.com/stackblitz-labs/pkg.pr.new/issues/117)
+        run: npx pkg-pr-new publish ./packages/api-client ./packages/api-reference ./packages/api-reference-editor ./packages/api-reference-react ./packages/build-tooling ./packages/cli ./packages/code-highlight ./packages/components ./packages/docusaurus ./packages/draggable ./packages/echo-server ./packages/express-api-reference ./packages/fastify-api-reference ./packages/galaxy ./packages/hono-api-reference ./packages/mock-server ./packages/nestjs-api-reference ./packages/nextjs-api-reference ./packages/nuxt ./packages/oas-utils ./packages/object-utils ./packages/play-button ./packages/themes ./packages/use-codemirror ./packages/use-toasts ./packages/use-tooltip ./packages/void-server


### PR DESCRIPTION
With this PR our packages are published on Stackblitz for all release PRs. 

This is great, because we can test the published version without publishing to npm (and all our users).

The publishing takes ~4 minutes, so I made it a separate workflow which can run in parallel to the `ci.yml`.