### PR TITLE
feat(scalar_fastapi): extend configuration for FastAPI

### DIFF
--- a/packages/scalar_fastapi/README.md
+++ b/packages/scalar_fastapi/README.md
@@ -34,8 +34,12 @@ async def scalar_html():
 ## Configuration
 
 Currently available [configuration options](https://github.com/scalar/scalar/blob/main/documentation/configuration.md) are listed below.
+- `layout` (default `Layout.MODERN`)
+- `show_sidebar` (defualt `true`)
 - `hide_download_button` (default `false`)
 - `hide_models` (default `false`)
+- `dark_mode` (default `true`)
+- `search_hot_key` (default `SearchHotKey.K`)
 - `hidden_clients` (default `[]`)
 - `servers` (default `[]`)
 - `default_open_all_tags` (default `false`)

--- a/packages/scalar_fastapi/README.md
+++ b/packages/scalar_fastapi/README.md
@@ -29,3 +29,11 @@ async def scalar_html():
         title=app.title,
     )
 ```
+
+
+## Configuration
+
+Currently available [configuration options](https://github.com/scalar/scalar/blob/main/documentation/configuration.md) are listed below.
+- `hide_models` (default `false`)
+- `hidden_clients` (default `[]`)
+- `servers` (default `[]`)

--- a/packages/scalar_fastapi/README.md
+++ b/packages/scalar_fastapi/README.md
@@ -34,6 +34,8 @@ async def scalar_html():
 ## Configuration
 
 Currently available [configuration options](https://github.com/scalar/scalar/blob/main/documentation/configuration.md) are listed below.
+- `hide_download_button` (default `false`)
 - `hide_models` (default `false`)
 - `hidden_clients` (default `[]`)
 - `servers` (default `[]`)
+- `default_open_all_tags` (default `false`)

--- a/packages/scalar_fastapi/README.md
+++ b/packages/scalar_fastapi/README.md
@@ -30,10 +30,10 @@ async def scalar_html():
     )
 ```
 
-
 ## Configuration
 
 Currently available [configuration options](https://github.com/scalar/scalar/blob/main/documentation/configuration.md) are listed below.
+
 - `layout` (default `Layout.MODERN`)
 - `show_sidebar` (defualt `true`)
 - `hide_download_button` (default `false`)

--- a/packages/scalar_fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/packages/scalar_fastapi/scalar_fastapi/scalar_fastapi.py
@@ -154,6 +154,15 @@ def get_scalar_api_reference(
             """
         ),
     ] = scalar_theme,
+    hide_download_button: Annotated[
+        bool,
+        Doc(
+            """
+            A boolean to hide the download button.
+            Default is False which means the download button is shown.
+            """
+        ),
+    ] = False,
     hide_models: Annotated[
         bool,
         Doc(
@@ -183,6 +192,15 @@ def get_scalar_api_reference(
             """
         ),
     ] = [],
+    default_open_all_tags: Annotated[
+        bool,
+        Doc(
+            """
+            A boolean to open all tags by default.
+            Default is False which means all tags are closed by default.
+            """
+        ),
+    ] = False,
 ) -> HTMLResponse:
     html = f"""
     <!DOCTYPE html>
@@ -213,9 +231,11 @@ def get_scalar_api_reference(
       data-proxy-url="{scalar_proxy_url}"></script>
     <script>
       var configuration = {{
+        hideDownloadButton: {json.dumps(hide_download_button)},
         hideModels: {json.dumps(hide_models)},
         hiddenClients: {json.dumps(hidden_clients)},
         servers: {json.dumps(servers)},
+        defaultOpenAllTags: {json.dumps(default_open_all_tags)},
       }}
 
       document.getElementById('api-reference').dataset.configuration =

--- a/packages/scalar_fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/packages/scalar_fastapi/scalar_fastapi/scalar_fastapi.py
@@ -1,6 +1,41 @@
 import json
+from enum import Enum
 from typing_extensions import Annotated, Doc
 from fastapi.responses import HTMLResponse
+
+
+class Layout(Enum):
+    MODERN = "modern"
+    CLASSIC = "classic"
+
+
+class SearchHotKey(Enum):
+    A = "a"
+    B = "b"
+    C = "c"
+    D = "d"
+    E = "e"
+    F = "f"
+    G = "g"
+    H = "h"
+    I = "i"
+    J = "j"
+    K = "k"
+    L = "l"
+    M = "m"
+    N = "n"
+    O = "o"
+    P = "p"
+    Q = "q"
+    R = "r"
+    S = "s"
+    T = "t"
+    U = "u"
+    V = "v"
+    W = "w"
+    X = "x"
+    Y = "y"
+    Z = "z"
 
 
 scalar_theme = """
@@ -154,6 +189,24 @@ def get_scalar_api_reference(
             """
         ),
     ] = scalar_theme,
+    layout: Annotated[
+        Layout,
+        Doc(
+            """
+            The layout to use for Scalar.
+            Default is "modern".
+            """
+        ),
+    ] = Layout.MODERN,
+    show_sidebar: Annotated[
+        bool,
+        Doc(
+            """
+            A boolean to show the sidebar.
+            Default is True which means the sidebar is shown.
+            """
+        ),
+    ] = True,
     hide_download_button: Annotated[
         bool,
         Doc(
@@ -172,6 +225,24 @@ def get_scalar_api_reference(
             """
         ),
     ] = False,
+    dark_mode: Annotated[
+        bool,
+        Doc(
+            """
+            Whether dark mode is on or off initially (light mode).
+            Default is True which means dark mode is used.
+            """
+        ),
+    ] = True,
+    search_hot_key: Annotated[
+        SearchHotKey,
+        Doc(
+            """
+            The hotkey to use for search.
+            Default is "k" (e.g. CMD+k).
+            """
+        ),
+    ] = SearchHotKey.K,
     hidden_clients: Annotated[
         bool | dict[str, bool | list[str]] | list[str],
         Doc(
@@ -231,8 +302,12 @@ def get_scalar_api_reference(
       data-proxy-url="{scalar_proxy_url}"></script>
     <script>
       var configuration = {{
+        layout: "{layout.value}",
+        showSidebar: {json.dumps(show_sidebar)},
         hideDownloadButton: {json.dumps(hide_download_button)},
         hideModels: {json.dumps(hide_models)},
+        darkMode: {json.dumps(dark_mode)},
+        searchHotKey: "{search_hot_key.value}",
         hiddenClients: {json.dumps(hidden_clients)},
         servers: {json.dumps(servers)},
         defaultOpenAllTags: {json.dumps(default_open_all_tags)},

--- a/packages/scalar_fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/packages/scalar_fastapi/scalar_fastapi/scalar_fastapi.py
@@ -1,3 +1,4 @@
+import json
 from typing_extensions import Annotated, Doc
 from fastapi.responses import HTMLResponse
 
@@ -153,6 +154,35 @@ def get_scalar_api_reference(
             """
         ),
     ] = scalar_theme,
+    hide_models: Annotated[
+        bool,
+        Doc(
+            """
+            A boolean to hide all models.
+            Default is False which means all models are shown.
+            """
+        ),
+    ] = False,
+    hidden_clients: Annotated[
+        bool | dict[str, bool | list[str]] | list[str],
+        Doc(
+            """
+            A dictionary with the keys being the target names and the values being a boolean to hide all clients of the target or a list clients.
+            If a boolean is provided, it will hide all the clients with that name.
+            Backwards compatibility: If a list of strings is provided, it will hide the clients with the name and the list of strings.
+            Default is [] which means no clients are hidden.
+            """
+        ),
+    ] = [],
+    servers: Annotated[
+        list[dict[str, str]],
+        Doc(
+            """
+            A list of dictionaries with the keys being the server name and the value being the server URL.
+            Default is [] which means no servers are provided.
+            """
+        ),
+    ] = [],
 ) -> HTMLResponse:
     html = f"""
     <!DOCTYPE html>
@@ -181,6 +211,16 @@ def get_scalar_api_reference(
       id="api-reference"
       data-url="{openapi_url}"
       data-proxy-url="{scalar_proxy_url}"></script>
+    <script>
+      var configuration = {{
+        hideModels: {json.dumps(hide_models)},
+        hiddenClients: {json.dumps(hidden_clients)},
+        servers: {json.dumps(servers)},
+      }}
+
+      document.getElementById('api-reference').dataset.configuration =
+        JSON.stringify(configuration)
+    </script>
     <script src="{scalar_js_url}"></script>
     </body>
     </html>


### PR DESCRIPTION
**Problem**
Currently, it's only possible to configure a few options when using FastAPI Scalar plugin.

**Explanation**
This happens because the configuration is missing

**Solution**
With this PR I add the following configurations:
- `hide_donwload_button`
- `hide_models`
- `hidden_clients`
- `servers`
- `default_open_all_tags`
- `layout`
- `show_sidebar`
- `dark_mode`
- `search_hot_key`

I chose these configs first, because I need them in my current project. More configs could be added easily.
