### PR TITLE
chore(build-tooling): public/ folder is emptied for all Vite builds

### DIFF
--- a/.changeset/weak-swans-serve.md
+++ b/.changeset/weak-swans-serve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+Prevent dist deletion in vite builds

--- a/packages/build-tooling/src/vite-options.ts
+++ b/packages/build-tooling/src/vite-options.ts
@@ -40,6 +40,7 @@ export function createViteBuildOptions(props: {
     rollupOptions: createRollupConfig({
       pkgFile: props.pkgFile,
       options: props.options?.rollupOptions,
+      emptyOutDir: false,
     }),
   }
 }


### PR DESCRIPTION
The public dir is not functioning as expected because rollup is re-deleting the dist directory. Need to disable the dist deletion for vite builds. 