### PR TITLE
chore: remove rule for all dot files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,6 @@
 # Root level code owners
 /.github @hanspagel
 /*.md @hanspagel
-/.* @hanspagel
 
 # Documentation
 /documentation/* @hanspagel


### PR DESCRIPTION
There are a few PRs where I’m added as the codeowner, but I don’t know exactly why.

One example with changes to the client:
https://github.com/scalar/scalar/pull/2690

Let’s just remove this one line from the codeowners file. It was meant to match all dotfiles in the root directory, but I think it also matches the changeset folder.