### PR TITLE
fix(api-reference): allow scrolling to collapsed sections via hash

### DIFF
--- a/.changeset/smooth-chairs-kneel.md
+++ b/.changeset/smooth-chairs-kneel.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/galaxy': patch
+---
+
+fix(api-reference): allow scrolling to collapsed sections via hash

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -107,9 +107,15 @@ onBeforeMount(() => updateHash())
 const scrollToSection = async (id?: string) => {
   isIntersectionEnabled.value = false
   updateHash()
-
-  if (id) scrollToId(id)
-  else documentEl.value?.scrollTo(0, 0)
+  if (id) {
+    // Open the section if it's collapsed
+    const sectionId = getSectionId(id)
+    if (sectionId !== id) {
+      setCollapsedSidebarItem(getSectionId(id), true)
+      await sleep(100)
+    }
+    scrollToId(id)
+  } else documentEl.value?.scrollTo(0, 0)
 
   await sleep(100)
   isIntersectionEnabled.value = true

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Scalar Galaxy
   description: |
-    The Scalar Galaxy is an example OpenAPI specification to test OpenAPI tools and libraries. It’s a fictional universe with fictional planets and fictional data. Get all the data for all planets.
+    The Scalar Galaxy is an example OpenAPI specification to test OpenAPI tools and libraries. It’s a fictional universe with fictional planets and fictional data. Get all the data for [all planets](#tag/planets/GET/planets).
 
     ## Resources
 
@@ -12,7 +12,7 @@ info:
 
     ## Markdown Support
 
-    All descriptions *can* contain ~~tons of text~~ **Markdown**. [If GitHub supports the syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax), chances are we’re supporting it, too.
+    All descriptions *can* contain ~~tons of text~~ **Markdown**. [If GitHub supports the syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax), chances are we’re supporting it, too. You can even create [internal links to reference endpoints](#tag/authentication/POST/user/signup).
 
     <details>
       <summary>Examples</summary>


### PR DESCRIPTION
Make sure the section is expanded so we can scroll to it on hash change. Also adds some internal links to the Scalar Galaxy description.

Fixes #2603

## Before: 

https://github.com/user-attachments/assets/2309ab56-b83c-48db-8f02-e510782c557f

## After:

https://github.com/user-attachments/assets/574b62a1-82d4-4a24-890e-938c65a9ad74

