### PR TITLE
fix(components): rebuild code block x-y scroll box

### DIFF
--- a/.changeset/nervous-houses-enjoy.md
+++ b/.changeset/nervous-houses-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/components': patch
+---
+
+fix(components): rebuild code block x-y scroll box

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/ExampleResponse.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/ExampleResponse.vue
@@ -26,6 +26,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
 <template>
   <template v-if="response?.example">
     <ScalarCodeBlock
+      class="bg-b-2"
       :content="prettyPrintJson(response?.example)"
       lang="json" />
   </template>
@@ -49,6 +50,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
             :key="index"
             class="rule-item">
             <ScalarCodeBlock
+              class="bg-b-2"
               :content="
                 getExampleFromSchema(example, {
                   emptyString: '…',
@@ -63,6 +65,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
         v-else-if="
           response?.schema[rule] && response?.schema[rule].length === 1
         "
+        class="bg-b-2"
         :content="
           getExampleFromSchema(response?.schema[rule][0], {
             emptyString: '…',
@@ -74,6 +77,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
     <!-- allOf-->
     <ScalarCodeBlock
       v-if="response?.schema['allOf']"
+      class="bg-b-2"
       :content="
         mergeAllObjects(
           response?.schema['allOf'].map((schema: any) =>
@@ -87,6 +91,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
       lang="json" />
     <ScalarCodeBlock
       v-else-if="response?.schema['items']?.['allOf']"
+      class="bg-b-2"
       :content="
         mergeAllObjects(
           response?.schema['items']['allOf'].map((schema: any) =>
@@ -101,6 +106,7 @@ const mergeAllObjects = (items: Record<any, any>[]): any => {
     <!-- Single Schema -->
     <ScalarCodeBlock
       v-else
+      class="bg-b-2"
       :content="
         prettyPrintJson(
           getExampleFromSchema(response?.schema, {

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -291,6 +291,7 @@ function updateHttpClient(value: string) {
       <!-- Multiple examples -->
       <div class="code-snippet">
         <ScalarCodeBlock
+          class="bg-b-2"
           :content="generatedCode"
           :hideCredentials="
             getSecretCredentialsFromAuthentication(authenticationState)

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -41,61 +41,83 @@ const isContentValid = computed(() => {
 })
 </script>
 <template>
-  <div class="scalar-code-block">
-    <button
-      v-if="isContentValid"
-      class="copy-button"
-      type="button"
-      @click="copyToClipboard(prettyPrintJson(props.content))">
-      <span class="sr-only">Copy content</span>
-      <ScalarIcon
-        icon="Clipboard"
-        size="md" />
-    </button>
-    <pre
-      class="scalar-codeblock-pre"
-      v-html="highlightedCode"></pre>
+  <div class="scalar-code-block custom-scroll">
+    <div class="scalar-code-copy">
+      <button
+        v-if="isContentValid"
+        class="copy-button"
+        type="button"
+        @click="copyToClipboard(prettyPrintJson(props.content))">
+        <span class="sr-only">Copy content</span>
+        <ScalarIcon
+          icon="Clipboard"
+          size="md" />
+      </button>
+    </div>
+    <div class="scalar-code-scroll custom-scroll">
+      <pre
+        class="scalar-codeblock-pre"
+        v-html="highlightedCode"></pre>
+    </div>
   </div>
 </template>
 <style>
 @import '@scalar/code-highlight/css/code.css';
 .scalar-code-block {
-  padding: 0.5rem 0.5rem 0.5rem 0.75rem;
   position: relative;
-  overflow: auto;
 }
 .scalar-code-block:hover .copy-button {
   opacity: 100;
   visibility: visible;
 }
+.scalar-code-block .scalar-code-scroll.custom-scroll {
+  padding: 0.5rem 0.5rem 0.5rem 0.75rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
 /* Code blocks */
 .scalar-codeblock-pre {
   margin: 0;
-  overflow: auto;
   background: transparent;
   text-wrap: nowrap;
   white-space-collapse: preserve;
   border-radius: 0;
 }
+/* Copy Button */
+.scalar-code-copy {
+  display: flex;
+  align-items: start;
+  justify-content: end;
+
+  position: sticky;
+  inset: 0;
+}
 .copy-button {
+  position: relative;
+  top: 8px;
+  right: 8px;
+
+  display: flex;
   align-items: center;
-  background-color: var(inherit, --scalar-background-2);
+
+  background-color: var(--scalar-background-2);
   border: 1px solid var(--scalar-border-color);
   border-radius: 3px;
   color: var(--scalar-color-3);
   cursor: pointer;
-  display: flex;
   height: 30px;
   margin-bottom: -30px;
   opacity: 0;
   padding: 6px;
-  position: sticky;
-  left: 100dvw;
-  top: 0;
   transition:
     opacity 0.15s ease-in-out,
     color 0.15s ease-in-out;
   visibility: hidden;
+}
+.scalar-code-copy,
+.copy-button {
+  /* Pass down the background color */
+  background: inherit;
 }
 .copy-button:after {
   content: '.';

--- a/packages/themes/src/scrollbars.css
+++ b/packages/themes/src/scrollbars.css
@@ -11,7 +11,7 @@
   }
   .cm-scroller:hover,
   .custom-scroll:hover {
-    scrollbar-color: var(--scalar-scrollbar-color, transparent);
+    scrollbar-color: var(--scalar-scrollbar-color, transparent) transparent;
   }
   .cm-scroller:hover::-webkit-scrollbar-thumb,
   .custom-scroll:hover::-webkit-scrollbar-thumb {


### PR DESCRIPTION
Looks like when we switched from codemirror to highlight JS we lost a bunch of our custom scroll classes that were targeting the code block. This PR should put things back to the way they were.

## Before / After

https://github.com/user-attachments/assets/779aff99-72df-4910-8f3b-80e25f9ecc92

