### PR TITLE
fix(api-client): request sidebar draft context menu

### DIFF
--- a/.changeset/flat-cups-agree.md
+++ b/.changeset/flat-cups-agree.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: request sidebar draft native context menu

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -332,7 +332,10 @@ const resourceTitle = computed(() => {
       <!-- Collection/Folder -->
       <ScalarContextMenu
         v-else-if="!isReadOnly || parentUids.length"
-        :disabled="isReadOnly">
+        :disabled="
+          isReadOnly || (item as Collection).spec?.info?.title === 'Drafts'
+        ">
+        >
         <template #trigger>
           <button
             class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5 z-[1]"


### PR DESCRIPTION
this pr brings back native context menu on draft folder, as highlighted in [#2788 by hans](https://github.com/scalar/scalar/pull/2788#pullrequestreview-2227517665) and will be follow up by other addition:

<img width="615" alt="image" src="https://github.com/user-attachments/assets/240a7a8a-2545-40dd-a3a0-cc75992a8123">
