### PR TITLE
fix(docusaurus): scope docusaurus theme styles

### DIFF
--- a/.changeset/nervous-parents-burn.md
+++ b/.changeset/nervous-parents-burn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/docusaurus': patch
+---
+
+fix: scope docusaurus theme styles

--- a/packages/docusaurus/src/theme.css
+++ b/packages/docusaurus/src/theme.css
@@ -133,6 +133,16 @@ html[data-theme='dark'] body {
 html[data-theme='light'] body .api-client-drawer {
   --scalar-background-1: white;
 }
+
+/* Headless UI Shims */
+#headlessui-portal-root {
+  position: fixed !important;
+  width: 100%;
+}
+#__docusaurus[aria-hidden='true'] ~ #headlessui-portal-root {
+  position: relative !important;
+}
+
 .sidebar-heading.sidebar-group-item__folder {
   flex-direction: row-reverse;
 }
@@ -205,13 +215,6 @@ html[data-theme='light'] body .api-client-drawer {
   max-height: calc(100dvh - var(--ifm-navbar-height));
   position: sticky;
   top: var(--ifm-navbar-height);
-}
-#headlessui-portal-root {
-  position: fixed !important;
-  width: 100%;
-}
-#__docusaurus[aria-hidden='true'] ~ #headlessui-portal-root {
-  position: relative !important;
 }
 .references-layout {
   overflow: initial !important;
@@ -295,143 +298,6 @@ html[data-theme='light'] body .api-client-drawer {
   }
 }
 
-code.hljs * {
-  font-size: var(--scalar-small);
-  font-family: var(--scalar-font-code);
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  word-wrap: normal;
-  line-height: 1.4;
-  tab-size: 4;
-}
-code.hljs {
-  font-size: var(--scalar-small);
-  font-family: var(--scalar-font-code);
-  display: inline-block;
-  counter-reset: linenumber;
-}
-.hljs {
-  background: transparent;
-  color: var(--scalar-color-2);
-}
-
-.hljs .line::before {
-  color: var(--scalar-color-3);
-  display: inline-block;
-  counter-increment: linenumber;
-  content: counter(linenumber);
-  margin-right: 0.7em;
-  /* Variable is set on the code element by the plugin when line numbers are used */
-  min-width: calc(var(--line-digits) * 1ch);
-  text-align: right;
-}
-/* ------------------------------------------------------------- */
-/* Data types */
-.hljs-comment,
-.hljs-quote {
-  color: var(--scalar-color-3);
-  font-style: italic;
-}
-
-.hljs-number {
-  color: var(--scalar-color-orange);
-}
-
-.hljs-regexp,
-.hljs-string {
-  color: var(--scalar-color-blue);
-}
-
-/** Globals such as `var()` and `!important` */
-.hljs-built_in {
-  color: var(--scalar-color-blue);
-}
-
-/** Class initializers such as `Array` or `Date` */
-/** Type declarations such as `Record` */
-.hljs-title.class_ {
-  color: var(--scalar-color-1);
-}
-
-/** Language indicators such as `new`, `const`, or `function` in JS  */
-.hljs-keyword {
-  color: var(--scalar-color-purple);
-}
-
-/** Function names when declaring and calling */
-.hljs-title.function_ {
-  color: var(--scalar-color-orange);
-}
-
-/** Template substitution */
-.hljs-subst {
-  color: var(--scalar-color-blue);
-}
-
-/** HTML Tag name */
-.hljs-name {
-  color: var(--scalar-color-blue);
-}
-
-/** Attribute name (ex. `class`, `id`) */
-.hljs-attr,
-.hljs-attribute {
-  color: var(--scalar-color-1);
-}
-
-.hljs-addition,
-.hljs-literal,
-.hljs-selector-tag,
-.hljs-type {
-  color: var(--scalar-color-green);
-}
-
-.hljs-selector-attr,
-.hljs-selector-pseudo {
-  color: var(--scalar-color-orange);
-}
-.hljs-doctag {
-  color: var(--scalar-color-blue);
-}
-
-.hljs-section,
-.hljs-title {
-  color: var(--scalar-color-blue);
-}
-
-.hljs-selector-id,
-.hljs-template-variable,
-.hljs-variable {
-  color: var(--scalar-color-1);
-}
-
-.hljs-name,
-.hljs-section,
-.hljs-strong {
-  font-weight: var(--scalar-semibold);
-}
-
-.hljs-bullet,
-.hljs-link,
-.hljs-meta,
-.hljs-symbol {
-  color: var(--scalar-color-blue);
-}
-
-.hljs-deletion {
-  color: var(--scalar-color-red);
-}
-
-.hljs-formula {
-  background: var(--scalar-color-1);
-}
-
-.hljs-emphasis {
-  font-style: italic;
-}
-
 /** Hide credentials */
 .credentials {
   font-size: 0 !important;
@@ -446,335 +312,474 @@ code.hljs {
   user-select: none;
 }
 
-/* -------------------------------------------------------------- */
-/* Language specific overrides */
+.scalar-app {
+  code.hljs * {
+    font-size: var(--scalar-small);
+    font-family: var(--scalar-font-code);
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    word-wrap: normal;
+    line-height: 1.4;
+    tab-size: 4;
+  }
+  code.hljs {
+    font-size: var(--scalar-small);
+    font-family: var(--scalar-font-code);
+    display: inline-block;
+    counter-reset: linenumber;
+  }
+  .hljs {
+    background: transparent;
+    color: var(--scalar-color-2);
+  }
 
-/** For HTML we leave the content strings brighter */
-.hljs.language-html {
-  color: var(--scalar-color-1);
-}
+  .hljs .line::before {
+    color: var(--scalar-color-3);
+    display: inline-block;
+    counter-increment: linenumber;
+    content: counter(linenumber);
+    margin-right: 0.7em;
+    /* Variable is set on the code element by the plugin when line numbers are used */
+    min-width: calc(var(--line-digits) * 1ch);
+    text-align: right;
+  }
+  /* ------------------------------------------------------------- */
+  /* Data types */
+  .hljs-comment,
+  .hljs-quote {
+    color: var(--scalar-color-3);
+    font-style: italic;
+  }
 
-/** For HTML make the attr text different than the content */
-.hljs.language-html .hljs-attr {
-  color: var(--scalar-color-2);
-}
+  .hljs-number {
+    color: var(--scalar-color-orange);
+  }
 
-.hljs.language-curl .hljs-keyword {
-  color: var(--scalar-color-orange);
-}
+  .hljs-regexp,
+  .hljs-string {
+    color: var(--scalar-color-blue);
+  }
 
-.hljs.language-curl .hljs-string {
-  color: var(--scalar-color-1);
-}
+  /** Globals such as `var()` and `!important` */
+  .hljs-built_in {
+    color: var(--scalar-color-blue);
+  }
 
-.hljs.language-curl .hljs-literal {
-  color: var(--scalar-color-blue);
-}
+  /** Class initializers such as `Array` or `Date` */
+  /** Type declarations such as `Record` */
+  .hljs-title.class_ {
+    color: var(--scalar-color-1);
+  }
 
-.hljs.language-curl .hljs-literal {
-  color: var(--scalar-color-blue);
-}
+  /** Language indicators such as `new`, `const`, or `function` in JS  */
+  .hljs-keyword {
+    color: var(--scalar-color-purple);
+  }
 
-/** Compromise here */
-.hljs.language-cpp .hljs-built_in {
-  /* color: var(--scalar-color-1); */
-}
+  /** Function names when declaring and calling */
+  .hljs-title.function_ {
+    color: var(--scalar-color-orange);
+  }
 
-.hljs.language-php .hljs-variable {
-  color: var(--scalar-color-blue);
-}
+  /** Template substitution */
+  .hljs-subst {
+    color: var(--scalar-color-blue);
+  }
 
-.hljs.language-objectivec .hljs-meta {
-  color: var(--scalar-color-1);
-}
+  /** HTML Tag name */
+  .hljs-name {
+    color: var(--scalar-color-blue);
+  }
 
-.hljs.language-objectivec .hljs-built_in {
-  color: var(--scalar-color-orange);
-}
+  /** Attribute name (ex. `class`, `id`) */
+  .hljs-attr,
+  .hljs-attribute {
+    color: var(--scalar-color-1);
+  }
 
-.hljs-built_in {
-  color: var(--scalar-color-orange);
-}
+  .hljs-addition,
+  .hljs-literal,
+  .hljs-selector-tag,
+  .hljs-type {
+    color: var(--scalar-color-green);
+  }
 
-.markdown {
-  font-family: var(--scalar-font);
-  color: var(--scalar-color-1);
-  word-break: break-word;
-}
+  .hljs-selector-attr,
+  .hljs-selector-pseudo {
+    color: var(--scalar-color-orange);
+  }
+  .hljs-doctag {
+    color: var(--scalar-color-blue);
+  }
 
-/* Apply base padding for all block elements */
-.markdown h1,
-.markdown h2,
-.markdown h3,
-.markdown h4,
-.markdown h5,
-.markdown h6,
-.markdown p,
-.markdown div,
-.markdown img,
-.markdown details,
-.markdown summary,
-.markdown ul,
-.markdown ol,
-.markdown table,
-.markdown blockquote,
-.markdown code {
-  margin: 12px 0;
-}
+  .hljs-section,
+  .hljs-title {
+    color: var(--scalar-color-blue);
+  }
 
-.markdown details {
-  margin: 12px 0;
-  color: var(--scalar-color-1);
-}
-.markdown summary {
-  display: block;
-  margin: 12px 0;
-  padding-left: 20px;
-  position: relative;
-  font-weight: var(--scalar-semibold);
-  cursor: pointer;
-  user-select: none;
-}
+  .hljs-selector-id,
+  .hljs-template-variable,
+  .hljs-variable {
+    color: var(--scalar-color-1);
+  }
 
-.markdown summary::after {
-  display: block;
-  content: '';
+  .hljs-name,
+  .hljs-section,
+  .hljs-strong {
+    font-weight: var(--scalar-semibold);
+  }
 
-  position: absolute;
-  top: 1px;
-  left: 1px;
+  .hljs-bullet,
+  .hljs-link,
+  .hljs-meta,
+  .hljs-symbol {
+    color: var(--scalar-color-blue);
+  }
 
-  width: 16px;
-  height: 16px;
+  .hljs-deletion {
+    color: var(--scalar-color-red);
+  }
 
-  background-color: var(--scalar-color-3);
-  mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.25 19.5L15.75 12L8.25 4.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>');
-}
+  .hljs-formula {
+    background: var(--scalar-color-1);
+  }
 
-.markdown summary:hover::after {
-  background-color: var(--scalar-color-1);
-}
+  .hljs-emphasis {
+    font-style: italic;
+  }
 
-.markdown details[open] summary::after {
-  transform: rotate(90deg);
-}
+  /* -------------------------------------------------------------- */
+  /* Language specific overrides */
 
-/* Fix for Safari displaying default caret next to `<summary>` */
-.markdown summary::-webkit-details-marker {
-  display: none;
-}
+  /** For HTML we leave the content strings brighter */
+  .hljs.language-html {
+    color: var(--scalar-color-1);
+  }
 
-.markdown img {
-  overflow: hidden;
-  border-radius: var(--scalar-radius);
-  max-width: 100%;
-}
-/* Don't add margin to the first block */
-.markdown > :first-child {
-  margin-top: 0;
-}
+  /** For HTML make the attr text different than the content */
+  .hljs.language-html .hljs-attr {
+    color: var(--scalar-color-2);
+  }
 
-.markdown h1 {
-  --font-size: 1.4em;
-}
+  .hljs.language-curl .hljs-keyword {
+    color: var(--scalar-color-orange);
+  }
 
-.markdown h2 {
-  --font-size: 1.25em;
-}
+  .hljs.language-curl .hljs-string {
+    color: var(--scalar-color-1);
+  }
 
-.markdown h3 {
-  --font-size: 1.1em;
-}
+  .hljs.language-curl .hljs-literal {
+    color: var(--scalar-color-blue);
+  }
 
-.markdown h4 {
-  --font-size: 1em;
-}
+  .hljs.language-curl .hljs-literal {
+    color: var(--scalar-color-blue);
+  }
 
-.markdown h6 {
-  --font-size: 1em;
-}
-.markdown h1,
-.markdown h2,
-.markdown h3,
-.markdown h4,
-.markdown h5,
-.markdown h6 {
-  font-size: var(--font-size);
-  margin: 18px 0 6px;
-  font-weight: var(--scalar-bold);
-  display: block;
-  line-height: 1.45;
-}
-.markdown b,
-.markdown strong {
-  font-weight: var(--scalar-bold);
-}
-.markdown p {
-  color: var(--scalar-color-1);
-  font-weight: var(--font-weight, var(--scalar-regular));
-  line-height: 1.5;
-  margin-bottom: 0;
-  display: block;
-}
+  /** Compromise here */
+  .hljs.language-cpp .hljs-built_in {
+    /* color: var(--scalar-color-1); */
+  }
 
-.markdown ul,
-.markdown ol {
-  padding-left: 24px;
-  line-height: 1.5;
-  margin: 12px 0;
-  display: block;
-}
+  .hljs.language-php .hljs-variable {
+    color: var(--scalar-color-blue);
+  }
 
-.markdown ul {
-  list-style: disc;
-}
+  .hljs.language-objectivec .hljs-meta {
+    color: var(--scalar-color-1);
+  }
 
-.markdown ol {
-  list-style: decimal;
-}
+  .hljs.language-objectivec .hljs-built_in {
+    color: var(--scalar-color-orange);
+  }
 
-.markdown ul.contains-task-list {
-  list-style: none;
-  padding-left: 0;
-}
+  .hljs-built_in {
+    color: var(--scalar-color-orange);
+  }
 
-.markdown li {
-  margin: 6px 0;
-  display: list-item;
-}
-.markdown a {
-  color: var(--scalar-color-accent);
-  text-decoration: var(--scalar-text-decoration);
-  cursor: pointer;
-}
-.markdown a:hover {
-  text-decoration: var(--scalar-text-decoration-hover);
-}
-.markdown em {
-  font-style: italic;
-}
-.markdown sup {
-  font-size: var(--scalar-micro);
-  vertical-align: super;
-  font-weight: 450;
-}
-.markdown sub {
-  font-size: var(--scalar-micro);
-  vertical-align: sub;
-  font-weight: 450;
-}
-.markdown del {
-  text-decoration: line-through;
-}
-.markdown code {
-  font-family: var(--scalar-font-code);
-  background-color: var(--scalar-background-2);
-  box-shadow: 0 0 0 1px var(--scalar-border-color);
-  font-size: var(--scalar-micro);
-  border-radius: 2px;
-  padding: 0 3px;
-}
+  .markdown {
+    font-family: var(--scalar-font);
+    color: var(--scalar-color-1);
+    word-break: break-word;
+  }
 
-.markdown pre code {
-  display: block;
-  white-space: pre;
-  padding: 12px;
-  line-height: 1.5;
-  margin: 12px 0;
-  -webkit-overflow-scrolling: touch;
-  overflow-x: auto;
-  max-width: 100%;
-  min-width: 100px;
-}
+  /* Apply base padding for all block elements */
+  .markdown h1,
+  .markdown h2,
+  .markdown h3,
+  .markdown h4,
+  .markdown h5,
+  .markdown h6,
+  .markdown p,
+  .markdown div,
+  .markdown img,
+  .markdown details,
+  .markdown summary,
+  .markdown ul,
+  .markdown ol,
+  .markdown table,
+  .markdown blockquote,
+  .markdown code {
+    margin: 12px 0;
+  }
 
-.markdown hr {
-  border: none;
-  border-bottom: 1px solid var(--scalar-border-color);
-}
+  .markdown details {
+    margin: 12px 0;
+    color: var(--scalar-color-1);
+  }
+  .markdown summary {
+    display: block;
+    margin: 12px 0;
+    padding-left: 20px;
+    position: relative;
+    font-weight: var(--scalar-semibold);
+    cursor: pointer;
+    user-select: none;
+  }
 
-.markdown blockquote {
-  border-left: 3px solid var(--scalar-border-color);
-  padding-left: 12px;
-  margin: 0;
-  display: block;
-}
+  .markdown summary::after {
+    display: block;
+    content: '';
 
-.markdown table {
-  display: block;
-  overflow-x: auto;
-  position: relative;
-  border-collapse: collapse;
-  width: max-content;
-  max-width: 100%;
-  margin: 1em 0;
-  box-shadow: 0 0 0 1px var(--scalar-border-color);
-  border-radius: var(--scalar-radius-lg);
-}
-.markdown tbody {
-  display: table-row-group;
-  vertical-align: middle;
-}
-.markdown thead {
-  display: table-header-group;
-  vertical-align: middle;
-}
+    position: absolute;
+    top: 1px;
+    left: 1px;
 
-.markdown tr {
-  display: table-row;
-  border-color: inherit;
-  vertical-align: inherit;
-}
-.markdown td,
-.markdown th {
-  display: table-cell;
-  vertical-align: inherit;
-  min-width: 1em;
-  padding: 6px 9px;
-  vertical-align: top;
-  line-height: 1.5;
-  position: relative;
-  word-break: initial;
-  font-size: var(--scalar-small);
-  color: var(--scalar-color-1);
-  font-weight: var(--font-weight, var(--scalar-regular));
-  border-right: 1px solid var(--scalar-border-color);
-  border-bottom: 1px solid var(--scalar-border-color);
-}
+    width: 16px;
+    height: 16px;
 
-.markdown td > *,
-.markdown th > * {
-  margin-bottom: 0;
-}
-.markdown th:empty {
-  display: none;
-}
-.markdown td:first-of-type,
-.markdown th:first-of-type {
-  border-left: none;
-}
+    background-color: var(--scalar-color-3);
+    mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.25 19.5L15.75 12L8.25 4.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  }
 
-.markdown td:last-of-type,
-.markdown th:last-of-type {
-  border-right: none;
-}
+  .markdown summary:hover::after {
+    background-color: var(--scalar-color-1);
+  }
 
-.markdown tr:last-of-type td {
-  border-bottom: none;
-}
+  .markdown details[open] summary::after {
+    transform: rotate(90deg);
+  }
 
-.markdown th {
-  font-weight: var(--scalar-semibold) !important;
-  text-align: left;
-  border-left-color: transparent;
-  background: var(--scalar-background-2);
-}
+  /* Fix for Safari displaying default caret next to `<summary>` */
+  .markdown summary::-webkit-details-marker {
+    display: none;
+  }
 
-.markdown tr > [align='left'] {
-  text-align: left;
-}
-.markdown tr > [align='right'] {
-  text-align: right;
-}
-.markdown tr > [align='center'] {
-  text-align: center;
+  .markdown img {
+    overflow: hidden;
+    border-radius: var(--scalar-radius);
+    max-width: 100%;
+  }
+  /* Don't add margin to the first block */
+  .markdown > :first-child {
+    margin-top: 0;
+  }
+
+  .markdown h1 {
+    --font-size: 1.4em;
+  }
+
+  .markdown h2 {
+    --font-size: 1.25em;
+  }
+
+  .markdown h3 {
+    --font-size: 1.1em;
+  }
+
+  .markdown h4 {
+    --font-size: 1em;
+  }
+
+  .markdown h6 {
+    --font-size: 1em;
+  }
+  .markdown h1,
+  .markdown h2,
+  .markdown h3,
+  .markdown h4,
+  .markdown h5,
+  .markdown h6 {
+    font-size: var(--font-size);
+    margin: 18px 0 6px;
+    font-weight: var(--scalar-bold);
+    display: block;
+    line-height: 1.45;
+  }
+  .markdown b,
+  .markdown strong {
+    font-weight: var(--scalar-bold);
+  }
+  .markdown p {
+    color: var(--scalar-color-1);
+    font-weight: var(--font-weight, var(--scalar-regular));
+    line-height: 1.5;
+    margin-bottom: 0;
+    display: block;
+  }
+
+  .markdown ul,
+  .markdown ol {
+    padding-left: 24px;
+    line-height: 1.5;
+    margin: 12px 0;
+    display: block;
+  }
+
+  .markdown ul {
+    list-style: disc;
+  }
+
+  .markdown ol {
+    list-style: decimal;
+  }
+
+  .markdown ul.contains-task-list {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  .markdown li {
+    margin: 6px 0;
+    display: list-item;
+  }
+  .markdown a {
+    color: var(--scalar-color-accent);
+    text-decoration: var(--scalar-text-decoration);
+    cursor: pointer;
+  }
+  .markdown a:hover {
+    text-decoration: var(--scalar-text-decoration-hover);
+  }
+  .markdown em {
+    font-style: italic;
+  }
+  .markdown sup {
+    font-size: var(--scalar-micro);
+    vertical-align: super;
+    font-weight: 450;
+  }
+  .markdown sub {
+    font-size: var(--scalar-micro);
+    vertical-align: sub;
+    font-weight: 450;
+  }
+  .markdown del {
+    text-decoration: line-through;
+  }
+  .markdown code {
+    font-family: var(--scalar-font-code);
+    background-color: var(--scalar-background-2);
+    box-shadow: 0 0 0 1px var(--scalar-border-color);
+    font-size: var(--scalar-micro);
+    border-radius: 2px;
+    padding: 0 3px;
+  }
+
+  .markdown pre code {
+    display: block;
+    white-space: pre;
+    padding: 12px;
+    line-height: 1.5;
+    margin: 12px 0;
+    -webkit-overflow-scrolling: touch;
+    overflow-x: auto;
+    max-width: 100%;
+    min-width: 100px;
+  }
+
+  .markdown hr {
+    border: none;
+    border-bottom: 1px solid var(--scalar-border-color);
+  }
+
+  .markdown blockquote {
+    border-left: 3px solid var(--scalar-border-color);
+    padding-left: 12px;
+    margin: 0;
+    display: block;
+  }
+
+  .markdown table {
+    display: block;
+    overflow-x: auto;
+    position: relative;
+    border-collapse: collapse;
+    width: max-content;
+    max-width: 100%;
+    margin: 1em 0;
+    box-shadow: 0 0 0 1px var(--scalar-border-color);
+    border-radius: var(--scalar-radius-lg);
+  }
+  .markdown tbody {
+    display: table-row-group;
+    vertical-align: middle;
+  }
+  .markdown thead {
+    display: table-header-group;
+    vertical-align: middle;
+  }
+
+  .markdown tr {
+    display: table-row;
+    border-color: inherit;
+    vertical-align: inherit;
+  }
+  .markdown td,
+  .markdown th {
+    display: table-cell;
+    vertical-align: inherit;
+    min-width: 1em;
+    padding: 6px 9px;
+    vertical-align: top;
+    line-height: 1.5;
+    position: relative;
+    word-break: initial;
+    font-size: var(--scalar-small);
+    color: var(--scalar-color-1);
+    font-weight: var(--font-weight, var(--scalar-regular));
+    border-right: 1px solid var(--scalar-border-color);
+    border-bottom: 1px solid var(--scalar-border-color);
+  }
+
+  .markdown td > *,
+  .markdown th > * {
+    margin-bottom: 0;
+  }
+  .markdown th:empty {
+    display: none;
+  }
+  .markdown td:first-of-type,
+  .markdown th:first-of-type {
+    border-left: none;
+  }
+
+  .markdown td:last-of-type,
+  .markdown th:last-of-type {
+    border-right: none;
+  }
+
+  .markdown tr:last-of-type td {
+    border-bottom: none;
+  }
+
+  .markdown th {
+    font-weight: var(--scalar-semibold) !important;
+    text-align: left;
+    border-left-color: transparent;
+    background: var(--scalar-background-2);
+  }
+
+  .markdown tr > [align='left'] {
+    text-align: left;
+  }
+  .markdown tr > [align='right'] {
+    text-align: right;
+  }
+  .markdown tr > [align='center'] {
+    text-align: center;
+  }
 }


### PR DESCRIPTION
Scopes the Docusaurus theme styles so they don't spill out of the references.

Fixes #2447

## Before

<img width="1409" alt="Google Chrome-2024-07-10-17-34-01@2x" src="https://github.com/scalar/scalar/assets/6374090/ea50d474-deaa-459c-ac18-83450a285af7">
<img width="1409" alt="Google Chrome-2024-07-10-17-34-08@2x" src="https://github.com/scalar/scalar/assets/6374090/cf5cd8a9-d235-4824-a140-d0b8b2db9a29">

## After

<img width="1409" alt="Google Chrome-2024-07-10-17-44-01@2x" src="https://github.com/scalar/scalar/assets/6374090/12a9b1cf-3c44-4fa8-a229-5f28d680ecfc">
<img width="1365" alt="Google Chrome-2024-07-10-17-44-18@2x" src="https://github.com/scalar/scalar/assets/6374090/f101b138-04d0-4fef-a3c9-9e325028c86f">
