### PR TITLE
feat(doc-1882): save client data to localStorage

### DIFF
--- a/.changeset/weak-kings-teach.md
+++ b/.changeset/weak-kings-teach.md
@@ -1,0 +1,8 @@
+---
+'@scalar/object-utils': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+'@scalar/themes': patch
+---
+
+feat: add localStorage syncing to client app

--- a/packages/api-client/src/App.vue
+++ b/packages/api-client/src/App.vue
@@ -20,8 +20,6 @@ onMounted(() => {
 const { isDark } = useDarkModeState()
 const workspaceStore = useWorkspace()
 
-workspaceStore.workspaceMutators.edit('proxyUrl', 'https://proxy.scalar.com')
-
 // Ensure we add our scalar wrapper class to the headless ui root
 onBeforeMount(async () => {
   // Check if we have localStorage data

--- a/packages/api-client/src/App.vue
+++ b/packages/api-client/src/App.vue
@@ -4,6 +4,7 @@ import TopNav from '@/components/TopNav/TopNav.vue'
 import { useDarkModeState } from '@/hooks'
 import { useWorkspace } from '@/store/workspace'
 import { addScalarClassesToHeadless } from '@scalar/components'
+import { LS_KEYS } from '@scalar/object-utils/mutator-record'
 import { ScalarToasts } from '@scalar/use-toasts'
 import { onBeforeMount, onMounted, watchEffect } from 'vue'
 import { RouterView } from 'vue-router'
@@ -20,19 +21,29 @@ const { importSpecFromUrl, workspaceMutators } = useWorkspace()
 
 workspaceMutators.edit('proxyUrl', 'https://proxy.scalar.com')
 
-/**
- * Ensure we add our scalar wrapper class to the headless ui root
- * mounted is too late
- */
-onBeforeMount(() => addScalarClassesToHeadless())
+// Ensure we add our scalar wrapper class to the headless ui root
+onBeforeMount(async () => {
+  // Check if we have localStorage data
+  const workspace = localStorage.getItem(LS_KEYS.WORKSPACE)
+  console.log({ workspace })
 
-onMounted(() => {
-  importSpecFromUrl(
-    'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-    // 'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
-    // 'https://proxy.scalar.com',
-  )
+  // eslint-disable-next-line no-constant-condition
+  if (false && workspace) {
+    console.log('=====')
+    console.log(workspace)
+    // Get raw mutator.add so no fancy business
+  } else {
+    importSpecFromUrl(
+      'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+      // 'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
+      // 'https://proxy.scalar.com',
+    )
+  }
+
+  addScalarClassesToHeadless()
 })
+
+onBeforeMount(() => {})
 </script>
 <template>
   <TopNav />

--- a/packages/api-client/src/App.vue
+++ b/packages/api-client/src/App.vue
@@ -34,9 +34,9 @@ onBeforeMount(async () => {
     // Get raw mutator.add so no fancy business
   } else {
     importSpecFromUrl(
-      'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-      // 'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
-      // 'https://proxy.scalar.com',
+      // 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+      'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
+      'https://proxy.scalar.com',
     )
   }
 

--- a/packages/api-client/src/App.vue
+++ b/packages/api-client/src/App.vue
@@ -23,7 +23,7 @@ const workspaceStore = useWorkspace()
 // Ensure we add our scalar wrapper class to the headless ui root
 onBeforeMount(async () => {
   // Check if we have localStorage data
-  if (localStorage.getItem(LS_KEYS.WORKSPACE)) {
+  if (localStorage.getItem(`${LS_KEYS.WORKSPACE}${'default'}`)) {
     // TODO remove this before going live
     console.info('Remove this before going live, but here are the stats: ')
     const size: Record<string, string> = {}

--- a/packages/api-client/src/App.vue
+++ b/packages/api-client/src/App.vue
@@ -2,6 +2,7 @@
 import SideNav from '@/components/SideNav/SideNav.vue'
 import TopNav from '@/components/TopNav/TopNav.vue'
 import { useDarkModeState } from '@/hooks'
+import { loadAllResources } from '@/libs'
 import { useWorkspace } from '@/store/workspace'
 import { addScalarClassesToHeadless } from '@scalar/components'
 import { LS_KEYS } from '@scalar/object-utils/mutator-record'
@@ -17,33 +18,43 @@ onMounted(() => {
 })
 
 const { isDark } = useDarkModeState()
-const { importSpecFromUrl, workspaceMutators } = useWorkspace()
+const workspaceStore = useWorkspace()
 
-workspaceMutators.edit('proxyUrl', 'https://proxy.scalar.com')
+workspaceStore.workspaceMutators.edit('proxyUrl', 'https://proxy.scalar.com')
 
 // Ensure we add our scalar wrapper class to the headless ui root
 onBeforeMount(async () => {
   // Check if we have localStorage data
-  const workspace = localStorage.getItem(LS_KEYS.WORKSPACE)
-  console.log({ workspace })
+  if (localStorage.getItem(LS_KEYS.WORKSPACE)) {
+    // TODO remove this before going live
+    console.info('Remove this before going live, but here are the stats: ')
+    const size: Record<string, string> = {}
+    let _lsTotal = 0
+    let _xLen = 0
+    let _key = ''
 
-  // eslint-disable-next-line no-constant-condition
-  if (false && workspace) {
-    console.log('=====')
-    console.log(workspace)
-    // Get raw mutator.add so no fancy business
+    for (_key in localStorage) {
+      if (!Object.prototype.hasOwnProperty.call(localStorage, _key)) {
+        continue
+      }
+      _xLen = (localStorage[_key].length + _key.length) * 2
+      _lsTotal += _xLen
+      size[_key] = (_xLen / 1024).toFixed(2) + ' KB'
+    }
+    size['Total'] = (_lsTotal / 1024).toFixed(2) + ' KB'
+    console.table(size)
+
+    loadAllResources(workspaceStore)
   } else {
-    importSpecFromUrl(
-      // 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-      'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
-      'https://proxy.scalar.com',
+    workspaceStore.importSpecFromUrl(
+      'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+      // 'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
+      // 'https://proxy.scalar.com',
     )
   }
 
   addScalarClassesToHeadless()
 })
-
-onBeforeMount(() => {})
 </script>
 <template>
   <TopNav />

--- a/packages/api-client/src/components/ActionModal/ActionModalFolder.vue
+++ b/packages/api-client/src/components/ActionModal/ActionModalFolder.vue
@@ -13,16 +13,16 @@ const emits = defineEmits<{
   (event: 'close'): void
 }>()
 
-const { collections, folderMutators, workspace } = useWorkspace()
+const { collections, folderMutators } = useWorkspace()
 const folderName = ref('')
 const selectedCollectionId = ref('')
 
-const availableCollections = computed(() => {
-  return workspace.collectionUids.map((collectionUid) => ({
-    id: collectionUid,
-    label: collections[collectionUid].spec?.info?.title ?? '',
-  }))
-})
+const availableCollections = computed(() =>
+  Object.values(collections).map((collection) => ({
+    id: collection.uid,
+    label: collection.spec?.info?.title ?? '',
+  })),
+)
 
 const selectedCollection = computed({
   get: () =>

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -15,9 +15,9 @@ import AddressBarServer from './AddressBarServer.vue'
 const {
   activeRequest,
   activeExample,
+  isReadOnly,
   requestMutators,
   requestsHistory,
-  workspace,
 } = useWorkspace()
 
 const history = requestsHistory
@@ -155,11 +155,11 @@ const handlePaste = (event: ClipboardEvent) => {
           <div class="flex gap-1">
             <HttpMethod
               class="font-code text-xxs font-medium"
-              :isEditable="!workspace.isReadOnly"
+              :isEditable="!isReadOnly"
               isSquare
               :method="activeRequest.method"
               @change="updateRequestMethod" />
-            <AddressBarServer :workspace="workspace" />
+            <AddressBarServer />
           </div>
           <div class="custom-scroll scroll-timeline-x relative flex w-full">
             <div class="fade-left"></div>
@@ -167,7 +167,7 @@ const handlePaste = (event: ClipboardEvent) => {
             <!-- TODO wrap vars in spans for special effects like mouseOver descriptions -->
             <div
               class="scroll-timeline-x-address font-code text-c-1 flex flex-1 items-center whitespace-nowrap lg:text-sm text-xs font-medium leading-[24.5px] outline-none"
-              :contenteditable="!workspace.isReadOnly"
+              :contenteditable="!isReadOnly"
               @input="(ev) => onUrlChange((ev.target as HTMLElement).innerText)"
               @keydown.enter.prevent="executeRequestBus.emit()"
               @paste="handlePaste">

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -50,7 +50,7 @@ whenever(isMacOS() ? keys.meta_enter : keys.ctrl_enter, () =>
 //
 /** update the instance path parameters on change */
 const onUrlChange = (newPath: string) => {
-  if (!activeRequest.value) return
+  if (!activeRequest.value || activeRequest.value.path === newPath) return
 
   requestMutators.edit(activeRequest.value.uid, 'path', newPath)
 }

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -8,11 +8,8 @@ import {
 } from '@scalar/components'
 import { computed } from 'vue'
 
-defineProps<{
-  workspace: any
-}>()
-
-const { activeCollection, servers, collectionMutators } = useWorkspace()
+const { activeCollection, isReadOnly, servers, collectionMutators } =
+  useWorkspace()
 
 const serverOptions = computed(() =>
   activeCollection.value?.spec.serverUids?.map((serverUid: string) => ({
@@ -53,7 +50,7 @@ const serverUrl = computed(() => {
 })
 </script>
 <template>
-  <template v-if="serverOptions && !workspace.isReadOnly">
+  <template v-if="serverOptions && !isReadOnly">
     <ScalarDropdown
       :options="serverOptions"
       resize
@@ -87,21 +84,19 @@ const serverUrl = computed(() => {
             {{ server.label }}
           </span>
         </ScalarDropdownItem>
-        <template v-if="!workspace.isReadOnly">
-          <ScalarDropdownDivider />
-          <ScalarDropdownItem>
-            <RouterLink
-              class="font-code text-xxs flex items-center gap-1.5"
-              to="/servers">
-              <div class="flex items-center justify-center h-4 w-4">
-                <ScalarIcon
-                  class="h-2.5"
-                  icon="Add" />
-              </div>
-              <span>Add Server</span>
-            </RouterLink>
-          </ScalarDropdownItem>
-        </template>
+        <ScalarDropdownDivider />
+        <ScalarDropdownItem>
+          <RouterLink
+            class="font-code text-xxs flex items-center gap-1.5"
+            to="/servers">
+            <div class="flex items-center justify-center h-4 w-4">
+              <ScalarIcon
+                class="h-2.5"
+                icon="Add" />
+            </div>
+            <span>Add Server</span>
+          </RouterLink>
+        </ScalarDropdownItem>
       </template>
     </ScalarDropdown>
   </template>

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { useWorkspace } from '@/store/workspace'
 
-const { workspace } = useWorkspace()
+const { isReadOnly } = useWorkspace()
 </script>
 <template>
   <aside class="w-sidebar relative flex flex-col border-r bg-b-1">
     <div
-      v-if="!workspace.isReadOnly"
+      v-if="!isReadOnly"
       class="xl:min-h-header py-2.5 flex items-center border-b px-4 text-sm">
       <h2 class="font-medium m-0 text-sm"><slot name="title" /></h2>
     </div>

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -3,4 +3,4 @@ export * from './Modal'
 
 export { useWorkspace } from './store/workspace'
 
-export { clientRoutes, clientRouter } from './router'
+export { modalRouter } from './router'

--- a/packages/api-client/src/libs/index.ts
+++ b/packages/api-client/src/libs/index.ts
@@ -1,4 +1,5 @@
 export * from './formatters'
 export * from './eventBusses'
+export * from './local-storage'
 export * from './pathParams'
 export { sendRequest } from './sendRequest'

--- a/packages/api-client/src/libs/local-storage.ts
+++ b/packages/api-client/src/libs/local-storage.ts
@@ -1,0 +1,84 @@
+import type { useWorkspace } from '@/store/workspace'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
+import type { Collection } from '@scalar/oas-utils/entities/workspace/collection'
+import type { Cookie } from '@scalar/oas-utils/entities/workspace/cookie'
+import type { Environment } from '@scalar/oas-utils/entities/workspace/environment'
+import type { Folder } from '@scalar/oas-utils/entities/workspace/folder'
+import type { SecurityScheme } from '@scalar/oas-utils/entities/workspace/security'
+import type { Server } from '@scalar/oas-utils/entities/workspace/server'
+import type {
+  Request,
+  RequestExample,
+} from '@scalar/oas-utils/entities/workspace/spec'
+import { LS_KEYS } from '@scalar/object-utils/mutator-record'
+
+/**
+ * Loads all resources from localStorage into mutators on app start
+ * We use the raw mutator.add here instead of the custom ones because we do NOT want any side effects
+ *
+ * Currently not working for workspace
+ */
+export const loadAllResources = (mutators: ReturnType<typeof useWorkspace>) => {
+  const {
+    collectionMutators,
+    cookieMutators,
+    environmentMutators,
+    folderMutators,
+    requestExampleMutators,
+    requestMutators,
+    serverMutators,
+    securitySchemeMutators,
+    workspaceMutators,
+  } = mutators
+
+  // Collections
+  const collections = Object.values(
+    JSON.parse(localStorage.getItem(LS_KEYS.COLLECTION) || '{}'),
+  ) as Collection[]
+  collections.forEach(collectionMutators.rawAdd)
+
+  // Cookies
+  const cookies = Object.values(
+    JSON.parse(localStorage.getItem(LS_KEYS.COOKIE) || '{}'),
+  ) as Cookie[]
+  cookies.forEach(cookieMutators.add)
+
+  // Environments
+  const environments = Object.values(
+    JSON.parse(localStorage.getItem(LS_KEYS.ENVIRONMENT) || '{}'),
+  ) as Environment[]
+  environments.forEach(environmentMutators.add)
+
+  // Folders
+  const folders = Object.values(
+    JSON.parse(localStorage.getItem(LS_KEYS.FOLDER) || '{}'),
+  ) as Folder[]
+  folders.forEach(folderMutators.rawAdd)
+
+  // Request Examples
+  const requestExamples = Object.values(
+    JSON.parse(localStorage.getItem(LS_KEYS.REQUEST_EXAMPLE) || '{}'),
+  ) as RequestExample[]
+  requestExamples.forEach(requestExampleMutators.rawAdd)
+
+  // Requests
+  const requests = Object.values(
+    JSON.parse(localStorage.getItem(LS_KEYS.REQUEST) || '{}'),
+  ) as Request[]
+  requests.forEach(requestMutators.rawAdd)
+
+  // Servers
+  const servers = Object.values(
+    JSON.parse(localStorage.getItem(LS_KEYS.SERVER) || '{}'),
+  ) as Server[]
+  servers.forEach(serverMutators.rawAdd)
+
+  // Security Schemes
+  const securitySchemes = Object.values(
+    JSON.parse(localStorage.getItem(LS_KEYS.SECURITY_SCHEME) || '{}'),
+  ) as SecurityScheme[]
+  securitySchemes.forEach(securitySchemeMutators.add)
+
+  // Workspace
+  // TODO
+}

--- a/packages/api-client/src/libs/local-storage.ts
+++ b/packages/api-client/src/libs/local-storage.ts
@@ -18,7 +18,10 @@ import { LS_KEYS } from '@scalar/object-utils/mutator-record'
  *
  * Currently not working for workspace
  */
-export const loadAllResources = (mutators: ReturnType<typeof useWorkspace>) => {
+export const loadAllResources = (
+  mutators: ReturnType<typeof useWorkspace>,
+  workspaceUid = 'default',
+) => {
   const {
     collectionMutators,
     cookieMutators,
@@ -81,7 +84,7 @@ export const loadAllResources = (mutators: ReturnType<typeof useWorkspace>) => {
 
   // Workspace
   const workspaces = Object.values(
-    JSON.parse(localStorage.getItem(LS_KEYS.WORKSPACE) || '{}'),
+    JSON.parse(localStorage.getItem(LS_KEYS.WORKSPACE + workspaceUid) || '{}'),
   ) as Workspace[]
   workspaces.forEach(workspaceMutators.add)
 }

--- a/packages/api-client/src/libs/local-storage.ts
+++ b/packages/api-client/src/libs/local-storage.ts
@@ -80,5 +80,8 @@ export const loadAllResources = (mutators: ReturnType<typeof useWorkspace>) => {
   securitySchemes.forEach(securitySchemeMutators.add)
 
   // Workspace
-  // TODO
+  const workspaces = Object.values(
+    JSON.parse(localStorage.getItem(LS_KEYS.WORKSPACE) || '{}'),
+  ) as Workspace[]
+  workspaces.forEach(workspaceMutators.add)
 }

--- a/packages/api-client/src/router.ts
+++ b/packages/api-client/src/router.ts
@@ -1,10 +1,5 @@
 import { computed } from 'vue'
-import {
-  type RouteRecordRaw,
-  createMemoryHistory,
-  createRouter,
-  createWebHistory,
-} from 'vue-router'
+import { createMemoryHistory, createRouter, createWebHistory } from 'vue-router'
 
 export enum PathId {
   Request = 'request',
@@ -14,126 +9,86 @@ export enum PathId {
   Schema = 'schema',
   Environment = 'environment',
   Server = 'server',
-  Workspace = 'workspace',
 }
-
-/** Routes for the request section */
-const requestRoutes = [
-  {
-    path: '',
-    redirect: (to) => `${to.fullPath.replace(/\/$/, '')}/request/default`,
-  },
-  {
-    path: 'request',
-    redirect: 'request/default',
-  },
-  {
-    name: PathId.Request,
-    path: `request/:${PathId.Request}`,
-    component: () => import('@/views/Request/Request.vue'),
-  },
-  {
-    path: `request/:${PathId.Request}/example/:${PathId.Example}`,
-    component: () => import('@/views/Request/Request.vue'),
-  },
-] satisfies RouteRecordRaw[]
 
 /** Routes required by the client modal */
 export const modalRoutes = [
+  { path: '/', redirect: '/request/default' },
   {
-    path: '/',
-    redirect: '/workspace/default/request/default',
+    path: '/request',
+    redirect: '/request/default',
   },
-  {
-    path: '/workspace',
-    redirect: '/workspace/default/request/default',
-  },
-  /** This redirect is for the modal so its okay to go to default workspace as there should only be one */
   {
     path: `/request/:${PathId.Request}`,
-    redirect: (to) => `/workspace/default/request/${to.params.request}`,
+    component: () => import('@/views/Request/Request.vue'),
   },
   {
-    path: `/workspace/:${PathId.Workspace}`,
-    children: requestRoutes,
+    path: `/request/:${PathId.Request}/example/:${PathId.Example}`,
+    component: () => import('@/views/Request/Request.vue'),
   },
-] satisfies RouteRecordRaw[]
+]
 
-/** Routes for the client app */
 const routes = [
+  ...modalRoutes,
   {
-    path: '/',
-    redirect: '/workspace/default/request/default',
+    path: '/collection',
+    redirect: '/collection/default',
   },
   {
-    path: '/workspace',
-    redirect: '/workspace/default/request/default',
-  },
-  {
-    path: `/workspace/:${PathId.Workspace}`,
+    name: PathId.Collection,
+    path: `/collection/:${PathId.Collection}`,
+    component: () => import('@/views/Collection/Collection.vue'),
     children: [
-      ...requestRoutes,
+      // Nested collection request
       {
-        path: '/collection',
-        redirect: '/collection/default',
-      },
-      {
-        name: PathId.Collection,
-        path: `/collection/:${PathId.Collection}`,
-        component: () => import('@/views/Collection/Collection.vue'),
-        children: [
-          // Nested collection request
-          {
-            path: `request/${PathId.Request}`,
-            component: () => import('@/views/Request/Request.vue'),
-          },
-        ],
-      },
-      /** Components will map to each section of the spec components object */
-      {
-        path: '/components',
-        redirect: '/components/schemas/default',
-        children: [
-          {
-            path: `schemas/:${PathId.Schema}`,
-            component: () => import('@/views/Components/Schemas/Schemas.vue'),
-          },
-        ],
-      },
-      {
-        path: '/environment',
-        redirect: '/environment/default',
-      },
-      {
-        path: `/environment/:${PathId.Environment}`,
-        component: () => import('@/views/Environment/Environment.vue'),
-      },
-      {
-        path: '/cookies',
-        redirect: '/cookies/default',
-      },
-      {
-        path: `/cookies/:${PathId.Cookies}`,
-        component: () => import('@/views/Cookies/Cookies.vue'),
-      },
-      {
-        path: '/servers',
-        redirect: '/servers/default',
-      },
-      {
-        path: `/servers/:${PathId.Server}`,
-        component: () => import('@/views/Servers/Servers.vue'),
+        path: `request/${PathId.Request}`,
+        component: () => import('@/views/Request/Request.vue'),
       },
     ],
   },
-] satisfies RouteRecordRaw[]
+  /** Components will map to each section of the spec components object */
+  {
+    path: '/components',
+    redirect: '/components/schemas/default',
+    children: [
+      {
+        path: `schemas/:${PathId.Schema}`,
+        component: () => import('@/views/Components/Schemas/Schemas.vue'),
+      },
+    ],
+  },
+  {
+    path: '/environment',
+    redirect: '/environment/default',
+  },
+  {
+    path: `/environment/:${PathId.Environment}`,
+    component: () => import('@/views/Environment/Environment.vue'),
+  },
+  {
+    path: '/cookies',
+    redirect: '/cookies/default',
+  },
+  {
+    path: `/cookies/:${PathId.Cookies}`,
+    component: () => import('@/views/Cookies/Cookies.vue'),
+  },
+  {
+    path: '/servers',
+    redirect: '/servers/default',
+  },
+  {
+    path: `/servers/:${PathId.Server}`,
+    component: () => import('@/views/Servers/Servers.vue'),
+  },
+]
 
 export const router = createRouter({
   history: createWebHistory(),
   routes,
 })
 
-/** Creates the in memory router for the modal */
+/** Creates the in memory client router */
 export const modalRouter = createRouter({
   history: createMemoryHistory(),
   routes: modalRoutes,
@@ -148,7 +103,6 @@ export const activeRouterParams = computed(() => {
     [PathId.Schema]: 'default',
     [PathId.Cookies]: 'default',
     [PathId.Server]: 'default',
-    [PathId.Workspace]: 'default',
   }
 
   // Snag current route from active router

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -46,7 +46,7 @@ import type { AnyObject, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import { computed, reactive, toRaw } from 'vue'
 
 const { setCollapsedSidebarFolder } = useSidebar()
-const isLocalStorageEnabled = true
+const isLocalStorageEnabled = !process.env.DISABLE_CLIENT_LOCAL_STORAGE
 
 // ---------------------------------------------------------------------------
 // REQUEST

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -370,7 +370,6 @@ watchDebounced(
   {
     debounce: LS_CONFIG.DEBOUNCE_MS,
     maxWait: LS_CONFIG.MAX_WAIT_MS,
-    immediate: true,
   },
 )
 

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -46,7 +46,12 @@ import type { AnyObject, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import { computed, reactive, toRaw } from 'vue'
 
 const { setCollapsedSidebarFolder } = useSidebar()
-const isLocalStorageEnabled = !process.env.DISABLE_CLIENT_LOCAL_STORAGE
+
+// Disable localStorage in references - we must check it like this ;)
+const isLocalStorageEnabled = Boolean(
+  typeof process !== 'undefined' &&
+    Object.hasOwn(process.env, 'ENABLE_LOCAL_STORAGE'),
+)
 
 // ---------------------------------------------------------------------------
 // REQUEST

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -62,11 +62,7 @@ const { setCollapsedSidebarFolder } = useSidebar()
 
 /** Local list of all requests (will be associated with a database collection) */
 const requests = reactive<Record<string, Request>>({})
-const requestMutators = mutationFactory(
-  requests,
-  reactive({}),
-  LS_KEYS.REQUESTS,
-)
+const requestMutators = mutationFactory(requests, reactive({}), LS_KEYS.REQUEST)
 
 /** Add request */
 const addRequest = (
@@ -183,7 +179,7 @@ const requestExamples = reactive<Record<string, RequestExample>>({})
 const requestExampleMutators = mutationFactory(
   requestExamples,
   reactive({}),
-  LS_KEYS.REQUEST_EXAMPLES,
+  LS_KEYS.REQUEST_EXAMPLE,
 )
 
 /** Create new instance parameter from a request parameter */
@@ -333,7 +329,7 @@ const environments = reactive<Record<string, Environment>>({
 const environmentMutators = mutationFactory(
   environments,
   reactive({}),
-  LS_KEYS.ENVIRONMENTS,
+  LS_KEYS.ENVIRONMENT,
 )
 
 /** prevent deletion of the default environment */
@@ -349,7 +345,7 @@ const deleteEnvironment = (uid: string) => {
 // COOKIES
 
 const cookies = reactive<Record<string, Cookie>>({})
-const cookieMutators = mutationFactory(cookies, reactive({}), LS_KEYS.COOKIES)
+const cookieMutators = mutationFactory(cookies, reactive({}), LS_KEYS.COOKIE)
 
 /** Cookie associated with the current route */
 const activeCookieId = computed<string | undefined>(
@@ -396,7 +392,7 @@ const collections = reactive<Record<string, Collection>>({})
 const collectionMutators = mutationFactory(
   collections,
   reactive({}),
-  LS_KEYS.COLLECTIONS,
+  LS_KEYS.COLLECTION,
 )
 
 const addCollection = (payload: CollectionPayload) => {
@@ -442,7 +438,7 @@ const activeServer = computed(
 // FOLDERS
 
 const folders = reactive<Record<string, Folder>>({})
-const folderMutators = mutationFactory(folders, reactive({}), LS_KEYS.FOLDERS)
+const folderMutators = mutationFactory(folders, reactive({}), LS_KEYS.FOLDER)
 
 /**
  * Add a new folder to a folder or colleciton
@@ -507,7 +503,7 @@ const securitySchemes = reactive<Record<string, SecurityScheme>>({})
 const securitySchemeMutators = mutationFactory(
   securitySchemes,
   reactive({}),
-  LS_KEYS.SECURITY_SCHEMES,
+  LS_KEYS.SECURITY_SCHEME,
 )
 
 type SecurityMutatorEditArgs = Parameters<typeof securitySchemeMutators.edit>
@@ -550,7 +546,7 @@ const activeSecurityRequirements = computed(
 // SERVERS
 
 const servers = reactive<Record<string, Server>>({})
-const serverMutators = mutationFactory(servers, reactive({}), LS_KEYS.SERVERS)
+const serverMutators = mutationFactory(servers, reactive({}), LS_KEYS.SERVER)
 
 /**
  * Add a server
@@ -632,65 +628,71 @@ const modalState = useModal()
  * Global hook which contains the store for the whole app
  * We may want to break this up at some point due to the massive file size
  */
-export const useWorkspace = () => ({
-  // ---------------------------------------------------------------------------
-  // STATE
-  workspace: readonly(workspace),
-  workspaceRequests,
-  collections,
-  cookies,
-  environments,
-  folders,
-  requestExamples,
-  requests,
-  servers,
-  securitySchemes,
-  activeCollection,
-  activeCookieId,
-  activeExample,
-  activeRequest,
-  activeSecurityRequirements,
-  activeSecurityScheme,
-  activeServer,
-  modalState,
-  // ---------------------------------------------------------------------------
-  // METHODS
-  importSpecFile,
-  importSpecFromUrl,
-  cookieMutators,
-  createExampleFromRequest,
-  collectionMutators: {
-    ...collectionMutators,
-    add: addCollection,
-    delete: deleteCollection,
-  },
-  environmentMutators: {
-    ...environmentMutators,
-    delete: deleteEnvironment,
-  },
-  folderMutators: {
-    ...folderMutators,
-    add: addFolder,
-    delete: deleteFolder,
-  },
-  requestMutators: {
-    ...requestMutators,
-    add: addRequest,
-    delete: deleteRequest,
-  },
-  requestExampleMutators: {
-    ...requestExampleMutators,
-    add: addRequestExample,
-    delete: deleteRequestExample,
-  },
-  requestsHistory,
-  securitySchemeMutators,
-  serverMutators: {
-    ...serverMutators,
-    add: addServer,
-    delete: deleteServer,
-  },
-  workspaceMutators: {
-    edit: editWorkspace,
-  },
-})
+export const useWorkspace = () =>
+  ({
+    // ---------------------------------------------------------------------------
+    // STATE
+    workspace: readonly(workspace),
+    workspaceRequests,
+    collections,
+    cookies,
+    environments,
+    folders,
+    requestExamples,
+    requests,
+    servers,
+    securitySchemes,
+    activeCollection,
+    activeCookieId,
+    activeExample,
+    activeRequest,
+    activeSecurityRequirements,
+    activeSecurityScheme,
+    activeServer,
+    modalState,
+    // ---------------------------------------------------------------------------
+    // METHODS
+    importSpecFile,
+    importSpecFromUrl,
+    cookieMutators,
+    createExampleFromRequest,
+    collectionMutators: {
+      ...collectionMutators,
+      rawAdd: collectionMutators.add,
+      add: addCollection,
+      delete: deleteCollection,
+    },
+    environmentMutators: {
+      ...environmentMutators,
+      delete: deleteEnvironment,
+    },
+    folderMutators: {
+      ...folderMutators,
+      rawAdd: folderMutators.add,
+      add: addFolder,
+      delete: deleteFolder,
+    },
+    requestMutators: {
+      ...requestMutators,
+      rawAdd: requestMutators.add,
+      add: addRequest,
+      delete: deleteRequest,
+    },
+    requestExampleMutators: {
+      ...requestExampleMutators,
+      rawAdd: requestExampleMutators.add,
+      add: addRequestExample,
+      delete: deleteRequestExample,
+    },
+    requestsHistory,
+    securitySchemeMutators,
+    serverMutators: {
+      ...serverMutators,
+      rawAdd: serverMutators.add,
+      add: addServer,
+      delete: deleteServer,
+    },
+    workspaceMutators: {
+      edit: editWorkspace,
+    },
+  }) as const

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -46,13 +46,18 @@ import type { AnyObject, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import { computed, reactive, toRaw } from 'vue'
 
 const { setCollapsedSidebarFolder } = useSidebar()
+const isLocalStorageEnabled = true
 
 // ---------------------------------------------------------------------------
 // REQUEST
 
 /** Local list of all requests (will be associated with a database collection) */
 const requests = reactive<Record<string, Request>>({})
-const requestMutators = mutationFactory(requests, reactive({}), LS_KEYS.REQUEST)
+const requestMutators = mutationFactory(
+  requests,
+  reactive({}),
+  isLocalStorageEnabled && LS_KEYS.REQUEST,
+)
 
 /** Add request */
 const addRequest = (
@@ -169,7 +174,7 @@ const requestExamples = reactive<Record<string, RequestExample>>({})
 const requestExampleMutators = mutationFactory(
   requestExamples,
   reactive({}),
-  LS_KEYS.REQUEST_EXAMPLE,
+  isLocalStorageEnabled && LS_KEYS.REQUEST_EXAMPLE,
 )
 
 /** Create new instance parameter from a request parameter */
@@ -319,7 +324,7 @@ const environments = reactive<Record<string, Environment>>({
 const environmentMutators = mutationFactory(
   environments,
   reactive({}),
-  LS_KEYS.ENVIRONMENT,
+  isLocalStorageEnabled && LS_KEYS.ENVIRONMENT,
 )
 
 /** prevent deletion of the default environment */
@@ -335,7 +340,11 @@ const deleteEnvironment = (uid: string) => {
 // COOKIES
 
 const cookies = reactive<Record<string, Cookie>>({})
-const cookieMutators = mutationFactory(cookies, reactive({}), LS_KEYS.COOKIE)
+const cookieMutators = mutationFactory(
+  cookies,
+  reactive({}),
+  isLocalStorageEnabled && LS_KEYS.COOKIE,
+)
 
 /** Cookie associated with the current route */
 const activeCookieId = computed<string | undefined>(
@@ -351,7 +360,7 @@ const createWorkspaceMutators = (workspaceUid: string) =>
   mutationFactory(
     workspaces,
     reactive({}),
-    `${LS_KEYS.WORKSPACE}${workspaceUid}`,
+    isLocalStorageEnabled && `${LS_KEYS.WORKSPACE}${workspaceUid}`,
   )
 // TODO we will create new mutators on workspace change with the updated workspace uid
 const workspaceMutators = createWorkspaceMutators('default')
@@ -384,7 +393,7 @@ const collections = reactive<Record<string, Collection>>({})
 const collectionMutators = mutationFactory(
   collections,
   reactive({}),
-  LS_KEYS.COLLECTION,
+  isLocalStorageEnabled && LS_KEYS.COLLECTION,
 )
 
 const addCollection = (payload: CollectionPayload) => {
@@ -434,7 +443,11 @@ const activeServer = computed(
 // FOLDERS
 
 const folders = reactive<Record<string, Folder>>({})
-const folderMutators = mutationFactory(folders, reactive({}), LS_KEYS.FOLDER)
+const folderMutators = mutationFactory(
+  folders,
+  reactive({}),
+  isLocalStorageEnabled && LS_KEYS.FOLDER,
+)
 
 /**
  * Add a new folder to a folder or colleciton
@@ -499,7 +512,7 @@ const securitySchemes = reactive<Record<string, SecurityScheme>>({})
 const securitySchemeMutators = mutationFactory(
   securitySchemes,
   reactive({}),
-  LS_KEYS.SECURITY_SCHEME,
+  isLocalStorageEnabled && LS_KEYS.SECURITY_SCHEME,
 )
 
 type SecurityMutatorEditArgs = Parameters<typeof securitySchemeMutators.edit>
@@ -542,7 +555,11 @@ const activeSecurityRequirements = computed(
 // SERVERS
 
 const servers = reactive<Record<string, Server>>({})
-const serverMutators = mutationFactory(servers, reactive({}), LS_KEYS.SERVER)
+const serverMutators = mutationFactory(
+  servers,
+  reactive({}),
+  isLocalStorageEnabled && LS_KEYS.SERVER,
+)
 
 /**
  * Add a server

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -347,11 +347,14 @@ const activeCookieId = computed<string | undefined>(
 
 /** Active workspace object (will be associated with an entry in the workspace collection) */
 const workspaces = reactive<Record<string, Workspace>>({})
-const workspaceMutators = mutationFactory(
-  workspaces,
-  reactive({}),
-  LS_KEYS.WORKSPACE,
-)
+const createWorkspaceMutators = (workspaceUid: string) =>
+  mutationFactory(
+    workspaces,
+    reactive({}),
+    `${LS_KEYS.WORKSPACE}${workspaceUid}`,
+  )
+// TODO we will create new mutators on workspace change with the updated workspace uid
+const workspaceMutators = createWorkspaceMutators('default')
 
 /** The currently selected workspace OR the first one */
 const activeWorkspace = computed(

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -40,7 +40,7 @@ const {
 const { collapsedSidebarFolders } = useSidebar()
 const actionModalState = useActionModal()
 const searchModalState = useModal()
-const showSideBar = ref(!workspace.isReadOnly)
+const showSideBar = ref(!activeWorkspace.value?.isReadOnly)
 
 const handleTabChange = (activeTab: string) => {
   actionModalState.tab = activeTab as ActionModalTab

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -33,9 +33,9 @@ const {
   activeRequest,
   activeServer,
   activeSecurityScheme,
+  activeWorkspace,
   collections,
   modalState,
-  workspace,
 } = useWorkspace()
 const { collapsedSidebarFolders } = useSidebar()
 const actionModalState = useActionModal()
@@ -79,7 +79,7 @@ const executeRequest = async () => {
     activeExample.value,
     url,
     activeSecurityScheme.value,
-    workspace.proxyUrl,
+    activeWorkspace.value?.proxyUrl,
   )
 
   if (request && response) {
@@ -101,12 +101,8 @@ onMounted(() => executeRequestBus.on(executeRequest))
  */
 onBeforeUnmount(() => executeRequestBus.off(executeRequest))
 
-// TODO temp switch for folder mode
-const FOLDER_MODE = true
+const workspaceCollections = computed(() => Object.values(collections))
 
-const workspaceCollections = computed(() =>
-  workspace.collectionUids.map((uid) => collections[uid]),
-)
 // const collections = computed(() => {
 //   if (FOLDER_MODE) {
 //     return workspace.collections
@@ -255,6 +251,7 @@ useEventListener(document, 'keydown', (event) => {
 </script>
 <template>
   <div
+    v-if="activeWorkspace"
     class="bg-b-2 flex flex-1 flex-col rounded-lg rounded-b-none rounded-r-none pt-0 h-full">
     <div
       class="lg:min-h-header flex items-center w-full justify-center p-1 flex-wrap t-app__top-container">
@@ -278,7 +275,7 @@ useEventListener(document, 'keydown', (event) => {
           Test Acctual Locally
         </button> -->
         <button
-          v-if="workspace.isReadOnly"
+          v-if="activeWorkspace.isReadOnly"
           class="text-c-3 hover:bg-b-3 active:text-c-1 p-2 rounded"
           type="button"
           @click="modalState.hide()">
@@ -292,7 +289,7 @@ useEventListener(document, 'keydown', (event) => {
       <Sidebar
         v-show="showSideBar"
         :class="[showSideBar ? 'sidebar-active-width' : '']">
-        <template #title>{{ workspace.name }}</template>
+        <template #title>{{ activeWorkspace.name }}</template>
         <template #content>
           <SearchButton @openSearchModal="searchModalState.show()" />
           <div
@@ -303,8 +300,8 @@ useEventListener(document, 'keydown', (event) => {
             <RequestSidebarItem
               v-for="(collection, collectionIndex) in workspaceCollections"
               :key="collection.uid"
-              :isDraggable="FOLDER_MODE && !workspace.isReadOnly"
-              :isDroppable="FOLDER_MODE && !workspace.isReadOnly"
+              :isDraggable="!activeWorkspace.isReadOnly"
+              :isDroppable="!activeWorkspace.isReadOnly"
               :item="collection"
               :parentUids="[]"
               @onDragEnd="
@@ -330,7 +327,7 @@ useEventListener(document, 'keydown', (event) => {
         </template>
         <template #button>
           <SidebarButton
-            v-if="!workspace.isReadOnly"
+            v-if="!activeWorkspace.isReadOnly"
             :click="addItemHandler">
             <template #title>Add Item</template>
           </SidebarButton>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -48,7 +48,7 @@ defineSlots<{
   leftIcon(): void
 }>()
 
-const { activeRequest, folders, requests, requestExamples, workspace } =
+const { activeRequest, folders, isReadOnly, requests, requestExamples } =
   useWorkspace()
 const { collapsedSidebarFolders, toggleSidebarFolder } = useSidebar()
 const router = useRouter()
@@ -115,8 +115,8 @@ const showChildren = computed(
   <div
     class="relative flex flex-row"
     :class="[
-      (workspace.isReadOnly && parentUids.length > 1) ||
-      (!workspace.isReadOnly && parentUids.length)
+      (isReadOnly && parentUids.length > 1) ||
+      (!isReadOnly && parentUids.length)
         ? 'before:bg-b-3 pl-4 before:absolute before:left-[calc(.75rem_+_.5px)] before:top-0 before:z-10 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-px mb-[.5px] last:mb-0'
         : '',
     ]">
@@ -150,7 +150,7 @@ const showChildren = computed(
           </span>
           <div class="relative">
             <RequestSidebarItemMenu
-              v-if="!workspace.isReadOnly"
+              v-if="!isReadOnly"
               :item="item" />
             <span class="flex">
               &hairsp;
@@ -164,7 +164,7 @@ const showChildren = computed(
 
       <!-- Collection/Folder -->
       <button
-        v-else-if="!workspace.isReadOnly || parentUids.length"
+        v-else-if="!isReadOnly || parentUids.length"
         class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5 z-[1]"
         :class="highlightClasses"
         type="button"

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -61,8 +61,7 @@ const highlightClasses =
 /** Due to the nesting, we need a dynamic left offset for hover and active backgrounds */
 const leftOffset = computed(() => {
   if (!props.parentUids.length) return '0px'
-  else if (workspace.isReadOnly)
-    return `-${(props.parentUids.length - 1) * 16}px`
+  else if (isReadOnly) return `-${(props.parentUids.length - 1) * 16}px`
   else return `-${props.parentUids.length * 16}px`
 })
 

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -6,7 +6,7 @@ import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useDarkModeState } from '@/hooks'
 import { useWorkspace } from '@/store/workspace'
 import { ScalarCodeBlock, ScalarIcon } from '@scalar/components'
-import { type ThemeId, getThemeStyles } from '@scalar/themes'
+import { getThemeStyles } from '@scalar/themes'
 import { computed, nextTick, ref, watch } from 'vue'
 
 const props = withDefaults(
@@ -22,7 +22,7 @@ const props = withDefaults(
   },
 )
 
-const { workspace } = useWorkspace()
+const { activeWorkspace } = useWorkspace()
 
 const codeLanguage = computed(() => {
   const contentTypeHeader =
@@ -87,9 +87,11 @@ watch(
         doc.write(
           '<style>body,html {body:not(:has(* + style + style)) {font-family: var(--scalar-font-code); font-size: 12px; font-weight: 400;background:var(--scalar-background-1); color: var(--scalar-color-2)}</style>',
         )
-        doc.write(
-          `<style>${getThemeStyles(workspace.themeId as ThemeId)}</style>`,
-        )
+        if (activeWorkspace.value?.themeId) {
+          doc.write(
+            `<style>${getThemeStyles(activeWorkspace.value.themeId)}</style>`,
+          )
+        }
         doc.close()
       }
     }

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -5,7 +5,7 @@ import ScalarHotkey from '@/components/ScalarHotkey.vue'
 import { executeRequestBus } from '@/libs'
 import { useWorkspace } from '@/store/workspace'
 
-const { workspace } = useWorkspace()
+const { isReadOnly } = useWorkspace()
 </script>
 <template>
   <div class="relative col-1 flex-center gap-6 p-2 capitalize">
@@ -23,7 +23,7 @@ const { workspace } = useWorkspace()
         <ScalarHotkey hotkey="↵" />
       </button>
       <button
-        v-if="!workspace.isReadOnly"
+        v-if="!isReadOnly"
         class="flex items-center gap-1.5"
         type="button">
         New Request

--- a/packages/api-client/vite.config.ts
+++ b/packages/api-client/vite.config.ts
@@ -10,6 +10,9 @@ import svgLoader from 'vite-svg-loader'
 
 export default defineConfig({
   plugins: [vue(), svgLoader(), ViteWatchWorkspace()],
+  define: {
+    'process.env.ENABLE_LOCAL_STORAGE': 'true',
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -5,7 +5,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   define: {
     'process.env.NODE_ENV': '"production"',
-    'process.env.DISABLE_CLIENT_LOCAL_STORAGE': 'true',
   },
   plugins: [vue()],
   build: createViteBuildOptions({

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   define: {
     'process.env.NODE_ENV': '"production"',
+    'process.env.DISABLE_CLIENT_LOCAL_STORAGE': 'true',
   },
   plugins: [vue()],
   build: createViteBuildOptions({

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -97,6 +97,7 @@
   ],
   "module": "dist/index.js",
   "dependencies": {
+    "@scalar/themes": "workspace:*",
     "axios": "^1.6.8",
     "nanoid": "^5.0.7",
     "yaml": "^2.4.5",

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -5,7 +5,7 @@ import { nanoidSchema } from './shared'
 
 const workspaceSchema = z.object({
   uid: nanoidSchema,
-  name: z.string().default('Workspace'),
+  name: z.string().default('Default Workspace'),
   /** Workspace description */
   description: z.string().default('Basic Scalar Workspace'),
   /** Controls read only mode for most entitites, but not things like params */

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -1,3 +1,4 @@
+import { themeIds } from '@scalar/themes'
 import { z } from 'zod'
 
 import { nanoidSchema } from './shared'
@@ -18,7 +19,7 @@ const workspaceSchema = z.object({
   /** Workspace level proxy for all requests to be sent through */
   proxyUrl: z.string().optional(),
   /** Workspace level theme, we might move this to user level later */
-  themeId: z.string().optional().default('default'),
+  themeId: z.enum(themeIds).optional().default('default'),
 })
 
 /** The base scalar workspace */

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -61,6 +61,7 @@
   ],
   "module": "dist/index.js",
   "dependencies": {
+    "@vueuse/core": "^10.10.0",
     "just-clone": "^6.2.0"
   },
   "devDependencies": {

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
+    "type-fest": "^4.20.0",
     "vite": "^5.2.10"
   }
 }

--- a/packages/object-utils/src/mutator-record/handlers.ts
+++ b/packages/object-utils/src/mutator-record/handlers.ts
@@ -30,10 +30,15 @@ export function mutationFactory<
   }
 
   /** Triggers on any action to the mutator */
+  // todo this debounce is not working
   const onChange = localStorageKey
-    ? useDebounceFn(() => {
-        localStorage.setItem(localStorageKey, JSON.stringify(entityMap))
-      }, 1000)
+    ? useDebounceFn(
+        () => {
+          localStorage.setItem(localStorageKey, JSON.stringify(entityMap))
+        },
+        100000,
+        { maxWait: 500 },
+      )
     : () => null
 
   return {

--- a/packages/object-utils/src/mutator-record/handlers.ts
+++ b/packages/object-utils/src/mutator-record/handlers.ts
@@ -13,7 +13,7 @@ export function mutationFactory<
 >(
   entityMap: Partial<Record<string, T>>,
   mutationMap: Partial<Record<string, Mutation<T>>>,
-  localStorageKey?: ValueOf<typeof LS_KEYS> | `workspace${string}`,
+  localStorageKey?: ValueOf<typeof LS_KEYS> | `workspace${string}` | false,
   maxNumberRecords: number = MAX_MUTATION_RECORDS,
 ) {
   function getMutator(uid: string) {

--- a/packages/object-utils/src/mutator-record/handlers.ts
+++ b/packages/object-utils/src/mutator-record/handlers.ts
@@ -13,7 +13,7 @@ export function mutationFactory<
 >(
   entityMap: Partial<Record<string, T>>,
   mutationMap: Partial<Record<string, Mutation<T>>>,
-  localStorageKey?: ValueOf<typeof LS_KEYS>,
+  localStorageKey?: ValueOf<typeof LS_KEYS> | `workspace${string}`,
   maxNumberRecords: number = MAX_MUTATION_RECORDS,
 ) {
   function getMutator(uid: string) {

--- a/packages/object-utils/src/mutator-record/handlers.ts
+++ b/packages/object-utils/src/mutator-record/handlers.ts
@@ -1,5 +1,8 @@
 import { Mutation } from '@/mutator-record/mutations'
 import type { Path, PathValue } from '@/nested'
+import type { ValueOf } from 'type-fest'
+
+import type { LS_CONFIG, LS_KEYS } from './local-storage'
 
 const MAX_MUTATION_RECORDS = 500
 
@@ -9,8 +12,10 @@ export function mutationFactory<
 >(
   entityMap: Partial<Record<string, T>>,
   mutationMap: Partial<Record<string, Mutation<T>>>,
+  localStorageKey: ValueOf<typeof LS_KEYS>,
   maxNumberRecords: number = MAX_MUTATION_RECORDS,
 ) {
+  const rando = localStorageKey
   function getMutator(uid: string) {
     const mutator = mutationMap[uid]
 
@@ -26,20 +31,24 @@ export function mutationFactory<
     add: (item: T) => {
       entityMap[item.uid] = item
       mutationMap[item.uid] = new Mutation(item, maxNumberRecords)
+      console.log('adding', rando, item)
     },
     delete: (uid: string) => {
       delete entityMap[uid]
       delete mutationMap[uid]
+      console.log('deleting', rando)
     },
     /** Destructive, overwrites a record to a new item and creates a new mutation tracking instance */
     set: (item: T) => {
       entityMap[item.uid] = item
       mutationMap[item.uid] = new Mutation(item, maxNumberRecords)
+      console.log('setting', rando, item)
     },
     /** Update a nested property and track the mutation */
     edit: <P extends Path<T>>(uid: string, path: P, value: PathValue<T, P>) => {
       const mutator = getMutator(uid)
       mutator?.mutate(path, value)
+      console.log('editing', rando, path)
     },
     /** Commit an untracked edit to the object (undo/redo will not work) */
     untrackedEdit: <P extends Path<T>>(
@@ -49,16 +58,19 @@ export function mutationFactory<
     ) => {
       const mutator = getMutator(uid)
       mutator?._unsavedMutate(path, value)
+      console.log('untracked edit', rando)
     },
     /** Undo the last mutation */
     undo: (uid: string) => {
       const mutator = getMutator(uid)
       mutator?.undo()
+      console.log('undo', rando)
     },
     /** Redo a mutation if available */
     redo: (uid: string) => {
       const mutator = getMutator(uid)
       mutator?.redo()
+      console.log('redo', rando)
     },
   }
 }

--- a/packages/object-utils/src/mutator-record/index.ts
+++ b/packages/object-utils/src/mutator-record/index.ts
@@ -1,3 +1,4 @@
 export * from './mutations'
+export * from './local-storage'
 
 export { mutationFactory } from './handlers'

--- a/packages/object-utils/src/mutator-record/local-storage.ts
+++ b/packages/object-utils/src/mutator-record/local-storage.ts
@@ -14,7 +14,7 @@ export const LS_KEYS = {
 /** Config options for localStorage mutators */
 export const LS_CONFIG = {
   /** The debounce time in milliseconds for saving to localStorage per resource */
-  DEBOUNCE_MS: 1000,
+  DEBOUNCE_MS: 328,
   /** The max wait time in milliseconds for saving to localStorage per resource */
-  MAX_WAIT_MS: 5000,
+  MAX_WAIT_MS: 1000,
 } as const

--- a/packages/object-utils/src/mutator-record/local-storage.ts
+++ b/packages/object-utils/src/mutator-record/local-storage.ts
@@ -1,13 +1,13 @@
 /** localStorage keys for resources */
 export const LS_KEYS = {
-  COLLECTIONS: 'collections',
-  COOKIES: 'cookies',
-  ENVIRONMENTS: 'environments',
-  FOLDERS: 'folders',
-  REQUEST_EXAMPLES: 'request-examples',
-  REQUESTS: 'requests',
-  SERVERS: 'servers',
-  SECURITY_SCHEMES: 'security-schemes',
+  COLLECTION: 'collection',
+  COOKIE: 'cookie',
+  ENVIRONMENT: 'environment',
+  FOLDER: 'folder',
+  REQUEST_EXAMPLE: 'requestExample',
+  REQUEST: 'request',
+  SERVER: 'server',
+  SECURITY_SCHEME: 'securityScheme',
   WORKSPACE: 'workspace',
 } as const
 

--- a/packages/object-utils/src/mutator-record/local-storage.ts
+++ b/packages/object-utils/src/mutator-record/local-storage.ts
@@ -1,0 +1,20 @@
+/** localStorage keys for resources */
+export const LS_KEYS = {
+  COLLECTIONS: 'collections',
+  COOKIES: 'cookies',
+  ENVIRONMENTS: 'environments',
+  FOLDERS: 'folders',
+  REQUEST_EXAMPLES: 'request-examples',
+  REQUESTS: 'requests',
+  SERVERS: 'servers',
+  SECURITY_SCHEMES: 'security-schemes',
+  WORKSPACE: 'workspace',
+} as const
+
+/** Config options for localStorage mutators */
+export const LS_CONFIG = {
+  /** The debounce time in milliseconds for saving to localStorage per resource */
+  DEBOUNCE_MS: 1000,
+  /** The max wait time in milliseconds for saving to localStorage per resource */
+  MAX_WAIT_MS: 5000,
+} as const

--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -13,21 +13,24 @@ import baseVariables from './variables.css?inline'
 
 export { migrateThemeVariables } from './utilities/legacy'
 
+export const themeIds = [
+  'alternate',
+  'default',
+  'moon',
+  'purple',
+  'solarized',
+  'bluePlanet',
+  'deepSpace',
+  'saturn',
+  'kepler',
+  'mars',
+  'none',
+] as const
+
 /**
  * Available theme IDs as a type.
  */
-export type ThemeId =
-  | 'alternate'
-  | 'default'
-  | 'moon'
-  | 'purple'
-  | 'solarized'
-  | 'bluePlanet'
-  | 'deepSpace'
-  | 'saturn'
-  | 'kepler'
-  | 'mars'
-  | 'none'
+export type ThemeId = (typeof themeIds)[number]
 
 /**
  * User readable theme names / labels

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1755,6 +1755,9 @@ importers:
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
+      type-fest:
+        specifier: ^4.20.0
+        version: 4.20.0
       vite:
         specifier: ^5.2.10
         version: 5.3.1(@types/node@20.14.9)(terser@5.31.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1748,6 +1748,9 @@ importers:
 
   packages/object-utils:
     dependencies:
+      '@vueuse/core':
+        specifier: ^10.10.0
+        version: 10.11.0(vue@3.4.31(typescript@5.5.2))
       just-clone:
         specifier: ^6.2.0
         version: 6.2.0
@@ -22398,6 +22401,16 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
+  '@vueuse/core@10.11.0(vue@3.4.31(typescript@5.5.2))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 10.11.0
+      '@vueuse/shared': 10.11.0(vue@3.4.31(typescript@5.5.2))
+      vue-demi: 0.14.8(vue@3.4.31(typescript@5.5.2))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
   '@vueuse/metadata@10.11.0': {}
 
   '@vueuse/shared@10.11.0(vue@3.4.29(typescript@5.4.5))':
@@ -22410,6 +22423,13 @@ snapshots:
   '@vueuse/shared@10.11.0(vue@3.4.29(typescript@5.5.2))':
     dependencies:
       vue-demi: 0.14.8(vue@3.4.29(typescript@5.5.2))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/shared@10.11.0(vue@3.4.31(typescript@5.5.2))':
+    dependencies:
+      vue-demi: 0.14.8(vue@3.4.31(typescript@5.5.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -33281,6 +33301,10 @@ snapshots:
   vue-demi@0.14.8(vue@3.4.29(typescript@5.5.2)):
     dependencies:
       vue: 3.4.29(typescript@5.5.2)
+
+  vue-demi@0.14.8(vue@3.4.31(typescript@5.5.2)):
+    dependencies:
+      vue: 3.4.31(typescript@5.5.2)
 
   vue-devtools-stub@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1705,6 +1705,9 @@ importers:
 
   packages/oas-utils:
     dependencies:
+      '@scalar/themes':
+        specifier: workspace:*
+        version: link:../themes
       axios:
         specifier: ^1.6.8
         version: 1.7.2(debug@4.3.5)
@@ -15049,8 +15052,8 @@ packages:
   vue-component-type-helpers@2.0.21:
     resolution: {integrity: sha512-3NaicyZ7N4B6cft4bfb7dOnPbE9CjLcx+6wZWAg5zwszfO4qXRh+U52dN5r5ZZfc6iMaxKCEcoH9CmxxoFZHLg==}
 
-  vue-component-type-helpers@2.0.24:
-    resolution: {integrity: sha512-Jr5N8QVYEcbQuMN1LRgvg61758G8HTnzUlQsAFOxx6Y6X8kmhJ7C+jOvWsQruYxi3uHhhS6BghyRlyiwO99DBg==}
+  vue-component-type-helpers@2.0.26:
+    resolution: {integrity: sha512-sO9qQ8oC520SW6kqlls0iqDak53gsTVSrYylajgjmkt1c0vcgjsGSy1KzlDrbEx8pm02IEYhlUkU5hCYf8rwtg==}
 
   vue-demi@0.14.8:
     resolution: {integrity: sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==}
@@ -20925,7 +20928,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.29(typescript@5.4.5)
-      vue-component-type-helpers: 2.0.24
+      vue-component-type-helpers: 2.0.26
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -20942,7 +20945,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.29(typescript@5.5.2)
-      vue-component-type-helpers: 2.0.24
+      vue-component-type-helpers: 2.0.26
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -33292,7 +33295,7 @@ snapshots:
 
   vue-component-type-helpers@2.0.21: {}
 
-  vue-component-type-helpers@2.0.24: {}
+  vue-component-type-helpers@2.0.26: {}
 
   vue-demi@0.14.8(vue@3.4.29(typescript@5.4.5)):
     dependencies:


### PR DESCRIPTION
Saves and loads data from localStorage. It persists now! Requires heavy testing before launch but looks ok

I ended up removing the workspace/routing from this PR, it can be added later. For now it just takes the first workspace but it will support multiple workspaces