### PR TITLE
feat: moved command palette to the client app base

### DIFF
--- a/.changeset/cuddly-meals-enjoy.md
+++ b/.changeset/cuddly-meals-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: move command palette into the client app base

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -93,6 +93,10 @@
       "import": "./dist/components/DarkModeToggle/index.js",
       "types": "./dist/components/DarkModeToggle/index.d.ts"
     },
+    "./components/CommandPalette": {
+      "import": "./dist/components/CommandPalette/index.js",
+      "types": "./dist/components/CommandPalette/index.d.ts"
+    },
     "./components/AddressBar": {
       "import": "./dist/components/AddressBar/index.js",
       "types": "./dist/components/AddressBar/index.d.ts"

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -78,17 +78,17 @@ const availableCommands = [
       {
         name: 'Add Server',
         icon: 'Brackets',
-        route: '/servers',
+        path: '/servers',
       },
       {
         name: 'Add Environment',
         icon: 'Server',
-        route: '/environment',
+        path: '/environment',
       },
       {
         name: 'Add Cookie',
         icon: 'Cookie',
-        route: '/cookies',
+        path: '/cookies',
       },
     ],
   },
@@ -169,13 +169,13 @@ whenever(keys.ArrowUp, () => {
   })
 })
 
-/** Handle execution of the command, some have routes while others trigger a palette */
+/** Handle execution of the command, some have routes while others show another palette */
 const executeCommand = (
   command: (typeof availableCommands)[number]['commands'][number],
 ) => {
   // Route to the page
-  if ('route' in command) {
-    push(`/workspace/${activeWorkspace.value.uid}${command.route}`)
+  if ('path' in command) {
+    push(`/workspace/${activeWorkspace.value.uid}${command.path}`)
     closeHandler()
   }
   // Open respective command palette

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -36,7 +36,10 @@ import { useMagicKeys, whenever } from '@vueuse/core'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
-import { commandPaletteBus } from '@/libs/eventBusses/command-palette'
+import {
+  commandPaletteBus,
+  type CommandPaletteEvent,
+} from '@/libs/eventBusses/command-palette'
 
 /** Available Commands for the Command Palette */
 const availableCommands = [
@@ -180,7 +183,7 @@ const executeCommand = (
 }
 
 /** Handles opening the command pallete to the correct palette */
-const openCommandPalette = (commandName?: CommandNames) => {
+const openCommandPalette = ({ commandName }: CommandPaletteEvent = {}) => {
   activeCommand.value = commandName ?? null
   modalState.show()
 }

--- a/packages/api-client/src/components/CommandPalette/index.ts
+++ b/packages/api-client/src/components/CommandPalette/index.ts
@@ -1,0 +1,1 @@
+export { default as TheCommandPalette } from './TheCommandPalette.vue'

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { TheCommandPalette } from '@/components/CommandPalette'
 import SideNav from '@/components/SideNav/SideNav.vue'
 import TopNav from '@/components/TopNav/TopNav.vue'
 import { useDarkModeState } from '@/hooks'
@@ -65,12 +66,17 @@ const fontsStyleTag = computed(
 <template>
   <div v-html="fontsStyleTag"></div>
   <TopNav />
+
   <!-- Ensure we have the workspace loaded from localStorage above -->
   <!-- min-h-0 is to allow scrolling of individual flex children -->
   <main
     v-if="workspaceStore.activeWorkspace.value?.uid"
     class="flex min-h-0 flex-1">
     <SideNav />
+
+    <!-- Popup command palette to add resources from anywhere -->
+    <TheCommandPalette />
+
     <div class="flex flex-1 flex-col min-w-0">
       <RouterView v-slot="{ Component }">
         <keep-alive>

--- a/packages/api-client/src/libs/eventBusses/command-palette.ts
+++ b/packages/api-client/src/libs/eventBusses/command-palette.ts
@@ -1,7 +1,8 @@
 import type { CommandNames } from '@/components/CommandPalette/TheCommandPalette.vue'
 import { type EventBusKey, useEventBus } from '@vueuse/core'
 
-const commandPaletteKey: EventBusKey<CommandNames | undefined> = Symbol()
+export type CommandPaletteEvent = { commandName?: CommandNames }
+const commandPaletteKey: EventBusKey<CommandPaletteEvent> = Symbol()
 
 /**
  * Event bus for controlling the Command Palette

--- a/packages/api-client/src/libs/eventBusses/command-palette.ts
+++ b/packages/api-client/src/libs/eventBusses/command-palette.ts
@@ -1,0 +1,11 @@
+import type { CommandNames } from '@/components/CommandPalette/TheCommandPalette.vue'
+import { type EventBusKey, useEventBus } from '@vueuse/core'
+
+const commandPaletteKey: EventBusKey<CommandNames | undefined> = Symbol()
+
+/**
+ * Event bus for controlling the Command Palette
+ *
+ * @param commandName - the command name you wish to execute, leave empty for the full palette
+ */
+export const commandPaletteBus = useEventBus(commandPaletteKey)

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { Sidebar } from '@/components'
 import AddressBar from '@/components/AddressBar/AddressBar.vue'
-import CommandPalette from '@/components/CommandPalette/CommandPalette.vue'
 import SearchButton from '@/components/Search/SearchButton.vue'
 import SearchModal from '@/components/Search/SearchModal.vue'
 import SidebarButton from '@/components/Sidebar/SidebarButton.vue'
@@ -9,6 +8,7 @@ import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
 import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import { useSidebar } from '@/hooks'
 import { executeRequestBus, sendRequest } from '@/libs'
+import { commandPaletteBus } from '@/libs/eventBusses/command-palette'
 import { useWorkspace } from '@/store/workspace'
 import RequestSection from '@/views/Request/RequestSection/RequestSection.vue'
 import ResponseSection from '@/views/Request/ResponseSection/ResponseSection.vue'
@@ -35,7 +35,6 @@ const {
 } = useWorkspace()
 const { collapsedSidebarFolders } = useSidebar()
 const searchModalState = useModal()
-const commandPaletteState = useModal()
 const showSideBar = ref(!activeWorkspace.value?.isReadOnly)
 
 /**
@@ -233,9 +232,8 @@ const onDragEnd = (
   // }
 }
 
-const addItemHandler = () => {
-  commandPaletteState.show()
-}
+/* Opens the Command Palette */
+const addItemHandler = () => commandPaletteBus.emit()
 
 const keys = useMagicKeys()
 
@@ -353,7 +351,6 @@ const getBackgroundColor = () => {
               ?.response
           " />
       </ViewLayoutContent>
-      <CommandPalette :state="commandPaletteState" />
     </ViewLayout>
   </div>
   <SearchModal :modalState="searchModalState" />

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -18,7 +18,8 @@ const updateSelected = (uid: string) => {
   push(`/workspace/${uid}`)
 }
 
-const createNewWorkspace = () => commandPaletteBus.emit('Create Workspace')
+const createNewWorkspace = () =>
+  commandPaletteBus.emit({ commandName: 'Create Workspace' })
 </script>
 
 <template>

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import CommandPalette from '@/components/CommandPalette/CommandPalette.vue'
+import { commandPaletteBus } from '@/libs/eventBusses/command-palette'
 import { useWorkspace } from '@/store/workspace'
 import {
   ScalarButton,
@@ -7,11 +7,8 @@ import {
   ScalarDropdownDivider,
   ScalarDropdownItem,
   ScalarIcon,
-  useModal,
 } from '@scalar/components'
 import { useRouter } from 'vue-router'
-
-const commandPaletteState = useModal()
 
 const { activeWorkspace, workspaces } = useWorkspace()
 const { push } = useRouter()
@@ -21,15 +18,10 @@ const updateSelected = (uid: string) => {
   push(`/workspace/${uid}`)
 }
 
-const createNewWorkspace = () => {
-  commandPaletteState.show()
-}
+const createNewWorkspace = () => commandPaletteBus.emit('Create Workspace')
 </script>
 
 <template>
-  <CommandPalette
-    defaultCommand="Create Workspace"
-    :state="commandPaletteState" />
   <div class="xl:min-h-header py-2.5 flex items-center border-b px-2.5 text-sm">
     <ScalarDropdown>
       <ScalarButton


### PR DESCRIPTION
Need some QA but I believe this should do it. Now we can trigger the command palette from anywhere. Should be trivial to add the hotkey opening as well!

- also leaned more towards type inference instead of setting types
- switched the event bus event to be an object so we can pass metadata in the future (pre-select request etc)