### PR TITLE
feat: add xl scalar modal

### DIFF
--- a/.changeset/slow-yaks-chew.md
+++ b/.changeset/slow-yaks-chew.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: add xl scalar modal

--- a/packages/components/src/components/ScalarModal/ScalarModal.stories.ts
+++ b/packages/components/src/components/ScalarModal/ScalarModal.stories.ts
@@ -10,7 +10,10 @@ const meta = {
   component: ScalarModal,
   tags: ['autodocs'],
   argTypes: {
-    size: { control: 'select', options: ['xxs', 'xs', 'sm', 'md', 'lg'] },
+    size: {
+      control: 'select',
+      options: ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'full'],
+    },
     variant: { control: 'select', options: ['history', 'search'] },
   },
 } satisfies Meta<typeof ScalarModal>
@@ -37,6 +40,52 @@ export const Base: Story = {
             <ScalarButton variant="outlined" @click="modalState.hide()" fullWidth>Cancel</ScalarButton>
             <ScalarButton @click="modalState.hide()" fullWidth>Go ahead</ScalarButton>
           </div>
+        </div>
+      </ScalarModal>
+      <ScalarButton @click="modalState.show()">Click me</ScalarButton>
+    `,
+  }),
+}
+
+export const Scrolling: Story = {
+  args: {} as any,
+  render: (args) => ({
+    components: { ScalarButton, ScalarModal },
+    setup() {
+      const modalState = useModal()
+      return { args, modalState }
+    },
+    template: `
+      <ScalarModal
+        :state="modalState"
+        title="Example modal"
+        v-bind="args">
+        <div class="markdown">
+<h1>HTML Ipsum Presents</h1>
+
+				<p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href="#">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p>
+
+				<h2>Header Level 2</h2>
+
+				<ol>
+				   <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+				   <li>Aliquam tincidunt mauris eu risus.</li>
+				</ol>
+
+				<blockquote><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est.</p></blockquote>
+
+				<h3>Header Level 3</h3>
+
+				<ul>
+				   <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+				   <li>Aliquam tincidunt mauris eu risus.</li>
+				</ul>
+
+<pre><code>#header h1 a {
+  display: block;
+  width: 300px;
+  height: 80px;
+}</code></pre>
         </div>
       </ScalarModal>
       <ScalarButton @click="modalState.show()">Click me</ScalarButton>

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -29,15 +29,16 @@ withDefaults(
 const modal = cva({
   base: [
     'scalar-modal',
-    'col relative mx-auto mb-0 mt-20 w-full rounded-lg bg-b-2 p-0 text-left leading-snug text-c-1 opacity-0',
+    'col relative mx-auto mb-0 mt-20 w-[calc(100vw-16px)] rounded-lg bg-b-2 p-0 text-left leading-snug text-c-1 opacity-0 lg:w-[calc(100vw-32px)]',
   ].join(' '),
   variants: {
     size: {
-      xxs: 'max-w-screen-xxs',
-      xs: 'max-w-screen-xs',
-      sm: 'max-w-screen-sm',
-      md: 'max-w-screen-md',
-      lg: 'max-w-screen-lg',
+      xxs: 'mt-20 max-w-screen-xxs',
+      xs: 'mt-20 max-w-screen-xs',
+      sm: 'mt-20 max-w-screen-sm',
+      md: 'mt-20 max-w-screen-md',
+      lg: 'mt-10 max-w-screen-lg',
+      xl: 'mt-2 max-w-screen-xl',
       full: 'mt-0 overflow-hidden',
     },
     variant: {
@@ -55,6 +56,15 @@ const body = cva({
     variant: {
       history: 'pt-3',
       search: 'col !m-0 max-h-[440px] overflow-hidden p-0',
+    },
+    size: {
+      xxs: 'max-h-[calc(100dvh-240px)]',
+      xs: 'max-h-[calc(100dvh-240px)]',
+      sm: 'max-h-[calc(100dvh-240px)]',
+      md: 'max-h-[calc(100dvh-240px)]',
+      lg: 'max-h-[calc(100dvh-180px)]',
+      xl: 'max-h-[calc(100dvh-120px)]',
+      full: 'max-h-dvh',
     },
   },
 })
@@ -100,7 +110,7 @@ export const useModal = () =>
         </div>
         <DialogDescription
           v-else
-          :class="cx(bodyClass, body({ variant }))">
+          :class="cx(bodyClass, body({ size, variant }))">
           <slot />
         </DialogDescription>
       </DialogPanel>

--- a/packages/components/tailwind.config.ts
+++ b/packages/components/tailwind.config.ts
@@ -25,6 +25,7 @@ export default {
         'screen-sm': '540px',
         'screen-md': '640px',
         'screen-lg': '800px',
+        'screen-xl': '1000px',
       },
       zIndex: {
         // Contextual overlays like dropdowns, popovers, tooltips


### PR DESCRIPTION
Add an `xl` Scalar modal and tweaks the sizing of the `lg` modal to allow it to be a bit taller before scrolling. I checked and we don't use the `lg` modal anywhere so this shouldn't break anything.


https://github.com/user-attachments/assets/859dd924-89f2-435b-a101-ad23d459b3ec

