### PR TITLE
docs: update import to @scalar/hono-api-reference 

### DIFF
--- a/packages/hono-api-reference/README.md
+++ b/packages/hono-api-reference/README.md
@@ -75,7 +75,7 @@ app.get(
 You can use a custom CDN ，default is `https://cdn.jsdelivr.net/npm/@scalar/api-reference`.
 
 ```ts
-import { apiReference } from '@scalar/nestjs-api-reference'
+import { apiReference } from '@scalar/hono-api-reference'
 
 app.use(
   '/reference',


### PR DESCRIPTION
This PR updates the README.md in `hono-api-reference` to correct the import.