### PR TITLE
fix(api-client): all request bodies are sent as form data, fix #2511

### DIFF
--- a/.changeset/witty-hats-compete.md
+++ b/.changeset/witty-hats-compete.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: set content type on body change and add proper header


### PR DESCRIPTION
**Problem**
Currently we don't save the raw encoding value and if you change we dont properly set the content-type

**Explanation**
This happens because we dont handle it

**Solution**
With this PR we save both the raw encoding value and set the Content-Type header depending on the content type


https://github.com/user-attachments/assets/771c273a-e29c-496d-9a79-ba9e9bf2a000

