### PR TITLE
fix(components): use single scroll container for codeblock

### DIFF
--- a/.changeset/green-turtles-allow.md
+++ b/.changeset/green-turtles-allow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): use single scroll container for codeblock

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -54,26 +54,21 @@ const isContentValid = computed(() => {
           size="md" />
       </button>
     </div>
-    <div class="scalar-code-scroll custom-scroll">
-      <pre
-        class="scalar-codeblock-pre"
-        v-html="highlightedCode"></pre>
-    </div>
+    <pre
+      class="scalar-codeblock-pre"
+      v-html="highlightedCode"></pre>
   </div>
 </template>
 <style>
 @import '@scalar/code-highlight/css/code.css';
 .scalar-code-block {
   position: relative;
+  overflow: auto;
+  padding: 0.5rem 0.5rem 0.5rem 0.75rem;
 }
 .scalar-code-block:hover .copy-button {
   opacity: 100;
   visibility: visible;
-}
-.scalar-code-block .scalar-code-scroll.custom-scroll {
-  padding: 0.5rem 0.5rem 0.5rem 0.75rem;
-  overflow-x: auto;
-  overflow-y: hidden;
 }
 /* Code blocks */
 .scalar-codeblock-pre {
@@ -94,8 +89,8 @@ const isContentValid = computed(() => {
 }
 .copy-button {
   position: relative;
-  top: 8px;
-  right: 8px;
+  top: 0px;
+  right: 0px;
 
   display: flex;
   align-items: center;


### PR DESCRIPTION
Switches to a single scroll container (both x and y) for `ScalarCodeBlock`.

## Before / After

### With automatic / hidden scrollbars

https://github.com/user-attachments/assets/adae3c6f-d603-44ff-bfce-37282802cf6e

### With obtrusive / always visible scrollbars

https://github.com/user-attachments/assets/201d4b72-dec9-49b4-8050-2c6ef453dfc8

