### PR TITLE
ci: don’t scope turborepo cache to the branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build
         run: pnpm turbo build
 
@@ -100,10 +97,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build
         run: pnpm turbo build
       - if: matrix.node-version == 20 || github.head_ref == 'changeset-release/main'
@@ -131,10 +125,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build packages
         run: pnpm build:packages
       - name: Run tests
@@ -161,10 +152,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build @scalar/api-reference
         run: pnpm build:api-reference
       - name: Send bundle stats and build information to RelativeCI

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -33,10 +33,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build
         run: cd examples/web && pnpm turbo run build
         env:

--- a/.github/workflows/deploy-preview-examples.yml
+++ b/.github/workflows/deploy-preview-examples.yml
@@ -50,10 +50,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build
         run: cd examples/web && pnpm turbo run build
         env:

--- a/.github/workflows/publish-on-stackblitz.yml
+++ b/.github/workflows/publish-on-stackblitz.yml
@@ -24,10 +24,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-20-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-20-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-20
       - name: Build packages
         run: pnpm build:packages
       - name: Publish on Stackblitz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build
         run: pnpm turbo build
       - name: Git Status

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -32,10 +32,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -26,10 +26,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -26,10 +26,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -29,10 +29,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-
-            turbo-${{ runner.os }}-node-
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build packages
         run: pnpm build:packages
       - name: Format OpenAPI File


### PR DESCRIPTION
> Note: I tried to make small PRs, but we will only see the benefits once #2399, #2400 and #2401 are all merged.

I’ve reread the documentation on the cache action and it says:

> The cache is scoped to the key, [version](https://github.com/actions/cache?tab=readme-ov-file#cache-version), and branch. The default branch cache is available to other branches.

Soo … there’s no need to add the branch to the cache key. And we want a fresh build for different Node versions anyway, so we can remove this restore key, too.

With this PR the Turborepo cache has access to the cache of the main branch for the first run of a PR, but only to the same Node version and the same branch for the next runs.