### PR TITLE
fix(components): provide a placeholder for icons while loading

### DIFF
--- a/.changeset/gentle-plants-cough.md
+++ b/.changeset/gentle-plants-cough.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: provide a placeholder for icons while loading

--- a/packages/components/src/components/ScalarIcon/icons/index.ts
+++ b/packages/components/src/components/ScalarIcon/icons/index.ts
@@ -1,4 +1,4 @@
-import { defineAsyncComponent } from 'vue'
+import { defineAsyncComponent, h } from 'vue'
 
 import type { ICONS } from './icons'
 
@@ -17,5 +17,10 @@ export const getIcon = (name: Icon) => {
     return null
   }
 
-  return defineAsyncComponent(icons[filename]!)
+  return defineAsyncComponent({
+    loader: icons[filename]!,
+    // Provide a square svg as a placeholder while the icon loads
+    loadingComponent: () => h('svg', { viewBox: '0 0 1 1' }),
+    delay: 0,
+  })
 }


### PR DESCRIPTION
This add a placeholder `<svg>` while the async component is loading to prevent layout shift.

I think by the nature of async components it needs to load them in anytime the view is mounted / unmounted, it doesn't send additional requests for the icons once they've been loaded in. Apparently the small amount of time it takes them to load from cache is enough to cause a flicker but this PR minimizes that flicker.

## Before / After

https://github.com/user-attachments/assets/52761105-03b7-498c-88e7-a37e84e41931
