### PR TITLE
fix(api client): add cookies

### DIFF
--- a/.changeset/mean-falcons-thank.md
+++ b/.changeset/mean-falcons-thank.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+fix: add cookie handler and schema

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -7,6 +7,7 @@ import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
 import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import { useWorkspace } from '@/store/workspace'
 import { createCookie } from '@scalar/oas-utils/entities/workspace/cookie'
+import { nanoid } from 'nanoid'
 
 import CookieForm from './CookieForm.vue'
 import CookieRaw from './CookieRaw.vue'
@@ -15,6 +16,7 @@ const { cookies, cookieMutators } = useWorkspace()
 
 const addCookieHandler = () => {
   const cookie = createCookie({
+    uid: nanoid(),
     name: 'new cookie',
     value: 'new value',
     domain: 'localhost',

--- a/packages/oas-utils/src/entities/workspace/cookie/cookie.ts
+++ b/packages/oas-utils/src/entities/workspace/cookie/cookie.ts
@@ -6,8 +6,8 @@ import { nanoidSchema } from '../shared'
 const cookieSchema = z.object({
   uid: nanoidSchema,
   /**  Defines the cookie name and its value. A cookie definition begins with a name-value pair.  */
-  name: z.string(),
-  value: z.string(),
+  name: z.string().default('Default Cookie'),
+  value: z.string().default('Default Value'),
   /** Defines the host to which the cookie will be sent. */
   domain: z.string().optional(),
   /** Indicates the maximum lifetime of the cookie as an HTTP-date timestamp. See Date for the required formatting. */
@@ -34,7 +34,9 @@ const cookieSchema = z.object({
    * Controls whether or not a cookie is sent with cross-site requests, providing some protection against cross-site
    * request forgery attacks (CSRF).
    */
-  sameSite: z.union([z.literal('Lax'), z.literal('Strict'), z.literal('None')]),
+  sameSite: z
+    .union([z.literal('Lax'), z.literal('Strict'), z.literal('None')])
+    .default('None'),
   /**
    * Indicates that the cookie is sent to the server only when a request is made with the https: scheme (except on
    * localhost), and therefore, is more resistant to man-in-the-middle attacks.


### PR DESCRIPTION
this pr fixes the zod error when adding a cookie by adding missing uid + default value to cookie schema. another take could be to use `cookieSchema.parse(deepMerge({}, payload))` vs `deepMerge(cookieSchema.parse({}), payload)` to only validate merged result and allow empty object, but i favored here adding default value to maintain code consistency.

<img width="1342" alt="image" src="https://github.com/scalar/scalar/assets/14966155/b89a0bf3-f555-4a59-9697-33eaf8ea109b">
