### PR TITLE
feat(void-server): (multipart) form data

### DIFF
--- a/.changeset/cool-worms-lie.md
+++ b/.changeset/cool-worms-lie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+feat: form data and multipart form data

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -158,6 +158,38 @@ describe('createVoidServer', () => {
     expect(body.file.lastModified).toBeDefined()
   })
 
+  it('returns multipart form data with multiple files', async () => {
+    const server = await createVoidServer()
+
+    // Multiple files in a single field
+    const formData = new FormData()
+    formData.append('files', new Blob(['foobar']), 'file1.txt')
+    formData.append('files', new Blob(['foobar']), 'file2.txt')
+
+    const response = await server.request('/', {
+      method: 'POST',
+      body: formData,
+    })
+
+    const body = (await response.json()).body
+
+    expect(body.files).toMatchObject([
+      {
+        name: 'file1.txt',
+        sizeInBytes: 6,
+        type: 'application/octet-stream',
+      },
+      {
+        name: 'file2.txt',
+        sizeInBytes: 6,
+        type: 'application/octet-stream',
+      },
+    ])
+
+    expect(body.files[0].lastModified).toBeDefined()
+    expect(body.files[1].lastModified).toBeDefined()
+  })
+
   it('returns form data with dot syntax', async () => {
     const server = await createVoidServer()
 

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -158,6 +158,26 @@ describe('createVoidServer', () => {
     expect(body.file.lastModified).toBeDefined()
   })
 
+  it('returns form data with dot syntax', async () => {
+    const server = await createVoidServer()
+
+    const formData = new FormData()
+
+    // Dot syntax
+    formData.append('foo.bar', 'yes')
+
+    const response = await server.request('/', {
+      method: 'POST',
+      body: formData,
+    })
+
+    expect((await response.json()).body).toStrictEqual({
+      foo: {
+        bar: 'yes',
+      },
+    })
+  })
+
   it('returns the cookies', async () => {
     const server = await createVoidServer()
 

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -210,6 +210,18 @@ describe('createVoidServer', () => {
     })
   })
 
+  it('returns just a blob', async () => {
+    const server = await createVoidServer()
+
+    // Send just a blob
+    const response = await server.request('/', {
+      method: 'POST',
+      body: new Blob(['foobar']),
+    })
+
+    expect((await response.json()).body).toStrictEqual('foobar')
+  })
+
   it('returns the cookies', async () => {
     const server = await createVoidServer()
 

--- a/packages/void-server/src/utils/getBody.ts
+++ b/packages/void-server/src/utils/getBody.ts
@@ -4,12 +4,52 @@ import type { Context } from 'hono'
  * Get the body of a request, no matter if it’s JSON or text
  */
 export async function getBody(c: Context) {
+  const contentType = c.req.header('Content-Type')
+
+  // (Multipart) form data
+  if (
+    contentType?.includes('application/x-www-form-urlencoded') ||
+    contentType?.includes('multipart/form-data')
+  ) {
+    const formData = await c.req.formData()
+
+    // Transform FormData to a key value object
+    const body: Record<string, any> = {}
+
+    for (const [key, value] of formData.entries()) {
+      // String
+      if (typeof value === 'string') {
+        body[key] = value
+        continue
+      }
+
+      // File
+      if (value instanceof File) {
+        body[key] = {
+          name: value?.name,
+          sizeInBytes: value?.size,
+          type: value?.type,
+          // Get date time string from unix timestamp
+          lastModified: value.lastModified
+            ? new Date(value.lastModified).toISOString()
+            : undefined,
+        }
+        continue
+      }
+    }
+
+    return body
+  }
+
   const body = await c.req.text()
 
-  // Try to parse the body as JSON
+  // JSON
   try {
     return JSON.parse(body)
   } catch {
-    return body
+    //
   }
+
+  // Plain text
+  return body
 }

--- a/packages/void-server/src/utils/getBody.ts
+++ b/packages/void-server/src/utils/getBody.ts
@@ -36,7 +36,6 @@ export async function getBody(c: Context) {
  * Transform form data to a more readable format, including file information
  */
 function transformFormData(formData: Record<string, any>) {
-  console.log(formData)
   const body: Record<string, any> = {}
 
   for (const [key, value] of Object.entries(formData)) {
@@ -62,15 +61,15 @@ function transformFormData(formData: Record<string, any>) {
 
     // Array
     if (Array.isArray(value)) {
-      body[key] = value.map((v) => {
-        if (value instanceof File) {
+      body[key] = value.map((item: string | File) => {
+        if (item instanceof File) {
           return {
-            name: value?.name,
-            sizeInBytes: value?.size,
-            type: value?.type,
+            name: item?.name,
+            sizeInBytes: item?.size,
+            type: item?.type,
             // Get date time string from unix timestamp
-            lastModified: value.lastModified
-              ? new Date(value.lastModified).toISOString()
+            lastModified: item.lastModified
+              ? new Date(item.lastModified).toISOString()
               : undefined,
           }
         }


### PR DESCRIPTION
I’ve missed that feature: This PR adds support for (multipart) form data to `@scalar/void-server`, including support for for fields containing a single or multiple fields and blob requests (just a blob, nothing else).

Great help to debug the file upload.