### PR TITLE
chore: add app output to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,4 @@ fixtures
 
 examples/docusaurus/**/*.mdx
 packages/nuxt/src/runtime/plugins/hydrateClient.d.mts
+packages/api-client-app/out


### PR DESCRIPTION
I just noticed we’re formatting the `out/` directory of the app, which has generated files only. Let’s ignore this. 😊 