### PR TITLE
fix(api-client): address bar history infos

### DIFF
--- a/.changeset/dirty-pumpkins-hammer.md
+++ b/.changeset/dirty-pumpkins-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: address bar history item infos

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -51,7 +51,6 @@ function handleHistoryClick(index: number) {
     router.push(`/request/${historicalRequest.request.requestUid}`)
   }
   requestExampleMutators.set(historicalRequest.request)
-  activeRequest.value.history[0].response = historicalRequest.response
 }
 </script>
 <template>


### PR DESCRIPTION
this pr fixes the address bar history item informations being changed when navigating within items in the api client package, by removing the activeRequest response value being stored on click.

to date when navigating within the history, selecting an item is updating the activeRequest value and hence setting the infos towards all the items as below:

https://github.com/scalar/scalar/assets/14966155/b0344bf3-a12e-4582-9364-f698af83cc56

