### PR TITLE
feat(client-app): command palette empty state

### DIFF
--- a/.changeset/serious-masks-press.md
+++ b/.changeset/serious-masks-press.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: command palette empty state

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -292,6 +292,11 @@ onBeforeUnmount(() => {
           {{ command.name }}
         </div>
       </template>
+      <div
+        v-if="!searchResultsWithPlaceholderResults.length"
+        class="text-c-3 text-center text-sm p-2 pt-3">
+        No commands found
+      </div>
     </template>
 
     <!-- Specific command palette -->


### PR DESCRIPTION
this pr adds a first empty state to the client app command palette component:

https://github.com/user-attachments/assets/a5c9b67b-21f9-453d-a53a-4e5afc3fb4b1

