### PR TITLE
fix: move css to style tag

### DIFF
--- a/.changeset/tender-snakes-chew.md
+++ b/.changeset/tender-snakes-chew.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(#2352): move css imports into style tag

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
 import { provideUseId } from '@headlessui/vue'
 import { addScalarClassesToHeadless } from '@scalar/components'
-import '@scalar/components/style.css'
 import type { SSRState } from '@scalar/oas-utils'
 import { defaultStateFactory } from '@scalar/oas-utils/helpers'
 import { type ThemeId, getThemeStyles } from '@scalar/themes'
-import '@scalar/themes/style.css'
 import { ScalarToasts, useToasts } from '@scalar/use-toasts'
 import { useDebounceFn, useMediaQuery, useResizeObserver } from '@vueuse/core'
 import {
@@ -338,6 +336,9 @@ useDeprecationWarnings(props.configuration)
   <ScalarToasts />
 </template>
 <style>
+@import '@scalar/components/style.css';
+@import '@scalar/themes/style.css';
+
 /** Used to check if css is loaded */
 :root {
   --scalar-loaded-api-reference: true;


### PR DESCRIPTION
This should fix #2352. Due to our new build system we must move our css imports into the `style` tags