### PR TITLE
fix(api-client): ensure complex auth is correctly initialized

### DIFF
--- a/.changeset/fuzzy-bears-dress.md
+++ b/.changeset/fuzzy-bears-dress.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): correctly initialize complex auth, fixes #2874

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -869,11 +869,13 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
       securityRequirements: Record<string, string[]>[],
       request: Request,
     ) => {
-      const firstKey = Object.keys(securityRequirements[0])?.[0]
-      if (!firstKey) return
+      const firstRequirement = Object.keys(securityRequirements[0])
+      if (!firstRequirement.length) return
 
-      const uid = collection.securitySchemeDict[firstKey]
-      requestMutators.edit(request.uid, 'selectedSecuritySchemeUids', [uid])
+      const uids = firstRequirement.map(
+        (key) => collection.securitySchemeDict[key],
+      )
+      requestMutators.edit(request.uid, 'selectedSecuritySchemeUids', uids)
     }
 
     // Security Schemes, we need to set some failsafes from the parsed spec


### PR DESCRIPTION
We need to correctly initialize multiple values for complex auth, this fixes #2871 