### PR TITLE
fix: remove ScalarCodeBlock that freezes browser in response preview

### DIFF
--- a/.changeset/ninety-birds-return.md
+++ b/.changeset/ninety-birds-return.md
@@ -1,0 +1,6 @@
+---
+'@scalar/use-codemirror': patch
+'@scalar/api-client': patch
+---
+
+fix: remove ScalarCodeBlock that freezes browser in response preview

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -39,18 +39,22 @@ useCodeMirror({
 <template>
   <ViewLayoutCollapse>
     <template #title>{{ title }}</template>
-    <DataTable :columns="['']">
-      <DataTableRow>
-        <div ref="codeMirrorRef" />
-      </DataTableRow>
-    </DataTable>
+    <div ref="codeMirrorRef" />
   </ViewLayoutCollapse>
 </template>
 <style scoped>
 .force-text-sm {
   --scalar-small: 13px;
 }
-iframe {
+:deep(.cm-editor) {
   background-color: transparent;
+  font-size: var(--scalar-mini);
+  outline: none;
+  border-radius: var(--scalar-radius);
+  border: 0.5px solid var(--scalar-border-color);
+}
+:deep(.cm-gutters) {
+  background-color: var(--scalar-background-1);
+  border-radius: var(--scalar-radius) 0 0 var(--scalar-radius);
 }
 </style>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -1,28 +1,20 @@
 <script lang="ts" setup>
 import DataTable from '@/components/DataTable/DataTable.vue'
-import DataTableHeader from '@/components/DataTable/DataTableHeader.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
-import { useDarkModeState } from '@/hooks'
-import { useWorkspace } from '@/store/workspace'
-import { ScalarCodeBlock, ScalarIcon } from '@scalar/components'
-import { getThemeStyles } from '@scalar/themes'
-import { computed, nextTick, ref, watch } from 'vue'
+import { useCodeMirror } from '@scalar/use-codemirror'
+import { computed, ref, toRef } from 'vue'
 
 const props = withDefaults(
   defineProps<{
     title: string
-    active: boolean
     data: any
     headers: { name: string; value: string; required: boolean }[]
   }>(),
   {
-    active: false,
     data: null,
   },
 )
-
-const { activeWorkspace } = useWorkspace()
 
 const codeLanguage = computed(() => {
   const contentTypeHeader =
@@ -31,120 +23,27 @@ const codeLanguage = computed(() => {
 
   if (contentTypeHeader.includes('json')) return 'json'
   if (contentTypeHeader.includes('html')) return 'html'
-  return 'plaintext'
+  return 'html'
 })
 
-const iframe = ref<HTMLIFrameElement | null>(null)
+const codeMirrorRef = ref<HTMLDivElement | null>(null)
 
-const activePreview = ref('raw')
-const previewOptions = ['raw', 'preview']
-
-const { isDark } = useDarkModeState()
-watch(
-  () => activePreview.value,
-  async (newValue) => {
-    if (newValue === 'preview') {
-      await nextTick()
-      if (iframe.value) {
-        const doc =
-          iframe.value.contentDocument || iframe.value.contentWindow?.document
-        if (!doc) return
-        doc.open()
-        doc.write(props.data)
-        doc.close()
-      }
-    }
-  },
-)
-
-watch(
-  () => isDark.value,
-  async (newValue) => {
-    await nextTick()
-    if (iframe.value) {
-      const doc =
-        iframe.value.contentDocument || iframe.value.contentWindow?.document
-      if (!doc) return
-      doc.body.classList.toggle('dark-mode', isDark.value)
-      doc.body.classList.toggle('light-mode', !isDark.value)
-    }
-  },
-)
-
-watch(
-  () => activePreview.value,
-  async (newValue) => {
-    if (newValue === 'preview') {
-      await nextTick()
-      if (iframe.value) {
-        const doc =
-          iframe.value.contentDocument || iframe.value.contentWindow?.document
-        if (!doc) return
-        doc.open()
-        doc.write(props.data)
-        doc.body.classList.toggle('dark-mode', isDark.value)
-        doc.body.classList.toggle('light-mode', !isDark.value)
-        doc.write(
-          '<style>body,html {body:not(:has(* + style + style)) {font-family: var(--scalar-font-code); font-size: 12px; font-weight: 400;background:var(--scalar-background-1); color: var(--scalar-color-2)}</style>',
-        )
-        if (activeWorkspace.value?.themeId) {
-          doc.write(
-            `<style>${getThemeStyles(activeWorkspace.value.themeId)}</style>`,
-          )
-        }
-        doc.close()
-      }
-    }
-  },
-)
+useCodeMirror({
+  codeMirrorRef,
+  readOnly: true,
+  lineNumbers: true,
+  content: toRef(() => props.data),
+  language: codeLanguage,
+})
 </script>
 <template>
   <ViewLayoutCollapse>
     <template #title>{{ title }}</template>
-    <template v-if="active">
-      <DataTable :columns="['']">
-        <DataTableRow>
-          <DataTableHeader
-            class="relative col-span-full flex h-8 cursor-pointer items-center px-[2.25px] py-[2.25px]">
-            <div
-              class="text-c-2 group-hover:text-c-1 flex h-full w-full items-center justify-start rounded px-1.5">
-              <span class="capitalize">{{ activePreview }}</span>
-              <ScalarIcon
-                class="text-c-3 ml-1 mt-px"
-                icon="ChevronDown"
-                size="xs" />
-            </div>
-            <select
-              v-model="activePreview"
-              class="absolute inset-0 w-auto opacity-0"
-              @click.prevent>
-              <option
-                v-for="value in previewOptions"
-                :key="value"
-                :value="value">
-                {{ value }}
-              </option>
-            </select>
-          </DataTableHeader>
-        </DataTableRow>
-        <DataTableRow>
-          <template v-if="activePreview === 'raw'">
-            <ScalarCodeBlock
-              class="force-text-sm rounded-b border-t-0"
-              :content="data"
-              :lang="codeLanguage" />
-          </template>
-          <template v-else>
-            <iframe
-              ref="iframe"
-              allowfullscreen
-              allowtransparency="true"
-              class="w-full aspect-video"
-              frameborder="0"></iframe>
-          </template>
-        </DataTableRow>
-      </DataTable>
-    </template>
+    <DataTable :columns="['']">
+      <DataTableRow>
+        <div ref="codeMirrorRef" />
+      </DataTableRow>
+    </DataTable>
   </ViewLayoutCollapse>
 </template>
 <style scoped>

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -72,7 +72,7 @@ export type UseCodeMirrorParameters =
   | (BaseParameters & {
       /** Prefill the content. Will be ignored when a provider is given. */
       content: MaybeRefOrGetter<string | undefined>
-      onChange: (v: string) => void
+      onChange?: (v: string) => void
     })
   | (BaseParameters & {
       provider: MaybeRefOrGetter<Extension | null>


### PR DESCRIPTION
**Problem**
Currently HighlightJS freezes for large responses > 700KB. https://github.com/scalar/scalar/issues/2503

Codemirror does a great job w large files + virtualization, so lets remove Highlight.js for the API Client Responses

In this PR I also remove "preview" mode, since it needs to be re-thought out :) 