### PR TITLE
fix(api-client): add scalar classes to headless ui root

### DIFF
--- a/.changeset/clean-llamas-appear.md
+++ b/.changeset/clean-llamas-appear.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: api client missing scalar ui root style

--- a/packages/api-client/src/App.vue
+++ b/packages/api-client/src/App.vue
@@ -3,6 +3,7 @@ import SideNav from '@/components/SideNav/SideNav.vue'
 import TopNav from '@/components/TopNav/TopNav.vue'
 import { useDarkModeState } from '@/hooks'
 import { useWorkspace } from '@/store/workspace'
+import { addScalarClassesToHeadless } from '@scalar/components'
 import { ScalarToasts } from '@scalar/use-toasts'
 import { onBeforeMount, onMounted, watchEffect } from 'vue'
 import { RouterView } from 'vue-router'
@@ -19,7 +20,11 @@ const { importSpecFromUrl, workspaceMutators } = useWorkspace()
 
 workspaceMutators.edit('proxyUrl', 'https://proxy.scalar.com')
 
-onBeforeMount(() => {})
+/**
+ * Ensure we add our scalar wrapper class to the headless ui root
+ * mounted is too late
+ */
+onBeforeMount(() => addScalarClassesToHeadless())
 
 onMounted(() => {
   importSpecFromUrl(


### PR DESCRIPTION
this pr adds scalar classes to headless ui root within api client package to maintain style within the workspace usage:

<img width="1470" alt="image" src="https://github.com/scalar/scalar/assets/14966155/e9d55989-d47c-4759-ab23-14ef097f777b">
