### PR TITLE
docs: Add reply.code in fastify example-route

### DIFF
--- a/documentation/fastify.md
+++ b/documentation/fastify.md
@@ -155,7 +155,7 @@ fastify.put(
     },
   },
   (req, reply) => {
-    reply.send({ hello: `Hello ${req.body.hello}` })
+    reply.code(201).send({ hello: `Hello ${req.body.hello}` })
   },
 )
 


### PR DESCRIPTION
**Problem**
Currently, in the Fastify documentation, the response schema for the `example-route` is defined with a status of 201. However, that route returns a status of 200. This discrepancy causes tests for that route to receive an empty object instead of the correct response.

**Solution**
With this PR, I aim to add `reply.code(201)` before sending the response object.
