### PR TITLE
fix: make tag background have more contrast when unopened

### DIFF
--- a/.changeset/selfish-foxes-exercise.md
+++ b/.changeset/selfish-foxes-exercise.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: add more contrasting background to unopened tags

--- a/packages/api-reference/src/components/Content/Tag/Tag.vue
+++ b/packages/api-reference/src/components/Content/Tag/Tag.vue
@@ -74,4 +74,7 @@ const observeAndNavigate = (operationId: string) => {
 .section-container {
   border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
+.section-container:has(.show-more) {
+  background-color: color-mix(in srgb, var(--scalar-background-2), transparent);
+}
 </style>

--- a/packages/api-reference/src/components/Content/Webhooks/Webhooks.vue
+++ b/packages/api-reference/src/components/Content/Webhooks/Webhooks.vue
@@ -60,3 +60,8 @@ const { getWebhookId } = useNavState()
     </template>
   </SectionContainer>
 </template>
+<style scoped>
+.section-container {
+  border-top: var(--scalar-border-width) solid var(--scalar-border-color);
+}
+</style>

--- a/packages/api-reference/src/components/Section/SectionContainer.vue
+++ b/packages/api-reference/src/components/Section/SectionContainer.vue
@@ -9,7 +9,7 @@
   width: 100%;
 }
 .section-container:last-of-type {
-  border-top: 1px solid var(--scalar-border-color);
+  border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 
 @container narrow-references-container (max-width: 900px) {

--- a/packages/api-reference/src/components/ShowMoreButton.vue
+++ b/packages/api-reference/src/components/ShowMoreButton.vue
@@ -37,9 +37,8 @@ const { setCollapsedSidebarItem } = useSidebar()
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-top: -48px;
-  margin-bottom: 48px;
   position: relative;
+  top: -48px;
 }
 .show-more:hover {
   color: var(--scalar-color-2);
@@ -56,14 +55,7 @@ const { setCollapsedSidebarItem } = useSidebar()
 }
 @container narrow-references-container (max-width: 900px) {
   .show-more {
-    margin-top: -25px;
-    margin-bottom: 25px;
-  }
-}
-@media (max-width: 1165px) {
-  .show-more {
-    margin-top: -24px;
-    margin-bottom: 24px;
+    top: -24px;
   }
 }
 </style>


### PR DESCRIPTION
For consideration - make tag background have more contrast when unopened?

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/49344cee-1881-44ef-a53c-35f6d68b8dad">
