### PR TITLE
feat(api-client): min max request params

### DIFF
--- a/.changeset/giant-suits-stare.md
+++ b/.changeset/giant-suits-stare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: add min max to request example parameters schema

--- a/.changeset/young-days-jump.md
+++ b/.changeset/young-days-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: add min max value to request params

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -16,6 +16,8 @@ const props = withDefaults(
     modelValue: string | number
     readOnly?: boolean
     enum?: string[]
+    min?: number
+    max?: number
   }>(),
   { required: false, readOnly: false },
 )
@@ -93,6 +95,8 @@ const handleDropdownMouseUp = () => {
           autocomplete="off"
           class="border-none focus:text-c-1 text-c-2 min-w-0 w-full px-2 py-1.5 outline-none"
           data-1p-ignore
+          :max="max"
+          :min="min"
           :readOnly="readOnly"
           :required="required"
           spellcheck="false"
@@ -102,6 +106,11 @@ const handleDropdownMouseUp = () => {
           @focus="emit('inputFocus')"
           @input="handleInput" />
       </template>
+    </div>
+    <div
+      v-if="$slots.warning"
+      class="absolute centered-y right-7 text-orange text-xs">
+      <slot name="warning" />
     </div>
     <slot name="icon" />
     <ScalarIconButton

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -190,6 +190,8 @@ const createParamInstance = (param: OpenAPIV3_1.ParameterObject) =>
     enum: param.schema?.enum,
     type: param.schema?.type,
     format: param.schema?.format,
+    minimum: param.schema?.minimum,
+    maximum: param.schema?.maximum,
     default: param.schema?.default,
   })
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -7,7 +7,7 @@ defineProps<{ item: RequestExampleParameter }>()
 <template>
   <ScalarTooltip
     align="start"
-    class="w-64"
+    class="w-full"
     :delay="0"
     side="left"
     triggerClass="p-[7px]">
@@ -28,14 +28,27 @@ defineProps<{ item: RequestExampleParameter }>()
             >{{ item.format }}</span
           >
           <span
+            v-if="item.minimum"
+            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-pre"
+            >min: {{ item.minimum }}</span
+          >
+          <span
+            v-if="item.maximum"
+            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-pre"
+            >max: {{ item.maximum }}</span
+          >
+          <span
             v-if="item.default"
             class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-pre"
             >default: {{ item.default }}</span
           >
         </div>
-        <span class="leading-snug text-pretty text-sm">{{
-          item.description
-        }}</span>
+        <span
+          v-if="item.description"
+          class="leading-snug text-pretty text-sm"
+          :style="{ maxWidth: '16rem' }"
+          >{{ item.description }}</span
+        >
       </div>
     </template>
   </ScalarTooltip>

--- a/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
@@ -14,6 +14,8 @@ const requestExampleParametersSchema = z.object({
   enum: z.array(z.string()).optional(),
   type: z.string().optional(),
   format: z.string().optional(),
+  minimum: z.number().optional(),
+  maximum: z.number().optional(),
   default: z.any().optional(),
 })
 


### PR DESCRIPTION
this pr adds min and max to request param items, along setting the input type as number according to item type + displaying warning for out of range value accordingly:

**tooltip**
<img width="756" alt="image" src="https://github.com/scalar/scalar/assets/14966155/c86395f0-0a62-4ee1-8f76-bb299420270e">

**warning**
<img width="756" alt="image" src="https://github.com/scalar/scalar/assets/14966155/296fa57f-fcea-4b21-886f-fe245610b049">
