### PR TITLE
feat(api-client): make the side nav a draggable region

### DIFF
--- a/.changeset/cold-trains-guess.md
+++ b/.changeset/cold-trains-guess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: make side navigation a drag region

--- a/packages/api-client/src/components/SideNav/SideNav.vue
+++ b/packages/api-client/src/components/SideNav/SideNav.vue
@@ -12,13 +12,14 @@ const { currentRoute } = useRouter()
 <template>
   <nav
     aria-label="Side Navigation"
-    class="text-c-2 w-15 flex flex-col items-center px-2 py-2 scalar-sidenav relative"
+    class="text-c-2 w-15 flex flex-col items-center px-2 py-2 scalar-sidenav relative drag-region"
     role="navigation">
-    <WorkspaceProfileIcon />
+    <WorkspaceProfileIcon class="no-drag-region" />
     <ul class="mt-3.5 flex flex-col gap-1.5">
       <li
         v-for="({ icon, name, prettyName }, i) in ROUTES"
-        :key="i">
+        :key="i"
+        class="no-drag-region">
         <SideNavLink
           :active="(currentRoute.name as string | undefined)?.startsWith(name)"
           :icon="icon"
@@ -29,10 +30,10 @@ const { currentRoute } = useRouter()
       </li>
     </ul>
     <ul class="mt-auto flex flex-col py-1.5">
-      <li class="flex items-center">
+      <li class="flex items-center no-drag-region">
         <SideHelp />
       </li>
-      <li class="flex items-center">
+      <li class="flex items-center no-drag-region">
         <DarkModeIconToggle />
       </li>
     </ul>
@@ -41,5 +42,15 @@ const { currentRoute } = useRouter()
 <style scoped>
 .scalar-sidenav {
   width: 52px;
+}
+
+/** Make the sidebar draggable */
+.drag-region {
+  -webkit-app-region: drag;
+}
+
+/** Clickable items must not be draggable, though */
+.no-drag-region {
+  -webkit-app-region: no-drag;
 }
 </style>


### PR DESCRIPTION
This PR makes the side nav (but not the buttons inside) a draggable region, so it’s easier to move the app window around:

https://github.com/user-attachments/assets/f14b822d-2343-4090-9169-ed71e9ab9d05