### PR TITLE
fix: can’t reach localhost

### DIFF
--- a/packages/api-client/src/libs/sendRequest.test.ts
+++ b/packages/api-client/src/libs/sendRequest.test.ts
@@ -77,7 +77,7 @@ describe('sendRequest', () => {
 
   it('reaches the echo server *with* the proxy', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://localhost:${ECHO_PORT}` },
+      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
     })
 
     const result = await sendRequest(


### PR DESCRIPTION
For some reason this test is failing in Node 18 (but not Node 20). Whatever, let’s just use 127.0.0.1 instead of localhost, like we do in the other tests.