### PR TITLE
chore: exclude peer dependencies to avoid React version conflicts

### DIFF
--- a/.changeset/calm-kids-fail.md
+++ b/.changeset/calm-kids-fail.md
@@ -1,0 +1,6 @@
+---
+'@scalar/nextjs-api-reference': patch
+'@scalar/api-reference-react': patch
+---
+
+chore: exclude react from the build to avoid version conflicts

--- a/packages/api-reference-react/vite.config.ts
+++ b/packages/api-reference-react/vite.config.ts
@@ -21,7 +21,10 @@ export default defineConfig({
       },
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: [...Object.keys(pkg.dependencies)],
+      external: [
+        ...Object.keys(pkg.dependencies),
+        ...Object.keys(pkg.peerDependencies),
+      ],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps

--- a/packages/nextjs-api-reference/vite.config.ts
+++ b/packages/nextjs-api-reference/vite.config.ts
@@ -22,7 +22,10 @@ export default defineConfig({
       },
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: [...Object.keys(pkg.dependencies)],
+      external: [
+        ...Object.keys(pkg.dependencies),
+        ...Object.keys(pkg.peerDependencies),
+      ],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps


### PR DESCRIPTION
With #2518 we moved `react` and `next` to the peer dependencies. The build configuration excludes all dependencies from the bundle, but not the peer dependencies. This would have led to version conflicts because we were about to ship a specific React version to users.

With this PR, we’re also excluding peer dependencies for the relevant packages. This way, users won’t run into React/Next.js version conflicts.