### PR TITLE
fix(mock-server): path to galaxy spec

### DIFF
--- a/packages/galaxy/Dockerfile
+++ b/packages/galaxy/Dockerfile
@@ -20,6 +20,7 @@ RUN chown node:node /app
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/packages/mock-server /app/packages/mock-server
+COPY --from=builder /app/packages/hono-api-reference /app/packages/hono-api-reference
 COPY --from=builder /app/packages/oas-utils /app/packages/oas-utils
 COPY --from=builder /app/packages/galaxy /app/packages/galaxy
 WORKDIR /app/packages/galaxy

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@hono/node-server": "^1.11.0",
     "@scalar/build-tooling": "workspace:*",
+    "@scalar/hono-api-reference": "workspace:*",
     "@scalar/mock-server": "workspace:*",
     "@scalar/openapi-parser": "^0.7.2",
     "vite": "^5.2.10"

--- a/packages/galaxy/playground/index.ts
+++ b/packages/galaxy/playground/index.ts
@@ -1,9 +1,14 @@
 import { serve } from '@hono/node-server'
 import { apiReference } from '@scalar/hono-api-reference'
 import { createMockServer } from '@scalar/mock-server'
-import fs from 'node:fs'
+import fs from 'fs/promises'
 
-const specification = fs.readFileSync('./dist/3.1.yaml', 'utf-8')
+const specification = await fs
+  .readFile('./src/specifications/3.1.yaml', 'utf-8')
+  .catch(() => {
+    console.error('MISSING GALAXY SPEC FOR PLAYGROUND')
+    return ''
+  })
 
 const port = process.env.PORT || 5052
 

--- a/packages/galaxy/playground/index.ts
+++ b/packages/galaxy/playground/index.ts
@@ -1,4 +1,5 @@
 import { serve } from '@hono/node-server'
+import { apiReference } from '@scalar/hono-api-reference'
 import { createMockServer } from '@scalar/mock-server'
 import fs from 'node:fs'
 
@@ -13,6 +14,17 @@ const app = await createMockServer({
     console.log(`${context.req.method} ${context.req.url}`)
   },
 })
+
+// Load the middleware
+app.get(
+  '/',
+  apiReference({
+    spec: {
+      content: specification,
+    },
+    pageTitle: 'Scalar Galaxy Spec',
+  }),
+)
 
 // Start the server
 serve(

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@hono/node-server": "^1.11.0",
     "@scalar/build-tooling": "workspace:*",
+    "@scalar/hono-api-reference": "workspace:*",
     "@types/node": "^20.14.10"
   }
 }

--- a/packages/mock-server/playground/index.ts
+++ b/packages/mock-server/playground/index.ts
@@ -10,8 +10,9 @@ const port = process.env.PORT || 5052
  * We do not want a circular depedency as galaxy uses mock server for its playground
  */
 const specification = await fs
-  .readFile('../../galaxy/dist/latest.json')
-  .catch(() => {
+  .readFile('../galaxy/dist/latest.json')
+  .catch((err) => {
+    console.error(err)
     console.error(
       'MISSING GALAXY SPEC FOR PLAYGROUND. PLEASE BUILD @scalar/galaxy',
     )

--- a/packages/mock-server/playground/index.ts
+++ b/packages/mock-server/playground/index.ts
@@ -18,8 +18,6 @@ const specification = await fs
     return ''
   })
 
-console.log(JSON.stringify(specification, null, 3))
-
 // Create the server instance
 const app = await createMockServer({
   specification,

--- a/packages/mock-server/playground/index.ts
+++ b/packages/mock-server/playground/index.ts
@@ -11,7 +11,7 @@ const port = process.env.PORT || 5052
  * We do not want a circular depedency as galaxy uses mock server for its playground
  */
 const specification = await fs
-  .readFile('dist/latest.json', 'utf8')
+  .readFile('../galaxy/src/specifications/3.1.yaml', 'utf8')
   .catch(() => {
     console.error(
       'MISSING GALAXY SPEC FOR PLAYGROUND. PLEASE BUILD @scalar/galaxy',

--- a/packages/mock-server/playground/index.ts
+++ b/packages/mock-server/playground/index.ts
@@ -10,14 +10,15 @@ const port = process.env.PORT || 5052
  * We do not want a circular depedency as galaxy uses mock server for its playground
  */
 const specification = await fs
-  .readFile('../galaxy/dist/latest.json')
+  .readFile('../galaxy/dist/latest.json', 'utf8')
   .catch((err) => {
-    console.error(err)
     console.error(
       'MISSING GALAXY SPEC FOR PLAYGROUND. PLEASE BUILD @scalar/galaxy',
     )
     return ''
   })
+
+console.log(JSON.stringify(specification, null, 3))
 
 // Create the server instance
 const app = await createMockServer({

--- a/packages/mock-server/playground/index.ts
+++ b/packages/mock-server/playground/index.ts
@@ -10,7 +10,7 @@ const port = process.env.PORT || 5052
  * We do not want a circular depedency as galaxy uses mock server for its playground
  */
 const specification = await fs
-  .readFile('../galaxy/dist/latest.json', 'utf8')
+  .readFile('dist/latest.json', 'utf8')
   .catch((err) => {
     console.error(
       'MISSING GALAXY SPEC FOR PLAYGROUND. PLEASE BUILD @scalar/galaxy',

--- a/packages/mock-server/playground/index.ts
+++ b/packages/mock-server/playground/index.ts
@@ -1,4 +1,5 @@
 import { serve } from '@hono/node-server'
+import { apiReference } from '@scalar/hono-api-reference'
 import fs from 'fs/promises'
 
 import { createMockServer } from '../src/createMockServer'
@@ -11,7 +12,7 @@ const port = process.env.PORT || 5052
  */
 const specification = await fs
   .readFile('dist/latest.json', 'utf8')
-  .catch((err) => {
+  .catch(() => {
     console.error(
       'MISSING GALAXY SPEC FOR PLAYGROUND. PLEASE BUILD @scalar/galaxy',
     )
@@ -25,6 +26,17 @@ const app = await createMockServer({
     console.log(`${context.req.method} ${context.req.url}`)
   },
 })
+
+// Load the middleware
+app.get(
+  '/',
+  apiReference({
+    spec: {
+      content: specification,
+    },
+    pageTitle: 'Scalar Galaxy Spec',
+  }),
+)
 
 // Start the server
 serve(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1521,6 +1521,9 @@ importers:
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
+      '@scalar/hono-api-reference':
+        specifier: workspace:*
+        version: link:../hono-api-reference
       '@scalar/mock-server':
         specifier: workspace:*
         version: link:../mock-server

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 12.3.2(typescript@5.5.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+        version: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -1583,6 +1583,9 @@ importers:
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
+      '@scalar/hono-api-reference':
+        specifier: workspace:*
+        version: link:../hono-api-reference
       '@types/node':
         specifier: ^20.14.10
         version: 20.14.10
@@ -30009,7 +30012,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -30040,7 +30043,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -32700,7 +32703,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
 
   postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.39):
     dependencies:
@@ -35371,7 +35374,7 @@ snapshots:
       '@swc/core': 1.5.29(@swc/helpers@0.5.5)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2):
+  ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11


### PR DESCRIPTION
This PR corrects the path so the mock server loads the galaxy json spec from the galaxy dist folder. 

This PR also adds `hono-api-reference` base route to the galaxy playground. 
