### PR TITLE
chore(void-server): remove unidici from void server

### DIFF
--- a/.changeset/heavy-flowers-tan.md
+++ b/.changeset/heavy-flowers-tan.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+chore: remove undici dependency

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -43,8 +43,7 @@
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "hono": "^4.2.7",
-    "object-to-xml": "^2.0.0",
-    "undici": "^6.19.2"
+    "object-to-xml": "^2.0.0"
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*"

--- a/packages/void-server/src/utils/getBody.ts
+++ b/packages/void-server/src/utils/getBody.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono'
-// Node 18 doesn’t have File, so we need to import it from 'undici'
+// Node 18 doesn’t have File, so we need to import it
 import { File } from 'node:buffer'
 
 /**

--- a/packages/void-server/src/utils/getBody.ts
+++ b/packages/void-server/src/utils/getBody.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 // Node 18 doesn’t have File, so we need to import it from 'undici'
-import { File } from 'undici'
+import { File } from 'node:buffer'
 
 /**
  * Get the body of a request, no matter if it’s JSON or text

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1942,9 +1942,6 @@ importers:
       object-to-xml:
         specifier: ^2.0.0
         version: 2.0.0
-      undici:
-        specifier: ^6.19.2
-        version: 6.19.2
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -15035,10 +15032,6 @@ packages:
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
-
-  undici@6.19.2:
-    resolution: {integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==}
-    engines: {node: '>=18.17'}
 
   unenv-nightly@1.10.0-1717606461.a117952:
     resolution: {integrity: sha512-u3TfBX02WzbHTpaEfWEKwDijDSFAHcgXkayUZ+MVDrjhLFvgAJzFGTSTmwlEhwWi2exyRQey23ah9wELMM6etg==}
@@ -34319,8 +34312,6 @@ snapshots:
   undici@5.28.4:
     dependencies:
       '@fastify/busboy': 2.1.1
-
-  undici@6.19.2: {}
 
   unenv-nightly@1.10.0-1717606461.a117952:
     dependencies:


### PR DESCRIPTION
The recent `@scalar/void-server` can’t be deployed to Cloudflare. We recently introduced `undici` as a dependency, but this requires a lot of Node APIs (`string_decoder`, `node:assert`), and this makes trouble on CF. :)

This PR tries to get rid of undici. Hopefully, this helps.