### PR TITLE
fix(client-app): codemirror bg color

### DIFF
--- a/.changeset/lucky-candles-give.md
+++ b/.changeset/lucky-candles-give.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: api client codemirror bg color

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -170,6 +170,7 @@ export default {
   height: 100%;
   outline: none;
   padding: 3px 0;
+  background: transparent;
 }
 :deep(.cm-content) {
   font-family: var(--scalar-font-code);


### PR DESCRIPTION
before:
<img width="628" alt="image" src="https://github.com/user-attachments/assets/2ded5986-2740-4ef4-bf44-74e683be2cd5">

after:
<img width="583" alt="image" src="https://github.com/user-attachments/assets/f82b61e9-a7c5-42f4-90be-91dbdbdad96b">
