### PR TITLE
fix(api-client): search modal data population

### DIFF
--- a/.changeset/slow-terms-hunt.md
+++ b/.changeset/slow-terms-hunt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: search modal data population


### PR DESCRIPTION
this pr as an attempts to fix the data not being retrieved when using the search modal in the client within an api reference and might fixes #2703. when opening the search the first time, data are displayed, but once it gets closed/re-opened, no results is displayed:

**before**
<img width="1467" alt="image" src="https://github.com/user-attachments/assets/ce1d6c8f-852a-4610-bdd7-4f5d63f38dfa">

**after**
<img width="1467" alt="image" src="https://github.com/user-attachments/assets/6ec8c927-0a7d-4027-b3d9-e6fdfc7bd826">
