### PR TITLE
ci: update turborepo cache after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,11 @@ jobs:
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build
         run: pnpm turbo build
+      - name: Update Turborepo cache
+        uses: actions/cache/save@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
 
   format:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
I noticed that the Turborepo cache is (still) not leveraged properly. We’re doing the build and then pick up the cache in other jobs, just to still see a high cache miss rate. Note how the type check and others are still taking forever:

<img width="1146" alt="Screenshot 2024-07-15 at 12 16 04" src="https://github.com/user-attachments/assets/71d9e943-f116-4c49-aeb1-b37f815cef8c">

So I’ve checked the logs and noticed this one in the Post Cache step:

> Cache hit occurred on the primary key turbo-Linux-node-20, not saving cache.

So … it found the cache and decided to not update the cache. This is not what we want. :)

With this PR the cache should be updated after the full build.

For a full-rebuild it looks like this now (notice how the type check and others are way faster):

<img width="1146" alt="Screenshot 2024-07-15 at 12 28 18" src="https://github.com/user-attachments/assets/70a2f3c9-d40a-4a21-b6b9-a6a98a2cbe42">

Because build time is down to 0-1s in those jobs:

<img width="1152" alt="Screenshot 2024-07-15 at 12 30 02" src="https://github.com/user-attachments/assets/69e79d63-832e-4e58-ad3c-64707d5352b3">