### PR TITLE
fix: whitespace http method

### DIFF
--- a/.changeset/three-spoons-grin.md
+++ b/.changeset/three-spoons-grin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: http method whitespace wrap

--- a/packages/api-client/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/api-client/src/components/HttpMethod/HttpMethod.vue
@@ -35,7 +35,7 @@ const variants = cva({
   base: 'text-center font-code text-3xs justify-center items-center flex',
   variants: {
     isSquare: {
-      true: 'px-2.5 rounded-md shadow-border',
+      true: 'px-2.5 rounded-md shadow-border whitespace-nowrap',
       false: 'rounded-full',
     },
     isEditable: {


### PR DESCRIPTION
collision in gitbook that should be fixed now: 

before:
<img width="347" alt="image" src="https://github.com/user-attachments/assets/3879848b-26e4-46c2-a0b6-91a267f08e92">

after:
<img width="352" alt="image" src="https://github.com/user-attachments/assets/842dd27d-d557-4458-a3f6-475d09feae10">
