### PR TITLE
fix(api-client): command palette import

### DIFF
--- a/.changeset/ninety-elephants-march.md
+++ b/.changeset/ninety-elephants-march.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: command palette import collection

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
@@ -51,6 +51,7 @@ onMounted(() => {
       <input
         id="requestimport"
         ref="importInput"
+        v-model="specUrl"
         class="border-transparent outline-none w-full pl-8 text-sm min-h-8 py-1.5"
         label="Paste Swagger File URL"
         placeholder="Paste Swagger File URL"

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -958,12 +958,8 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
     proxy?: string,
     overloadServers?: Spec['servers'],
   ) {
-    try {
-      const spec = await fetchSpecFromUrl(url, proxy)
-      await importSpecFile(spec, undefined, overloadServers)
-    } catch (error) {
-      console.error('Failed to fetch spec from URL:', error)
-    }
+    const spec = await fetchSpecFromUrl(url, proxy)
+    await importSpecFile(spec, undefined, overloadServers)
   }
 
   /** Helper function to manage the sidebar width */


### PR DESCRIPTION
this pr adds a missing v-model on the command palette import collection in order to be able to import document collection using url + add toast state:

https://github.com/user-attachments/assets/3213c6a3-b320-4ff7-8794-538f4fc6aa9f
