### PR TITLE
fix(#2634): remove default proxy

### DIFF
--- a/.changeset/neat-beds-guess.md
+++ b/.changeset/neat-beds-guess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): remove default proxy

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -100,7 +100,7 @@ export const createApiClient = ({
       uid: 'default',
       name: 'Workspace',
       isReadOnly,
-      proxyUrl: configuration.proxyUrl ?? 'https://proxy.scalar.com',
+      proxyUrl: configuration.proxyUrl,
     }),
   )
 


### PR DESCRIPTION
closes #2634

We had defaulted the proxy to the scalar one with no way to disable. This allows users to disable it