### PR TITLE
fix(api-client-app): allow blob: as source in Content-Security-Policy

### DIFF
--- a/.changeset/fifty-walls-cheer.md
+++ b/.changeset/fifty-walls-cheer.md
@@ -1,0 +1,5 @@
+---
+'scalar-api-client': patch
+---
+
+fix(api-client-app): allow blob: as source in Content-Security-Policy

--- a/packages/api-client-app/src/renderer/index.html
+++ b/packages/api-client-app/src/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src https://fonts.scalar.com" />
+      content="default-src 'self' blob:; connect-src *; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src https://fonts.scalar.com" />
   </head>
 
   <body>


### PR DESCRIPTION
Turns out our electron app is a little more locked down than a browser so we have to whitelist displaying `blob:` sources (which is what we use to display response previews).

## Before

<img width="350" alt="Electron-2024-08-01-16-59-59@2x" src="https://github.com/user-attachments/assets/d109294a-2f6c-4d47-b230-5712bf5fd9d6">
<img width="350" alt="Electron-2024-08-01-16-58-39@2x" src="https://github.com/user-attachments/assets/663df731-9872-4ba4-96f9-1521a40c8804">

## After

<img width="350" alt="Electron-2024-08-01-16-55-42@2x" src="https://github.com/user-attachments/assets/5402c41b-8263-45bb-a83a-1a2ca3d6fea1">
<img width="350" alt="Electron-2024-08-01-16-55-22@2x" src="https://github.com/user-attachments/assets/d13f221e-b638-4d17-afee-50f92b653153">




