### PR TITLE
fix(themes): restrict flare overflow for themes

### DIFF
--- a/.changeset/fresh-frogs-help.md
+++ b/.changeset/fresh-frogs-help.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix(themes): restrict flare overflow for themes

--- a/packages/themes/src/presets/bluePlanet.css
+++ b/packages/themes/src/presets/bluePlanet.css
@@ -170,6 +170,7 @@
   height: 100vh;
   background: linear-gradient(#000, var(--scalar-background-1));
   width: 100vw;
+  overflow-x: hidden;
 }
 .light-mode .section-flare {
   display: none;

--- a/packages/themes/src/presets/mars.css
+++ b/packages/themes/src/presets/mars.css
@@ -105,8 +105,16 @@
   padding-top: 0;
 }
 /* Hero section flare */
+.section-flare {
+  overflow-x: hidden;
+  height: 100vh;
+  left: initial;
+}
 .section-flare-item:nth-of-type(1) {
   background: #d25019;
+  position: relative;
+  top: -150px;
+  right: -400px;
   width: 80vw;
   height: 500px;
   margin-top: -150px;
@@ -116,10 +124,4 @@
 }
 .light-mode .section-flare {
   display: none;
-}
-.section-flare {
-  top: -150px !important;
-  height: 100vh;
-  right: -400px !important;
-  left: initial;
 }


### PR DESCRIPTION
I think when we moved the scroll to the `<body>` we allowed the flare for these themes to spill outside and create horizontal scroll.