### PR TITLE
chore: do not release scalar-api-client

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@scalar-examples/*", "playwright"]
+  "ignore": ["@scalar-examples/*", "playwright", "scalar-api-client"]
 }

--- a/packages/api-client-app/package.json
+++ b/packages/api-client-app/package.json
@@ -5,10 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "engines": {
     "node": ">=20"
   },
+  "private": true,
   "scripts": {
     "build": "npm run typecheck && electron-vite build",
     "build:linux": "npm run build && electron-builder --linux",


### PR DESCRIPTION
This release workflow failed:

> npm error 403 403 Forbidden - PUT https://registry.npmjs.org/scalar-api-client - You may not perform that action with these credentials.

Looks like it tried to publish the scalar-api-client. Let’s set it to private and ignore it for changesets.