### PR TITLE
docs: add documentation for additional hooks in Fastify

### DIFF
--- a/documentation/integrations/fastify.md
+++ b/documentation/integrations/fastify.md
@@ -212,6 +212,15 @@ import ScalarApiReference from '@scalar/fastify-api-reference'
 
 await fastify.register(ScalarApiReference, {
   routePrefix: '/reference',
+  // Additional hooks for the API reference routes. You can provide the onRequest and preHandler hooks
+  hooks: {
+    onRequest: function (request, reply, done) {
+      done()
+    },
+    preHandler: function (request, reply, done) {
+      done()
+    },
+  },
 })
 
 // …
@@ -224,6 +233,8 @@ Wow, this is it already. Restart the server, if it didn’t already and take a l
 <http://localhost:3000/reference>
 
 That’s it, you made it! You can keep adding routes to Fastify now and the reference will keep in sync with them.
+
+For Additional hooks you can learn more about [route's options](https://fastify.dev/docs/latest/Reference/Routes/#routes-options) interface.
 
 ## Customize everything (optional)
 


### PR DESCRIPTION
This PR adds documentation for the usage of the additional hooks option in the `fastify-api-reference`, related to #2834.