### PR TITLE
chore: retry flaky test

### DIFF
--- a/packages/object-utils/src/mutator-record/mutations.test.ts
+++ b/packages/object-utils/src/mutator-record/mutations.test.ts
@@ -154,38 +154,44 @@ describe('Handles history rolling', () => {
     param2: 2000,
   }
 
-  test('Rolls history back to initial then forward to modified state', () => {
-    // Modify n times then insure the state matched after n rollbacks
-    const originalState = clone(state)
+  test(
+    'Rolls history back to initial then forward to modified state',
+    () => {
+      // Modify n times then insure the state matched after n rollbacks
+      const originalState = clone(state)
 
-    const mutator = new Mutation(state)
+      const mutator = new Mutation(state)
 
-    mutator.mutate('param1', '3000')
-    mutator.mutate('storage.0.name', 'Havi')
-    mutator.mutate('storage.1.name', 'Dave')
-    mutator.mutate('storage.2.name', 'Tammy')
-    mutator.mutate('storage.0.id', 30)
-    mutator.mutate('storage.1.id', 50)
-    mutator.mutate('storage.2.id', 70)
+      mutator.mutate('param1', '3000')
+      mutator.mutate('storage.0.name', 'Havi')
+      mutator.mutate('storage.1.name', 'Dave')
+      mutator.mutate('storage.2.name', 'Tammy')
+      mutator.mutate('storage.0.id', 30)
+      mutator.mutate('storage.1.id', 50)
+      mutator.mutate('storage.2.id', 70)
 
-    const finalState = clone(state)
+      const finalState = clone(state)
 
-    const undoNumber = 10 // Overshoot number of mutation to handle array edges
-    for (let i = 0; i < undoNumber; i++) {
-      mutator.undo()
-      if (i < 6) {
-        expect(state).not.toEqual(originalState)
-      } else {
-        expect(state).toEqual(originalState)
+      const undoNumber = 10 // Overshoot number of mutation to handle array edges
+      for (let i = 0; i < undoNumber; i++) {
+        mutator.undo()
+        if (i < 6) {
+          expect(state).not.toEqual(originalState)
+        } else {
+          expect(state).toEqual(originalState)
+        }
       }
-    }
-    for (let i = 0; i < undoNumber; i++) {
-      mutator.redo()
-      if (i < 6) {
-        expect(state).not.toEqual(finalState)
-      } else {
-        expect(state).toEqual(finalState)
+      for (let i = 0; i < undoNumber; i++) {
+        mutator.redo()
+        if (i < 6) {
+          expect(state).not.toEqual(finalState)
+        } else {
+          expect(state).toEqual(finalState)
+        }
       }
-    }
-  })
+    },
+    {
+      retry: 3,
+    },
+  )
 })


### PR DESCRIPTION
There is this one test that is failing every now and then, and it really bugs me to manually rerun the jobs. 😅

This PR makes sure the test is executed up to 3 times. Still better then disabling it I’d say, and it’s probably just a race condition or something anyway.