### PR TITLE
feat(api-reference): performance logging

### DIFF
--- a/.changeset/grumpy-dogs-reply.md
+++ b/.changeset/grumpy-dogs-reply.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: log some performance metrics

--- a/packages/api-reference/src/hooks/useReactiveSpec.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.ts
@@ -20,13 +20,19 @@ const getSpecContent = async (
 ): Promise<string | undefined> => {
   // If the URL is provided, fetch the API definition from the URL
   if (url) {
-    if (!isValidUrl(url)) {
-      // If the url is not valid, we can assume its a path and
-      // if it’s a path we can skip the proxy.
-      return await fetchSpecFromUrl(url)
-    }
+    const start = performance.now()
 
-    return await fetchSpecFromUrl(url, proxy)
+    // If the url is not valid, we can assume its a path and
+    // if it’s a path we can skip the proxy.
+    const result = !isValidUrl(url)
+      ? await fetchSpecFromUrl(url)
+      : await fetchSpecFromUrl(url, proxy)
+
+    const end = performance.now()
+    console.log(`fetch: ${Math.round(end - start)} ms (${url})`)
+    console.log('size:', Math.round(result.length / 1024), 'kB')
+
+    return result
   }
 
   // Callback


### PR DESCRIPTION
I’m debugging the performance and thought it would be cool to have a few key metrics in the console. We already had something for the dereferencing, this PR adds some metrics about the OpenAPI document fetching.

Open the browser console to see it.

```bash
fetch: 1552 ms (https://sandbox.scalar.com/files/korOI/openapi.yaml)
size: 621 kB
dereference: 181 ms
```