### PR TITLE
feat(api-client): request query params tooltip

### DIFF
--- a/.changeset/clean-birds-hang.md
+++ b/.changeset/clean-birds-hang.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: type, format and default to request example parameters schema

--- a/.changeset/kind-masks-laugh.md
+++ b/.changeset/kind-masks-laugh.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: request table tooltip component

--- a/.changeset/warm-pugs-mate.md
+++ b/.changeset/warm-pugs-mate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: add props to scalar tooltip

--- a/packages/api-client/src/components/TopNav/TopNavItem.vue
+++ b/packages/api-client/src/components/TopNav/TopNavItem.vue
@@ -20,6 +20,7 @@ defineEmits<{
   <ScalarTooltip
     class="scalar-client"
     :delay="500"
+    resize
     :sideOffset="4">
     <template #trigger>
       <div

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -188,6 +188,9 @@ const createParamInstance = (param: OpenAPIV3_1.ParameterObject) =>
     description: param.description,
     required: param.required,
     enum: param.schema?.enum,
+    type: param.schema?.type,
+    format: param.schema?.format,
+    default: param.schema?.default,
   })
 
 /**

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -7,6 +7,8 @@ import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import { ScalarButton, ScalarIcon } from '@scalar/components'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/workspace/spec'
 
+import RequestTableTooltip from './RequestTableTooltip.vue'
+
 const props = withDefaults(
   defineProps<{
     items?: RequestExampleParameter[]
@@ -41,6 +43,10 @@ const handleSelectVariable = (
 const handleFileUpload = (idx: number) => {
   emit('uploadFile', idx)
 }
+
+const showTooltip = (item: RequestExampleParameter) => {
+  return !!(item.description || item.type || item.default || item.format)
+}
 </script>
 <template>
   <DataTable
@@ -71,19 +77,10 @@ const handleFileUpload = (idx: number) => {
         @input="items && idx === items.length - 1 && emit('addRow')"
         @selectVariable="(v) => handleSelectVariable(idx, 'value', v)"
         @update:modelValue="(v) => emit('updateRow', idx, 'value', v)">
-        <template
-          v-if="item.description"
-          #icon>
-          <div class="relative group/info flex items-center pr-2">
-            <ScalarIcon
-              class="ml-1 text-c-3 group-hover/info:text-c-1"
-              icon="Info"
-              size="sm" />
-            <span
-              class="absolute pointer-events-none w-40 shadow-lg rounded bg-b-1 z-100 p-1.5 text-xxs leading-5 -translate-x-full translate-y-[24px] opacity-0 group-hover/info:opacity-100 z-10 text-c-1">
-              {{ item.description }}
-            </span>
-          </div>
+        <template #icon>
+          <RequestTableTooltip
+            v-if="showTooltip(item)"
+            :item="item" />
         </template>
       </DataTableInput>
       <DataTableCell

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ScalarIcon, ScalarTooltip } from '@scalar/components'
+import type { RequestExampleParameter } from '@scalar/oas-utils/entities/workspace/spec'
+
+defineProps<{ item: RequestExampleParameter }>()
+</script>
+<template>
+  <ScalarTooltip
+    align="start"
+    class="w-64"
+    :delay="0"
+    side="left"
+    triggerClass="p-[7px]">
+    <template #trigger>
+      <ScalarIcon
+        class="ml-1 text-c-3 group-hover/info:text-c-1"
+        icon="Info"
+        size="sm" />
+    </template>
+    <template #content>
+      <div
+        class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
+        <div class="flex items-center text-c-2">
+          <span v-if="item.type">{{ item.type }}</span>
+          <span
+            v-if="item.format"
+            class="before:content-['·'] before:block before:mx-[0.5ch] flex"
+            >{{ item.format }}</span
+          >
+          <span
+            v-if="item.default"
+            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-pre"
+            >default: {{ item.default }}</span
+          >
+        </div>
+        <span class="leading-snug text-pretty text-sm">{{
+          item.description
+        }}</span>
+      </div>
+    </template>
+  </ScalarTooltip>
+</template>

--- a/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
+++ b/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
@@ -12,13 +12,17 @@ const props = withDefaults(
     click?: () => void
     delay?: number
     skipDelay?: number
+    align?: 'start' | 'center' | 'end'
     side?: 'top' | 'right' | 'bottom' | 'left'
     sideOffset?: number
     class?: string
+    triggerClass?: string
+    resize?: boolean
   }>(),
   {
     skipDelay: 1000,
     side: 'top',
+    align: 'center',
   },
 )
 
@@ -33,12 +37,14 @@ defineEmits<{
     :skipDelayDuration="props.skipDelay">
     <TooltipRoot>
       <TooltipTrigger
-        class="w-full"
+        class="flex items-center justify-center"
+        :class="[props.resize ? 'w-full' : '', props.triggerClass]"
         @click="props.click">
         <slot name="trigger" />
       </TooltipTrigger>
-      <TooltipPortal>
+      <TooltipPortal to=".scalar-client">
         <TooltipContent
+          :align="props.align"
           class="scalar-app"
           :class="props.class"
           :side="props.side"

--- a/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
@@ -12,6 +12,9 @@ const requestExampleParametersSchema = z.object({
   refUid: nanoidSchema.optional(),
   required: z.boolean().optional(),
   enum: z.array(z.string()).optional(),
+  type: z.string().optional(),
+  format: z.string().optional(),
+  default: z.any().optional(),
 })
 
 /** Request examples - formerly known as instances - are "children" of requests */


### PR DESCRIPTION
this pr introduces type, format, and default properties for query params within a new request table tooltip component as seen below:

**before**
<img width="807" alt="image" src="https://github.com/scalar/scalar/assets/14966155/55d45c85-a7e1-4c64-9ad7-808feba728bf">


**after**
<img width="807" alt="image" src="https://github.com/scalar/scalar/assets/14966155/9d82c724-2115-4adc-892e-45f746a15cef">
