### PR TITLE
fix(themes): switch from font-size unset to inherit

### DIFF
--- a/.changeset/wise-ants-rescue.md
+++ b/.changeset/wise-ants-rescue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix: switch from font-size unset to inherit

--- a/packages/themes/src/reset.css
+++ b/packages/themes/src/reset.css
@@ -32,7 +32,7 @@
     font-family: inherit;
     font-feature-settings: inherit;
     font-variation-settings: inherit;
-    font-size: unset;
+    font-size: inherit;
     font-weight: inherit;
     line-height: inherit;
     color: inherit;


### PR DESCRIPTION
This is _probably_ what this should be otherwise we sometimes get unexpected behaviour where the font size reverts to the browser default of 16px on certain elements.

I checked and I don't think this should break anything.