### PR TITLE
ci: split ci and release workflow (again)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Trigger Release workflow
-        run: gh workflow run release.yml -f message="${{ github.event.head_commit.message }}"
+        run: gh workflow run release.yml
+          --ref ${{ github.ref }}
+          --raw-field message="${{ github.event.head_commit.message }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Trigger Release workflow
         run: gh workflow run release.yml -f message="${{ github.event.head_commit.message }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,62 +132,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           webpackStatsFile: ./packages/api-reference/dist/browser/webpack-stats.json
 
-  release:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: write
-      id-token: write
-    needs: [build, test]
-    strategy:
-      matrix:
-        node-version: [20]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Build
-        uses: ./.github/actions/build
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Git Status
-        run: git status
-      - name: Stash changes
-        run: git stash
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          # The pull request title.
-          title: 'chore: release'
-          # The command to update version, edit CHANGELOG, read and delete changesets.
-          version: 'pnpm changeset version'
-          # The commit message to use.
-          commit: 'chore: version packages'
-          # The command to use to build and publish packages
-          publish: 'pnpm -r publish --access public'
-        env:
-          # https://github.com/settings/tokens/new
-          # Expiration: No expiration
-          # Select: repo.*
-          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          # https://www.npmjs.com/settings/YOUR_ACCOUNT_HANDLE/tokens/granular-access-tokens/new
-          # Custom Expiration: 01-01-2100
-          # Permissions: Read and Write
-          # Select packages: @scalar
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - if: startsWith(github.event.head_commit.message, 'RELEASING:')
-        name: Check which files were touched
-        id: changed-files
-        uses: tj-actions/changed-files@v44
-        with:
-          files_yaml: |
-            api_client_app:
-              - packages/api-client-app/package.json
-      - if: steps.changed-files.outputs.api_client_app_any_changed == 'true'
-        name: Check whether scalar-api-client was published
-        run: echo "✅ A new version of scalar-api-client was published."
-
   stackblitz:
     if: github.head_ref == 'changeset-release/main'
     runs-on: ubuntu-20.04
@@ -234,6 +178,18 @@ jobs:
           ./packages/use-toasts
           ./packages/use-tooltip
           ./packages/void-server
+
+  # Only in main branch, run GitHub CLI to trigger release.yml workflow
+  trigger-release:
+    # TODO: Eventually, this is only going to run on the main branch.
+    # if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-20.04
+    needs: [build, format, types, test]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Trigger Release workflow
+        run: gh workflow run release.yml
 
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Trigger Release workflow
-        run: gh workflow run release.yml
+        run: gh workflow run release.yml -f message="${{ github.event.head_commit.message }}"
 
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Trigger Release workflow
         run: gh workflow run release.yml
-          --ref ${{ github.ref }}
+          --ref ${{ github.ref.branch }}
           --raw-field message="${{ github.event.head_commit.message }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+# Triggered through GitHub CLI
+on:
+  workflow_dispatch:
+
+jobs:
+  npm:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+      id-token: write
+    strategy:
+      matrix:
+        node-version: [20]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Git Status
+        run: git status
+      - name: Stash changes
+        run: git stash
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # The pull request title.
+          title: 'chore: release'
+          # The command to update version, edit CHANGELOG, read and delete changesets.
+          version: 'pnpm changeset version'
+          # The commit message to use.
+          commit: 'chore: version packages'
+          # The command to use to build and publish packages
+          publish: 'pnpm -r publish --access public'
+        env:
+          # https://github.com/settings/tokens/new
+          # Expiration: No expiration
+          # Select: repo.*
+          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          # https://www.npmjs.com/settings/YOUR_ACCOUNT_HANDLE/tokens/granular-access-tokens/new
+          # Custom Expiration: 01-01-2100
+          # Permissions: Read and Write
+          # Select packages: @scalar
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  todesktop:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [20]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Git Status
+        run: git status
+      - name: Stash changes
+        run: git stash
+        # TODO: Doesn’t work with manual trigger?
+      - if: startsWith(github.event.head_commit.message, 'RELEASING:')
+        name: Check which files were touched
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files_yaml: |
+            api_client_app:
+              - packages/api-client-app/package.json
+      - if: steps.changed-files.outputs.api_client_app_any_changed == 'true'
+        name: Check whether scalar-api-client was published
+        run: echo "✅ A new version of scalar-api-client was published."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,28 +34,28 @@ jobs:
         run: git status
       - name: Stash changes
         run: git stash
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          # The pull request title.
-          title: 'chore: release'
-          # The command to update version, edit CHANGELOG, read and delete changesets.
-          version: 'pnpm changeset version'
-          # The commit message to use.
-          commit: 'chore: version packages'
-          # The command to use to build and publish packages
-          publish: 'pnpm -r publish --access public'
-        env:
-          # https://github.com/settings/tokens/new
-          # Expiration: No expiration
-          # Select: repo.*
-          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          # https://www.npmjs.com/settings/YOUR_ACCOUNT_HANDLE/tokens/granular-access-tokens/new
-          # Custom Expiration: 01-01-2100
-          # Permissions: Read and Write
-          # Select packages: @scalar
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # - name: Create Release Pull Request or Publish to npm
+      #   id: changesets
+      #   uses: changesets/action@v1
+      #   with:
+      #     # The pull request title.
+      #     title: 'chore: release'
+      #     # The command to update version, edit CHANGELOG, read and delete changesets.
+      #     version: 'pnpm changeset version'
+      #     # The commit message to use.
+      #     commit: 'chore: version packages'
+      #     # The command to use to build and publish packages
+      #     publish: 'pnpm -r publish --access public'
+      #   env:
+      #     # https://github.com/settings/tokens/new
+      #     # Expiration: No expiration
+      #     # Select: repo.*
+      #     GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      #     # https://www.npmjs.com/settings/YOUR_ACCOUNT_HANDLE/tokens/granular-access-tokens/new
+      #     # Custom Expiration: 01-01-2100
+      #     # Permissions: Read and Write
+      #     # Select packages: @scalar
+      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   todesktop:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 # Triggered through GitHub CLI
 on:
   workflow_dispatch:
+    inputs:
+      message:
+        description: 'Commit Message'
+        required: true
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   npm:
@@ -17,6 +23,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Get current branch
+        id: branch
+        run: echo "Current branch is ${{ github.ref }}"
       - name: Build
         uses: ./.github/actions/build
         with:
@@ -65,8 +74,7 @@ jobs:
         run: git status
       - name: Stash changes
         run: git stash
-        # TODO: Doesn’t work with manual trigger?
-      - if: startsWith(github.event.head_commit.message, 'RELEASING:')
+      - if: startsWith('${{ github.event.inputs.message }}', 'RELEASING:')
         name: Check which files were touched
         id: changed-files
         uses: tj-actions/changed-files@v44


### PR DESCRIPTION
WIP

Sorry for all the back and forth, but I think it’s better to to do small changes on a regular basis then doing everything at once, and testing CI changes isn’t straight forward. Anyway:

Sometimes the CI workflow isn’t executed in the release PR. This seems to happen when the PR is rebased (by GitHub Actions).

This PR tries to fix this.