### PR TITLE
feat(api-client): add pre/post request scripts  🤖

### DIFF
--- a/.changeset/chatty-jobs-tell.md
+++ b/.changeset/chatty-jobs-tell.md
@@ -1,0 +1,7 @@
+---
+'@scalar/use-codemirror': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: add pre/post request scripts

--- a/packages/api-client/src/libs/scalarScripts.ts
+++ b/packages/api-client/src/libs/scalarScripts.ts
@@ -1,0 +1,74 @@
+import type { ResponseTest } from '@scalar/oas-utils/entities/workspace/spec'
+import type { AxiosRequestConfig, AxiosResponse } from 'axios'
+
+function getPreRequestScalarObject(config: AxiosRequestConfig) {
+  const _config = config
+  return {
+    environment: {
+      set: (key: string, value: string) => {},
+      get: (key: string) => '',
+    },
+    request: {
+      headers: {
+        add({ key, value }: { key: string; value: string }) {
+          _config.headers = _config.headers || {}
+          _config.headers[key] = value
+        },
+      },
+    },
+    _config,
+  }
+}
+export const executePreRequestScript = (
+  script: string,
+  config: AxiosRequestConfig,
+) => {
+  const scalar = getPreRequestScalarObject(config)
+  const executeScript = new Function('scalar', script)
+
+  const output = executeScript(scalar)
+
+  return { output, config: scalar._config }
+}
+
+function expect(actual: any) {
+  return {
+    toBe: (expected: any) => {
+      if (actual !== expected) {
+        throw new Error(`Expected ${actual} to be ${expected}`)
+      }
+    },
+  }
+}
+
+function getPostRequestScriptObject(response?: AxiosResponse) {
+  const testResults: ResponseTest[] = []
+  return {
+    sub: (a: number, b: number) => a - b,
+    test: (title: string, func: () => boolean) => {
+      try {
+        func()
+        testResults.push({ title, passed: true })
+      } catch (e) {
+        testResults.push({ title, passed: false, error: e as string })
+      }
+    },
+    expect,
+    response,
+    _testResults: testResults,
+  }
+}
+export const executePostRequestScript = (
+  script: string,
+  response?: AxiosResponse,
+) => {
+  const scalar = getPostRequestScriptObject(response)
+  const executeScript = new Function('scalar', script)
+
+  const output = executeScript(scalar)
+
+  return {
+    output,
+    testResults: scalar._testResults,
+  }
+}

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -76,7 +76,7 @@ const executeRequest = async () => {
     })
   }
 
-  const { request, response } = await sendRequest(
+  const { request, response, testResults } = await sendRequest(
     activeRequest.value,
     activeExample.value,
     url,
@@ -89,6 +89,7 @@ const executeRequest = async () => {
       request,
       response,
       timestamp: Date.now(),
+      testResults,
     })
   } else {
     console.warn('No response or request was returned')
@@ -350,6 +351,10 @@ useEventListener(document, 'keydown', (event) => {
           :response="
             activeRequest?.history?.[activeRequest?.history?.length - 1]
               ?.response
+          "
+          :tests="
+            activeRequest?.history?.[activeRequest?.history?.length - 1]
+              ?.testResults
           " />
       </ViewLayoutContent>
       <ActionModal

--- a/packages/api-client/src/views/Request/RequestSection/RequestScripts.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestScripts.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import CodeInput from '@/components/CodeInput/CodeInput.vue'
+import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
+import { useWorkspace } from '@/store/workspace'
+
+const { activeExample, requestExampleMutators } = useWorkspace()
+
+function updateExamplePreRequestScript(content: string) {
+  requestExampleMutators.edit(activeExample.value.uid, 'preSendScript', content)
+}
+
+function updateExamplePostRequestScript(content: string) {
+  requestExampleMutators.edit(
+    activeExample.value.uid,
+    'postSendScript',
+    content,
+  )
+}
+</script>
+<template>
+  <ViewLayoutCollapse>
+    <template #title>Scripts</template>
+    <div>
+      <div>
+        <h2>Pre Request</h2>
+        <CodeInput
+          content=""
+          language="javascript"
+          lineNumbers
+          :modelValue="activeExample?.preSendScript ?? ''"
+          @update:modelValue="updateExamplePreRequestScript" />
+      </div>
+      <div>
+        <h2>Post Request</h2>
+        <CodeInput
+          content=""
+          language="javascript"
+          lineNumbers
+          :modelValue="activeExample?.postSendScript ?? ''"
+          @update:modelValue="updateExamplePostRequestScript" />
+      </div>
+    </div>
+  </ViewLayoutCollapse>
+</template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -6,11 +6,16 @@ import RequestAuth from '@/views/Request/RequestSection/RequestAuth.vue'
 import RequestBody from '@/views/Request/RequestSection/RequestBody.vue'
 import RequestParams from '@/views/Request/RequestSection/RequestParams.vue'
 import RequestPathParams from '@/views/Request/RequestSection/RequestPathParams.vue'
+import RequestScripts from '@/views/Request/RequestSection/RequestScripts.vue'
 import { ScalarIcon } from '@scalar/components'
 import { computed, ref, watch } from 'vue'
 
-const { activeRequest, activeExample, activeSecurityRequirements } =
-  useWorkspace()
+const {
+  activeRequest,
+  activeExample,
+  activeSecurityRequirements,
+  activeWorkspace,
+} = useWorkspace()
 
 const bodyMethods = ['POST', 'PUT', 'PATCH', 'DELETE']
 
@@ -24,6 +29,8 @@ const sections = computed(() => {
     'Query',
     'Body',
   ]
+
+  if (!activeWorkspace.value.isReadOnly) allSections.push('Scripts')
 
   if (!activeExample.value.parameters.path.length) {
     allSections.splice(allSections.indexOf('Request'), 1)
@@ -107,6 +114,11 @@ watch(activeRequest, (newRequest) => {
         "
         body="foo"
         title="Body" />
+      <RequestScripts
+        v-show="
+          (activeSection === 'All' || activeSection === 'Scripts') &&
+          !activeWorkspace.isReadOnly
+        " />
     </div>
   </ViewLayoutSection>
 </template>

--- a/packages/api-client/src/views/Request/RequestSidebarItemFolder.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemFolder.vue
@@ -1,0 +1,34 @@
+<script lang="ts" setup>
+import ScalarHotkey from '@/components/ScalarHotkey.vue'
+import {
+  ScalarButton,
+  ScalarDropdown,
+  ScalarDropdownItem,
+  ScalarIcon,
+} from '@scalar/components'
+</script>
+<template>
+  <ScalarDropdown teleport="#scalar-client">
+    <ScalarButton
+      class="z-10 hover:bg-b-3 transition-none p-1 group-hover:flex ui-open:flex absolute left-0 hidden -translate-x-full -ml-1"
+      size="sm"
+      variant="ghost"
+      @click.stop>
+      <ScalarIcon
+        icon="Ellipses"
+        size="sm" />
+    </ScalarButton>
+    <template #items>
+      <ScalarDropdownItem class="flex !gap-2">
+        <ScalarIcon
+          class="text-c-2 inline-flex p-px"
+          icon="Edit"
+          size="xs" />
+        <span>Rename</span>
+        <ScalarHotkey
+          class="absolute right-2 text-c-3"
+          hotkey="1" />
+      </ScalarDropdownItem>
+    </template>
+  </ScalarDropdown>
+</template>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -1,20 +1,28 @@
 <script setup lang="ts">
 import ContextBar from '@/components/ContextBar.vue'
 import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import { useWorkspace } from '@/store/workspace'
 import ResponseBody from '@/views/Request/ResponseSection/ResponseBody.vue'
 import ResponseEmpty from '@/views/Request/ResponseSection/ResponseEmpty.vue'
 import ResponseMetaInformation from '@/views/Request/ResponseSection/ResponseMetaInformation.vue'
 import { ScalarIcon } from '@scalar/components'
-import type { ResponseInstance } from '@scalar/oas-utils/entities/workspace/spec'
+import type {
+  ResponseInstance,
+  ResponseTest,
+} from '@scalar/oas-utils/entities/workspace/spec'
 import { isJsonString } from '@scalar/oas-utils/helpers'
 import { computed, ref, toRaw } from 'vue'
 
 import ResponseCookies from './ResponseCookies.vue'
 import ResponseHeaders from './ResponseHeaders.vue'
+import ResponseTests from './ResponseTests.vue'
 
 const props = defineProps<{
   response: ResponseInstance | undefined
+  tests?: ResponseTest[]
 }>()
+
+const { activeWorkspace } = useWorkspace()
 
 // Headers
 const responseHeaders = computed(() => {
@@ -65,7 +73,9 @@ const responseData = computed(() => {
   return value
 })
 
-const sections = ['All', 'Body', 'Headers', 'Cookies']
+const sections = ['All', 'Body', 'Headers', 'Cookies', 'Tests']
+if (!activeWorkspace.value.isReadOnly) sections.push('Scripts')
+
 type ActiveSections = (typeof sections)[number]
 
 const activeSection = ref<ActiveSections>('All')
@@ -105,6 +115,12 @@ const activeSection = ref<ActiveSections>('All')
           :data="responseData"
           :headers="responseHeaders"
           title="Body" />
+        <ResponseTests
+          v-if="
+            (activeSection === 'All' || activeSection === 'Tests') &&
+            !activeWorkspace.isReadOnly
+          "
+          :tests="tests" />
       </template>
     </div>
   </ViewLayoutSection>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseTests.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseTests.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import DataTable from '@/components/DataTable/DataTable.vue'
+import DataTableHeader from '@/components/DataTable/DataTableHeader.vue'
+import DataTableRow from '@/components/DataTable/DataTableRow.vue'
+import DataTableText from '@/components/DataTable/DataTableText.vue'
+import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
+import type { ResponseTest } from '@scalar/oas-utils/entities/workspace/spec'
+
+defineProps<{
+  tests?: ResponseTest[]
+}>()
+</script>
+<template>
+  <ViewLayoutCollapse>
+    <template #title>Tests</template>
+    <template v-if="true">
+      <DataTable
+        v-if="tests?.length"
+        class="flex-1"
+        :columns="['', '']">
+        <DataTableRow>
+          <DataTableHeader>Title</DataTableHeader>
+          <DataTableHeader>Status</DataTableHeader>
+        </DataTableRow>
+        <DataTableRow
+          v-for="(item, idx) in tests"
+          :key="idx">
+          <DataTableText :text="item.title" />
+          <DataTableText :text="item.passed ? 'Success' : 'Failed'" />
+        </DataTableRow>
+      </DataTable>
+      <!-- Empty state -->
+      <div
+        v-else
+        class="text-c-3 px-4 text-sm border border-1/2 rounded min-h-12 justify-center flex items-center bg-b-1 mx-1">
+        No cookies
+      </div>
+    </template>
+  </ViewLayoutCollapse>
+</template>

--- a/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
@@ -79,6 +79,8 @@ const requestExampleSchema = z.object({
     })
     .optional()
     .default({}),
+  preSendScript: z.string().optional().default(''),
+  postSendScript: z.string().optional().default(''),
   auth: z.record(z.string(), z.any()).default({}),
 })
 

--- a/packages/oas-utils/src/entities/workspace/spec/requests.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/requests.ts
@@ -16,11 +16,20 @@ export type ResponseInstance = AxiosResponse & {
   duration: number
 }
 
+export type ResponseTest = {
+  title: string
+  passed: boolean
+  error?: string
+}
+
+const responseTestSchema = z.any() satisfies ZodSchema<ResponseTest>
+
 /** A single request/response set to save to the history stack */
 export type RequestEvent = {
   request: RequestExample
   response: ResponseInstance
   timestamp: number
+  testResults?: ResponseTest[]
 }
 
 // TODO fill out body
@@ -78,6 +87,8 @@ const requestSchema = z.object({
   /** Ordered exampleUids for the sidenav */
   childUids: nanoidSchema.array().default([]),
   history: z.any().array().default([]),
+  /** Test Results */
+  testResults: responseTestSchema.array().default([]),
 })
 
 /**

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -41,14 +41,15 @@
   ],
   "module": "dist/index.js",
   "optionalDependencies": {
-    "yjs": "^13.6.0",
-    "y-codemirror.next": "^0.3.2"
+    "y-codemirror.next": "^0.3.2",
+    "yjs": "^13.6.0"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.12.0",
     "@codemirror/commands": "^6.3.3",
     "@codemirror/lang-css": "^6.2.1",
     "@codemirror/lang-html": "^6.4.8",
+    "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lang-json": "^6.0.0",
     "@codemirror/lang-yaml": "^6.0.0",
     "@codemirror/language": "^6.10.1",

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -7,6 +7,7 @@ import {
 import { indentWithTab } from '@codemirror/commands'
 import { css } from '@codemirror/lang-css'
 import { html } from '@codemirror/lang-html'
+import { javascript } from '@codemirror/lang-javascript'
 import { json } from '@codemirror/lang-json'
 import { yaml } from '@codemirror/lang-yaml'
 import {
@@ -235,6 +236,7 @@ const languageExtensions: {
   json: json,
   yaml: yaml,
   css: css,
+  javascript: javascript,
 }
 
 /** Generate  the list of extension from parameters */

--- a/packages/use-codemirror/src/types.ts
+++ b/packages/use-codemirror/src/types.ts
@@ -1,1 +1,1 @@
-export type CodeMirrorLanguage = 'html' | 'json' | 'yaml' | 'css'
+export type CodeMirrorLanguage = 'html' | 'json' | 'yaml' | 'css' | 'javascript'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1868,6 +1868,9 @@ importers:
       '@codemirror/lang-html':
         specifier: ^6.4.8
         version: 6.4.9
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.2
+        version: 6.2.2
       '@codemirror/lang-json':
         specifier: ^6.0.0
         version: 6.0.1


### PR DESCRIPTION
🚨 new feature alert 🚨 

Scripting in the Scalar API Client : ) it's pure javascript, with access to a `scalar` object, with some namespaces for functionality depending on if you are in the pre or post script sections

**Present**
Pre Request:
- can access the `request` and add headers : ) (do we give access to the AxiosConfig and let users modify or slight helpers like i did here?)

Post Request:
- tests! you can now run tests and expect values : )
- you also get access to the `response` object to check whats going on : )

![image](https://github.com/scalar/scalar/assets/6176314/ae16d2df-7749-4f68-9dd1-5a52f555fd1b)

**Future**
- we should add the scalar object to the Codemirror config so we can add code completion + hints
- we should fix javascript script highlighting
- add a `x-scalar-scripts` OpenAPI extension so we can add these on the fly ✨ 
- Add way more test functionality (do we just use `vitest` browser only?
- This is just at the request level, but we can eventually do: Folder, Collection and workspace level : )
- We should also be able to send requests from the pre request script (foundationally request chaining 😏 )

i disabled this for the Modal mode, so we can get this merged and play around with it as we build : ) but it's pretty fun!!

