### PR TITLE
feat: add empty state + drafts collection

### DIFF
--- a/.changeset/metal-mirrors-tickle.md
+++ b/.changeset/metal-mirrors-tickle.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: add empty state + drafts collection

--- a/packages/api-client/src/App.vue
+++ b/packages/api-client/src/App.vue
@@ -5,6 +5,7 @@ import { useDarkModeState } from '@/hooks'
 import { loadAllResources } from '@/libs'
 import { useWorkspace } from '@/store/workspace'
 import { addScalarClassesToHeadless } from '@scalar/components'
+import { createWorkspace } from '@scalar/oas-utils/entities/workspace'
 import { LS_KEYS } from '@scalar/object-utils/mutator-record'
 import { ScalarToasts } from '@scalar/use-toasts'
 import { onBeforeMount, onMounted, watchEffect } from 'vue'
@@ -44,10 +45,25 @@ onBeforeMount(async () => {
 
     loadAllResources(workspaceStore)
   } else {
-    workspaceStore.importSpecFromUrl(
-      'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-      // 'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
-      // 'https://proxy.scalar.com',
+    // Create default workspace
+    const _workspace = createWorkspace({
+      uid: 'default',
+      proxyUrl: 'https://proxy.scalar.com',
+    })
+    workspaceStore.workspaceMutators.add(_workspace)
+
+    workspaceStore.collectionMutators.add({
+      uid: 'drafts',
+      spec: {
+        info: {
+          title: 'Drafts',
+        },
+      },
+    })
+
+    workspaceStore.requestMutators.add(
+      { summary: 'My First Request' },
+      'drafts',
     )
   }
 
@@ -60,7 +76,6 @@ onBeforeMount(async () => {
   <main class="flex min-h-0 flex-1">
     <SideNav />
     <div class="flex flex-1 flex-col min-w-0">
-      <!-- <AddressBar /> -->
       <RouterView />
     </div>
   </main>

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -50,7 +50,7 @@ const serverUrl = computed(() => {
 })
 </script>
 <template>
-  <template v-if="serverOptions && !isReadOnly">
+  <template v-if="serverOptions && serverOptions.length > 0 && !isReadOnly">
     <ScalarDropdown
       :options="serverOptions"
       resize
@@ -100,7 +100,7 @@ const serverUrl = computed(() => {
       </template>
     </ScalarDropdown>
   </template>
-  <template v-else>
+  <template v-else-if="serverUrl">
     <div
       class="flex whitespace-nowrap items-center font-code lg:text-sm text-xs">
       {{ serverUrl }}

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -58,7 +58,9 @@ const executeRequest = async () => {
     return
   }
 
-  let url = activeServer.value?.url + activeRequest.value.path
+  let url = activeServer.value?.url
+    ? activeServer.value?.url + activeRequest.value.path
+    : activeRequest.value.path
 
   // Replace vraible
   // TODO: use `replaceVariables` from `@scalar/oas-utils/helpers`
@@ -101,7 +103,18 @@ onMounted(() => executeRequestBus.on(executeRequest))
  */
 onBeforeUnmount(() => executeRequestBus.off(executeRequest))
 
-const workspaceCollections = computed(() => Object.values(collections))
+const workspaceCollections = computed(() => {
+  // let's move drafts to the bottom
+  const c = Object.values(collections)
+  const index = c.findIndex((obj) => obj.uid === 'drafts')
+
+  const [draftsObj] = c.splice(index, 1)
+
+  // Add the object to the end of the array
+  c.push(draftsObj)
+
+  return c
+})
 
 // const collections = computed(() => {
 //   if (FOLDER_MODE) {
@@ -251,7 +264,6 @@ useEventListener(document, 'keydown', (event) => {
 </script>
 <template>
   <div
-    v-if="activeWorkspace"
     class="bg-b-2 flex flex-1 flex-col rounded-lg rounded-b-none rounded-r-none pt-0 h-full">
     <div
       class="lg:min-h-header flex items-center w-full justify-center p-1 flex-wrap t-app__top-container">
@@ -269,11 +281,6 @@ useEventListener(document, 'keydown', (event) => {
       <AddressBar />
       <div
         class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-0.5 lg:flex-1 justify-end w-6/12">
-        <!-- <button
-          class="request-text-color-text bg-mix-transparent hover:bg-mix-amount-95 px-2 py-1.5 rounded bg-mix-amount-90 font-medium text-sm"
-          type="button">
-          Test Acctual Locally
-        </button> -->
         <button
           v-if="activeWorkspace.isReadOnly"
           class="text-c-3 hover:bg-b-3 active:text-c-1 p-2 rounded"

--- a/packages/oas-utils/src/entities/workspace/spec/requests.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/requests.ts
@@ -30,7 +30,7 @@ const requestBodySchema = z.any() satisfies ZodSchema<RequestBody>
 const parametersSchema = z.record(z.string(), z.any())
 
 const requestSchema = z.object({
-  path: z.string().optional().default('/'),
+  path: z.string().optional().default(''),
   method: z
     .enum(Object.keys(REQUEST_METHODS) as [RequestMethod])
     .optional()


### PR DESCRIPTION
Currently we always load the galaxy client, but now we have a ✨ drafts ✨ collection which wont be saved to the cloud, and when you initially go to the app it will have the My First Request as the default

Handled scenarios with:
- no servers 
- keep drafts collection at the bottom

![image](https://github.com/scalar/scalar/assets/6176314/8440c050-841d-4c41-ad02-ed6d3824a149)

some things to improve:
 - make drafts have its own icon
 - ensure we dont have > 1 example for each draft request since its not an openapi compliant request
 - ensure Auth shows up always