### PR TITLE
fix(api-client): authentication select

### DIFF
--- a/.changeset/sweet-clocks-speak.md
+++ b/.changeset/sweet-clocks-speak.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: authentication select

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth.vue
@@ -107,8 +107,14 @@ const schemeOptions = computed<SecuritySchemeOption[] | SecuritySchemeGroup[]>(
         }
       })
 
+      /** Filter out when an auth option get unchecked */
+      const selectedUids = activeRequest.value.selectedSecuritySchemeUids
+      const filteredOptions = options.filter((option) =>
+        selectedUids.includes(option.id),
+      )
+
       return [
-        { label: 'Select auth', options: [...specOptions, ...options] },
+        { label: 'Select auth', options: [...specOptions, ...filteredOptions] },
         {
           label: 'Add new auth',
           options: ADD_AUTH_OPTIONS,
@@ -276,7 +282,7 @@ const unselectAuth = (id: string) => {
               <RequestAuthDataTableInput
                 :id="`http-bearer-token-${scheme.uid}`"
                 :modelValue="scheme.value"
-                placeholder="QUxMIFlPVVIgQkFTRSBBUkUgQkVMT05HIFRPIFVT"
+                placeholder="Token"
                 type="password"
                 @update:modelValue="(v) => updateScheme(scheme, 'value', v)">
                 Bearer Token


### PR DESCRIPTION
this pr updates the api client authentication combobox in order to only display select auth and filter out unselected ones, to avoid infinite list:

<img width="827" alt="image" src="https://github.com/user-attachments/assets/7a2cbf1f-33e9-4df1-9fea-c533740380f1">
