### PR TITLE
fix(api-client): delete sidebar list element

### DIFF
--- a/.changeset/perfect-panthers-look.md
+++ b/.changeset/perfect-panthers-look.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: adds delete sidebar list element close event

--- a/packages/api-client/src/components/Sidebar/SidebarListElementActions.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElementActions.vue
@@ -69,6 +69,7 @@ function handleDelete(id: string) {
       v-if="currentAction.action === ModalAction.Delete"
       :variableName="currentAction.name"
       warningMessage="Are you sure you want to delete this cookie?"
+      @close="handleModalClose"
       @delete="handleDelete(variable.uid)" />
   </ScalarModal>
 </template>


### PR DESCRIPTION
this pr adds missing event listener to be able to close the delete sidebar list element modal.