### PR TITLE
ci: reusable composite actions

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -27,7 +27,7 @@ runs:
       with:
         path: .turbo
         key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}
-    - if: ${{ inputs.packages-only != 'false' }}
+    - if: ${{ inputs.packages-only == 'false' }}
       name: Build
       shell: bash
       run: pnpm turbo build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,19 @@
+name: 'Build'
+runs:
+  using: 'composite'
+  steps:
+    - uses: pnpm/action-setup@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+    - name: Install dependencies
+      run: pnpm install
+    - name: Turborepo cache
+      uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
+    - name: Build
+      run: pnpm turbo build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,13 +1,18 @@
 name: 'Build'
 description: 'Build everything'
+inputs:
+  node-version:
+    description: 'Node Version'
+    required: false
+    default: '20'
 runs:
   using: 'composite'
   steps:
     - uses: pnpm/action-setup@v4
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
     - name: Install dependencies
       shell: bash
@@ -16,7 +21,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: .turbo
-        key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
+        key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}
     - name: Build
       shell: bash
       run: pnpm turbo build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Node Version'
     required: false
     default: '20'
+  packages-only:
+    description: 'Whether to build packages/ only'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -22,6 +26,15 @@ runs:
       with:
         path: .turbo
         key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}
-    - name: Build
+    - if: ${{ inputs.packages-only != 'false' }}
+      name: Build
       shell: bash
       run: pnpm turbo build
+    - if: ${{ inputs.packages-only == 'true' }}
+      name: Build packages
+      shell: bash
+      run: pnpm build:packages
+    - if: ${{ inputs.packages-only != 'true' && inputs.packages-only != 'false' }}
+      name: Build package
+      shell: bash
+      run: pnpm turbo --filter './packages/${{inputs.packages-only}}' build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,4 +1,5 @@
 name: 'Build'
+description: 'Build everything'
 runs:
   using: 'composite'
   steps:
@@ -9,6 +10,7 @@ runs:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
     - name: Install dependencies
+      shell: bash
       run: pnpm install
     - name: Turborepo cache
       uses: actions/cache@v4
@@ -16,4 +18,5 @@ runs:
         path: .turbo
         key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
     - name: Build
+      shell: bash
       run: pnpm turbo build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,7 +12,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
     - name: Use Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Build @scalar/api-reference
         uses: ./.github/actions/build
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           packages-only: 'api-reference'
       - name: Send bundle stats and build information to RelativeCI
         uses: relative-ci/agent-action@v2
@@ -235,10 +235,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Build
-        uses: ./.github/actions/build
-        with:
-          node-version: ${{ matrix.node-version }}
       - name: Check which files were touched
         id: changed-files
         uses: tj-actions/changed-files@v44
@@ -247,6 +243,11 @@ jobs:
             api_client:
               - examples/api-client/**
               - packages/api-client/**
+      - if: steps.changed-files.outputs.api_client_any_changed == 'true'
+        name: Build
+        uses: ./.github/actions/build
+        with:
+          node-version: ${{ matrix.node-version }}
       - if: steps.changed-files.outputs.api_client_any_changed == 'true'
         name: Deploy to client.scalar.com
         id: deploy-client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,21 +44,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
-      - name: Build
-        run: pnpm turbo build
+      - uses: ./.github/actions/build
       - name: Update Turborepo cache
         uses: actions/cache/save@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,21 +103,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - name: Build packages
+        uses: ./.github/actions/build
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Turborepo cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
-      - name: Build packages
-        run: pnpm build:packages
+          packages-only: 'true'
       - name: Run tests
         run: pnpm test:ci
 
@@ -131,21 +121,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Turborepo cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build @scalar/api-reference
-        run: pnpm build:api-reference
+        uses: ./.github/actions/build
+        with:
+          node-version: 20
+          packages-only: 'api-reference'
       - name: Send bundle stats and build information to RelativeCI
         uses: relative-ci/agent-action@v2
         with:
@@ -209,21 +189,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - name: Build packages
+        uses: ./.github/actions/build
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Turborepo cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
-      - name: Build packages
-        run: pnpm build:packages
+          packages-only: 'true'
       - name: Publish on Stackblitz
         # We can’t use npx pkg-pr-new publish ./packages/* here.
         # We want to explicitly publish the packages we want to save some time.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,21 +85,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - name: Build
+        uses: ./.github/actions/build
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Turborepo cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
-      - name: Build
-        run: pnpm turbo build
       - if: matrix.node-version == 20 || github.head_ref == 'changeset-release/main'
         name: Check types
         run: pnpm turbo types:check
@@ -178,21 +167,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - name: Build
+        uses: ./.github/actions/build
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Turborepo cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
-      - name: Build
-        run: pnpm turbo build
       - name: Git Status
         run: git status
       - name: Stash changes
@@ -287,21 +265,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - name: Build
+        uses: ./.github/actions/build
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Turborepo cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
-      - name: Build
-        run: pnpm turbo build
       - name: Check which files were touched
         id: changed-files
         uses: tj-actions/changed-files@v44

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Build
         uses: ./.github/actions/build
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Update Turborepo cache
         uses: actions/cache/save@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           node-version: ${{ matrix.node-version }}
-      - if: matrix.node-version == 20 || github.head_ref == 'changeset-release/main'
-        name: Check types
+      - name: Check types
         run: pnpm turbo types:check
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,10 @@ jobs:
         node-version: ${{ fromJSON(needs.define-matrix.outputs.node-versions) }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/build
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build
+        uses: ./.github/actions/build
       - name: Update Turborepo cache
         uses: actions/cache/save@v4
         with:
@@ -58,7 +60,8 @@ jobs:
         node-version: [20]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -78,7 +81,8 @@ jobs:
         node-version: ${{ fromJSON(needs.define-matrix.outputs.node-versions) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -106,7 +110,8 @@ jobs:
         node-version: ${{ fromJSON(needs.define-matrix.outputs.node-versions) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -133,7 +138,8 @@ jobs:
         node-version: [20]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -168,7 +174,8 @@ jobs:
         node-version: [20]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -220,7 +227,8 @@ jobs:
         node-version: [20]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -275,7 +283,8 @@ jobs:
         node-version: [20]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
This PR introduces a composite action for the steps that are required to do a (full) build of the repository. A build (even if cached) is required for most jobs, so we’ve repeated the code over and over. But no more! This PR puts it into a single place.

Makes the CI workflow file smaller and a litte easier to grasp. :)

Read more: https://docs.github.com/en/actions/using-workflows/avoiding-duplication