### PR TITLE
ci: only write to the turborepo cache once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
@@ -128,7 +128,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}
@@ -158,7 +158,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: pnpm --filter web install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}

--- a/.github/workflows/deploy-preview-examples.yml
+++ b/.github/workflows/deploy-preview-examples.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: pnpm --filter web install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}

--- a/.github/workflows/publish-on-stackblitz.yml
+++ b/.github/workflows/publish-on-stackblitz.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-20-branch-${{ github.head_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Turborepo cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-branch-${{ github.head_ref }}


### PR DESCRIPTION
> Note: I tried to make small PRs, but we will only see the benefits once #2399, #2400 and #2401 are all merged.

I’ve seen the type:check job often doesn’t have cache for all the examples. My theory is that the workflows that only do `build:packages` overwrite the cache with just the packages and then jobs that start later only have that cache.

But the GitHub Action has a great feature, where you can only restore the cache, but not write to it. So this PR just restores the cache in all cases, and writes to it only in the ci.yml workflow and only in the build job.

Let’s see if we can increase the cache hit rate that way. :)