### PR TITLE
feat: deploy void-server to cloud run

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -282,6 +282,44 @@ steps:
         '--service-account=$_SERVICE_ACCOUNT',
       ]
   # ---------------------------------------------------------------
+  # Void Server
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-void-server'
+    waitFor: ['push-base']
+    args:
+      [
+        'buildx',
+        'build',
+        '--build-arg',
+        'BASE_IMAGE=gcr.io/${_PROJECT_ID}/${_BASE_BUILDER}',
+        '-t',
+        'gcr.io/${_PROJECT_ID}/${_SERVICE_VOID_SERVER}',
+        '-f',
+        './packages/void-server/Dockerfile',
+        '.',
+      ]
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'push-void-server'
+    waitFor: ['build-void-server']
+    args: ['push', 'gcr.io/${_PROJECT_ID}/${_SERVICE_VOID_SERVER}']
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    waitFor: ['push-void-server']
+    args:
+      [
+        'run',
+        'deploy',
+        '$_SERVICE_VOID_SERVER',
+        '--image=gcr.io/${_PROJECT_ID}/${_SERVICE_VOID_SERVER}',
+        '--region=$_REGION',
+        '--platform=managed',
+        '--allow-unauthenticated',
+        '--execution-environment=gen2',
+        '--cpu=$_CPU',
+        '--memory=$_MEMORY',
+        '--service-account=$_SERVICE_ACCOUNT',
+      ]
+  # ---------------------------------------------------------------
   # Other Integration
   # - name: OTHER INTEGRATION
 # ---------------------------------------------------------------

--- a/packages/void-server/Dockerfile
+++ b/packages/void-server/Dockerfile
@@ -4,30 +4,15 @@ WORKDIR /app
 
 ENV BUILD_PLAYGROUND=1
 
-# process init system
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
-RUN npm install pnpm@9.2.0 --global
-RUN pnpm config set store-dir ~/.pnpm-store
+# Build the package with the BUILD_PLAYGROUND flag set
+RUN pnpm --filter @scalar/void-server build
 
-# Copy and build the void server package
-COPY pnpm-lock.yaml .
-COPY pnpm-workspace.yaml .
-COPY package.json .
-COPY tsconfig.json .
-COPY turbo.json .
-COPY packages/build-tooling ./packages/build-tooling
-COPY packages/void-server ./packages/void-server
-
-RUN pnpm --filter @scalar/void-server install --frozen-lockfile && \
-    pnpm --filter @scalar/void-server build
-
-
-FROM node:18-bullseye-slim AS runner
-# Copy from the previous stage to keep this image minimal
+FROM node:20-bullseye-slim AS runner
 COPY --from=builder /usr/bin/dumb-init /usr/bin/dumb-init
 
 ENV NODE_ENV=production
 ENV PORT=$PORT
+ENV HOST='0.0.0.0'
 
 # Use default non-root user from the node image
 USER node
@@ -37,7 +22,6 @@ RUN chown node:node /app
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/packages/void-server /app/packages/void-server
-
 WORKDIR /app/packages/void-server
 
 CMD ["dumb-init", "node", "dist/playground/index.js"]

--- a/packages/void-server/Dockerfile
+++ b/packages/void-server/Dockerfile
@@ -1,0 +1,43 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS builder
+WORKDIR /app
+
+ENV BUILD_PLAYGROUND=1
+
+# process init system
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
+RUN npm install pnpm@9.2.0 --global
+RUN pnpm config set store-dir ~/.pnpm-store
+
+# Copy and build the void server package
+COPY pnpm-lock.yaml .
+COPY pnpm-workspace.yaml .
+COPY package.json .
+COPY tsconfig.json .
+COPY turbo.json .
+COPY packages/build-tooling ./packages/build-tooling
+COPY packages/void-server ./packages/void-server
+
+RUN pnpm --filter @scalar/void-server install --frozen-lockfile && \
+    pnpm --filter @scalar/void-server build
+
+
+FROM node:18-bullseye-slim AS runner
+# Copy from the previous stage to keep this image minimal
+COPY --from=builder /usr/bin/dumb-init /usr/bin/dumb-init
+
+ENV NODE_ENV=production
+ENV PORT=$PORT
+
+# Use default non-root user from the node image
+USER node
+WORKDIR /app
+RUN chown node:node /app
+
+# Copy root node modules and any utilized packages
+COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/packages/void-server /app/packages/void-server
+
+WORKDIR /app/packages/void-server
+
+CMD ["dumb-init", "node", "dist/playground/index.js"]

--- a/packages/void-server/Dockerfile
+++ b/packages/void-server/Dockerfile
@@ -11,8 +11,6 @@ FROM node:20-bullseye-slim AS runner
 COPY --from=builder /usr/bin/dumb-init /usr/bin/dumb-init
 
 ENV NODE_ENV=production
-ENV PORT=$PORT
-ENV HOST='0.0.0.0'
 
 # Use default non-root user from the node image
 USER node

--- a/packages/void-server/playground/index.ts
+++ b/packages/void-server/playground/index.ts
@@ -2,6 +2,7 @@ import { serve } from '@hono/node-server'
 
 import { createVoidServer } from '../src/createVoidServer'
 
+const host = process.env.HOST || '0.0.0.0'
 const port = process.env.PORT || 5052
 
 // Create the server instance
@@ -11,11 +12,12 @@ const app = await createVoidServer()
 serve(
   {
     fetch: app.fetch,
+    hostname: host,
     port: Number(port),
   },
   (info) => {
     console.log()
-    console.log(`🔁 Void Server listening on http://localhost:${info.port}`)
+    console.log(`🔁 Void Server listening on http://${host}:${info.port}`)
     console.log()
   },
 )

--- a/packages/void-server/rollup.config.ts
+++ b/packages/void-server/rollup.config.ts
@@ -5,6 +5,11 @@ import {
 
 const entries = ['src/index.ts']
 
+// Build the playground for docker deployments
+if (process.env.BUILD_PLAYGROUND) {
+  entries.push('playground/index.ts')
+}
+
 export default createRollupConfig({
   typescript: true,
   options: {

--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:18-bullseye AS base
+FROM node:20-bullseye AS base
+
+# process init system
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
 
 RUN npm install pnpm@9.2.0 --global
 RUN pnpm config set store-dir ~/.pnpm-store


### PR DESCRIPTION
With this PR, the `void-server` playground example is deployed to cloud run. 
