### PR TITLE
fix(api-reference): hash replacement

### DIFF
--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -75,7 +75,7 @@ const getSectionId = (hashStr = hash.value) => {
 const updateHash = () => {
   hash.value = pathRouting.value
     ? getPathRoutingId(window.location.pathname)
-    : decodeURIComponent(window.location.hash.replace(/^#/, ''))
+    : decodeURIComponent(window.location.hash.replace(/^#\/?/, ''))
 }
 
 /**


### PR DESCRIPTION
this pr fixes hash replacement that is leading to some redirection issue turning `#tag/authentication` into `#/tag/authentication` in some cases.