### PR TITLE
chore: make react a peer dependency, fix #2482

### DIFF
--- a/.changeset/pink-dots-march.md
+++ b/.changeset/pink-dots-march.md
@@ -1,0 +1,7 @@
+---
+'@scalar/nextjs-api-reference': patch
+'@scalar/api-reference-react': patch
+'@scalar/docusaurus': patch
+---
+
+chore: make react and next a peer dependency

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -42,8 +42,7 @@
   ],
   "module": "./dist/index.js",
   "dependencies": {
-    "@scalar/api-reference": "workspace:*",
-    "react": "^18.3.1"
+    "@scalar/api-reference": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.2.60",
@@ -52,9 +51,11 @@
     "character-entities": "^2.0.2",
     "decode-named-character-reference": "^1.0.2",
     "path": "^0.12.7",
-    "react": "^18.3.1",
     "vite": "^5.2.10",
     "vite-plugin-dts": "^3.6.3",
     "vue": "^3.4.29"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
   }
 }

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -35,14 +35,15 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@scalar/api-reference-react": "workspace:*",
-    "react": "^18.3.1"
+    "@scalar/api-reference-react": "workspace:*"
   },
   "devDependencies": {
     "@docusaurus/types": "^3.4.0",
     "@types/react": "^18.2.60",
     "@types/react-dom": "^18.2.19",
-    "path": "^0.12.7",
-    "react": "^18.3.1"
+    "path": "^0.12.7"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
   }
 }

--- a/packages/nextjs-api-reference/package.json
+++ b/packages/nextjs-api-reference/package.json
@@ -42,9 +42,7 @@
   ],
   "module": "./dist/index.js",
   "dependencies": {
-    "@scalar/api-reference": "workspace:*",
-    "next": "^14.1.1",
-    "react": "^18.3.1"
+    "@scalar/api-reference": "workspace:*"
   },
   "devDependencies": {
     "@scalar/api-reference": "workspace:*",
@@ -53,9 +51,12 @@
     "@types/react-dom": "^18.2.19",
     "@vitejs/plugin-react": "^4.2.1",
     "next": "^14.1.1",
-    "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "vite": "^5.2.10",
     "vite-plugin-dts": "^3.6.3"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "next": "^14.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,7 +1065,7 @@ importers:
         specifier: workspace:*
         version: link:../api-reference
       react:
-        specifier: ^18.3.1
+        specifier: ^18.0.0
         version: 18.3.1
     devDependencies:
       '@types/react':
@@ -1448,7 +1448,7 @@ importers:
         specifier: workspace:*
         version: link:../api-reference-react
       react:
-        specifier: ^18.3.1
+        specifier: ^18.0.0
         version: 18.3.1
     devDependencies:
       '@docusaurus/types':
@@ -1707,11 +1707,8 @@ importers:
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../api-reference
-      next:
-        specifier: ^14.1.1
-        version: 14.2.4(@babel/core@7.24.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.44.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
-        specifier: ^18.3.1
+        specifier: ^18.0.0
         version: 18.3.1
     devDependencies:
       '@types/node':
@@ -1726,6 +1723,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.3.1(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))
+      next:
+        specifier: ^14.1.1
+        version: 14.2.4(@babel/core@7.24.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.44.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)


### PR DESCRIPTION
As correctly stated in https://github.com/scalar/scalar/issues/2482#issuecomment-2231993359, React and Nextjs should be peer dependencies.

Means, they have to be installed, but we don’t care about the exact version as long as it’s in the React 18.* or Next 14.* range.

See #2482 for more context on why it’s probably fixing the issue.