### PR TITLE
feat(use-codemirror): add json linter

### DIFF
--- a/.changeset/curly-crabs-battle.md
+++ b/.changeset/curly-crabs-battle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: enable lint on request body

--- a/.changeset/fresh-seals-trade.md
+++ b/.changeset/fresh-seals-trade.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-codemirror': patch
+---
+
+feat: add json linter

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -124,7 +124,7 @@ export default {
 :deep(.cm-tooltip) {
   background: transparent !important;
   filter: brightness(var(--scalar-lifted-brightness));
-  border-radius: var(--scalar-radius-xl);
+  border-radius: var(--scalar-radius);
   box-shadow: var(--scalar-shadow-2);
   border: none !important;
   outline: none !important;

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -15,6 +15,7 @@ const props = withDefaults(
     error?: boolean
     emitOnBlur?: boolean
     lineNumbers?: boolean
+    lint?: boolean
     language?: CodeMirrorLanguage
     handleFieldSubmit?: (e: string) => void
     handleFieldChange?: (e: string) => void
@@ -75,6 +76,7 @@ const { codeMirror } = useCodeMirror({
   codeMirrorRef,
   lineNumbers: toRef(() => props.lineNumbers),
   language: toRef(() => props.language),
+  lint: toRef(() => props.lint),
   extensions,
 })
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -404,6 +404,7 @@ watch(
               content=""
               :language="codeInputLanguage"
               lineNumbers
+              lint
               :modelValue="activeExample?.body.raw.value ?? ''"
               @update:modelValue="updateRequestBody" />
           </template>

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -41,8 +41,8 @@
   ],
   "module": "dist/index.js",
   "optionalDependencies": {
-    "yjs": "^13.6.0",
-    "y-codemirror.next": "^0.3.2"
+    "y-codemirror.next": "^0.3.2",
+    "yjs": "^13.6.0"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.12.0",
@@ -52,6 +52,7 @@
     "@codemirror/lang-json": "^6.0.0",
     "@codemirror/lang-yaml": "^6.0.0",
     "@codemirror/language": "^6.10.1",
+    "@codemirror/lint": "^6.8.1",
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.23.1",
     "@lezer/common": "^1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1877,6 +1877,9 @@ importers:
       '@codemirror/language':
         specifier: ^6.10.1
         version: 6.10.2
+      '@codemirror/lint':
+        specifier: ^6.8.1
+        version: 6.8.1
       '@codemirror/state':
         specifier: ^6.4.0
         version: 6.4.1
@@ -2974,8 +2977,8 @@ packages:
   '@codemirror/language@6.10.2':
     resolution: {integrity: sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==}
 
-  '@codemirror/lint@6.8.0':
-    resolution: {integrity: sha512-lsFofvaw0lnPRJlQylNsC4IRt/1lI4OD/yYslrSGVndOJfStc58v+8p9dgGiD90ktOfL7OhBWns1ZETYgz0EJA==}
+  '@codemirror/lint@6.8.1':
+    resolution: {integrity: sha512-IZ0Y7S4/bpaunwggW2jYqwLuHj0QtESf5xcROewY6+lDNwZ/NzvR4t+vpYgg9m7V8UXLPYqG+lu3DF470E5Oxg==}
 
   '@codemirror/search@6.5.6':
     resolution: {integrity: sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==}
@@ -16861,7 +16864,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.16.2(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.1)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
-      '@codemirror/lint': 6.8.0
+      '@codemirror/lint': 6.8.1
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.28.1
       '@lezer/common': 1.2.1
@@ -16892,7 +16895,7 @@ snapshots:
       '@lezer/lr': 1.4.1
       style-mod: 4.1.2
 
-  '@codemirror/lint@6.8.0':
+  '@codemirror/lint@6.8.1':
     dependencies:
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.28.1
@@ -23495,7 +23498,7 @@ snapshots:
       '@codemirror/autocomplete': 6.16.2(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.1)(@lezer/common@1.2.1)
       '@codemirror/commands': 6.6.0
       '@codemirror/language': 6.10.2
-      '@codemirror/lint': 6.8.0
+      '@codemirror/lint': 6.8.1
       '@codemirror/search': 6.5.6
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.28.1


### PR DESCRIPTION
this pr adds the lint option in use-codemirror package and enable json linter in api client request body (unstyled):

<img width="839" alt="image" src="https://github.com/scalar/scalar/assets/14966155/81efc147-4b48-4513-8ea6-82049c5cc486">

