### PR TITLE
fix(oas-utils): request default tag

### DIFF
--- a/.changeset/tiny-students-provide.md
+++ b/.changeset/tiny-students-provide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: remove default tag in request schema

--- a/packages/oas-utils/src/entities/workspace/spec/requests.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/requests.ts
@@ -40,7 +40,7 @@ const requestSchema = z.object({
    * A list of tags for API documentation control. Tags can be used for logical
    * grouping of operations by resources or any other qualifier.
    */
-  tags: z.string().array().default(['default']),
+  tags: z.string().array().optional(),
   /** A short summary of what the operation does. */
   summary: z.string().optional(),
   /** A verbose explanation of the operation behavior. CommonMark syntax MAY be used for rich text representation. */

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -106,7 +106,7 @@ export const importSpecToWorkspace = async (
         parameters,
       })
 
-      request.tags.forEach((t) => requestTags.add(t))
+      request.tags?.forEach((t) => requestTags.add(t))
       requests.push(request)
     })
   })
@@ -135,7 +135,7 @@ export const importSpecToWorkspace = async (
     const folder = createFolder({
       ...t,
       childUids: requests
-        .filter((r) => r.tags.includes(t.name))
+        .filter((r) => r.tags?.includes(t.name))
         .map((r) => r.uid),
     })
 


### PR DESCRIPTION
this pr fixes the `default` tag issue that is now added to every request instead of just request without tag, which was duplicating them in the api client and creating an unneeded `default` collection:

<img width="833" alt="image" src="https://github.com/user-attachments/assets/0910ed82-b728-44f9-918a-3d9b5374164d">
