### PR TITLE
fix: server description padding

### DIFF
--- a/.changeset/twelve-spiders-sparkle.md
+++ b/.changeset/twelve-spiders-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: server description padding

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -142,6 +142,9 @@ const isLazy = props.layout !== 'accordion' && !hash.value.startsWith('model')
   border: 1px solid var(--scalar-border-color);
   border-radius: var(--scalar-radius-lg);
 }
+.introduction-card :deep(.description) {
+  padding: 0;
+}
 .introduction-card-title {
   font-weight: var(--scalar-semibold);
   font-size: var(--scalar-mini);


### PR DESCRIPTION
before:
<img width="600" alt="image" src="https://github.com/scalar/scalar/assets/6201407/a22f46b4-f21e-494e-a2ec-8df652b07404">

after:
<img width="604" alt="image" src="https://github.com/scalar/scalar/assets/6201407/395bdcb3-d68f-49d2-8821-f834f8a52d13">
