### PR TITLE
chore(api-client-app): block all permission requests

### DIFF
--- a/.changeset/stale-ravens-dress.md
+++ b/.changeset/stale-ravens-dress.md
@@ -1,0 +1,5 @@
+---
+'scalar-api-client': patch
+---
+
+security: block all permission requests

--- a/packages/api-client-app/src/main/index.ts
+++ b/packages/api-client-app/src/main/index.ts
@@ -1,6 +1,7 @@
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import todesktop from '@todesktop/runtime'
 import { BrowserWindow, app, ipcMain, shell } from 'electron'
+import { session } from 'electron'
 import { join } from 'path'
 
 import icon from '../../build/icon.png?asset'
@@ -88,6 +89,17 @@ app.whenReady().then(() => {
     // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
+
+  // Block all permission requests (but for notifications)
+  session
+    .fromPartition('main')
+    .setPermissionRequestHandler((_, permission, callback) => {
+      if (permission === 'notifications') {
+        callback(true)
+      } else {
+        callback(false)
+      }
+    })
 })
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/packages/api-client-app/src/renderer/index.html
+++ b/packages/api-client-app/src/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' *; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src https://fonts.scalar.com" />
+      content="default-src 'self'; connect-src *; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src https://fonts.scalar.com" />
   </head>
 
   <body>


### PR DESCRIPTION
The toDesktop static analysis pointed out a security issue, this PR tries to fix it.

More context: https://www.todesktop.com/static-analysis/permission-request-handler-global-check

> You may have seen permission requests while using Chrome: they pop up whenever the website attempts to use a feature that the user has to manually approve (like notifications).
> …
> By default, Electron will automatically approve all permission requests unless the developer has manually configured a custom handler. 

Source: https://www.electronjs.org/docs/latest/tutorial/security#5-handle-session-permission-requests-from-remote-content

Note: I use the opportunity to also simplify the CSP header (shouldn't change what it does). We need to add `connect-src: *` to allow requests to all hosts.