### PR TITLE
chore: rename Webhook to Webhooks

### DIFF
--- a/.changeset/stale-experts-itch.md
+++ b/.changeset/stale-experts-itch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: rename Webhook to Webhooks

--- a/packages/api-reference/src/hooks/useSidebar.test.ts
+++ b/packages/api-reference/src/hooks/useSidebar.test.ts
@@ -82,7 +82,7 @@ describe('useSidebar', async () => {
       entries: [
         { title: 'Hello World' },
         {
-          title: 'Webhook',
+          title: 'Webhooks',
           children: [
             {
               title: 'Hello Webhook',
@@ -368,7 +368,7 @@ describe('useSidebar', async () => {
           ],
         },
         {
-          title: 'Webhook',
+          title: 'Webhooks',
           children: [
             {
               title: 'Hello Webhook',
@@ -428,7 +428,7 @@ describe('useSidebar', async () => {
               ],
             },
             {
-              title: 'Webhook',
+              title: 'Webhooks',
               children: [
                 {
                   title: 'Hello Webhook',
@@ -492,7 +492,7 @@ describe('useSidebar', async () => {
           ],
         },
         {
-          title: 'Webhook',
+          title: 'Webhooks',
           children: [
             {
               title: 'Hello Webhook',

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -204,7 +204,7 @@ const items = computed(() => {
     ? [
         {
           id: getWebhookId(),
-          title: 'Webhook',
+          title: 'Webhooks',
           show: !state.showApiClient,
           children: Object.keys(parsedSpec.value?.webhooks ?? {})
             .map((name) => {


### PR DESCRIPTION
In the sidebar, we have Model*s*, but for webhooks we just write Webhook. 🤔 This PR adds an S, so we end up with:

<img width="289" alt="Screenshot 2024-07-16 at 16 44 51" src="https://github.com/user-attachments/assets/8de7442d-33d1-4d55-a1ae-01a3d41cde35">
