### PR TITLE
chore: extend the list of codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,7 +22,7 @@
 /packages/hono-api-reference @hanspagel
 # /packages/object-utils
 # /packages/use-codemirror
-# /packages/build-tooling
+/packages/build-tooling @geoffgscott
 # /packages/draggable
 /packages/mock-server @hanspagel
 /packages/play-button @marclave

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,48 @@
+# Default code owner (overwritten by more specific entries)
 * @marclave
+
+# Root level code owners
+/.github @hanspagel
+/*.md @hanspagel
+/.* @hanspagel
+
+# Documentation
+/documentation/* @hanspagel
+
+# Packages
+/packages/api-client @amritk
+/packages/api-reference-editor @geoffgscott
+# /packages/components
+/packages/galaxy @hanspagel
+# /packages/oas-utils
+# /packages/themes
+/packages/api-client-app @hanspagel
+/packages/api-reference-react @amritk
+/packages/docusaurus @amritk
+/packages/hono-api-reference @hanspagel
+# /packages/object-utils
+# /packages/use-codemirror
+# /packages/build-tooling
+# /packages/draggable
+/packages/mock-server @hanspagel
+/packages/play-button @marclave
+# /packages/use-modal
+/packages/build-watch @geoffgscott
+/packages/nestjs-api-reference @marclave
+/packages/scalar.aspnetcore @marclave
+# /packages/use-toasts
+/packages/api-client-react @amritk
+/packages/cli @hanspagel
+/packages/express-api-reference @hanspagel
+/packages/nextjs-api-reference @amritk
+/packages/scalar_django_ninja @marclave
+# /packages/use-tooltip
+/packages/api-reference @hanspagel
+/packages/code-highlight @geoffgscott
+/packages/fastify-api-reference @hanspagel
+/packages/nuxt @amritk
+/packages/scalar_fastapi @marclave
+/packages/void-server @hanspagel
+
+# Testing
+/playwright @tmastrom


### PR DESCRIPTION
Currently, @marclave has to review all the PRs. But that might not scale too well. :)

This PR suggests to extend the list of code owners and just falls back for to @marclave for everything else.

Feedback highly appreciated! Feel free to comment if you feel (not) responsible for a specific part.