### PR TITLE
fix(use-codemirror): lint

### DIFF
--- a/.changeset/seven-jars-thank.md
+++ b/.changeset/seven-jars-thank.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-codemirror': patch
+---
+
+fix: lint only if content is given

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -377,16 +377,19 @@ function getCodeMirrorExtensions({
   if (lint && language === 'json') {
     const jsonLinter = linter((view) => {
       const diagnostics: Diagnostic[] = []
-      try {
-        JSON.parse(view.state.doc.toString())
-      } catch (e) {
-        if (e instanceof Error) {
-          diagnostics.push({
-            from: 0,
-            to: view.state.doc.length,
-            severity: 'error',
-            message: e.message,
-          })
+      const content = view.state.doc.toString()
+      if (content.trim()) {
+        try {
+          JSON.parse(content)
+        } catch (e) {
+          if (e instanceof Error) {
+            diagnostics.push({
+              from: 0,
+              to: view.state.doc.length,
+              severity: 'error',
+              message: e.message,
+            })
+          }
         }
       }
       return diagnostics


### PR DESCRIPTION
this pr updates scalar/use-codemirror package in order to enable linting only on given content to avoid following behavior:

<img width="551" alt="image" src="https://github.com/user-attachments/assets/b86be04d-d343-40f8-80d3-3c1a733fd2da">
