### PR TITLE
docs: .net 8 integration

### DIFF
--- a/packages/scalar.aspnetcore/README.md
+++ b/packages/scalar.aspnetcore/README.md
@@ -35,6 +35,7 @@ app.Run();
 ```
 
 .NET 8
+
 ```c#
 using Scalar.AspNetCore;
 


### PR DESCRIPTION
**Problem**
Currently, there's no integration guide for .NET 8

**Explanation**
.NET 8 integration is different from .NET 9 where `Swashbuckle.AspNetCore` is deprecated and `Microsoft.AspNetCore.OpenApi` is used by default, thus the setup will also be slightly different.

**Solution**
With this PR, hopefully user will get a more comprehensive guide on how to integrate Scalar into both .NET 8 and 9 which it supported.
