### PR TITLE
fix(api-client): remove timeline scrollbar offset

### DIFF
--- a/.changeset/angry-kiwis-report.md
+++ b/.changeset/angry-kiwis-report.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: address bar scrollbar shown offset

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -161,7 +161,8 @@ const handlePaste = (event: ClipboardEvent) => {
               @change="updateRequestMethod" />
             <AddressBarServer />
           </div>
-          <div class="custom-scroll scroll-timeline-x relative flex w-full">
+          <div
+            class="scroll-timeline-x scroll-timeline-x-hidden relative flex w-full">
             <div class="fade-left"></div>
 
             <!-- TODO wrap vars in spans for special effects like mouseOver descriptions -->
@@ -207,6 +208,14 @@ const handlePaste = (event: ClipboardEvent) => {
   /* Firefox supports */
   scroll-timeline: --scroll-timeline horizontal;
   -ms-overflow-style: none; /* IE and Edge */
+}
+.scroll-timeline-x-hidden {
+  overflow: auto;
+  scrollbar-width: none;
+}
+.scroll-timeline-x-hidden::-webkit-scrollbar {
+  width: 0;
+  height: 0;
 }
 .scroll-timeline-x-address {
   line-height: 27px;


### PR DESCRIPTION
fixes scrollbar shown offset

before:
<img width="508" alt="image" src="https://github.com/scalar/scalar/assets/6201407/c4402702-5c63-4480-9cc1-75a5d95375ad">

after:
<img width="550" alt="image" src="https://github.com/scalar/scalar/assets/6201407/a000636a-2d02-4d76-87ed-1def7a184289">
