### PR TITLE
feat(api-client): make the configuration for `createApiClientApp` and `createApiClientModal` optional

### DIFF
--- a/.changeset/rotten-apes-explain.md
+++ b/.changeset/rotten-apes-explain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: make the configuration for createApiClientApp and createApiClientModal optional

--- a/packages/api-client/src/layouts/App/create-api-client-app.ts
+++ b/packages/api-client/src/layouts/App/create-api-client-app.ts
@@ -9,8 +9,8 @@ import ApiClientApp from './ApiClientApp.vue'
 export const createApiClientApp = async (
   /** Element to mount the references to */
   el: HTMLElement | null,
-  /** Configuration object for Scalar References */
-  configuration?: ClientConfiguration,
+  /** Configuration object for API client */
+  configuration: ClientConfiguration = {},
   /**
    * Will attempt to mount the references immediately
    * For SSR this may need to be blocked and done client side
@@ -22,7 +22,7 @@ export const createApiClientApp = async (
   const client = createApiClient({
     el,
     appComponent: ApiClientApp,
-    configuration: configuration ?? {},
+    configuration: configuration,
     mountOnInitialize,
     router,
   })
@@ -30,10 +30,10 @@ export const createApiClientApp = async (
   const { importSpecFile, importSpecFromUrl } = client.store
 
   // Import the spec if needed
-  if (configuration?.spec?.url) {
-    await importSpecFromUrl(configuration?.spec.url, configuration?.proxyUrl)
-  } else if (configuration?.spec?.content) {
-    await importSpecFile(configuration?.spec?.content)
+  if (configuration.spec?.url) {
+    await importSpecFromUrl(configuration.spec.url, configuration.proxyUrl)
+  } else if (configuration.spec?.content) {
+    await importSpecFile(configuration.spec?.content)
   }
 
   return client

--- a/packages/api-client/src/layouts/App/create-api-client-app.ts
+++ b/packages/api-client/src/layouts/App/create-api-client-app.ts
@@ -10,7 +10,7 @@ export const createApiClientApp = async (
   /** Element to mount the references to */
   el: HTMLElement | null,
   /** Configuration object for Scalar References */
-  configuration: ClientConfiguration,
+  configuration?: ClientConfiguration,
   /**
    * Will attempt to mount the references immediately
    * For SSR this may need to be blocked and done client side
@@ -22,7 +22,7 @@ export const createApiClientApp = async (
   const client = createApiClient({
     el,
     appComponent: ApiClientApp,
-    configuration,
+    configuration: configuration ?? {},
     mountOnInitialize,
     router,
   })
@@ -30,10 +30,10 @@ export const createApiClientApp = async (
   const { importSpecFile, importSpecFromUrl } = client.store
 
   // Import the spec if needed
-  if (configuration.spec?.url) {
-    await importSpecFromUrl(configuration.spec.url, configuration.proxyUrl)
-  } else if (configuration.spec?.content) {
-    await importSpecFile(configuration.spec?.content)
+  if (configuration?.spec?.url) {
+    await importSpecFromUrl(configuration?.spec.url, configuration?.proxyUrl)
+  } else if (configuration?.spec?.content) {
+    await importSpecFile(configuration?.spec?.content)
   }
 
   return client

--- a/packages/api-client/src/layouts/Modal/api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/api-client-modal.ts
@@ -11,8 +11,8 @@ import ApiClientModal from './ApiClientModal.vue'
 export const createApiClientModal = async (
   /** Element to mount the references to */
   el: HTMLElement | null,
-  /** Configuration object for Scalar References */
-  configuration?: ClientConfiguration,
+  /** Configuration object for the API client */
+  configuration: ClientConfiguration = {},
   /**
    * Will attempt to mount the references immediately
    * For SSR this may need to be blocked and done client side
@@ -22,7 +22,7 @@ export const createApiClientModal = async (
   const client = createApiClient({
     el,
     appComponent: ApiClientModal,
-    configuration,
+    configuration: configuration,
     persistData: false,
     isReadOnly: true,
     mountOnInitialize,
@@ -58,8 +58,8 @@ export const createApiClientModal = async (
 export const createApiClientModalSync = (
   /** Element to mount the references to */
   el: HTMLElement | null,
-  /** Configuration object for Scalar References */
-  configuration?: ClientConfiguration,
+  /** Configuration object for API client */
+  configuration: ClientConfiguration = {},
   /**
    * Will attempt to mount the references immediately
    * For SSR this may need to be blocked and done client side

--- a/packages/api-client/src/layouts/Modal/api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/api-client-modal.ts
@@ -12,7 +12,7 @@ export const createApiClientModal = async (
   /** Element to mount the references to */
   el: HTMLElement | null,
   /** Configuration object for Scalar References */
-  configuration: ClientConfiguration,
+  configuration?: ClientConfiguration,
   /**
    * Will attempt to mount the references immediately
    * For SSR this may need to be blocked and done client side
@@ -59,7 +59,7 @@ export const createApiClientModalSync = (
   /** Element to mount the references to */
   el: HTMLElement | null,
   /** Configuration object for Scalar References */
-  configuration: ClientConfiguration,
+  configuration?: ClientConfiguration,
   /**
    * Will attempt to mount the references immediately
    * For SSR this may need to be blocked and done client side

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -63,7 +63,7 @@ type CreateApiClientParams = {
   el: HTMLElement | null
   /** Main vue app component to create the vue app */
   appComponent: Component
-  /** Configuration object for Scalar References */
+  /** Configuration object for API client */
   configuration?: Omit<ClientConfiguration, 'spec'>
   /** Read only version of the client app */
   isReadOnly?: boolean

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -64,7 +64,7 @@ type CreateApiClientParams = {
   /** Main vue app component to create the vue app */
   appComponent: Component
   /** Configuration object for Scalar References */
-  configuration: Omit<ClientConfiguration, 'spec'>
+  configuration?: Omit<ClientConfiguration, 'spec'>
   /** Read only version of the client app */
   isReadOnly?: boolean
   /** Persist the workspace to localStoragfe */
@@ -100,7 +100,7 @@ export const createApiClient = ({
       uid: 'default',
       name: 'Workspace',
       isReadOnly,
-      proxyUrl: configuration.proxyUrl,
+      proxyUrl: configuration?.proxyUrl,
     }),
   )
 
@@ -140,19 +140,19 @@ export const createApiClient = ({
   if (activeWorkspace.value) {
     if (mountOnInitialize) mount()
 
-    if (configuration.proxyUrl) {
+    if (configuration?.proxyUrl) {
       workspaceMutators.edit(
         activeWorkspace.value.uid,
         'proxyUrl',
-        configuration.proxyUrl,
+        configuration?.proxyUrl,
       )
     }
 
-    if (configuration.themeId) {
+    if (configuration?.themeId) {
       workspaceMutators.edit(
         activeWorkspace.value.uid,
         'themeId',
-        configuration.themeId,
+        configuration?.themeId,
       )
     }
   }
@@ -163,9 +163,9 @@ export const createApiClient = ({
     /** Update the API client config */
     updateConfig(newConfig: ClientConfiguration, mergeConfigs = true) {
       if (mergeConfigs) {
-        Object.assign(configuration, newConfig)
+        Object.assign(configuration ?? {}, newConfig)
       } else {
-        objectMerge(configuration, newConfig)
+        objectMerge(configuration ?? {}, newConfig)
       }
       if (newConfig.spec) {
         importSpecFile(newConfig.spec)
@@ -261,7 +261,7 @@ export const createApiClient = ({
     /** Update the spec file, this will re-parse it and clear your store */
     updateSpec: async (spec: SpecConfiguration) => {
       if (spec?.url) {
-        await importSpecFromUrl(spec.url, configuration.proxyUrl)
+        await importSpecFromUrl(spec.url, configuration?.proxyUrl)
       } else if (spec?.content) {
         await importSpecFile(spec?.content)
       } else {

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -86,7 +86,7 @@ type CreateApiClientParams = {
 export const createApiClient = ({
   el,
   appComponent,
-  configuration,
+  configuration = {},
   isReadOnly = false,
   persistData = true,
   mountOnInitialize = true,

--- a/packages/api-reference/src/esm.ts
+++ b/packages/api-reference/src/esm.ts
@@ -6,7 +6,7 @@ import { createApp, reactive } from 'vue'
 import ApiReference from './components/ApiReference.vue'
 import type { ReferenceConfiguration } from './types'
 
-/** Initialize Scalar References and  */
+/** Initialize Scalar References */
 export function createScalarReferences(
   /** Element to mount the references to */
   el: HTMLElement | null,


### PR DESCRIPTION
I was wondering why the configuration is required and thought about making it optional. With this PR you can just omit the configuration:

```diff
-await createApiClientModal(document.getElementById('app'), {})
+await createApiClientModal(document.getElementById('app'))
```