### PR TITLE
fix(api-client): request table tooltip value

### DIFF
--- a/.changeset/brave-eels-obey.md
+++ b/.changeset/brave-eels-obey.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: favor nowrap over pre for table tooltip value

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -29,17 +29,17 @@ defineProps<{ item: RequestExampleParameter }>()
           >
           <span
             v-if="item.minimum"
-            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-pre"
+            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-nowrap"
             >min: {{ item.minimum }}</span
           >
           <span
             v-if="item.maximum"
-            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-pre"
+            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-nowrap"
             >max: {{ item.maximum }}</span
           >
           <span
             v-if="item.default"
-            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-pre"
+            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-nowrap"
             >default: {{ item.default }}</span
           >
         </div>


### PR DESCRIPTION
this pr sets nowrap for request table tooltip component value over pre to better handle potential unsupported usage:

**before**
<img width="683" alt="image" src="https://github.com/scalar/scalar/assets/14966155/df898f34-e573-4853-9800-c51ea19af21d">

**after**
<img width="683" alt="image" src="https://github.com/scalar/scalar/assets/14966155/bad846e0-38f1-4a1a-88b5-35f82956f2f9">
