### PR TITLE
feat(api-client): hotkeys modifiers

### DIFF
--- a/.changeset/perfect-scissors-smash.md
+++ b/.changeset/perfect-scissors-smash.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: add topnav and addressbar hotkeys

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -151,6 +151,13 @@ const booleanOptions = computed(() => {
     ? ['true', 'false', 'null']
     : ['true', 'false']
 })
+
+/** Expose focus method */
+defineExpose({
+  focus: () => {
+    codeMirror.value?.focus()
+  },
+})
 </script>
 <script lang="ts">
 // use normal <script> to declare options

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { ROUTES } from '@/constants'
+import { type HotKeyEvents, hotKeyBus } from '@/libs'
 import { useWorkspace } from '@/store'
 import { type Icon, ScalarIcon } from '@scalar/components'
 import { capitalize } from '@scalar/oas-utils/helpers'
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 
 import TopNavItem from './TopNavItem.vue'
 
@@ -80,6 +81,19 @@ function removeNavItem(idx: number) {
 }
 
 const activeNavItemIdxValue = computed(() => activeNavItemIdx.value)
+
+/** Handle hotkeys */
+const handleHotKey = (event: HotKeyEvents) => {
+  if (event.addTopNav) addNavItem()
+  if (event.closeTopNav) removeNavItem(activeNavItemIdx.value)
+  if (event.navigateTopNavLeft)
+    setNavItemIdx(Math.max(activeNavItemIdx.value - 1, 0))
+  if (event.navigateTopNavRight)
+    setNavItemIdx(Math.min(activeNavItemIdx.value + 1, topNavItems.length - 1))
+}
+
+onMounted(() => hotKeyBus.on(handleHotKey))
+onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
 </script>
 <template>
   <nav class="flex h-10 t-app__top-nav">

--- a/packages/api-client/src/libs/event-busses/hot-keys-bus.ts
+++ b/packages/api-client/src/libs/event-busses/hot-keys-bus.ts
@@ -40,6 +40,7 @@ export const DEFAULT_HOTKEYS: HotKeyConfig = {
   w: { event: 'closeTopNav', modifiers: ['default'] },
   ArrowLeft: { event: 'navigateTopNavLeft', modifiers: ['default', 'Alt'] },
   ArrowRight: { event: 'navigateTopNavRight', modifiers: ['default', 'Alt'] },
+  l: { event: 'focusAddressBar', modifiers: ['default'] },
 }
 
 /** Checks if we are in an "input" */

--- a/packages/oas-utils/src/entities/workspace/consts/hot-keys.ts
+++ b/packages/oas-utils/src/entities/workspace/consts/hot-keys.ts
@@ -12,6 +12,7 @@ export const HOTKEY_EVENT_NAMES = [
   'closeTopNav',
   'navigateTopNavLeft',
   'navigateTopNavRight',
+  'focusAddressBar',
 ] as const
 export type HotkeyEventName = (typeof HOTKEY_EVENT_NAMES)[number]
 

--- a/packages/oas-utils/src/entities/workspace/consts/hot-keys.ts
+++ b/packages/oas-utils/src/entities/workspace/consts/hot-keys.ts
@@ -8,6 +8,10 @@ export const HOTKEY_EVENT_NAMES = [
   'commandPaletteUp',
   'openCommandPalette',
   'toggleSidebar',
+  'addTopNav',
+  'closeTopNav',
+  'navigateTopNavLeft',
+  'navigateTopNavRight',
 ] as const
 export type HotkeyEventName = (typeof HOTKEY_EVENT_NAMES)[number]
 

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -8,13 +8,14 @@ const modifier = z
   .enum(['Meta', 'Control', 'Shift', 'Alt', 'default'] as const)
   .optional()
   .default('default')
+const modifiers = z.array(modifier).optional().default(['default'])
 
-export type HotKeyModifier = z.infer<typeof modifier>
+export type HotKeyModifiers = z.infer<typeof modifiers>
 
 const hotKeys = z.record(
   z.enum(KEYDOWN_KEYS),
   z.object({
-    modifier: modifier.optional(),
+    modifiers: modifiers.optional(),
     event: z.enum(HOTKEY_EVENT_NAMES),
   }),
 )
@@ -22,7 +23,7 @@ export type HotKeyConfig = z.infer<typeof hotKeys>
 
 const hotKeyConfigSchema = z
   .object({
-    modifier,
+    modifiers,
     hotKeys: hotKeys.optional(),
   })
   .optional()


### PR DESCRIPTION
this pr is a follow up on #2814 and aims to:
- enable multiple hotkey modifier  usage (e.g. meta + alt + key)
- add topnav hotkeys
- add addressbar focus hotkey