### PR TITLE
fix(api-client): search modal isn’t centered

### DIFF
--- a/.changeset/gentle-frogs-doubt.md
+++ b/.changeset/gentle-frogs-doubt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: scalar api client fixed to bottom

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -117,7 +117,6 @@ export const useModal = () =>
   top: 0;
   bottom: 0;
   right: 0;
-  margin: auto;
 }
 .scalar-modal.scalar-modal-search {
   max-width: 540px;


### PR DESCRIPTION
**before**
was stuck to the bottom

**after :)** 
![image](https://github.com/user-attachments/assets/577f8b74-2ec4-47b1-b66a-110f8e1f22b6)
