### PR TITLE
fix(api-client): upload file in form-data with key

### DIFF
--- a/.changeset/wet-dolphins-poke.md
+++ b/.changeset/wet-dolphins-poke.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: upload file in form-data with key

--- a/packages/api-client/src/libs/sendRequest.test.ts
+++ b/packages/api-client/src/libs/sendRequest.test.ts
@@ -287,4 +287,58 @@ describe('sendRequest', () => {
       path: '/v1/',
     })
   })
+
+  it('sends a multipart/form-data request', async () => {
+    const { request, example, server } = createRequestExampleServer({
+      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
+      requestPayload: { path: '', method: 'POST' },
+      requestExamplePayload: {
+        body: {
+          activeBody: 'formData',
+          formData: {
+            encoding: 'form-data',
+            value: [
+              {
+                key: 'name',
+                value: 'John Doe',
+              },
+              {
+                key: 'file',
+                file: new File(['hello'], 'hello.txt', { type: 'text/plain' }),
+              },
+              {
+                key: 'image',
+                file: new File(['hello'], 'hello.png', { type: 'image/png' }),
+                value: 'ignore me',
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    const result = await sendRequest(
+      request,
+      example,
+      server?.url + request.path,
+    )
+
+    expect(result?.response?.data).toMatchObject({
+      method: 'POST',
+      path: '/',
+      body: {
+        name: 'John Doe',
+        file: {
+          name: 'hello.txt',
+          sizeInBytes: 5,
+          type: 'text/plain',
+        },
+        image: {
+          name: 'hello.png',
+          sizeInBytes: 5,
+          type: 'image/png',
+        },
+      },
+    })
+  })
 })

--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -82,10 +82,9 @@ export const sendRequest = async (
     if (example.body.formData.encoding === 'form-data') {
       example.body.formData.value.forEach(
         (formParam: { key: string; value: string; file?: File }) => {
-          if (formParam.key && formParam.value) {
-            bodyFormData.append(formParam.key, formParam.value)
-          } else if (formParam.file) {
-            bodyFormData.append(formParam.file.name, formParam.file)
+          const value = formParam.file ? formParam.file : formParam.value
+          if (formParam.key && value) {
+            bodyFormData.append(formParam.key, value)
           }
         },
       )


### PR DESCRIPTION
**Problem**
Currently, when I try to upload a file with form-data, the key is sent as the file name instead of the correct key.

![Screenshot 2567-07-28 at 18 19 09](https://github.com/user-attachments/assets/050596aa-06d9-4f35-8d4d-f430c113367a)


**Solution**
With this PR, I ensure that the correct key is used instead of the file name when sending the request. Additionally, if both a file and a value are present, the file will be used for the request.
