### PR TITLE
feat(api-client): websocket support, see #2670

### DIFF
--- a/packages/api-client/src/components/CommandPalette/CommandPaletteWebsocket.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteWebsocket.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
+import { useWorkspace } from '@/store/workspace'
+import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import type { RequestMethod } from '@scalar/oas-utils/helpers'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { handleKeyDown } from './handleKeyDown'
+
+const emits = defineEmits<{
+  (event: 'close'): void
+}>()
+
+const { push } = useRouter()
+
+const {
+  activeCollection,
+  activeWorkspace,
+  activeWorkspaceCollections,
+  requestMutators,
+  activeRequest,
+  folders: _folders,
+} = useWorkspace()
+
+const requestName = ref('')
+const requestMethod = ref('GET')
+const selectedCollectionId = ref(activeCollection.value?.uid ?? '')
+
+// we only allow websockets to be added to drafts or non OpenAPI collections
+// so we would call it AsyncAPI collections maybe? Graphql/websocket/mqtt/ssr/grpc etc
+const collections = computed(() =>
+  activeWorkspaceCollections.value
+    .filter((collection) => collection.spec.info?.title === 'Drafts')
+    .map((collection) => ({
+      id: collection.uid,
+      label: collection.spec.info?.title ?? 'Unititled Collection',
+    })),
+)
+
+const selectedCollection = computed({
+  get: () =>
+    collections.value.find(({ id }) => id === selectedCollectionId.value),
+  set: (opt) => {
+    if (opt?.id) selectedCollectionId.value = opt.id
+  },
+})
+
+const handleSubmit = () => {
+  if (!selectedCollectionId.value) return
+  const parentUid = selectedCollection.value?.id
+
+  // const newRequest = requestMutators.add(
+  //   {
+  //     path: '',
+  //     method: requestMethod.value.toUpperCase() as RequestMethod,
+  //     description: requestName.value,
+  //     operationId: requestName.value,
+  //     summary: requestName.value,
+  //     tags: ['default'],
+  //   },
+  //   parentUid,
+  // )
+
+  // push(`/workspace/${activeWorkspace.value.uid}/request/${newRequest.uid}`)
+  push(`/workspace/${activeWorkspace.value.uid}/websocket/default`)
+  emits('close')
+}
+
+const requestInput = ref<HTMLInputElement | null>(null)
+onMounted(() => {
+  requestInput.value?.focus()
+  window.addEventListener(
+    'keydown',
+    (event) => handleKeyDown(event, handleSubmit),
+    true,
+  )
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener(
+    'keydown',
+    (event) => handleKeyDown(event, handleSubmit),
+    true,
+  )
+})
+</script>
+<template>
+  <div class="flex w-full flex-col gap-3">
+    <div
+      class="gap-3 rounded bg-b-2 focus-within:bg-b-1 focus-within:shadow-border min-h-20 relative">
+      <label
+        class="absolute w-full h-full opacity-0 cursor-text"
+        for="requestname"></label>
+      <input
+        id="requestname"
+        ref="requestInput"
+        v-model="requestName"
+        class="border-transparent outline-none w-full pl-8 text-sm min-h-8 py-1.5"
+        label="Websocket Name"
+        placeholder="Websocket Name" />
+    </div>
+    <div class="flex">
+      <div class="flex flex-1 gap-2 max-h-8">
+        <ScalarListbox
+          v-model="selectedCollection"
+          :options="collections">
+          <ScalarButton
+            class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+            variant="outlined">
+            <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
+              selectedCollection
+                ? selectedCollection.label
+                : 'Select Collection'
+            }}</span>
+            <ScalarIcon
+              class="text-c-3"
+              icon="ChevronDown"
+              size="xs" />
+          </ScalarButton>
+        </ScalarListbox>
+      </div>
+      <ScalarButton
+        class="max-h-8 text-xs p-0 px-3"
+        @click="handleSubmit">
+        Create Request
+      </ScalarButton>
+    </div>
+  </div>
+</template>

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -6,6 +6,7 @@ import CommandPaletteExample from './CommandPaletteExample.vue'
 import CommandPaletteFolder from './CommandPaletteFolder.vue'
 import CommandPaletteImport from './CommandPaletteImport.vue'
 import CommandPaletteRequest from './CommandPaletteRequest.vue'
+import CommandPaletteWebsocket from './CommandPaletteWebsocket.vue'
 import CommandPaletteWorkspace from './CommandPaletteWorkspace.vue'
 
 /**
@@ -20,6 +21,7 @@ export default {
 export const PaletteComponents = {
   'Import Collection': CommandPaletteImport,
   'Create Request': CommandPaletteRequest,
+  'Create Websocket': CommandPaletteWebsocket,
   'Create Workspace': CommandPaletteWorkspace,
   'Add Folder': CommandPaletteFolder,
   'Create Collection': CommandPaletteCollection,
@@ -50,6 +52,10 @@ const availableCommands = [
       {
         name: 'Create Request',
         icon: 'ExternalLink',
+      },
+      {
+        name: 'Create Websocket',
+        icon: 'PaperAirplane',
       },
       {
         name: 'Import Collection',

--- a/packages/api-client/src/router.ts
+++ b/packages/api-client/src/router.ts
@@ -8,6 +8,7 @@ import {
 
 export enum PathId {
   Request = 'request',
+  Websocket = 'websocket',
   Examples = 'examples',
   Cookies = 'cookies',
   Collection = 'collection',
@@ -123,6 +124,15 @@ const routes = [
         name: PathId.Servers,
         path: `servers/:${PathId.Servers}`,
         component: () => import('@/views/Servers/Servers.vue'),
+      },
+      {
+        path: 'websocket',
+        redirect: (to) => `${to.fullPath.replace(/\/$/, '')}/default`,
+      },
+      {
+        name: PathId.Websocket,
+        path: `websocket/:${PathId.Websocket}`,
+        component: () => import('@/views/Websocket/Websocket.vue'),
       },
     ],
   },

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -74,6 +74,7 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
       [PathId.Cookies]: 'default',
       [PathId.Servers]: 'default',
       [PathId.Workspace]: 'default',
+      [PathId.Websocket]: 'default',
     }
 
     const currentRoute = router.currentRoute.value

--- a/packages/api-client/src/views/Websocket/Websocket.vue
+++ b/packages/api-client/src/views/Websocket/Websocket.vue
@@ -48,17 +48,12 @@ const showSideBar = ref(!activeWorkspace.value?.isReadOnly)
             @dragover.prevent>
             <!-- Collections -->
             <RequestSidebarItem
-              v-for="(
-                collection, collectionIndex
-              ) in activeWorkspaceCollections"
+              v-for="collection in activeWorkspaceCollections"
               :key="collection.uid"
               :isDraggable="!activeWorkspace.isReadOnly"
               :isDroppable="!activeWorkspace.isReadOnly"
               :item="collection"
-              :parentUids="[]"
-              @onDragEnd="
-                (...args) => onDragEnd(collection, collectionIndex, ...args)
-              ">
+              :parentUids="[]">
               <template #leftIcon>
                 <ScalarIcon
                   class="text-sidebar-c-2 text-sm group-hover:hidden"
@@ -77,13 +72,6 @@ const showSideBar = ref(!activeWorkspace.value?.isReadOnly)
               </template>
             </RequestSidebarItem>
           </div>
-        </template>
-        <template #button>
-          <SidebarButton
-            v-if="!activeWorkspace.isReadOnly"
-            :click="addItemHandler">
-            <template #title>Add Item</template>
-          </SidebarButton>
         </template>
       </Sidebar>
       <!-- TODO possible loading state -->

--- a/packages/api-client/src/views/Websocket/Websocket.vue
+++ b/packages/api-client/src/views/Websocket/Websocket.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { Sidebar } from '@/components'
+import SearchButton from '@/components/Search/SearchButton.vue'
+import SearchModal from '@/components/Search/SearchModal.vue'
+import SidebarButton from '@/components/Sidebar/SidebarButton.vue'
+import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
+import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
+import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
+import { useSidebar } from '@/hooks'
+import { useWorkspace } from '@/store/workspace'
+import { ScalarIcon, useModal } from '@scalar/components'
+import { ref } from 'vue'
+
+import RequestSidebarItem from '../Request/RequestSidebarItem.vue'
+import { WorkspaceDropdown } from '../Request/components'
+import WebsocketBar from './WebsocketBar.vue'
+import WebsocketResponse from './WebsocketResponse.vue'
+import WebsocketSection from './WebsocketSection.vue'
+
+const { activeExample, activeWorkspace, activeWorkspaceCollections } =
+  useWorkspace()
+const { collapsedSidebarFolders } = useSidebar()
+const searchModalState = useModal()
+
+const showSideBar = ref(!activeWorkspace.value?.isReadOnly)
+</script>
+<template>
+  <div
+    class="flex flex-1 flex-col rounded rounded-b-none rounded-r-none pt-0 h-full client-wrapper-bg-color relative">
+    <div
+      class="lg:min-h-header flex items-center w-full justify-center p-1 flex-wrap t-app__top-container">
+      <WebsocketBar />
+    </div>
+    <ViewLayout>
+      <Sidebar
+        v-show="showSideBar"
+        :class="[showSideBar ? 'sidebar-active-width' : '']">
+        <template
+          v-if="!activeWorkspace.isReadOnly"
+          #header>
+          <WorkspaceDropdown />
+        </template>
+        <template #content>
+          <SearchButton @openSearchModal="searchModalState.show()" />
+          <div
+            class="custom-scroll flex flex-1 flex-col overflow-visible px-3 pb-12 pt-2.5"
+            @dragenter.prevent
+            @dragover.prevent>
+            <!-- Collections -->
+            <RequestSidebarItem
+              v-for="(
+                collection, collectionIndex
+              ) in activeWorkspaceCollections"
+              :key="collection.uid"
+              :isDraggable="!activeWorkspace.isReadOnly"
+              :isDroppable="!activeWorkspace.isReadOnly"
+              :item="collection"
+              :parentUids="[]"
+              @onDragEnd="
+                (...args) => onDragEnd(collection, collectionIndex, ...args)
+              ">
+              <template #leftIcon>
+                <ScalarIcon
+                  class="text-sidebar-c-2 text-sm group-hover:hidden"
+                  icon="CodeFolder"
+                  size="sm"
+                  thickness="2" />
+                <div
+                  :class="{
+                    'rotate-90': collapsedSidebarFolders[collection.uid],
+                  }">
+                  <ScalarIcon
+                    class="text-c-3 hidden text-sm group-hover:block"
+                    icon="ChevronRight"
+                    size="sm" />
+                </div>
+              </template>
+            </RequestSidebarItem>
+          </div>
+        </template>
+        <template #button>
+          <SidebarButton
+            v-if="!activeWorkspace.isReadOnly"
+            :click="addItemHandler">
+            <template #title>Add Item</template>
+          </SidebarButton>
+        </template>
+      </Sidebar>
+      <!-- TODO possible loading state -->
+      <ViewLayoutContent
+        v-if="activeExample"
+        class="flex-1"
+        :class="[showSideBar ? 'sidebar-active-hide-layout' : '']">
+        <WebsocketSection />
+        <WebsocketResponse />
+      </ViewLayoutContent>
+    </ViewLayout>
+  </div>
+  <SearchModal :modalState="searchModalState" />
+</template>

--- a/packages/api-client/src/views/Websocket/WebsocketBar.vue
+++ b/packages/api-client/src/views/Websocket/WebsocketBar.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts">
+import CodeInput from '@/components/CodeInput/CodeInput.vue'
+import { executeRequestBus } from '@/libs'
+import { useWorkspace } from '@/store/workspace'
+import { Listbox } from '@headlessui/vue'
+import { ScalarButton, ScalarIcon } from '@scalar/components'
+import { REQUEST_METHODS, type RequestMethod } from '@scalar/oas-utils/helpers'
+import { isMacOS } from '@scalar/use-tooltip'
+import { useMagicKeys, whenever } from '@vueuse/core'
+import { ref, watch } from 'vue'
+
+import { useWebSocket } from './useWebSocket'
+
+const { setUrl, connect, disconnect, isConnected, url } = useWebSocket()
+
+function handleUrlUpdate(value: string) {
+  console.log('handleUrlUpdate', value)
+  setUrl(value)
+}
+
+function handleConnect() {
+  console.log('handleConnect', isConnected.value)
+  if (isConnected.value) {
+    disconnect()
+  } else {
+    connect()
+  }
+}
+</script>
+<template>
+  <div class="order-last lg:order-none lg:w-auto w-full">
+    <div class="m-auto flex basis-1/2 flex-row items-center">
+      <!-- Address Bar -->
+      <Listbox v-slot="{ open }">
+        <div
+          :class="[
+            'text-xxs bg-b-1 relative flex w-full lg:min-w-[720px] lg:max-w-[720px] order-last lg:order-none flex-1 flex-row items-stretch rounded border p-[3px]',
+            { 'rounded-b-none': open },
+            { 'border-transparent': open },
+          ]">
+          <div class="flex gap-1">
+            <span class="font-code text-xxs font-medium">websocket</span>
+          </div>
+          <div
+            class="scroll-timeline-x scroll-timeline-x-hidden relative flex w-full">
+            <div class="fade-left"></div>
+
+            <CodeInput
+              disableCloseBrackets
+              disableEnter
+              disableTabIndent
+              :emitOnBlur="false"
+              :modelValue="url"
+              placeholder="Enter URL to get started"
+              @update:modelValue="handleUrlUpdate" />
+            <div class="fade-right"></div>
+          </div>
+
+          <ScalarButton
+            class="relative h-auto shrink-0 gap-1 overflow-hidden pl-2 pr-2.5 py-1 z-[1] font-bold"
+            @click="handleConnect">
+            <ScalarIcon
+              class="relative z-10 shrink-0 fill-current"
+              icon="Play"
+              size="xs" />
+            <span class="text-xxs relative z-10 lg:flex hidden">{{
+              isConnected ? 'Disconnect' : 'Connect'
+            }}</span>
+          </ScalarButton>
+        </div>
+      </Listbox>
+    </div>
+  </div>
+</template>
+<style scoped>
+:deep(.cm-editor) {
+  background-color: var(--scalar-background-1);
+  height: 100%;
+  outline: none;
+  width: 100%;
+}
+:deep(.cm-content) {
+  padding: 0;
+  display: flex;
+  align-items: center;
+}
+.scroll-timeline-x {
+  scroll-timeline: --scroll-timeline x;
+  /* Firefox supports */
+  scroll-timeline: --scroll-timeline horizontal;
+  -ms-overflow-style: none; /* IE and Edge */
+}
+.scroll-timeline-x-hidden {
+  overflow: auto;
+  scrollbar-width: none;
+}
+.scroll-timeline-x-hidden::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+.scroll-timeline-x-address {
+  line-height: 27px;
+  scrollbar-width: none; /* Firefox */
+}
+/* make clickable are to left of send button */
+.scroll-timeline-x-address:after {
+  content: '';
+  position: absolute;
+  height: 100%;
+  width: 24px;
+  right: 0;
+  cursor: text;
+}
+.scroll-timeline-x-address:empty:before {
+  content: 'Enter URL or cURL request';
+  color: var(--scalar-color-3);
+  pointer-events: none;
+}
+.fade-left,
+.fade-right {
+  content: '';
+  position: sticky;
+  height: 100%;
+  animation-name: fadein;
+  animation-duration: 1ms;
+  animation-direction: reverse;
+  animation-timeline: --scroll-timeline;
+  z-index: 1;
+  pointer-events: none;
+}
+.fade-left {
+  background: linear-gradient(
+    -90deg,
+    color-mix(in srgb, var(--scalar-background-1), transparent 100%) 0%,
+    color-mix(in srgb, var(--scalar-background-1), transparent 20%) 30%,
+    var(--scalar-background-1) 100%
+  );
+  left: 0;
+  min-width: 3px;
+  animation-direction: normal;
+}
+.fade-right {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--scalar-background-1), transparent 100%) 0%,
+    color-mix(in srgb, var(--scalar-background-1), transparent 20%) 30%,
+    var(--scalar-background-1) 100%
+  );
+  right: 0;
+  min-width: 24px;
+}
+@keyframes fadein {
+  0% {
+    opacity: 0;
+  }
+  1% {
+    opacity: 1;
+  }
+}
+</style>

--- a/packages/api-client/src/views/Websocket/WebsocketMessage.vue
+++ b/packages/api-client/src/views/Websocket/WebsocketMessage.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import CodeInput from '@/components/CodeInput/CodeInput.vue'
+import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
+import { ref } from 'vue'
+
+import { useWebSocket } from './useWebSocket'
+
+const { isConnected, sendMessage } = useWebSocket()
+
+const message = ref('')
+
+function handleSend() {
+  sendMessage(message.value)
+  message.value = ''
+}
+</script>
+<template>
+  <ViewLayoutCollapse class="group/params">
+    <template #title>Message</template>
+    <CodeInput
+      v-model="message"
+      content=""
+      lineNumbers />
+    <button
+      :disabled="!isConnected"
+      type="button"
+      @click="handleSend">
+      send
+    </button>
+  </ViewLayoutCollapse>
+</template>

--- a/packages/api-client/src/views/Websocket/WebsocketResponse.vue
+++ b/packages/api-client/src/views/Websocket/WebsocketResponse.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import { ScalarIcon } from '@scalar/components'
+
+import { useWebSocket } from './useWebSocket'
+
+const { messageHistory } = useWebSocket()
+</script>
+<template>
+  <ViewLayoutSection>
+    <template #title>
+      <ScalarIcon
+        class="text-c-3 mr-2 rotate-180"
+        icon="ExternalLink"
+        size="sm"
+        thickness="2.5" />
+      <div class="flex items-center flex-1">Response</div>
+    </template>
+    <div class="custom-scroll flex flex-1 flex-col px-2 xl:px-6 py-2.5">
+      <div
+        v-for="history in messageHistory"
+        :key="history.message">
+        {{ history.type }} : {{ history.message }}
+      </div>
+    </div>
+  </ViewLayoutSection>
+</template>

--- a/packages/api-client/src/views/Websocket/WebsocketSection.vue
+++ b/packages/api-client/src/views/Websocket/WebsocketSection.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import ContextBar from '@/components/ContextBar.vue'
+import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import { useWorkspace } from '@/store/workspace'
+import RequestParams from '@/views/Request/RequestSection/RequestParams.vue'
+import { ScalarIcon } from '@scalar/components'
+import { computed, ref, watch } from 'vue'
+
+import WebsocketMessage from './WebsocketMessage.vue'
+
+const { activeRequest, activeExample, activeSecurityRequirements, isReadOnly } =
+  useWorkspace()
+
+const bodyMethods = ['POST', 'PUT', 'PATCH', 'DELETE']
+
+const sections = computed(() => {
+  const allSections = ['All', 'Message', 'Headers', 'Query']
+
+  if (isAuthHidden.value) allSections.splice(allSections.indexOf('Auth'), 1)
+
+  return allSections
+})
+
+// If security = [] or [{}] just hide it on readOnly mode
+const isAuthHidden = computed(
+  () =>
+    isReadOnly.value &&
+    (activeSecurityRequirements.value.length === 0 ||
+      JSON.stringify(activeSecurityRequirements.value) === '[{}]'),
+)
+
+type ActiveSections = (typeof sections.value)[number]
+
+const activeSection = ref<ActiveSections>('All')
+
+watch(activeRequest, (newRequest) => {
+  if (
+    activeSection.value === 'Body' &&
+    !bodyMethods.includes(newRequest.method)
+  ) {
+    activeSection.value = 'All'
+  }
+})
+</script>
+<template>
+  <ViewLayoutSection>
+    <template #title>
+      <ScalarIcon
+        class="text-c-3 mr-2"
+        icon="ExternalLink"
+        size="sm"
+        thickness="2.5" />
+      <div class="flex-1">
+        Request
+        <span class="text-c-3 pl-1">{{ activeRequest?.summary }}</span>
+      </div>
+    </template>
+    <div
+      class="request-section-content custom-scroll flex flex-1 flex-col px-2 xl:px-5 py-2.5">
+      <ContextBar
+        :activeSection="activeSection"
+        :sections="sections"
+        @setActiveSection="activeSection = $event" />
+      <WebsocketMessage
+        v-show="activeSection === 'All' || activeSection === 'Message'" />
+      <RequestParams
+        v-show="activeSection === 'All' || activeSection === 'Headers'"
+        paramKey="headers"
+        title="Headers" />
+      <RequestParams
+        v-show="activeSection === 'All' || activeSection === 'Query'"
+        paramKey="query"
+        title="Query Parameters" />
+    </div>
+  </ViewLayoutSection>
+</template>
+<style>
+.request-section-content {
+  --scalar-border-width: 0.5px;
+}
+.request-section-content-filter {
+  box-shadow: 0 -10px 0 10px var(--scalar-background-1);
+}
+.request-item:focus-within .request-meta-buttons {
+  opacity: 1;
+}
+</style>

--- a/packages/api-client/src/views/Websocket/useWebSocket.ts
+++ b/packages/api-client/src/views/Websocket/useWebSocket.ts
@@ -1,0 +1,71 @@
+import { onUnmounted, reactive, ref } from 'vue'
+
+const socket = ref<WebSocket | null>(null)
+const isConnected = ref(false)
+const messageHistory = reactive<
+  { type: 'sent' | 'received'; message: string }[]
+>([])
+const url = ref('')
+
+export function useWebSocket() {
+  const connect = () => {
+    console.log('connecting!')
+    if (socket.value?.readyState === WebSocket.OPEN) {
+      console.warn('WebSocket is already connected')
+      return
+    }
+
+    socket.value = new WebSocket(url.value)
+
+    socket.value.onopen = () => {
+      isConnected.value = true
+      console.log('WebSocket connected')
+    }
+
+    socket.value.onmessage = (event) => {
+      messageHistory.push({ type: 'received', message: event.data })
+    }
+
+    socket.value.onclose = () => {
+      isConnected.value = false
+      console.log('WebSocket disconnected')
+    }
+
+    socket.value.onerror = (error) => {
+      console.error('WebSocket error:', error)
+    }
+  }
+
+  const disconnect = () => {
+    socket.value?.close()
+    socket.value = null
+    isConnected.value = false
+  }
+
+  const sendMessage = (message: string) => {
+    if (socket.value?.readyState === WebSocket.OPEN) {
+      socket.value.send(message)
+      messageHistory.push({ type: 'sent', message })
+    } else {
+      console.error('WebSocket is not connected')
+    }
+  }
+
+  const setUrl = (newUrl: string) => {
+    url.value = newUrl
+  }
+
+  onUnmounted(() => {
+    disconnect()
+  })
+
+  return {
+    isConnected,
+    messageHistory,
+    connect,
+    disconnect,
+    sendMessage,
+    setUrl,
+    url,
+  }
+}


### PR DESCRIPTION
wanted to take a super rough hacked-prototype-swing at this for a few hours and a lot of things came up! I wanted to just make it so we can add it to the drafts collection.. but then it made me think about the #2663 PR 🤔 

so some initial thoughts:

CollectionRoute:
- have a type in the collection -> OpenAPI | AsyncAPI
- render OpenAPI Collection Viewer vs AsyncAPI Viewer
- AsyncAPI Collection Viewer has different renders for "Websocket vs Graphql" that are root level
- we still have a "collection page" for both buuuuut theyre pretty different (no tests for websocket and stuff)
- we still render the same sidebar for both, but the address bar is different.
-  this actually kind of solves our addressbar conundrum, cause we probably wanna abstract out the sidebar to always render maybe we use a slot at the root of the routerview!

but yeah on a personal note i would love to have websocket support cause omg


https://github.com/user-attachments/assets/f2306aaf-caa9-4db9-8ff1-6d4bd1319232

