### PR TITLE
ci: output all published packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,12 @@ jobs:
           # Permissions: Read and Write
           # Select packages: @scalar
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - if: steps.changesets.outputs.published == 'true'
+        name: List all published packages
+        run: echo "${{ steps.changesets.outputs.publishedPackages }}"
+      - if: steps.changesets.outputs.publishedPackages.*.name == 'scalar-api-client'
+        name: Check whether scalar-api-client was published
+        run: echo "scalar-api-client was published"
 
   stackblitz:
     if: github.head_ref == 'changeset-release/main'


### PR DESCRIPTION
With this PR a list of all published packages should be echo’d in CI, right after publishing.

I’m just testing if and how that works to eventually hook into the process to automate the release of our app.

Unfortunately, I couldn’t come up with another way to test it, then actually adding it to the workflow and waiting for the next release. Even if it has errors, it shouldn’t break the release workflow, because it comes *after* everything is published.