### PR TITLE
feat(api-client): set path variables from url

### DIFF
--- a/.changeset/weak-laws-yawn.md
+++ b/.changeset/weak-laws-yawn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: set path variables from url


### PR DESCRIPTION
this pr is a proposal to set path variables according to url updates, adding a `{value}` will populate the path variables table, and removing it from the url will remove it from the table, unless is has a value or is required.

https://github.com/user-attachments/assets/986f3a2d-6f16-41a9-aba2-75728c58781f