### PR TITLE
test(api-client): createRequest with circular reference

### DIFF
--- a/packages/api-client/playground/modal/main.ts
+++ b/packages/api-client/playground/modal/main.ts
@@ -2,7 +2,33 @@ import { createApiClientModal } from '@/layouts/Modal'
 
 const { open } = await createApiClientModal(document.getElementById('app'), {
   spec: {
-    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+    content: `openapi: "3.0.1"
+info:
+  title: "Test OpenAPI definition"
+  version: "1.0.0"
+paths:
+  /api/v1/updateEmployee:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/Employee"
+components:
+  schemas:
+    Employee:
+      type: "object"
+      properties:
+        id:
+          type: "integer"
+        manager:
+          $ref: "#/components/schemas/Employee"
+        team:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Employee"`,
   },
   proxyUrl: 'https://proxy.scalar.com',
 })

--- a/packages/api-client/playground/modal/main.ts
+++ b/packages/api-client/playground/modal/main.ts
@@ -2,33 +2,7 @@ import { createApiClientModal } from '@/layouts/Modal'
 
 const { open } = await createApiClientModal(document.getElementById('app'), {
   spec: {
-    content: `openapi: "3.0.1"
-info:
-  title: "Test OpenAPI definition"
-  version: "1.0.0"
-paths:
-  /api/v1/updateEmployee:
-    put:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: "array"
-              items:
-                $ref: "#/components/schemas/Employee"
-components:
-  schemas:
-    Employee:
-      type: "object"
-      properties:
-        id:
-          type: "integer"
-        manager:
-          $ref: "#/components/schemas/Employee"
-        team:
-          type: "array"
-          items:
-            $ref: "#/components/schemas/Employee"`,
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
   },
   proxyUrl: 'https://proxy.scalar.com',
 })

--- a/packages/oas-utils/src/entities/workspace/spec/createRequest.test.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/createRequest.test.ts
@@ -1,0 +1,24 @@
+import { createRequest } from '@/entities/workspace/spec/requests'
+import { describe, expect, it } from 'vitest'
+
+describe('createRequest', () => {
+  it('should create a request', () => {
+    const request = createRequest({})
+
+    expect(request).toMatchObject({
+      path: '',
+    })
+  })
+
+  it('deals with circular references', () => {
+    const foo: Record<string, any> = {
+      bar: 'baz',
+    }
+
+    // Circular reference
+    foo.bar = foo
+
+    // See it failing
+    createRequest(foo)
+  })
+})


### PR DESCRIPTION
This PR has a ~~failing~~ test for #2736. It used to throw a max call stack exceeded error. Run it like this:

```
pnpm test createRequest
```

The actual issue was fixed in #2805 and #2807.