### PR TITLE
feat(components): add multiselect combobox

### DIFF
--- a/.changeset/proud-tips-listen.md
+++ b/.changeset/proud-tips-listen.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat(components): add multiselect combobox

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
@@ -4,6 +4,7 @@ import { ref } from 'vue'
 
 import { ScalarButton, ScalarIcon } from '../..'
 import ScalarCombobox from './ScalarCombobox.vue'
+import ScalarComboboxMultiselect from './ScalarComboboxMultiselect.vue'
 import type { Option } from './types'
 
 const meta = {
@@ -23,17 +24,17 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+const options = [
+  { id: '1', label: 'Apple' },
+  { id: '2', label: 'Banana' },
+  { id: '3', label: 'Superduperlongnameberry' },
+  { id: '4', label: 'Strawberry' },
+  { id: '5', label: 'Raspberry' },
+  { id: '7', label: 'Blackberry' },
+]
+
 export const Base: Story = {
-  args: {
-    options: [
-      { id: '1', label: 'Apple' },
-      { id: '2', label: 'Banana' },
-      { id: '3', label: 'Superduperlongnameberry' },
-      { id: '4', label: 'Strawberry' },
-      { id: '5', label: 'Raspberry' },
-      { id: '7', label: 'Blackberry' },
-    ],
-  },
+  args: { options },
   render: (args) => ({
     components: {
       ScalarCombobox,
@@ -55,6 +56,33 @@ export const Base: Story = {
       </div>
     </ScalarButton>
   </ScalarCombobox>
+</div>
+`,
+  }),
+}
+export const Multiselect: Story = {
+  args: { options },
+  render: (args) => ({
+    components: {
+      ScalarComboboxMultiselect,
+      ScalarButton,
+      ScalarIcon,
+    },
+    setup() {
+      const selected = ref<Option[]>([])
+      return { args, selected }
+    },
+    template: `
+<div class="flex justify-center w-full h-72">
+  <ScalarComboboxMultiselect v-model="selected" placeholder="Select fruits..." v-bind="args">
+    <ScalarButton class="w-48 px-3" variant="outlined">
+      <div class="flex flex-1 items-center min-w-0">
+        <span class="inline-block truncate flex-1 min-w-0 text-left">
+        {{ selected.length }} fruits selected
+        </span>
+      </div>
+    </ScalarButton>
+  </ScalarComboboxMultiselect>
 </div>
 `,
   }),

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
-
-import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
+import type { FloatingOptions } from '../ScalarFloating'
 import ComboboxOptions from './ScalarComboboxOptions.vue'
+import ComboboxPopover from './ScalarComboboxPopover.vue'
 import type { Option } from './types'
 
 defineProps<
@@ -16,40 +15,23 @@ defineProps<
 defineEmits<{
   (e: 'update:modelValue', v: Option): void
 }>()
-
-defineOptions({ inheritAttrs: false })
 </script>
 <template>
-  <Popover
-    v-slot="{ open }"
-    as="template">
-    <ScalarFloating
-      :isOpen="open ?? isOpen"
-      :placement="placement ?? 'bottom-start'"
-      :resize="resize"
-      :teleport="teleport">
-      <PopoverButton as="template">
-        <slot />
-      </PopoverButton>
-      <template #floating="{ width }">
-        <PopoverPanel
-          v-slot="{ close }"
-          class="relative flex w-40 flex-col rounded border text-sm"
-          focus
-          :style="{ width }"
-          v-bind="$attrs">
-          <ComboboxOptions
-            :modelValue="modelValue ? [modelValue] : []"
-            :open="open"
-            :options="options"
-            :placeholder="placeholder"
-            @update:modelValue="
-              (v) => (close(), $emit('update:modelValue', v[0]))
-            " />
-          <div
-            class="absolute inset-0 -z-1 rounded bg-b-1 shadow-md brightness-lifted" />
-        </PopoverPanel>
-      </template>
-    </ScalarFloating>
-  </Popover>
+  <ComboboxPopover
+    :isOpen="isOpen"
+    :placement="placement ?? 'bottom-start'"
+    :resize="resize"
+    :teleport="teleport">
+    <slot />
+    <template #popover="{ open, close }">
+      <ComboboxOptions
+        :modelValue="modelValue ? [modelValue] : []"
+        :open="open"
+        :options="options"
+        :placeholder="placeholder"
+        @update:modelValue="
+          (v) => (close(), $emit('update:modelValue', v[0]))
+        " />
+    </template>
+  </ComboboxPopover>
 </template>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
@@ -8,13 +8,13 @@ import type { Option } from './types'
 defineProps<
   {
     options: Option[]
-    modelValue?: Option
+    modelValue?: Option[]
     placeholder?: string
   } & Omit<FloatingOptions, 'middleware'>
 >()
 
 defineEmits<{
-  (e: 'update:modelValue', v: Option): void
+  (e: 'update:modelValue', v: Option[]): void
 }>()
 
 defineOptions({ inheritAttrs: false })
@@ -33,19 +33,17 @@ defineOptions({ inheritAttrs: false })
       </PopoverButton>
       <template #floating="{ width }">
         <PopoverPanel
-          v-slot="{ close }"
           class="relative flex w-40 flex-col rounded border text-sm"
           focus
           :style="{ width }"
           v-bind="$attrs">
           <ComboboxOptions
-            :modelValue="modelValue ? [modelValue] : []"
+            :modelValue="modelValue"
+            multiselect
             :open="open"
             :options="options"
             :placeholder="placeholder"
-            @update:modelValue="
-              (v) => (close(), $emit('update:modelValue', v[0]))
-            " />
+            @update:modelValue="(v) => $emit('update:modelValue', v)" />
           <div
             class="absolute inset-0 -z-1 rounded bg-b-1 shadow-md brightness-lifted" />
         </PopoverPanel>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
-
-import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
+import type { FloatingOptions } from '../ScalarFloating'
 import ComboboxOptions from './ScalarComboboxOptions.vue'
+import ComboboxPopover from './ScalarComboboxPopover.vue'
 import type { Option } from './types'
 
 defineProps<
@@ -16,38 +15,22 @@ defineProps<
 defineEmits<{
   (e: 'update:modelValue', v: Option[]): void
 }>()
-
-defineOptions({ inheritAttrs: false })
 </script>
 <template>
-  <Popover
-    v-slot="{ open }"
-    as="template">
-    <ScalarFloating
-      :isOpen="open ?? isOpen"
-      :placement="placement ?? 'bottom-start'"
-      :resize="resize"
-      :teleport="teleport">
-      <PopoverButton as="template">
-        <slot />
-      </PopoverButton>
-      <template #floating="{ width }">
-        <PopoverPanel
-          class="relative flex w-40 flex-col rounded border text-sm"
-          focus
-          :style="{ width }"
-          v-bind="$attrs">
-          <ComboboxOptions
-            :modelValue="modelValue"
-            multiselect
-            :open="open"
-            :options="options"
-            :placeholder="placeholder"
-            @update:modelValue="(v) => $emit('update:modelValue', v)" />
-          <div
-            class="absolute inset-0 -z-1 rounded bg-b-1 shadow-md brightness-lifted" />
-        </PopoverPanel>
-      </template>
-    </ScalarFloating>
-  </Popover>
+  <ComboboxPopover
+    :isOpen="isOpen"
+    :placement="placement ?? 'bottom-start'"
+    :resize="resize"
+    :teleport="teleport">
+    <slot />
+    <template #popover="{ open }">
+      <ComboboxOptions
+        :modelValue="modelValue"
+        multiselect
+        :open="open"
+        :options="options"
+        :placeholder="placeholder"
+        @update:modelValue="(v) => $emit('update:modelValue', v)" />
+    </template>
+  </ComboboxPopover>
 </template>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -98,8 +98,7 @@ function moveActive(dir: 1 | -1) {
   <ul
     v-show="filtered.length"
     :id="id"
-    class="border-t p-0.75"
-    static>
+    class="border-t p-0.75">
     <ComboboxOption
       v-for="option in filtered"
       :key="option.id"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -91,9 +91,9 @@ function moveActive(dir: 1 | -1) {
       role="combobox"
       tabindex="0"
       type="text"
-      @keydown.down="moveActive(1)"
+      @keydown.down.prevent="moveActive(1)"
       @keydown.enter.prevent="toggleSelected(active)"
-      @keydown.up="moveActive(-1)" />
+      @keydown.up.prevent="moveActive(-1)" />
   </div>
   <ul
     v-show="filtered.length"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
@@ -6,6 +6,13 @@ import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
 defineProps<Omit<FloatingOptions, 'middleware'>>()
 
 defineOptions({ inheritAttrs: false })
+
+/** Open the popover of the up or down arrows are pressed */
+function handleKeydown(e: KeyboardEvent) {
+  if (!['ArrowUp', 'ArrowDown'].includes(e.key)) return
+  e.preventDefault()
+  e.target?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+}
 </script>
 <template>
   <Popover
@@ -16,7 +23,9 @@ defineOptions({ inheritAttrs: false })
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
       :teleport="teleport">
-      <PopoverButton as="template">
+      <PopoverButton
+        as="template"
+        @keydown="handleKeydown">
         <slot />
       </PopoverButton>
       <template #floating="{ width }">

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
+
+import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
+
+defineProps<Omit<FloatingOptions, 'middleware'>>()
+
+defineOptions({ inheritAttrs: false })
+</script>
+<template>
+  <Popover
+    v-slot="{ open }"
+    as="template">
+    <ScalarFloating
+      :isOpen="open ?? isOpen"
+      :placement="placement ?? 'bottom-start'"
+      :resize="resize"
+      :teleport="teleport">
+      <PopoverButton as="template">
+        <slot />
+      </PopoverButton>
+      <template #floating="{ width }">
+        <PopoverPanel
+          v-slot="{ close }"
+          class="relative flex w-40 flex-col rounded border text-sm"
+          focus
+          :style="{ width }"
+          v-bind="$attrs">
+          <slot
+            :close="close"
+            name="popover"
+            :open="open" />
+          <div
+            class="absolute inset-0 -z-1 rounded bg-b-1 shadow-md brightness-lifted" />
+        </PopoverPanel>
+      </template>
+    </ScalarFloating>
+  </Popover>
+</template>

--- a/packages/components/src/components/ScalarCombobox/index.ts
+++ b/packages/components/src/components/ScalarCombobox/index.ts
@@ -1,3 +1,4 @@
 export { default as ScalarCombobox } from './ScalarCombobox.vue'
+export { default as ScalarComboboxMultiselect } from './ScalarComboboxMultiselect.vue'
 
 export type { Option as ScalarComboboxOption } from './types'

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -2,6 +2,7 @@ import { ScalarButton } from './components/ScalarButton'
 import { ScalarCodeBlock } from './components/ScalarCodeBlock'
 import {
   ScalarCombobox,
+  ScalarComboboxMultiselect,
   type ScalarComboboxOption,
 } from './components/ScalarCombobox'
 import {
@@ -39,6 +40,7 @@ export {
   ScalarButton,
   ScalarCodeBlock,
   ScalarCombobox,
+  ScalarComboboxMultiselect,
   ScalarMarkdown,
   ScalarDropdown,
   ScalarDropdownDivider,


### PR DESCRIPTION
Multiselect combobox as requested by @amritk. I split it into two components to make it easier to have correct types for the `v-model` props (I think we need to do this for `ScalarListbox` too at some point).

I also made the combobox open when you press the up or down arrows while the target / button is focused (this is what the HeadlessUI combobox does). 

https://github.com/user-attachments/assets/aad92afd-89de-41de-be33-141cb15a728d

