### PR TITLE
fix: update section accordian icons + stroke widths

### DIFF
--- a/.changeset/yellow-donkeys-do.md
+++ b/.changeset/yellow-donkeys-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: update classic theme section accordian icons

--- a/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
+++ b/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
@@ -57,7 +57,7 @@ const { copyToClipboard } = useClipboard()
       <ScalarIcon
         v-else
         class="endpoint-try-hint"
-        icon="PaperAirplane" />
+        icon="Play" />
       <ScalarIconButton
         class="endpoint-copy"
         icon="Clipboard"
@@ -176,19 +176,13 @@ const { copyToClipboard } = useClipboard()
   height: 24px;
   width: 24px;
   flex-shrink: 0;
-  opacity: 0.44;
-}
-
-.endpoint-copy,
-.endpoint-copy:hover {
-  color: currentColor;
 }
 
 .endpoint-copy {
-  opacity: 0.44;
+  color: currentColor;
 }
-.endpoint-copy:hover {
-  opacity: 1;
+.endpoint-copy :deep(svg) {
+  stroke-width: 2px;
 }
 
 .endpoint-content {


### PR DESCRIPTION
before:
<img width="218" alt="image" src="https://github.com/scalar/scalar/assets/6201407/1419525b-7e84-4cba-b2d0-aeca354ee6e8">

after:
<img width="273" alt="image" src="https://github.com/scalar/scalar/assets/6201407/e85ed977-207e-48bf-9d49-81d1b2e9ce10">
