### PR TITLE
feat(api-client): support body params when importing 2.0 specs

### DIFF
--- a/.changeset/many-pans-nail.md
+++ b/.changeset/many-pans-nail.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+support OpenAPI 2.0 body params when importing spec

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -287,23 +287,39 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
       },
     }
 
-    if (request.requestBody) {
-      const requestBody = getRequestBodyFromOperation({
+    const bodyParams = Object.values(request.parameters.body)
+
+    let requestBody
+
+    if (bodyParams.length) {
+      requestBody = getRequestBodyFromOperation({
+        httpVerb: request.method,
+        path: request.path,
+        information: {
+          parameters: bodyParams,
+        },
+      })
+    } else if (request.requestBody) {
+      requestBody = getRequestBodyFromOperation({
         httpVerb: request.method,
         path: request.path,
         information: {
           requestBody: request.requestBody,
         },
       })
-      if (requestBody?.postData?.['mimeType'] === 'application/json') {
-        parameters.headers.push({
-          key: 'Content-Type',
-          value: 'application/json',
-          enabled: true,
-        })
-        body.activeBody = 'raw'
-        body.raw.value = requestBody.postData.text
-      }
+    }
+
+    if (
+      requestBody &&
+      requestBody?.postData?.['mimeType'] === 'application/json'
+    ) {
+      parameters.headers.push({
+        key: 'Content-Type',
+        value: 'application/json',
+        enabled: true,
+      })
+      body.activeBody = 'raw'
+      body.raw.value = requestBody.postData.text
     }
 
     // Check all current examples for the title and iterate

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -309,10 +309,7 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
       })
     }
 
-    if (
-      requestBody &&
-      requestBody?.postData?.['mimeType'] === 'application/json'
-    ) {
+    if (requestBody?.postData?.['mimeType'] === 'application/json') {
       parameters.headers.push({
         key: 'Content-Type',
         value: 'application/json',

--- a/packages/oas-utils/src/entities/workspace/spec/requests.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/requests.ts
@@ -56,8 +56,9 @@ const requestSchema = z.object({
       query: parametersSchema,
       headers: parametersSchema,
       cookies: parametersSchema,
+      body: parametersSchema,
     })
-    .default({ path: {}, query: {}, headers: {}, cookies: {} }),
+    .default({ path: {}, query: {}, headers: {}, cookies: {}, body: {} }),
   /**
    * A declaration of which security mechanisms can be used across the API. The list of
    * values includes alternative security requirement objects that can be used. Only

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -10,6 +10,7 @@ import { dereference, load } from '@scalar/openapi-parser'
 import type { OpenAPIV3_1 } from 'openapi-types'
 
 const PARAM_DICTIONARY = {
+  body: 'body',
   cookie: 'cookies',
   header: 'headers',
   path: 'path',
@@ -67,6 +68,7 @@ export const importSpecToWorkspace = async (spec: string | AnyObject) => {
         query: {},
         headers: {},
         cookies: {},
+        body: {},
       }
 
       // An operation can have component level parameters as well :)


### PR DESCRIPTION
Not sure if there's a better way we want to abstract the different spec versions, but for now I've just included a very clear separate path for using body params, since requestBody was only introduced in 3.0

Documentation here: https://swagger.io/docs/specification/2-0/describing-request-body/

Happy to hear any thoughts if you would like this done differently; but works for now :D