### PR TITLE
fix(api-reference): additional properties, fix #2457, fix #1858, fix #2606

### DIFF
--- a/.changeset/weak-fishes-burn.md
+++ b/.changeset/weak-fishes-burn.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/oas-utils': patch
+---
+
+fix: additionalProperties are not rendered correctly

--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -93,3 +93,25 @@ paths:
       summary: Create a new planet
 +      x-internal: true
 ```
+
+## x-additionalPropertiesName
+
+You can add a custom attribute name to `additionalProperties` with `x-additionalPropertiesName`.
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: '1.0'
+components:
+  schemas:
+    Planet:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+      additionalProperties:
++        x-additionalPropertiesName: anyCustomAttribute
+        type: string
+```

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -130,7 +130,7 @@ const handleClick = (e: MouseEvent) =>
                 :level="level"
                 noncollapsible
                 :value="{
-                  type: 'any',
+                  type: 'anything',
                   ...(typeof value.additionalProperties === 'object'
                     ? value.additionalProperties
                     : {}),

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -36,7 +36,7 @@ const flattenValue = (value: Record<string, any>) => {
       <template v-if="value?.['x-additionalPropertiesName']">
         {{ value['x-additionalPropertiesName'] }}
       </template>
-      <template v-else> additional properties </template>
+      <template v-else>additional properties</template>
     </div>
     <div
       v-if="value?.deprecated"
@@ -59,13 +59,8 @@ const flattenValue = (value: Record<string, any>) => {
     <div
       v-else-if="value?.type"
       class="property-details">
-      <SchemaPropertyDetail v-if="additional">
-        <template #prefix>key:</template>
-        string
-      </SchemaPropertyDetail>
       <SchemaPropertyDetail>
         <!-- prettier-ignore -->
-        <template v-if="additional" #prefix>value:</template >
         <template v-if="value?.items?.type">
           {{ value.type }}
           {{ value.items.type }}[]
@@ -156,6 +151,7 @@ const flattenValue = (value: Record<string, any>) => {
 }
 .property-additional {
   font-size: var(--scalar-font-size-3);
+  font-family: var(--scalar-font-code);
 }
 
 .property-required,

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -150,7 +150,6 @@ const flattenValue = (value: Record<string, any>) => {
   font-family: var(--scalar-font-code);
 }
 .property-additional {
-  font-size: var(--scalar-font-size-3);
   font-family: var(--scalar-font-code);
 }
 

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -750,103 +750,88 @@ describe('getExampleFromSchema', () => {
     ).toBe(undefined)
   })
 
-  it('merges object from additionalProperties', () => {
+  it('allows any additonalProperty', () => {
     expect(
       getExampleFromSchema({
-        properties: {
-          myProperty: {
-            additionalProperties: {
-              properties: {
-                propertyOne: {
-                  type: 'string',
-                  title: 'Message',
-                },
-                propertyTwo: {
-                  type: 'string',
-                  title: 'Message',
-                },
-              },
-              type: 'object',
-            },
-            type: 'object',
-            title: 'MyProperty',
-          },
-        },
         type: 'object',
+        additionalProperties: {},
       }),
     ).toMatchObject({
-      myProperty: {
-        propertyOne: '',
-        propertyTwo: '',
-      },
+      ANY_ADDITIONAL_PROPERTY: 'anything',
+    })
+
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        additionalProperties: true,
+      }),
+    ).toMatchObject({
+      ANY_ADDITIONAL_PROPERTY: 'anything',
     })
   })
 
-  it('adds a key-value pair example with the schema additionalProperties', () => {
+  it('adds an additionalProperty with specific types', () => {
     expect(
       getExampleFromSchema({
-        properties: {
-          myProperty: {
-            additionalProperties: {
-              type: 'string',
-              title: 'Message',
-            },
-            type: 'object',
-            title: 'MyProperty',
-          },
-        },
         type: 'object',
+        additionalProperties: {
+          type: 'integer',
+        },
       }),
     ).toMatchObject({
-      myProperty: {
-        '{{key}}': '',
-      },
+      ANY_ADDITIONAL_PROPERTY: 1,
     })
-  })
 
-  it('adds a key-value pair example with the schema additionalProperties (omitEmptyAndOptionalProperties: true)', () => {
     expect(
-      getExampleFromSchema(
-        {
+      getExampleFromSchema({
+        type: 'object',
+        additionalProperties: {
+          type: 'boolean',
+        },
+      }),
+    ).toMatchObject({
+      ANY_ADDITIONAL_PROPERTY: true,
+    })
+
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        additionalProperties: {
+          type: 'boolean',
+          default: false,
+        },
+      }),
+    ).toMatchObject({
+      ANY_ADDITIONAL_PROPERTY: false,
+    })
+
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        additionalProperties: {
+          type: 'string',
+        },
+      }),
+    ).toMatchObject({
+      ANY_ADDITIONAL_PROPERTY: '',
+    })
+
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        additionalProperties: {
           type: 'object',
           properties: {
-            myProperty: {
-              additionalProperties: {
-                type: 'string',
-                title: 'Message',
-              },
-              type: 'object',
-              title: 'MyProperty',
+            foo: {
+              type: 'string',
             },
           },
         },
-        {
-          omitEmptyAndOptionalProperties: true,
-        },
-      ),
-    ).toMatchObject({
-      myProperty: {
-        '{{key}}': '',
-      },
-    })
-  })
-
-  it('overwrites with nullable additionalProperties schema', () => {
-    expect(
-      getExampleFromSchema({
-        properties: {
-          myProperty: {
-            additionalProperties: {
-              nullable: true,
-            },
-            type: 'object',
-            title: 'MyProperty',
-          },
-        },
-        type: 'object',
       }),
     ).toMatchObject({
-      myProperty: null,
+      ANY_ADDITIONAL_PROPERTY: {
+        foo: '',
+      },
     })
   })
 })

--- a/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.test.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.test.ts
@@ -181,7 +181,7 @@ describe('getRequestBodyFromOperation', () => {
     })
   })
 
-  it.only('creates key-value pair examples from object schema', () => {
+  it('creates key-value pair examples from object schema', () => {
     const request = getRequestBodyFromOperation({
       httpVerb: 'POST',
       path: '/foobar',
@@ -203,39 +203,21 @@ describe('getRequestBodyFromOperation', () => {
                 ],
                 properties: {
                   recordString: {
-                    type: 'object',
-                    additionalProperties: {
-                      type: 'string',
-                    },
+                    type: 'string',
                   },
                   recordInteger: {
-                    type: 'object',
-                    additionalProperties: {
-                      type: 'integer',
-                    },
+                    type: 'integer',
                   },
                   recordArray: {
-                    type: 'object',
-                    additionalProperties: {
-                      type: 'array',
-                    },
+                    type: 'array',
                   },
                   recordBoolean: {
-                    type: 'object',
-                    additionalProperties: {
-                      type: 'boolean',
-                    },
+                    type: 'boolean',
                   },
                   recordNullable: {
-                    type: 'object',
-                    additionalProperties: {
-                      nullable: 'true',
-                    },
+                    nullable: 'true',
                   },
                   recordObject: {
-                    type: 'object',
-                  },
-                  recordWithoutAdditionalProperties: {
                     type: 'object',
                   },
                 },
@@ -247,23 +229,12 @@ describe('getRequestBodyFromOperation', () => {
     })
 
     const expectedResult = {
-      recordString: {
-        ANY_ADDITIONAL_PROPERTY: '',
-      },
-      recordInteger: {
-        ANY_ADDITIONAL_PROPERTY: 1,
-      },
-      recordArray: {
-        ANY_ADDITIONAL_PROPERTY: [],
-      },
-      recordBoolean: {
-        ANY_ADDITIONAL_PROPERTY: true,
-      },
-      recordNullable: {
-        ANY_ADDITIONAL_PROPERTY: null,
-      },
+      recordString: '',
+      recordInteger: 1,
+      recordArray: [],
+      recordBoolean: true,
+      recordNullable: null,
       recordObject: {},
-      recordWithoutAdditionalProperties: {},
     }
 
     expect(request?.postData).toMatchObject({

--- a/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.test.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.test.ts
@@ -181,7 +181,7 @@ describe('getRequestBodyFromOperation', () => {
     })
   })
 
-  it('creates key-value pair examples from object schema', () => {
+  it.only('creates key-value pair examples from object schema', () => {
     const request = getRequestBodyFromOperation({
       httpVerb: 'POST',
       path: '/foobar',
@@ -248,19 +248,19 @@ describe('getRequestBodyFromOperation', () => {
 
     const expectedResult = {
       recordString: {
-        '{{key}}': '',
+        ANY_ADDITIONAL_PROPERTY: '',
       },
       recordInteger: {
-        '{{key}}': 1,
+        ANY_ADDITIONAL_PROPERTY: 1,
       },
       recordArray: {
-        '{{key}}': [],
+        ANY_ADDITIONAL_PROPERTY: [],
       },
       recordBoolean: {
-        '{{key}}': true,
+        ANY_ADDITIONAL_PROPERTY: true,
       },
       recordNullable: {
-        '{{key}}': null,
+        ANY_ADDITIONAL_PROPERTY: null,
       },
       recordObject: {},
       recordWithoutAdditionalProperties: {},


### PR DESCRIPTION
This PR refactors how we deal with `additionalProperties`. After reading the bug reports from the community and re-reading the specification, I got a completely different understand of how they were meant to work. :)

Fixes #2457, #1858, #2606.

**Example**

```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "Hello World",
    "version": "1.0.0"
  },
  "paths": {
    "/Auth/Login": {
      "get": {
        "tags": [
          "Auth"
        ],
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/as-obj"
              }
            }
          },
        },
          "responses": {
          "400": {
            "description": "Error",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/as-false"
                }
              }
            }
          },
          "401": {
            "description": "Error",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/as-obj"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "as-false": {
        "type": "object",
        "properties": {
          "value": {
            "type": "string"
          }
        },

        "additionalProperties": false
      },
      "as-obj": {
        "type": "object",
        "properties": {
          "value": {
            "type": "string"
          }
        },
        "additionalProperties": {
          "description": "example description",
          "type": "string"
        },
      }
    }
  }
}
```