### PR TITLE
fix(api-reference): don't constrain markdown image height

### DIFF
--- a/.changeset/sharp-jeans-prove.md
+++ b/.changeset/sharp-jeans-prove.md
@@ -1,0 +1,6 @@
+---
+'@scalar/code-highlight': patch
+'@scalar/docusaurus': patch
+---
+
+fix: don't constrain markdown image height

--- a/packages/api-reference/src/components/Content/Introduction/Description.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Description.vue
@@ -112,4 +112,7 @@ onServerPrefetch(async () => {
   flex-direction: column;
   gap: 18px;
 }
+.references-classic .introduction-description :deep(img) {
+  max-width: 720px;
+}
 </style>

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -197,11 +197,6 @@
     border-bottom: 1px solid var(--scalar-border-color);
   }
 
-  .markdown img {
-    max-height: 150px;
-    border-radius: var(--scalar-radius);
-  }
-
   .markdown blockquote {
     border-left: 3px solid var(--scalar-border-color);
     padding-left: 12px;

--- a/packages/docusaurus/src/theme.css
+++ b/packages/docusaurus/src/theme.css
@@ -692,11 +692,6 @@ code.hljs {
   border-bottom: 1px solid var(--scalar-border-color);
 }
 
-.markdown img {
-  max-height: 150px;
-  border-radius: var(--scalar-radius);
-}
-
 .markdown blockquote {
   border-left: 3px solid var(--scalar-border-color);
   padding-left: 12px;


### PR DESCRIPTION
Chatted with @cameronrohani and it sounds like we want to constrain markdown images by width not height 👍 

## Before

![Google Chrome-2024-07-03-13-22-34@2x](https://github.com/scalar/scalar/assets/6374090/e4feb85b-c5a6-414d-a002-9c200fb092eb)

## After

![Google Chrome-2024-07-03-23-59-42@2x](https://github.com/scalar/scalar/assets/6374090/6a2e4256-2e5b-4145-beba-088f3805a0bc)