### PR TITLE
feat(api-client): command palette input required

### DIFF
--- a/.changeset/selfish-paws-jog.md
+++ b/.changeset/selfish-paws-jog.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: update scalar icon disabled state

--- a/.changeset/wet-deers-remain.md
+++ b/.changeset/wet-deers-remain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: command palette input required on submit

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteCollection.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteCollection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useWorkspace } from '@/store/workspace'
 import { ScalarButton } from '@scalar/components'
+import { useToasts } from '@scalar/use-toasts'
 import { onMounted, ref } from 'vue'
 
 const emits = defineEmits<{
@@ -9,8 +10,13 @@ const emits = defineEmits<{
 
 const { activeWorkspace, collectionMutators } = useWorkspace()
 const collectionName = ref('')
+const { toast } = useToasts()
 
 const handleSubmit = () => {
+  if (!collectionName.value) {
+    toast('Please enter a name before creating a collection.', 'error')
+    return
+  }
   collectionMutators.add(
     {
       spec: {
@@ -54,6 +60,7 @@ onMounted(() => {
       <div class="flex flex-1 gap-2 max-h-8"></div>
       <ScalarButton
         class="max-h-8 text-xs p-0 px-3"
+        :disabled="!collectionName.trim()"
         @click="handleSubmit">
         Continue
       </ScalarButton>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -8,6 +8,7 @@ import {
   ScalarIcon,
 } from '@scalar/components'
 import type { Request } from '@scalar/oas-utils/entities/workspace/spec'
+import { useToasts } from '@scalar/use-toasts'
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -28,6 +29,7 @@ const {
   requests,
   requestExampleMutators,
 } = useWorkspace()
+const { toast } = useToasts()
 
 const exampleName = ref('')
 const selectedRequest = ref(
@@ -44,6 +46,10 @@ onMounted(() => exampleInput.value?.focus())
 
 /** Add a new request example */
 const handleSubmit = () => {
+  if (!exampleName.value) {
+    toast('Please enter a name before creating an example.', 'error')
+    return
+  }
   const example = requestExampleMutators.add(
     selectedRequest.value,
     exampleName.value,
@@ -111,6 +117,7 @@ onMounted(() => {
       </div>
       <ScalarButton
         class="max-h-8 text-xs p-0 px-3"
+        :disabled="!exampleName.trim()"
         @click="handleSubmit">
         Create Example
       </ScalarButton>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteFolder.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteFolder.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useWorkspace } from '@/store/workspace'
 import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import { useToasts } from '@scalar/use-toasts'
 import { computed, onMounted, ref } from 'vue'
 
 const emits = defineEmits<{
@@ -11,6 +12,7 @@ const { activeWorkspaceCollections, folderMutators, activeCollection } =
   useWorkspace()
 const folderName = ref('')
 const selectedCollectionId = ref(activeCollection.value?.uid ?? '')
+const { toast } = useToasts()
 
 const availableCollections = computed(() =>
   activeWorkspaceCollections.value.map((collection) => ({
@@ -30,6 +32,10 @@ const selectedCollection = computed({
 })
 
 const handleSubmit = () => {
+  if (!folderName.value) {
+    toast('Please enter a name before creating a folder.', 'error')
+    return
+  }
   if (folderName.value && selectedCollection.value) {
     folderMutators.add(
       {
@@ -88,6 +94,7 @@ onMounted(() => {
       </div>
       <ScalarButton
         class="max-h-8 text-xs p-0 px-3"
+        :disabled="!folderName.trim()"
         @click="handleSubmit">
         Create Folder
       </ScalarButton>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
@@ -3,6 +3,7 @@ import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
 import { useWorkspace } from '@/store/workspace'
 import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
 import type { RequestMethod } from '@scalar/oas-utils/helpers'
+import { useToasts } from '@scalar/use-toasts'
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -11,6 +12,7 @@ const emits = defineEmits<{
 }>()
 
 const { push } = useRouter()
+const { toast } = useToasts()
 
 const {
   activeCollection,
@@ -77,6 +79,10 @@ function handleChangeMethod(method: string) {
 }
 
 const handleSubmit = () => {
+  if (!requestName.value.trim()) {
+    toast('Please enter a name before creating a request.', 'error')
+    return
+  }
   if (!selectedCollectionId.value && !selectedFolder.value?.id) return
   const parentUid = selectedFolder.value?.id ?? selectedCollection.value?.id
 
@@ -163,6 +169,7 @@ onMounted(() => {
       </div>
       <ScalarButton
         class="max-h-8 text-xs p-0 px-3"
+        :disabled="!requestName.trim()"
         @click="handleSubmit">
         Create Request
       </ScalarButton>

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -76,14 +76,14 @@ const availableCommands = [
         name: 'Create Workspace',
         icon: 'Workspace',
       },
-      {
-        name: 'Add Server',
-        icon: 'Brackets',
-        path: '/servers',
-      },
+      // {
+      //   name: 'Add Server',
+      //   icon: 'Server',
+      //   path: '/servers',
+      // },
       {
         name: 'Add Environment',
-        icon: 'Server',
+        icon: 'Brackets',
         path: '/environment',
       },
       {

--- a/packages/components/src/components/ScalarButton/variants.ts
+++ b/packages/components/src/components/ScalarButton/variants.ts
@@ -25,7 +25,7 @@ export const variants = cva({
   base: 'scalar-button scalar-row cursor-pointer items-center justify-center rounded font-medium',
   variants: {
     disabled: {
-      true: 'bg-background-2 text-color-3 cursor-not-allowed shadow-none',
+      true: 'bg-background-2 text-color-3 shadow-none',
     },
     fullWidth: { true: 'w-full' },
     size: { sm: 'px-2 py-1 text-xs', md: 'h-10 px-6 text-sm' },
@@ -34,8 +34,8 @@ export const variants = cva({
   compoundVariants: [
     {
       disabled: true,
-      variant: 'ghost',
-      class: 'text-ghost bg-transparent',
+      variant: ['solid', 'outlined', 'ghost', 'danger'],
+      class: 'bg-b-2 text-c-3 shadow-none',
     },
   ],
 })


### PR DESCRIPTION
this pr prevents command palette data submission if input value is empty, set error state toast accordingly and comments out the server link which will be reactivated once the server view is set:

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/3e36420c-2d14-4408-a58f-ebdefc8d1f7e">
