### PR TITLE
fix(api-client-app): check whether the renderer is executed in the Electron context

### DIFF
--- a/.changeset/gorgeous-spies-hope.md
+++ b/.changeset/gorgeous-spies-hope.md
@@ -1,0 +1,5 @@
+---
+'scalar-api-client': patch
+---
+
+fix: check whether Fathom has access to the Electron context

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -16,24 +16,23 @@ const client = await createApiClientApp(
  * Fathom Analytics offers simple & privacy-first tracking
  * @see https://usefathom.com/
  */
-load('EUNBEXQC', {
-  // Skips automatically tracking page views
-  auto: false,
-})
+load('EUNBEXQC')
 
 // Track the launch event
-const { platform } = window.electron.process
+if (window.electron) {
+  const { platform } = window.electron.process
 
-const os =
-  platform === 'darwin'
-    ? 'mac'
-    : platform === 'win32'
-      ? 'windows'
-      : platform === 'linux'
-        ? 'linux'
-        : 'unknown'
+  const os =
+    platform === 'darwin'
+      ? 'mac'
+      : platform === 'win32'
+        ? 'windows'
+        : platform === 'linux'
+          ? 'linux'
+          : 'unknown'
 
-trackEvent(`launch: ${os}`)
+  trackEvent(`launch: ${os}`)
+}
 
 // Open… menu
 window.electron.ipcRenderer?.on(

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -16,7 +16,9 @@ const client = await createApiClientApp(
  * Fathom Analytics offers simple & privacy-first tracking
  * @see https://usefathom.com/
  */
-load('EUNBEXQC')
+load('EUNBEXQC', {
+  spa: 'hash',
+})
 
 // Track the launch event
 if (window.electron) {


### PR DESCRIPTION
With this PR, we’re checking whether the Electron context is available before tracking an event in Fathom. This PR also removes the `auto: false` flag to enable the anonymous tracking of page views, and it’s configured to work with the hash router now.