### PR TITLE
fix(components): display ScalarTextField errors properly

### DIFF
--- a/.changeset/afraid-glasses-work.md
+++ b/.changeset/afraid-glasses-work.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+fix(components): show icon for ScalarTextField errors

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -427,7 +427,6 @@ const resourceTitle = computed(() => {
     <ScalarTextField
       v-model="tempName"
       :label="resourceTitle"
-      labelShadowColor="var(--scalar-background-1)"
       @keydown.prevent.enter="handleItemRename" />
     <div class="flex gap-3">
       <ScalarButton

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -200,7 +200,6 @@ const deleteWorkspace = async () => {
     <ScalarTextField
       v-model="tempName"
       label="Workspace"
-      labelShadowColor="var(--scalar-background-1)"
       @keydown.prevent.enter="handleWorkspaceRename" />
     <div class="flex gap-3">
       <ScalarButton

--- a/packages/components/src/components/ScalarTextField/ScalarTextField.stories.ts
+++ b/packages/components/src/components/ScalarTextField/ScalarTextField.stories.ts
@@ -30,9 +30,18 @@ export const Base: Story = {
   },
 }
 
-export const Error: Story = {
+export const HelperText: Story = {
   args: {
     modelValue: '',
+    label: 'Scalar Text Field',
+    placeholder: 'This is a place where you can type out anything',
+    helperText: 'This is some helpful text',
+  },
+}
+
+export const Error: Story = {
+  args: {
+    modelValue: 'Bad Input',
     label: 'Scalar Text Field',
     placeholder: 'This is a place where you can type out anything',
     helperText: 'There was some sort of error with the field',

--- a/packages/components/src/components/ScalarTextField/ScalarTextField.vue
+++ b/packages/components/src/components/ScalarTextField/ScalarTextField.vue
@@ -39,7 +39,7 @@ const textField = cva({
     focus: {
       true: 'scalar-input-wrapper-focus border-c-3 has-actv-btn:border has-actv-btn:border-border',
     },
-    error: { true: 'scalar-input-wrapper-error border-error' },
+    error: { true: 'scalar-input-wrapper-error border-red' },
   },
 })
 
@@ -165,7 +165,7 @@ onMounted(() => {
   color: var(--scalar-color-1);
 }
 .scalar-input-wrapper-error .scalar-input-label {
-  color: var(--scalar-color-error-color);
+  color: var(--scalar-color-red);
 }
 .scalar-input::selection {
   color: var(--scalar-color-1);

--- a/packages/components/src/components/ScalarTextField/ScalarTextField.vue
+++ b/packages/components/src/components/ScalarTextField/ScalarTextField.vue
@@ -4,6 +4,7 @@ import { nanoid } from 'nanoid'
 import { type Ref, onMounted, ref, useAttrs } from 'vue'
 
 import { cva, cx } from '../../cva'
+import { ScalarIcon } from '../ScalarIcon'
 
 const props = withDefaults(
   defineProps<{
@@ -23,7 +24,7 @@ const props = withDefaults(
   }>(),
   {
     emitOnBlur: true,
-    labelShadowColor: 'var(--scalar-background-2)',
+    labelShadowColor: 'var(--scalar-background-1)',
     disableTrim: false,
   },
 )
@@ -143,13 +144,13 @@ onMounted(() => {
       </div>
     </div>
     <span
-      :class="
-        cx(
-          'helper-text before:font-black mt-1.5 flex items-center text-sm text-red before:rounded-full',
-          'before:mr-1.5 before:block before:h-4 before:w-4 before:text-center before:text-xxs before:leading-4',
-          `before:text-white empty:hidden`,
-        )
-      ">
+      v-if="helperText"
+      class="helper-text mt-1.5 flex items-center gap-1 text-sm"
+      :class="error ? 'font-medium text-red' : 'text-c-2'">
+      <ScalarIcon
+        v-if="error"
+        icon="Error"
+        size="sm" />
       {{ helperText }}
     </span>
   </div>


### PR DESCRIPTION
Seems like our text field got a little broken at some point. This fixes the error text and makes it so helper text works on its own again.

I also made the error text medium to align with the icon and set the default label background to `scalar-background-1` instead of `scalar-background-2` which I think makes more sense as the default, @cameronrohani let me know if this is a bad idea.

## Before

<img width="493" alt="Google Chrome-2024-08-16-15-09-11@2x" src="https://github.com/user-attachments/assets/97ffe9a1-e041-416d-87a2-ed27a3540e1e">

## After

<img width="493" alt="Google Chrome-2024-08-16-15-08-10@2x" src="https://github.com/user-attachments/assets/ddafb952-2ea3-4552-a843-a9e910d79a7d">
<img width="493" alt="Google Chrome-2024-08-16-15-08-18@2x" src="https://github.com/user-attachments/assets/3afcb1cc-394e-45cc-8a89-6f3a3cf66012">




