### PR TITLE
fix(api-reference): initial dark mode state bug and add configuration for darkmode

### DIFF
--- a/.changeset/fluffy-poems-try.md
+++ b/.changeset/fluffy-poems-try.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: initial dark mode state bug and add configuration for darkmode

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -90,6 +90,36 @@ Whether to show the "Download OpenAPI Specification" button
 }
 ```
 
+#### darkMode?: boolean
+
+Whether dark mode is on or off initially (light mode)
+
+```js
+{
+  darkMode: true
+}
+```
+
+#### forceDarkModeState?: 'dark' | 'light'
+
+forceDarkModeState makes it always this state no matter what
+
+```js
+{
+  forceDarkModeState: 'dark'
+}
+```
+
+#### hideDarkModeToggle?: boolean
+
+Whether to show the dark mode toggle
+
+```js
+{
+  hideDarkModeToggle: true
+}
+```
+
 ### customCss?: string
 
 You can pass custom CSS directly to the component. This is helpful for the integrations for Fastify, Express, Hono and others where you it’s easier to add CSS to the configuration.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -18,6 +18,7 @@ defineEmits<{
 
 const { toggleDarkMode, isDark } = useDarkModeState(
   props.configuration?.darkMode,
+  props.configuration?.forceDarkModeState,
 )
 
 /** Update the dark mode state when props change */

--- a/packages/api-reference/src/components/Layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ClassicLayout.vue
@@ -41,6 +41,7 @@ const config = computed(() => ({ ...props.configuration, showSidebar: false }))
           :spec="spec" />
         <template #dark-mode-toggle>
           <DarkModeIconToggle
+            v-if="!!!props.configuration.hideDarkModeToggle"
             :isDarkMode="isDark"
             @toggleDarkMode="$emit('toggleDarkMode')" />
         </template>

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -62,6 +62,7 @@ watch(hash, (newHash, oldHash) => {
     </template>
     <template #sidebar-end>
       <DarkModeToggle
+        v-if="!!!props.configuration.hideDarkModeToggle"
         :isDarkMode="isDark"
         @toggleDarkMode="$emit('toggleDarkMode')" />
     </template>

--- a/packages/api-reference/src/hooks/useDarkModeState.test.ts
+++ b/packages/api-reference/src/hooks/useDarkModeState.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { useDarkModeState } from './useDarkModeState'
+
+describe('useDarkModeState', () => {
+  it('works with light mode as the system setting', async () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+    })
+
+    const { isDark } = useDarkModeState()
+
+    expect(isDark.value).toBe(false)
+  })
+
+  it('sets dark mode initially', async () => {
+    const { isDark } = useDarkModeState(true)
+
+    expect(isDark.value).toBe(true)
+  })
+
+  it('toggles the dark mode', async () => {
+    const { isDark, toggleDarkMode } = useDarkModeState()
+
+    expect(isDark.value).toBe(false)
+
+    toggleDarkMode()
+    expect(isDark.value).toBe(true)
+  })
+
+  it('sets the dark mode', async () => {
+    const { isDark, setDarkMode } = useDarkModeState()
+
+    expect(isDark.value).toBe(true)
+
+    setDarkMode(false)
+    expect(isDark.value).toBe(false)
+  })
+
+  it('forces light mode', async () => {
+    const { isDark } = useDarkModeState(undefined, 'light')
+
+    expect(isDark.value).toBe(false)
+  })
+
+  it('forces dark mode', async () => {
+    const { isDark } = useDarkModeState(undefined, 'dark')
+
+    expect(isDark.value).toBe(true)
+  })
+})

--- a/packages/api-reference/src/hooks/useDarkModeState.ts
+++ b/packages/api-reference/src/hooks/useDarkModeState.ts
@@ -4,7 +4,10 @@ import { ref, watch } from 'vue'
 const isDark = ref<boolean>(false)
 
 /** This hook helps with retrieving the dark mode setting from local storage or from system settings. */
-export function useDarkModeState(isDarkInitially?: boolean) {
+export function useDarkModeState(
+  isDarkInitially?: boolean,
+  forceDarkModeState?: 'dark' | 'light',
+) {
   // Get initial dark mode state
   const getDarkModeState = () => {
     // Use setting from local storage
@@ -46,13 +49,17 @@ export function useDarkModeState(isDarkInitially?: boolean) {
     }
   }
 
-  // Priority of initial values is: LocalStorage/App Config/Fallback
-  isDark.value =
-    (typeof window === 'undefined'
-      ? null
-      : JSON.parse(window.localStorage?.getItem('isDark') || 'null')) ??
-    isDarkInitially ??
-    getDarkModeState()
+  // Priority of initial values is: forceState -> LocalStorage/App ->  Config/Fallback
+  if (forceDarkModeState) {
+    isDark.value = forceDarkModeState === 'dark' ? true : false
+  } else {
+    isDark.value =
+      (typeof window === 'undefined'
+        ? null
+        : JSON.parse(window.localStorage?.getItem('isDark') || 'null')) ??
+      isDarkInitially ??
+      getDarkModeState()
+  }
 
   watch(
     isDark,

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -80,6 +80,10 @@ export type ReferenceConfiguration = {
   hideDownloadButton?: boolean
   /** Whether dark mode is on or off initially (light mode) */
   darkMode?: boolean
+  /** forceDarkModeState makes it always this state no matter what*/
+  forceDarkModeState?: 'dark' | 'light'
+  /** Whether to show the dark mode toggle */
+  hideDarkModeToggle?: boolean
   /** Key used with CTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k) */
   searchHotKey?:
     | 'a'


### PR DESCRIPTION
**Problem**
Currently users arent able to disable the dark mode button or force a state, this often leads to us defaulting to the browser or system settings which can be infinitely jarring


**Solution**
I updated the docs, added some more configuration for the user :) we are so back

#### darkMode?: boolean

Whether dark mode is on or off initially (light mode)

```js
{
  darkMode: true
}
```

#### forceDarkModeState?: 'dark' | 'light'

forceDarkModeState makes it always this state no matter what

```js
{
  forceDarkModeState: 'dark'
}
```

#### hideDarkModeToggle?: boolean

Whether to show the dark mode toggle

```js
{
  hideDarkModeToggle: true
}
```


some people might have external night and day mode buttons, so these arent all inclusive :) 