### PR TITLE
fix: adjust command palette icon thickness

### DIFF
--- a/.changeset/lemon-pillows-bathe.md
+++ b/.changeset/lemon-pillows-bathe.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: adjust command palette icon thickness

--- a/packages/api-client/src/components/CommandPalette/CommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPalette.vue
@@ -196,7 +196,7 @@ whenever(keys.ArrowUp, () => {
             class="text-c-1 mr-2.5"
             icon="Search"
             size="sm"
-            thickness="3" />
+            thickness="1.5" />
         </label>
         <input
           id="commandmenu"
@@ -242,7 +242,7 @@ whenever(keys.ArrowUp, () => {
             class="text-c-1 mr-2.5"
             :icon="command.icon"
             size="md"
-            thickness="3" />
+            thickness="1.5" />
           {{ command.name }}
         </div>
       </template>
@@ -254,8 +254,7 @@ whenever(keys.ArrowUp, () => {
         @click="activeCommand = ''">
         <ScalarIcon
           icon="ChevronLeft"
-          size="sm"
-          thickness="3" />
+          size="sm" />
       </button>
       <component
         :is="PaletteComponents[activeCommand]"


### PR DESCRIPTION
## Before

<img width="608" alt="Google Chrome-2024-07-16-13-54-10@2x" src="https://github.com/user-attachments/assets/2de999c1-27f9-44ee-b829-c99f675dce66">

## After

<img width="608" alt="Google Chrome-2024-07-16-13-53-54@2x" src="https://github.com/user-attachments/assets/52f0a70f-c635-44d6-9861-9a04307b6101">
