### PR TITLE
fix: app adds galaxy example on every start, fix #2627

### DIFF
--- a/.changeset/rare-files-sparkle.md
+++ b/.changeset/rare-files-sparkle.md
@@ -1,0 +1,5 @@
+---
+'scalar-api-client': patch
+---
+
+fix: don’t load @scalar/galaxy example on every start

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -6,9 +6,6 @@ import '@scalar/api-client/style.css'
 createApiClientApp(
   document.getElementById('scalar-client'),
   {
-    spec: {
-      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-    },
     proxyUrl: 'https://proxy.scalar.com',
   },
   true,


### PR DESCRIPTION
We used to load the galaxy example on every app start. This was fine as long as we didn’t have persistence, but now it’s added again and again.

This PR fixes it, because it’s not added at all. :)

See #2627