### PR TITLE
chore(api-references): use thickness instead of css overrides

### DIFF
--- a/.changeset/sixty-items-add.md
+++ b/.changeset/sixty-items-add.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore(api-references): use thickness instead of css overrides

--- a/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
+++ b/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
@@ -57,7 +57,8 @@ const { copyToClipboard } = useClipboard()
       <ScalarIcon
         v-else
         class="endpoint-try-hint"
-        icon="Play" />
+        icon="Play"
+        thickness="1.75px" />
       <ScalarIconButton
         class="endpoint-copy"
         icon="Clipboard"
@@ -176,11 +177,6 @@ const { copyToClipboard } = useClipboard()
   height: 24px;
   width: 24px;
   flex-shrink: 0;
-  stroke-width: 1.75px !important;
-  fill: transparent;
-}
-.endpoint-try-hint :deep(path) {
-  stroke-width: 1.75px !important;
 }
 .endpoint-copy {
   color: currentColor;


### PR DESCRIPTION
Just switched to using the thickness prop

Looks the same:

https://github.com/user-attachments/assets/246a58f0-d9b9-4c32-89fc-7163ae070cdc

