### PR TITLE
fix(client-app): back to requests redirection link

### DIFF
--- a/.changeset/empty-eagles-join.md
+++ b/.changeset/empty-eagles-join.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: back to requests link

--- a/packages/api-client/src/components/SubpageHeader.vue
+++ b/packages/api-client/src/components/SubpageHeader.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components'
+import { useRoute } from 'vue-router'
+
+const currentRoute = useRoute()
 </script>
 <template>
   <div
@@ -8,7 +11,7 @@ import { ScalarIcon } from '@scalar/components'
       class="lg:min-h-header items-center w-full p-1 t-app__top-container flex items-center">
       <router-link
         class="text-c-2 text-sm font-medium gitbook-show ml-1 flex items-center p-1.5 hover:bg-b-3 rounded cursor-pointer gap-1 active:text-c-1 no-underline"
-        to="/workspace/default/request/default">
+        :to="`/workspace/${currentRoute.params.workspace}/request/default`">
         <ScalarIcon
           icon="ChevronLeft"
           size="sm" />


### PR DESCRIPTION
this pr fixes the back to requests redirection link to be effective when navigating from another workspace than default:

<img width="901" alt="image" src="https://github.com/user-attachments/assets/279c139f-0200-471a-a0ac-f5f3694f92bc">
