### PR TITLE
ci: cache build, run jobs in parallel ⚡

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Check build, types, and units tests
+name: Check build, types, and unit tests
 
 on:
   pull_request:
@@ -32,7 +32,7 @@ jobs:
             exit 1
           fi
 
-  ci:
+  build:
     runs-on: ubuntu-20.04
     needs: define-matrix
     strategy:
@@ -56,18 +56,113 @@ jobs:
           key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
           restore-keys: |
             ${{ runner.os }}-turbo-node-
-      - if: matrix.node-version == 20
-        name: Check code style
+      - name: Build
+        run: pnpm turbo build
+
+  format:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [20]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dev dependencies
+        run: pnpm install --dev
+      - name: Check code style
         run: pnpm format:check
+
+  types:
+    runs-on: ubuntu-20.04
+    needs: [define-matrix, build]
+    strategy:
+      matrix:
+        node-version: ${{ fromJSON(needs.define-matrix.outputs.node-versions) }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
       - name: Build
         run: pnpm turbo build
       - if: matrix.node-version == 20 || github.head_ref == 'changeset-release/main'
         name: Check types
         run: pnpm turbo types:check
+
+  test:
+    runs-on: ubuntu-20.04
+    needs: [define-matrix, build]
+    strategy:
+      matrix:
+        node-version: ${{ fromJSON(needs.define-matrix.outputs.node-versions) }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
+      - name: Build packages
+        run: pnpm build:packages
       - name: Run tests
         run: pnpm test:ci
-      - if: matrix.node-version == 20
-        name: Send bundle stats and build information to RelativeCI
+
+  stats:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [20]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-node-
+      - name: Build @scalar/api-reference
+        run: pnpm build:api-reference
+      - name: Send bundle stats and build information to RelativeCI
         uses: relative-ci/agent-action@v2
         with:
           key: ${{ secrets.RELATIVE_CI_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
 
   build:
     runs-on: ubuntu-20.04
-    if: ${{ always() }}
     needs: define-matrix
     strategy:
       matrix:
@@ -82,7 +81,6 @@ jobs:
 
   types:
     runs-on: ubuntu-20.04
-    if: ${{ always() }}
     needs: [define-matrix, build]
     strategy:
       matrix:
@@ -114,7 +112,6 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
-    if: ${{ always() }}
     needs: [define-matrix, build]
     strategy:
       matrix:
@@ -145,7 +142,6 @@ jobs:
 
   stats:
     runs-on: ubuntu-20.04
-    if: ${{ always() }}
     needs: build
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
             echo "Node version matrix is not [18, 20] or [20]"
             exit 1
           fi
+      - name: Print Node Version Matrix
+        run: echo ${{ steps.node-versions.outputs.node-versions }}
 
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build
         run: pnpm turbo build
 
@@ -99,9 +100,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build
         run: pnpm turbo build
       - if: matrix.node-version == 20 || github.head_ref == 'changeset-release/main'
@@ -129,9 +131,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build packages
         run: pnpm build:packages
       - name: Run tests
@@ -158,9 +161,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build @scalar/api-reference
         run: pnpm build:api-reference
       - name: Send bundle stats and build information to RelativeCI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
 
   build:
     runs-on: ubuntu-20.04
+    if: ${{ always() }}
     needs: define-matrix
     strategy:
       matrix:
@@ -81,6 +82,7 @@ jobs:
 
   types:
     runs-on: ubuntu-20.04
+    if: ${{ always() }}
     needs: [define-matrix, build]
     strategy:
       matrix:
@@ -112,6 +114,7 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
+    if: ${{ always() }}
     needs: [define-matrix, build]
     strategy:
       matrix:
@@ -142,6 +145,7 @@ jobs:
 
   stats:
     runs-on: ubuntu-20.04
+    if: ${{ always() }}
     needs: build
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
 
   stats:
     runs-on: ubuntu-20.04
+    needs: build
     strategy:
       matrix:
         node-version: [20]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
             echo "Node version matrix is not [18, 20] or [20]"
             exit 1
           fi
-      - name: Print Node Version Matrix
-        run: echo ${{ steps.node-versions.outputs.node-versions }}
 
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Check build, types, and unit tests
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -33,9 +33,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build
         run: cd examples/web && pnpm turbo run build
         env:

--- a/.github/workflows/deploy-preview-examples.yml
+++ b/.github/workflows/deploy-preview-examples.yml
@@ -50,9 +50,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build
         run: cd examples/web && pnpm turbo run build
         env:

--- a/.github/workflows/publish-on-stackblitz.yml
+++ b/.github/workflows/publish-on-stackblitz.yml
@@ -24,9 +24,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-20
+          key: turbo-${{ runner.os }}-node-20-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-20-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build packages
         run: pnpm build:packages
       - name: Publish on Stackblitz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build
         run: pnpm turbo build
       - name: Git Status

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -32,9 +32,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -26,9 +26,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -26,9 +26,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -29,9 +29,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-turbo-node-
+            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
+            turbo-${{ runner.os }}-node-
       - name: Build packages
         run: pnpm build:packages
       - name: Format OpenAPI File

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "build": "turbo build",
     "build:packages": "turbo --filter './packages/**' build",
+    "build:api-reference": "turbo --filter './packages/api-reference' build",
     "build:standalone": "pnpm --filter api-reference --filter play-button build:standalone",
     "bump": "pnpm test:ci && pnpm changeset version",
     "clean": "pnpm clean:nodeModules; pnpm clean:dist; pnpm clean:turbo; pnpm clean:nuxt",


### PR DESCRIPTION
With this PR the one job in our main GitHub Action workflow is split up into multiple jobs that all wait for a single build. That way, jobs can be run in parallel and speed up CI.

Note: This makes the ci.yml way longer (+94 LOC) and one could argue also harder to understand, but personally, I think it’s worth it. [Reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow) could help here. I’ll look into that soon.

**Additional changes**
* Every PR starts from a global Turborepo cache, but keeps its own separate cache for every PR. This should decrease the cache miss rate.

## Before: 6m 24s

The build cache never really worked for all packages, the cache miss rate was pretty high, so this was the fastest possible run before:

<img width="1492" alt="Screenshot 2024-07-03 at 13 13 09" src="https://github.com/scalar/scalar/assets/1577992/f59ffbe6-fc00-4dc3-b21d-6c94a80d9ade">

## After: 2m 33s

Restoring the pnpm cache and installing cached dependencies takes 20-30s already, but build time is down to 1s (no cache miss for the build), so this is the fastest possible run with this PR:

<img width="1149" alt="Screenshot 2024-07-03 at 12 58 56" src="https://github.com/scalar/scalar/assets/1577992/8cbcb3ae-9a15-41f0-b583-a1ca1dab30fa">
