### PR TITLE
feat: support customizing DataUrl via ScalarOptions

### DIFF
--- a/packages/scalar.aspnetcore/Scalar.AspNetCore.cs
+++ b/packages/scalar.aspnetcore/Scalar.AspNetCore.cs
@@ -11,7 +11,7 @@ namespace Scalar.AspNetCore
     {
         public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints)
         {
-              return endpoints.MapScalarApiReference(_ => { });
+            return endpoints.MapScalarApiReference(_ => { });
         }
 
         private static readonly JsonSerializerOptions JsonSerializerOptions = new()
@@ -32,6 +32,7 @@ namespace Scalar.AspNetCore
             return endpoints.MapGet(options.EndpointPathPrefix + "/{documentName}", (string documentName) =>
                 {
                     var title = options.Title ?? $"Scalar API Reference -- {documentName}";
+                    var dataUrl = options.DataUrlFunc is not null ? options.DataUrlFunc(documentName) : $"/openapi/{documentName}.json";
                     return Results.Content(
                         $$"""
                           <!doctype html>
@@ -42,7 +43,7 @@ namespace Scalar.AspNetCore
                               <meta name="viewport" content="width=device-width, initial-scale=1" />
                           </head>
                           <body>
-                              <script id="api-reference" data-url="/openapi/{{documentName}}.json"></script>
+                              <script id="api-reference" data-url="{{dataUrl}}"></script>
                               <script>
                               var configuration = {{configurationJson}}
 

--- a/packages/scalar.aspnetcore/Scalar.AspNetCore.csproj
+++ b/packages/scalar.aspnetcore/Scalar.AspNetCore.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.5" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 
 </Project>

--- a/packages/scalar.aspnetcore/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/ScalarOptions.cs
@@ -8,7 +8,7 @@ public class ScalarOptions
     [JsonIgnore]
     public string EndpointPathPrefix { get; set; } = "/scalar";
 
-    [JsonIgnore] 
+    [JsonIgnore]
     public string? Title { get; set; }
 
     public string Theme { get; set; } = "purple";
@@ -28,6 +28,12 @@ public class ScalarOptions
     public Dictionary<string, string>? Metadata { get; set; }
 
     public ScalarAuthenticationOptions? Authentication { get; set; }
+
+    /// <summary>
+    /// Provides a function for setting the data URL for the API reference
+    /// given the document name.
+    /// </summary>
+    public Func<string, string>? DataUrlFunc { get; set; }
 }
 
 public class ScalarAuthenticationOptions


### PR DESCRIPTION
Addressing user feedback from https://github.com/scalar/scalar/pull/1737#issuecomment-2171906715.

Instead of exposing the `DataUrl` as a single string property, I've expsoed customization for it as a function that takes the document name as an argument.

Someone can configure the options like so:

```csharp
app.MapScalarApiReference(options =>
{
	options.DataUrlFunc = (documentName) => $"/swagger/{documentName}.json";
});
```