### PR TITLE
fix: ensure path and operation params are merged on import

### DIFF
--- a/.changeset/happy-taxis-join.md
+++ b/.changeset/happy-taxis-join.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: ensure path and operation params are merged on import

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -72,8 +72,14 @@ export const importSpecToWorkspace = async (spec: string | AnyObject) => {
         cookies: {},
       }
 
+      // An operation can have component level parameters as well :)
+      const pathAndOperationParameters = [
+        ...path.parameters,
+        operation.parameters,
+      ].filter((p) => p)
+
       // Loop over params to set request params
-      operation.parameters?.forEach((_param: any) => {
+      pathAndOperationParameters.forEach((_param: any) => {
         const param = _param
 
         if (

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -74,9 +74,11 @@ export const importSpecToWorkspace = async (spec: string | AnyObject) => {
 
       // An operation can have component level parameters as well :)
       const pathAndOperationParameters = [
-        ...path.parameters,
-        operation.parameters,
+        ...(path.parameters || []),
+        ...(operation.parameters || []),
       ].filter((p) => p)
+
+      console.log(pathAndOperationParameters)
 
       // Loop over params to set request params
       pathAndOperationParameters.forEach((_param: any) => {

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -78,8 +78,6 @@ export const importSpecToWorkspace = async (spec: string | AnyObject) => {
         ...(operation.parameters || []),
       ].filter((p) => p)
 
-      console.log(pathAndOperationParameters)
-
       // Loop over params to set request params
       pathAndOperationParameters.forEach((_param: any) => {
         const param = _param


### PR DESCRIPTION
**Problem**
Currently, we miss path level params on import

**Explanation**
This happens because we dont check them only operation params

**Solution**
With this PR we check both :) 

<img width="1163" alt="image" src="https://github.com/scalar/scalar/assets/6176314/25829165-464c-4596-ba01-f8bbda27f5d7">

