### PR TITLE
fix: only send query params with a value

### DIFF
--- a/.changeset/violet-owls-wave.md
+++ b/.changeset/violet-owls-wave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: only send query params with a value

--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -99,7 +99,11 @@ export const sendRequest = async (
   })
 
   const query: Record<string, string> = {
-    ...paramsReducer(example.parameters.query.filter(({ enabled }) => enabled)),
+    ...paramsReducer(
+      example.parameters.query
+        .filter(({ enabled }) => enabled)
+        .filter(({ value }) => value !== ''),
+    ),
     ...paramsReducer(queryParametersFromUrl),
   }
   const cookies: Record<string, string> = {


### PR DESCRIPTION
**Problem**
Currently, we send query param values regardless of if a value is in there or not

**Explanation**
This happens because we send it always

**Solution**
With this PR we only send it if theres a value
