### PR TITLE
fix(api-client): address bar active server

### DIFF
--- a/.changeset/late-dogs-type.md
+++ b/.changeset/late-dogs-type.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: set active server back in active example

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -348,11 +348,17 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
   }
 
   /** Currently active example OR the first one */
-  const activeExample = computed(
-    () =>
+  const activeExample = computed(() => {
+    const example =
       requestExamples[activeRouterParams.value[PathId.Examples]] ??
-      requestExamples[activeRequest.value?.childUids[0] ?? ''],
-  )
+      requestExamples[activeRequest.value?.childUids[0] ?? '']
+
+    if (example && activeServer.value) {
+      example.url = activeServer.value.url + activeRequest.value.path
+    }
+
+    return example
+  })
 
   // ---------------------------------------------------------------------------
   // REQUEST HISTORY


### PR DESCRIPTION
this pr is an attempt to fix #2595 by setting back the active server in the active example method in order to display the selected one in the api client address bar + request.