### PR TITLE
fix(components): don't clear loading state automatically

### DIFF
--- a/.changeset/stale-files-love.md
+++ b/.changeset/stale-files-love.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): don't clear loading state automatically

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.stories.ts
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.stories.ts
@@ -20,11 +20,13 @@ const meta = {
       return { loadingState }
     },
     template: `
-      <div className="row gap-4 items-center">
+      <div className="row gap-16 items-center">
         <ScalarLoading :loadingState="loadingState" />
-        <ScalarButton @click="loadingState.validate()">Success</ScalarButton>
-        <ScalarButton variant="danger" @click="loadingState.invalidate()">Error</ScalarButton>
-        <ScalarButton variant="ghost" @click="loadingState.clear() && loadingState.startLoading()">Reset</ScalarButton>
+        <div className="row gap-4 items-center">
+          <ScalarButton @click="loadingState.validate()">Validate</ScalarButton>
+          <ScalarButton variant="danger" @click="loadingState.invalidate()">Invalidate</ScalarButton>
+          <ScalarButton variant="outlined" @click="loadingState.clear() && loadingState.startLoading()">Clear</ScalarButton>
+        </div>
       </div>
     `,
   }),

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.vue
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.vue
@@ -32,20 +32,26 @@ export function useLoadingState() {
     stopLoading() {
       this.isLoading = false
     },
-    validate(time = 800) {
+    validate(time = 800, clear?: boolean) {
+      this.isInvalid = false
       this.isValid = true
-      const diff = time - 300
+      const diff = clear ? time - 300 : time
       // Allow chaining after animation
       return new Promise((res) =>
-        setTimeout(() => this.clear().then(() => res(true)), diff),
+        clear
+          ? setTimeout(() => this.clear().then(() => res(true)), diff)
+          : setTimeout(() => res(true), diff),
       )
     },
-    invalidate(time = 1100) {
+    invalidate(time = 1100, clear?: boolean) {
+      this.isValid = false
       this.isInvalid = true
-      const diff = time - 300
+      const diff = clear ? time - 300 : time
       // Allow chaining after animation
       return new Promise((res) =>
-        setTimeout(() => this.clear().then(() => res(true)), diff),
+        clear
+          ? setTimeout(() => this.clear().then(() => res(true)), diff)
+          : setTimeout(() => res(true), diff),
       )
     },
     clear(time = 300) {


### PR DESCRIPTION
Changes `useLoadingState` to not automatically clear when calling `useLoadingState.validate()` or `useLoadingState.invalidate()`. I checked and the only usages this should affect are the Dashboard.

Motivation: it seems like in forms where we redirect somewhere on success (like in the Dashboard) it's distracting to have the checkmark clear itself before redirecting.

## Before

https://github.com/user-attachments/assets/3e0334ed-41f2-4069-888a-56aa94137263

## After

https://github.com/user-attachments/assets/d980e5ea-1f26-4606-a4be-1173b7dbd15a


