### PR TITLE
feat(mock-server): headers, redirects and all content types

### DIFF
--- a/.changeset/cold-birds-doubt.md
+++ b/.changeset/cold-birds-doubt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+feat: add headers to mocked responses

--- a/.changeset/eleven-teachers-appear.md
+++ b/.changeset/eleven-teachers-appear.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+feat: support redirects

--- a/.changeset/weak-books-give.md
+++ b/.changeset/weak-books-give.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+feat: support all content types

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -44,7 +44,8 @@
   "dependencies": {
     "@scalar/oas-utils": "workspace:*",
     "@scalar/openapi-parser": "^0.7.2",
-    "hono": "^4.2.7"
+    "hono": "^4.2.7",
+    "object-to-xml": "^2.0.0"
   },
   "devDependencies": {
     "@hono/node-server": "^1.11.0",

--- a/packages/mock-server/src/createMockServer.test.ts
+++ b/packages/mock-server/src/createMockServer.test.ts
@@ -42,6 +42,92 @@ describe('createMockServer', () => {
     })
   })
 
+  it('GET /foobar -> return HTML if accepted', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    example: {
+                      foo: 'bar',
+                    },
+                  },
+                  'text/html': {
+                    example: 'foobar',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/foobar', {
+      headers: {
+        Accept: 'text/html',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('foobar')
+  })
+
+  it('GET /foobar -> fall back to JSON', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    example: {
+                      foo: 'bar',
+                    },
+                  },
+                  'text/html': {
+                    example: 'foobar',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      foo: 'bar',
+    })
+  })
+
   it('uses http verbs only to register routes', async () => {
     const specification = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/createMockServer.test.ts
+++ b/packages/mock-server/src/createMockServer.test.ts
@@ -407,4 +407,42 @@ describe('createMockServer', () => {
       foo: 'bar',
     })
   })
+
+  it('adds headers', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                headers: {
+                  'X-Custom': {
+                    schema: {
+                      type: 'string',
+                      example: 'foobar',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('X-Custom')).toBe('foobar')
+  })
 })

--- a/packages/mock-server/src/createMockServer.test.ts
+++ b/packages/mock-server/src/createMockServer.test.ts
@@ -128,6 +128,43 @@ describe('createMockServer', () => {
     })
   })
 
+  it('GET /foobar -> XML', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/xml': {
+                    example: {
+                      foo: 'bar',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('<foo>bar</foo>')
+  })
+
   it('uses http verbs only to register routes', async () => {
     const specification = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -1,6 +1,7 @@
 import { getExampleFromSchema } from '@scalar/oas-utils/spec-getters'
 import { type OpenAPI, openapi } from '@scalar/openapi-parser'
 import { type Context, Hono } from 'hono'
+import { accepts } from 'hono/accepts'
 import { cors } from 'hono/cors'
 import type { StatusCode } from 'hono/utils/http-status'
 
@@ -135,18 +136,45 @@ export async function createMockServer(options?: {
           Object.keys(operation.responses ?? {}),
         )
 
-        // Focus on JSON for now
-        const jsonResponse = preferredResponseKey
-          ? operation.responses?.[preferredResponseKey]?.content?.[
-              'application/json'
-            ]
+        const preferredResponse = preferredResponseKey
+          ? operation.responses?.[preferredResponseKey]
           : null
 
-        // Get or generate JSON
-        const response = jsonResponse?.example
-          ? jsonResponse.example
-          : jsonResponse?.schema
-            ? getExampleFromSchema(jsonResponse.schema, {
+        const supportedContentTypes = Object.keys(
+          preferredResponse?.content ?? {},
+        )
+
+        // Headers
+        const headers = preferredResponse?.headers ?? {}
+
+        Object.keys(headers).forEach((header) => {
+          c.header(
+            header,
+            headers[header].schema
+              ? getExampleFromSchema(headers[header].schema)
+              : null,
+          )
+        })
+
+        // Content-Type
+        const acceptedContentType = accepts(c, {
+          header: 'Accept',
+          supports: supportedContentTypes,
+          default: supportedContentTypes.includes('application/json')
+            ? 'application/json'
+            : supportedContentTypes[0],
+        })
+
+        c.header('Content-Type', acceptedContentType)
+
+        const acceptedResponse =
+          preferredResponse?.content?.[acceptedContentType]
+
+        // Body
+        const body = acceptedResponse?.example
+          ? acceptedResponse.example
+          : acceptedResponse?.schema
+            ? getExampleFromSchema(acceptedResponse.schema, {
                 emptyString: '…',
                 variables: c.req.param(),
               })
@@ -160,21 +188,12 @@ export async function createMockServer(options?: {
           10,
         ) as StatusCode
 
-        // Headers
-        const headers = preferredResponseKey
-          ? operation.responses?.[preferredResponseKey]?.headers ?? {}
-          : {}
+        c.status(statusCode)
 
-        Object.keys(headers).forEach((header) => {
-          c.header(
-            header,
-            headers[header].schema
-              ? getExampleFromSchema(headers[header].schema)
-              : null,
-          )
-        })
-
-        return c.json(response, statusCode)
+        return c.body(
+          // TODO: What about xml?
+          typeof body === 'object' ? JSON.stringify(body, null, 2) : body,
+        )
       })
     })
   })

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -159,6 +159,23 @@ export async function createMockServer(options?: {
             : preferredResponseKey ?? '200',
           10,
         ) as StatusCode
+
+        // Headers
+        const headers = preferredResponseKey
+          ? operation.responses?.[preferredResponseKey]?.headers ?? {}
+          : {}
+
+        Object.keys(headers).forEach((header) => {
+          c.header(
+            header,
+            headers[header].examples?.[0] ??
+              headers[header].example ??
+              headers[header].schema
+              ? getExampleFromSchema(headers[header].schema)
+              : null,
+          )
+        })
+
         return c.json(response, statusCode)
       })
     })

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -4,6 +4,7 @@ import { type Context, Hono } from 'hono'
 import { accepts } from 'hono/accepts'
 import { cors } from 'hono/cors'
 import type { StatusCode } from 'hono/utils/http-status'
+import objectToXML from 'object-to-xml'
 
 import type { HttpMethod } from './types'
 import {
@@ -191,8 +192,14 @@ export async function createMockServer(options?: {
         c.status(statusCode)
 
         return c.body(
-          // TODO: What about xml?
-          typeof body === 'object' ? JSON.stringify(body, null, 2) : body,
+          typeof body === 'object'
+            ? // XML
+              acceptedContentType?.includes('xml')
+              ? `<?xml version="1.0" encoding="UTF-8"?>${objectToXML(body)}`
+              : // JSON
+                JSON.stringify(body, null, 2)
+            : // String
+              body,
         )
       })
     })

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -4,6 +4,7 @@ import { type Context, Hono } from 'hono'
 import { accepts } from 'hono/accepts'
 import { cors } from 'hono/cors'
 import type { StatusCode } from 'hono/utils/http-status'
+// @ts-expect-error Doesn’t come with types
 import objectToXML from 'object-to-xml'
 
 import type { HttpMethod } from './types'

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -168,9 +168,7 @@ export async function createMockServer(options?: {
         Object.keys(headers).forEach((header) => {
           c.header(
             header,
-            headers[header].examples?.[0] ??
-              headers[header].example ??
-              headers[header].schema
+            headers[header].schema
               ? getExampleFromSchema(headers[header].schema)
               : null,
           )

--- a/packages/mock-server/src/utils/findPreferredResponseKey.test.ts
+++ b/packages/mock-server/src/utils/findPreferredResponseKey.test.ts
@@ -14,4 +14,12 @@ describe('findPreferredResponseKey', () => {
   it('returns 200 over 201', () => {
     expect(findPreferredResponseKey(['200', '201'])).toBe('200')
   })
+
+  it('uses what’s there', () => {
+    expect(findPreferredResponseKey(['301'])).toBe('301')
+  })
+
+  it('doesn’t return anything if there’s no key at all', () => {
+    expect(findPreferredResponseKey([])).toBe(undefined)
+  })
 })

--- a/packages/mock-server/src/utils/findPreferredResponseKey.ts
+++ b/packages/mock-server/src/utils/findPreferredResponseKey.ts
@@ -2,7 +2,13 @@
  * Find the preferred response key: default, 200, 201 …
  */
 export function findPreferredResponseKey(responses?: string[]) {
-  return ['default', '200', '201', '204', '404', '500'].find(
-    (key) => responses?.includes(key) ?? false,
+  return (
+    // Regular status codes
+    ['default', '200', '201', '204', '404', '500'].find(
+      (key) => responses?.includes(key) ?? false,
+    ) ??
+    // Lowest status code
+    responses?.sort()[0] ??
+    undefined
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 12.3.2(typescript@5.5.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+        version: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -1537,6 +1537,9 @@ importers:
       hono:
         specifier: ^4.2.7
         version: 4.4.6
+      object-to-xml:
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       '@hono/node-server':
         specifier: ^1.11.0
@@ -18097,7 +18100,7 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.8)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.8)
       '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.8)
-      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.8)
       '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.24.8)
       '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.8)
       '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.8)
@@ -29502,7 +29505,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -29533,7 +29536,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -32193,7 +32196,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
 
   postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.39):
     dependencies:
@@ -34858,7 +34861,7 @@ snapshots:
       '@swc/core': 1.5.29(@swc/helpers@0.5.5)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2):
+  ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11


### PR DESCRIPTION
This PR adds three great features to `@scalar/mock-server`:

**Headers**

Adds headers (defined in the OpenAPI document) to the mocked response.

**Redirects**

You can now define a redirect (`Location` header and status code 30*)

**Content types**

No matter what content type is given, it tries to pick the appropriate content type (based on the `Accept` header, falls back to JSON or what’s available). Even works with XML.