### PR TITLE
fix(api-client): update active body when content type changes

### DIFF
--- a/.changeset/late-keys-push.md
+++ b/.changeset/late-keys-push.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: update active body when content type changes

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -180,6 +180,24 @@ const updateRequestBody = (content: string) => {
 //   )
 // }
 
+const updateActiveBody = (type: keyof typeof contentTypeOptions) => {
+  let bodyType: 'raw' | 'formData' | 'binary' = 'raw'
+
+  if (type === 'multipartForm' || type === 'formUrlEncoded') {
+    bodyType = 'formData'
+  } else if (type === 'binaryFile') {
+    bodyType = 'binary'
+  } else {
+    bodyType = 'raw'
+  }
+
+  requestExampleMutators.edit(
+    activeExample.value.uid,
+    'body.activeBody',
+    bodyType,
+  )
+}
+
 const handleFileUploadFormData = async (rowIdx: number) => {
   const { open } = useFileDialog({
     onChange: async (files) => {
@@ -295,6 +313,7 @@ watch(
     if (val === 'multipartForm' || val === 'formUrlEncoded') {
       defaultRow()
     }
+    updateActiveBody(val)
   },
   { immediate: true },
 )


### PR DESCRIPTION
**Problem**
Currently, when I test a request and the content type of the body is JSON, changing the content type of the body to others, such as multipart/form-data, does not update the activeBody. This results in the body remaining as JSON when the request is sent.

**Solution**
With this PR, I have added a function to update the activeBody when the content type changes.

This is my second contribution. If there's anything else, you can let me know. 😅

![Screenshot 2567-07-14 at 21 27 40](https://github.com/user-attachments/assets/fc08f377-7135-4d52-aae5-cbfa871eb690)
![Screenshot 2567-07-14 at 21 27 51](https://github.com/user-attachments/assets/61a3b357-cf92-41da-a64f-68d964bb1fe1)

