### PR TITLE
fix: api client top position mobile

### DIFF
--- a/.changeset/young-toes-sit.md
+++ b/.changeset/young-toes-sit.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: api client top position on mobile

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -136,7 +136,7 @@ export const useModal = () =>
 @media (max-width: 1280px) {
   .scalar-modal {
     height: calc(100% - 56px);
-    top: 46px;
+    top: 28px;
   }
 }
 @keyframes modal-fade {


### PR DESCRIPTION
new api client top position on mobile is too low, this pr fixes that!

before:
<img width="451" alt="image" src="https://github.com/scalar/scalar/assets/6201407/af29f6f3-9aea-44a0-ab15-1be1da724dfe">


after:
<img width="452" alt="image" src="https://github.com/scalar/scalar/assets/6201407/e93dadf4-378c-4e7a-a520-e70d4320b564">
