### PR TITLE
feat(api-client-app): drag and drop files and urls

### DIFF
--- a/.changeset/thin-ladybugs-eat.md
+++ b/.changeset/thin-ladybugs-eat.md
@@ -1,0 +1,5 @@
+---
+'scalar-api-client': patch
+---
+
+feat: drag’n’drop files and URLs

--- a/packages/api-client-app/src/main/index.ts
+++ b/packages/api-client-app/src/main/index.ts
@@ -231,9 +231,6 @@ app.whenReady().then(() => {
     optimizer.watchWindowShortcuts(window)
   })
 
-  // IPC test
-  ipcMain.on('ping', () => console.log('pong'))
-
   // Open file dialog
   ipcMain.handle('openFile', handleFileOpen)
   // Read files
@@ -251,7 +248,6 @@ app.whenReady().then(() => {
   session
     .fromPartition('main')
     .setPermissionRequestHandler((_, permission, callback) => {
-      console.log('permission', permission)
       if (permission === 'notifications') {
         callback(true)
       } else {

--- a/packages/api-client-app/src/preload/index.ts
+++ b/packages/api-client-app/src/preload/index.ts
@@ -2,7 +2,18 @@ import { electronAPI } from '@electron-toolkit/preload'
 import { contextBridge, ipcRenderer } from 'electron/renderer'
 
 // Custom APIs for renderer
-const api = {}
+const api = {
+  openFile: () => ipcRenderer.invoke('openFile'),
+  readFile: (filePath: string) => ipcRenderer.invoke('readFile', filePath),
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface Window {
+    electron: typeof electronAPI
+    api: typeof api
+  }
+}
 
 // Use `contextBridge` APIs to expose Electron APIs to
 // renderer only if context isolation is enabled, otherwise
@@ -11,16 +22,10 @@ if (process.contextIsolated) {
   try {
     contextBridge.exposeInMainWorld('electron', electronAPI)
     contextBridge.exposeInMainWorld('api', api)
-    contextBridge.exposeInMainWorld('mainProcess', {
-      openFile: () => ipcRenderer.invoke('openFile'),
-      readFile: (filePath: string) => ipcRenderer.invoke('readFile', filePath),
-    })
   } catch (error) {
     console.error(error)
   }
 } else {
-  // @ts-ignore (define in dts)
   window.electron = electronAPI
-  // @ts-ignore (define in dts)
   window.api = api
 }

--- a/packages/api-client-app/src/preload/index.ts
+++ b/packages/api-client-app/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { electronAPI } from '@electron-toolkit/preload'
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron/renderer'
 
 // Custom APIs for renderer
 const api = {}
@@ -11,6 +11,10 @@ if (process.contextIsolated) {
   try {
     contextBridge.exposeInMainWorld('electron', electronAPI)
     contextBridge.exposeInMainWorld('api', api)
+    contextBridge.exposeInMainWorld('electronAPI', {
+      openFile: () => ipcRenderer.invoke('openFile'),
+      readFile: (filePath: string) => ipcRenderer.invoke('readFile', filePath),
+    })
   } catch (error) {
     console.error(error)
   }

--- a/packages/api-client-app/src/preload/index.ts
+++ b/packages/api-client-app/src/preload/index.ts
@@ -15,6 +15,11 @@ if (process.contextIsolated) {
       openFile: () => ipcRenderer.invoke('openFile'),
       readFile: (filePath: string) => ipcRenderer.invoke('readFile', filePath),
     })
+    contextBridge.exposeInMainWorld('ipcRenderer', {
+      on: (channel, func) => {
+        ipcRenderer.on(channel, (event, ...args) => func(...args))
+      },
+    })
   } catch (error) {
     console.error(error)
   }

--- a/packages/api-client-app/src/preload/index.ts
+++ b/packages/api-client-app/src/preload/index.ts
@@ -11,14 +11,9 @@ if (process.contextIsolated) {
   try {
     contextBridge.exposeInMainWorld('electron', electronAPI)
     contextBridge.exposeInMainWorld('api', api)
-    contextBridge.exposeInMainWorld('electronAPI', {
+    contextBridge.exposeInMainWorld('mainProcess', {
       openFile: () => ipcRenderer.invoke('openFile'),
       readFile: (filePath: string) => ipcRenderer.invoke('readFile', filePath),
-    })
-    contextBridge.exposeInMainWorld('ipcRenderer', {
-      on: (channel, func) => {
-        ipcRenderer.on(channel, (event, ...args) => func(...args))
-      },
     })
   } catch (error) {
     console.error(error)

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -35,19 +35,15 @@ const os =
 
 trackEvent(`launch: ${os}`)
 
-// Open file dialog
-// // @ts-expect-error not typed yet
-// const filePath = await window.electronAPI.openFile()
-// // @ts-expect-error not typed yet
-// const fileContent = await window.electronAPI.readFile(filePath)
-
 // Open… menu
-// @ts-expect-error not typed yet
-window.ipcRenderer?.on('importFile', function (fileContent: string) {
-  if (fileContent) {
-    client.store.importSpecFile(fileContent)
-  }
-})
+window.electron.ipcRenderer?.on(
+  'importFile',
+  function (_: IpcRendererEvent, fileContent: string) {
+    if (fileContent) {
+      client.store.importSpecFile(fileContent)
+    }
+  },
+)
 
 // Open… menu
 window.electron.ipcRenderer?.on(
@@ -80,8 +76,8 @@ async function drop(e: DragEvent) {
 
   // Check if the user dropped a file
   for (const f of e.dataTransfer?.files ?? []) {
-    // @ts-expect-error not typed yet
-    const fileContent = await window.mainProcess.readFile(f.path)
+    // @ts-expect-error TypeScript doesn’t know about the types in the preload script yet
+    const fileContent = await window.api.readFile(f.path)
 
     if (fileContent) {
       client.store.importSpecFile(fileContent)

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -4,7 +4,7 @@ import '@scalar/api-client/style.css'
 import { load, trackEvent } from 'fathom-client'
 
 // Initialize
-await createApiClientApp(
+const client = await createApiClientApp(
   document.getElementById('scalar-client'),
   {},
   true,
@@ -33,3 +33,50 @@ const os =
         : 'unknown'
 
 trackEvent(`launch: ${os}`)
+
+// Open file dialog
+// // @ts-expect-error not typed yet
+// const filePath = await window.electronAPI.openFile()
+// // @ts-expect-error not typed yet
+// const fileContent = await window.electronAPI.readFile(filePath)
+
+// console.log('fileContent', fileContent)
+
+// if (fileContent) {
+//   client.store.importSpecFile(fileContent)
+// }
+
+document.addEventListener('drop', drop)
+document.addEventListener('dragover', dragover)
+
+async function drop(e: DragEvent) {
+  e.preventDefault()
+  e.stopPropagation()
+
+  // Check if the user dropped an URL
+  if (e.dataTransfer?.getData('text/uri-list')) {
+    const url = e.dataTransfer.getData('text/uri-list')
+    console.log('URL you dragged here:', url)
+
+    client.store.importSpecFromUrl(url)
+    return
+  }
+
+  // Check if the user dropped a file
+  for (const f of e.dataTransfer?.files ?? []) {
+    // console.log('File(s) you dragged here: ', f.path)
+    console.log('File you dragged here:', f)
+
+    // @ts-expect-error not typed yet
+    const fileContent = await window.electronAPI.readFile(f.path)
+
+    if (fileContent) {
+      client.store.importSpecFile(fileContent)
+    }
+  }
+}
+
+function dragover(e: DragEvent) {
+  e.preventDefault()
+  e.stopPropagation()
+}

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -70,17 +70,16 @@ async function drop(e: DragEvent) {
   // Check if the user dropped an URL
   if (e.dataTransfer?.getData('text/uri-list')) {
     const url = e.dataTransfer.getData('text/uri-list')
-    console.log('URL you dragged here:', url)
 
-    client.store.importSpecFromUrl(url)
+    if (url) {
+      client.store.importSpecFromUrl(url)
+    }
+
     return
   }
 
   // Check if the user dropped a file
   for (const f of e.dataTransfer?.files ?? []) {
-    // console.log('File(s) you dragged here: ', f.path)
-    console.log('File you dragged here:', f)
-
     // @ts-expect-error not typed yet
     const fileContent = await window.mainProcess.readFile(f.path)
 

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -40,12 +40,15 @@ trackEvent(`launch: ${os}`)
 // // @ts-expect-error not typed yet
 // const fileContent = await window.electronAPI.readFile(filePath)
 
-// console.log('fileContent', fileContent)
+// Open… menu
+// @ts-expect-error not typed yet
+window.ipcRenderer?.on('importFile', function (fileContent: string) {
+  if (fileContent) {
+    client.store.importSpecFile(fileContent)
+  }
+})
 
-// if (fileContent) {
-//   client.store.importSpecFile(fileContent)
-// }
-
+// Drag and drop
 document.addEventListener('drop', drop)
 document.addEventListener('dragover', dragover)
 

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -1,6 +1,7 @@
 import { webHashRouter } from '@scalar/api-client'
 import { createApiClientApp } from '@scalar/api-client/layouts/App'
 import '@scalar/api-client/style.css'
+import type { IpcRendererEvent } from 'electron'
 import { load, trackEvent } from 'fathom-client'
 
 // Initialize
@@ -48,6 +49,16 @@ window.ipcRenderer?.on('importFile', function (fileContent: string) {
   }
 })
 
+// Open… menu
+window.electron.ipcRenderer?.on(
+  'importFile',
+  function (_: IpcRendererEvent, fileContent: string) {
+    if (fileContent) {
+      client.store.importSpecFile(fileContent)
+    }
+  },
+)
+
 // Drag and drop
 document.addEventListener('drop', drop)
 document.addEventListener('dragover', dragover)
@@ -71,7 +82,7 @@ async function drop(e: DragEvent) {
     console.log('File you dragged here:', f)
 
     // @ts-expect-error not typed yet
-    const fileContent = await window.electronAPI.readFile(f.path)
+    const fileContent = await window.mainProcess.readFile(f.path)
 
     if (fileContent) {
       client.store.importSpecFile(fileContent)


### PR DESCRIPTION
This PR adds a way to open a file dialog, read files from disk and drag and drop files and URLs into the app to import new OpenAPI documents.

**Drag’n’drop**

https://github.com/user-attachments/assets/e18b72c2-0179-4730-8d7e-dd5e2efa3564

**Open…**

<img width="253" alt="Screenshot 2024-08-02 at 11 24 01" src="https://github.com/user-attachments/assets/44d923f6-66d9-4e1f-a73d-509d38d40ca2">