### PR TITLE
fix: superfluous yaml or json parse before spec parsing

### DIFF
--- a/.changeset/thin-garlics-jam.md
+++ b/.changeset/thin-garlics-jam.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: superfluous yaml or json parse before spec parsing


### PR DESCRIPTION
we only used the parsedSpec for checking "servers" but we really dont need that at all, we should let our amazing openapi-parser handle all things loading of spec and we then use the result

this fixes a bug where if a yaml file has newlines, or wrapped in string characters that it fails to load 😨 