### PR TITLE
fix: matchMedia is not a function

### DIFF
--- a/.changeset/real-ways-dance.md
+++ b/.changeset/real-ways-dance.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: window.matchMedia is not a function

--- a/packages/api-client/src/hooks/useDarkModeState.ts
+++ b/packages/api-client/src/hooks/useDarkModeState.ts
@@ -20,6 +20,7 @@ export function useDarkModeState(isDarkInitially?: boolean) {
     // Fall back to system setting
     if (
       typeof window !== 'undefined' &&
+      typeof window?.matchMedia === 'function' &&
       window?.matchMedia('(prefers-color-scheme: dark)')?.matches
     ) {
       return true

--- a/packages/api-reference/src/hooks/useDarkModeState.ts
+++ b/packages/api-reference/src/hooks/useDarkModeState.ts
@@ -20,6 +20,7 @@ export function useDarkModeState(isDarkInitially?: boolean) {
     // Fall back to system setting
     if (
       typeof window !== 'undefined' &&
+      typeof window?.matchMedia === 'function' &&
       window?.matchMedia('(prefers-color-scheme: dark)')?.matches
     ) {
       return true


### PR DESCRIPTION
I saw an exception in jsdom, which doesn’t have the matchMedia API:

```bash
TypeError: window?.matchMedia is not a function
 ❯ getDarkModeState src/hooks/useDarkModeState.ts:23:15
     21|     if (
     22|       typeof window !== 'undefined' &&
     23|       window?.matchMedia('(prefers-color-scheme: dark)')?.matches
       |               ^
     24|     ) {
     25|       return true
```

This PR fixes it!