### PR TITLE
style(components): outline user icon

### DIFF
--- a/.changeset/three-eggs-shout.md
+++ b/.changeset/three-eggs-shout.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+style(components): outline user icon

--- a/packages/components/src/components/ScalarIcon/icons/User.svg
+++ b/packages/components/src/components/ScalarIcon/icons/User.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-    <path d="M6.5 6.25a5.5 5.5 0 1 0 11 0 5.5 5.5 0 1 0-11 0"></path>
-    <path d="M12 13.25a9.51 9.51 0 0 0-9.5 9.5.5.5 0 0 0 .5.5h18a.5.5 0 0 0 .5-.5 9.51 9.51 0 0 0-9.5-9.5Z"></path>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"
+    stroke-linejoin="round">
+    <path d="M3.5 22.2c.3-4.5 4-8 8.5-8s8.2 3.5 8.5 8h-17z" />
+    <circle cx="12" cy="6.2" r="4.5" />
 </svg>


### PR DESCRIPTION
Outlines the user icon to better match our other icons. As far as I can tell the Dashboard is the only place using this icon at the moment.

Similar to the Play icon we can add the fill back if we want to use it as a filled icon somewhere.

## Before / After

<img width="221" alt="Google Chrome-2024-08-07-17-52-20@2x" src="https://github.com/user-attachments/assets/8a18bddb-4299-4614-82b6-f064466b168d">
<br />
<img width="221" alt="Google Chrome-2024-08-07-17-51-47@2x" src="https://github.com/user-attachments/assets/613c4abe-6eca-4ce0-9451-0db0ceb4d3e4">
