### PR TITLE
chore(void-server): remove `node:buffer` import

### DIFF
--- a/.changeset/hot-timers-cough.md
+++ b/.changeset/hot-timers-cough.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+chore: remove node:buffer import

--- a/packages/void-server/src/utils/getBody.ts
+++ b/packages/void-server/src/utils/getBody.ts
@@ -1,6 +1,4 @@
 import type { Context } from 'hono'
-// Node 18 doesn’t have File, so we need to import it
-import { File } from 'node:buffer'
 
 /**
  * Get the body of a request, no matter if it’s JSON or text
@@ -48,7 +46,14 @@ function transformFormData(formData: Record<string, any>) {
     }
 
     // File
-    if (value instanceof File) {
+    const isFile =
+      typeof value === 'object' &&
+      value.name !== undefined &&
+      value.size !== undefined &&
+      value.type !== undefined &&
+      value.lastModified !== undefined
+
+    if (isFile) {
       body[key] = {
         name: value?.name,
         sizeInBytes: value?.size,


### PR DESCRIPTION
I have still trouble with the import from `node:buffer`, so let’s try to remove it entirely.

I think, comparing `myObject instanceof myClass` is basically comparing if it has the same attributes, so we can also just do this manually.

This should make it easier to deploy `@scalar/void-server`.