### PR TITLE
fix(api-reference): long base url

### DIFF
--- a/.changeset/polite-buttons-work.md
+++ b/.changeset/polite-buttons-work.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: long base url

--- a/packages/api-reference/src/features/BaseUrl/ServerUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerUrl.vue
@@ -51,7 +51,6 @@ const formattedServerUrl = computed(() => {
   display: inline-block;
   font-size: var(--scalar-micro);
   min-width: 0;
-  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }

--- a/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
@@ -41,7 +41,7 @@ const selected = computed<ScalarListboxOption | undefined>({
         :class="{ 'pointer-events-none': options.length <= 1 }"
         fullWidth
         variant="ghost">
-        <span>
+        <span class="custom-scroll">
           <slot></slot>
         </span>
         <ScalarIcon


### PR DESCRIPTION
this pr fixes long base url and make it scrollable as seen below:

**before**
<img width="603" alt="image" src="https://github.com/scalar/scalar/assets/14966155/ee052f28-61f5-44ac-8233-3e89585dd641">

**after**
<img width="603" alt="image" src="https://github.com/scalar/scalar/assets/14966155/f1f349a6-59f2-4bd7-bd53-7d3bcc7d3d5d">
