### PR TITLE
feat(api-client): address bar history infos

### DIFF
--- a/.changeset/calm-suits-remain.md
+++ b/.changeset/calm-suits-remain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: address bar history item infos

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { formatMs } from '@/libs/formatters'
 import { useTopNav } from '@/store/topNav'
 import { useWorkspace } from '@/store/workspace'
 import { ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/vue'
@@ -81,11 +82,10 @@ function handleHistoryClick(index: number) {
         :value="index"
         @click="handleHistoryClick(index)">
         <div class="font-code flex flex-1 gap-1.5 text-sm font-medium">
-          <span
-            class="mr-[1px] min-w-[44px] pr-2 text-right"
-            :class="[getStatusCodeColor(response.status).color]">
-            {{ response.status }}
-          </span>
+          <HttpMethod
+            v-if="response.config.method"
+            class="text-[11px] min-w-[44px]"
+            :method="response.config.method" />
           <span class="text-c-2 gap-0">
             {{
               getUrlPart(response.request, 'origin') +
@@ -93,19 +93,16 @@ function handleHistoryClick(index: number) {
             }}
           </span>
         </div>
-
         <!-- Response info -->
         <div
-          class="font-code text-c-3 flex flex-row items-center gap-3 text-sm font-medium">
-          <!-- <span>{{ formatMs(response.ms) }}</span> -->
-          <!-- <span>{{ formatBytes(response.bytes) }}</span> -->
+          class="font-code text-c-3 flex flex-row items-center gap-1.5 text-sm font-medium">
+          <span>{{ formatMs(response.duration) }}</span>
+          <span :class="[getStatusCodeColor(response.status).color]">
+            {{ response.status }}
+          </span>
           <span>
             {{ httpStatusCodes[response.status]?.name }}
           </span>
-          <HttpMethod
-            v-if="response.config.method"
-            class="lg:text-sm text-xs"
-            :method="response.config.method" />
         </div>
       </ListboxOption>
     </ListboxOptions>


### PR DESCRIPTION
this pr adds response duration infos to the history items + a different ordering proposal as seen below:

**before**
<img width="997" alt="image" src="https://github.com/scalar/scalar/assets/14966155/ce681bf4-9560-4973-95c4-ef160edcc3ae">

**after**
<img width="997" alt="image" src="https://github.com/scalar/scalar/assets/14966155/118e5409-8ce4-4636-a30d-35eab130186b">
