### PR TITLE
fix: galaxy playground example loads spec in dev and prod

### DIFF
--- a/packages/galaxy/Dockerfile
+++ b/packages/galaxy/Dockerfile
@@ -3,6 +3,7 @@ FROM ${BASE_IMAGE} AS builder
 WORKDIR /app
 
 ENV BUILD_PLAYGROUND=1
+ENV SPEC_PATH='../3.1.yaml'
 
 # Build the package with the BUILD_PLAYGROUND flag set
 RUN pnpm --filter @scalar/galaxy build
@@ -20,6 +21,7 @@ RUN chown node:node /app
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/packages/mock-server /app/packages/mock-server
+COPY --from=builder /app/packages/oas-utils /app/packages/oas-utils
 COPY --from=builder /app/packages/galaxy /app/packages/galaxy
 WORKDIR /app/packages/galaxy
 

--- a/packages/galaxy/Dockerfile
+++ b/packages/galaxy/Dockerfile
@@ -3,7 +3,6 @@ FROM ${BASE_IMAGE} AS builder
 WORKDIR /app
 
 ENV BUILD_PLAYGROUND=1
-ENV SPEC_PATH='../3.1.yaml'
 
 # Build the package with the BUILD_PLAYGROUND flag set
 RUN pnpm --filter @scalar/galaxy build

--- a/packages/galaxy/playground/index.ts
+++ b/packages/galaxy/playground/index.ts
@@ -2,8 +2,8 @@ import { serve } from '@hono/node-server'
 import { createMockServer } from '@scalar/mock-server'
 import fs from 'node:fs'
 
-const specification = fs.readFileSync('../src/specifications/3.1.yaml', 'utf-8')
-console.log(typeof specification)
+const specification = fs.readFileSync('./dist/3.1.yaml', 'utf-8')
+
 const port = process.env.PORT || 5052
 
 // Create the server instance

--- a/packages/galaxy/rollup.config.ts
+++ b/packages/galaxy/rollup.config.ts
@@ -19,6 +19,6 @@ export default createRollupConfig({
     },
   ],
   options: {
-    input: ['./src/index.ts'],
+    input: input,
   },
 })


### PR DESCRIPTION
**Problem**
This PR adds the playground example to the rollup build entrypoints and fixes the playground path to load the spec. 
