### PR TITLE
feat(api-client): tab focus style

### DIFF
--- a/.changeset/young-waves-glow.md
+++ b/.changeset/young-waves-glow.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/themes': patch
+---
+
+feat: focus visible outline style

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -178,7 +178,7 @@ const handlePaste = (event: ClipboardEvent) => {
 
           <AddressBarHistory :open="open" />
           <ScalarButton
-            class="relative h-auto shrink-0 gap-1.5 overflow-hidden px-2.5 py-1"
+            class="relative h-auto shrink-0 gap-1.5 overflow-hidden px-2.5 py-1 z-[1]"
             :disabled="isRequesting"
             @click="executeRequestBus.emit()">
             <ScalarIcon

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -60,7 +60,7 @@ const serverUrl = computed(() => {
       teleport="#scalar-client"
       :value="activeCollection?.selectedServerUid">
       <button
-        class="font-code lg:text-sm text-xs whitespace-nowrap border border-b-3 border-solid rounded px-1.5 text-c-2"
+        class="font-code lg:text-sm text-xs whitespace-nowrap border border-b-3 border-solid rounded px-1.5 text-c-2 z-[1]"
         type="button"
         @click.stop>
         {{ serverUrl }}

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -135,7 +135,7 @@ const showChildren = computed(
         custom
         :to="`/request/${item.uid}`">
         <div
-          class="group relative flex min-h-8 cursor-pointer flex-row items-start justify-between gap-2 py-1.5 pr-2 editable-sidebar-hover"
+          class="group relative flex min-h-8 cursor-pointer flex-row items-start justify-between gap-2 py-1.5 pr-2 rounded editable-sidebar-hover"
           :class="[
             highlightClasses,
             activeRequest?.uid === item.uid
@@ -165,7 +165,7 @@ const showChildren = computed(
       <!-- Collection/Folder -->
       <button
         v-else-if="!workspace.isReadOnly || parentUids.length"
-        class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5"
+        class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5 z-[1]"
         :class="highlightClasses"
         type="button"
         @click="toggleSidebarFolder(item.uid)">

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -143,6 +143,7 @@ const showChildren = computed(
               : 'text-sidebar-c-2',
             !isDroppable ? `pl-3` : 'pl-3',
           ]"
+          tabindex="0"
           @click="($event) => handleNavigation($event, item.uid)">
           <span class="z-10 font-medium w-full editable-sidebar-hover-item">
             {{ getTitle(item) }}

--- a/packages/themes/src/reset.css
+++ b/packages/themes/src/reset.css
@@ -69,4 +69,10 @@
   input:-webkit-autofill {
     background-clip: text !important;
   }
+
+  /** Custom outline style for focus visible */
+  :focus-visible {
+    outline: 1px solid var(--scalar-color-accent);
+    outline-offset: 1px;
+  }
 }


### PR DESCRIPTION
this pr adds tab index to sidebar child item in order to make them focusable + custom style focus visible:

<img width="1392" alt="image" src="https://github.com/scalar/scalar/assets/14966155/af689c1d-aed0-4a57-82d8-2ad9d05390cb">
