### PR TITLE
fix(scalar.aspnetcore): additional brackets break the configuration, fix #2368

### DIFF
--- a/packages/scalar.aspnetcore/Scalar.AspNetCore.cs
+++ b/packages/scalar.aspnetcore/Scalar.AspNetCore.cs
@@ -44,9 +44,7 @@ namespace Scalar.AspNetCore
                           <body>
                               <script id="api-reference" data-url="/openapi/{{documentName}}.json"></script>
                               <script>
-                              var configuration = {
-                                  {{configurationJson}}
-                              }
+                              var configuration = {{configurationJson}}
 
                               document.getElementById('api-reference').dataset.configuration =
                                   JSON.stringify(configuration)

--- a/packages/scalar.aspnetcore/Scalar.AspNetCore.cs
+++ b/packages/scalar.aspnetcore/Scalar.AspNetCore.cs
@@ -11,7 +11,7 @@ namespace Scalar.AspNetCore
     {
         public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints)
         {
-              return endpoints.MapScalarApiReference(_ => { });   
+              return endpoints.MapScalarApiReference(_ => { });
         }
 
         private static readonly JsonSerializerOptions JsonSerializerOptions = new()
@@ -28,7 +28,7 @@ namespace Scalar.AspNetCore
             configureOptions(options);
 
             var configurationJson = JsonSerializer.Serialize(options, JsonSerializerOptions);
-            
+
             return endpoints.MapGet(options.EndpointPathPrefix + "/{documentName}", (string documentName) =>
                 {
                     var title = options.Title ?? $"Scalar API Reference -- {documentName}";
@@ -47,7 +47,7 @@ namespace Scalar.AspNetCore
                               var configuration = {
                                   {{configurationJson}}
                               }
-                          
+
                               document.getElementById('api-reference').dataset.configuration =
                                   JSON.stringify(configuration)
                               </script>


### PR DESCRIPTION
This PR removes the additional brackets from the configuration output, which otherwise break the configuration.

See #2368

How do we test this integration? @marclave 