### PR TITLE
fix(themes): sets a default for scalar brightness filters

### DIFF
--- a/.changeset/flat-books-leave.md
+++ b/.changeset/flat-books-leave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix(themes): sets a default for scalar brightness filters

--- a/packages/themes/src/variables.css
+++ b/packages/themes/src/variables.css
@@ -62,6 +62,9 @@
   --scalar-shadow-2: rgba(15, 15, 15, 0.2) 0px 3px 6px,
     rgba(15, 15, 15, 0.4) 0px 9px 24px, 0 0 0 1px rgba(255, 255, 255, 0.1);
 
+  --scalar-lifted-brightness: 1.45;
+  --scalar-backdrop-brightness: 0.5;
+
   --scalar-sidebar-indent-border: transparent;
   --scalar-sidebar-indent-border-hover: transparent;
   --scalar-sidebar-indent-border-active: transparent;
@@ -77,6 +80,9 @@
   --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
   --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
     rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 0.5px;
+
+  --scalar-lifted-brightness: 1;
+  --scalar-backdrop-brightness: 1;
 
   --scalar-sidebar-indent-border: transparent;
   --scalar-sidebar-indent-border-hover: transparent;


### PR DESCRIPTION
## Before

<img width="1486" alt="Google Chrome-2024-08-06-17-58-01@2x" src="https://github.com/user-attachments/assets/a4fbddf7-1306-4882-80bb-e0752e227fe3">

## After

<img width="1486" alt="Google Chrome-2024-08-06-17-57-14@2x" src="https://github.com/user-attachments/assets/034ba923-5360-4bf3-b009-f7f6cd9915e9">
