### PR TITLE
fix(api-client): sidenav ui

### DIFF
--- a/.changeset/serious-paws-doubt.md
+++ b/.changeset/serious-paws-doubt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sidenav endpoint ui

--- a/packages/api-client/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/api-client/src/components/HttpMethod/HttpMethod.vue
@@ -75,7 +75,7 @@ const httpLabel = computed(() => method.value.short)
   <!-- Display only -->
   <div
     v-else
-    class="relative gap-1"
+    class="relative gap-1 whitespace-nowrap"
     :class="cx(variants({ isSquare, isEditable }), method.color)"
     type="button">
     {{ method.short }}

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -213,7 +213,7 @@ const _isDroppable = (draggingItem: DraggingItem, hoveredItem: HoveredItem) => {
                 :item="item"
                 :parentUids="parentUids" />
             </div>
-            <span class="flex">
+            <span class="flex items-start">
               &hairsp;
               <HttpMethod
                 class="font-bold"
@@ -230,7 +230,7 @@ const _isDroppable = (draggingItem: DraggingItem, hoveredItem: HoveredItem) => {
         :class="highlightClasses"
         type="button"
         @click="toggleSidebarFolder(item.uid)">
-        <span class="z-10 flex h-fit items-center justify-center max-w-[14px]">
+        <span class="z-10 flex h-5 items-center justify-center max-w-[14px]">
           <slot name="leftIcon">
             <div
               :class="{


### PR DESCRIPTION
this pr aims to fix few glitches on api client sidenav ui within gitbook as seen below:

**before**
<img width="827" alt="image" src="https://github.com/user-attachments/assets/ef672558-5047-4c3c-b9c0-f2af86852daf">

**after**
<img width="827" alt="image" src="https://github.com/user-attachments/assets/63f7e73b-f99f-46f1-a9bb-d368f2417620">
