### PR TITLE
ci: output published packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
       - if: steps.changesets.outputs.publishedPackages
         name: List all published packages
         run: echo "${{ steps.changesets.outputs.publishedPackages }}"
-      - if: steps.changesets.outputs.publishedPackages.*.name == 'scalar-api-client'
+      - if: contains(steps.changesets.outputs.publishedPackages, 'scalar-api-client')
         name: Check whether scalar-api-client was published
         run: echo "scalar-api-client was published"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
           # Permissions: Read and Write
           # Select packages: @scalar
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - if: steps.changesets.outputs.published == 'true'
+      - if: steps.changesets.outputs.publishedPackages
         name: List all published packages
         run: echo "${{ steps.changesets.outputs.publishedPackages }}"
       - if: steps.changesets.outputs.publishedPackages.*.name == 'scalar-api-client'


### PR DESCRIPTION
Another attempt to just output all packages and check whether `scalar-api-client` was published (it’s never really published to npm, but I think it’s in the output and it would help to have access to that information).

Slowly working my way towards automating the app release process. 🤡 