### PR TITLE
fix: temporary fix set type to any

### DIFF
--- a/.changeset/thin-monkeys-melt.md
+++ b/.changeset/thin-monkeys-melt.md
@@ -1,0 +1,5 @@
+---
+"@scalar/oas-utils": patch
+---
+
+fix: temporary fix set type to any

--- a/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
@@ -6,7 +6,7 @@ const requestExampleParametersSchema = z.object({
   key: z.string().default(''),
   value: z.union([z.string(), z.number()]).transform(String).default(''),
   enabled: z.boolean().default(true),
-  file: z.instanceof(File).optional(),
+  file: z.any().optional(),
   description: z.string().optional(),
   /** Params are linked to parents such as path params and global headers/cookies */
   refUid: nanoidSchema.optional(),


### PR DESCRIPTION
**Problem**
Currently, `File` is not a global type in node 18 and is causing release issues 

**Solution**
With this PR, temporary fix to use `any` type to avoid release issues 
