### PR TITLE
ci: do not restore cache for other playwright versions

### DIFF
--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm build:packages
       - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
       - name: Playwright binary cache
         uses: actions/cache@v4
         id: playwright-cache

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm build:packages
       - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
       - name: Playwright binary cache
         uses: actions/cache@v4
         id: playwright-cache

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -48,8 +48,6 @@ jobs:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
       - name: Install Playwright browsers
         run: npx playwright install
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -42,8 +42,6 @@ jobs:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
       - name: Install Playwright browsers
         run: npx playwright install
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm build:packages
       - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
       - name: Playwright binary cache
         uses: actions/cache@v4
         id: playwright-cache

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm build:packages
       - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
       - name: Playwright binary cache
         uses: actions/cache@v4
         id: playwright-cache

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -42,8 +42,6 @@ jobs:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
       - name: Install Playwright browsers
         run: npx playwright install
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm build:packages
       - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
       - name: Playwright binary cache
         uses: actions/cache@v4
         id: playwright-cache

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm build:packages
       - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
       - name: Playwright binary cache
         uses: actions/cache@v4
         id: playwright-cache


### PR DESCRIPTION
> Note: I tried to make small PRs, but we will only see the benefits once #2399, #2400 and #2401 are all merged.

The Cache action has a great feature: It can restore the cache for other keys, in our cases from other Playwright binaries. But that’s not really what we want, because the dependencies are incompatible then. :(

Let’s only restore the cache for the exact same Playwright version.

Oh, and getting the Playwright version didn’t work at all. This PR fixes that, too.

Extracted from #2354.