### PR TITLE
fix(components): refactor loading to match icon sizes

### DIFF
--- a/.changeset/popular-crews-peel.md
+++ b/.changeset/popular-crews-peel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): refactor loading to match icon sizes

--- a/packages/components/src/components/ScalarButton/ScalarButton.vue
+++ b/packages/components/src/components/ScalarButton/ScalarButton.vue
@@ -62,7 +62,7 @@ const attrs = computed(() => {
       class="centered-x absolute">
       <ScalarLoading
         :loadingState="loading"
-        size="12px" />
+        size="xs" />
     </div>
   </button>
 </template>

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.stories.ts
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.stories.ts
@@ -9,9 +9,7 @@ import ScalarLoading, { useLoadingState } from './ScalarLoading.vue'
 const meta = {
   component: ScalarLoading,
   tags: ['autodocs'],
-  argTypes: {
-    size: { control: 'text', default: '24px' },
-  },
+  argTypes: {},
   render: () => ({
     components: { ScalarButton, ScalarLoading },
     setup() {
@@ -21,7 +19,7 @@ const meta = {
     },
     template: `
       <div className="row gap-16 items-center">
-        <ScalarLoading :loadingState="loadingState" />
+        <ScalarLoading size="xl" :loadingState="loadingState" />
         <div className="row gap-4 items-center">
           <ScalarButton @click="loadingState.validate()">Validate</ScalarButton>
           <ScalarButton variant="danger" @click="loadingState.invalidate()">Invalidate</ScalarButton>

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.vue
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.vue
@@ -1,18 +1,33 @@
 <script setup lang="ts">
-import { cx } from '../../cva'
+import type { VariantProps } from 'cva'
+import { cva, cx } from '../../cva'
 import { reactive } from 'vue'
 
-withDefaults(
-  defineProps<{
-    loadingState: LoadingState
-    size?: string
-  }>(),
-  {
-    size: '24px',
-  },
-)
-</script>
+type Variants = VariantProps<typeof variants>
 
+defineProps<{
+  loadingState: LoadingState
+  size?: Variants['size']
+}>()
+
+const variants = cva({
+  variants: {
+    size: {
+      'xs': 'size-3',
+      'sm': 'size-3.5',
+      'md': 'size-4',
+      'lg': 'size-5',
+      'xl': 'size-6',
+      '2xl': 'size-8',
+      '3xl': 'size-10',
+      'full': 'size-full',
+    },
+  },
+  defaultVariants: {
+    size: 'full',
+  },
+})
+</script>
 <script lang="ts">
 export type LoadingState = ReturnType<typeof useLoadingState>
 
@@ -68,11 +83,10 @@ export function useLoadingState() {
   })
 }
 </script>
-
 <template>
   <div
     v-if="loadingState"
-    :class="cx('loader-wrapper')">
+    :class="cx('loader-wrapper', variants({ size }))">
     <svg
       class="svg-loader"
       :class="{
@@ -117,8 +131,6 @@ export function useLoadingState() {
 <style scoped>
 .loader-wrapper {
   position: relative;
-  height: v-bind(size);
-  width: v-bind(size);
 
   display: flex;
   align-items: center;

--- a/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
+++ b/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
@@ -50,7 +50,7 @@ const attrs = computed(() => {
       v-if="loading && loading.isLoading"
       class="mr-3 self-center"
       :loadingState="loading"
-      size="20px" />
+      size="md" />
     <ScalarIconButton
       v-else-if="modelValue"
       class="p-2.5"


### PR DESCRIPTION
Switches the `<ScalarLoading>` component to use the same sizes as our `<ScalarIcon>` component