### PR TITLE
feat(api-client): hotkeys search

### DIFF
--- a/.changeset/dirty-goats-kiss.md
+++ b/.changeset/dirty-goats-kiss.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: search hotkeys

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -40,6 +40,7 @@ import {
   hotKeyBus,
   type HotKeyEvents,
   type CommandPaletteEvent,
+  isCommandPaletteOpen,
 } from '@/libs'
 
 /** Available Commands for the Command Palette */
@@ -122,6 +123,7 @@ const closeHandler = () => {
   commandQuery.value = ''
   activeCommand.value = null
   selectedSearchResult.value = -1
+  isCommandPaletteOpen.value = false
 }
 
 /** Handle execution of the command, some have routes while others show another palette */
@@ -148,6 +150,7 @@ const openCommandPalette = ({
   metaData.value = _metaData
   modalState.show()
   commandInputRef.value?.focus()
+  isCommandPaletteOpen.value = true
 }
 
 /** Handle up and down arrow keys in the menu */
@@ -183,12 +186,14 @@ const handleHotKey = (event: HotKeyEvents) => {
   if (event.commandPaletteUp) handleArrowKey('up')
   if (event.commandPaletteDown) handleArrowKey('down')
   if (event.commandPaletteSelect) handleSelect()
+  if (event.search) commandInputRef.value?.focus()
 }
 
 onMounted(() => {
   commandPaletteBus.on(openCommandPalette)
   hotKeyBus.on(handleHotKey)
 })
+
 onBeforeUnmount(() => {
   commandPaletteBus.off(openCommandPalette)
   hotKeyBus.off(handleHotKey)

--- a/packages/api-client/src/components/Search/SearchButton.vue
+++ b/packages/api-client/src/components/Search/SearchButton.vue
@@ -1,9 +1,24 @@
 <script setup lang="ts">
+import { type HotKeyEvents, hotKeyBus, isCommandPaletteOpen } from '@/libs'
 import { ScalarIcon } from '@scalar/components'
+import { onBeforeUnmount, onMounted } from 'vue'
 
 const emit = defineEmits<{
   (e: 'openSearchModal'): void
 }>()
+
+/** Handle hotkeys */
+const handleHotKey = (event: HotKeyEvents) => {
+  if (event.search && !isCommandPaletteOpen.value) emit('openSearchModal')
+}
+
+onMounted(() => {
+  hotKeyBus.on(handleHotKey)
+})
+
+onBeforeUnmount(() => {
+  hotKeyBus.off(handleHotKey)
+})
 </script>
 <template>
   <div class="search-button-fade sticky top-0 z-50 px-3 py-2.5 pb-2.5">

--- a/packages/api-client/src/components/Search/SearchModal.vue
+++ b/packages/api-client/src/components/Search/SearchModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { HttpMethod } from '@/components/HttpMethod'
+import { commandPaletteBus } from '@/libs'
 import { useWorkspace } from '@/store/workspace'
 import {
   type ModalState,
@@ -11,7 +12,7 @@ import {
 import type { Request } from '@scalar/oas-utils/entities/workspace/spec'
 import { useMagicKeys, whenever } from '@vueuse/core'
 import Fuse, { type FuseResult } from 'fuse.js'
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 const props = defineProps<{
@@ -172,6 +173,14 @@ whenever(keys.ArrowUp, () => {
       behavior: 'smooth',
       block: 'center',
     })
+})
+
+onMounted(() => {
+  commandPaletteBus.on(() => {
+    if (props.modalState.open) {
+      props.modalState.hide()
+    }
+  })
 })
 </script>
 <template>

--- a/packages/api-client/src/libs/event-busses/command-palette-bus.ts
+++ b/packages/api-client/src/libs/event-busses/command-palette-bus.ts
@@ -1,5 +1,8 @@
 import type { CommandNames } from '@/components/CommandPalette/TheCommandPalette.vue'
 import { type EventBusKey, useEventBus } from '@vueuse/core'
+import { ref } from 'vue'
+
+export const isCommandPaletteOpen = ref(false)
 
 export type CommandPaletteEvent = {
   /** The command name which matches with the command palette */
@@ -15,3 +18,7 @@ const commandPaletteKey: EventBusKey<CommandPaletteEvent> = Symbol()
  * @param commandName - the command name you wish to execute, leave empty for the full palette
  */
 export const commandPaletteBus = useEventBus(commandPaletteKey)
+
+commandPaletteBus.on((event) => {
+  isCommandPaletteOpen.value = event ? !!event.commandName : false
+})

--- a/packages/api-client/src/libs/event-busses/hot-keys-bus.ts
+++ b/packages/api-client/src/libs/event-busses/hot-keys-bus.ts
@@ -30,17 +30,18 @@ export const hotKeyBus = useEventBus(hotKeyBusKey)
  * - if you explicitly set it, the event must match ex: modifier false will not trigger if the modifier was pressed
  */
 export const DEFAULT_HOTKEYS: HotKeyConfig = {
-  Escape: { event: 'closeModal' },
-  b: { event: 'toggleSidebar', modifiers: ['default'] },
-  k: { event: 'openCommandPalette', modifiers: ['default'] },
-  ArrowUp: { event: 'commandPaletteUp' },
-  ArrowDown: { event: 'commandPaletteDown' },
-  Enter: { event: 'commandPaletteSelect' },
-  t: { event: 'addTopNav', modifiers: ['default'] },
-  w: { event: 'closeTopNav', modifiers: ['default'] },
-  ArrowLeft: { event: 'navigateTopNavLeft', modifiers: ['default', 'Alt'] },
-  ArrowRight: { event: 'navigateTopNavRight', modifiers: ['default', 'Alt'] },
-  l: { event: 'focusAddressBar', modifiers: ['default'] },
+  'Escape': { event: 'closeModal' },
+  'b': { event: 'toggleSidebar', modifiers: ['default'] },
+  'k': { event: 'openCommandPalette', modifiers: ['default'] },
+  'ArrowUp': { event: 'commandPaletteUp' },
+  'ArrowDown': { event: 'commandPaletteDown' },
+  'Enter': { event: 'commandPaletteSelect' },
+  't': { event: 'addTopNav', modifiers: ['default'] },
+  'w': { event: 'closeTopNav', modifiers: ['default'] },
+  'ArrowLeft': { event: 'navigateTopNavLeft', modifiers: ['default', 'Alt'] },
+  'ArrowRight': { event: 'navigateTopNavRight', modifiers: ['default', 'Alt'] },
+  'l': { event: 'focusAddressBar', modifiers: ['default'] },
+  '/': { event: 'search' },
 }
 
 /** Checks if we are in an "input" */
@@ -98,6 +99,10 @@ export const handleHotKeyDown = (
       } else if (!isInput(ev.target) && hotKeyEvent.modifiers === undefined) {
         /** Check if we are in an input as modifier === 'undefined' */
         hotKeyBus.emit({ [hotKeyEvent.event]: ev })
+        if (key === '/') {
+          /** Prevent character from being typed in the input */
+          ev.preventDefault()
+        }
       }
     }
   }

--- a/packages/oas-utils/src/entities/workspace/consts/hot-keys.ts
+++ b/packages/oas-utils/src/entities/workspace/consts/hot-keys.ts
@@ -13,6 +13,7 @@ export const HOTKEY_EVENT_NAMES = [
   'navigateTopNavLeft',
   'navigateTopNavRight',
   'focusAddressBar',
+  'search',
 ] as const
 export type HotkeyEventName = (typeof HOTKEY_EVENT_NAMES)[number]
 


### PR DESCRIPTION
this pr adds the `/` search hotkey in order to open from the request view the search modal, or focus from the command modal on the search bar:

https://github.com/user-attachments/assets/0b509480-79d3-4454-ab10-8bca914981d2

