### PR TITLE
fix: add reply response in fastify-api-reference example.

### DIFF
--- a/examples/fastify-api-reference/src/index.ts
+++ b/examples/fastify-api-reference/src/index.ts
@@ -27,7 +27,7 @@ await fastify.register(fastifySwagger, {
 })
 
 // Add some routes
-fastify.put(
+fastify.put<{ Body: { hello: string; obj?: { some?: string } } }>(
   '/example-route/:id',
   {
     schema: {
@@ -54,6 +54,7 @@ fastify.put(
             },
           },
         },
+        required: ['hello'],
       },
       response: {
         201: {
@@ -66,7 +67,9 @@ fastify.put(
       },
     },
   },
-  () => {},
+  (req, reply) => {
+    reply.code(201).send({ hello: `Hello ${req.body.hello}` })
+  },
 )
 
 // Add the plugin

--- a/examples/fastify-api-reference/src/index.ts
+++ b/examples/fastify-api-reference/src/index.ts
@@ -37,7 +37,10 @@ fastify.put<{ Body: { name: string } }>(
       body: {
         type: 'object',
         properties: {
-          name: { type: 'string' },
+          name: {
+            type: 'string',
+            examples: ['Marc'],
+          },
         },
         required: ['name'],
       },

--- a/examples/fastify-api-reference/src/index.ts
+++ b/examples/fastify-api-reference/src/index.ts
@@ -27,69 +27,45 @@ await fastify.register(fastifySwagger, {
 })
 
 // Add some routes
-fastify.put<{ Body: { hello: string; obj?: { some?: string } } }>(
-  '/example-route/:id',
+fastify.put<{ Body: { name: string } }>(
+  '/hello',
   {
     schema: {
-      description: 'post some data',
-      tags: ['user', 'code'],
-      summary: 'qwerty',
-      params: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string',
-            description: 'user id',
-          },
-        },
-      },
+      description: 'Greet a user',
+      tags: ['user'],
+      summary: 'Replies with a nice greeting',
       body: {
         type: 'object',
         properties: {
-          hello: { type: 'string' },
-          obj: {
-            type: 'object',
-            properties: {
-              some: { type: 'string' },
-            },
-          },
+          name: { type: 'string' },
         },
-        required: ['hello'],
+        required: ['name'],
       },
       response: {
         201: {
           description: 'Successful response',
           type: 'object',
           properties: {
-            hello: { type: 'string' },
+            greeting: { type: 'string' },
           },
         },
       },
     },
   },
   (req, reply) => {
-    reply.code(201).send({ hello: `Hello ${req.body.hello}` })
+    reply.code(201).send({ greeting: `Hello ${req.body.name}` })
   },
 )
 
 // Add the plugin
 await fastify.register(fastifyApiReference, {
   routePrefix: '/reference',
-  // configuration: {
-  // theme: 'moon',
-  // spec: {
-  // content: { openapi: '3.1.0', info: { title: 'Example' }, paths: {} },
-  // content: () => fastify.swagger(),
-  // url: '/scalar.json',
-  // },
-  // customCss: `body { border: 10px solid red; }`,
-  // },
 })
 
 const PORT = Number(process.env.PORT) || 5053
 const HOST = process.env.HOST || '0.0.0.0'
 
 // Start the server
-fastify.listen({ port: PORT, host: HOST }, function (err, address) {
+fastify.listen({ port: PORT, host: HOST }, function (_, address) {
   console.log(`⚡️ Fastify Plugin running on ${address}/reference`)
 })


### PR DESCRIPTION
**Problem**
Currently, when I try using the example from the `fastify-api-reference` and send a request, I don't get anything because it doesn't return a response and the API request remains pending.

**Solution**
With this PR, I ensure the API responds correctly.

<img width="707" alt="Screenshot 2567-07-15 at 14 27 35" src="https://github.com/user-attachments/assets/c72fa4be-30cb-42ce-8788-c2aa4b765091">

