### PR TITLE
fix(api-client): sidebar title

### DIFF
--- a/.changeset/shaggy-llamas-wonder.md
+++ b/.changeset/shaggy-llamas-wonder.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sidebar title

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -105,7 +105,7 @@ onMounted(() => {
       v-if="!isReadOnly && title"
       class="xl:min-h-header py-2.5 flex items-center border-b-1/2 px-4 text-sm">
       <h2 class="font-medium m-0 text-sm whitespace-nowrap">
-        <slot name="title" />
+        {{ title }}
       </h2>
     </div>
     <div


### PR DESCRIPTION
this pr brings back the sidebar title removed by mistake in #2459:

**before**
<img width="259" alt="image" src="https://github.com/user-attachments/assets/84fe36aa-56c7-4ae0-920c-cbbf506a7112">

**after**
<img width="262" alt="image" src="https://github.com/user-attachments/assets/e205729c-7b9b-4535-8632-3d1ba08057b7">
