### PR TITLE
feat(api-reference): hide schemas with `x-internal: true`, fix #2468

### DIFF
--- a/.changeset/four-emus-pull.md
+++ b/.changeset/four-emus-pull.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: hide schemas with `x-internal: true`

--- a/packages/api-reference/src/helpers/getModels.ts
+++ b/packages/api-reference/src/helpers/getModels.ts
@@ -9,7 +9,7 @@ export function getModels(spec?: Spec) {
     return {} as Record<string, OpenAPIV3_1.SchemaObject>
   }
 
-  return (
+  const models =
     // OpenAPI 3.x
     (
       Object.keys(spec?.components?.schemas ?? {}).length
@@ -23,5 +23,14 @@ export function getModels(spec?: Spec) {
       | OpenAPIV2.DefinitionsObject
       | Record<string, OpenAPIV3.SchemaObject>
       | Record<string, OpenAPIV3_1.SchemaObject>
-  )
+
+  // Filter out all schemas with `x-internal: true`
+  Object.keys(models ?? {}).forEach((key) => {
+    // @ts-expect-error upstream type issue in @scalar/openapi-parser
+    if (models[key]?.['x-internal']) {
+      delete models[key]
+    }
+  })
+
+  return models
 }

--- a/packages/api-reference/src/helpers/getModels.ts
+++ b/packages/api-reference/src/helpers/getModels.ts
@@ -27,7 +27,7 @@ export function getModels(spec?: Spec) {
   // Filter out all schemas with `x-internal: true`
   Object.keys(models ?? {}).forEach((key) => {
     // @ts-expect-error upstream type issue in @scalar/openapi-parser
-    if (models[key]?.['x-internal']) {
+    if (models[key]?.['x-internal'] === true) {
       delete models[key]
     }
   })

--- a/packages/api-reference/src/hooks/useSidebar.test.ts
+++ b/packages/api-reference/src/hooks/useSidebar.test.ts
@@ -502,4 +502,155 @@ describe('useSidebar', async () => {
       ],
     })
   })
+
+  it('hides operations with x-internal: true', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              'summary': 'Get',
+              'x-internal': false,
+            },
+            post: {
+              'summary': 'Post',
+              'x-internal': true,
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [{ title: 'Get' }],
+    })
+  })
+
+  it('hides webhooks with x-internal: true', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Get',
+            },
+          },
+        },
+        webhooks: {
+          hello: {
+            post: {
+              'summary': 'Hello Webhook',
+              'x-internal': true,
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [{ title: 'Get' }],
+    })
+  })
+
+  it('shows schemas', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Get',
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Planet: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        { title: 'Get' },
+        {
+          title: 'Models',
+          children: [
+            {
+              title: 'Planet',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('hides schemas with x-internal: true', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Get',
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Planet: {
+              'type': 'object',
+              'x-internal': false,
+              'properties': {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+            User: {
+              'type': 'object',
+              'x-internal': true,
+              'properties': {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        { title: 'Get' },
+        {
+          title: 'Models',
+          children: [
+            {
+              title: 'Planet',
+            },
+          ],
+        },
+      ],
+    })
+  })
 })


### PR DESCRIPTION
We hide operations and webhooks with `x-internal: true`, but we don't hide schemas. With this PR schemas/models with `x-internal: true` are hidden, too.

See #2468