### PR TITLE
feat(api-client): add actions for requests in the sidebar

### DIFF
--- a/.changeset/dry-cooks-hunt.md
+++ b/.changeset/dry-cooks-hunt.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+feat: add sidebar actions for requests

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -150,7 +150,12 @@ const showChildren = computed(
           <div class="relative">
             <RequestSidebarItemMenu
               v-if="!isReadOnly"
-              :item="item" />
+              :item="item"
+              :parentUid="
+                parentUids.length
+                  ? parentUids[parentUids.length - 1]
+                  : undefined
+              " />
             <span class="flex">
               &hairsp;
               <HttpMethod

--- a/packages/components/src/components/ScalarTextField/ScalarTextField.vue
+++ b/packages/components/src/components/ScalarTextField/ScalarTextField.vue
@@ -147,7 +147,7 @@ onMounted(() => {
         cx(
           'helper-text before:font-black mt-1.5 flex items-center text-xs text-error before:rounded-full',
           'before:mr-1.5 before:block before:h-4 before:w-4 before:text-center before:text-xxs before:leading-4',
-          `before:bg-error before:text-white before:content-['!'] empty:hidden`,
+          `before:bg-error before:text-white empty:hidden`,
         )
       ">
       {{ helperText }}


### PR DESCRIPTION
now we can rename and delete examples + requests!

There was a duplicate item, but thats a bit more involved and we can add it later :) 

also there was a `content before !` in tailwind for the component library maybe @hwkr and @amritk can touch base on that ✨ 
https://github.com/scalar/scalar/pull/2418/files#diff-56f8d484750bbaf10d8d267641bb388b91f388c953715e9a5d2078d97ad1f898L150

also, not sure whats up with our modal but we need to fix that too :) seems to be almost full height of page regardless of variant specified