### PR TITLE
fix(api-client): remove click.stop page refresh action item

### DIFF
--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -69,8 +69,7 @@ const isRequest = computed(() => 'summary' in props.item)
     <ScalarButton
       class="z-10 hover:bg-b-3 transition-none p-1 group-hover:flex ui-open:flex absolute left-0 hidden -translate-x-full -ml-1"
       size="sm"
-      variant="ghost"
-      @click.stop>
+      variant="ghost">
       <ScalarIcon
         icon="Ellipses"
         size="sm" />


### PR DESCRIPTION
**Problem**
Currently, when you click `...` twice  it reloads the page

**Explanation**
This happens because of a click.stop headless recursive event

**Solution**
With this PR we just dont click.stop
