### PR TITLE
fix: remove trailing whitespace codemirror env pill

### DIFF
--- a/.changeset/seven-schools-jump.md
+++ b/.changeset/seven-schools-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: remove trailing whitespace codemirror env pill

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -277,4 +277,7 @@ export default {
 .cm-pill:first-of-type {
   margin-left: 0;
 }
+.cm-widgetBuffer {
+  /* display: none !important; */
+}
 </style>

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -277,7 +277,7 @@ export default {
 .cm-pill:first-of-type {
   margin-left: 0;
 }
-.cm-widgetBuffer {
-  display: none !important;
+.cm-editor .cm-widgetBuffer {
+  display: none;
 }
 </style>

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -278,6 +278,6 @@ export default {
   margin-left: 0;
 }
 .cm-widgetBuffer {
-  /* display: none !important; */
+  display: none !important;
 }
 </style>


### PR DESCRIPTION
was driving me 🫨 

before:
https://github.com/user-attachments/assets/45cc2c00-2438-405a-9a37-e087e4f2eec5

after:

https://github.com/user-attachments/assets/272e8612-1577-4a3d-bde2-aef690cb3e25

