### PR TITLE
ci: omit the build step before the type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
   types:
     runs-on: ubuntu-20.04
-    needs: [define-matrix, build]
+    needs: [define-matrix]
     strategy:
       matrix:
         node-version: ${{ fromJSON(needs.define-matrix.outputs.node-versions) }}
@@ -85,10 +85,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Build
-        uses: ./.github/actions/build
-        with:
-          node-version: ${{ matrix.node-version }}
       - name: Check types
         run: pnpm turbo types:check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
       - name: Check types
         run: pnpm turbo types:check
 


### PR DESCRIPTION
The type check is one of the slower jobs, which isn’t really cached (yet). 

But I’m not sure whether we need a build before we run the type check. 🤔 Let’s try without that, that would be an easy way to run it earlier and speed it up.