### PR TITLE
fix(api-client): force code mirror to scroll on overflow

### DIFF
--- a/.changeset/tough-sheep-chew.md
+++ b/.changeset/tough-sheep-chew.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): force code mirror to scroll on overflow

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -265,7 +265,7 @@ export default {
 }
 /* Number gutter */
 :deep(.cm-gutters) {
-  background-color: transparent;
+  background-color: var(--scalar-background-1);
   border-right: none;
   color: var(--scalar-color-3);
   font-size: var(--scalar-mini);

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -184,7 +184,7 @@ export default {
       :id="uid"
       v-bind="$attrs"
       ref="codeMirrorRef"
-      class="peer font-code w-full whitespace-nowrap text-xs leading-[1.44] relative"
+      class="peer font-code w-full whitespace-nowrap overflow-hidden text-xs leading-[1.44] relative"
       :class="{
         'flow-code-input--error': error,
       }"></div>
@@ -282,14 +282,7 @@ export default {
   padding-left: 0 !important;
 }
 :deep(.cm-scroller) {
-  scrollbar-width: none;
-  -ms-overflow-style: none;
   overflow: auto;
-}
-:deep(.cm-scroller::-webkit-scrollbar) {
-  width: 0;
-  height: 0;
-  display: none;
 }
 </style>
 <style>


### PR DESCRIPTION
## Before

<img width="1534" alt="Google Chrome-2024-08-16-13-44-02@2x" src="https://github.com/user-attachments/assets/a4a7dcfd-c3dc-462d-be2d-49d67b4056e8">

## After

<img width="1534" alt="Google Chrome-2024-08-16-13-43-42@2x" src="https://github.com/user-attachments/assets/2af61951-35a0-425c-b6ce-2a64a2ee9314">

