### PR TITLE
fix: only add body data if body data is not null

### DIFF
--- a/.changeset/quiet-gorillas-float.md
+++ b/.changeset/quiet-gorillas-float.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: only add body data if body data is not null

--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -67,7 +67,7 @@ export const sendRequest = async (
     headers['Content-Disposition'] =
       `attachment; filename="${example.body.binary.name}"`
     data = example.body.binary
-  } else if (example.body.activeBody === 'raw') {
+  } else if (example.body.activeBody === 'raw' && example.body.raw.value) {
     data = example.body.raw.value
   } else if (example.body.activeBody === 'formData') {
     headers['Content-Type'] = 'multipart/form-data'
@@ -180,8 +180,10 @@ export const sendRequest = async (
     url: redirectToProxy(proxyUrl, url),
     method: request.method,
     headers,
-    data,
   }
+
+  console.log(data)
+  if (data) config.data = data
 
   // Start timer to get response duration
   const startTime = Date.now()

--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -182,7 +182,6 @@ export const sendRequest = async (
     headers,
   }
 
-  console.log(data)
   if (data) config.data = data
 
   // Start timer to get response duration


### PR DESCRIPTION
**Problem**
Currently we always send the body on http requests

**Explanation**
This happens because we dont do any null checks

**Solution**
With this PR we null check and only add it the body is not null
