### PR TITLE
feat(api-client): show sidebar by default in workspace

### DIFF
--- a/.changeset/loud-ties-accept.md
+++ b/.changeset/loud-ties-accept.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: display sidebar by default if not read-only

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -40,7 +40,7 @@ const {
 const { collapsedSidebarFolders } = useSidebar()
 const actionModalState = useActionModal()
 const searchModalState = useModal()
-const showSideBar = ref(false)
+const showSideBar = ref(!workspace.isReadOnly)
 
 const handleTabChange = (activeTab: string) => {
   actionModalState.tab = activeTab as ActionModalTab


### PR DESCRIPTION
this pr displays request sidebar by default in workspace, while keeping it hidden in reference.