### PR TITLE
fix: default array value

### DIFF
--- a/.changeset/purple-cows-sniff.md
+++ b/.changeset/purple-cows-sniff.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: flatten default array value

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -63,6 +63,12 @@ const valueOutOfRange = (item: RequestExampleParameter) => {
     return false
   })
 }
+
+const flattenValue = (item: RequestExampleParameter) => {
+  return Array.isArray(item.default) && item.default.length === 1
+    ? item.default[0]
+    : item.default
+}
 </script>
 <template>
   <DataTable
@@ -104,7 +110,7 @@ const valueOutOfRange = (item: RequestExampleParameter) => {
         <template #icon>
           <RequestTableTooltip
             v-if="showTooltip(item)"
-            :item="item" />
+            :item="{ ...item, default: flattenValue(item) }" />
         </template>
       </DataTableInput>
       <DataTableCell

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -16,6 +16,12 @@ withDefaults(
 )
 
 const rules = ['oneOf', 'anyOf', 'allOf', 'not']
+
+const flattenValue = (value: Record<string, any>) => {
+  return Array.isArray(value?.default) && value.default.length === 1
+    ? value.default[0]
+    : value?.default
+}
 </script>
 <template>
   <div class="property-heading">
@@ -117,7 +123,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         v-if="value.default"
         truncate>
         <template #prefix>default:</template>
-        {{ value.default }}
+        {{ flattenValue(value) }}
       </SchemaPropertyDetail>
     </div>
     <div


### PR DESCRIPTION
this pr normalizes the value displayed in reference / client in case we receive an array value as default, [as brought up in x](https://x.com/seancassiere/status/1809011620141748607/photo/1) and as seen below:

**before**
<img width="683" alt="image" src="https://github.com/scalar/scalar/assets/14966155/79773514-67ba-4b26-bd02-517d2a3941fb">
<img width="683" alt="image" src="https://github.com/scalar/scalar/assets/14966155/c25bd6a6-44f6-49a4-bfb9-a75826d42902">

**after**
<img width="683" alt="image" src="https://github.com/scalar/scalar/assets/14966155/fd60b6d0-d8e5-4971-a6e0-7a8e2d8e196a">
<img width="683" alt="image" src="https://github.com/scalar/scalar/assets/14966155/8d34fc23-fe67-478f-96a6-f393daecf0fe">