### PR TITLE
ci: do not create PR comment in main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
           # 1) Go to https://dash.cloudflare.com/profile/api-tokens
           # 2) Create a token with the following permissions:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      - if: steps.deploy-client.outputs.deployment-url
+      - if: github.ref != 'refs/heads/main' && steps.deploy-client.outputs.deployment-url
         name: Add Cloudflare Preview URL to the PR
         uses: thollander/actions-comment-pull-request@v2
         with:


### PR DESCRIPTION
In #2621 I’ve added a step to create PR comments, but that fails in `main` — because there’s no PR then. :)

This PR just skips the step in `main`.