### PR TITLE
feat: add environment selector to addressbar

### DIFF
--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -497,6 +497,10 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
       workspaces[Object.keys(workspaces)[0]],
   )
 
+  const activeEnvironment = computed(
+    () => environments[activeWorkspace.value?.activeEnvironmentId ?? 'default'],
+  )
+
   /** Ordered list of the active workspace's collections with drafts last */
   const activeWorkspaceCollections = computed(() =>
     activeWorkspace.value?.collectionUids
@@ -819,6 +823,7 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
     activeWorkspaceServers,
     activeParsedEnvironments,
     activeWorkspaceRequests,
+    activeEnvironment,
     modalState,
     isReadOnly,
     router,

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Sidebar } from '@/components'
 import AddressBar from '@/components/AddressBar/AddressBar.vue'
+import EnvironmentSelector from '@/components/EnvironmentSelector/EnvironmentSelector.vue'
 import SearchButton from '@/components/Search/SearchButton.vue'
 import SearchModal from '@/components/Search/SearchModal.vue'
 import SidebarButton from '@/components/Sidebar/SidebarButton.vue'
@@ -282,6 +283,7 @@ const getBackgroundColor = () => {
         </a>
       </div>
       <AddressBar />
+      <EnvironmentSelector />
       <div
         class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-0.5 lg:flex-1 justify-end w-6/12">
         <!-- TODO: There should be an `ìsModal` flag instead -->

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -14,6 +14,8 @@ const workspaceSchema = z.object({
   collectionUids: z.array(z.string()).default([]),
   /** List of all environment uids in a given workspace */
   environmentUids: z.array(z.string()).default([]),
+  /** Active Environment ID to use for requests  */
+  activeEnvironmentId: z.string().optional(),
   /** List of all cookie uids in a given workspace */
   cookieUids: z.array(z.string()).default([]),
   /** Workspace level proxy for all requests to be sent through */


### PR DESCRIPTION
Now we have an active environment selector! Still needs some styling from @cameronrohani but this is a reallllly cool feature because, its probably the first openapi extension we should support asap!

![image](https://github.com/user-attachments/assets/afa686ae-564d-40fc-bfad-bed4b88ce338)
![image](https://github.com/user-attachments/assets/e3d5d2df-60e1-42f8-ae91-34475a28bc67)

and we dont show create environment in readOnlyMode : )

@hanspagel @amritk we should do something like

```
x-scalarEnvironments:
  activeEnvironment: some_id
  global: `string of environments ORRRR key values (which makes more sense probably`
  some_id: `some id yahooo`

```

then we can parse an OpenAPI spec, and have environments loaded for our users! 🤯 

Apart from styling we should also hook this into variable highlighting to pick the proper environment : )

We also might want to think about doing collection level environments vs workspace? so maybe the extension is specific if its a collection vs workspace collection