### PR TITLE
feat(api-client-app): don’t use the proxy, intercept requests instead

### DIFF
--- a/.changeset/twenty-jobs-cough.md
+++ b/.changeset/twenty-jobs-cough.md
@@ -1,0 +1,6 @@
+---
+'scalar-api-client': patch
+'@scalar/api-client': patch
+---
+
+feat: intercept requests to avoid CORS issues

--- a/packages/api-client-app/src/main/index.ts
+++ b/packages/api-client-app/src/main/index.ts
@@ -74,24 +74,16 @@ function createWindow(): void {
 
   mainWindow.webContents.session.webRequest.onHeadersReceived(
     (details, callback) => {
-      const { responseHeaders, url } = details
+      const { responseHeaders } = details
 
       // If headers have already been modified, skip
       if (!responseHeaders?.[MODIFIED_HEADERS_KEY]) {
-        if (url.endsWith('openapi.yaml')) {
-          console.log('originalResponseHeaders', responseHeaders)
-        }
-
         upsertKeyValue(responseHeaders, 'Access-Control-Allow-Origin', ['*'])
         upsertKeyValue(responseHeaders, 'Access-Control-Allow-Methods', [
           'POST, GET, OPTIONS, PUT, DELETE, PATCH',
         ])
         upsertKeyValue(responseHeaders, 'Access-Control-Allow-Headers', ['*'])
         upsertKeyValue(responseHeaders, 'Access-Control-Expose-Headers', ['*'])
-
-        if (url.endsWith('openapi.yaml')) {
-          console.log('modifiedResponseHeaders', responseHeaders)
-        }
       }
 
       callback({

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -5,9 +5,7 @@ import '@scalar/api-client/style.css'
 // Initialize
 createApiClientApp(
   document.getElementById('scalar-client'),
-  {
-    proxyUrl: 'https://proxy.scalar.com',
-  },
+  {},
   true,
   webHashRouter,
 )

--- a/packages/api-client/src/libs/normalizeHeaders.test.ts
+++ b/packages/api-client/src/libs/normalizeHeaders.test.ts
@@ -1,0 +1,63 @@
+import { normalizeHeaders } from '@/libs/normalizeHeaders'
+import type { AxiosResponseHeaders } from 'axios'
+import { describe, expect, it } from 'vitest'
+
+describe('normalizeHeaders', () => {
+  it('removes headers listed in `X-Scalar-Modified-Headers`', () => {
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Scalar-Modified-Headers': 'Content-Type',
+    }
+
+    const normalizedHeaders = normalizeHeaders(
+      headers as unknown as AxiosResponseHeaders,
+    )
+
+    expect(normalizedHeaders).toStrictEqual({})
+  })
+
+  it('sorts headers alphabetically', () => {
+    const headers = {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+    }
+
+    const normalizedHeaders = normalizeHeaders(
+      headers as unknown as AxiosResponseHeaders,
+    )
+
+    expect(Object.keys(normalizedHeaders)).toStrictEqual([
+      'Access-Control-Allow-Origin',
+      'Content-Type',
+    ])
+  })
+
+  it('restores original headers', () => {
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Scalar-Original-Content-Type': 'text/html',
+    }
+
+    const normalizedHeaders = normalizeHeaders(
+      headers as unknown as AxiosResponseHeaders,
+    )
+
+    expect(normalizedHeaders).toStrictEqual({
+      'Content-Type': 'text/html',
+    })
+  })
+
+  it('normalizes the header keys', () => {
+    const headers = {
+      'cOntent-tyPe': 'application/json',
+    }
+
+    const normalizedHeaders = normalizeHeaders(
+      headers as unknown as AxiosResponseHeaders,
+    )
+
+    expect(normalizedHeaders).toStrictEqual({
+      'Content-Type': 'application/json',
+    })
+  })
+})

--- a/packages/api-client/src/libs/normalizeHeaders.ts
+++ b/packages/api-client/src/libs/normalizeHeaders.ts
@@ -1,0 +1,72 @@
+import type { RawAxiosResponseHeaders } from 'axios'
+
+/**
+ * Normalize headers:
+ *
+ * - Electron modifies the headers to allow CORS, this function hides the modifications
+ * - Restores original headers
+ * - Normalizes the header keys
+ * - Sorts headers alphabetically
+ *
+ */
+export function normalizeHeaders(
+  headers: Partial<RawAxiosResponseHeaders>,
+): Partial<RawAxiosResponseHeaders> {
+  /** Exact key of the modified headers header */
+  const modifiedHeaderKey = Object.keys(headers).find(
+    (key) => key.toLowerCase() === 'x-scalar-modified-headers',
+  )
+
+  /** List of modified headers */
+  const modifiedHeaders = modifiedHeaderKey
+    ? headers[modifiedHeaderKey]
+        ?.toString()
+        .split(', ')
+        ?.map((value: string) => value.toLowerCase()) ?? []
+    : []
+
+  // Remove headers listed in `X-Scalar-Modified-Headers`
+  Object.keys(headers).forEach((key) => {
+    if (modifiedHeaders.includes(key.toLowerCase())) {
+      delete headers[key]
+    }
+  })
+
+  // Remove `X-Scalar-Modified-Headers` header
+  if (modifiedHeaderKey) {
+    delete headers[modifiedHeaderKey]
+  }
+
+  // Restore original headers (remove the `X-Scalar-Original-` prefix)
+  Object.keys(headers).forEach((key) => {
+    if (key.toLowerCase().startsWith('x-scalar-original-')) {
+      const originalKey = key.replace('X-Scalar-Original-', '')
+      headers[originalKey] = headers[key]
+      delete headers[key]
+    }
+  })
+
+  // Normalizes the header keys
+  Object.keys(headers).forEach((key) => {
+    const formattedKey = formatHeaderKey(key)
+    if (key !== formattedKey) {
+      headers[formattedKey] = headers[key]
+      delete headers[key]
+    }
+  })
+
+  // Sort headers alphebetically by key
+  return Object.fromEntries(
+    Object.entries(headers).sort(([a], [b]) => a.localeCompare(b)),
+  )
+}
+
+/** Make the first letter and all letters after a dash uppercase */
+function formatHeaderKey(key: string) {
+  return key
+    .split('-')
+    .map((word) => {
+      return word.charAt(0).toUpperCase() + word.toLowerCase().slice(1)
+    })
+    .join('-')
+}

--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -1,3 +1,4 @@
+import { normalizeHeaders } from '@/libs/normalizeHeaders'
 import { textMediaTypes } from '@/views/Request/consts'
 import type { Cookie } from '@scalar/oas-utils/entities/workspace/cookie'
 import type { SecurityScheme } from '@scalar/oas-utils/entities/workspace/security'
@@ -12,7 +13,11 @@ import {
   redirectToProxy,
   shouldUseProxy,
 } from '@scalar/oas-utils/helpers'
-import axios, { type AxiosError, type AxiosRequestConfig } from 'axios'
+import axios, {
+  type AxiosError,
+  type AxiosHeaders,
+  type AxiosRequestConfig,
+} from 'axios'
 import Cookies from 'js-cookie'
 import MIMEType from 'whatwg-mimetype'
 
@@ -239,11 +244,14 @@ export const sendRequest = async (
 
     const responseData = decodeBuffer(buffer, `${contentType}`)
 
+    const responseHeaders = normalizeHeaders(response.headers)
+
     return {
       sentTime: Date.now(),
       request: example,
       response: {
         ...response,
+        headers: responseHeaders,
         data: responseData,
         duration: Date.now() - startTime,
       },

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -4,9 +4,61 @@ import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import DataTableText from '@/components/DataTable/DataTableText.vue'
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 
-defineProps<{
-  headers: { name: string; value: string; required: boolean }[]
+type Header = { name: string; value: string; required: boolean }
+
+const props = defineProps<{
+  headers: Header[]
 }>()
+
+// TODO: This should probably in the sendRequest method
+// TODO: Add tests for this
+// TODO: Should we add the same logic to the proxy?
+/** List of modified headers */
+const modifiedHeaders =
+  props.headers
+    .find((h) => {
+      return h.name.toLowerCase() === 'x-scalar-modified-headers'
+    })
+    ?.value?.split(', ')
+    ?.map((value) => value.toLowerCase()) ?? []
+
+/** Headers, but without the modifications from the Electron app */
+const normalizedHeaders = props.headers
+  // Remove headers listed in `X-Scalar-Modified-Headers`
+  .filter((header) => {
+    return !modifiedHeaders.includes(header.name.toLowerCase())
+  })
+  // Remove list of modified headers
+  .filter((header) => {
+    return header.name.toLowerCase() !== 'x-scalar-modified-headers'
+  })
+  // Restore original headers (prefixed with `X-Scalar-Original-`)
+  .map((header) => {
+    const originalHeaderName = header.name
+      .toLowerCase()
+      .replace('x-scalar-original-', '')
+
+    const originalHeader = props.headers.find((h) => {
+      return h.name === originalHeaderName
+    })
+
+    if (originalHeader) {
+      return {
+        name: originalHeader.name,
+        value: originalHeader.value,
+      }
+    }
+
+    return header
+  })
+  // Remove headers that are prefixed with `X-Scalar-Original-`
+  .filter((header) => {
+    return !header.name.toLowerCase().startsWith('x-scalar-original-')
+  })
+  // Sort headers alphebetically by `name`
+  .sort((a, b) => {
+    return a.name.localeCompare(b.name)
+  })
 
 // Make the first letter and all letters after a - uppercase
 const formatHeaderName = (headerName: string) => {
@@ -21,14 +73,14 @@ const formatHeaderName = (headerName: string) => {
 <template>
   <ViewLayoutCollapse
     :defaultOpen="false"
-    :itemCount="headers.length">
+    :itemCount="normalizedHeaders.length">
     <template #title>Headers</template>
     <DataTable
-      v-if="headers.length"
+      v-if="normalizedHeaders.length"
       :columns="['minmax(auto, min-content)', 'minmax(50%, 1fr)']"
       scroll>
       <DataTableRow
-        v-for="(item, idx) in headers"
+        v-for="(item, idx) in normalizedHeaders"
         :key="idx"
         class="text-c-1">
         <DataTableText

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -6,86 +6,26 @@ import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 
 type Header = { name: string; value: string; required: boolean }
 
-const props = defineProps<{
+defineProps<{
   headers: Header[]
 }>()
-
-// TODO: This should probably in the sendRequest method
-// TODO: Add tests for this
-// TODO: Should we add the same logic to the proxy?
-/** List of modified headers */
-const modifiedHeaders =
-  props.headers
-    .find((h) => {
-      return h.name.toLowerCase() === 'x-scalar-modified-headers'
-    })
-    ?.value?.split(', ')
-    ?.map((value) => value.toLowerCase()) ?? []
-
-/** Headers, but without the modifications from the Electron app */
-const normalizedHeaders = props.headers
-  // Remove headers listed in `X-Scalar-Modified-Headers`
-  .filter((header) => {
-    return !modifiedHeaders.includes(header.name.toLowerCase())
-  })
-  // Remove list of modified headers
-  .filter((header) => {
-    return header.name.toLowerCase() !== 'x-scalar-modified-headers'
-  })
-  // Restore original headers (prefixed with `X-Scalar-Original-`)
-  .map((header) => {
-    const originalHeaderName = header.name
-      .toLowerCase()
-      .replace('x-scalar-original-', '')
-
-    const originalHeader = props.headers.find((h) => {
-      return h.name === originalHeaderName
-    })
-
-    if (originalHeader) {
-      return {
-        name: originalHeader.name,
-        value: originalHeader.value,
-      }
-    }
-
-    return header
-  })
-  // Remove headers that are prefixed with `X-Scalar-Original-`
-  .filter((header) => {
-    return !header.name.toLowerCase().startsWith('x-scalar-original-')
-  })
-  // Sort headers alphebetically by `name`
-  .sort((a, b) => {
-    return a.name.localeCompare(b.name)
-  })
-
-// Make the first letter and all letters after a - uppercase
-const formatHeaderName = (headerName: string) => {
-  return headerName
-    .split('-')
-    .map((word) => {
-      return word.charAt(0).toUpperCase() + word.slice(1)
-    })
-    .join('-')
-}
 </script>
 <template>
   <ViewLayoutCollapse
     :defaultOpen="false"
-    :itemCount="normalizedHeaders.length">
+    :itemCount="headers.length">
     <template #title>Headers</template>
     <DataTable
-      v-if="normalizedHeaders.length"
+      v-if="headers.length"
       :columns="['minmax(auto, min-content)', 'minmax(50%, 1fr)']"
       scroll>
       <DataTableRow
-        v-for="(item, idx) in normalizedHeaders"
+        v-for="(item, idx) in headers"
         :key="idx"
         class="text-c-1">
         <DataTableText
           class="sticky left-0 z-1 bg-b-1 max-w-48"
-          :text="formatHeaderName(item.name)" />
+          :text="item.name" />
         <DataTableText
           class="z-0"
           :text="item.value" />


### PR DESCRIPTION
Currently, we’re using proxy.scalar.com to avoid CORS issues. This has some caveats:

* Local domains can’t be processed
* The traffic goes through a remote server that users might not want to trust (though it’s open source)
* It’s adds some overhead to the request

There are two obvious solutions to this, that I decided against:

**❌ Bundle our proxy with the Electron app and run it locally**

It could be error prone to compile, bundle and ship an additional executable, that then needs to occupy a port on the user’s machine.

There are a lot of limitations around cookies and other domains, so we’d never really be able to set cookies properly.

**❌ Execute requests in Node**

We could add a way to intercept requests and - instead of executing them in the frontend - execute them in a Node process. That way we wouldn’t face any CORS issues.

I’ve actually build this solution, but we’d need to serialize the response to pass it to the renderer process. But currently, the response has some functions and circular references and can’t easily be serialized.

**❌ Disable all security features**

We could just enable all the security features Chrome comes with. But then all the security features would be disabled. :|

**✅ Intercept requests on the browser level**

This is what the PR does: We’re intercepting the requests through Electron on the browser level and modify the headers to avoid any CORS issues.

There’s just one issue: As a user I’d wonder why the headers are modified. With this PR the modified headers are removed and the original headers are restored after the request was sent.

A bit strange, but I think this is the leanest approach.