### PR TITLE
feat: use pathstring when req summary isn't available

### DIFF
--- a/.changeset/smooth-nails-sing.md
+++ b/.changeset/smooth-nails-sing.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+Fallback request summary to path on spec import

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -97,7 +97,7 @@ export const importSpecToWorkspace = async (spec: string | AnyObject) => {
         description: operation.description,
         operationId: operation.operationId,
         security: operation.security,
-        summary: operation.summary,
+        summary: operation.summary || pathString,
         externalDocs: operation.externalDocs,
         requestBody: operation.requestBody,
         parameters,


### PR DESCRIPTION
I've done quite a lot of specs previously were the path of the request is just used as the default identifier, which makes the most sense to me if there is no summary. No need to add the type as a prefix/suffix since we already display it.

This is just a simple fallback so that the summary is set to something sensible rather than being empty or having the same default label for all requests.

![image](https://github.com/user-attachments/assets/a4ac3278-b12b-4081-810b-b096919853f3)
