### PR TITLE
ci: check whether scalar-api-client has a new version number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,12 +176,17 @@ jobs:
           # Permissions: Read and Write
           # Select packages: @scalar
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - if: steps.changesets.outputs.publishedPackages
-        name: List all published packages
-        run: echo "${{ steps.changesets.outputs.publishedPackages }}"
-      - if: contains(steps.changesets.outputs.publishedPackages, 'scalar-api-client')
+      - if: startsWith(github.event.head_commit.message, 'RELEASING:')
+        name: Check which files were touched
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files_yaml: |
+            api_client_app:
+              - packages/api-client-app/package.json
+      - if: steps.changed-files.outputs.api_client_app_any_changed == 'true'
         name: Check whether scalar-api-client was published
-        run: echo "scalar-api-client was published"
+        run: echo "✅ A new version of scalar-api-client was published."
 
   stackblitz:
     if: github.head_ref == 'changeset-release/main'


### PR DESCRIPTION
This is a new attempt to detect when the app got a new version number, which we could eventually use to automate the release of it.

The old attempt relied on the output of the changeset action, but that was empty. :(

With this PR we’re checking whether the commit message starts with `RELEASING:` (generated by the changeset workflow),  and if the `package.json` of the app was touched.

This should only happen at the same time when the version is increased. :)

