### PR TITLE
feat(api-reference): add `tagsSorter` to the configuration, fix #1436

### DIFF
--- a/.changeset/silver-seahorses-shave.md
+++ b/.changeset/silver-seahorses-shave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: new `tagsSorter` option

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -244,7 +244,9 @@ Sort tags alphanumerically (`'alpha'`):
 }
 ```
 
-Or specify a custom function to sort the tags:
+Or specify a custom function to sort the tags.
+
+> Note: Most of our integrations pass the configuration as JSON and you can’t use custom sort functions there. It will work in Vue, Nuxt, React, Next and all integrations that don’t need to pass the configuration as a JSON string.
 
 ```js
 {

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -234,6 +234,30 @@ By default we only open the relevant tag based on the url, however if you want a
 }
 ```
 
+#### tagsSorter?: 'alpha' | (a: Tag, b: Tag) => number
+
+Sort tags alphanumerically (`'alpha'`):
+
+```js
+{
+  tagsSorter: 'alpha'
+}
+```
+
+Or specify a custom function to sort the tags:
+
+```js
+{
+  /** @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort */
+  tagsSorter: (a, b) => {
+    if (a.name === 'Super Important Tag') return -1
+    return 1
+  }
+}
+```
+
+Learn more about Array sort functions: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+
 #### theme?: string
 
 You don’t like the color scheme? We’ve prepared some themes for you:

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -269,7 +269,9 @@ const fontsStyleTag = computed(
       class="references-navigation t-doc__sidebar">
       <!-- Navigation tree / Table of Contents -->
       <div class="references-navigation-list">
-        <Sidebar :parsedSpec="parsedSpec">
+        <Sidebar
+          :parsedSpec="parsedSpec"
+          :tagsSorter="configuration.tagsSorter">
           <template #sidebar-start>
             <slot
               v-bind="referenceSlotProps"

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -3,19 +3,22 @@ import type { Spec } from '@scalar/oas-utils'
 import { onMounted, ref, watch } from 'vue'
 
 import { sleep } from '../../helpers'
-import { useNavState, useSidebar } from '../../hooks'
+import { type TagsSorterOption, useNavState, useSidebar } from '../../hooks'
 import SidebarElement from './SidebarElement.vue'
 import SidebarGroup from './SidebarGroup.vue'
 
-const props = defineProps<{
-  parsedSpec: Spec
-}>()
+const props = defineProps<
+  {
+    parsedSpec: Spec
+  } & TagsSorterOption
+>()
 
 const { hash, isIntersectionEnabled } = useNavState()
 
 const { items, toggleCollapsedSidebarItem, collapsedSidebarItems } = useSidebar(
   {
     parsedSpec: props.parsedSpec,
+    tagsSorter: props.tagsSorter,
   },
 )
 

--- a/packages/api-reference/src/hooks/useSidebar.test.ts
+++ b/packages/api-reference/src/hooks/useSidebar.test.ts
@@ -2,15 +2,22 @@ import { describe, expect, it } from 'vitest'
 import { toValue } from 'vue'
 
 import { parse } from '../helpers'
-import { useSidebar } from './useSidebar'
+import { type TagsSorterOption, useSidebar } from './useSidebar'
 
 /**
  * Parse the given OpenAPI definition and return the items for the sidebar.
  */
-async function getItemsForDocument(definition: Record<string, any>) {
+async function getItemsForDocument(
+  definition: Record<string, any>,
+  options?: TagsSorterOption,
+) {
   const parsedSpec = await parse(definition)
 
   const { items } = useSidebar({
+    ...{
+      tagsSorter: undefined,
+      ...options,
+    },
     parsedSpec,
   })
 
@@ -162,6 +169,100 @@ describe('useSidebar', async () => {
           },
         },
       }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+        {
+          title: 'Barfoo',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('sorts tags alphabetically', async () => {
+    expect(
+      await getItemsForDocument(
+        {
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Hello World',
+                tags: ['Foobar', 'Barfoo'],
+              },
+            },
+          },
+        },
+        {
+          tagsSorter: 'alpha',
+        },
+      ),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Barfoo',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('sorts tags with custom function', async () => {
+    expect(
+      await getItemsForDocument(
+        {
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Hello World',
+                tags: ['Foobar', 'Barfoo'],
+              },
+            },
+          },
+        },
+        {
+          tagsSorter: (a) => {
+            if (a.name === 'Foobar') {
+              return -1
+            }
+
+            return 1
+          },
+        },
+      ),
     ).toMatchObject({
       entries: [
         {

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -1,3 +1,4 @@
+import type { TagsSorterOption } from '@/hooks'
 import type {
   AuthenticationState,
   ContentType,
@@ -161,6 +162,10 @@ export type ReferenceConfiguration = {
    * @default false
    */
   defaultOpenAllTags?: boolean
+  /**
+   * Sort tags alphabetically or with a custom sort function
+   */
+  tagsSorter?: TagsSorterOption['tagsSorter']
 }
 
 export type PathRouting = {


### PR DESCRIPTION
This PR adds an option to sort the tags, this makes switching from Swagger UI to Scalar even easier:

**Notes**

* Custom functions can’t be passed when `JSON.stringify` is used to pass the configuration.
* Models & Webhooks aren’t in that list.
* Tag groups aren’t sorted aswell, but I think you can just define them in the order that you like.

**Relevant links**

* #1436 
* https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#:~:text=values%20for%20Parameters.-,tagsSorter,-Unavailable