### PR TITLE
feat(api-client): group cookies

### DIFF
--- a/.changeset/twelve-pugs-doubt.md
+++ b/.changeset/twelve-pugs-doubt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: group cookie by domain and path

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -33,7 +33,7 @@ const handleDelete = (id: string) => {
 <template>
   <li>
     <router-link
-      class="text-c-2 hover:bg-b-2 group relative block flex items-center gap-1 rounded py-1 pr-2 font-medium no-underline"
+      class="h-8 text-c-2 hover:bg-b-2 group relative block flex items-center gap-1 rounded py-1 pr-2 font-medium no-underline"
       :class="[variable.color ? 'pl-1' : 'pl-2']"
       exactActiveClass="active-link"
       :to="`${variable.uid}`"
@@ -61,5 +61,8 @@ const handleDelete = (id: string) => {
 .empty-variable-name:empty:before {
   content: 'No Name';
   color: var(--scalar-color-3);
+}
+.cookie > a {
+  @apply pl-10;
 }
 </style>

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -31,7 +31,6 @@ const updateCookie = (key: any, value: any) => {
     :options="options">
     <template #title>
       <div class="flex items-center pointer-events-none">
-        <span>Cookie</span>
         <label
           class="absolute w-full h-full top-0 left-0 pointer-events-auto opacity-0 cursor-text"
           for="cookiename"></label>

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -6,26 +6,32 @@ import SidebarListElement from '@/components/Sidebar/SidebarListElement.vue'
 import SubpageHeader from '@/components/SubpageHeader.vue'
 import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
 import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
+import { useSidebar } from '@/hooks'
 import { useWorkspace } from '@/store/workspace'
+import { ScalarIcon } from '@scalar/components'
 import {
   type Cookie,
   createCookie,
 } from '@scalar/oas-utils/entities/workspace/cookie'
 import { nanoid } from 'nanoid'
+import { computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 
 import CookieForm from './CookieForm.vue'
 import CookieRaw from './CookieRaw.vue'
 
 const { cookies, cookieMutators } = useWorkspace()
+const { collapsedSidebarFolders, toggleSidebarFolder } = useSidebar()
 const router = useRouter()
 
 const addCookieHandler = () => {
+  const cookieIndex = Object.keys(cookies).length
+
   const cookie = createCookie({
     uid: nanoid(),
-    name: 'Cookie',
+    name: `Cookie ${cookieIndex}`,
     value: '',
-    domain: '',
+    domain: 'example.com',
     path: '/',
     secure: false,
     httpOnly: false,
@@ -51,6 +57,40 @@ const removeCookie = (uid: string) => {
     router.push('default')
   }
 }
+
+const groupedCookies = computed(() => {
+  const groups: Record<string, Record<string, Cookie[]>> = {}
+  Object.values(cookies).forEach((cookie) => {
+    if (cookie.domain && cookie.path) {
+      if (!groups[cookie.domain]) {
+        groups[cookie.domain] = {}
+      }
+      if (!groups[cookie.domain][cookie.path]) {
+        groups[cookie.domain][cookie.path] = []
+      }
+      groups[cookie.domain][cookie.path].push(cookie)
+    }
+  })
+  return groups
+})
+
+const showChildren = (key: string) => {
+  return collapsedSidebarFolders[key]
+}
+
+/** Initialize collapsedSidebarFolders to be open by default */
+onMounted(() => {
+  const domains = Object.keys(groupedCookies.value)
+  const allPaths = Object.entries(groupedCookies.value).flatMap(
+    ([domain, paths]) => Object.keys(paths).map((path) => domain + path),
+  )
+  domains.forEach((domain) => {
+    collapsedSidebarFolders[domain] = true
+  })
+  allPaths.forEach((path) => {
+    collapsedSidebarFolders[path] = true
+  })
+})
 </script>
 <template>
   <SubpageHeader>
@@ -59,12 +99,56 @@ const removeCookie = (uid: string) => {
         <template #content>
           <div class="flex-1">
             <SidebarList>
-              <SidebarListElement
-                v-for="cookie in cookies"
-                :key="cookie.uid"
-                class="text-xs"
-                :variable="{ name: cookie.name, uid: cookie.uid }"
-                @delete="removeCookie(cookie.uid)" />
+              <div
+                v-for="(paths, domain) in groupedCookies"
+                :key="domain">
+                <button
+                  class="flex font-medium gap-1.5 items-center px-2 py-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
+                  type="button"
+                  @click="toggleSidebarFolder(domain)">
+                  <ScalarIcon
+                    class="text-c-3"
+                    :class="{
+                      'rotate-90': collapsedSidebarFolders[domain],
+                    }"
+                    icon="ChevronRight"
+                    size="sm"
+                    thickness="2.5" />
+                  {{ domain }}
+                </button>
+                <div
+                  v-show="showChildren(domain)"
+                  class="before:bg-b-3 before:absolute before:left-[calc(1rem_-_1.5px)] before:top-0 before:z-10 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                  <div
+                    v-for="(cookieList, path) in paths"
+                    :key="path">
+                    <button
+                      class="flex font-medium gap-1.5 items-center pl-5 pr-2 py-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
+                      type="button"
+                      @click="toggleSidebarFolder(domain + path)">
+                      <ScalarIcon
+                        class="text-c-3"
+                        :class="{
+                          'rotate-90': collapsedSidebarFolders[domain + path],
+                        }"
+                        icon="ChevronRight"
+                        size="sm"
+                        thickness="2.5" />
+                      {{ path }}
+                    </button>
+                    <div
+                      v-show="showChildren(domain + path)"
+                      class="before:bg-b-3 before:absolute before:left-[calc(1.75rem_-_1.5px)] before:top-0 before:z-10 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                      <SidebarListElement
+                        v-for="cookie in cookieList"
+                        :key="cookie.uid"
+                        class="cookie text-xs"
+                        :variable="{ name: cookie.name, uid: cookie.uid }"
+                        @delete="removeCookie(cookie.uid)" />
+                    </div>
+                  </div>
+                </div>
+              </div>
             </SidebarList>
           </div>
         </template>


### PR DESCRIPTION
this pr updates the cookie sidebar list element in order to:
- group cookie per domain
- subgroup cookie per path
- set cookie name placeholder name using index

**before**
<img width="897" alt="image" src="https://github.com/user-attachments/assets/787ae1f1-252f-483f-ac58-3c4153cae01c">

**after**
<img width="897" alt="image" src="https://github.com/user-attachments/assets/0f488930-ea9b-4867-9c26-6cd96016cf2a">
