### PR TITLE
feat(api-reference): add response schema

### DIFF
--- a/.changeset/soft-jobs-bake.md
+++ b/.changeset/soft-jobs-bake.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/oas-utils': patch
+---
+
+feat: add response schema

--- a/packages/api-reference/src/components/Content/Operation/ContentTypeSelect.vue
+++ b/packages/api-reference/src/components/Content/Operation/ContentTypeSelect.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import type { ContentType, RequestBody } from '@scalar/oas-utils'
+import { computed, defineEmits, ref } from 'vue'
+
+const prop = defineProps<{
+  requestBody?: RequestBody
+  defaultValue?: ContentType
+}>()
+
+const emit = defineEmits<{
+  (e: 'selectContentType', payload: { contentType: ContentType }): void
+}>()
+
+const handleSelectChange = (event: Event) => {
+  const target = event.target as HTMLSelectElement
+  const contentType = target.value as ContentType
+  selectedContentType.value = contentType
+  emit('selectContentType', { contentType })
+}
+
+const contentTypes = computed(() => {
+  if (prop.requestBody?.content) {
+    return Object.keys(prop.requestBody.content)
+  }
+  return []
+})
+
+const selectedContentType = ref<ContentType>(
+  prop.defaultValue || (contentTypes.value[0] as ContentType),
+)
+</script>
+<template>
+  <div
+    class="content-type-select"
+    :class="{ 'content-type-no-select': contentTypes.length <= 1 }">
+    <span>{{ selectedContentType }}</span>
+    <select
+      v-if="prop?.requestBody && contentTypes.length > 1"
+      :value="selectedContentType"
+      @change="handleSelectChange($event)">
+      <option
+        v-for="(value, key) in prop.requestBody?.content"
+        :key="key"
+        :value="key">
+        {{ key }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<style scoped>
+.content-type {
+  display: flex;
+  align-items: center;
+  font-size: var(--scalar-heading-4);
+  font-weight: var(--scalar-semibold);
+  color: var(--scalar-color-1);
+  line-height: 1.45;
+  margin-top: 24px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--scalar-border-color);
+  flex-flow: wrap;
+}
+.content-type-select {
+  position: relative;
+  padding-left: 9px;
+  height: fit-content;
+  color: var(--scalar-color-2);
+  font-size: var(--scalar-font-size-3);
+  display: flex;
+  align-items: center;
+}
+.content-type-no-select.content-type-select {
+  pointer-events: none;
+}
+.content-type-no-select.content-type-select:after {
+  display: none;
+}
+.content-type-select span {
+  display: flex;
+  align-items: center;
+}
+.content-type-select:after {
+  content: '';
+  width: 7px;
+  height: 7px;
+  transform: rotate(45deg) translate3d(-2px, -4px, 0);
+  display: block;
+  margin-left: 7px;
+  box-shadow: 1px 1px 0 currentColor;
+}
+.content-type-select select {
+  border: none;
+  outline: none;
+  cursor: pointer;
+  background: var(--scalar-background-3);
+  box-shadow: -2px 0 0 0 var(--scalar-background-3);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  appearance: none;
+}
+.content-type-select:hover {
+  color: var(--scalar-color-1);
+}
+@media (max-width: 460px) {
+  .content-type-select {
+    margin-left: auto;
+    padding-right: 3px;
+  }
+}
+</style>

--- a/packages/api-reference/src/components/Content/Operation/RequestBody.vue
+++ b/packages/api-reference/src/components/Content/Operation/RequestBody.vue
@@ -4,6 +4,7 @@ import type { ContentType, RequestBody } from '@scalar/oas-utils'
 import { computed, ref } from 'vue'
 
 import { Schema } from '../Schema'
+import ContentTypeSelect from './ContentTypeSelect.vue'
 
 const prop = defineProps<{ requestBody?: RequestBody }>()
 
@@ -25,21 +26,13 @@ if (prop.requestBody?.content) {
   <div v-if="prop?.requestBody">
     <div class="request-body-title">
       <slot name="title" />
-      <div
-        class="request-body-title-select"
-        :class="{ 'request-body-title-no-select': contentTypes.length <= 1 }">
-        <span>{{ selectedContentType }}</span>
-        <select
-          v-if="prop?.requestBody && contentTypes.length > 1"
-          v-model="selectedContentType">
-          <option
-            v-for="(value, key) in prop.requestBody?.content"
-            :key="key"
-            :value="key">
-            {{ key }}
-          </option>
-        </select>
-      </div>
+      <ContentTypeSelect
+        v-if="prop.requestBody?.content"
+        :defaultValue="selectedContentType"
+        :requestBody="prop.requestBody"
+        @selectContentType="
+          ({ contentType }) => (selectedContentType = contentType)
+        " />
       <div
         v-if="prop?.requestBody.description"
         class="request-body-description">
@@ -70,51 +63,6 @@ if (prop.requestBody?.content) {
   border-bottom: 1px solid var(--scalar-border-color);
   flex-flow: wrap;
 }
-.request-body-title-select {
-  position: relative;
-  padding-left: 9px;
-  height: fit-content;
-  color: var(--scalar-color-2);
-  font-size: var(--scalar-font-size-3);
-  display: flex;
-  align-items: center;
-}
-.request-body-title-no-select.request-body-title-select {
-  pointer-events: none;
-}
-.request-body-title-no-select.request-body-title-select:after {
-  display: none;
-}
-.request-body-title-select span {
-  display: flex;
-  align-items: center;
-}
-.request-body-title-select:after {
-  content: '';
-  width: 7px;
-  height: 7px;
-  transform: rotate(45deg) translate3d(-2px, -4px, 0);
-  display: block;
-  margin-left: 7px;
-  box-shadow: 1px 1px 0 currentColor;
-}
-.request-body-title-select select {
-  border: none;
-  outline: none;
-  cursor: pointer;
-  background: var(--scalar-background-3);
-  box-shadow: -2px 0 0 0 var(--scalar-background-3);
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  appearance: none;
-}
-.request-body-title-select:hover {
-  color: var(--scalar-color-1);
-}
 .request-body-description {
   margin-top: 6px;
   font-size: var(--scalar-small);
@@ -122,11 +70,5 @@ if (prop.requestBody?.content) {
 }
 .request-body-description :deep(.markdown) * {
   color: var(--scalar-color-2) !important;
-}
-@media (max-width: 460px) {
-  .request-body-title-select {
-    margin-left: auto;
-    padding-right: 3px;
-  }
 }
 </style>

--- a/packages/api-reference/src/hooks/useResponses.ts
+++ b/packages/api-reference/src/hooks/useResponses.ts
@@ -1,4 +1,7 @@
-import type { TransformedOperation } from '@scalar/oas-utils'
+import type {
+  RequestBodyMimeTypes,
+  TransformedOperation,
+} from '@scalar/oas-utils'
 import { computed } from 'vue'
 
 /**
@@ -10,13 +13,18 @@ export function useResponses(operation: TransformedOperation) {
 
     const { responses } = operation.information
 
-    const res: { name: string; description: string }[] = []
+    const res: {
+      name: string
+      description: string
+      content: RequestBodyMimeTypes
+    }[] = []
 
     if (responses) {
       Object.keys(responses).forEach((statusCode: string) => {
         res.push({
           name: statusCode,
           description: responses[statusCode].description,
+          content: responses[statusCode].content,
         })
       })
     }

--- a/packages/oas-utils/src/types.ts
+++ b/packages/oas-utils/src/types.ts
@@ -93,6 +93,7 @@ export type Parameters = {
   schema?: Schema
   example?: any
   examples?: Map<string, any>
+  content?: RequestBodyMimeTypes
 }
 
 export type Query = {


### PR DESCRIPTION
**Problem**
Currently, there no user friendly way to see response schema (available only in raw/text format)
https://github.com/scalar/scalar/issues/1481

**Solution**
With this PR content type select introduces. It allows user to select response content type. Schema for selected content type displayed (same as for request schema)
#1481 
