### PR TITLE
fix(api-reference): markdown links

### DIFF
--- a/.changeset/twenty-beers-attack.md
+++ b/.changeset/twenty-beers-attack.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): scrolling to markdown links

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -23,7 +23,6 @@ import {
   HIDE_DOWNLOAD_BUTTON_SYMBOL,
   downloadSpecBus,
   downloadSpecFile,
-  scrollToId,
   sleep,
 } from '../helpers'
 import { useDeprecationWarnings, useNavState, useSidebar } from '../hooks'
@@ -34,7 +33,6 @@ import type {
 } from '../types'
 import ApiClientModal from './ApiClientModal.vue'
 import { Content } from './Content'
-import { lazyBus } from './Content/Lazy/lazyBus'
 import GettingStarted from './GettingStarted.vue'
 import { Sidebar } from './Sidebar'
 
@@ -87,6 +85,7 @@ const {
   hideModels,
   defaultOpenAllTags,
   setParsedSpec,
+  scrollToIdWhenLoaded,
 } = useSidebar()
 
 const {
@@ -110,19 +109,7 @@ const scrollToSection = async (id?: string) => {
   updateHash()
 
   if (id) {
-    const sectionId = getSectionId(id)
-    if (sectionId !== id) {
-      // We use the lazyBus to check when the target has loaded then scroll to it
-      if (!collapsedSidebarItems[sectionId]) {
-        const unsubscribe = lazyBus.on((ev) => {
-          if (ev.id === id) {
-            scrollToId(id)
-            unsubscribe()
-          }
-        })
-        setCollapsedSidebarItem(sectionId, true)
-      } else scrollToId(id)
-    }
+    scrollToIdWhenLoaded(id)
   } else documentEl.value?.scrollTo(0, 0)
 
   await sleep(100)

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -85,7 +85,7 @@ const {
   hideModels,
   defaultOpenAllTags,
   setParsedSpec,
-  scrollToIdWhenLoaded,
+  scrollToOperation,
 } = useSidebar()
 
 const {
@@ -109,7 +109,7 @@ const scrollToSection = async (id?: string) => {
   updateHash()
 
   if (id) {
-    scrollToIdWhenLoaded(id)
+    scrollToOperation(id)
   } else documentEl.value?.scrollTo(0, 0)
 
   await sleep(100)

--- a/packages/api-reference/src/components/Content/Tag/Endpoints.vue
+++ b/packages/api-reference/src/components/Content/Tag/Endpoints.vue
@@ -16,21 +16,13 @@ import {
 
 const props = defineProps<{ id?: string; tag: Tag }>()
 
-const emit = defineEmits<{
-  (event: 'observeAndNavigate', value: string): void
-}>()
-
 const { getOperationId, getTagId } = useNavState()
-const { setCollapsedSidebarItem } = useSidebar()
-
-const navigateToOperation = (operationId: string) => {
-  emit('observeAndNavigate', operationId)
-}
+const { scrollToIdWhenLoaded } = useSidebar()
 
 // TODO in V2 we need to do the same loading trick as the initial load
-async function scrollHandler(operation: TransformedOperation) {
-  navigateToOperation(getOperationId(operation, props.tag))
-  setCollapsedSidebarItem(getTagId(props.tag), true)
+const scrollHandler = async (operation: TransformedOperation) => {
+  const id = getOperationId(operation, props.tag)
+  scrollToIdWhenLoaded(id)
 }
 </script>
 <template>

--- a/packages/api-reference/src/components/Content/Tag/Endpoints.vue
+++ b/packages/api-reference/src/components/Content/Tag/Endpoints.vue
@@ -17,12 +17,12 @@ import {
 const props = defineProps<{ id?: string; tag: Tag }>()
 
 const { getOperationId, getTagId } = useNavState()
-const { scrollToIdWhenLoaded } = useSidebar()
+const { scrollToOperation } = useSidebar()
 
 // TODO in V2 we need to do the same loading trick as the initial load
 const scrollHandler = async (operation: TransformedOperation) => {
-  const id = getOperationId(operation, props.tag)
-  scrollToIdWhenLoaded(id)
+  const operationId = getOperationId(operation, props.tag)
+  scrollToOperation(operationId)
 }
 </script>
 <template>

--- a/packages/api-reference/src/components/Content/Tag/Tag.vue
+++ b/packages/api-reference/src/components/Content/Tag/Tag.vue
@@ -6,7 +6,6 @@ import { useNavState, useSidebar } from '../../../hooks'
 import { SectionContainer } from '../../Section'
 import ShowMoreButton from '../../ShowMoreButton.vue'
 import Endpoints from './Endpoints.vue'
-import { observeMutations } from './mutationObserver'
 
 const props = defineProps<{
   id?: string
@@ -25,33 +24,6 @@ const moreThanOneDefaultTag = computed(
     props.tag?.name !== 'default' ||
     props.tag?.description !== '',
 )
-
-const redirectToOperation = (operationId: string) => {
-  window.location.href = `#${operationId}`
-}
-
-const observeSectionMutations = (operationId: string) => {
-  observeMutations(sectionContainerRef, (mutations, observer) => {
-    mutations.forEach((mutation) => {
-      const operationIsAdded = Array.from(mutation.addedNodes).some((node) => {
-        return node instanceof HTMLElement && node.id === operationId
-      })
-      if (operationIsAdded) {
-        redirectToOperation(operationId)
-        observer.disconnect()
-      }
-    })
-  })
-}
-
-const observeAndNavigate = (operationId: string) => {
-  const operationIsVisible = document.getElementById(operationId)
-  if (!operationIsVisible) {
-    observeSectionMutations(operationId)
-  } else {
-    redirectToOperation(operationId)
-  }
-}
 </script>
 <template>
   <SectionContainer
@@ -60,8 +32,7 @@ const observeAndNavigate = (operationId: string) => {
     <Endpoints
       v-if="moreThanOneDefaultTag"
       :id="id"
-      :tag="tag"
-      @observeAndNavigate="observeAndNavigate" />
+      :tag="tag" />
     <ShowMoreButton
       v-if="!collapsedSidebarItems[getTagId(tag)] && tag.operations?.length > 1"
       :id="id ?? ''" />

--- a/packages/api-reference/src/components/Content/Tag/mutationObserver.ts
+++ b/packages/api-reference/src/components/Content/Tag/mutationObserver.ts
@@ -1,9 +1,0 @@
-import { useMutationObserver } from '@vueuse/core'
-import type { Ref } from 'vue'
-
-export const observeMutations = (
-  target: Ref<HTMLElement | null>,
-  callback: MutationCallback,
-) => {
-  useMutationObserver(target, callback, { childList: true, subtree: true })
-}

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -318,26 +318,26 @@ export type TagsSorterOption = {
 }
 
 /**
- * Scroll to ID when loaded
+ * Scroll to operation
  *
  * Similar to scrollToId BUT in the case of a section not being open,
  * it uses the lazyBus to ensure the section is open before scrolling to it
  *
  */
-export const scrollToIdWhenLoaded = (id: string) => {
-  const sectionId = getSectionId(id)
+export const scrollToOperation = (operationId: string) => {
+  const sectionId = getSectionId(operationId)
 
-  if (sectionId !== id) {
+  if (sectionId !== operationId) {
     // We use the lazyBus to check when the target has loaded then scroll to it
     if (!collapsedSidebarItems[sectionId]) {
       const unsubscribe = lazyBus.on((ev) => {
-        if (ev.id === id) {
-          scrollToId(id)
+        if (ev.id === operationId) {
+          scrollToId(operationId)
           unsubscribe()
         }
       })
       setCollapsedSidebarItem(sectionId, true)
-    } else scrollToId(id)
+    } else scrollToId(operationId)
   }
 }
 
@@ -392,6 +392,6 @@ export function useSidebar(options?: ParsedSpecOption & TagsSorterOption) {
     hideModels,
     setParsedSpec,
     defaultOpenAllTags,
-    scrollToIdWhenLoaded,
+    scrollToOperation,
   }
 }


### PR DESCRIPTION
Currently we use a 100ms timeout to detect when a section should be open. If a section has a lot of elements or the client is just slow, it will miss this window and try to scroll to an element which does not exist. 

Here we leverage our already existing and firing lazyBus to detect when the element has loaded to ensure we scroll at the correct time.

Also used the same method for endpoint links in the tag headers