### PR TITLE
feat(api-client): improve client request loading and feedback

### DIFF
--- a/.changeset/witty-rings-peel.md
+++ b/.changeset/witty-rings-peel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat(api-client): improve client request loading and feedback

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -62,6 +62,13 @@ function stopLoading() {
   isRequesting.value = false
 }
 
+function abortLoading() {
+  clearInterval(interval.value)
+  interval.value = undefined
+  percentage.value = 100
+  isRequesting.value = false
+}
+
 function load() {
   if (isRequesting.value) {
     // Reduce asymptotically up to 85% loaded
@@ -72,15 +79,14 @@ function load() {
   }
   if (percentage.value <= 0) {
     clearInterval(interval.value)
+    interval.value = undefined
     percentage.value = 100
     isRequesting.value = false
   }
 }
 
-const executeRequest = () => {
-  startLoading()
-  executeRequestBus.emit(stopLoading) // Stop loading when a request completes
-}
+const executeRequest = () =>
+  executeRequestBus.emit({ startLoading, stopLoading, abortLoading })
 
 whenever(isMacOS() ? keys.meta_enter : keys.ctrl_enter, executeRequest)
 

--- a/packages/api-client/src/errors.ts
+++ b/packages/api-client/src/errors.ts
@@ -1,0 +1,4 @@
+export const ERRORS = {
+  URL_EMPTY: 'The adress bar seems to be empty. Try adding an URL.',
+  INVALID_URL: 'The URL seems to be invalid. Try adding a valid URL.',
+}

--- a/packages/api-client/src/libs/eventBusses/executeRequestBus.ts
+++ b/packages/api-client/src/libs/eventBusses/executeRequestBus.ts
@@ -1,16 +1,8 @@
 import { type EventBusKey, useEventBus } from '@vueuse/core'
 
-/** A callback for when the request completes */
-type ExecuteRequestCallbacks = {
-  startLoading?: () => void
-  stopLoading?: () => void
-  abortLoading?: () => void
-}
-
 /**
  * Event bus to execute requests, usually triggered by the send button in the address bar
  * OR the keyboard shortcut
  */
 const executeRequestBusKey: EventBusKey<void> = Symbol()
-export const executeRequestBus =
-  useEventBus<ExecuteRequestCallbacks>(executeRequestBusKey)
+export const executeRequestBus = useEventBus(executeRequestBusKey)

--- a/packages/api-client/src/libs/eventBusses/executeRequestBus.ts
+++ b/packages/api-client/src/libs/eventBusses/executeRequestBus.ts
@@ -1,8 +1,12 @@
 import { type EventBusKey, useEventBus } from '@vueuse/core'
 
+/** A callback for when the request completes */
+type ExecuteRequestCallback = () => void
+
 /**
  * Event bus to execute requests, usually triggered by the send button in the address bar
  * OR the keyboard shortcut
  */
 const executeRequestBusKey: EventBusKey<void> = Symbol()
-export const executeRequestBus = useEventBus(executeRequestBusKey)
+export const executeRequestBus =
+  useEventBus<ExecuteRequestCallback>(executeRequestBusKey)

--- a/packages/api-client/src/libs/eventBusses/executeRequestBus.ts
+++ b/packages/api-client/src/libs/eventBusses/executeRequestBus.ts
@@ -1,7 +1,11 @@
 import { type EventBusKey, useEventBus } from '@vueuse/core'
 
 /** A callback for when the request completes */
-type ExecuteRequestCallback = () => void
+type ExecuteRequestCallbacks = {
+  startLoading?: () => void
+  stopLoading?: () => void
+  abortLoading?: () => void
+}
 
 /**
  * Event bus to execute requests, usually triggered by the send button in the address bar
@@ -9,4 +13,4 @@ type ExecuteRequestCallback = () => void
  */
 const executeRequestBusKey: EventBusKey<void> = Symbol()
 export const executeRequestBus =
-  useEventBus<ExecuteRequestCallback>(executeRequestBusKey)
+  useEventBus<ExecuteRequestCallbacks>(executeRequestBusKey)

--- a/packages/api-client/src/libs/eventBusses/index.ts
+++ b/packages/api-client/src/libs/eventBusses/index.ts
@@ -1,1 +1,2 @@
 export { executeRequestBus } from './executeRequestBus'
+export { requestStatusBus } from './requestStatusBus'

--- a/packages/api-client/src/libs/eventBusses/requestStatusBus.ts
+++ b/packages/api-client/src/libs/eventBusses/requestStatusBus.ts
@@ -1,0 +1,11 @@
+import { type EventBusKey, useEventBus } from '@vueuse/core'
+
+/** Possible request statuses */
+type RequestStatus = 'start' | 'stop' | 'abort'
+
+/**
+ * Event bus to execute requests, usually triggered by the send button in the address bar
+ * OR the keyboard shortcut
+ */
+const requestStatusBusKey: EventBusKey<void> = Symbol()
+export const requestStatusBus = useEventBus<RequestStatus>(requestStatusBusKey)

--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -1,3 +1,4 @@
+import { ERRORS } from '@/errors'
 import { normalizeHeaders } from '@/libs/normalizeHeaders'
 import { textMediaTypes } from '@/views/Request/consts'
 import type { Cookie } from '@scalar/oas-utils/entities/workspace/cookie'
@@ -129,6 +130,16 @@ export const sendRequest = async (
   }
 
   if (workspaceCookies) {
+    if (!rawUrl) {
+      throw new Error(ERRORS.URL_EMPTY)
+    }
+
+    try {
+      new URL(rawUrl)
+    } catch (error) {
+      throw new Error(ERRORS.INVALID_URL)
+    }
+
     const origin = new URL(rawUrl).host
     Object.keys(workspaceCookies).forEach((key) => {
       const c = workspaceCookies[key]

--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -13,11 +13,7 @@ import {
   redirectToProxy,
   shouldUseProxy,
 } from '@scalar/oas-utils/helpers'
-import axios, {
-  type AxiosError,
-  type AxiosHeaders,
-  type AxiosRequestConfig,
-} from 'axios'
+import axios, { type AxiosError, type AxiosRequestConfig } from 'axios'
 import Cookies from 'js-cookie'
 import MIMEType from 'whatwg-mimetype'
 
@@ -62,6 +58,7 @@ export const sendRequest = async (
   sentTime?: number
   request?: RequestExample
   response?: ResponseInstance
+  error?: AxiosError
 }> => {
   let url = rawUrl
 
@@ -275,6 +272,7 @@ export const sendRequest = async (
             duration: Date.now() - startTime,
           }
         : undefined,
+      error: axiosError,
     }
   }
 }

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -66,7 +66,7 @@ watch(
  * Execute the request
  * called from the send button as well as keyboard shortcuts
  */
-const executeRequest = async () => {
+const executeRequest = async (done: () => void) => {
   if (!activeRequest.value || !activeExample.value) {
     console.warn(
       'There is no request active at the moment. Please select one then try again.',
@@ -125,6 +125,8 @@ const executeRequest = async () => {
   } catch (error) {
     toast(`${error}`, 'error')
   }
+
+  done()
 }
 onMounted(() => executeRequestBus.on(executeRequest))
 

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -126,7 +126,8 @@ const executeRequest = async () => {
       requestStatusBus.emit('abort')
     }
   } catch (error) {
-    toast(`${error}`, 'error')
+    console.error(error)
+    toast(`Oops! \n${error}`, 'error')
     requestStatusBus.emit('abort')
   }
 }

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -66,7 +66,15 @@ watch(
  * Execute the request
  * called from the send button as well as keyboard shortcuts
  */
-const executeRequest = async (done: () => void) => {
+const executeRequest = async ({
+  startLoading,
+  stopLoading,
+  abortLoading,
+}: {
+  startLoading: () => void
+  stopLoading: () => void
+  abortLoading: () => void
+}) => {
   if (!activeRequest.value || !activeExample.value) {
     console.warn(
       'There is no request active at the moment. Please select one then try again.',
@@ -100,6 +108,7 @@ const executeRequest = async (done: () => void) => {
     return variables[key] || key
   })
 
+  startLoading()
   try {
     const { request, response, error } = await sendRequest(
       activeRequest.value,
@@ -119,14 +128,15 @@ const executeRequest = async (done: () => void) => {
           timestamp: Date.now(),
         },
       ])
-    } else if (error) {
-      toast(error.message, 'error')
-    } else toast('Send Request Failed', 'error')
+      stopLoading()
+    } else {
+      toast(error?.message ?? 'Send Request Failed', 'error')
+      abortLoading()
+    }
   } catch (error) {
     toast(`${error}`, 'error')
+    abortLoading()
   }
-
-  done()
 }
 onMounted(() => executeRequestBus.on(executeRequest))
 


### PR DESCRIPTION
Redid the address bar loading logic so it actually reflects whether or not the request has loaded yet, the logic itself is a little complicated but I think it makes for a nice UX.

Basically while we're waiting on a request the loading bar progresses asymptotically towards 85% (i.e. it will never actually get to 85%). Then when the request gets back we fill the rest of the bar linearly in 400ms which is the timing we were using before to fill the entire bar. 400ms feels about long enough that you can tell whats happening while still feeling snappy.

The tl;dr; is fast requests feel the same as they did before but with slow requests you can actually tell that the request hasn't loaded yet.

Other changes:
- Made the loading bar a little bit darker
- Added toasts for all Axios errors (some of the error messages suck but better than silently failing in my opinion, we can make the error handling better in the future).


https://github.com/user-attachments/assets/8183cbe5-2481-44e5-bb4f-cbac0e50abbd

