### PR TITLE
fix(themes): reset list styles and body margin

### DIFF
--- a/packages/themes/src/reset.css
+++ b/packages/themes/src/reset.css
@@ -4,6 +4,14 @@
   @see https://github.com/tailwindlabs/tailwindcss/blob/3.3/src/css/preflight.css
 */
 
+/* Reset <body> in a layer  */
+@layer scalar-base {
+  body {
+    margin: 0;
+    line-height: inherit;
+  }
+}
+
 /* Use :where to lower specificity */
 :where(.scalar-app) {
   /** Add some more things which are normally applied to `html`. */
@@ -50,6 +58,13 @@
   textarea,
   ::file-selector-button {
     background: transparent;
+  }
+
+  /** Remove the default list style */
+  ol,
+  ul,
+  menu {
+    list-style: none;
   }
 
   /** Bring back a basic border style for form controls */


### PR DESCRIPTION
Turns out there was a little bit more resetting to do for the client app.

The reset on `<body>` is in a layer so it should be easy to override.