### PR TITLE
fix: activate query params by default only if required

### DIFF
--- a/.changeset/rotten-camels-taste.md
+++ b/.changeset/rotten-camels-taste.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: only trigger codeinput change event if the value has changed

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -63,6 +63,9 @@ const { activeWorkspace } = useWorkspace()
 
 /** Change is emitted during typing. This does not trigger validation */
 function handleChange(value: string) {
+  // We need to be careful, only if the value is different we trigger an update
+  // on initial load of the component, this gets triggered cause we set the content
+  if (value === props.modelValue) return null
   return props.handleFieldChange
     ? props.handleFieldChange(value)
     : emit('update:modelValue', value)


### PR DESCRIPTION
this is actually a spooky bug, cause we were always triggering an onChange on first load for all inputs.

now we only trigger if its actually different!