### PR TITLE
fix(api-reference): set background color on body, fix #2496

### DIFF
--- a/.changeset/tidy-peas-call.md
+++ b/.changeset/tidy-peas-call.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: set background color on body

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -104,7 +104,10 @@ const { parsedSpec, rawSpec } = useReactiveSpec({
   </Layouts>
 </template>
 <style>
-body {
-  margin: 0;
+@layer scalar-base {
+  body {
+    margin: 0;
+    background-color: var(--scalar-background-1);
+  }
 }
 </style>


### PR DESCRIPTION
Sets the background color on the `<body>` tag in a layer so it's set for iOS. It turns out this also colors the address bar in addition to the top chrome which is nice.

Since it's in a layer it _should_ be easy to override if anyone doesn't want it set for their use.

Fixes #2496

## Before (Default / Kepler)

<img width="300px" src="https://github.com/user-attachments/assets/0b255907-72f7-4df8-a326-902f3e195853" />
<img width="300px" src="https://github.com/user-attachments/assets/924f817e-50ff-445a-b83f-e0f0e94e71df" />


## After (Default / Kepler)

<img width="300px" src="https://github.com/user-attachments/assets/36fb7ed7-f70f-492f-8e2e-ab563029ecc2" />
<img width="300px" src="https://github.com/user-attachments/assets/a6ef6a36-de54-4425-b32a-643e6b37a56e" />
