### PR TITLE
fix(api-client): request params deletion

### DIFF
--- a/.changeset/purple-ties-call.md
+++ b/.changeset/purple-ties-call.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: request params deletion

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -104,10 +104,15 @@ const toggleRow = (rowIdx: number, enabled: boolean) =>
 const deleteAllRows = () => {
   if (!activeRequest.value || !activeExample.value) return
 
+  // filter out params that are enabled or required
+  const exampleParams = params.value.filter(
+    (param) => param.enabled || param.required,
+  )
+
   requestExampleMutators.edit(
     activeExample.value.uid,
     `parameters.${props.paramKey}`,
-    [],
+    exampleParams,
   )
 
   nextTick(() => {


### PR DESCRIPTION
this pr updates the delete all rows method in order to avoid to clear all the rows when pushing the `clear` action, and instead filter out param that are enabled or required.

we could also prevent the deletion of param coming from a specification whether being enabled or not.