### PR TITLE
feat(mock-server): check OpenAuth2 password grant authentication is required

### DIFF
--- a/.changeset/six-laws-attack.md
+++ b/.changeset/six-laws-attack.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+feat: add OpenAuth2 token endpoint

--- a/.changeset/soft-rules-float.md
+++ b/.changeset/soft-rules-float.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+feat: check whether OpenAuth2 password grant authentication is required

--- a/packages/mock-server/src/utils/anyOpenAuthPasswordGrantAuthentication.ts
+++ b/packages/mock-server/src/utils/anyOpenAuthPasswordGrantAuthentication.ts
@@ -1,0 +1,22 @@
+import type { Context } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+
+/**
+ * Middleware to check for any bearer authentication header
+ */
+export function anyOpenAuthPasswordGrantAuthentication() {
+  return async function (ctx: Context, next: () => Promise<void>) {
+    // Check if the request has an Authorization header
+    // Note: We don’t care *what* credentials are sent, though.
+    if (ctx.req.header('Authorization')?.startsWith('Bearer ')) {
+      return await next()
+    }
+
+    // Unauthorized
+    throw new HTTPException(401, {
+      res: new Response('Unauthorized', {
+        status: 401,
+      }),
+    })
+  }
+}

--- a/packages/mock-server/src/utils/getOpenAuthTokenUrl.ts
+++ b/packages/mock-server/src/utils/getOpenAuthTokenUrl.ts
@@ -1,0 +1,34 @@
+import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
+
+export function getOpenAuthTokenUrl(schema?: OpenAPI.Document) {
+  const securitySchemes: Record<
+    string,
+    OpenAPIV3.SecuritySchemeObject | OpenAPIV3_1.SecuritySchemeObject
+  > = schema?.components?.securitySchemes
+
+  if (securitySchemes === undefined) {
+    return false
+  }
+
+  const openAuthPasswordGrant = Object.values(securitySchemes).filter(
+    (securityScheme) => {
+      if (
+        securityScheme.type === 'oauth2' &&
+        securityScheme.flows?.password !== undefined
+      ) {
+        return true
+      }
+
+      return false
+    },
+  )
+
+  if (!openAuthPasswordGrant.length) {
+    return undefined
+  }
+
+  // @ts-expect-error TypeScript, I know it’s there (or undefined, both is fine).
+  return openAuthPasswordGrant[0]?.flows?.password?.tokenUrl as
+    | undefined
+    | string
+}

--- a/packages/mock-server/src/utils/getOpenAuthTokenUrl.ts
+++ b/packages/mock-server/src/utils/getOpenAuthTokenUrl.ts
@@ -10,6 +10,7 @@ export function getOpenAuthTokenUrl(schema?: OpenAPI.Document) {
     return false
   }
 
+  // TODO: Make this work with other OpenAuth workflows
   const openAuthPasswordGrant = Object.values(securitySchemes).filter(
     (securityScheme) => {
       if (

--- a/packages/mock-server/src/utils/isOpenAuthPasswordGrantRequired.ts
+++ b/packages/mock-server/src/utils/isOpenAuthPasswordGrantRequired.ts
@@ -1,6 +1,6 @@
 import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 
-export function isBasicAuthenticationRequired(
+export function isOpenAuthPasswordGrantRequired(
   operation: OpenAPI.Operation,
   schema?: OpenAPI.Document,
 ) {
@@ -14,16 +14,17 @@ export function isBasicAuthenticationRequired(
     },
   )
 
-  // Check if one of them is HTTP Basic Auth
-  const httpBasicAuthIsRequired =
+  // Check if one of them is OpenAuth2 Password Grant
+  const passwordGrantRequired =
     allowedSecuritySchemes?.findIndex((securitySchemeKey: string) => {
       const securityScheme =
         schema?.components?.securitySchemes?.[securitySchemeKey]
 
       return (
-        securityScheme?.type === 'http' && securityScheme?.scheme === 'basic'
+        securityScheme?.type === 'oauth2' &&
+        securityScheme?.flows?.password !== undefined
       )
     }) >= 0
 
-  return httpBasicAuthIsRequired
+  return passwordGrantRequired
 }

--- a/packages/mock-server/tests/basicAuthentication.test.ts
+++ b/packages/mock-server/tests/basicAuthentication.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { createMockServer } from '../src/createMockServer'
 
-describe('authentication', () => {
+describe('basicAuthentication', () => {
   it('doesn’t require authentication', async () => {
     const specification = {
       openapi: '3.1.0',

--- a/packages/mock-server/tests/oAuthPasswordGrant.test.ts
+++ b/packages/mock-server/tests/oAuthPasswordGrant.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMockServer } from '../src/createMockServer'
+
+describe('oAuthPasswordGrant', () => {
+  it('fails without credentials', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/secret': {
+          get: {
+            security: [
+              {
+                passwordGrant: [],
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          passwordGrant: {
+            type: 'oauth2',
+            flows: {
+              password: {
+                tokenUrl: '/oauth/token',
+                scopes: {},
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/secret')
+
+    expect(response.status).toBe(401)
+  })
+
+  it('responds with a token', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/secret': {
+          get: {
+            security: [
+              {
+                passwordGrant: [],
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          passwordGrant: {
+            type: 'oauth2',
+            flows: {
+              password: {
+                tokenUrl: '/my-custom-token-endpoint',
+                scopes: {},
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/my-custom-token-endpoint', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        grant_type: 'password',
+        username: 'foo',
+        password: 'bar',
+        client_id: 'my-client-id',
+        client_secret: 'my-client-secret',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      access_token: expect.any(String),
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: expect.any(String),
+    })
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  it('succeeds with credentials', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/secret': {
+          get: {
+            security: [
+              {
+                passwordGrant: [],
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          passwordGrant: {
+            type: 'oauth2',
+            flows: {
+              password: {
+                tokenUrl: '/oauth/token',
+                scopes: {},
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/secret', {
+      headers: {
+        Authorization: `Bearer super-secret-token`,
+      },
+    })
+
+    expect(response.status).toBe(200)
+  })
+})


### PR DESCRIPTION
With this PR, the `@scalar/mock-server` adds an OpenAuth2 token endpoint and requires the OpenAuth2 password grant authentication if it’s required in the given OpenAPI document.

* Currently, the token endpoint doesn’t care what data you send, as long as it's a POST request.
* And the authentication checks for the `Authentication: Bearer ***` header and doesn’t care about the given token.

I kept it simple for this PR, but this can be further improved by adding support for other OpenAuth workflows, or by being a little bit more strict in the token endpoint (at least requiring the necessary parameters).