### PR TITLE
fix: add overload to servers as prop for create client app

### DIFF
--- a/.changeset/tender-gorillas-sparkle.md
+++ b/.changeset/tender-gorillas-sparkle.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+fix: add overload to servers as prop for create client app

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
@@ -33,9 +33,17 @@ export const createApiClientModal = async (
 
   // Import the spec if needed
   if (configuration.spec?.url) {
-    await importSpecFromUrl(configuration.spec.url, configuration.proxyUrl)
+    await importSpecFromUrl(
+      configuration.spec.url,
+      configuration.proxyUrl,
+      configuration?.servers,
+    )
   } else if (configuration.spec?.content) {
-    await importSpecFile(configuration.spec?.content)
+    await importSpecFile(
+      configuration.spec?.content,
+      undefined,
+      configuration?.servers,
+    )
   }
   // Or add default workspace
   else {

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -1,5 +1,9 @@
 import { createWorkspaceStore } from '@/store/workspace'
-import type { AuthenticationState, SpecConfiguration } from '@scalar/oas-utils'
+import type {
+  AuthenticationState,
+  Spec,
+  SpecConfiguration,
+} from '@scalar/oas-utils'
 import { createWorkspace } from '@scalar/oas-utils/entities/workspace'
 import type { Collection } from '@scalar/oas-utils/entities/workspace/collection'
 import type { SecurityScheme } from '@scalar/oas-utils/entities/workspace/security'
@@ -21,6 +25,8 @@ export type ClientConfiguration = {
   themeId?: ThemeId
   /** Whether to show the sidebar */
   showSidebar?: boolean
+  /** override the initial servers */
+  servers?: Spec['servers']
   /** Whether dark mode is on or off initially (light mode) */
   // darkMode?: boolean
   /** Key used with CTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k) */

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -1,5 +1,6 @@
 import { PathId, fallbackMissingParams } from '@/router'
 import { useModal } from '@scalar/components'
+import type { Spec } from '@scalar/oas-utils'
 import {
   type Workspace,
   type WorkspacePayload,
@@ -824,9 +825,11 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
   const importSpecFile = async (
     _spec: string | AnyObject,
     workspaceUid = 'default',
+    overloadServers?: Spec['servers'],
   ) => {
     const spec = toRaw(_spec)
-    const workspaceEntities = await importSpecToWorkspace(spec)
+    console.log('overloadServers', overloadServers)
+    const workspaceEntities = await importSpecToWorkspace(spec, overloadServers)
 
     // Add all the new requests into the request collection, the already have parent folders
     workspaceEntities.requests.forEach((request) =>
@@ -943,10 +946,14 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
   }
 
   // Function to fetch and import a spec from a URL
-  async function importSpecFromUrl(url: string, proxy?: string) {
+  async function importSpecFromUrl(
+    url: string,
+    proxy?: string,
+    overloadServers?: Spec['servers'],
+  ) {
     try {
       const spec = await fetchSpecFromUrl(url, proxy)
-      await importSpecFile(spec, undefined)
+      await importSpecFile(spec, undefined, overloadServers)
     } catch (error) {
       console.error('Failed to fetch spec from URL:', error)
     }

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -828,7 +828,6 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
     overloadServers?: Spec['servers'],
   ) => {
     const spec = toRaw(_spec)
-    console.log('overloadServers', overloadServers)
     const workspaceEntities = await importSpecToWorkspace(spec, overloadServers)
 
     // Add all the new requests into the request collection, the already have parent folders

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -23,6 +23,12 @@
         //   targetKey: 'node',
         //   clientKey: 'undici',
         // },
+        servers: [
+          {
+            url: 'https://api.scalar.com',
+            description: 'Scalar API',
+          },
+        ],
       }
 
       document.getElementById('api-reference').dataset.configuration =

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -23,12 +23,6 @@
         //   targetKey: 'node',
         //   clientKey: 'undici',
         // },
-        servers: [
-          {
-            url: 'https://api.scalar.com',
-            description: 'Scalar API',
-          },
-        ],
       }
 
       document.getElementById('api-reference').dataset.configuration =

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -46,8 +46,6 @@ onMounted(async () => {
       const serverUrl = getUrlFromServerState(server)
       if (serverUrl) updateServerUrl(serverUrl)
 
-      console.log(props.servers, 'marc', serverUrl, server)
-
       open(event.open)
     }
 

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -4,7 +4,7 @@ import {
   useAuthenticationStore,
   useServerStore,
 } from '#legacy'
-import type { SpecConfiguration } from '@scalar/oas-utils'
+import type { Spec, SpecConfiguration } from '@scalar/oas-utils'
 import { type App, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import { apiClientBus, modalStateBus } from './api-client-bus'
@@ -12,6 +12,7 @@ import { apiClientBus, modalStateBus } from './api-client-bus'
 const props = defineProps<{
   proxyUrl?: string
   spec?: SpecConfiguration
+  servers?: Spec['servers']
 }>()
 
 const el = ref<HTMLDivElement | null>(null)
@@ -29,6 +30,7 @@ onMounted(async () => {
     await createApiClientModal(el.value, {
       spec: props.spec ?? {},
       proxyUrl: props.proxyUrl,
+      servers: props.servers,
     })
 
   modalStateBus.emit(modalState)
@@ -43,6 +45,8 @@ onMounted(async () => {
       // Just replace the current server with this string
       const serverUrl = getUrlFromServerState(server)
       if (serverUrl) updateServerUrl(serverUrl)
+
+      console.log(props.servers, 'marc', serverUrl, server)
 
       open(event.open)
     }

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -344,6 +344,7 @@ const fontsStyleTag = computed(
     <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withDefaultFonts: false` -->
     <ApiClientModal
       :proxyUrl="configuration.proxy"
+      :servers="configuration.servers"
       :spec="configuration.spec" />
   </div>
   <ScalarToasts />

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -5,7 +5,7 @@ import { type Request, createRequest } from '@/entities/workspace/spec'
 import { tagObjectSchema } from '@/entities/workspace/spec/spec'
 import type { RequestMethod } from '@/helpers'
 import { schemaModel } from '@/helpers/schema-model'
-import type { AnyObject } from '@/types'
+import type { AnyObject, Spec } from '@/types'
 import { dereference, load } from '@scalar/openapi-parser'
 import type { OpenAPIV3_1 } from 'openapi-types'
 
@@ -17,7 +17,10 @@ const PARAM_DICTIONARY = {
 } as const
 
 /** Import an OpenAPI spec file and convert it to workspace entities */
-export const importSpecToWorkspace = async (spec: string | AnyObject) => {
+export const importSpecToWorkspace = async (
+  spec: string | AnyObject,
+  overloadServers?: Spec['servers'],
+) => {
   const importWarnings: string[] = []
   const requests: Request[] = []
 
@@ -139,18 +142,21 @@ export const importSpecToWorkspace = async (spec: string | AnyObject) => {
     folders.push(folder)
   })
 
+  console.log('overloadServers', overloadServers)
   // Toss in a default server if there aren't any
-  const unparsedServers: OpenAPIV3_1.ServerObject[] = schema?.servers?.length
-    ? schema.servers!
-    : [
-        {
-          url:
-            typeof window !== 'undefined'
-              ? window.location.origin
-              : 'http://localhost',
-          description: 'Replace with your API server',
-        },
-      ]
+  const unparsedServers: OpenAPIV3_1.ServerObject[] =
+    overloadServers ??
+    (schema?.servers?.length
+      ? schema.servers!
+      : [
+          {
+            url:
+              typeof window !== 'undefined'
+                ? window.location.origin
+                : 'http://localhost',
+            description: 'Replace with your API server',
+          },
+        ])
 
   const servers = unparsedServers.map((server) => createServer(server))
 

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -142,7 +142,6 @@ export const importSpecToWorkspace = async (
     folders.push(folder)
   })
 
-  console.log('overloadServers', overloadServers)
   // Toss in a default server if there aren't any
   const unparsedServers: OpenAPIV3_1.ServerObject[] =
     overloadServers ??


### PR DESCRIPTION
we allow for overrides of the servers in the references but we need to initialize the api client as well : )

this fixes https://github.com/scalar/scalar/issues/2761

```
        servers: [
          {
            url: 'https://api.scalar.com',
            description: 'Scalar API',
          },
        ],
```

this now works

<img width="1456" alt="image" src="https://github.com/user-attachments/assets/49d17504-7bc7-41a6-baba-d1e06fe3dd5d">
