### PR TITLE
fix: README.md

### DIFF
--- a/packages/scalar.aspnetcore/README.md
+++ b/packages/scalar.aspnetcore/README.md
@@ -34,7 +34,7 @@ app.MapGet("/", () => "Hello world!");
 app.Run();
 ```
 
-Now you will see the Scalar UI when using the defaults at `https://localhost:XXXXX/scalar/v1` (where XXXXX is, of course, the port for your app). 
+Now you will see the Scalar UI when using the defaults at `https://localhost:XXXXX/scalar/v1` (where XXXXX is, of course, the port for your app).
 
 ## Building & Release
 

--- a/packages/scalar.aspnetcore/README.md
+++ b/packages/scalar.aspnetcore/README.md
@@ -23,10 +23,9 @@ builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
-app.MapOpenApi();
-
 if (app.Environment.IsDevelopment())
 {
+    app.MapOpenApi();
     app.MapScalarApiReference();
 }
 
@@ -34,6 +33,8 @@ app.MapGet("/", () => "Hello world!");
 
 app.Run();
 ```
+
+Now you will see the Scalar UI when using the defaults at `https://localhost:XXXXX/scalar/v1` (where XXXXX is, of course, the port for your app). 
 
 ## Building & Release
 


### PR DESCRIPTION
Updating .NET readme usage snippet

- Updating `app.MapOpenAPi()` to match how .NET 9 default templates use it (behind IsDevelopment guard).
- Updating usage text to indicate the default URL of the usage snippet would be