### PR TITLE
fix(api-client): param components style

### DIFF
--- a/.changeset/famous-ducks-repair.md
+++ b/.changeset/famous-ducks-repair.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: data table input fixtures

--- a/.changeset/green-mirrors-roll.md
+++ b/.changeset/green-mirrors-roll.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: remove scalar dropdown button border

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -76,12 +76,7 @@ const handleDropdownMouseUp = () => {
       class="text-c-2 flex min-w-[100px] items-center border-r-1/2 pl-2 pr-0">
       <slot />
     </div>
-    <div
-      class="group row-1"
-      :class="{
-        'relative required after:absolute after:centered-y after:right-0 after:pt-px after:pr-2 after:text-xxs after:font-medium after:text-c-3 after:bg-b-1 after:shadow-[-8px_0_4px_var(--scalar-background-1)] group-has-[:focus]:after:hidden':
-          required,
-      }">
+    <div class="row-1">
       <template v-if="props.enum && props.enum.length">
         <DataTableInputEnumSelect
           :enum="props.enum"
@@ -93,7 +88,7 @@ const handleDropdownMouseUp = () => {
           v-bind="$attrs"
           :id="id"
           autocomplete="off"
-          class="border-none focus:text-c-1 text-c-2 min-w-0 w-full px-2 py-1.5 outline-none"
+          class="border-none focus:text-c-1 text-c-2 min-w-0 w-full peer px-2 py-1.5 outline-none"
           data-1p-ignore
           :max="max"
           :min="min"
@@ -105,6 +100,11 @@ const handleDropdownMouseUp = () => {
           @blur="handleBlur"
           @focus="emit('inputFocus')"
           @input="handleInput" />
+        <div
+          v-if="required"
+          class="absolute centered-y right-0 pt-px pr-2 text-xxs text-c-3 bg-b-1 shadow-[-8px_0_4px_var(--scalar-background-1)] opacity-100 duration-150 transition-opacity peer-focus:opacity-0">
+          Required
+        </div>
       </template>
     </div>
     <div

--- a/packages/api-client/src/components/DataTable/DataTableInputEnumSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputEnumSelect.vue
@@ -85,7 +85,7 @@ const isSelected = (value: string) => {
             :value="option"
             @click="updateSelected(option)">
             <div
-              class="flex items-center justify-center rounded-full p-[3px] group-hover/item:shadow-border"
+              class="flex items-center justify-center rounded-full p-[3px] w-4 h-4 group-hover/item:shadow-border"
               :class="
                 isSelected(option) ? 'bg-blue text-b-1' : 'text-transparent'
               ">

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdownItem.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdownItem.vue
@@ -15,7 +15,6 @@ const variants = cva({
   base: [
     // Layout
     'min-w-0 items-center gap-3 rounded px-2.5 py-1.5 text-left',
-    'first-of-type:mt-0.75 last-of-type:mb-0.75',
     // Text / background style
     'truncate text-xs text-c-1',
     // Interaction


### PR DESCRIPTION
this pr fixes dropdown button component style issue and adds enhancements, in order to hide the `Required` hint only when the peer input is focus vs previously where both input focus (key/value) were hiding it.

