### PR TITLE
fix: make default tag check computed for reactivity bugs

### DIFF
--- a/.changeset/small-lamps-sip.md
+++ b/.changeset/small-lamps-sip.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: make default tag check computed for reactivity bugs

--- a/packages/api-reference/src/components/Content/Tag/Tag.vue
+++ b/packages/api-reference/src/components/Content/Tag/Tag.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Spec, Tag } from '@scalar/oas-utils'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import { useNavState, useSidebar } from '../../../hooks'
 import { SectionContainer } from '../../Section'
@@ -19,10 +19,12 @@ const sectionContainerRef = ref<HTMLElement | null>(null)
 const { collapsedSidebarItems } = useSidebar()
 const { getTagId } = useNavState()
 
-const moreThanOneDefaultTag = (tag: Tag) =>
-  props.spec.tags?.length !== 1 ||
-  tag?.name !== 'default' ||
-  tag?.description !== ''
+const moreThanOneDefaultTag = computed(
+  () =>
+    props.spec.tags?.length !== 1 ||
+    props.tag?.name !== 'default' ||
+    props.tag?.description !== '',
+)
 
 const redirectToOperation = (operationId: string) => {
   window.location.href = `#${operationId}`
@@ -56,7 +58,7 @@ const observeAndNavigate = (operationId: string) => {
     ref="sectionContainerRef"
     class="tag-section-container">
     <Endpoints
-      v-if="moreThanOneDefaultTag(tag)"
+      v-if="moreThanOneDefaultTag"
       :id="id"
       :tag="tag"
       @observeAndNavigate="observeAndNavigate" />


### PR DESCRIPTION
**Problem**
Currently in the docs we lose reactivity for the show more button

**Explanation**
This happens because onMounted post parsedSpec

**Solution**
With this PR we make it a computed property just incase : )
