### PR TITLE
fix: client search missing a few things!

### DIFF
--- a/.changeset/neat-plants-explode.md
+++ b/.changeset/neat-plants-explode.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: the client search modal was missing icons, methods, and had a racecondition

--- a/packages/api-client/src/components/Search/SearchModal.vue
+++ b/packages/api-client/src/components/Search/SearchModal.vue
@@ -90,7 +90,6 @@ const selectedEntry = computed<FuseResult<FuseData>>(
 const searchResultsWithPlaceholderResults = computed(
   (): FuseResult<FuseData>[] => {
     if (searchText.value.length === 0) {
-      console.log({ fuseDataArray })
       return fuseDataArray.value.map((item) => {
         return {
           item: item,

--- a/packages/api-client/src/components/Search/SearchModal.vue
+++ b/packages/api-client/src/components/Search/SearchModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { HttpMethod } from '@/components/HttpMethod'
 import { useWorkspace } from '@/store/workspace'
 import {
   type ModalState,
@@ -9,7 +10,7 @@ import {
 } from '@scalar/components'
 import { useMagicKeys, whenever } from '@vueuse/core'
 import Fuse, { type FuseResult } from 'fuse.js'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 const props = defineProps<{
@@ -49,28 +50,33 @@ watch(
   () => props.modalState.open,
   (open) => {
     if (!open) return
+    searchModalRef.value?.focus()
     searchText.value = ''
     selectedSearchResult.value = 0
     searchResults.value = []
   },
 )
 
-onMounted(() => {
-  searchModalRef.value?.focus()
-  Object.keys(requests).forEach((request) => {
-    const req = requests[request]
+// Populate our fuseDataArray with the request items
+watch(
+  requests,
+  (newRequests) => {
+    Object.keys(newRequests).forEach((request) => {
+      const req = requests[request]
 
-    fuseDataArray.value.push({
-      id: request,
-      title: req.summary ?? req.method,
-      description: req.description ?? '',
-      httpVerb: req.method,
-      path: req.path,
+      fuseDataArray.value.push({
+        id: request,
+        title: req.summary ?? req.method,
+        description: req.description ?? '',
+        httpVerb: req.method,
+        path: req.path,
+      })
     })
-  })
 
-  fuse.setCollection(fuseDataArray.value)
-})
+    fuse.setCollection(fuseDataArray.value)
+  },
+  { immediate: true },
+)
 
 function onSearchResultClick(entry: FuseResult<FuseData>) {
   router.push(entry.item.id)
@@ -84,6 +90,7 @@ const selectedEntry = computed<FuseResult<FuseData>>(
 const searchResultsWithPlaceholderResults = computed(
   (): FuseResult<FuseData>[] => {
     if (searchText.value.length === 0) {
+      console.log({ fuseDataArray })
       return fuseDataArray.value.map((item) => {
         return {
           item: item,
@@ -176,6 +183,7 @@ whenever(keys.ArrowUp, () => {
         :id="`#search-modal-${entry.item.id}`"
         :key="entry.refIndex"
         :active="selectedSearchResult === index"
+        icon="Terminal"
         @click="onSearchResultClick(entry)"
         @focus="selectedSearchResult = index">
         {{ entry.item.title }}
@@ -191,6 +199,9 @@ whenever(keys.ArrowUp, () => {
           v-else-if="entry.item.description"
           #description>
           {{ entry.item.description }}
+        </template>
+        <template #addon>
+          <HttpMethod :method="entry.item.httpVerb ?? 'get'" />
         </template>
       </ScalarSearchResultItem>
       <template #query>{{ searchText }}</template>

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -290,7 +290,7 @@ useEventListener(document, 'keydown', (event) => {
     </div>
     <ViewLayout>
       <Sidebar
-        v-if="showSideBar"
+        v-show="showSideBar"
         :class="[showSideBar ? 'sidebar-active-width' : '']">
         <template #title>{{ workspace.name }}</template>
         <template #content>

--- a/packages/api-reference/src/components/SearchModal.vue
+++ b/packages/api-reference/src/components/SearchModal.vue
@@ -96,7 +96,7 @@ watch(
 
     // Headings from the description
     const headingsData: FuseData[] = []
-    const headings = await getHeadingsFromMarkdown(
+    const headings = getHeadingsFromMarkdown(
       props.parsedSpec.info?.description ?? '',
     )
 

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -23,7 +23,7 @@ const attrs = computed(() => {
       v-bind="attrs.rest"
       :class="
         cx(
-          'group flex cursor-pointer gap-2 rounded px-3 py-1.5 no-underline hover:bg-b-2',
+          'group flex cursor-pointer gap-2.5 rounded px-3 py-1.5 no-underline hover:bg-b-2',
           {
             'bg-b-2': active,
           },

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -23,7 +23,7 @@ const attrs = computed(() => {
       v-bind="attrs.rest"
       :class="
         cx(
-          'group flex cursor-pointer gap-3 rounded px-3 py-1.5 no-underline hover:bg-b-2',
+          'group flex cursor-pointer gap-2 rounded px-3 py-1.5 no-underline hover:bg-b-2',
           {
             'bg-b-2': active,
           },
@@ -31,13 +31,15 @@ const attrs = computed(() => {
         )
       ">
       <!-- Icon -->
-      <div class="text-c-3 group-hover:text-c-1">
+      <div
+        class="flex h-fit items-center text-sm font-medium text-c-3 group-hover:text-c-1">
         <slot name="icon">
           <ScalarIcon
             v-if="icon"
             :icon="icon"
             size="sm" />
         </slot>
+        <span>&hairsp;</span>
       </div>
       <!-- Content -->
       <div class="flex min-w-0 flex-1 flex-col gap-0.75">


### PR DESCRIPTION
Looks like the search modal on the client was missing a couple things. Also added a fail safe (watch) to avoid the current race condition on getting requests.

Before:
![image](https://github.com/scalar/scalar/assets/2039539/fce88c42-8a93-4dd0-a443-183183dcdca8)
![image](https://github.com/scalar/scalar/assets/2039539/1ad4d8cc-3c94-440a-bccb-c6d533678bdd)


After:
![image](https://github.com/scalar/scalar/assets/2039539/e7ae8145-0b64-420b-a7d6-27e20e8c92a0)
