### PR TITLE
fix: release workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,9 @@ jobs:
   release:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      id-token: write
     needs: [build, test]
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-20.04
     permissions:
-      contents: read
+      contents: write
       id-token: write
     needs: [build, test]
     strategy:


### PR DESCRIPTION
Add permissions for publishing to npm. Documentation [here](https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow)

