### PR TITLE
fix: latest changes broke testing base url

### DIFF
--- a/.changeset/shiny-trees-hunt.md
+++ b/.changeset/shiny-trees-hunt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: use window location origin if no servers

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -147,7 +147,10 @@ export const importSpecToWorkspace = async (spec: string | AnyObject) => {
     ? parsedSpec.servers!
     : [
         {
-          url: 'http://localhost',
+          url:
+            typeof window !== 'undefined'
+              ? window.location.origin
+              : 'http://localhost',
           description: 'Replace with your API server',
         },
       ]


### PR DESCRIPTION
Currently we use a default of localhost, but this breaks for our opensource integrations that rely on the servers origin to fallback to for the server, now we default to the origin the server is hosted on! we might want to eventually do something different for the Scalar App where we actually _dont_ have a server populated if theres no server, and have an empty varible in an error state so the user can update it : )

but that can be a future thing
