### PR TITLE
chore: ignore changesets for deprecated packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,12 +2,15 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": ["@changesets/cli/commit", { "skipCI": false }],
-  "fixed": [
-    ["@scalar/api-reference", "@scalar/fastify-api-reference"]
-  ],
+  "fixed": [["@scalar/api-reference", "@scalar/fastify-api-reference"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@scalar-examples/*", "playwright"]
+  "ignore": [
+    "@scalar-examples/*",
+    "playwright",
+    "@scalar/api-client-react",
+    "@scalar/echo-server"
+  ]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,7 +15,7 @@
 **/.venv
 
 pnpm-lock.yaml
-.changeset/
+.changeset/*.md
 cdn
 
 fixtures


### PR DESCRIPTION
This PR adds two of our deprecated packages to the changeset ignore list. We shouldn’t bother with changesets for packages we don't release anyway.