### PR TITLE
fix: indent request sidebar highlight properly in readonly mode

### DIFF
--- a/.changeset/thick-drinks-cross.md
+++ b/.changeset/thick-drinks-cross.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: indent request sidebar highlight properly in readonly mode

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -61,7 +61,8 @@ const highlightClasses =
 /** Due to the nesting, we need a dynamic left offset for hover and active backgrounds */
 const leftOffset = computed(() => {
   if (!props.parentUids.length) return '0px'
-  else if (hasChildren.value) return `-${props.parentUids.length * 16}px`
+  else if (workspace.isReadOnly)
+    return `-${(props.parentUids.length - 1) * 16}px`
   else return `-${props.parentUids.length * 16}px`
 })
 


### PR DESCRIPTION
## Before / After

<img width="350px" src="https://github.com/scalar/scalar/assets/6374090/db7db1e3-b805-4ef4-b50a-8eed72e75bde" />
<img width="350px" src="https://github.com/scalar/scalar/assets/6374090/47795777-5e09-47d3-be61-6fc5eb39479f" />
