### PR TITLE
fix: add max height to search modal

### DIFF
--- a/.changeset/twelve-keys-push.md
+++ b/.changeset/twelve-keys-push.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: add max height to search modal

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -121,6 +121,7 @@ export const useModal = () =>
 }
 .scalar-modal.scalar-modal-search {
   max-width: 540px;
+  max-height: 540px;
   background-color: transparent;
 }
 .modal-content-search .modal-body {


### PR DESCRIPTION

can make it better later but marc-gpt css has been implemented

before:
![image](https://github.com/user-attachments/assets/31ef36b3-a449-49c4-a413-a041d8f907fe)


after:
![image](https://github.com/user-attachments/assets/d2848589-d1eb-40cc-9bef-28c89a746a52)
