### PR TITLE
style(components): icon chevron left

### DIFF
--- a/.changeset/popular-rockets-wonder.md
+++ b/.changeset/popular-rockets-wonder.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+fix: scalar icon chevron left update

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -302,12 +302,13 @@ onBeforeUnmount(() => {
     <!-- Specific command palette -->
     <template v-else>
       <button
-        class="absolute p-1 hover:bg-b-3 rounded text-c-3 active:text-c-1 m-1.5 z-10"
+        class="absolute p-0.75 hover:bg-b-3 rounded text-c-3 active:text-c-1 m-1.5 z-10"
         type="button"
         @click="activeCommand = null">
         <ScalarIcon
           icon="ChevronLeft"
-          size="sm" />
+          size="md"
+          thickness="1.5" />
       </button>
       <component
         :is="PaletteComponents[activeCommand]"

--- a/packages/api-client/src/components/SubpageHeader.vue
+++ b/packages/api-client/src/components/SubpageHeader.vue
@@ -10,12 +10,13 @@ const currentRoute = useRoute()
     <div
       class="lg:min-h-header items-center w-full p-1 t-app__top-container flex items-center">
       <router-link
-        class="text-c-2 text-sm font-medium ml-1 flex items-center p-1.5 hover:bg-b-3 rounded cursor-pointer gap-1 active:text-c-1 no-underline dark:hover:bg-b-2"
+        class="text-c-2 text-sm font-medium ml-1 flex items-center p-1.5 hover:bg-b-3 rounded cursor-pointer gap-0.5 active:text-c-1 no-underline dark:hover:bg-b-2"
         :to="`/workspace/${currentRoute.params.workspace}/request/default`">
         <ScalarIcon
           icon="ChevronLeft"
-          size="sm" />
-        <span>Back To Requests</span>
+          size="md"
+          thickness="1.75" />
+        <span class="leading-none">Back To Requests</span>
       </router-link>
     </div>
     <slot />

--- a/packages/components/src/components/ScalarIcon/icons/ChevronLeft.svg
+++ b/packages/components/src/components/ScalarIcon/icons/ChevronLeft.svg
@@ -1,3 +1,1 @@
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M15.75 19.5L8.25 12L15.75 4.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" />
-</svg>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m14 18-6-6 6-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>


### PR DESCRIPTION
this pr updates the scalar icon chevron left element in order to fix position issue:

**before**
<img width="708" alt="image" src="https://github.com/user-attachments/assets/ec15bcd1-29c0-452e-aa21-625685ac142b">

<img width="708" alt="image" src="https://github.com/user-attachments/assets/2adba76e-f158-4d26-a751-f80b040bd86d">


**after**
<img width="708" alt="image" src="https://github.com/user-attachments/assets/0cf4ab30-3da2-49bb-9164-9cc9fcd9abac">

<img width="708" alt="image" src="https://github.com/user-attachments/assets/bb8cee59-dbd2-47d7-bf54-d05d24393af0">

