### PR TITLE
fix(void-server): Node 18 does not have File

### DIFF
--- a/.changeset/early-phones-invite.md
+++ b/.changeset/early-phones-invite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+fix: Node 18 does not have File

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "hono": "^4.2.7",
-    "object-to-xml": "^2.0.0"
+    "object-to-xml": "^2.0.0",
+    "undici": "^6.19.2"
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",

--- a/packages/void-server/src/utils/getBody.ts
+++ b/packages/void-server/src/utils/getBody.ts
@@ -1,4 +1,6 @@
 import type { Context } from 'hono'
+// Node 18 doesn’t have File, so we need to import it from 'undici'
+import { File } from 'undici'
 
 /**
  * Get the body of a request, no matter if it’s JSON or text

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2019,6 +2019,9 @@ importers:
       object-to-xml:
         specifier: ^2.0.0
         version: 2.0.0
+      undici:
+        specifier: ^6.19.2
+        version: 6.19.2
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -14527,6 +14530,10 @@ packages:
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
+
+  undici@6.19.2:
+    resolution: {integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==}
+    engines: {node: '>=18.17'}
 
   unenv@1.9.0:
     resolution: {integrity: sha512-QKnFNznRxmbOF1hDgzpqrlIf6NC5sbZ2OJ+5Wl3OX8uM+LUJXbj4TXvLJCtwbPTmbMHCLIz6JLKNinNsMShK9g==}
@@ -32477,6 +32484,8 @@ snapshots:
   undici@5.28.4:
     dependencies:
       '@fastify/busboy': 2.1.1
+
+  undici@6.19.2: {}
 
   unenv@1.9.0:
     dependencies:


### PR DESCRIPTION
We didn’t run the tests in CI (read more in #2367), but now we do. Turns out `createVoidServer` uses `File` in Node, which isn’t available in Node 18.

This PR adds File from the `undici` package (which is what the recent Node versions use under the hood). This should make CI pass for Node 18 again, at least it does locally.