### PR TITLE
fix(use-codemirror): enter doesn’t create a new line

### DIFF
--- a/.changeset/strong-eels-greet.md
+++ b/.changeset/strong-eels-greet.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-codemirror': patch
+---
+
+Add explicit newline

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -4,7 +4,7 @@ import {
   closeBracketsKeymap,
   completionKeymap,
 } from '@codemirror/autocomplete'
-import { indentWithTab } from '@codemirror/commands'
+import { indentWithTab, insertNewline } from '@codemirror/commands'
 import { css } from '@codemirror/lang-css'
 import { html } from '@codemirror/lang-html'
 import { json } from '@codemirror/lang-json'
@@ -419,6 +419,15 @@ function getCodeMirrorExtensions({
           run: () => {
             return true
           },
+        },
+      ]),
+    )
+  } else {
+    extensions.push(
+      keymap.of([
+        {
+          key: 'Enter',
+          run: insertNewline,
         },
       ]),
     )


### PR DESCRIPTION
Codemirror has stopped recognizing newlines with enter key. 