### PR TITLE
fix: remove layout code from scalar-app

### DIFF
--- a/.changeset/early-clouds-share.md
+++ b/.changeset/early-clouds-share.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: remove layout code from scalar-app class

--- a/packages/api-client/src/layouts/Modal/ApiClientModal.vue
+++ b/packages/api-client/src/layouts/Modal/ApiClientModal.vue
@@ -32,7 +32,7 @@ onBeforeUnmount(() => document.documentElement.style.removeProperty('overflow'))
     v-show="modalState.open"
     class="scalar">
     <div className="scalar-container">
-      <div className="scalar-app scalar-client">
+      <div className="scalar-app scalar-client scalar-app-layout">
         <RouterView key="$route.fullPath" />
       </div>
       <div
@@ -53,7 +53,7 @@ onBeforeUnmount(() => document.documentElement.style.removeProperty('overflow'))
   max-height: calc(100% - calc(var(--scalar-app-header-height)));
   border-radius: 8px;
 }
-.scalar .scalar-app {
+.scalar .scalar-app-layout {
   background: var(--scalar-background-3);
   height: calc(100% - 120px);
   max-width: 1390px;


### PR DESCRIPTION
with the addition of the "scalar-app" class to headless ui we needed to remove layout code that was being written on 'scalar-app'