### PR TITLE
chore(mock-server): clean up

### DIFF
--- a/.changeset/dirty-dodos-matter.md
+++ b/.changeset/dirty-dodos-matter.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+fix: imports cause a circular reference

--- a/.changeset/thick-boxes-marry.md
+++ b/.changeset/thick-boxes-marry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+fix: wrong directory in package.json

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -5,17 +5,15 @@ import { cors } from 'hono/cors'
 import type { StatusCode } from 'hono/utils/http-status'
 
 import type { HttpMethod } from './types'
-import {
-  anyBasicAuthentication,
-  anyOpenAuthPasswordGrantAuthentication,
-  findPreferredResponseKey,
-  getOpenAuthTokenUrl,
-  getOperations,
-  honoRouteFromPath,
-  isAuthenticationRequired,
-  isBasicAuthenticationRequired,
-  isOpenAuthPasswordGrantRequired,
-} from './utils'
+import { anyBasicAuthentication } from './utils/anyBasicAuthentication'
+import { anyOpenAuthPasswordGrantAuthentication } from './utils/anyOpenAuthPasswordGrantAuthentication'
+import { findPreferredResponseKey } from './utils/findPreferredResponseKey'
+import { getOpenAuthTokenUrl } from './utils/getOpenAuthTokenUrl'
+import { getOperations } from './utils/getOperations'
+import { honoRouteFromPath } from './utils/honoRouteFromPath'
+import { isAuthenticationRequired } from './utils/isAuthenticationRequired'
+import { isBasicAuthenticationRequired } from './utils/isBasicAuthenticationRequired'
+import { isOpenAuthPasswordGrantRequired } from './utils/isOpenAuthPasswordGrantRequired'
 
 /**
  * Create a mock server instance

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -8,7 +8,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/void"
+    "directory": "packages/void-server"
   },
   "keywords": [
     "scalar",

--- a/packages/void-server/tsconfig.build.json
+++ b/packages/void-server/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "skipLibCheck": true,
     "declaration": true,

--- a/packages/void-server/tsconfig.json
+++ b/packages/void-server/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {},
-  "include": ["src", "rollup.config.ts"]
+  "include": ["src", "playground", "rollup.config.ts"]
 }


### PR DESCRIPTION
I tried to start the playground for the mock-server, but it failed. The root cause was the import from `./utils`. I couldn’t really figure out why, but I know that we’ve had circular references there a while ago. Though I didn’t saw a wrong import, I didn’t care enough to really find out what’s wrong (at least not today).

While debugging, I found a few tiny things that I’d like to improve.

Read the commit messages for more context. :)