### PR TITLE
feat(nuxt): add dynamic styles import, update README

### DIFF
--- a/.changeset/long-carrots-own.md
+++ b/.changeset/long-carrots-own.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/nuxt': minor
+'@scalar/nuxt': patch
 ---
 
 Added dynamic theme configuration, update README

--- a/.changeset/long-carrots-own.md
+++ b/.changeset/long-carrots-own.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nuxt': minor
+---
+
+Added dynamic theme configuration, update README

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -108,6 +108,17 @@ export default defineNuxtConfig({
 })
 ```
 
+For theme configuration, you can pass a `theme` property to the configuration object. The default theme is `nuxt`, but you can also pass `default` to use the default theme.
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@scalar/nuxt'],
+  scalar: {
+    theme: 'nuxt',
+  },
+})
+```
+
 ## Troubleshooting
 
 If you come across any `**** not default export` errors, its likely you are using `pnpm`.

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -48,7 +48,7 @@ export default defineNuxtConfig({
 })
 ```
 
-By default the docs will be hosted at `/scalar` but you an easily customize that, here's a more in
+By default the docs will be hosted at `/docs` but you an easily customize that, here's a more in
 depth config example.
 
 ```ts

--- a/packages/nuxt/playground/nuxt.config.ts
+++ b/packages/nuxt/playground/nuxt.config.ts
@@ -29,18 +29,24 @@ export default defineNuxtConfig({
       },
     ],
   },
+
   nitro: {
     experimental: {
       openAPI: true,
     },
   },
+
   imports: {
     transform: {
       exclude: [/scalar/],
     },
   },
+
   devtools: { enabled: true },
+
   devServer: {
     port: 5062,
   },
+
+  compatibilityDate: '2024-08-20',
 } as NuxtConfig)

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -29,7 +29,7 @@ export default defineNuxtModule<ModuleOptions>({
       title: 'API Documentation by Scalar',
     },
     pathRouting: {
-      basePath: '/scalar',
+      basePath: '/docs',
     },
     showSidebar: true,
     devtools: true,

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -29,7 +29,7 @@ export default defineNuxtModule<ModuleOptions>({
       title: 'API Documentation by Scalar',
     },
     pathRouting: {
-      basePath: '/docs',
+      basePath: '/scalar',
     },
     showSidebar: true,
     devtools: true,

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -34,6 +34,7 @@ export default defineNuxtModule<ModuleOptions>({
     showSidebar: true,
     devtools: true,
     configurations: [],
+    theme: 'nuxt',
   },
   setup(_options, _nuxt) {
     const resolver = createResolver(import.meta.url)

--- a/packages/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/packages/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -4,11 +4,20 @@ import { ModernLayout, parse } from '@scalar/api-reference'
 import { reactive, ref, toRaw } from 'vue'
 import type { Configuration } from '~/src/types'
 
-import './nuxt-theme.css'
-
 const props = defineProps<{
   configuration: Configuration
 }>()
+
+if (props.configuration.theme === 'nuxt') {
+  useHead({
+    link: [
+      {
+        rel: 'stylesheet',
+        href: new URL('./nuxt-theme.css', import.meta.url).href,
+      },
+    ],
+  })
+}
 
 const isDark = ref(props.configuration.darkMode)
 

--- a/packages/nuxt/src/types.ts
+++ b/packages/nuxt/src/types.ts
@@ -2,7 +2,7 @@ import type { ReferenceConfiguration } from '@scalar/api-reference'
 
 export type Configuration = Omit<
   ReferenceConfiguration,
-  'layout' | 'isEditable' | 'onSpecUpdate'
+  'layout' | 'isEditable' | 'onSpecUpdate' | 'theme'
 > & {
   /**
    * Whether to show scalar in Nuxt DevTools
@@ -10,6 +10,12 @@ export type Configuration = Omit<
    * @default true
    */
   devtools: boolean
+  /**
+   * The theme to use for the reference
+   *
+   * @default 'nuxt'
+   */
+  theme?: ReferenceConfiguration['theme'] | 'nuxt'
 }
 
 export type Meta = {


### PR DESCRIPTION
In this PR, I made these changes:
1. Update Nuxt default config, as in Docs mentioned default route `/scalar` [commit](https://github.com/scalar/scalar/commit/71ff33b05572e78138be88fa54fb9cb845a72dc8)
<img width="847" alt="image" src="https://github.com/user-attachments/assets/b7b1be85-7027-4b63-8139-1b512123fe8a">

2. Added `theme` config because I want to use the default theme, not only `nuxt` once; I think this will be better if the user could select from predefined ones or an exclusive `nuxt` theme, which is the default; also updated README.md file

https://github.com/user-attachments/assets/01c4f182-25d7-44a6-9ba8-1a010813833e


