### PR TITLE
feat(api-client): data table input enum select

### DIFF
--- a/.changeset/dirty-parrots-sin.md
+++ b/.changeset/dirty-parrots-sin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: oas-utils request example parameters enum

--- a/.changeset/serious-clouds-pretend.md
+++ b/.changeset/serious-clouds-pretend.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: api client data table input enum select component

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -4,6 +4,7 @@ import { ScalarIconButton } from '@scalar/components'
 import { computed, ref } from 'vue'
 
 import DataTableCell from './DataTableCell.vue'
+import DataTableInputEnumSelect from './DataTableInputEnumSelect.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -14,6 +15,7 @@ const props = withDefaults(
     required?: boolean
     modelValue: string | number
     readOnly?: boolean
+    enum?: string[]
   }>(),
   { required: false, readOnly: false },
 )
@@ -78,20 +80,28 @@ const handleDropdownMouseUp = () => {
         'relative after:absolute after:content-[\'Required\'] after:centered-y after:right-0 after:pt-px after:pr-2 after:text-xxs after:font-medium after:text-c-3 after:bg-b-1 after:shadow-[-8px_0_4px_var(--scalar-background-1)] group-has-[:focus]:after:hidden':
           required,
       }">
-      <input
-        v-bind="$attrs"
-        :id="id"
-        autocomplete="off"
-        class="border-none focus:text-c-1 text-c-2 min-w-0 w-full px-2 py-1.5 outline-none"
-        data-1p-ignore
-        :readOnly="readOnly"
-        :required="required"
-        spellcheck="false"
-        :type="inputType"
-        :value="modelValue"
-        @blur="handleBlur"
-        @focus="emit('inputFocus')"
-        @input="handleInput" />
+      <template v-if="props.enum && props.enum.length">
+        <DataTableInputEnumSelect
+          :enum="props.enum"
+          :modelValue="props.modelValue"
+          @update:modelValue="emit('update:modelValue', $event)" />
+      </template>
+      <template v-else>
+        <input
+          v-bind="$attrs"
+          :id="id"
+          autocomplete="off"
+          class="border-none focus:text-c-1 text-c-2 min-w-0 w-full px-2 py-1.5 outline-none"
+          data-1p-ignore
+          :readOnly="readOnly"
+          :required="required"
+          spellcheck="false"
+          :type="inputType"
+          :value="modelValue"
+          @blur="handleBlur"
+          @focus="emit('inputFocus')"
+          @input="handleInput" />
+      </template>
     </div>
     <slot name="icon" />
     <ScalarIconButton

--- a/packages/api-client/src/components/DataTable/DataTableInputEnumSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputEnumSelect.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import {
+  ScalarButton,
+  ScalarDropdown,
+  ScalarDropdownDivider,
+  ScalarDropdownItem,
+  ScalarIcon,
+} from '@scalar/components'
+import { computed, ref, watch } from 'vue'
+
+const props = defineProps<{
+  modelValue: string | number
+  enum?: string[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: string): void
+}>()
+
+const options = computed(() => props.enum ?? [])
+
+const selected = ref<string>(props.modelValue.toString())
+const addingCustomValue = ref(false)
+const customValue = ref('')
+
+watch(customValue, (newValue) => {
+  emit('update:modelValue', newValue)
+})
+
+const updateSelected = (value: string) => {
+  selected.value = value
+  emit('update:modelValue', value)
+  addingCustomValue.value = false
+}
+
+const addCustomValue = () => {
+  if (customValue.value.trim()) {
+    updateSelected(customValue.value)
+    customValue.value = ''
+  }
+}
+
+const handleBlur = () => {
+  if (!customValue.value.trim()) {
+    selected.value = ''
+    addingCustomValue.value = false
+  }
+}
+
+const isSelected = (value: string) => {
+  return selected.value === value
+}
+</script>
+
+<template>
+  <div class="w-full">
+    <template v-if="addingCustomValue">
+      <input
+        v-model="customValue"
+        class="border-none focus:text-c-1 text-c-2 min-w-0 w-full px-2 py-1.5 outline-none"
+        placeholder="Value"
+        type="text"
+        @blur="handleBlur"
+        @keyup.enter="addCustomValue" />
+    </template>
+    <template v-else>
+      <ScalarDropdown
+        resize
+        :value="selected">
+        <ScalarButton
+          class="gap-1.5 font-normal h-full justify-start px-2 py-1.5"
+          fullWidth
+          variant="ghost">
+          <span>{{ selected || 'Select a value' }}</span>
+          <ScalarIcon
+            v-if="!selected"
+            icon="ChevronDown"
+            size="xs" />
+        </ScalarButton>
+        <template #items>
+          <ScalarDropdownItem
+            v-for="option in options"
+            :key="option"
+            class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden"
+            :value="option"
+            @click="updateSelected(option)">
+            <div
+              class="flex items-center justify-center rounded-full p-[3px] group-hover/item:shadow-border"
+              :class="
+                isSelected(option) ? 'bg-blue text-b-1' : 'text-transparent'
+              ">
+              <ScalarIcon
+                class="size-2.5 stroke-[1.75]"
+                icon="Checkmark" />
+            </div>
+            {{ option }}
+          </ScalarDropdownItem>
+          <ScalarDropdownDivider />
+          <ScalarDropdownItem
+            class="flex items-center gap-1.5"
+            @click="addingCustomValue = true">
+            <div class="flex items-center justify-center h-4 w-4">
+              <ScalarIcon
+                class="h-2.5"
+                icon="Add" />
+            </div>
+            <span>Add value</span>
+          </ScalarDropdownItem>
+        </template>
+      </ScalarDropdown>
+    </template>
+  </div>
+</template>

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -187,6 +187,7 @@ const createParamInstance = (param: OpenAPIV3_1.ParameterObject) =>
           : '',
     description: param.description,
     required: param.required,
+    enum: param.schema?.enum,
   })
 
 /**

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -63,6 +63,7 @@ const handleFileUpload = (idx: number) => {
         @selectVariable="(v) => handleSelectVariable(idx, 'key', v)"
         @update:modelValue="(v) => emit('updateRow', idx, 'key', v)" />
       <DataTableInput
+        :enum="item.enum"
         :modelValue="item.value"
         placeholder="Value"
         @blur="emit('inputBlur')"

--- a/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
@@ -11,6 +11,7 @@ const requestExampleParametersSchema = z.object({
   /** Params are linked to parents such as path params and global headers/cookies */
   refUid: nanoidSchema.optional(),
   required: z.boolean().optional(),
+  enum: z.array(z.string()).optional(),
 })
 
 /** Request examples - formerly known as instances - are "children" of requests */


### PR DESCRIPTION
this pr adds an input enum select component to the api client package, in order to be able to select an enum value when available, along maintaining the capacity of adding our own value:

<img width="1392" alt="image" src="https://github.com/scalar/scalar/assets/14966155/79abe627-faf2-4911-976d-b11f7f158ee8">
