### PR TITLE
feat(api-client): input select for enum and boolean

### DIFF
--- a/.changeset/lovely-garlics-buy.md
+++ b/.changeset/lovely-garlics-buy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: display select for boolean type

--- a/.changeset/wild-lies-cover.md
+++ b/.changeset/wild-lies-cover.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: data table input enum select back

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -26,6 +26,7 @@ const props = withDefaults(
     disableEnter?: boolean
     disableCloseBrackets?: boolean
     enum?: string[]
+    type?: string
   }>(),
   {
     disableCloseBrackets: false,
@@ -119,6 +120,12 @@ export default {
     <DataTableInputSelect
       :modelValue="props.modelValue"
       :value="props.enum"
+      @update:modelValue="emit('update:modelValue', $event)" />
+  </template>
+  <template v-else-if="props.type === 'boolean'">
+    <DataTableInputSelect
+      :modelValue="props.modelValue"
+      :value="['true', 'false']"
       @update:modelValue="emit('update:modelValue', $event)" />
   </template>
   <template v-else>

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -6,7 +6,7 @@ import {
   type Extension,
 } from '@scalar/use-codemirror'
 import { nanoid } from 'nanoid'
-import { ref, toRef, useAttrs, watch, type Ref } from 'vue'
+import { ref, toRef, useAttrs, watch, type Ref, computed } from 'vue'
 import DataTableInputSelect from '../DataTable/DataTableInputSelect.vue'
 
 const props = withDefaults(
@@ -27,6 +27,7 @@ const props = withDefaults(
     disableCloseBrackets?: boolean
     enum?: string[]
     type?: string
+    nullable?: boolean
   }>(),
   {
     disableCloseBrackets: false,
@@ -34,6 +35,7 @@ const props = withDefaults(
     disableTabIndent: false,
     emitOnBlur: true,
     colorPicker: false,
+    nullable: false,
   },
 )
 const emit = defineEmits<{
@@ -108,6 +110,15 @@ watch(codeMirror, () => {
     codeMirror.value.focus()
   }
 })
+
+// Computed property to check if type is boolean and nullable
+const booleanOptions = computed(() => {
+  return props.type === 'boolean' ||
+    props.type?.includes('boolean') ||
+    props.nullable
+    ? ['true', 'false', 'null']
+    : ['true', 'false']
+})
 </script>
 <script lang="ts">
 // use normal <script> to declare options
@@ -122,10 +133,11 @@ export default {
       :value="props.enum"
       @update:modelValue="emit('update:modelValue', $event)" />
   </template>
-  <template v-else-if="props.type === 'boolean'">
+  <template
+    v-else-if="props.type === 'boolean' || props.type?.includes('boolean')">
     <DataTableInputSelect
       :modelValue="props.modelValue"
-      :value="['true', 'false']"
+      :value="booleanOptions"
       @update:modelValue="emit('update:modelValue', $event)" />
   </template>
   <template v-else>

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -7,6 +7,7 @@ import {
 } from '@scalar/use-codemirror'
 import { nanoid } from 'nanoid'
 import { ref, toRef, useAttrs, watch, type Ref } from 'vue'
+import DataTableInputSelect from '../DataTable/DataTableInputSelect.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -24,6 +25,7 @@ const props = withDefaults(
     required?: boolean
     disableEnter?: boolean
     disableCloseBrackets?: boolean
+    enum?: string[]
   }>(),
   {
     disableCloseBrackets: false,
@@ -113,14 +115,22 @@ export default {
 }
 </script>
 <template>
-  <div
-    :id="uid"
-    v-bind="$attrs"
-    ref="codeMirrorRef"
-    class="peer font-code w-full whitespace-nowrap text-xs leading-[1.44] relative"
-    :class="{
-      'flow-code-input--error': error,
-    }"></div>
+  <template v-if="props.enum && props.enum.length">
+    <DataTableInputSelect
+      :modelValue="props.modelValue"
+      :value="props.enum"
+      @update:modelValue="emit('update:modelValue', $event)" />
+  </template>
+  <template v-else>
+    <div
+      :id="uid"
+      v-bind="$attrs"
+      ref="codeMirrorRef"
+      class="peer font-code w-full whitespace-nowrap text-xs leading-[1.44] relative"
+      :class="{
+        'flow-code-input--error': error,
+      }"></div>
+  </template>
   <div
     v-if="$slots.warning"
     class="absolute centered-y right-7 text-orange text-xs">
@@ -138,7 +148,6 @@ export default {
  Deep styling for customizing Codemirror
 */
 :deep(.cm-editor) {
-  background-color: transparent;
   height: 100%;
   outline: none;
   padding: 3px 0;

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -4,7 +4,7 @@ import { ScalarIconButton } from '@scalar/components'
 import { computed, ref } from 'vue'
 
 import DataTableCell from './DataTableCell.vue'
-import DataTableInputEnumSelect from './DataTableInputEnumSelect.vue'
+import DataTableInputSelect from './DataTableInputSelect.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -78,9 +78,9 @@ const handleDropdownMouseUp = () => {
     </div>
     <div class="row-1">
       <template v-if="props.enum && props.enum.length">
-        <DataTableInputEnumSelect
-          :enum="props.enum"
+        <DataTableInputSelect
           :modelValue="props.modelValue"
+          :value="props.enum"
           @update:modelValue="emit('update:modelValue', $event)" />
       </template>
       <template v-else>

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -6,7 +6,7 @@ import {
   ScalarDropdownItem,
   ScalarIcon,
 } from '@scalar/components'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 
 const props = defineProps<{
   modelValue: string | number
@@ -22,6 +22,7 @@ const options = computed(() => props.value ?? [])
 const selected = ref<string>(props.modelValue.toString())
 const addingCustomValue = ref(false)
 const customValue = ref('')
+const inputRef = ref<HTMLInputElement | null>(null)
 
 watch(customValue, (newValue) => {
   emit('update:modelValue', newValue)
@@ -50,12 +51,21 @@ const handleBlur = () => {
 const isSelected = (value: string) => {
   return selected.value === value
 }
+
+watch(addingCustomValue, (newValue) => {
+  if (newValue) {
+    nextTick(() => {
+      inputRef.value?.focus()
+    })
+  }
+})
 </script>
 
 <template>
   <div class="w-full">
     <template v-if="addingCustomValue">
       <input
+        ref="inputRef"
         v-model="customValue"
         class="border-none focus:text-c-1 text-c-2 min-w-0 w-full px-2 py-1.5 outline-none"
         placeholder="Value"

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -10,14 +10,14 @@ import { computed, ref, watch } from 'vue'
 
 const props = defineProps<{
   modelValue: string | number
-  enum?: string[]
+  value?: string[]
 }>()
 
 const emit = defineEmits<{
   (e: 'update:modelValue', v: string): void
 }>()
 
-const options = computed(() => props.enum ?? [])
+const options = computed(() => props.value ?? [])
 
 const selected = ref<string>(props.modelValue.toString())
 const addingCustomValue = ref(false)

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -202,6 +202,7 @@ const createParamInstance = (param: OpenAPIV3_1.ParameterObject) =>
     minimum: param.schema?.minimum,
     maximum: param.schema?.maximum,
     default: param.schema?.default,
+    nullable: param.schema?.nullable,
   })
 
 /**

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -106,6 +106,7 @@ const flattenValue = (item: RequestExampleParameter) => {
           :max="item.maximum"
           :min="item.minimum"
           :modelValue="item.value"
+          :nullable="item.nullable"
           placeholder="Value"
           :type="item.type"
           @blur="emit('inputBlur')"

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -107,7 +107,7 @@ const flattenValue = (item: RequestExampleParameter) => {
           :min="item.minimum"
           :modelValue="item.value"
           placeholder="Value"
-          :type="item.type === 'integer' ? 'number' : 'text'"
+          :type="item.type"
           @blur="emit('inputBlur')"
           @focus="emit('inputFocus')"
           @input="items && idx === items.length - 1 && emit('addRow')"
@@ -164,6 +164,7 @@ const flattenValue = (item: RequestExampleParameter) => {
   padding: 0;
 }
 :deep(.cm-content) {
+  background-color: var(--scalar-background-1);
   font-family: var(--scalar-font);
   font-size: var(--scalar-mini);
   padding: 6px 8px;

--- a/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
@@ -17,6 +17,7 @@ const requestExampleParametersSchema = z.object({
   minimum: z.number().optional(),
   maximum: z.number().optional(),
   default: z.any().optional(),
+  nullable: z.boolean().optional(),
 })
 
 /** Request examples - formerly known as instances - are "children" of requests */


### PR DESCRIPTION
this pr makes the previous data table input enum select more generic, add it to the code input component to bring back the enum support while bringing it to boolean type in the meantime:

<img width="686" alt="image" src="https://github.com/scalar/scalar/assets/14966155/c9baafd5-fa8d-4062-a99d-ae3f873bf150">
