### PR TITLE
fix(api-client): clipped border radius in requests

### DIFF
--- a/.changeset/breezy-insects-explode.md
+++ b/.changeset/breezy-insects-explode.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: clipped border radius in requests items

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -166,7 +166,7 @@ const flattenValue = (item: RequestExampleParameter) => {
   padding: 0;
 }
 :deep(.cm-content) {
-  background-color: var(--scalar-background-1);
+  background-color: transparent;
   font-family: var(--scalar-font);
   font-size: var(--scalar-mini);
   padding: 6px 8px;


### PR DESCRIPTION
before:
<img width="323" alt="image" src="https://github.com/user-attachments/assets/48894350-02e3-4978-bfb8-c13160fd642d">

after:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/44311f45-54e0-4c3b-aa0c-f75d592d264b">
