### PR TITLE
docs: documented new showNavLink option in docusaurus plugin

### DIFF
--- a/.changeset/cool-kiwis-run.md
+++ b/.changeset/cool-kiwis-run.md
@@ -1,5 +1,0 @@
----
-'@scalar/docusaurus': patch
----
-
-Documentation for new showNavLink option

--- a/.changeset/cool-kiwis-run.md
+++ b/.changeset/cool-kiwis-run.md
@@ -1,0 +1,5 @@
+---
+'@scalar/docusaurus': patch
+---
+
+Documentation for new showNavLink option

--- a/packages/docusaurus/README.md
+++ b/packages/docusaurus/README.md
@@ -26,6 +26,7 @@ plugins: [
     {
       label: 'Scalar',
       route: '/scalar',
+      showNavLink: true, // optional, default is true
       configuration: {
         spec: {
           url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
@@ -54,6 +55,7 @@ plugins: [
       id: 'scalar/galaxy',
       label: 'Scalar',
       route: '/scalar',
+      showNavLink: true, // optional, default is true
       configuration: {
         spec: {
           url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
@@ -69,6 +71,7 @@ plugins: [
       id: 'petstore',
       label: 'Petstore',
       route: '/petstore',
+      showNavLink: true, // optional, default is true
       configuration: {
         spec: {
           url: 'https://petstore3.swagger.io/api/v3/openapi.json',


### PR DESCRIPTION
**Problem**
New `showNavLink` option for the docusaurus plugin did not have any documentation besides the type file that it existed.

**Solution**
Now it is documented
