### PR TITLE
chore(build-tooling): remove `dist/` folder by default

### DIFF
--- a/.changeset/gold-horses-travel.md
+++ b/.changeset/gold-horses-travel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+feat: rollup removes dist folder by default

--- a/packages/build-tooling/src/rollup-options.ts
+++ b/packages/build-tooling/src/rollup-options.ts
@@ -45,14 +45,23 @@ export function createRollupConfig(props: {
     ? [...props.options.plugins]
     : []
 
-  // Optional list of files to copy over
-  if (props?.emptyOutDir !== false)
+  // Remove the ./dist folder by default
+  if (props?.emptyOutDir !== false) {
     plugins.push(
       emptyOutDir({
         dir: './dist',
       }),
     )
-  if (props?.copy) plugins.push(copy({ targets: props.copy }))
+  }
+  // Optional list of files to copy over
+  if (props?.copy)
+    plugins.push(
+      copy({
+        targets: props.copy,
+        // Use the `generateBundle` hook to copy files, otherwise they are deleted by the `emptyOutDir` plugin
+        hook: 'generateBundle',
+      }),
+    )
   // For vanilla rollup (not Vite) we need to enable transpilation
   if (props.typescript) plugins.push(typescript())
   plugins.push(json())
@@ -77,6 +86,7 @@ export function createRollupConfig(props: {
     external.push(...Object.keys(pkgFile.devDependencies))
   if ('peerDependencies' in pkgFile)
     external.push(...Object.keys(pkgFile.peerDependencies))
+
   return {
     treeshake: {
       annotations: true,

--- a/packages/build-tooling/src/rollup-options.ts
+++ b/packages/build-tooling/src/rollup-options.ts
@@ -7,6 +7,8 @@ import type { InputPluginOption, RollupOptions } from 'rollup'
 import copy, { type Target } from 'rollup-plugin-copy'
 import css from 'rollup-plugin-import-css'
 
+import emptyOutDir from './rollup-plugins/emptyOutDir'
+
 export type StrictPluginOptions = RollupOptions & {
   plugins?: InputPluginOption[]
 }
@@ -28,6 +30,12 @@ export function createRollupConfig(props: {
   typescript?: boolean
   copy?: Target[]
   options?: StrictPluginOptions
+  /**
+   * Remove the ./dist folder
+   *
+   * @default true
+   */
+  emptyOutDir?: boolean
 }): RollupOptions {
   /** Load the pkg file if not provided */
   const pkgFile =
@@ -38,6 +46,12 @@ export function createRollupConfig(props: {
     : []
 
   // Optional list of files to copy over
+  if (props?.emptyOutDir !== false)
+    plugins.push(
+      emptyOutDir({
+        dir: './dist',
+      }),
+    )
   if (props?.copy) plugins.push(copy({ targets: props.copy }))
   // For vanilla rollup (not Vite) we need to enable transpilation
   if (props.typescript) plugins.push(typescript())

--- a/packages/build-tooling/src/rollup-plugins/emptyOutDir.ts
+++ b/packages/build-tooling/src/rollup-plugins/emptyOutDir.ts
@@ -9,18 +9,24 @@ import type { Plugin } from 'rollup'
  */
 export default function emptyOutDir({ dir }: { dir: string }): Plugin {
   let removePromise: Promise<void>
+
   return {
-    // eslint-disable-next-line consistent-return
-    generateBundle(_options, _bundle, isWrite) {
-      if (isWrite) {
-        // Only remove before first write, but make all writes wait on the removal
-        removePromise ??= rm(dir, {
-          force: true,
-          recursive: true,
-        })
-        return removePromise
-      }
-    },
     name: 'empty-out-dir',
+    generateBundle: {
+      // Run before all other `generateBundle` plugins
+      order: 'pre',
+      // eslint-disable-next-line consistent-return
+      handler(_options, _bundle, isWrite) {
+        if (isWrite) {
+          // Only remove before first write, but make all writes wait on the removal
+          removePromise ??= rm(dir, {
+            force: true,
+            recursive: true,
+          })
+
+          return removePromise
+        }
+      },
+    },
   }
 }

--- a/packages/build-tooling/src/rollup-plugins/emptyOutDir.ts
+++ b/packages/build-tooling/src/rollup-plugins/emptyOutDir.ts
@@ -1,0 +1,26 @@
+import { rm } from 'node:fs/promises'
+import type { Plugin } from 'rollup'
+
+/**
+ * Remove all files in a directory before writing to it
+ * Taken from rollup/rollup
+ *
+ * @see https://github.com/rollup/rollup/blob/master/build-plugins/clean-before-write.ts
+ */
+export default function emptyOutDir({ dir }: { dir: string }): Plugin {
+  let removePromise: Promise<void>
+  return {
+    // eslint-disable-next-line consistent-return
+    generateBundle(_options, _bundle, isWrite) {
+      if (isWrite) {
+        // Only remove before first write, but make all writes wait on the removal
+        removePromise ??= rm(dir, {
+          force: true,
+          recursive: true,
+        })
+        return removePromise
+      }
+    },
+    name: 'empty-out-dir',
+  }
+}


### PR DESCRIPTION
With this PR our Rollup script removes the `dist/` folder by default.

Keeping the `dist/` folder can be confusing, or make you think the build works, but it maybe just kept the files from before your changes.

If - for some reason - that’s not the expected behaviour, you can disable the plugin like this:

```ts
createRollupConfig({
  emptyOutDir: false,
})
```

The Rollup plugin is taken from the official Rollup repository.