### PR TITLE
feat(void-server): force JSON responses

### DIFF
--- a/.changeset/thirty-donkeys-retire.md
+++ b/.changeset/thirty-donkeys-retire.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+feat: force json responses for all paths ending with .json

--- a/.changeset/unlucky-islands-stare.md
+++ b/.changeset/unlucky-islands-stare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+feat: force xml responses for all paths ending with .xml

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -340,7 +340,7 @@ describe('createVoidServer', () => {
     expect(await response.text()).toContain('<strong>method:</strong> GET</li>')
   })
 
-  it.only('returns HTML for path ending with .html', async () => {
+  it('returns HTML for path ending with .html', async () => {
     const server = await createVoidServer()
 
     const response = await server.request('/foobar.html')

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -300,6 +300,14 @@ describe('createVoidServer', () => {
     })
   })
 
+  it('returns JSON for a path ending with .json', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/foobar.json')
+
+    expect(await response.text()).toContain('{"method":"GET"')
+  })
+
   it('returns XML', async () => {
     const server = await createVoidServer()
 
@@ -312,6 +320,14 @@ describe('createVoidServer', () => {
     expect(await response.text()).toContain('<method>GET</method>')
   })
 
+  it('returns XML for a path ending with .zip', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/foobar.xml')
+
+    expect(await response.text()).toContain('<method>GET</method>')
+  })
+
   it('returns HTML', async () => {
     const server = await createVoidServer()
 
@@ -320,6 +336,14 @@ describe('createVoidServer', () => {
         Accept: 'text/html',
       },
     })
+
+    expect(await response.text()).toContain('<strong>method:</strong> GET</li>')
+  })
+
+  it.only('returns HTML for path ending with .html', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/foobar.html')
 
     expect(await response.text()).toContain('<strong>method:</strong> GET</li>')
   })

--- a/packages/void-server/src/createVoidServer.ts
+++ b/packages/void-server/src/createVoidServer.ts
@@ -51,6 +51,15 @@ export async function createVoidServer() {
     return createJsonResponse(c, requestData)
   })
 
+  // Return XML for all requests ending with .xml
+  app.all('/:filename{.+\\.xml$}', async (c: Context) => {
+    console.info(`${c.req.method} ${c.req.path}`)
+
+    const requestData = await getRequestData(c)
+
+    return createJsonResponse(c, requestData)
+  })
+
   // All other requests just respond with a JSON containing all the request data
   app.all('/*', async (c: Context) => {
     console.info(`${c.req.method} ${c.req.path}`)

--- a/packages/void-server/src/createVoidServer.ts
+++ b/packages/void-server/src/createVoidServer.ts
@@ -37,11 +37,18 @@ export async function createVoidServer() {
   app.all('/:filename{.+\\.html$}', async (c: Context) => {
     console.info(`${c.req.method} ${c.req.path}`)
 
-    // make sure to not execute another route
-
     const requestData = await getRequestData(c)
 
     return createHtmlResponse(c, requestData)
+  })
+
+  // Return JSON for all requests ending with .json
+  app.all('/:filename{.+\\.json$}', async (c: Context) => {
+    console.info(`${c.req.method} ${c.req.path}`)
+
+    const requestData = await getRequestData(c)
+
+    return createJsonResponse(c, requestData)
   })
 
   // All other requests just respond with a JSON containing all the request data

--- a/packages/void-server/src/createVoidServer.ts
+++ b/packages/void-server/src/createVoidServer.ts
@@ -33,29 +33,21 @@ export async function createVoidServer() {
     return c.text(errors?.[status] ?? 'Unknown Error')
   })
 
-  // Return HTML files for all requests ending with .html
-  app.all('/:filename{.+\\.html$}', async (c: Context) => {
+  // Return content based on the file extension
+  app.all('/:filename{.+\\.(html|xml|json|zip)$}', async (c: Context) => {
     console.info(`${c.req.method} ${c.req.path}`)
 
     const requestData = await getRequestData(c)
 
-    return createHtmlResponse(c, requestData)
-  })
+    const { filename } = c.req.param()
 
-  // Return JSON for all requests ending with .json
-  app.all('/:filename{.+\\.json$}', async (c: Context) => {
-    console.info(`${c.req.method} ${c.req.path}`)
-
-    const requestData = await getRequestData(c)
-
-    return createJsonResponse(c, requestData)
-  })
-
-  // Return XML for all requests ending with .xml
-  app.all('/:filename{.+\\.xml$}', async (c: Context) => {
-    console.info(`${c.req.method} ${c.req.path}`)
-
-    const requestData = await getRequestData(c)
+    if (filename.endsWith('.html')) {
+      return createHtmlResponse(c, requestData)
+    } else if (filename.endsWith('.xml')) {
+      return createXmlResponse(c, requestData)
+    } else if (filename.endsWith('.zip')) {
+      return createZipFileResponse(c)
+    }
 
     return createJsonResponse(c, requestData)
   })
@@ -74,13 +66,9 @@ export async function createVoidServer() {
 
     if (acceptedContentType === 'text/html') {
       return createHtmlResponse(c, requestData)
-    }
-
-    if (acceptedContentType === 'application/xml') {
+    } else if (acceptedContentType === 'application/xml') {
       return createXmlResponse(c, requestData)
-    }
-
-    if (acceptedContentType === 'application/zip') {
+    } else if (acceptedContentType === 'application/zip') {
       return createZipFileResponse(c)
     }
 


### PR DESCRIPTION
I just wanted to force a JSON response, so I’ve added more file extensions to force a specific content type and refactored the routes to just use one single route for `.json`, `.html`, `.xml` and `.zip`.