### PR TITLE
fix(api-client): rebuild address bar history with grid

### DIFF
--- a/.changeset/beige-pumas-heal.md
+++ b/.changeset/beige-pumas-heal.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/themes': patch
+---
+
+fix(api-client): rebuild address bar history with grid

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -32,16 +32,14 @@ function getPrettyResponseUrl(rawUrl: string) {
   return scalarUrlParsed.href
 }
 
-function handleHistoryClick(index: number) {
-  const historicalRequest = activeRequest.value.history[index]
-
+function handleHistoryClick(historicalRequest: any) {
   // see if we need to update the topnav
   // todo potentially search and find a previous open request id of this maybe
   // or we can open it in a draft state if the request is already open :)
   if (activeRequest.value.uid !== historicalRequest.request.requestUid) {
     router.push(`/request/${historicalRequest.request.requestUid}`)
   }
-  requestExampleMutators.set(historicalRequest.request)
+  requestExampleMutators.set({ ...historicalRequest.request })
 }
 </script>
 <template>
@@ -66,26 +64,26 @@ function handleHistoryClick(index: number) {
     <ListboxOptions
       class="bg-b-1 custom-scroll bg-mix-transparent bg-mix-amount-30 max-h-[300px] rounded-b p-[3px] pt-0 backdrop-blur grid grid-cols-[44px,1fr,repeat(3,auto)] items-center">
       <ListboxOption
-        v-for="({ response }, index) in history"
+        v-for="(entry, index) in history"
         :key="index"
         class="contents font-code text-sm *:rounded-none first:*:rounded-l last:*:rounded-r *:h-8 *:hover:bg-b-2 *:flex *:items-center *:cursor-pointer *:px-1.5 text-c-2 font-medium"
         :value="index"
-        @click="handleHistoryClick(index)">
+        @click="handleHistoryClick(entry)">
         <HttpMethod
-          v-if="response.config.method"
+          v-if="entry.response.config.method"
           class="text-[11px]"
-          :method="response.config.method" />
+          :method="entry.response.config.method" />
         <div class="min-w-0">
           <div class="min-w-0 truncate text-c-1">
-            {{ getPrettyResponseUrl(response.config.url) }}
+            {{ getPrettyResponseUrl(entry.response.config.url) }}
           </div>
         </div>
-        <div>{{ formatMs(response.duration) }}</div>
-        <div :class="[getStatusCodeColor(response.status).color]">
-          {{ response.status }}
+        <div>{{ formatMs(entry.response.duration) }}</div>
+        <div :class="[getStatusCodeColor(entry.response.status).color]">
+          {{ entry.response.status }}
         </div>
         <div>
-          {{ httpStatusCodes[response.status]?.name }}
+          {{ httpStatusCodes[entry.response.status]?.name }}
         </div>
       </ListboxOption>
     </ListboxOptions>

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -4,6 +4,7 @@ import { useWorkspace } from '@/store/workspace'
 import { ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/vue'
 import { ScalarIcon } from '@scalar/components'
 import { httpStatusCodes } from '@scalar/oas-utils/helpers'
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 
 import HttpMethod from '../HttpMethod/HttpMethod.vue'
@@ -16,6 +17,8 @@ defineProps<{
 const { activeRequest, requestExampleMutators } = useWorkspace()
 
 const router = useRouter()
+
+const history = computed(() => activeRequest.value.history.slice().reverse())
 
 function getPrettyResponseUrl(rawUrl: string) {
   const url = new URL(rawUrl)
@@ -61,31 +64,28 @@ function handleHistoryClick(index: number) {
     ]">
     <!-- History Item -->
     <ListboxOptions
-      class="bg-b-1 custom-scroll bg-mix-transparent bg-mix-amount-30 max-h-[300px] rounded-b p-[3px] pt-0 backdrop-blur">
+      class="bg-b-1 custom-scroll bg-mix-transparent bg-mix-amount-30 max-h-[300px] rounded-b p-[3px] pt-0 backdrop-blur grid grid-cols-[44px,1fr,repeat(3,auto)] items-center">
       <ListboxOption
-        v-for="({ response }, index) in activeRequest.history"
+        v-for="({ response }, index) in history"
         :key="index"
-        class="ui-active:bg-b-2 text-c-1 ui-active:text-c-1 flex cursor-pointer flex-row gap-2.5 rounded py-1.5 pr-3"
+        class="contents font-code text-sm *:rounded-none first:*:rounded-l last:*:rounded-r *:h-8 *:hover:bg-b-2 *:flex *:items-center *:cursor-pointer *:px-1.5 text-c-2 font-medium"
         :value="index"
         @click="handleHistoryClick(index)">
-        <div class="font-code flex flex-1 gap-1.5 text-sm font-medium">
-          <HttpMethod
-            v-if="response.config.method"
-            class="text-[11px] min-w-[44px]"
-            :method="response.config.method" />
-          <span class="text-c-2 gap-0">
+        <HttpMethod
+          v-if="response.config.method"
+          class="text-[11px]"
+          :method="response.config.method" />
+        <div class="min-w-0">
+          <div class="min-w-0 truncate text-c-1">
             {{ getPrettyResponseUrl(response.config.url) }}
-          </span>
+          </div>
         </div>
-        <div
-          class="font-code text-c-3 flex flex-row items-center gap-1.5 text-sm font-medium">
-          <span>{{ formatMs(response.duration) }}</span>
-          <span :class="[getStatusCodeColor(response.status).color]">
-            {{ response.status }}
-          </span>
-          <span>
-            {{ httpStatusCodes[response.status]?.name }}
-          </span>
+        <div>{{ formatMs(response.duration) }}</div>
+        <div :class="[getStatusCodeColor(response.status).color]">
+          {{ response.status }}
+        </div>
+        <div>
+          {{ httpStatusCodes[response.status]?.name }}
         </div>
       </ListboxOption>
     </ListboxOptions>

--- a/packages/themes/src/tailwind.ts
+++ b/packages/themes/src/tailwind.ts
@@ -50,6 +50,7 @@ export default {
     },
     colors: {
       current: 'currentColor',
+      inherit: 'inherit',
       // Backdrop Colors
       b: {
         1: 'var(--scalar-background-1)',


### PR DESCRIPTION
Fixes some of the layout issues with the address bar history and reverses the order so the most recent entry is at the top. 

There seems to be another bug where clicking a history item doesn't always mutate the address bar properly and that's still outstanding.

## Before

<img width="1538" alt="Google Chrome-2024-08-01-21-31-37@2x" src="https://github.com/user-attachments/assets/03135dc5-07b2-400d-b417-d643c514f112">

## After

<img width="1538" alt="Google Chrome-2024-08-01-21-30-40@2x" src="https://github.com/user-attachments/assets/e1eae6e1-8383-4ebf-b41a-2c41bd1ef580">
