### PR TITLE
chore: rename `createScalarApiClient` to `createApiClientModal` (RFC)

### DIFF
--- a/.changeset/two-cougars-draw.md
+++ b/.changeset/two-cougars-draw.md
@@ -1,0 +1,8 @@
+---
+'@scalar/api-client-react': patch
+'@scalar/api-reference': patch
+'@scalar/play-button': patch
+'@scalar/api-client': patch
+---
+
+refactor!: rename `createScalarApiClient` to `createApiClientModal`

--- a/packages/api-client-react/src/ApiClientReact.tsx
+++ b/packages/api-client-react/src/ApiClientReact.tsx
@@ -1,4 +1,4 @@
-import { ClientConfiguration, createScalarApiClient } from '@scalar/api-client'
+import { ClientConfiguration, createApiClientModal } from '@scalar/api-client'
 import React, { ReactNode, useEffect, useRef, useState } from 'react'
 
 import './style.css'
@@ -25,12 +25,12 @@ export const ApiClientReact = ({
   const el = useRef(null)
 
   const [client, setClient] = useState<Awaited<
-    ReturnType<typeof createScalarApiClient>
+    ReturnType<typeof createApiClientModal>
   > | null>(null)
 
   useEffect(() => {
     if (!el.current) return
-    createScalarApiClient(el.current, configuration).then(setClient)
+    createApiClientModal(el.current, configuration).then(setClient)
   }, [el])
 
   useEffect(() => {

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -14,12 +14,12 @@ npm install @scalar/api-client
 ## Usage
 
 ```ts
-import { createScalarApiClient } from '@scalar/api-client'
+import { createApiClientModal } from '@scalar/api-client'
 
 const targetElement = document.getElementById('root')
 
 // Initialize
-const { open } = await createScalarApiClient(targetElement, {
+const { open } = await createApiClientModal(targetElement, {
   spec: {
     // Load a spec from URL
     url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
@@ -89,7 +89,7 @@ export type ClientConfiguration = {
 
 ## Available Methods
 
-The following methods are returned from the `createScalarApiClient` call:
+The following methods are returned from the `createApiClientModal` call:
 
 ### open
 

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "vite build && pnpm types:build && tsc-alias -p tsconfig.build.json",
     "dev": "vite",
-    "dev:modal": "vite ./playground -c ./vite.config.ts",
+    "dev:playground": "vite ./playground -c ./vite.config.ts",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "preview": "vite preview",

--- a/packages/api-client/playground/main.ts
+++ b/packages/api-client/playground/main.ts
@@ -1,7 +1,7 @@
-import { createScalarApiClient } from '@/Modal'
+import { createApiClientModal } from '@/Modal'
 
 // Initialize
-const { open } = await createScalarApiClient(document.getElementById('root'), {
+const { open } = await createApiClientModal(document.getElementById('root'), {
   spec: {
     url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
   },

--- a/packages/api-client/src/Modal/api-client-modal.ts
+++ b/packages/api-client/src/Modal/api-client-modal.ts
@@ -57,7 +57,7 @@ export type ClientConfiguration = {
 export type OpenClientPayload = { path: string; method: RequestMethod }
 
 /** Initialize Scalar API Client Modal */
-export const createScalarApiClient = async (
+export const createApiClientModal = async (
   /** Element to mount the references to */
   el: HTMLElement | null,
   /** Configuration object for Scalar References */

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -23,10 +23,10 @@ const { server } = useServerStore()
 onMounted(async () => {
   if (!el.value) return
 
-  const { createScalarApiClient } = await import('@scalar/api-client')
+  const { createApiClientModal } = await import('@scalar/api-client')
 
   const { app, open, updateAuth, updateServerUrl, modalState, updateSpec } =
-    await createScalarApiClient(el.value, {
+    await createApiClientModal(el.value, {
       spec: props.spec ?? {},
       proxyUrl: props.proxyUrl,
     })

--- a/packages/play-button/src/index.ts
+++ b/packages/play-button/src/index.ts
@@ -2,7 +2,7 @@
  * This file is the entry point for the CDN version of the Scalar Test Button.
  * It’s responsible for finding the spec and configuration in the HTML, and mounting the Vue.js app.
  */
-import { createScalarApiClient } from '@scalar/api-client'
+import { createApiClientModal } from '@scalar/api-client'
 import { parse } from '@scalar/api-reference'
 import type { Spec, Tag, TransformedOperation } from '@scalar/oas-utils'
 import { reactive } from 'vue'
@@ -79,7 +79,7 @@ if (!specUrlElement && !specElement && !specScriptTag) {
       return null
     }
 
-    const { open } = await createScalarApiClient(container as HTMLElement, {
+    const { open } = await createApiClientModal(container as HTMLElement, {
       spec: {
         url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       },


### PR DESCRIPTION
This PR renames `createScalarApiClient` to `createApiClientModal`, and this is why:

* The method mounts a modal, which needs to be opened to be visible.
* It’s living in `packages/api-client/src/Modal/api-client-modal.ts`
* The comment says: `/** Initialize Scalar API Client Modal */`

I’d also like to propose to drop the `Scalar` in the function name, for the following reasons:

* It’s consistent with what we have already: https://gist.github.com/hanspagel/a696fa7371263dedf9f3d11f2122807c
* It’s very unlikely we run into any conflicts with `createApiClientModal`
* `createScalarApiClientModal` becomes so long, I don’t like to read it anymore

Looking for feedback!

## Alternative

If we’d keep the `Scalar` in the method name, I’d rename the others as following:

* `createScalarApiClientModal`
* `createScalarMockServer`
* `createScalarVoidServer`