### PR TITLE
feat(api-client): create a default workspace if no OpenAPI document is passed to the modal

### DIFF
--- a/.changeset/giant-chefs-argue.md
+++ b/.changeset/giant-chefs-argue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: create a default workspace if no OpenAPI document is passed to the modal

--- a/packages/api-client/src/layouts/Modal/api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/api-client-modal.ts
@@ -15,7 +15,7 @@ import ApiClientModal from './ApiClientModal.vue'
 /** Configuration options for the Scalar API client */
 export type ClientConfiguration = {
   /** The Swagger/OpenAPI spec to render */
-  spec: SpecConfiguration
+  spec?: SpecConfiguration
   /** Pass in a proxy to the API client */
   proxyUrl?: string
   /** Pass in a theme API client */
@@ -88,11 +88,11 @@ export const createApiClientModal = async (
   } else if (config.spec?.content) {
     await importSpecFile(config.spec?.content)
   } else {
-    console.error(
-      `[@scalar/api-client-modal] Could not create the API client.`,
-      `Please provide an OpenAPI document: { spec: { url: '…' } }`,
-      `Read more: https://github.com/scalar/scalar/tree/main/packages/api-client-modal`,
-    )
+    workspaceMutators.add({
+      uid: 'default',
+      name: 'Workspace',
+      proxyUrl: 'https://proxy.scalar.com',
+    })
   }
 
   const app = createApp(ApiClientModal, { modalState })


### PR DESCRIPTION
Currently, we log an error when no OpenAPI document is passed to the API client modal.

This PR just creates an empty workspace instead. :)

See #2555