### PR TITLE
feat(api-client): added application/problem+json media type

### DIFF
--- a/.changeset/purple-pugs-give.md
+++ b/.changeset/purple-pugs-give.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: added application/problem+json media type

--- a/packages/api-client/src/views/Request/consts/mediaTypes.ts
+++ b/packages/api-client/src/views/Request/consts/mediaTypes.ts
@@ -18,6 +18,11 @@ export const mediaTypes: { [type: string]: MediaConfig | undefined } = {
   'application/javascript': { extension: '.js', raw: true },
   'application/json': { extension: '.json', raw: true, language: 'json' },
   'application/ld+json': { extension: '.jsonld', raw: true, language: 'json' },
+  'application/problem+json': {
+    extension: '.json',
+    raw: true,
+    language: 'json',
+  },
   'application/msword': { extension: '.doc' },
   'application/octet-stream': { extension: '.bin' },
   'application/ogg': { extension: '.ogx' },


### PR DESCRIPTION
**Problem**
Currently, `application/problem+json` responses are displayed as binary files.

**Explanation**
This happens because it is not added to the list of supported media types.

**Solution**
With this PR I added it to the list of supported media types.
