### PR TITLE
feat(api-client): add loading state and cancellation for slow requests

### DIFF
--- a/.changeset/wise-goats-develop.md
+++ b/.changeset/wise-goats-develop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat(api-client): add loading state and cancellation for slow requests

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -77,7 +77,7 @@ function load() {
 }
 
 function startLoading() {
-  if (isRequesting.value) return
+  if (interval.value) return
   isRequesting.value = true
   interval.value = setInterval(load, 20)
 }
@@ -111,8 +111,13 @@ function getBackgroundColor() {
   return REQUEST_METHODS[method as RequestMethod].backgroundColor
 }
 
+function handleExecuteRequest() {
+  if (isRequesting.value) return
+  isRequesting.value = true
+  executeRequestBus.emit()
+}
+
 const updateExampleUrlHandler = (url: string) => {
-  if (!activeExample.value) return
   requestExampleMutators.edit(activeExample.value.uid, 'url', url)
 }
 
@@ -169,7 +174,7 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
               :modelValue="activeExample.url"
               placeholder="Enter URL to get started"
               server
-              @submit="executeRequestBus.emit()"
+              @submit="handleExecuteRequest"
               @update:modelValue="updateExampleUrlHandler" />
             <div class="fade-right"></div>
           </div>
@@ -178,7 +183,7 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
           <ScalarButton
             class="relative h-auto shrink-0 gap-1 overflow-hidden pl-2 pr-2.5 py-1 z-[1] font-bold"
             :disabled="isRequesting"
-            @click="executeRequestBus.emit()">
+            @click="handleExecuteRequest">
             <ScalarIcon
               class="relative z-10 shrink-0 fill-current"
               icon="Play"

--- a/packages/api-client/src/libs/event-busses/cancel-request-bus.ts
+++ b/packages/api-client/src/libs/event-busses/cancel-request-bus.ts
@@ -1,0 +1,8 @@
+import { type EventBusKey, useEventBus } from '@vueuse/core'
+
+/**
+ * Event bus to execute requests, usually triggered by the send button in the address bar
+ * OR the keyboard shortcut
+ */
+const cancelRequestBusKey: EventBusKey<void> = Symbol()
+export const cancelRequestBus = useEventBus(cancelRequestBusKey)

--- a/packages/api-client/src/libs/event-busses/index.ts
+++ b/packages/api-client/src/libs/event-busses/index.ts
@@ -1,4 +1,5 @@
 export * from './command-palette-bus'
-export * from './execute-request-bus'
 export * from './hot-keys-bus'
+export * from './execute-request-bus'
+export * from './cancel-request-bus'
 export * from './request-status-bus'

--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -14,7 +14,11 @@ import {
   redirectToProxy,
   shouldUseProxy,
 } from '@scalar/oas-utils/helpers'
-import axios, { type AxiosError, type AxiosRequestConfig } from 'axios'
+import axios, {
+  type AxiosError,
+  type AxiosRequestConfig,
+  type GenericAbortSignal,
+} from 'axios'
 import Cookies from 'js-cookie'
 import MIMEType from 'whatwg-mimetype'
 
@@ -55,6 +59,7 @@ export const sendRequest = async (
   securitySchemes?: SecurityScheme[],
   proxyUrl?: string,
   workspaceCookies?: Record<string, Cookie>,
+  abortSignal?: GenericAbortSignal,
 ): Promise<{
   sentTime?: number
   request?: RequestExample
@@ -219,6 +224,7 @@ export const sendRequest = async (
     method: request.method,
     responseType: 'arraybuffer',
     headers,
+    signal: abortSignal,
   }
 
   if (data) config.data = data

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseLoadingOverlay.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseLoadingOverlay.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { requestStatusBus } from '@/libs'
+import { ScalarLoading, useLoadingState } from '@scalar/components'
+import { ref } from 'vue'
+
+const loading = useLoadingState()
+
+const timeout = ref<ReturnType<typeof setTimeout>>()
+
+requestStatusBus.on((status) => {
+  if (status === 'start')
+    timeout.value = setTimeout(() => loading.startLoading(), 1000)
+  else (timeout.value = undefined), loading.stopLoading()
+})
+</script>
+<template>
+  <Transition>
+    <div
+      v-if="loading.isLoading"
+      class="absolute inset-0 bg-b-1 bg-mix-transparent bg-mix-amount-10 z-10 flex items-center justify-center">
+      <ScalarLoading
+        class="text-c-3"
+        :loadingState="loading"
+        size="48px" />
+    </div>
+  </Transition>
+</template>
+<style scoped>
+.v-enter-active {
+  transition: opacity 0.5s ease;
+}
+
+.v-enter-from {
+  opacity: 0;
+}
+</style>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseLoadingOverlay.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseLoadingOverlay.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { requestStatusBus } from '@/libs'
-import { ScalarLoading, useLoadingState } from '@scalar/components'
+import { cancelRequestBus, requestStatusBus } from '@/libs'
+import {
+  ScalarButton,
+  ScalarLoading,
+  useLoadingState,
+} from '@scalar/components'
 import { ref } from 'vue'
 
 const loading = useLoadingState()
@@ -10,18 +14,26 @@ const timeout = ref<ReturnType<typeof setTimeout>>()
 requestStatusBus.on((status) => {
   if (status === 'start')
     timeout.value = setTimeout(() => loading.startLoading(), 1000)
-  else (timeout.value = undefined), loading.stopLoading()
+  else
+    clearTimeout(timeout.value),
+      (timeout.value = undefined),
+      loading.stopLoading()
 })
 </script>
 <template>
   <Transition>
     <div
       v-if="loading.isLoading"
-      class="absolute inset-0 bg-b-1 bg-mix-transparent bg-mix-amount-10 z-10 flex items-center justify-center">
+      class="absolute inset-0 bg-b-1 bg-mix-transparent bg-mix-amount-10 z-10 flex flex-col gap-6 items-center justify-center">
       <ScalarLoading
         class="text-c-3"
         :loadingState="loading"
-        size="48px" />
+        size="3xl" />
+      <ScalarButton
+        variant="ghost"
+        @click="cancelRequestBus.emit()">
+        Cancel
+      </ScalarButton>
     </div>
   </Transition>
 </template>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseLoadingOverlay.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseLoadingOverlay.vue
@@ -24,7 +24,7 @@ requestStatusBus.on((status) => {
   <Transition>
     <div
       v-if="loading.isLoading"
-      class="absolute inset-0 bg-b-1 bg-mix-transparent bg-mix-amount-10 z-10 flex flex-col gap-6 items-center justify-center">
+      class="absolute inset-0 bg-b-1 z-10 flex flex-col gap-6 items-center justify-center">
       <ScalarLoading
         class="text-c-3"
         :loadingState="loading"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseMetaInformation.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseMetaInformation.vue
@@ -1,17 +1,32 @@
 <script lang="ts" setup>
 import HelpfulLink from '@/components/HelpfulLink.vue'
+import { requestStatusBus } from '@/libs'
 import type { ResponseInstance } from '@scalar/oas-utils/entities/workspace/spec'
 import { type HttpStatusCode, httpStatusCodes } from '@scalar/oas-utils/helpers'
 import prettyBytes from 'pretty-bytes'
 import prettyMilliseconds from 'pretty-ms'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 const props = defineProps<{ response: ResponseInstance }>()
+
+const interval = ref<ReturnType<typeof setInterval>>()
+const stopwatch = ref(0)
+
+requestStatusBus.on((status) => {
+  if (status === 'start')
+    interval.value = setInterval(() => (stopwatch.value += 1000), 1000)
+  else
+    clearInterval(interval.value),
+      (interval.value = undefined),
+      (stopwatch.value = 0)
+})
 
 /** Size of the response */
 const getContentLength = (response: ResponseInstance) => {
   const contentLength = parseInt(
-    response.headers?.['content-length'] || '0',
+    response.headers?.['Content-Length'] ||
+      response.headers?.['content-length'] ||
+      '0',
     10,
   )
 
@@ -31,19 +46,24 @@ const statusCodeInformation = computed((): HttpStatusCode | undefined => {
 </script>
 <template>
   <div class="flex gap-1.5 text-c-3 pl-1">
-    <span>{{ prettyMilliseconds(response.duration) }}</span>
-    <span v-if="getContentLength(response)">{{
-      getContentLength(response)
+    <span v-if="interval && stopwatch">{{
+      prettyMilliseconds(stopwatch)
     }}</span>
-    <template v-if="statusCodeInformation">
-      <HelpfulLink
-        v-if="statusCodeInformation.url"
-        :href="statusCodeInformation.url">
-        {{ response.status }} {{ statusCodeInformation.name }}
-      </HelpfulLink>
-      <span v-else>
-        {{ response.status }} {{ statusCodeInformation.name }}
-      </span>
+    <template v-else>
+      <span>{{ prettyMilliseconds(response.duration) }}</span>
+      <span v-if="getContentLength(response)">{{
+        getContentLength(response)
+      }}</span>
+      <template v-if="statusCodeInformation">
+        <HelpfulLink
+          v-if="statusCodeInformation.url"
+          :href="statusCodeInformation.url">
+          {{ response.status }} {{ statusCodeInformation.name }}
+        </HelpfulLink>
+        <span v-else>
+          {{ response.status }} {{ statusCodeInformation.name }}
+        </span>
+      </template>
     </template>
   </div>
 </template>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -3,6 +3,7 @@ import ContextBar from '@/components/ContextBar.vue'
 import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
 import ResponseBody from '@/views/Request/ResponseSection/ResponseBody.vue'
 import ResponseEmpty from '@/views/Request/ResponseSection/ResponseEmpty.vue'
+import ResponseLoadingOverlay from '@/views/Request/ResponseSection/ResponseLoadingOverlay.vue'
 import ResponseMetaInformation from '@/views/Request/ResponseSection/ResponseMetaInformation.vue'
 import { ScalarIcon } from '@scalar/components'
 import type { ResponseInstance } from '@scalar/oas-utils/entities/workspace/spec'
@@ -70,7 +71,8 @@ const activeSection = ref<ActiveSections>('All')
           :response="response" />
       </div>
     </template>
-    <div class="custom-scroll flex flex-1 flex-col px-2 xl:px-6 py-2.5">
+    <div
+      class="custom-scroll relative flex flex-1 flex-col px-2 xl:px-6 py-2.5">
       <template v-if="!response">
         <ResponseEmpty />
       </template>
@@ -92,6 +94,7 @@ const activeSection = ref<ActiveSections>('All')
           :headers="responseHeaders"
           title="Body" />
       </template>
+      <ResponseLoadingOverlay />
     </div>
   </ViewLayoutSection>
 </template>


### PR DESCRIPTION
Adds a loading state for slow requests (appears when the request takes more than 1 second) and a cancel button.

Also fixed a bug where you can click the request button multiple times.

https://github.com/user-attachments/assets/efa3b2f5-2100-4b66-a721-e84ddbd5c866

