### PR TITLE
fix: add default active collection to folder create command

### DIFF
--- a/.changeset/strange-ears-clean.md
+++ b/.changeset/strange-ears-clean.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: add default active collection to folder create command

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteFolder.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteFolder.vue
@@ -7,12 +7,13 @@ const emits = defineEmits<{
   (event: 'close'): void
 }>()
 
-const { collections, folderMutators } = useWorkspace()
+const { activeWorkspaceCollections, folderMutators, activeCollection } =
+  useWorkspace()
 const folderName = ref('')
-const selectedCollectionId = ref('')
+const selectedCollectionId = ref(activeCollection.value?.uid ?? '')
 
 const availableCollections = computed(() =>
-  Object.values(collections).map((collection) => ({
+  activeWorkspaceCollections.value.map((collection) => ({
     id: collection.uid,
     label: collection.spec?.info?.title ?? '',
   })),


### PR DESCRIPTION
we now show only the collections to a workspace and default to the active collection