### PR TITLE
fix(api-reference): webhooks section anchor, fix #2774

### DIFF
--- a/.changeset/twenty-candles-jump.md
+++ b/.changeset/twenty-candles-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: webhooks anchor

--- a/packages/api-reference/src/components/Content/Webhooks/Webhooks.vue
+++ b/packages/api-reference/src/components/Content/Webhooks/Webhooks.vue
@@ -26,6 +26,7 @@ const { getWebhookId } = useNavState()
 </script>
 <template>
   <SectionContainer v-if="webhookKeys.length">
+    <div id="webhooks" />
     <template
       v-for="name in webhookKeys"
       :key="name">


### PR DESCRIPTION
this pr fixes #2774 by adding anchor id reference in the section container.