### PR TITLE
docs: change example theme config to string and fix some typo.

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -291,6 +291,6 @@ Can be one of: **alternate**, **default**, **moon**, **purple**, **solarized**, 
 
 ```js
 {
-  theme: default
+  theme: 'default'
 }
 ```

--- a/documentation/integrations/nextjs.md
+++ b/documentation/integrations/nextjs.md
@@ -67,7 +67,7 @@ But you can also just use our React integration and add a page route:
 npm add @scalar/api-reference-react
 ```
 
-… and aa a new page route:
+… and add a new page route:
 
 ```js
 import { ApiReferenceReact } from '@scalar/api-reference-react'


### PR DESCRIPTION
This PR changes the example theme configuration to a string and fix some typo.