### PR TITLE
fix(api-client): close tab hotkey event prevent

### DIFF
--- a/.changeset/sixty-sloths-tease.md
+++ b/.changeset/sixty-sloths-tease.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: close tab hotkey event prevent

--- a/packages/api-client-app/src/main/index.ts
+++ b/packages/api-client-app/src/main/index.ts
@@ -149,7 +149,22 @@ function createWindow(): void {
           accelerator: 'CmdOrCtrl+O',
           click: () => handleFileOpenMenuItem(mainWindow),
         },
-        ...[isMac ? { role: 'close' } : { role: 'quit' }],
+        {
+          label: 'Close Window',
+          accelerator: 'Shift+CmdOrCtrl+W',
+          click: () => {
+            const focusedWindow = BrowserWindow.getFocusedWindow()
+            if (focusedWindow) focusedWindow.close()
+          },
+        },
+        {
+          label: 'Close Tab',
+          accelerator: 'CmdOrCtrl+W',
+          click: () => {
+            const focusedWindow = BrowserWindow.getFocusedWindow()
+            if (focusedWindow) focusedWindow.webContents.send('closeTab')
+          },
+        },
       ],
     },
     // { role: 'editMenu' }


### PR DESCRIPTION
this pr updates the app native shortcut to be able to use `meta + w` to close tab as expected:

<img width="553" alt="image" src="https://github.com/user-attachments/assets/b65f8f46-cb4e-4581-a739-4a59d861ab7b">
