### PR TITLE
fix: build, test, format:check, types:check isn’t executed in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         run: echo "node-versions=${{ steps.node-versions.outputs.node-versions }}"
       - name: Check Node version matrix
         run: |
-          if [ -z "${{ steps.node-versions.outputs.node-versions }}" ]; then
-            echo "No Node versions found in the matrix"
+          if [ "${{ steps.node-versions.outputs.node-versions }}" != "[18, 20]" ] && [ "${{ steps.node-versions.outputs.node-versions }}" != "[20]" ]; then
+            echo "Node version matrix is not [18, 20] or [20]"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
         id: node-versions
         run: |
           if [ "${{ github.head_ref }}" == "changeset-release/main" ]; then
-            echo 'node-versions=[18, 20]' >> "$GITHUB_ENV"
+            echo 'node-versions=[18, 20]' >> "$GITHUB_OUTPUT"
           else
-            echo 'node-versions=[20]' >> "$GITHUB_ENV"
+            echo 'node-versions=[20]' >> "$GITHUB_OUTPUT"
           fi
       - name: Print Node version matrix
         run: echo "node-versions=${{ steps.node-versions.outputs.node-versions }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       node-versions: ${{ steps.node-versions.outputs.node-versions }}
 
     steps:
-      - name: Node Version Matrix
+      - name: Node version matrix
         id: node-versions
         run: |
           if [ "${{ github.head_ref }}" == "changeset-release/main" ]; then
@@ -23,8 +23,14 @@ jobs:
           else
             echo 'node-versions=[20]' >> "$GITHUB_ENV"
           fi
-      - name: Print Node Version Matrix
+      - name: Print Node version matrix
         run: echo "node-versions=${{ steps.node-versions.outputs.node-versions }}"
+      - name: Check Node version matrix
+        run: |
+          if [ -z "${{ steps.node-versions.outputs.node-versions }}" ]; then
+            echo "No Node versions found in the matrix"
+            exit 1
+          fi
 
   ci:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           else
             echo 'node-versions=[20]' >> "$GITHUB_ENV"
           fi
+      - name: Print Node Version Matrix
+        run: echo "node-versions=${{ steps.node-versions.outputs.node-versions }}"
 
   ci:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
 
   ci:
     runs-on: ubuntu-20.04
+    if: ${{ always() }}
     needs: define-matrix
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
 
   ci:
     runs-on: ubuntu-20.04
-    if: ${{ always() }}
     needs: define-matrix
     strategy:
       matrix:


### PR DESCRIPTION
Something very unfortunate: I’ve recently added a new job to define the Node version matrix in #2309, but that had a bug.

The build, format:check, types:check, test:ci scripts all require the `define-matrix` job to have a correct Node version matrix output though.

In other words: Those weren‘t executed a single time since I added the `define-matrix` job 5 days ago! I don’t know how I was able to not see this, but here we are.

## Example

https://github.com/scalar/scalar/actions/runs/9713252509/job/26809641617

It shows a green checkmark in the overview, because `define-matrix` is green, but it’s actually red - which isn’t visible inside the PR. Super misleading!

<img width="1487" alt="Screenshot 2024-07-03 at 12 38 04" src="https://github.com/scalar/scalar/assets/1577992/73ed448d-75ca-4c2a-add6-8204e3d4adc4">

## Solution

This PR adds a check to make sure the node version matrix is [18, 20] or [20] and nothing else.

I consider this urgent and will skip the further review process.