### PR TITLE
fix(nuxt): add specific optimize dependency for vite

### DIFF
--- a/.changeset/healthy-teachers-burn.md
+++ b/.changeset/healthy-teachers-burn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nuxt': patch
+---
+
+fix(nuxt): do not optimize whole module but only references

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       rollupOptions: {
         plugins: [autoCSSInject('references')],
       },
+      ssr: true,
     },
   }),
   resolve: {

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
       rollupOptions: {
         plugins: [autoCSSInject('references')],
       },
-      ssr: true,
     },
   }),
   resolve: {

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -64,7 +64,7 @@ export default defineNuxtModule<ModuleOptions>({
     _nuxt.options.vite.optimizeDeps ||= {}
     _nuxt.options.vite.optimizeDeps.include ||= []
     _nuxt.options.vite.optimizeDeps.include.push(
-      '@scalar/nuxt',
+      '@scalar/nuxt > @scalar/api-reference',
       '@scalar/nuxt > jsonpointer',
       '@scalar/nuxt > ajv-draft-04',
       '@scalar/nuxt > ajv-formats',


### PR DESCRIPTION
Optimizing the whole module was incorrect as it causes other issues with unicorn. This _should_ only optimize references which should be ok