### PR TITLE
fix(api-client): input checked by default if required

### DIFF
--- a/.changeset/clean-papayas-call.md
+++ b/.changeset/clean-papayas-call.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: input checked by default on required item

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -79,7 +79,7 @@ const flattenValue = (item: RequestExampleParameter) => {
       :key="idx">
       <DataTableCheckbox
         v-if="!isEnabledHidden"
-        :modelValue="item.enabled"
+        :modelValue="!!item.required"
         @update:modelValue="(v) => emit('toggleRow', idx, v)" />
       <DataTableCell>
         <CodeInput


### PR DESCRIPTION
this pr fixes #2467 and checked here by default only required item.