### PR TITLE
fix(api-reference): improve enum support

### DIFF
--- a/.changeset/funny-rivers-watch.md
+++ b/.changeset/funny-rivers-watch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat(api-reference): improve enum support

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -65,6 +65,14 @@ const generatePropertyDescription = function (property?: Record<string, any>) {
   return descriptions[property.type][property.format || '_default']
 }
 
+const isEnum = function (value?: Record<string, any>): boolean {
+  return !!value?.enum
+}
+
+const isEnumArray = function (value?: Record<string, any>): boolean {
+  return !!value?.items?.enum
+}
+
 const getEnumFromValue = function (value?: Record<string, any>): any[] | [] {
   return value?.enum || value?.items?.enum || []
 }
@@ -83,7 +91,7 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     ]">
     <SchemaPropertyHeading
       :additional="additional"
-      :enum="getEnumFromValue(value).length > 1"
+      :enum="isEnum(value)"
       :required="required"
       :value="value">
       <template
@@ -134,7 +142,12 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
     </template>
     <!-- Enum -->
     <div
-      v-if="getEnumFromValue(value)?.length > 1"
+      v-if="isEnumArray(value)"
+      class="array-values-label">
+      Allowed values:
+    </div>
+    <div
+      v-if="getEnumFromValue(value)?.length >= 1"
       class="property-enum">
       <template v-if="value?.['x-enumDescriptions']">
         <div class="property-list">
@@ -154,7 +167,11 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         </div>
       </template>
       <template v-else>
-        <ul class="property-enum-values">
+        <ul
+          class="property-enum-values"
+          :class="{
+            'property-enum-values-long': getEnumFromValue(value)?.length > 4,
+          }">
           <li
             v-for="enumValue in getEnumFromValue(value)"
             :key="enumValue"
@@ -305,6 +322,14 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
   border-radius: var(--scalar-radius-lg);
 }
 
+.property-enum-values {
+  display: flex;
+  gap: 6px;
+}
+.property-enum-values-long {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+}
 .property-enum-value {
   padding: 3px 0;
   color: var(--scalar-color-2);
@@ -322,6 +347,10 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 .property--compact .property-example {
   display: none;
 }
+.array-values-label {
+  margin-top: 10px;
+}
+
 .property-list {
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   border-radius: var(--scalar-radius);


### PR DESCRIPTION
**Explanation**
Scalar has multiple issues & improvements related to Enum support in query parameters:
https://github.com/scalar/scalar/pull/1212
https://github.com/scalar/scalar/issues/1846
https://github.com/scalar/scalar/issues/2006

Here is a sandbox to check the the current support state. https://sandbox.scalar.com/e/8lwnj


**Solution**
With this PR following improvements was implemented:
- display enum value with a single value enum
- do not display 'enum' if it is an array of enum values
- display up to 5 enum values in a line (display flex) + >5 - (display grid)
- add 'allowed values' for array values if it is enum

Links:
https://github.com/scalar/scalar/discussions/2798
