### PR TITLE
chore(fastify-api-reference): change default routePrefix

### DIFF
--- a/.changeset/forty-ravens-teach.md
+++ b/.changeset/forty-ravens-teach.md
@@ -2,4 +2,4 @@
 '@scalar/fastify-api-reference': patch
 ---
 
-change default routePrefix to /reference
+chore!: change default routePrefix to /reference

--- a/.changeset/forty-ravens-teach.md
+++ b/.changeset/forty-ravens-teach.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+change default routePrefix to /reference

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -64,7 +64,7 @@ describe('fastifyApiReference', () => {
     })
 
     const address = await fastify.listen({ port: 0 })
-    const response = await fetch(`${address}/`)
+    const response = await fetch(`${address}/reference`)
     expect(response.status).toBe(200)
   })
 
@@ -214,5 +214,23 @@ describe('fastifyApiReference', () => {
     const response = await fetch(`${address}/reference`)
     expect(response.headers.has('content-type')).toBe(true)
     expect(response.headers.get('content-type')).toContain('text/html')
+  })
+
+  it('has the JS url with default routePrefix', async () => {
+    const fastify = Fastify({
+      logger: false,
+    })
+
+    fastify.register(fastifyApiReference, {
+      configuration: {
+        spec: { url: '/openapi.json' },
+      },
+    })
+
+    const address = await fastify.listen({ port: 0 })
+    const response = await fetch(`${address}/reference`)
+    expect(await response.text()).toContain(
+      '/reference/@scalar/fastify-api-reference/js/browser.js',
+    )
   })
 })

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -19,7 +19,7 @@ export type FastifyApiReferenceOptions = {
   /**
    * Prefix the route with a path. This is where the API Reference will be available.
    *
-   * @default ''
+   * @default '/reference'
    */
   routePrefix?: string
   /**
@@ -37,7 +37,7 @@ const schemaToHideRoute = {
 }
 
 const getJavaScriptUrl = (routePrefix?: string, publicPath?: string) =>
-  `${publicPath ?? ''}${routePrefix ?? ''}/@scalar/fastify-api-reference/js/browser.js`.replace(
+  `${publicPath ?? ''}${routePrefix ?? '/reference'}/@scalar/fastify-api-reference/js/browser.js`.replace(
     /\/\//g,
     '/',
   )
@@ -192,7 +192,7 @@ const fastifyApiReference = fp<
     // If no theme is passed, use the default theme.
     fastify.route({
       method: 'GET',
-      url: options.routePrefix ?? '/',
+      url: options.routePrefix ?? '/reference',
       // We don’t know whether @fastify/swagger is registered, but it doesn’t hurt to add a schema anyway.
       // @ts-ignore
       schema: schemaToHideRoute,


### PR DESCRIPTION
This PR updates the default `routePrefix` in the `fastify-api-reference` configuration from an empty string to `/reference`. For helps avoid potential conflicts with root route in the application.