### PR TITLE
feat(api-client): request sidebar context menu

### DIFF
--- a/.changeset/fast-comics-sparkle.md
+++ b/.changeset/fast-comics-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: workspace rename and deletion

--- a/.changeset/metal-rats-sin.md
+++ b/.changeset/metal-rats-sin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: scalar context menu component

--- a/.changeset/witty-chefs-grin.md
+++ b/.changeset/witty-chefs-grin.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+feat: set request sidebar item context menu

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -483,11 +483,19 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
 
   /** Prevent deletion of the default workspace */
   const deleteWorkspace = (uid: string) => {
-    if (uid === 'default') {
-      console.warn('Default environment cannot be deleted.')
+    if (Object.keys(workspaces).length <= 1) {
+      console.warn('The last workspace cannot be deleted.')
       return
     }
     workspaceMutators.delete(uid)
+  }
+
+  const renameWorkspace = (uid: string, newName: string) => {
+    if (workspaces[uid]) {
+      workspaceMutators.edit(uid, 'name', newName)
+    } else {
+      console.warn(`Workspace with uid ${uid} not found.`)
+    }
   }
 
   /** The currently selected workspace OR the first one */
@@ -1041,6 +1049,7 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
       rawAdd: workspaceMutators.add,
       add: addWorkspace,
       delete: deleteWorkspace,
+      rename: renameWorkspace,
     },
   }
 }

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -1,16 +1,10 @@
 <script setup lang="ts">
-import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
 import { commandPaletteBus } from '@/libs/event-busses'
-import { PathId } from '@/router'
-import { useWorkspace } from '@/store/workspace'
 import {
   ScalarButton,
   ScalarDropdown,
   ScalarDropdownItem,
   ScalarIcon,
-  ScalarModal,
-  ScalarTextField,
-  useModal,
 } from '@scalar/components'
 import type { Collection } from '@scalar/oas-utils/entities/workspace/collection'
 import type { Folder } from '@scalar/oas-utils/entities/workspace/folder'
@@ -18,24 +12,22 @@ import type {
   Request,
   RequestExample,
 } from '@scalar/oas-utils/entities/workspace/spec'
-import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed } from 'vue'
 
-const props = defineProps<{
-  /** Both inidicate the level and provide a way to traverse upwards */
-  parentUids: string[]
-  item: Collection | Folder | Request | RequestExample
+const props = withDefaults(
+  defineProps<{
+    /** Both inidicate the level and provide a way to traverse upwards */
+    item: Collection | Folder | Request | RequestExample
+    resourceTitle: string
+    static?: boolean
+  }>(),
+  { static: false },
+)
+
+const emit = defineEmits<{
+  (event: 'delete'): void
+  (event: 'rename'): void
 }>()
-
-const {
-  activeWorkspace,
-  activeRouterParams,
-  collectionMutators,
-  folderMutators,
-  requestMutators,
-  requestExampleMutators,
-} = useWorkspace()
-const { replace } = useRouter()
 
 /** Add example */
 const handleAddExample = () =>
@@ -44,91 +36,13 @@ const handleAddExample = () =>
     metaData: props.item.uid,
   })
 
-const handleItemDuplicate = () => {
-  console.log('duplicate')
-}
-
-/** Delete handles both requests and requestExamples */
-const handleItemDelete = () => {
-  // Delete example
-  if ('requestUid' in props.item) {
-    requestExampleMutators.delete(props.item)
-    if (activeRouterParams.value[PathId.Examples] === props.item.uid) {
-      replace(`/workspace/${activeWorkspace.value}/request/default`)
-    }
-  }
-  // Delete request
-  else if ('summary' in props.item) {
-    requestMutators.delete(
-      props.item,
-      props.parentUids[props.parentUids.length - 1],
-    )
-    if (activeRouterParams.value[PathId.Request] === props.item.uid) {
-      replace(`/workspace/${activeWorkspace.value.uid}/request/default`)
-    }
-  }
-  // Delete Collection
-  else if ('spec' in props.item) {
-    collectionMutators.delete(props.item)
-  }
-  // Delete folder
-  else if ('name' in props.item) {
-    folderMutators.delete(
-      props.item,
-      props.parentUids[props.parentUids.length - 1],
-    )
-  }
-}
-
 const isRequest = computed(() => 'summary' in props.item)
-const itemName = computed(() => {
-  if ('summary' in props.item) return props.item.summary || ''
-  if ('name' in props.item) return props.item.name || ''
-  if ('spec' in props.item) return props.item.spec.info?.title || ''
-  return ''
-})
-
-const tempName = ref('')
-
-const handleItemRename = () => {
-  // Request
-  if ('summary' in props.item) {
-    requestMutators.edit(props.item.uid, 'summary', tempName.value)
-  }
-  // Example
-  else if ('requestUid' in props.item) {
-    requestExampleMutators.edit(props.item.uid, 'name', tempName.value)
-  }
-  // Collection
-  else if ('spec' in props.item) {
-    collectionMutators.edit(props.item.uid, 'spec.info.title', tempName.value)
-  }
-  // Folder
-  else {
-    folderMutators.edit(props.item.uid, 'name', tempName.value)
-  }
-
-  renameModal.hide()
-}
-
-const renameModal = useModal()
-const deleteModal = useModal()
-const openRenameModal = () => {
-  tempName.value = itemName.value
-  renameModal.show()
-}
-
-/** Gets the title of the resource to use in the modal titles */
-const resourceTitle = computed(() => {
-  if ('requestUid' in props.item) return 'Example'
-  if ('summary' in props.item) return 'Request'
-  if ('spec' in props.item) return 'Collection'
-  return 'Folder'
-})
 </script>
 
 <template>
-  <ScalarDropdown teleport="#scalar-client">
+  <ScalarDropdown
+    :static="static"
+    :teleport="!static ?? '#scalar-client'">
     <ScalarButton
       class="px-0.5 py-0 z-10 hover:bg-b-3 hidden group-hover:flex ui-open:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
       size="sm"
@@ -136,7 +50,10 @@ const resourceTitle = computed(() => {
       @click="
         (ev) => {
           // We must stop propagation on folders and collections to prevent them from toggling
-          if (resourceTitle === 'Collection' || resourceTitle === 'Folder')
+          if (
+            props.resourceTitle === 'Collection' ||
+            props.resourceTitle === 'Folder'
+          )
             ev.stopPropagation()
         }
       ">
@@ -161,7 +78,7 @@ const resourceTitle = computed(() => {
       <!-- Rename -->
       <ScalarDropdownItem
         class="flex !gap-2"
-        @click="openRenameModal">
+        @click="emit('rename')">
         <ScalarIcon
           class="inline-flex"
           icon="Edit"
@@ -186,7 +103,7 @@ const resourceTitle = computed(() => {
       <!-- Delete -->
       <ScalarDropdownItem
         class="flex !gap-2"
-        @click="deleteModal.show()">
+        @click="emit('delete')">
         <ScalarIcon
           class="inline-flex"
           icon="Trash"
@@ -196,39 +113,6 @@ const resourceTitle = computed(() => {
       </ScalarDropdownItem>
     </template>
   </ScalarDropdown>
-  <ScalarModal
-    :size="'sm'"
-    :state="deleteModal"
-    :title="`Delete ${resourceTitle}`">
-    <DeleteSidebarListElement
-      :variableName="itemName"
-      warningMessage="Warning: Deleting this will delete all items inside of this"
-      @close="deleteModal.hide()"
-      @delete="handleItemDelete" />
-  </ScalarModal>
-  <ScalarModal
-    :state="renameModal"
-    :title="`Rename ${resourceTitle}`">
-    <ScalarTextField
-      v-model="tempName"
-      :label="resourceTitle"
-      labelShadowColor="var(--scalar-background-1)"
-      @keydown.prevent.enter="handleItemRename" />
-    <div class="flex gap-3">
-      <ScalarButton
-        class="flex-1"
-        variant="outlined"
-        @click="renameModal.hide()">
-        Cancel
-      </ScalarButton>
-      <ScalarButton
-        class="flex-1"
-        type="submit"
-        @click="handleItemRename">
-        Save
-      </ScalarButton>
-    </div>
-  </ScalarModal>
 </template>
 <style scoped>
 .ellipsis-position {

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -1,16 +1,23 @@
 <script setup lang="ts">
+import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
 import { commandPaletteBus } from '@/libs/event-busses'
 import { useWorkspace } from '@/store/workspace'
 import {
   ScalarButton,
+  ScalarContextMenu,
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
   ScalarIcon,
+  ScalarModal,
+  ScalarTextField,
+  ScalarTooltip,
+  useModal,
 } from '@scalar/components'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
-const { activeWorkspace, workspaces } = useWorkspace()
+const { activeWorkspace, workspaces, workspaceMutators } = useWorkspace()
 const { push } = useRouter()
 
 const updateSelected = (uid: string) => {
@@ -18,8 +25,51 @@ const updateSelected = (uid: string) => {
   push(`/workspace/${uid}`)
 }
 
+const isLastWorkspace = computed(() => Object.keys(workspaces).length === 1)
+
 const createNewWorkspace = () =>
   commandPaletteBus.emit({ commandName: 'Create Workspace' })
+
+const tempName = ref('')
+const tempUid = ref('')
+const renameModal = useModal()
+const deleteModal = useModal()
+
+const openRenameModal = (uid: string) => {
+  tempName.value = workspaces[uid].name
+  tempUid.value = uid
+  renameModal.show()
+}
+
+const handleWorkspaceRename = () => {
+  if (tempName.value.trim()) {
+    workspaceMutators.rename(tempUid.value, tempName.value.trim())
+    renameModal.hide()
+  }
+}
+
+const openDeleteModal = (uid: string) => {
+  tempName.value = workspaces[uid].name
+  tempUid.value = uid
+  deleteModal.show()
+}
+
+const deleteWorkspace = async () => {
+  if (!isLastWorkspace.value) {
+    const isActiveWorkspace = activeWorkspace.value.uid === tempUid.value
+    const currentWorkspaces = { ...workspaces }
+    delete currentWorkspaces[tempUid.value]
+
+    workspaceMutators.delete(tempUid.value)
+
+    if (isActiveWorkspace) {
+      // Switch to another workspace if the active one is deleted
+      const newWorkspaceUid = Object.keys(currentWorkspaces)[0]
+      await push(`/workspace/${newWorkspaceUid}/`)
+    }
+  }
+  deleteModal.hide()
+}
 </script>
 
 <template>
@@ -41,25 +91,82 @@ const createNewWorkspace = () =>
 
       <!-- Workspace list -->
       <template #items>
-        <ScalarDropdownItem
+        <ScalarContextMenu
           v-for="(workspace, uid) in workspaces"
-          :key="uid"
-          class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden"
-          @click.stop="updateSelected(uid)">
-          <div
-            class="flex items-center justify-center rounded-full p-[3px] w-4 h-4 group-hover/item:shadow-border"
-            :class="
-              activeWorkspace.uid === uid
-                ? 'bg-blue text-b-1'
-                : 'text-transparent'
-            ">
-            <ScalarIcon
-              class="size-2.5"
-              icon="Checkmark"
-              thickness="3.5" />
-          </div>
-          {{ workspace.name }}
-        </ScalarDropdownItem>
+          :key="uid">
+          <template #trigger>
+            <ScalarDropdownItem
+              class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden w-full"
+              @click.stop="updateSelected(uid)">
+              <div
+                class="flex items-center justify-center rounded-full p-[3px] w-4 h-4 group-hover/item:shadow-border"
+                :class="
+                  activeWorkspace.uid === uid
+                    ? 'bg-blue text-b-1'
+                    : 'text-transparent'
+                ">
+                <ScalarIcon
+                  class="size-2.5"
+                  icon="Checkmark"
+                  thickness="3.5" />
+              </div>
+              {{ workspace.name }}
+            </ScalarDropdownItem>
+          </template>
+          <template #content>
+            <ScalarDropdown static>
+              <template #items>
+                <ScalarDropdownItem
+                  class="flex !gap-2"
+                  @mousedown="openRenameModal(uid)">
+                  <ScalarIcon
+                    class="inline-flex"
+                    icon="Edit"
+                    size="sm"
+                    thickness="1.5" />
+                  <span>Rename</span>
+                </ScalarDropdownItem>
+                <ScalarTooltip
+                  v-if="isLastWorkspace"
+                  class="z-10"
+                  side="bottom">
+                  <template #trigger>
+                    <ScalarDropdownItem
+                      class="flex w-full"
+                      disabled
+                      @mousedown.prevent>
+                      <ScalarIcon
+                        class="inline-flex"
+                        icon="Trash"
+                        size="sm"
+                        thickness="1.5" />
+                      <span>Delete</span>
+                    </ScalarDropdownItem>
+                  </template>
+                  <template #content>
+                    <div
+                      class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
+                      <div class="flex items-center text-c-2">
+                        <span>Only workspace cannot be deleted.</span>
+                      </div>
+                    </div>
+                  </template>
+                </ScalarTooltip>
+                <ScalarDropdownItem
+                  v-else
+                  class="flex !gap-2"
+                  @mousedown.prevent="openDeleteModal(uid)">
+                  <ScalarIcon
+                    class="inline-flex"
+                    icon="Trash"
+                    size="sm"
+                    thickness="1.5" />
+                  <span>Delete</span>
+                </ScalarDropdownItem>
+              </template>
+            </ScalarDropdown>
+          </template>
+        </ScalarContextMenu>
         <ScalarDropdownDivider />
 
         <!-- Add new workspace -->
@@ -76,4 +183,37 @@ const createNewWorkspace = () =>
       </template>
     </ScalarDropdown>
   </div>
+  <ScalarModal
+    :size="'sm'"
+    :state="deleteModal"
+    :title="`Delete ${tempName}`">
+    <DeleteSidebarListElement
+      :variableName="tempName"
+      warningMessage="Warning: Deleting this will delete all items inside of this"
+      @close="deleteModal.hide()"
+      @delete="deleteWorkspace" />
+  </ScalarModal>
+  <ScalarModal
+    :state="renameModal"
+    title="Rename Workspace">
+    <ScalarTextField
+      v-model="tempName"
+      label="Workspace"
+      labelShadowColor="var(--scalar-background-1)"
+      @keydown.prevent.enter="handleWorkspaceRename" />
+    <div class="flex gap-3">
+      <ScalarButton
+        class="flex-1"
+        variant="outlined"
+        @click="renameModal.hide()">
+        Cancel
+      </ScalarButton>
+      <ScalarButton
+        class="flex-1"
+        type="submit"
+        @click="handleWorkspaceRename">
+        Save
+      </ScalarButton>
+    </div>
+  </ScalarModal>
 </template>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,7 +53,7 @@
     "@vueuse/core": "^10.10.0",
     "cva": "1.0.0-beta.1",
     "nanoid": "^5.0.7",
-    "radix-vue": "^1.8.4",
+    "radix-vue": "^1.9.3",
     "tailwind-merge": "^2.3.0",
     "vue": "^3.4.29"
   },

--- a/packages/components/src/components/ScalarContextMenu/ScalarContextMenu.spec.ts
+++ b/packages/components/src/components/ScalarContextMenu/ScalarContextMenu.spec.ts
@@ -1,0 +1,23 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import ScalarContextMenu from './ScalarContextMenu.vue'
+
+describe('ScalarContextMenu', () => {
+  it('renders properly', async () => {
+    const wrapper = mount(ScalarContextMenu, {
+      props: {
+        items: [
+          { id: '1', label: 'Item 1' },
+          { id: '2', label: 'Item 2' },
+        ],
+      },
+      slots: {
+        trigger: `<span>Right click here</span>`,
+        content: `<div>Context Menu Content</div>`,
+      },
+    })
+
+    expect(wrapper.exists()).toBeTruthy()
+  })
+})

--- a/packages/components/src/components/ScalarContextMenu/ScalarContextMenu.stories.ts
+++ b/packages/components/src/components/ScalarContextMenu/ScalarContextMenu.stories.ts
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+import { ScalarButton } from '../../'
+import ScalarContextMenu from './ScalarContextMenu.vue'
+
+const meta = {
+  component: ScalarContextMenu,
+  tags: ['autodocs'],
+  argTypes: {
+    side: {
+      control: 'select',
+      options: ['top', 'right', 'bottom', 'left'],
+    },
+    sideOffset: {
+      control: 'number',
+    },
+    class: {
+      control: 'text',
+    },
+  },
+  render: (args) => ({
+    components: {
+      ScalarContextMenu,
+      ScalarButton,
+    },
+    setup() {
+      return { args }
+    },
+    template: `
+<div class="flex items-center justify-center w-full h-screen">
+  <ScalarContextMenu v-bind="args">
+    <template #trigger>
+      <div class="border border-dashed p-6 rounded">Right Click Me</div>
+    </template>
+    <template #content>
+      <div class="bg-b-1 border p-2 rounded">Context Menu Content</div>
+    </template>
+  </ScalarContextMenu>
+</div>
+`,
+  }),
+} satisfies Meta<typeof ScalarContextMenu>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Base: Story = {}

--- a/packages/components/src/components/ScalarContextMenu/ScalarContextMenu.vue
+++ b/packages/components/src/components/ScalarContextMenu/ScalarContextMenu.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import {
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuPortal,
+  ContextMenuRoot,
+  ContextMenuTrigger,
+} from 'radix-vue'
+
+const props = withDefaults(
+  defineProps<{
+    align?: 'start' | 'center' | 'end'
+    side?: 'top' | 'right' | 'bottom' | 'left'
+    sideOffset?: number
+    disabled?: boolean
+  }>(),
+  {
+    side: 'bottom',
+    align: 'center',
+    disabled: false,
+  },
+)
+</script>
+
+<template>
+  <ContextMenuRoot>
+    <ContextMenuTrigger :disabled="props.disabled">
+      <slot name="trigger" />
+    </ContextMenuTrigger>
+    <ContextMenuPortal>
+      <ContextMenuContent
+        :align="props.align"
+        :side="props.side"
+        :sideOffset="props.sideOffset">
+        <ContextMenuItem>
+          <slot name="content" />
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenuPortal>
+  </ContextMenuRoot>
+</template>

--- a/packages/components/src/components/ScalarContextMenu/index.ts
+++ b/packages/components/src/components/ScalarContextMenu/index.ts
@@ -1,0 +1,1 @@
+export { default as ScalarContextMenu } from './ScalarContextMenu.vue'

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -3,25 +3,31 @@ import { Menu, MenuButton, MenuItems } from '@headlessui/vue'
 
 import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
 
-defineProps<Omit<FloatingOptions, 'middleware'>>()
+withDefaults(
+  defineProps<Omit<FloatingOptions, 'middleware'> & { static?: boolean }>(),
+  { static: false },
+)
 
 defineOptions({ inheritAttrs: false })
 </script>
 <template>
   <Menu v-slot="{ open }">
     <ScalarFloating
-      :isOpen="open ?? isOpen"
+      :isOpen="static ? true : open ?? isOpen"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
       :teleport="teleport">
-      <MenuButton as="template">
+      <MenuButton
+        v-if="!static"
+        as="template">
         <slot />
       </MenuButton>
       <template #floating="{ width }">
         <MenuItems
           class="relative flex w-56 flex-col p-0.75"
-          :style="{ width }"
-          v-bind="$attrs">
+          v-bind="$attrs"
+          :static="static"
+          :style="{ width }">
           <slot name="items" />
           <div
             class="absolute inset-0 -z-1 rounded bg-b-1 shadow-lg brightness-lifted" />

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdownItem.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdownItem.vue
@@ -14,7 +14,7 @@ defineEmits<{
 const variants = cva({
   base: [
     // Layout
-    'min-w-0 items-center gap-1.5 rounded px-2.5 py-1.5 text-left',
+    'h-8 min-w-0 items-center gap-1.5 rounded px-2.5 py-1.5 text-left',
     // Text / background style
     'truncate text-sm text-c-1',
     // Interaction

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -5,6 +5,7 @@ import {
   ScalarComboboxMultiselect,
   type ScalarComboboxOption,
 } from './components/ScalarCombobox'
+import { ScalarContextMenu } from './components/ScalarContextMenu'
 import {
   ScalarDropdown,
   ScalarDropdownDivider,
@@ -50,6 +51,7 @@ export {
   ScalarIconButton,
   ScalarListbox,
   ScalarLoading,
+  ScalarContextMenu,
   ScalarModal,
   ScalarPopover,
   ScalarSearchInput,

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -66,9 +66,9 @@
   "module": "dist/index.js",
   "dependencies": {
     "@vueuse/core": "^10.10.0",
+    "flatted": "^3.3.1",
     "just-clone": "^6.2.0",
-    "ts-deepmerge": "^7.0.1",
-    "flatted": "^3.3.1"
+    "ts-deepmerge": "^7.0.1"
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 12.3.2(typescript@5.5.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
+        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -711,7 +711,7 @@ importers:
         version: 5.0.5(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))(vue@3.4.31(typescript@5.5.2))
       '@vue/eslint-config-prettier':
         specifier: ^9.0.0
-        version: 9.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.3.2)
+        version: 9.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.3.3)
       '@vue/eslint-config-typescript':
         specifier: ^12.0.0
         version: 12.0.0(eslint-plugin-vue@9.27.0(eslint@8.57.0))(eslint@8.57.0)(typescript@5.5.2)
@@ -885,7 +885,7 @@ importers:
         version: link:../galaxy
       '@storybook/addon-essentials':
         specifier: ^8.0.8
-        version: 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-interactions':
         specifier: ^8.0.8
         version: 8.1.9(vitest@1.6.0(@types/node@20.14.10)(jsdom@24.1.0)(terser@5.31.2))
@@ -894,16 +894,16 @@ importers:
         version: 8.1.9(react@18.3.1)
       '@storybook/blocks':
         specifier: ^8.0.8
-        version: 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/testing-library':
         specifier: ^0.2.2
         version: 0.2.2
       '@storybook/vue3':
         specifier: ^8.0.8
-        version: 8.1.9(encoding@0.1.13)(prettier@3.3.2)(vue@3.4.31(typescript@5.5.2))
+        version: 8.1.9(encoding@0.1.13)(prettier@3.3.3)(vue@3.4.31(typescript@5.5.2))
       '@storybook/vue3-vite':
         specifier: ^8.0.8
-        version: 8.1.9(encoding@0.1.13)(prettier@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))(vue@3.4.31(typescript@5.5.2))
+        version: 8.1.9(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))(vue@3.4.31(typescript@5.5.2))
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
         version: 5.0.5(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))(vue@3.4.31(typescript@5.5.2))
@@ -921,7 +921,7 @@ importers:
         version: 0.2.6(rollup@4.18.1)
       storybook:
         specifier: ^8.0.8
-        version: 8.1.9(@babel/preset-env@7.24.7(@babel/core@7.24.8))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.1.9(@babel/preset-env@7.24.7)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-dark-mode:
         specifier: ^4.0.1
         version: 4.0.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1252,8 +1252,8 @@ importers:
         specifier: ^5.0.7
         version: 5.0.7
       radix-vue:
-        specifier: ^1.8.4
-        version: 1.8.4(vue@3.4.31(typescript@5.5.2))
+        specifier: ^1.9.3
+        version: 1.9.3(vue@3.4.31(typescript@5.5.2))
       tailwind-merge:
         specifier: ^2.3.0
         version: 2.3.0
@@ -1329,7 +1329,7 @@ importers:
         version: 1.16.1(postcss@8.4.38)
       storybook:
         specifier: ^8.0.8
-        version: 8.1.9(@babel/preset-env@7.24.7)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.1.9(@babel/preset-env@7.24.7(@babel/core@7.24.8))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-dark-mode:
         specifier: ^4.0.1
         version: 4.0.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4173,6 +4173,12 @@ packages:
   '@floating-ui/core@1.6.2':
     resolution: {integrity: sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==}
 
+  '@floating-ui/core@1.6.7':
+    resolution: {integrity: sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==}
+
+  '@floating-ui/dom@1.6.10':
+    resolution: {integrity: sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==}
+
   '@floating-ui/dom@1.6.5':
     resolution: {integrity: sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==}
 
@@ -4185,8 +4191,14 @@ packages:
   '@floating-ui/utils@0.2.2':
     resolution: {integrity: sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==}
 
+  '@floating-ui/utils@0.2.7':
+    resolution: {integrity: sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==}
+
   '@floating-ui/vue@1.0.6':
     resolution: {integrity: sha512-EdrOljjkpkkqZnrpqUcPoz9NvHxuTjUtSInh6GMv3+Mcy+giY2cE2pHh9rpacRcZ2eMSCxel9jWkWXTjLmY55w==}
+
+  '@floating-ui/vue@1.1.4':
+    resolution: {integrity: sha512-ammH7T3vyCx7pmm9OF19Wc42zrGnUw0QvLoidgypWsCLJMtGXEwY7paYIHO+K+oLC3mbWpzIHzeTVienYenlNg==}
 
   '@grpc/grpc-js@1.11.1':
     resolution: {integrity: sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==}
@@ -6145,8 +6157,16 @@ packages:
   '@tanstack/virtual-core@3.5.1':
     resolution: {integrity: sha512-046+AUSiDru/V9pajE1du8WayvBKeCvJ2NmKPy/mR8/SbKKrqmSbj7LJBfXE+nSq4f5TBXvnCzu0kcYebI9WdQ==}
 
+  '@tanstack/virtual-core@3.8.4':
+    resolution: {integrity: sha512-iO5Ujgw3O1yIxWDe9FgUPNkGjyT657b1WNX52u+Wv1DyBFEpdCdGkuVaky0M3hHFqNWjAmHWTn4wgj9rTr7ZQg==}
+
   '@tanstack/vue-virtual@3.5.1':
     resolution: {integrity: sha512-6mc4HtDPieDVKD6GqzHiJkdzuqRNdQZuoIbkwE6af939WV+w62YmSF69jN+BOqClqh/ObiW+X1VOQx1Pftrx1A==}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.0.0
+
+  '@tanstack/vue-virtual@3.8.5':
+    resolution: {integrity: sha512-JBHw3xFUslYgrbvNlCYtTWwFo8zjzRs7c2rs6B4JKFXWyP5yHuoeivgQgeZ34t6O6lJTNqc/K4ccmmcmKqpMPA==}
     peerDependencies:
       vue: ^2.7.0 || ^3.0.0
 
@@ -9834,6 +9854,9 @@ packages:
   get-tsconfig@4.7.5:
     resolution: {integrity: sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==}
 
+  get-tsconfig@4.7.6:
+    resolution: {integrity: sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==}
+
   giget@1.2.3:
     resolution: {integrity: sha512-8EHPljDvs7qKykr6uw8b+lqLiUc/vUg+KVTI0uND4s63TdsZM2Xus3mflvF0DDG9SiM4RlCkFGL+7aAjRmV7KA==}
     hasBin: true
@@ -10565,6 +10588,10 @@ packages:
 
   is-core-module@2.14.0:
     resolution: {integrity: sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.15.0:
+    resolution: {integrity: sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==}
     engines: {node: '>= 0.4'}
 
   is-data-view@1.0.1:
@@ -13354,6 +13381,11 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
@@ -13575,8 +13607,8 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  radix-vue@1.8.4:
-    resolution: {integrity: sha512-Pc8BKFQouARED1Lb7/s18Fxny3ZodET5fyXLorW5zf/BiUDQv9gk7NZEYv9sU3uldSvpO3JLLChd0q2repBdGw==}
+  radix-vue@1.9.3:
+    resolution: {integrity: sha512-9pewcgzghM+B+FO1h9mMsZa/csVH6hElpN1sqmG4/qoeieiDG0i4nhMjS7p2UOz11EEdVm7eLandHSPyx7hYhg==}
     peerDependencies:
       vue: '>= 3.2.0'
 
@@ -14305,6 +14337,11 @@ packages:
 
   semver@7.6.2:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -15401,6 +15438,9 @@ packages:
   ufo@1.5.3:
     resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
 
+  ufo@1.5.4:
+    resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
+
   uglify-js@3.18.0:
     resolution: {integrity: sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==}
     engines: {node: '>=0.8.0'}
@@ -15978,6 +16018,17 @@ packages:
 
   vue-component-type-helpers@2.0.29:
     resolution: {integrity: sha512-58i+ZhUAUpwQ+9h5Hck0D+jr1qbYl4voRt5KffBx8qzELViQ4XdT/Tuo+mzq8u63teAG8K0lLaOiL5ofqW38rg==}
+
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   vue-demi@0.14.8:
     resolution: {integrity: sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==}
@@ -17049,7 +17100,7 @@ snapshots:
     dependencies:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -17388,7 +17439,7 @@ snapshots:
 
   '@babel/plugin-transform-class-properties@7.24.7':
     dependencies:
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -17412,9 +17463,9 @@ snapshots:
 
   '@babel/plugin-transform-class-static-block@7.24.7':
     dependencies:
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.8)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -17819,7 +17870,7 @@ snapshots:
 
   '@babel/plugin-transform-private-methods@7.24.7':
     dependencies:
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -17844,9 +17895,9 @@ snapshots:
   '@babel/plugin-transform-private-property-in-object@7.24.7':
     dependencies:
       '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.8)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -18126,81 +18177,81 @@ snapshots:
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-validator-option': 7.24.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.8)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.8)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.8)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.8)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.8)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.8)
-      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.7)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.7)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-class-properties': 7.24.7
       '@babel/plugin-transform-class-static-block': 7.24.7
-      '@babel/plugin-transform-classes': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-destructuring': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-classes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-destructuring': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-modules-amd': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-modules-systemjs': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-modules-umd': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-private-methods': 7.24.7
       '@babel/plugin-transform-private-property-in-object': 7.24.7
-      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-typeof-symbol': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.8)
-      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.8)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.8)
-      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.8)
+      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-typeof-symbol': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.7)
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.7)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.7)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.7)
       core-js-compat: 3.37.1
       semver: 6.3.1
     transitivePeerDependencies:
@@ -20229,6 +20280,15 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.2
 
+  '@floating-ui/core@1.6.7':
+    dependencies:
+      '@floating-ui/utils': 0.2.7
+
+  '@floating-ui/dom@1.6.10':
+    dependencies:
+      '@floating-ui/core': 1.6.7
+      '@floating-ui/utils': 0.2.7
+
   '@floating-ui/dom@1.6.5':
     dependencies:
       '@floating-ui/core': 1.6.2
@@ -20236,17 +20296,28 @@ snapshots:
 
   '@floating-ui/react-dom@2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@floating-ui/dom': 1.6.5
+      '@floating-ui/dom': 1.6.10
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/utils@0.2.2': {}
+
+  '@floating-ui/utils@0.2.7': {}
 
   '@floating-ui/vue@1.0.6(vue@3.4.31(typescript@5.5.2))':
     dependencies:
       '@floating-ui/dom': 1.6.5
       '@floating-ui/utils': 0.2.2
       vue-demi: 0.14.8(vue@3.4.31(typescript@5.5.2))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@floating-ui/vue@1.1.4(vue@3.4.31(typescript@5.5.2))':
+    dependencies:
+      '@floating-ui/dom': 1.6.10
+      '@floating-ui/utils': 0.2.7
+      vue-demi: 0.14.10(vue@3.4.31(typescript@5.5.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -22250,11 +22321,54 @@ snapshots:
       - react-dom
       - supports-color
 
+  '@storybook/addon-controls@8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/blocks': 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      dequal: 2.0.3
+      lodash: 4.17.21
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - encoding
+      - prettier
+      - react
+      - react-dom
+      - supports-color
+
   '@storybook/addon-docs@8.1.9(@types/react-dom@18.3.0)(encoding@0.1.13)(prettier@3.3.2)':
     dependencies:
       '@babel/core': 7.24.8
       '@mdx-js/react': 3.0.1(@types/react@18.3.3)(react@18.3.1)
       '@storybook/blocks': 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/client-logger': 8.1.9
+      '@storybook/components': 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/csf-plugin': 8.1.9
+      '@storybook/csf-tools': 8.1.9
+      '@storybook/global': 5.0.0
+      '@storybook/node-logger': 8.1.9
+      '@storybook/preview-api': 8.1.9
+      '@storybook/react-dom-shim': 8.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/theming': 8.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/types': 8.1.9
+      '@types/react': 18.3.3
+      fs-extra: 11.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      rehype-external-links: 3.0.0
+      rehype-slug: 6.0.0
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - encoding
+      - prettier
+      - supports-color
+
+  '@storybook/addon-docs@8.1.9(@types/react-dom@18.3.0)(encoding@0.1.13)(prettier@3.3.3)':
+    dependencies:
+      '@babel/core': 7.24.8
+      '@mdx-js/react': 3.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@storybook/blocks': 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/client-logger': 8.1.9
       '@storybook/components': 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/csf-plugin': 8.1.9
@@ -22290,6 +22404,31 @@ snapshots:
       '@storybook/addon-toolbars': 8.1.9
       '@storybook/addon-viewport': 8.1.9
       '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.2)
+      '@storybook/manager-api': 8.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/node-logger': 8.1.9
+      '@storybook/preview-api': 8.1.9
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - encoding
+      - prettier
+      - react
+      - react-dom
+      - supports-color
+
+  '@storybook/addon-essentials@8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/addon-actions': 8.1.9
+      '@storybook/addon-backgrounds': 8.1.9
+      '@storybook/addon-controls': 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/addon-docs': 8.1.9(@types/react-dom@18.3.0)(encoding@0.1.13)(prettier@3.3.3)
+      '@storybook/addon-highlight': 8.1.9
+      '@storybook/addon-measure': 8.1.9
+      '@storybook/addon-outline': 8.1.9
+      '@storybook/addon-toolbars': 8.1.9
+      '@storybook/addon-viewport': 8.1.9
+      '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
       '@storybook/manager-api': 8.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/node-logger': 8.1.9
       '@storybook/preview-api': 8.1.9
@@ -22414,10 +22553,67 @@ snapshots:
       - prettier
       - supports-color
 
+  '@storybook/blocks@8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/channels': 8.1.9
+      '@storybook/client-logger': 8.1.9
+      '@storybook/components': 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-events': 8.1.9
+      '@storybook/csf': 0.1.8
+      '@storybook/docs-tools': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/manager-api': 8.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/preview-api': 8.1.9
+      '@storybook/theming': 8.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/types': 8.1.9
+      '@types/lodash': 4.17.5
+      color-convert: 2.0.1
+      dequal: 2.0.3
+      lodash: 4.17.21
+      markdown-to-jsx: 7.3.2(react@18.3.1)
+      memoizerific: 1.11.3
+      polished: 4.3.1
+      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      telejson: 7.2.0
+      tocbot: 4.28.2
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - encoding
+      - prettier
+      - supports-color
+
   '@storybook/builder-manager@8.1.9(encoding@0.1.13)(prettier@3.3.2)':
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
       '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.2)
+      '@storybook/manager': 8.1.9
+      '@storybook/node-logger': 8.1.9
+      '@types/ejs': 3.1.5
+      '@yarnpkg/esbuild-plugin-pnp': 3.0.0-rc.15(esbuild@0.20.2)
+      browser-assert: 1.2.1
+      ejs: 3.1.10
+      esbuild: 0.20.2
+      esbuild-plugin-alias: 0.2.1
+      express: 4.19.2
+      fs-extra: 11.2.0
+      process: 0.11.10
+      util: 0.12.5
+    transitivePeerDependencies:
+      - encoding
+      - prettier
+      - supports-color
+
+  '@storybook/builder-manager@8.1.9(encoding@0.1.13)(prettier@3.3.3)':
+    dependencies:
+      '@fal-works/esbuild-plugin-global-externals': 2.1.2
+      '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
       '@storybook/manager': 8.1.9
       '@storybook/node-logger': 8.1.9
       '@types/ejs': 3.1.5
@@ -22440,6 +22636,33 @@ snapshots:
       '@storybook/channels': 8.1.9
       '@storybook/client-logger': 8.1.9
       '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.2)
+      '@storybook/core-events': 8.1.9
+      '@storybook/csf-plugin': 8.1.9
+      '@storybook/node-logger': 8.1.9
+      '@storybook/preview': 8.1.9
+      '@storybook/preview-api': 8.1.9
+      '@storybook/types': 8.1.9
+      '@types/find-cache-dir': 3.2.1
+      browser-assert: 1.2.1
+      es-module-lexer: 1.5.3
+      express: 4.19.2
+      find-cache-dir: 3.3.2
+      fs-extra: 11.2.0
+      magic-string: 0.30.10
+      ts-dedent: 2.2.0
+      vite: 5.3.3(@types/node@20.14.10)(terser@5.31.2)
+    optionalDependencies:
+      typescript: 5.5.2
+    transitivePeerDependencies:
+      - encoding
+      - prettier
+      - supports-color
+
+  '@storybook/builder-vite@8.1.9(encoding@0.1.13)(prettier@3.3.3)(typescript@5.5.2)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))':
+    dependencies:
+      '@storybook/channels': 8.1.9
+      '@storybook/client-logger': 8.1.9
+      '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
       '@storybook/core-events': 8.1.9
       '@storybook/csf-plugin': 8.1.9
       '@storybook/node-logger': 8.1.9
@@ -22673,7 +22896,7 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier-fallback: prettier@3.3.2
+      prettier-fallback: prettier@3.3.3
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.6.2
@@ -22683,6 +22906,43 @@ snapshots:
       util: 0.12.5
     optionalDependencies:
       prettier: 3.3.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@storybook/core-common@8.1.9(encoding@0.1.13)(prettier@3.3.3)':
+    dependencies:
+      '@storybook/core-events': 8.1.9
+      '@storybook/csf-tools': 8.1.9
+      '@storybook/node-logger': 8.1.9
+      '@storybook/types': 8.1.9
+      '@yarnpkg/fslib': 2.10.3
+      '@yarnpkg/libzip': 2.3.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      esbuild: 0.20.2
+      esbuild-register: 3.5.0(esbuild@0.20.2)
+      execa: 5.1.1
+      file-system-cache: 2.3.0
+      find-cache-dir: 3.3.2
+      find-up: 5.0.0
+      fs-extra: 11.2.0
+      glob: 10.4.1
+      handlebars: 4.7.8
+      lazy-universal-dotenv: 4.0.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+      picomatch: 2.3.1
+      pkg-dir: 5.0.0
+      prettier-fallback: prettier@3.3.3
+      pretty-hrtime: 1.0.3
+      resolve-from: 5.0.0
+      semver: 7.6.2
+      tempy: 3.1.0
+      tiny-invariant: 1.3.3
+      ts-dedent: 2.2.0
+      util: 0.12.5
+    optionalDependencies:
+      prettier: 3.3.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -22756,6 +23016,62 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@storybook/core-server@8.1.9(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@aw-web-design/x-default-browser': 1.4.126
+      '@babel/core': 7.24.8
+      '@babel/parser': 7.24.8
+      '@discoveryjs/json-ext': 0.5.7
+      '@storybook/builder-manager': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
+      '@storybook/channels': 8.1.9
+      '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
+      '@storybook/core-events': 8.1.9
+      '@storybook/csf': 0.1.8
+      '@storybook/csf-tools': 8.1.9
+      '@storybook/docs-mdx': 3.1.0-next.0
+      '@storybook/global': 5.0.0
+      '@storybook/manager': 8.1.9
+      '@storybook/manager-api': 8.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/node-logger': 8.1.9
+      '@storybook/preview-api': 8.1.9
+      '@storybook/telemetry': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
+      '@storybook/types': 8.1.9
+      '@types/detect-port': 1.3.5
+      '@types/diff': 5.2.1
+      '@types/node': 18.19.39
+      '@types/pretty-hrtime': 1.0.3
+      '@types/semver': 7.5.8
+      better-opn: 3.0.2
+      chalk: 4.1.2
+      cli-table3: 0.6.5
+      compression: 1.7.4
+      detect-port: 1.6.1
+      diff: 5.2.0
+      express: 4.19.2
+      fs-extra: 11.2.0
+      globby: 14.0.2
+      lodash: 4.17.21
+      open: 8.4.2
+      pretty-hrtime: 1.0.3
+      prompts: 2.4.2
+      read-pkg-up: 7.0.1
+      semver: 7.6.2
+      telejson: 7.2.0
+      tiny-invariant: 1.3.3
+      ts-dedent: 2.2.0
+      util: 0.12.5
+      util-deprecate: 1.0.2
+      watchpack: 2.4.1
+      ws: 8.17.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - prettier
+      - react
+      - react-dom
+      - supports-color
+      - utf-8-validate
+
   '@storybook/csf-plugin@8.1.9':
     dependencies:
       '@storybook/csf-tools': 8.1.9
@@ -22790,6 +23106,21 @@ snapshots:
   '@storybook/docs-tools@8.1.9(encoding@0.1.13)(prettier@3.3.2)':
     dependencies:
       '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.2)
+      '@storybook/core-events': 8.1.9
+      '@storybook/preview-api': 8.1.9
+      '@storybook/types': 8.1.9
+      '@types/doctrine': 0.0.3
+      assert: 2.1.0
+      doctrine: 3.0.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - encoding
+      - prettier
+      - supports-color
+
+  '@storybook/docs-tools@8.1.9(encoding@0.1.13)(prettier@3.3.3)':
+    dependencies:
+      '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
       '@storybook/core-events': 8.1.9
       '@storybook/preview-api': 8.1.9
       '@storybook/types': 8.1.9
@@ -22932,6 +23263,21 @@ snapshots:
       - prettier
       - supports-color
 
+  '@storybook/telemetry@8.1.9(encoding@0.1.13)(prettier@3.3.3)':
+    dependencies:
+      '@storybook/client-logger': 8.1.9
+      '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
+      '@storybook/csf-tools': 8.1.9
+      chalk: 4.1.2
+      detect-package-manager: 2.0.1
+      fetch-retry: 5.0.6
+      fs-extra: 11.2.0
+      read-pkg-up: 7.0.1
+    transitivePeerDependencies:
+      - encoding
+      - prettier
+      - supports-color
+
   '@storybook/test@8.1.9(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)))(vitest@1.6.0(@types/node@20.14.10)(jsdom@22.1.0)(terser@5.31.2))':
     dependencies:
       '@storybook/client-logger': 8.1.9
@@ -23048,9 +23394,50 @@ snapshots:
       - vite-plugin-glimmerx
       - vue
 
+  '@storybook/vue3-vite@8.1.9(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))(vue@3.4.31(typescript@5.5.2))':
+    dependencies:
+      '@storybook/builder-vite': 8.1.9(encoding@0.1.13)(prettier@3.3.3)(typescript@5.5.2)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))
+      '@storybook/core-server': 8.1.9(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/types': 8.1.9
+      '@storybook/vue3': 8.1.9(encoding@0.1.13)(prettier@3.3.3)(vue@3.4.31(typescript@5.5.2))
+      find-package-json: 1.2.0
+      magic-string: 0.30.10
+      typescript: 5.5.2
+      vite: 5.3.3(@types/node@20.14.10)(terser@5.31.2)
+      vue-component-meta: 2.0.21(typescript@5.5.2)
+      vue-docgen-api: 4.78.0(vue@3.4.31(typescript@5.5.2))
+    transitivePeerDependencies:
+      - '@preact/preset-vite'
+      - bufferutil
+      - encoding
+      - prettier
+      - react
+      - react-dom
+      - supports-color
+      - utf-8-validate
+      - vite-plugin-glimmerx
+      - vue
+
   '@storybook/vue3@8.1.9(encoding@0.1.13)(prettier@3.3.2)(vue@3.4.31(typescript@5.5.2))':
     dependencies:
       '@storybook/docs-tools': 8.1.9(encoding@0.1.13)(prettier@3.3.2)
+      '@storybook/global': 5.0.0
+      '@storybook/preview-api': 8.1.9
+      '@storybook/types': 8.1.9
+      '@vue/compiler-core': 3.4.29
+      lodash: 4.17.21
+      ts-dedent: 2.2.0
+      type-fest: 2.19.0
+      vue: 3.4.31(typescript@5.5.2)
+      vue-component-type-helpers: 2.0.29
+    transitivePeerDependencies:
+      - encoding
+      - prettier
+      - supports-color
+
+  '@storybook/vue3@8.1.9(encoding@0.1.13)(prettier@3.3.3)(vue@3.4.31(typescript@5.5.2))':
+    dependencies:
+      '@storybook/docs-tools': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 8.1.9
       '@storybook/types': 8.1.9
@@ -23290,9 +23677,16 @@ snapshots:
 
   '@tanstack/virtual-core@3.5.1': {}
 
+  '@tanstack/virtual-core@3.8.4': {}
+
   '@tanstack/vue-virtual@3.5.1(vue@3.4.31(typescript@5.5.2))':
     dependencies:
       '@tanstack/virtual-core': 3.5.1
+      vue: 3.4.31(typescript@5.5.2)
+
+  '@tanstack/vue-virtual@3.8.5(vue@3.4.31(typescript@5.5.2))':
+    dependencies:
+      '@tanstack/virtual-core': 3.8.4
       vue: 3.4.31(typescript@5.5.2)
 
   '@testing-library/dom@9.3.4':
@@ -24388,12 +24782,12 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/eslint-config-prettier@9.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.3.2)':
+  '@vue/eslint-config-prettier@9.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.3.3)':
     dependencies:
       eslint: 8.57.0
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
-      eslint-plugin-prettier: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.2)
-      prettier: 3.3.2
+      eslint-plugin-prettier: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3)
+      prettier: 3.3.3
     transitivePeerDependencies:
       - '@types/eslint'
 
@@ -25355,7 +25749,7 @@ snapshots:
 
   builtins@5.1.0:
     dependencies:
-      semver: 7.6.2
+      semver: 7.6.3
 
   bundle-name@3.0.0:
     dependencies:
@@ -27054,7 +27448,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
-      semver: 7.6.2
+      semver: 7.6.3
 
   eslint-config-flat-gitignore@0.1.7:
     dependencies:
@@ -27144,7 +27538,7 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
-      is-core-module: 2.14.0
+      is-core-module: 2.15.0
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.fromentries: 2.0.8
@@ -27197,19 +27591,29 @@ snapshots:
       builtins: 5.1.0
       eslint: 8.57.0
       eslint-plugin-es-x: 7.8.0(eslint@8.57.0)
-      get-tsconfig: 4.7.5
+      get-tsconfig: 4.7.6
       globals: 13.24.0
       ignore: 5.3.1
       is-builtin-module: 3.2.1
-      is-core-module: 2.14.0
+      is-core-module: 2.15.0
       minimatch: 3.1.2
       resolve: 1.22.8
-      semver: 7.6.2
+      semver: 7.6.3
 
   eslint-plugin-prettier@5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.2):
     dependencies:
       eslint: 8.57.0
       prettier: 3.3.2
+      prettier-linter-helpers: 1.0.0
+      synckit: 0.8.8
+    optionalDependencies:
+      '@types/eslint': 8.56.10
+      eslint-config-prettier: 9.1.0(eslint@8.57.0)
+
+  eslint-plugin-prettier@5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3):
+    dependencies:
+      eslint: 8.57.0
+      prettier: 3.3.3
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.8
     optionalDependencies:
@@ -28102,6 +28506,10 @@ snapshots:
       get-intrinsic: 1.2.4
 
   get-tsconfig@4.7.5:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-tsconfig@4.7.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -29119,6 +29527,10 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  is-core-module@2.15.0:
+    dependencies:
+      hasown: 2.0.2
+
   is-data-view@1.0.1:
     dependencies:
       is-typed-array: 1.1.13
@@ -29573,7 +29985,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -29604,7 +30016,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -30397,7 +30809,7 @@ snapshots:
       mlly: 1.7.1
       regexp-tree: 0.1.27
       type-level-regexp: 0.1.17
-      ufo: 1.5.3
+      ufo: 1.5.4
       unplugin: 1.11.0
 
   magic-string-ast@0.6.2:
@@ -31178,7 +31590,7 @@ snapshots:
       acorn: 8.12.1
       pathe: 1.1.2
       pkg-types: 1.1.1
-      ufo: 1.5.3
+      ufo: 1.5.4
 
   mnemonist@0.39.6:
     dependencies:
@@ -31624,7 +32036,7 @@ snapshots:
       consola: 3.2.3
       execa: 8.0.1
       pathe: 1.1.2
-      ufo: 1.5.3
+      ufo: 1.5.4
 
   nypm@0.3.9:
     dependencies:
@@ -31633,7 +32045,7 @@ snapshots:
       execa: 8.0.1
       pathe: 1.1.2
       pkg-types: 1.1.3
-      ufo: 1.5.3
+      ufo: 1.5.4
 
   object-assign@4.1.1: {}
 
@@ -32264,7 +32676,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
 
   postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.39):
     dependencies:
@@ -32630,6 +33042,8 @@ snapshots:
 
   prettier@3.3.2: {}
 
+  prettier@3.3.3: {}
+
   pretty-bytes@5.6.0: {}
 
   pretty-bytes@6.1.1: {}
@@ -32890,13 +33304,13 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  radix-vue@1.8.4(vue@3.4.31(typescript@5.5.2)):
+  radix-vue@1.9.3(vue@3.4.31(typescript@5.5.2)):
     dependencies:
-      '@floating-ui/dom': 1.6.5
-      '@floating-ui/vue': 1.0.6(vue@3.4.31(typescript@5.5.2))
+      '@floating-ui/dom': 1.6.10
+      '@floating-ui/vue': 1.1.4(vue@3.4.31(typescript@5.5.2))
       '@internationalized/date': 3.5.4
       '@internationalized/number': 3.5.3
-      '@tanstack/vue-virtual': 3.5.1(vue@3.4.31(typescript@5.5.2))
+      '@tanstack/vue-virtual': 3.8.5(vue@3.4.31(typescript@5.5.2))
       '@vueuse/core': 10.11.0(vue@3.4.31(typescript@5.5.2))
       '@vueuse/shared': 10.11.0(vue@3.4.31(typescript@5.5.2))
       aria-hidden: 1.2.4
@@ -33839,6 +34253,8 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.6.2: {}
+
+  semver@7.6.3: {}
 
   send@0.18.0:
     dependencies:
@@ -34931,7 +35347,7 @@ snapshots:
       '@swc/core': 1.5.29(@swc/helpers@0.5.5)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2):
+  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -35140,6 +35556,8 @@ snapshots:
 
   ufo@1.5.3: {}
 
+  ufo@1.5.4: {}
+
   uglify-js@3.18.0: {}
 
   uid@2.0.2:
@@ -35212,7 +35630,7 @@ snapshots:
       mime: 3.0.0
       node-fetch-native: 1.6.4
       pathe: 1.1.2
-      ufo: 1.5.3
+      ufo: 1.5.4
 
   unenv@1.9.0:
     dependencies:
@@ -36012,6 +36430,10 @@ snapshots:
   vue-component-type-helpers@2.0.21: {}
 
   vue-component-type-helpers@2.0.29: {}
+
+  vue-demi@0.14.10(vue@3.4.31(typescript@5.5.2)):
+    dependencies:
+      vue: 3.4.31(typescript@5.5.2)
 
   vue-demi@0.14.8(vue@3.4.31(typescript@5.5.2)):
     dependencies:


### PR DESCRIPTION
this pr adds a new scalar context menu component and uses it:
- for the request sidebar item actions (rename, delete...)
- for the workspace actions (rename, delete)

this fixes #2702  as workspace can be removed unless it is the only existing one, in that case the button is disabled and a tooltip is displayed.

https://github.com/user-attachments/assets/8138d920-6452-4ef2-801a-d26de57c8380