### PR TITLE
feat(doc-2064): make examples functional in api client

### DIFF
--- a/.changeset/modern-goats-jump.md
+++ b/.changeset/modern-goats-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: made request examples functional in client

--- a/packages/api-client/playground/app/main.ts
+++ b/packages/api-client/playground/app/main.ts
@@ -1,9 +1,8 @@
-import { createApiClientApp } from '@/layouts/App'
+import App from '@/layouts/App/ApiClientApp.vue'
+import { router } from '@/router'
+import { createApp } from 'vue'
 
-// Initialize
-await createApiClientApp(document.getElementById('scalar-client'), {
-  spec: {
-    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-  },
-  proxyUrl: 'https://proxy.scalar.com',
-})
+const app = createApp(App)
+
+app.use(router)
+app.mount('#scalar-client')

--- a/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
+++ b/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
@@ -130,7 +130,6 @@ export const pillPlugin = ViewPlugin.fromClass(
           const start = from + match.index
           const end = start + match[0].length
           const variableName = match[1]
-          console.log(variableName)
           builder.add(
             start,
             end,

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -13,18 +13,23 @@ const emits = defineEmits<{
   (event: 'close'): void
 }>()
 
-const { activeWorkspaceRequests } = useWorkspace()
+const { activeRequest, activeWorkspaceRequests } = useWorkspace()
 const exampleName = ref('')
-const selectedRequest = ref(activeWorkspaceRequests.value[0])
+const selectedRequest = ref(activeRequest.value)
 
 function handleSelect(request: any) {
+  console.log('handleSelectasinsd')
+  console.log(request)
   selectedRequest.value = request
 }
 
+// Autofocus input
 const exampleInput = ref<HTMLInputElement | null>(null)
-onMounted(() => {
-  exampleInput.value?.focus()
-})
+onMounted(() => exampleInput.value?.focus())
+
+const handleSubmit = () => {
+  console.log('submitting')
+}
 </script>
 <template>
   <form
@@ -77,7 +82,8 @@ onMounted(() => {
       </div>
       <ScalarButton
         class="max-h-8 text-xs p-0 px-3"
-        type="submit">
+        type="submit"
+        @click="handleSubmit">
         Create Example
       </ScalarButton>
     </div>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -31,6 +31,7 @@ const {
 
 const exampleName = ref('')
 const selectedRequest = ref(
+  // Ensure we pre-select the correct request
   requests[props.metaData ?? ''] ?? activeRequest.value,
 )
 

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -7,28 +7,44 @@ import {
   ScalarDropdownItem,
   ScalarIcon,
 } from '@scalar/components'
+import type { Request } from '@scalar/oas-utils/entities/workspace/spec'
 import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 
 const emits = defineEmits<{
   (event: 'close'): void
 }>()
 
-const { activeRequest, activeWorkspaceRequests } = useWorkspace()
+const { push } = useRouter()
+const {
+  activeRequest,
+  activeWorkspace,
+  activeWorkspaceRequests,
+  requestExampleMutators,
+} = useWorkspace()
+
 const exampleName = ref('')
 const selectedRequest = ref(activeRequest.value)
 
-const handleSelect = (request: any) => {
-  console.log('handleSelectasinsd')
-  console.log(request)
-  selectedRequest.value = request
-}
+/** Select request in dropdown */
+const handleSelect = (request: Request) => (selectedRequest.value = request)
 
-// Autofocus input
+/** Autofocus input */
 const exampleInput = ref<HTMLInputElement | null>(null)
 onMounted(() => exampleInput.value?.focus())
 
+/** Add a new request example */
 const handleSubmit = () => {
-  console.log('submitting')
+  const example = requestExampleMutators.add(
+    selectedRequest.value,
+    exampleName.value,
+  )
+  if (!example) return
+
+  // Route to new request example
+  push(
+    `/workspace/${activeWorkspace.value.uid}/request/${selectedRequest.value.uid}/examples/${example.uid}`,
+  )
 }
 </script>
 <template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -11,6 +11,11 @@ import type { Request } from '@scalar/oas-utils/entities/workspace/spec'
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
+const props = defineProps<{
+  /** The request uid to pre-select */
+  metaData?: string
+}>()
+
 const emits = defineEmits<{
   (event: 'close'): void
 }>()
@@ -20,11 +25,14 @@ const {
   activeRequest,
   activeWorkspace,
   activeWorkspaceRequests,
+  requests,
   requestExampleMutators,
 } = useWorkspace()
 
 const exampleName = ref('')
-const selectedRequest = ref(activeRequest.value)
+const selectedRequest = ref(
+  requests[props.metaData ?? ''] ?? activeRequest.value,
+)
 
 /** Select request in dropdown */
 const handleSelect = (request: Request) => (selectedRequest.value = request)

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -17,7 +17,7 @@ const { activeRequest, activeWorkspaceRequests } = useWorkspace()
 const exampleName = ref('')
 const selectedRequest = ref(activeRequest.value)
 
-function handleSelect(request: any) {
+const handleSelect = (request: any) => {
   console.log('handleSelectasinsd')
   console.log(request)
   selectedRequest.value = request
@@ -45,8 +45,8 @@ const handleSubmit = () => {
         ref="exampleInput"
         v-model="exampleName"
         class="border-transparent outline-none w-full pl-8 text-sm min-h-8 py-1.5"
-        label="Variant Name"
-        placeholder="Variant Name" />
+        label="Example Name"
+        placeholder="Example Name" />
     </div>
     <div class="flex gap-2">
       <div class="flex flex-1 max-h-8">

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -95,14 +95,7 @@ const availableCommands = [
 ] as const
 type Command = (typeof availableCommands)[number]['commands'][number]
 
-const keys = useMagicKeys({
-  passive: false,
-  onEventFired(e) {
-    // Prevent enter from submitting the next form
-    if (e.key === 'Enter' && e.type === 'keydown') e.preventDefault()
-  },
-})
-
+const keys = useMagicKeys()
 const modalState = useModal()
 const { push } = useRouter()
 const { activeWorkspace } = useWorkspace()

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -100,6 +100,8 @@ const modalState = useModal()
 const { push } = useRouter()
 const { activeWorkspace } = useWorkspace()
 
+/** Additional metadata for the command palettes */
+const metaData = ref<string>()
 const commandQuery = ref('')
 const activeCommand = ref<keyof typeof PaletteComponents | null>(null)
 const selectedSearchResult = ref<number>(0)
@@ -183,8 +185,12 @@ const executeCommand = (
 }
 
 /** Handles opening the command pallete to the correct palette */
-const openCommandPalette = ({ commandName }: CommandPaletteEvent = {}) => {
+const openCommandPalette = ({
+  commandName,
+  metaData: _metaData,
+}: CommandPaletteEvent = {}) => {
   activeCommand.value = commandName ?? null
+  metaData.value = _metaData
   modalState.show()
 }
 
@@ -271,6 +277,7 @@ onBeforeUnmount(() => commandPaletteBus.off(openCommandPalette))
       </button>
       <component
         :is="PaletteComponents[activeCommand]"
+        :metaData="metaData"
         @close="closeHandler" />
     </template>
   </div>

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -95,7 +95,14 @@ const availableCommands = [
 ] as const
 type Command = (typeof availableCommands)[number]['commands'][number]
 
-const keys = useMagicKeys()
+const keys = useMagicKeys({
+  passive: false,
+  onEventFired(e) {
+    // Prevent enter from submitting the next form
+    if (e.key === 'Enter' && e.type === 'keydown') e.preventDefault()
+  },
+})
+
 const modalState = useModal()
 const { push } = useRouter()
 const { activeWorkspace } = useWorkspace()

--- a/packages/api-client/src/components/SideNav/SideNav.vue
+++ b/packages/api-client/src/components/SideNav/SideNav.vue
@@ -19,7 +19,7 @@ const { currentRoute } = useRouter()
         v-for="({ icon, name }, i) in ROUTES"
         :key="i">
         <SideNavLink
-          :active="currentRoute.name === name"
+          :active="(currentRoute.name as string | undefined)?.startsWith(name)"
           :icon="icon"
           :name="name">
           {{ name }}

--- a/packages/api-client/src/libs/eventBusses/command-palette.ts
+++ b/packages/api-client/src/libs/eventBusses/command-palette.ts
@@ -1,7 +1,12 @@
 import type { CommandNames } from '@/components/CommandPalette/TheCommandPalette.vue'
 import { type EventBusKey, useEventBus } from '@vueuse/core'
 
-export type CommandPaletteEvent = { commandName?: CommandNames }
+export type CommandPaletteEvent = {
+  /** The command name which matches with the command palette */
+  commandName?: CommandNames
+  /** Any extra metadata we want to pass to the command palettes */
+  metaData?: string
+}
 const commandPaletteKey: EventBusKey<CommandPaletteEvent> = Symbol()
 
 /**

--- a/packages/api-client/src/router.ts
+++ b/packages/api-client/src/router.ts
@@ -33,6 +33,7 @@ const requestRoutes = [
     component: () => import('@/views/Request/Request.vue'),
   },
   {
+    name: 'requestExamples',
     path: `request/:${PathId.Request}/examples/:${PathId.Examples}`,
     component: () => import('@/views/Request/Request.vue'),
   },

--- a/packages/api-client/src/router.ts
+++ b/packages/api-client/src/router.ts
@@ -8,7 +8,7 @@ import {
 
 export enum PathId {
   Request = 'request',
-  Example = 'example',
+  Examples = 'examples',
   Cookies = 'cookies',
   Collection = 'collection',
   Schema = 'schema',
@@ -33,7 +33,7 @@ const requestRoutes = [
     component: () => import('@/views/Request/Request.vue'),
   },
   {
-    path: `request/:${PathId.Request}/example/:${PathId.Example}`,
+    path: `request/:${PathId.Request}/examples/:${PathId.Examples}`,
     component: () => import('@/views/Request/Request.vue'),
   },
 ] satisfies RouteRecordRaw[]
@@ -146,7 +146,7 @@ export const activeRouterParams = computed(() => {
     [PathId.Collection]: 'default',
     [PathId.Environment]: 'default',
     [PathId.Request]: 'default',
-    [PathId.Example]: 'default',
+    [PathId.Examples]: 'default',
     [PathId.Schema]: 'default',
     [PathId.Cookies]: 'default',
     [PathId.Servers]: 'default',

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -151,7 +151,7 @@ const activeRequest = computed(() => {
  * TODO we definitely need a more performant way of doing this, but because folders can have multiple parents
  * theres no easy short circuit we can store. This can work for now but replace this!
  */
-const findRequestFolders = (
+export const findRequestFolders = (
   uid: string,
   foldersToOpen: string[] = [],
 ): string[] => {
@@ -505,6 +505,16 @@ const addCollection = (payload: CollectionPayload, workspaceUid: string) => {
 const deleteCollection = (collectionUid: string) => {
   if (!activeWorkspace.value) return
 
+  if (collections[collectionUid]?.spec?.info?.title === 'Drafts') {
+    console.warn('The drafts collection cannot be deleted')
+    return
+  }
+
+  if (Object.values(collections).length === 1) {
+    console.warn('You must have at least one collection')
+    return
+  }
+
   workspaceMutators.edit(
     activeWorkspace.value.uid,
     'collectionUids',
@@ -519,13 +529,14 @@ const deleteCollection = (collectionUid: string) => {
  * TODO we should add collection to the route and grab this from the params
  */
 const activeCollection = computed(() => {
-  if (!activeRequest.value) return null
+  const firstCollection = Object.values(collections)[0]
+  if (!activeRequest.value) return firstCollection
 
   const uids = findRequestFolders(activeRequest.value.uid)
   if (!uids.length) return null
 
   const collectionUid = uids[uids.length - 1]
-  return collections[collectionUid]
+  return collections[collectionUid] ?? firstCollection
 })
 
 /** The currently selected server in the addressBar */

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -275,7 +275,6 @@ const createExampleFromRequest = (
   })
 
   requestExampleMutators.add(example)
-
   return example
 }
 

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -304,7 +304,7 @@ const deleteRequestExample = (requestExample: RequestExample) => {
 /** Currently active example OR the first one */
 const activeExample = computed(
   () =>
-    requestExamples[activeRouterParams.value[PathId.Example]] ??
+    requestExamples[activeRouterParams.value[PathId.Examples]] ??
     requestExamples[activeRequest.value?.childUids[0] ?? ''],
 )
 

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -292,7 +292,7 @@ const addRequestExample = (request: Request, name?: string) => {
     example.uid,
   ])
 
-  return request
+  return example
 }
 
 /** Ensure we remove from the base as well as from the request it is in */

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { HttpMethod } from '@/components/HttpMethod'
 import { useSidebar } from '@/hooks'
+import { PathId, activeRouterParams } from '@/router'
 import { useWorkspace } from '@/store/workspace'
 import { ScalarIcon } from '@scalar/components'
 import {
@@ -116,6 +117,13 @@ const generateLink = () =>
   'requestUid' in props.item
     ? `/workspace/${activeWorkspace.value.uid}/request/${props.item.requestUid}/examples/${props.item.uid}`
     : `/workspace/${activeWorkspace.value.uid}/request/${props.item.uid}`
+
+/** Since we have exact routing, we should check if the default request is active */
+const isDefaultActive = computed(
+  () =>
+    activeRouterParams.value[PathId.Request] === 'default' &&
+    activeRequest.value.uid === props.item.uid,
+)
 </script>
 <template>
   <div
@@ -145,7 +153,7 @@ const generateLink = () =>
           class="group relative flex min-h-8 cursor-pointer flex-row items-start justify-between gap-2 py-1.5 pr-2 rounded editable-sidebar-hover"
           :class="[
             highlightClasses,
-            isExactActive
+            isExactActive || isDefaultActive
               ? 'bg-sidebar-active-b text-sidebar-active-c transition-none'
               : 'text-sidebar-c-2',
           ]"

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -121,6 +121,12 @@ const showChildren = computed(
     (activeRequest.value?.uid === props.item.uid &&
       (props.item as Request).childUids.length > 1),
 )
+
+/** Generate the request OR example link */
+const generateLink = () =>
+  'requestUid' in props.item
+    ? `/workspace/${activeWorkspace.value.uid}/request/${props.item.requestUid}/examples/${props.item.uid}`
+    : `/workspace/${activeWorkspace.value.uid}/request/${props.item.uid}`
 </script>
 <template>
   <div
@@ -144,7 +150,7 @@ const showChildren = computed(
       <RouterLink
         v-if="'summary' in item || 'requestUid' in item"
         custom
-        :to="`/workspace/${activeWorkspace.uid}/request/${item.uid}`">
+        :to="generateLink()">
         <div
           class="group relative flex min-h-8 cursor-pointer flex-row items-start justify-between gap-2 py-1.5 pr-2 rounded editable-sidebar-hover"
           :class="[

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -15,7 +15,7 @@ import type {
   RequestExample,
 } from '@scalar/oas-utils/entities/workspace/spec'
 import { computed } from 'vue'
-import { RouterLink, useRouter } from 'vue-router'
+import { RouterLink } from 'vue-router'
 
 import RequestSidebarItemMenu from './RequestSidebarItemMenu.vue'
 
@@ -57,7 +57,6 @@ const {
   requestExamples,
 } = useWorkspace()
 const { collapsedSidebarFolders, toggleSidebarFolder } = useSidebar()
-const router = useRouter()
 
 const hasChildren = computed(() => 'childUids' in props.item)
 
@@ -74,16 +73,6 @@ const paddingOffset = computed(() => {
   else if (isReadOnly.value) return `${(props.parentUids.length - 1) * 12}px`
   else return `${props.parentUids.length * 12}px`
 })
-
-const handleNavigation = (event: MouseEvent, uid: string) => {
-  const requestLink = `/workspace/${activeWorkspace.value.uid}/request/${uid}`
-
-  if (event.metaKey) {
-    window.open(requestLink, '_blank')
-  } else {
-    router.push(requestLink)
-  }
-}
 
 const getTitle = (item: (typeof props)['item']) => {
   // Collection
@@ -149,18 +138,18 @@ const generateLink = () =>
       <!-- Request -->
       <RouterLink
         v-if="'summary' in item || 'requestUid' in item"
-        custom
+        v-slot="{ isExactActive }"
+        class="no-underline"
         :to="generateLink()">
         <div
           class="group relative flex min-h-8 cursor-pointer flex-row items-start justify-between gap-2 py-1.5 pr-2 rounded editable-sidebar-hover"
           :class="[
             highlightClasses,
-            activeRequest?.uid === item.uid
+            isExactActive
               ? 'bg-sidebar-active-b text-sidebar-active-c transition-none'
               : 'text-sidebar-c-2',
           ]"
-          tabindex="0"
-          @click="($event) => handleNavigation($event, item.uid)">
+          tabindex="0">
           <span
             class="z-10 font-medium w-full editable-sidebar-hover-item pl-2">
             {{ getTitle(item) }}
@@ -209,8 +198,11 @@ const generateLink = () =>
       <div
         v-if="'childUids' in item"
         v-show="showChildren">
+        <!-- We never want to show the first example -->
         <RequestSidebarItem
-          v-for="uid in item.childUids"
+          v-for="uid in 'summary' in item
+            ? item.childUids.slice(1)
+            : item.childUids"
           :key="uid"
           :isDraggable="isDraggable"
           :isDroppable="isDroppable"

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -26,7 +26,10 @@ const { replace } = useRouter()
 
 /** Add example */
 const handleAddExample = () =>
-  commandPaletteBus.emit({ commandName: 'Add Example' })
+  commandPaletteBus.emit({
+    commandName: 'Add Example',
+    metaData: props.item.uid,
+  })
 
 const handleItemRename = () => {
   console.log('rename')

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { useWorkspace } from '@/store/workspace'
+import { CommandPalette } from '@/components/CommandPalette'
 import {
   ScalarButton,
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
   ScalarIcon,
+  useModal,
 } from '@scalar/components'
 import type {
   Request,
@@ -16,20 +17,11 @@ import { computed } from 'vue'
 const props = defineProps<{
   item: Request | RequestExample
 }>()
-const { createExampleFromRequest, requestMutators } = useWorkspace()
 
-const addExample = () => {
-  if (!('summary' in props.item)) return
+const commandPaletteState = useModal()
 
-  const example = createExampleFromRequest(props.item)
-
-  requestMutators.edit(props.item.uid, 'childUids', [
-    ...props.item.childUids,
-    example.uid,
-  ])
-
-  // TOOD route to example?
-}
+/** Add example */
+const handleAddExample = () => commandPaletteState.show()
 
 const handleItemRename = () => {
   console.log('rename')
@@ -47,6 +39,9 @@ const isRequest = computed(() => 'summary' in props.item)
 </script>
 
 <template>
+  <CommandPalette
+    defaultCommand="Add Example"
+    :state="commandPaletteState" />
   <ScalarDropdown teleport="#scalar-client">
     <ScalarButton
       class="z-10 hover:bg-b-3 transition-none p-1 group-hover:flex ui-open:flex absolute left-0 hidden -translate-x-full -ml-1"
@@ -61,7 +56,7 @@ const isRequest = computed(() => 'summary' in props.item)
       <ScalarDropdownItem
         v-if="isRequest"
         class="flex !gap-2"
-        @click="addExample">
+        @click="handleAddExample">
         <ScalarIcon
           class="inline-flex"
           icon="Add"

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -22,7 +22,7 @@ const props = defineProps<{
 
 const { activeWorkspace, requestMutators, requestExampleMutators } =
   useWorkspace()
-const { currentRoute, replace } = useRouter()
+const { replace } = useRouter()
 
 /** Add example */
 const handleAddExample = () =>
@@ -73,6 +73,7 @@ const isRequest = computed(() => 'summary' in props.item)
         size="sm" />
     </ScalarButton>
     <template #items>
+      <!-- Add example -->
       <ScalarDropdownItem
         v-if="isRequest"
         class="flex !gap-2"
@@ -83,14 +84,22 @@ const isRequest = computed(() => 'summary' in props.item)
           size="sm" />
         <span>Add Example</span>
       </ScalarDropdownItem>
-      <ScalarDropdownItem class="flex !gap-2">
+
+      <!-- Rename -->
+      <ScalarDropdownItem
+        class="flex !gap-2"
+        @click="handleItemRename">
         <ScalarIcon
           class="inline-flex"
           icon="Edit"
           size="sm" />
         <span>Rename</span>
       </ScalarDropdownItem>
-      <ScalarDropdownItem class="flex !gap-2">
+
+      <!-- Duplicate -->
+      <ScalarDropdownItem
+        class="flex !gap-2"
+        @click="handleItemDuplicate">
         <ScalarIcon
           class="inline-flex"
           icon="Duplicate"
@@ -98,6 +107,8 @@ const isRequest = computed(() => 'summary' in props.item)
         <span>Duplicate</span>
       </ScalarDropdownItem>
       <ScalarDropdownDivider />
+
+      <!-- Delete -->
       <ScalarDropdownItem
         class="flex !gap-2"
         @click="handleItemDelete">

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { CommandPalette } from '@/components/CommandPalette'
+import { commandPaletteBus } from '@/libs/eventBusses/command-palette'
 import {
   ScalarButton,
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
   ScalarIcon,
-  useModal,
 } from '@scalar/components'
 import type {
   Request,
@@ -18,10 +17,9 @@ const props = defineProps<{
   item: Request | RequestExample
 }>()
 
-const commandPaletteState = useModal()
-
 /** Add example */
-const handleAddExample = () => commandPaletteState.show()
+const handleAddExample = () =>
+  commandPaletteBus.emit({ commandName: 'Add Example' })
 
 const handleItemRename = () => {
   console.log('rename')
@@ -39,9 +37,6 @@ const isRequest = computed(() => 'summary' in props.item)
 </script>
 
 <template>
-  <CommandPalette
-    defaultCommand="Add Example"
-    :state="commandPaletteState" />
   <ScalarDropdown teleport="#scalar-client">
     <ScalarButton
       class="z-10 hover:bg-b-3 transition-none p-1 group-hover:flex ui-open:flex absolute left-0 hidden -translate-x-full -ml-1"


### PR DESCRIPTION
Made requests functional. We still have the double enter problem but I will leave that for another PR.
- fixed the phantom galaxy workspace
- built out the request example command palette
- added add and delete for examples and requests
- added routing for examples
- switched back to routerLink instead of @click handler on sidebar