### PR TITLE
fix: remove tailwind preflight from api client app

### DIFF
--- a/.changeset/polite-windows-do.md
+++ b/.changeset/polite-windows-do.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+'@scalar/themes': patch
+---
+
+fix: remove tailwind preflight from api client app

--- a/packages/api-client/src/App.vue
+++ b/packages/api-client/src/App.vue
@@ -48,6 +48,7 @@ onMounted(() => {
 </template>
 <style>
 @import '@scalar/components/style.css';
+@import '@scalar/themes/style.css';
 @import './assets/tailwind.css';
 @import './assets/variables.css';
 

--- a/packages/api-client/src/assets/tailwind.css
+++ b/packages/api-client/src/assets/tailwind.css
@@ -5,6 +5,9 @@
   @tailwind utilities;
   @tailwind variants;
 
+  line-height: 1.5;
+  color: var(--scalar-color-1);
+
   /** 
    * Custom utilities to make life easier 
    * For some reason it was bugging on apply so I just used css for now 
@@ -71,7 +74,4 @@
         scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
     }
   }
-
-  line-height: 1.5;
-  color: var(--scalar-color-1);
 }

--- a/packages/api-client/tailwind.config.ts
+++ b/packages/api-client/tailwind.config.ts
@@ -6,6 +6,7 @@ import colorMix from 'tailwindcss-color-mix'
 export default {
   presets: [scalarPreset],
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx,vue}'],
+  corePlugins: { preflight: false },
   darkMode: ['selector', '.dark-mode'],
   theme: {
     extend: {

--- a/packages/components/tailwind.config.ts
+++ b/packages/components/tailwind.config.ts
@@ -7,9 +7,7 @@ import plugin from 'tailwindcss/plugin'
 export default {
   presets: [scalarPreset],
   content: ['./src/**/*.{vue,ts}'],
-  corePlugins: {
-    preflight: false,
-  },
+  corePlugins: { preflight: false },
   plugins: [
     headlessPlugin,
     colorMix(),

--- a/packages/themes/src/reset.css
+++ b/packages/themes/src/reset.css
@@ -1,7 +1,7 @@
 /*
   Custom reset (loosely) based on Tailwind Preflight
 
-  @see https://github.com/tailwindlabs/tailwindcss/blob/next/packages/tailwindcss/preflight.css
+  @see https://github.com/tailwindlabs/tailwindcss/blob/3.3/src/css/preflight.css
 */
 
 /* Use :where to lower specificity */
@@ -35,6 +35,11 @@
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+  }
+
+  ::before,
+  ::after {
+    --tw-content: '';
   }
 
   /*
@@ -74,5 +79,16 @@
   :focus-visible {
     outline: 1px solid var(--scalar-color-accent);
     outline-offset: 1px;
+  }
+
+  /** Set the default cursor for buttons. */
+  button,
+  [role='button'] {
+    cursor: pointer;
+  }
+
+  /** Make sure disabled buttons don't get the pointer cursor. */
+  :disabled {
+    cursor: default;
   }
 }

--- a/packages/themes/src/reset.css
+++ b/packages/themes/src/reset.css
@@ -42,9 +42,7 @@
     --tw-content: '';
   }
 
-  /*
-    Remove the default background color.
-  */
+  /** Remove the default background color. */
   button,
   input,
   optgroup,
@@ -54,9 +52,7 @@
     background: transparent;
   }
 
-  /*
-    Bring back a basic border style for form controls
-  */
+  /** Bring back a basic border style for form controls */
   input:where(:not([type='button'], [type='reset'], [type='submit'])),
   select,
   textarea {
@@ -90,5 +86,27 @@
   /** Make sure disabled buttons don't get the pointer cursor. */
   :disabled {
     cursor: default;
+  }
+
+  /**
+    1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+    2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+  */
+
+  img,
+  svg,
+  video,
+  canvas,
+  audio,
+  iframe,
+  embed,
+  object {
+    display: block; /* 1 */
+    vertical-align: middle; /* 2 */
+  }
+
+  /** Make elements with the HTML hidden attribute stay hidden by default */
+  [hidden] {
+    display: none;
   }
 }


### PR DESCRIPTION
This should fix the leaky reset styles that were coming out of `@scalar/api-client`. It's worth doing some testing to make sure removing the Tailwind preflight didn't break anything.