### PR TITLE
feat(api-reference): scalar icons

### DIFF
--- a/.changeset/cuddly-seas-fail.md
+++ b/.changeset/cuddly-seas-fail.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/components': patch
+---
+
+feat: set copy clipboard in scalar codeblock

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -178,11 +178,11 @@ const handlePaste = (event: ClipboardEvent) => {
 
           <AddressBarHistory :open="open" />
           <ScalarButton
-            class="relative h-auto shrink-0 gap-1.5 overflow-hidden px-2.5 py-1 z-[1]"
+            class="relative h-auto shrink-0 gap-1 overflow-hidden pl-2 pr-2.5 py-1 z-[1]"
             :disabled="isRequesting"
             @click="executeRequestBus.emit()">
             <ScalarIcon
-              class="relative z-10 w-2 shrink-0"
+              class="relative z-10 shrink-0"
               icon="Play"
               size="xs" />
             <span class="text-xxs relative z-10 lg:flex hidden">Send</span>

--- a/packages/api-client/src/components/Sidebar/SidebarListElementActions.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElementActions.vue
@@ -42,22 +42,22 @@ function handleDelete(id: string) {
 }
 </script>
 <template>
-  <div class="absolute right-1 opacity-0 group-hover:opacity-100">
+  <div class="absolute flex right-1 opacity-0 group-hover:opacity-100">
     <button
-      class="text-c-3 hover:bg-b-3 hover:text-c-1 rounded p-1.5"
+      class="text-c-3 hover:bg-b-3 hover:text-c-1 rounded p-[5px]"
       type="button"
       @click="copyToClipboard(variable.name)">
       <ScalarIcon
-        class="h-2.5 w-2.5"
+        class="h-3 w-3 stroke-[1.5]"
         icon="Clipboard" />
     </button>
     <button
       v-if="!variable.isDefault"
-      class="text-c-3 hover:bg-b-3 hover:text-c-1 rounded p-1.5"
+      class="text-c-3 hover:bg-b-3 hover:text-c-1 rounded p-1"
       type="button"
       @click.prevent="startActionFlow(ModalAction.Delete)">
       <ScalarIcon
-        class="h-2.5 w-2.5"
+        class="h-3.5 w-3.5 stroke-[1.5]"
         icon="Close" />
     </button>
   </div>

--- a/packages/api-client/src/components/TopNav/TopNavItem.vue
+++ b/packages/api-client/src/components/TopNav/TopNavItem.vue
@@ -39,7 +39,9 @@ defineEmits<{
           class="nav-item-close"
           type="button"
           @click="$emit('close')">
-          <ScalarIcon icon="Close" />
+          <ScalarIcon
+            class="stroke-[1.75]"
+            icon="Close" />
         </button>
       </div>
     </template>
@@ -99,7 +101,7 @@ defineEmits<{
 .nav-item-close {
   position: absolute;
   right: 3px;
-  padding: 5px;
+  padding: 2px;
   border-radius: var(--scalar-radius);
   background: transparent;
   max-width: 20px;

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -287,8 +287,9 @@ useEventListener(document, 'keydown', (event) => {
           type="button"
           @click="modalState.hide()">
           <ScalarIcon
+            class="stroke-[1.75]"
             icon="Close"
-            size="xs" />
+            size="lg" />
         </button>
       </div>
     </div>

--- a/packages/api-reference/src/components/Card/CardHeader.vue
+++ b/packages/api-reference/src/components/Card/CardHeader.vue
@@ -24,7 +24,7 @@ const props = defineProps<CardContentProps>()
   font-weight: var(--scalar-semibold);
   font-size: var(--scalar-mini);
   color: var(--scalar-color-3);
-  padding: 9px 0 9px 12px;
+  padding: 9px 3px 9px 12px;
   flex-shrink: 0;
 }
 .scalar-card-header.scalar-card--borderless + :deep(.scalar-card-content) {

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -111,7 +111,7 @@ const showSchema = ref(false)
           @click="() => copyToClipboard(currentJsonResponse?.example)">
           <ScalarIcon
             icon="Clipboard"
-            width="10px"
+            width="12px"
             x="asd" />
         </button>
         <label

--- a/packages/api-reference/src/components/Content/Operation/TestRequestButton.vue
+++ b/packages/api-reference/src/components/Content/Operation/TestRequestButton.vue
@@ -21,7 +21,9 @@ defineProps<{
         },
       })
     ">
-    <ScalarIcon icon="PaperAirplane" />
+    <ScalarIcon
+      icon="Play"
+      size="sm" />
     <span>Test Request</span>
   </button>
 </template>
@@ -55,8 +57,6 @@ defineProps<{
   background: var(--scalar-button-1-hover);
 }
 .show-api-client-button svg {
-  height: 12px;
-  width: auto;
-  margin-right: 6px;
+  margin-right: 4px;
 }
 </style>

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -6,7 +6,7 @@ import {
   useAuthenticationStore,
   useServerStore,
 } from '#legacy'
-import { ScalarCodeBlock, ScalarIcon } from '@scalar/components'
+import { ScalarCodeBlock } from '@scalar/components'
 import type {
   CustomRequestExample,
   ExampleRequestSSRKey,
@@ -39,7 +39,6 @@ import {
   getApiClientRequest,
   getHarRequest,
 } from '../../helpers'
-import { useClipboard } from '../../hooks'
 import { type HttpClientState, useHttpClientStore } from '../../stores'
 import ExamplePicker from './ExamplePicker.vue'
 import TextSelect from './TextSelect.vue'
@@ -57,7 +56,6 @@ const ssrStateKey =
 
 const selectedExampleKey = ref<string>()
 
-const { copyToClipboard } = useClipboard()
 const {
   httpClient,
   setHttpClient,
@@ -284,15 +282,6 @@ function updateHttpClient(value: string) {
             {{ httpClientTitle }}
           </template>
         </TextSelect>
-
-        <button
-          class="copy-button"
-          type="button"
-          @click="copyToClipboard(generatedCode)">
-          <ScalarIcon
-            icon="Clipboard"
-            width="10px" />
-        </button>
       </template>
     </CardHeader>
     <CardContent
@@ -346,43 +335,7 @@ function updateHttpClient(value: string) {
 .request-client-picker {
   padding-left: 12px;
   padding-right: 9px;
-  border-right: 1px solid var(--scalar-border-color);
 }
-
-.copy-button {
-  appearance: none;
-  -webkit-appearance: none;
-  outline: none;
-  background: transparent;
-  display: flex;
-  cursor: pointer;
-  color: var(--scalar-color-3);
-  margin-left: 6px;
-  margin-right: 10.5px;
-  border: none;
-  border-radius: 3px;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  height: fit-content;
-}
-/* Can't use flex align center on parent (scalar-card-header-actions) so have to match sibling font size vertically align*/
-.copy-button:after {
-  content: '.';
-  color: transparent;
-  font-size: var(--scalar-mini);
-  line-height: 1.35;
-  width: 0px;
-}
-.copy-button:hover {
-  color: var(--scalar-color-1);
-}
-
-.copy-button svg {
-  width: 13px;
-  height: 13px;
-}
-
 .request-card-footer {
   display: flex;
   justify-content: flex-end;
@@ -400,7 +353,6 @@ function updateHttpClient(value: string) {
   display: flex;
   flex: 1;
 }
-
 .code-snippet {
   display: flex;
   flex-direction: column;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -61,6 +61,7 @@
     "@headlessui/tailwindcss": "^0.2.0",
     "@scalar/build-tooling": "workspace:*",
     "@scalar/themes": "workspace:*",
+    "@scalar/use-toasts": "workspace:*",
     "@storybook/addon-essentials": "^8.0.8",
     "@storybook/addon-interactions": "^8.0.8",
     "@storybook/addon-links": "^8.0.8",

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.spec.ts
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.spec.ts
@@ -15,7 +15,7 @@ describe('ScalarCodeBlock', () => {
     await flushPromises()
 
     // Check the outer elements
-    const pre = wrapper.find('*')
+    const pre = wrapper.find('pre.scalar-codeblock-pre')
     const code = pre.find('code')
 
     expect(pre.element.nodeName.toLowerCase()).toBe('pre')
@@ -55,7 +55,7 @@ describe('ScalarCodeBlock', () => {
     await flushPromises()
 
     // Check the outer elements
-    const pre = wrapper.find('*')
+    const pre = wrapper.find('pre.scalar-codeblock-pre')
     const code = pre.find('code')
 
     expect(pre.element.nodeName.toLowerCase()).toBe('pre')
@@ -81,5 +81,35 @@ describe('ScalarCodeBlock', () => {
     <span class="hljs-punctuation">}</span>
   <span class="hljs-punctuation">}</span>
 <span class="hljs-punctuation">}</span></code>`)
+  })
+
+  it('does not render the copy button when content is null', async () => {
+    const wrapper = mount(ScalarCodeBlock, {
+      attrs: {
+        content: null,
+        lang: 'js',
+      },
+    })
+
+    await flushPromises()
+
+    // Check that the button is not rendered
+    const button = wrapper.find('button.copy-button')
+    expect(button.exists()).toBe(false)
+  })
+
+  it('does not render the copy button when content is "null"', async () => {
+    const wrapper = mount(ScalarCodeBlock, {
+      attrs: {
+        content: 'null',
+        lang: 'js',
+      },
+    })
+
+    await flushPromises()
+
+    // Check that the button is not rendered
+    const button = wrapper.find('button.copy-button')
+    expect(button.exists()).toBe(false)
   })
 })

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -3,6 +3,8 @@ import { standardLanguages, syntaxHighlight } from '@scalar/code-highlight'
 import { computed } from 'vue'
 
 import { prettyPrintJson } from '../../helpers/oas-utils'
+import { ScalarIcon } from '../ScalarIcon'
+import { useClipboard } from './useClipboard'
 
 /**
  * Uses highlight.js for syntax highlighting
@@ -31,22 +33,77 @@ const highlightedCode = computed(() => {
   // Need to remove the wrapping <pre> element so we can use v-html without another wrapper
   return html.slice(5, -6)
 })
+
+const { copyToClipboard } = useClipboard()
+
+const isContentValid = computed(() => {
+  return props.content !== null && props.content !== 'null'
+})
 </script>
 <template>
-  <pre
-    class="scalar-component scalar-codeblock-pre"
-    v-html="highlightedCode"></pre>
+  <div class="scalar-code-block">
+    <pre
+      class="scalar-codeblock-pre"
+      v-html="highlightedCode"></pre>
+    <button
+      v-if="isContentValid"
+      class="copy-button"
+      type="button"
+      @click="copyToClipboard(prettyPrintJson(props.content))">
+      <span class="sr-only">Copy content</span>
+      <ScalarIcon
+        icon="Clipboard"
+        size="md" />
+    </button>
+  </div>
 </template>
 <style>
 @import '@scalar/code-highlight/css/code.css';
+.scalar-code-block:hover .copy-button {
+  opacity: 100;
+  visibility: visible;
+}
 /* Code blocks */
 .scalar-codeblock-pre {
   margin: 0;
-  padding: 0.5rem;
+  padding: 0.5rem 3rem 0.5rem 0.75rem;
   overflow: auto;
   background: transparent;
   text-wrap: nowrap;
   white-space-collapse: preserve;
   border-radius: 0;
+}
+.copy-button {
+  align-items: center;
+  background: var(--scalar-background-2);
+  border: 1px solid var(--scalar-border-color);
+  border-radius: 3px;
+  color: var(--scalar-color-3);
+  cursor: pointer;
+  display: flex;
+  height: 30px;
+  margin: 8px;
+  opacity: 0;
+  padding: 6px;
+  position: absolute;
+  right: 0;
+  top: 36px;
+  transition:
+    opacity 0.15s ease-in-out,
+    color 0.15s ease-in-out;
+  visibility: hidden;
+}
+.copy-button:after {
+  content: '.';
+  color: transparent;
+  font-size: var(--scalar-mini);
+  line-height: 1.35;
+  width: 0px;
+}
+.copy-button:hover {
+  color: var(--scalar-color-1);
+}
+.copy-button svg {
+  stroke-width: 1.5;
 }
 </style>

--- a/packages/components/src/components/ScalarCodeBlock/useClipboard.ts
+++ b/packages/components/src/components/ScalarCodeBlock/useClipboard.ts
@@ -1,0 +1,14 @@
+import { useToasts } from '@scalar/use-toasts'
+
+export const useClipboard = () => {
+  const { toast } = useToasts()
+
+  const copyToClipboard = (value: string) => {
+    navigator.clipboard.writeText(value).then(() => {
+      toast('Copied to the clipboard', 'info')
+    })
+  }
+  return {
+    copyToClipboard,
+  }
+}

--- a/packages/components/src/components/ScalarIcon/icons/Clipboard.svg
+++ b/packages/components/src/components/ScalarIcon/icons/Clipboard.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16">
-    <path d="M6,5h4c1.7,0,2-1.3,2-3c1.1,0,2,0.9,2,2v10c0,1.1-0.9,2-2,2H4c-1.1,0-2-0.9-2-2V4c0-1.1,0.9-2,2-2C4,3.7,4.3,5,6,5z M6,2V1
-	c0-0.6,0.5-1,1-1h2c0.5,0,1,0.4,1,1v1.3C10,2.9,9.6,3,9,3H7C6.4,3,6,2.6,6,2z" />
-</svg>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2m-6 4h10a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/components/src/components/ScalarIcon/icons/Close.svg
+++ b/packages/components/src/components/ScalarIcon/icons/Close.svg
@@ -1,3 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="none">
-    <path stroke-linecap="round" stroke-linejoin="round" stroke="currentColor" d="M10.7 1.3l-9.4 9.4m0-9.4l9.4 9.4" />
-</svg>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M18 6 6 18M6 6l12 12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/components/src/components/ScalarIcon/icons/Play.svg
+++ b/packages/components/src/components/ScalarIcon/icons/Play.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" fill="currentColor">
-	<path
-		d="M8.3 3.6L3.7.3C3.4.1 3.1 0 2.8 0c-.3 0-.6 0-.9.2-.3.2-.5.4-.7.7-.1.2-.2.5-.2.9v6.5c0 .3.1.6.2.9.2.3.4.5.7.6.3.1.6.2.9.2.3 0 .6-.1.9-.3l4.6-3.2c.2-.2.4-.4.5-.6.1-.3.2-.6.2-.9 0-.3-.1-.6-.2-.8-.1-.3-.3-.5-.5-.6z" />
-</svg>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 6.663c0-1.582 1.75-2.538 3.082-1.682l8.301 5.337a2 2 0 0 1 0 3.364L9.082 19.02C7.75 19.875 6 18.919 6 17.337V6.663Z" fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
+++ b/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
@@ -53,10 +53,9 @@ const attrs = computed(() => {
       size="20px" />
     <ScalarIconButton
       v-else-if="modelValue"
-      class="self-center"
+      class="stroke-[1.5] p-2.5"
       icon="Close"
       label="Clear Search"
-      size="md"
       @click="emit('update:modelValue', '')" />
   </label>
 </template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,94 +287,6 @@ importers:
         version: 10.3.2(@swc/cli@0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0))(@swc/core@1.5.29(@swc/helpers@0.5.5))
       '@nestjs/schematics':
         specifier: ^10.0.1
-        version: 10.1.1(chokidar@3.6.0)(typescript@5.3.3)
-      '@nestjs/testing':
-        specifier: ^10.0.0
-        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9))
-      '@swc/cli':
-        specifier: ^0.1.62
-        version: 0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0)
-      '@swc/core':
-        specifier: ^1.3.64
-        version: 1.5.29(@swc/helpers@0.5.5)
-      '@types/jest':
-        specifier: ^29.5.2
-        version: 29.5.12
-      '@types/node':
-        specifier: ^20.8.4
-        version: 20.14.2
-      '@types/supertest':
-        specifier: ^2.0.12
-        version: 2.0.16
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^6.21.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
-      '@typescript-eslint/parser':
-        specifier: ^6.21.0
-        version: 6.21.0(eslint@8.57.0)(typescript@5.3.3)
-      eslint:
-        specifier: ^8.56.0
-        version: 8.57.0
-      eslint-config-prettier:
-        specifier: ^9.1.0
-        version: 9.1.0(eslint@8.57.0)
-      eslint-plugin-prettier:
-        specifier: ^5.1.3
-        version: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.2)
-      jest:
-        specifier: ^29.5.0
-        version: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.2)(typescript@5.3.3))
-      prettier:
-        specifier: ^3.2.5
-        version: 3.3.2
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
-      supertest:
-        specifier: ^6.3.3
-        version: 6.3.4
-      ts-jest:
-        specifier: ^29.1.0
-        version: 29.1.4(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.2)(typescript@5.3.3)))(typescript@5.3.3)
-      ts-loader:
-        specifier: ^9.4.3
-        version: 9.5.1(typescript@5.3.3)(webpack@5.90.1(@swc/core@1.5.29(@swc/helpers@0.5.5)))
-      ts-node:
-        specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.2)(typescript@5.3.3)
-      tsconfig-paths:
-        specifier: ^4.2.0
-        version: 4.2.0
-
-  examples/nestjs-api-reference-fastify:
-    dependencies:
-      '@nestjs/common':
-        specifier: ^10.3.8
-        version: 10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/core':
-        specifier: ^10.3.8
-        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/platform-fastify':
-        specifier: ^10.3.8
-        version: 10.3.9(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))
-      '@nestjs/swagger':
-        specifier: ^7.3.1
-        version: 7.3.1(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)
-      '@scalar/nestjs-api-reference':
-        specifier: workspace:*
-        version: link:../../packages/nestjs-api-reference
-      reflect-metadata:
-        specifier: ^0.1.13
-        version: 0.1.14
-      rxjs:
-        specifier: ^7.8.1
-        version: 7.8.1
-    devDependencies:
-      '@nestjs/cli':
-        specifier: ^10.0.1
-        version: 10.3.2(@swc/cli@0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0))(@swc/core@1.5.29(@swc/helpers@0.5.5))
-      '@nestjs/schematics':
-        specifier: ^10.0.1
         version: 10.1.1(chokidar@3.6.0)(typescript@5.5.2)
       '@nestjs/testing':
         specifier: ^10.0.0
@@ -430,6 +342,94 @@ importers:
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.2)(typescript@5.5.2)
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
+
+  examples/nestjs-api-reference-fastify:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^10.3.8
+        version: 10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/core':
+        specifier: ^10.3.8
+        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/platform-fastify':
+        specifier: ^10.3.8
+        version: 10.3.9(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))
+      '@nestjs/swagger':
+        specifier: ^7.3.1
+        version: 7.3.1(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)
+      '@scalar/nestjs-api-reference':
+        specifier: workspace:*
+        version: link:../../packages/nestjs-api-reference
+      reflect-metadata:
+        specifier: ^0.1.13
+        version: 0.1.14
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
+    devDependencies:
+      '@nestjs/cli':
+        specifier: ^10.0.1
+        version: 10.3.2(@swc/cli@0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0))(@swc/core@1.5.29(@swc/helpers@0.5.5))
+      '@nestjs/schematics':
+        specifier: ^10.0.1
+        version: 10.1.1(chokidar@3.6.0)(typescript@5.3.3)
+      '@nestjs/testing':
+        specifier: ^10.0.0
+        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9))
+      '@swc/cli':
+        specifier: ^0.1.62
+        version: 0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0)
+      '@swc/core':
+        specifier: ^1.3.64
+        version: 1.5.29(@swc/helpers@0.5.5)
+      '@types/jest':
+        specifier: ^29.5.2
+        version: 29.5.12
+      '@types/node':
+        specifier: ^20.8.4
+        version: 20.14.2
+      '@types/supertest':
+        specifier: ^2.0.12
+        version: 2.0.16
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.21.0
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/parser':
+        specifier: ^6.21.0
+        version: 6.21.0(eslint@8.57.0)(typescript@5.3.3)
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.0
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.0)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.2)
+      jest:
+        specifier: ^29.5.0
+        version: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.2)(typescript@5.3.3))
+      prettier:
+        specifier: ^3.2.5
+        version: 3.3.2
+      source-map-support:
+        specifier: ^0.5.21
+        version: 0.5.21
+      supertest:
+        specifier: ^6.3.3
+        version: 6.3.4
+      ts-jest:
+        specifier: ^29.1.0
+        version: 29.1.4(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.2)(typescript@5.3.3)))(typescript@5.3.3)
+      ts-loader:
+        specifier: ^9.4.3
+        version: 9.5.1(typescript@5.3.3)(webpack@5.90.1(@swc/core@1.5.29(@swc/helpers@0.5.5)))
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.2)(typescript@5.3.3)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1275,6 +1275,9 @@ importers:
       '@scalar/themes':
         specifier: workspace:*
         version: link:../themes
+      '@scalar/use-toasts':
+        specifier: workspace:*
+        version: link:../use-toasts
       '@storybook/addon-essentials':
         specifier: ^8.0.8
         version: 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22148,7 +22151,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.7
       '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
-      '@vue/compiler-sfc': 3.4.29
+      '@vue/compiler-sfc': 3.4.31
       ast-kit: 0.12.2
       local-pkg: 0.5.0
       magic-string-ast: 0.6.1
@@ -22184,7 +22187,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/parser': 7.24.7
-      '@vue/compiler-sfc': 3.4.29
+      '@vue/compiler-sfc': 3.4.31
 
   '@vue/compiler-core@3.4.29':
     dependencies:
@@ -22233,7 +22236,7 @@ snapshots:
       '@vue/shared': 3.4.31
       estree-walker: 2.0.2
       magic-string: 0.30.10
-      postcss: 8.4.38
+      postcss: 8.4.39
       source-map-js: 1.2.0
 
   '@vue/compiler-ssr@3.4.29':


### PR DESCRIPTION
this pr is a proposal to update some icons + moves the copy action capability to the scalar codeblock component in order to make it available in both request / response examples:

nb. it does not display copy action when response value is `null`

**before**
<img width="839" alt="image" src="https://github.com/scalar/scalar/assets/14966155/3d641087-77a1-43fc-bec6-f0c8b8d93172">

**after**
<img width="839" alt="image" src="https://github.com/scalar/scalar/assets/14966155/080c659d-37df-4eba-894c-e947b6f03413">
<img width="839" alt="image" src="https://github.com/scalar/scalar/assets/14966155/df1d8bff-f3b5-41fa-ba29-3e42c08963af">

[Uploading scalar-copy.mp4…](https://github.com/scalar/scalar/assets/14966155/d031f9f0-4915-49c3-9021-229297a478f5)