### PR TITLE
fix(play-button): does not work with yaml

### DIFF
--- a/.changeset/rare-kangaroos-sit.md
+++ b/.changeset/rare-kangaroos-sit.md
@@ -1,0 +1,5 @@
+---
+'@scalar/play-button': patch
+---
+
+fix: does not work with YAML

--- a/examples/cdn-api-reference/src/public/play-button-local.html
+++ b/examples/cdn-api-reference/src/public/play-button-local.html
@@ -13,7 +13,7 @@
       data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json"></script>
     <script src="/play-button/standalone.js"></script>
     <button
-      scalar-operation-id="getPetById"
+      scalar-operation-id="getAllData"
       class="scalar-play-button">
       Try it Out
     </button>

--- a/packages/play-button/index.html
+++ b/packages/play-button/index.html
@@ -8,8 +8,9 @@
       content="width=device-width, initial-scale=1" />
   </head>
   <body>
+    <h2>getMe</h2>
     <button
-      scalar-operation-id="getPetById"
+      scalar-operation-id="getMe"
       class="scalar-play-button scalar-api-client-small"
       style="
         all: unset;
@@ -46,8 +47,10 @@
       </svg>
       Test API
     </button>
+
+    <h2>getAllData</h2>
     <button
-      scalar-operation-id="deletePet"
+      scalar-operation-id="getAllData"
       class="scalar-play-button scalar-api-client-small"
       style="
         all: unset;
@@ -86,11 +89,7 @@
     </button>
     <script
       id="scalar-play-button-script"
-      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
-      type="application/json">
-      { "openapi": "3.1.0", "info": { "title": "Example" }, "paths": {} }
-    </script>
-
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"></script>
     <script
       type="module"
       src="src/index.ts"></script>

--- a/packages/play-button/src/index.ts
+++ b/packages/play-button/src/index.ts
@@ -66,63 +66,55 @@ if (!specUrlElement && !specElement && !specScriptTag) {
 
     const parsedSpec: Spec = reactive(await parse(specUrl))
 
-    // const _app = createApp(
-    //   h(ScalarButtonStyles, null, {
-    //     default: () =>
-    //       h(ApiClientModal, {
-    //         parsedSpec,
-    //         theme: 'default',
-    //       }),
-    //   }),
-    // )
-
-    if (container) {
-      const { open } = await createScalarApiClient(container as HTMLElement, {
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
-        proxyUrl: 'https://proxy.scalar.com',
-      })
-
-      for (const testButton of testButtons) {
-        testButton?.addEventListener('click', () => {
-          // Operation ID from data attribute
-          const operationId = testButton.getAttribute('scalar-operation-id')
-
-          // Loop through all tags and operations to find the specified operation
-          const specifiedOperation = parsedSpec.tags?.reduce(
-            (acc: TransformedOperation | undefined, tag: Tag) => {
-              if (acc) {
-                return acc
-              }
-
-              return tag.operations?.find(
-                (operation) => operation.operationId === operationId,
-              )
-            },
-            undefined,
-          ) as unknown as TransformedOperation
-
-          if (specifiedOperation) {
-            open({
-              path: specifiedOperation.path,
-              method: specifiedOperation.httpVerb,
-            })
-          } else {
-            const firstOperation = parsedSpec.tags?.[0]?.operations?.[0]
-
-            if (firstOperation) {
-              open({
-                path: firstOperation.path,
-                method: firstOperation.httpVerb,
-              })
-            }
-          }
-        })
-      }
-    } else {
+    if (!container) {
       console.error('Could not find a mount point for API References')
+      return null
     }
+
+    const { open } = await createScalarApiClient(container as HTMLElement, {
+      spec: {
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+      },
+      proxyUrl: 'https://proxy.scalar.com',
+    })
+
+    for (const testButton of testButtons) {
+      testButton?.addEventListener('click', () => {
+        // Operation ID from data attribute
+        const operationId = testButton.getAttribute('scalar-operation-id')
+
+        // Loop through all tags and operations to find the specified operation
+        const specifiedOperation = parsedSpec.tags?.reduce(
+          (acc: TransformedOperation | undefined, tag: Tag) => {
+            if (acc) {
+              return acc
+            }
+
+            return tag.operations?.find(
+              (operation) => operation.operationId === operationId,
+            )
+          },
+          undefined,
+        ) as unknown as TransformedOperation
+
+        if (specifiedOperation) {
+          open({
+            path: specifiedOperation.path,
+            method: specifiedOperation.httpVerb,
+          })
+        } else {
+          const firstOperation = parsedSpec.tags?.[0]?.operations?.[0]
+
+          if (firstOperation) {
+            open({
+              path: firstOperation.path,
+              method: firstOperation.httpVerb,
+            })
+          }
+        }
+      })
+    }
+
     return null
   }
 

--- a/packages/play-button/src/index.ts
+++ b/packages/play-button/src/index.ts
@@ -34,6 +34,14 @@ const getSpecUrl = () => {
     }
   }
 
+  // <script id="scalar-play-button-script" type="application/json">{ "openapi": "3.1.0", … }</script>
+  // <script id="scalar-play-button-script" type="application/yaml">…</script>
+  const specFromScriptTag = specScriptTag?.innerHTML?.trim()
+
+  if (specFromScriptTag) {
+    return specFromScriptTag
+  }
+
   return undefined
 }
 

--- a/playwright/tests/jsdelivr.spec.ts
+++ b/playwright/tests/jsdelivr.spec.ts
@@ -10,7 +10,8 @@ test('@scalar/api-reference jsdelivr build', async ({ page, isMobile }) => {
   await testApiReference(page, isMobile)
 
   // TODO: fix the dev workflow
-  /** Visual Regression Testing
+  /**
+   * Visual Regression Testing
    * use Playwright built in screenshot functionality https://playwright.dev/docs/screenshots
    * Playwright uses pixelmatch to compare screenshots
    * update screenshots with npx playwright test --update-snapshots
@@ -20,7 +21,8 @@ test('@scalar/api-reference jsdelivr build', async ({ page, isMobile }) => {
   //   maxDiffPixelRatio: 0.02,
   // })
 
-  /** Capture into buffer
+  /**
+   * Capture into buffer
    * If we are unsatisfied with the built in visual regression testing
    * this is how we could pass it to a third party pixel diff facility eg. Chromatic
    *   const buffer = await page.screenshot()

--- a/playwright/tests/jsdelivr.spec.ts
+++ b/playwright/tests/jsdelivr.spec.ts
@@ -50,7 +50,7 @@ test.skip('@scalar/api-reference jsdelivr build (yaml content)', async ({
 })
 
 // TODO: The package is just broken and needs to be fixed.
-test.skip('@scalar/play-button jsdelivr build', async ({ page, isMobile }) => {
+test.skip('@scalar/play-button jsdelivr build', async ({ page }) => {
   await page.goto(`http://${HOST}:3173/play-button-jsdelivr.html`)
-  await testPlayButton(page, isMobile)
+  await testPlayButton(page)
 })

--- a/playwright/tests/local.spec.ts
+++ b/playwright/tests/local.spec.ts
@@ -43,8 +43,7 @@ test('@scalar/api-reference local build (yaml content)', async ({ page }) => {
   await testHelloWorld(page)
 })
 
-// TODO: The package is just broken and needs to be fixed.
-test.only('@scalar/play-button local build', async ({ page }) => {
+test('@scalar/play-button local build', async ({ page }) => {
   await page.goto(`http://${HOST}:3173/play-button-local.html`)
   await testPlayButton(page)
 })

--- a/playwright/tests/local.spec.ts
+++ b/playwright/tests/local.spec.ts
@@ -44,7 +44,7 @@ test('@scalar/api-reference local build (yaml content)', async ({ page }) => {
 })
 
 // TODO: The package is just broken and needs to be fixed.
-test.skip('@scalar/play-button local build', async ({ page, isMobile }) => {
+test.only('@scalar/play-button local build', async ({ page }) => {
   await page.goto(`http://${HOST}:3173/play-button-local.html`)
-  await testPlayButton(page, isMobile)
+  await testPlayButton(page)
 })

--- a/playwright/tests/local.spec.ts
+++ b/playwright/tests/local.spec.ts
@@ -13,7 +13,8 @@ test('@scalar/api-reference local build (data-url)', async ({
   await testApiReference(page, isMobile)
 
   // TODO: fix the dev workflow
-  /** Visual Regression Testing
+  /**
+   * Visual Regression Testing
    * use Playwright built in screenshot functionality https://playwright.dev/docs/screenshots
    * Playwright uses pixelmatch to compare screenshots
    * update screenshots with npx playwright test --update-snapshots
@@ -23,7 +24,8 @@ test('@scalar/api-reference local build (data-url)', async ({
   //     maxDiffPixelRatio: 0.02,
   //   })
 
-  /** Capture into buffer
+  /**
+   * Capture into buffer
    * If we are unsatisfied with the built in visual regression testing
    * this is how we could pass it to a third party pixel diff facility eg. Chromatic
    *   const buffer = await page.screenshot()

--- a/playwright/tests/testApiReference.ts
+++ b/playwright/tests/testApiReference.ts
@@ -1,6 +1,8 @@
 import { type Page, expect } from '@playwright/test'
 
-// Check for basic elements
+/**
+ * Test the @scalar/api-reference page
+ */
 export async function testApiReference(page: Page, isMobile: boolean) {
   // The heading
   await expect(
@@ -20,6 +22,9 @@ export async function testApiReference(page: Page, isMobile: boolean) {
   }
 }
 
+/**
+ * Test the hello world page
+ */
 export async function testHelloWorld(page: Page) {
   // The heading
   await expect(page.getByRole('heading', { name: 'Hello World' })).toBeVisible()

--- a/playwright/tests/testPlayButton.ts
+++ b/playwright/tests/testPlayButton.ts
@@ -1,9 +1,21 @@
 import { type Page, expect } from '@playwright/test'
 
-// Check for basic elements
-export async function testPlayButton(page: Page, isMobile: boolean) {
+/**
+ * Test the play button
+ */
+export async function testPlayButton(page: Page) {
+  // Wait
+  await page.waitForTimeout(500)
+  // Button has scalar-operation-id="getAllData"
+  await page.waitForSelector('button[scalar-operation-id="getAllData"]')
   // Click button
   await page.click('text=Try it Out')
 
-  // TODO: Write test :)
+  // Wait until a button with text="Send Request" is visible
+  await page.waitForSelector('.scalar-client')
+
+  // URL
+  await expect(page.getByText('https://galaxy.scalar.com')).toBeVisible()
+  // Path
+  await expect(page.getByText('/planets')).toBeVisible()
 }


### PR DESCRIPTION
The `@scalar/play-button` doesn’t support YAML (as shown in the example in the README). This PR fixes it and some more issues:

* We’ve had a `await resp.json()` in there, so it wasn’t working with anything else than JSON. We’re now just passing whatever content we receive to the `parse` function.
* To open a specified operation, it just looked in the first tag (`parsedSpec.tags?.[0]?.operations?.find(…)`), so it didn’t work for operations in other tags.
* We were looking for the specified operation on load, not on click. This broke for URLs that first need to be fetched.
* The example mentioned operationIds from the petstore example, but used the `@scalar/galaxy` example.
* The package ignored `script` tag content, this PR adds support for it.

This PR also adds basic tests for the local `@scalar/play-button` script.