### PR TITLE
feat(api-reference): collapse models by default

### DIFF
--- a/.changeset/dull-suits-hang.md
+++ b/.changeset/dull-suits-hang.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat(api-reference): collapse models by default

--- a/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
+++ b/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { ScalarIcon } from '@scalar/components'
+import { ref } from 'vue'
+
+import { useNavState } from '../../../hooks'
+import { Schema, SchemaHeading } from '../Schema'
+
+defineProps<{ name: string; schemas: Record<string, any> }>()
+const { getModelId } = useNavState()
+
+const showCollapsedItems = ref(false)
+</script>
+<template>
+  <div
+    :id="getModelId(name)"
+    :label="name"
+    @click="showCollapsedItems = !showCollapsedItems">
+    <template v-if="(schemas as any)[name]">
+      <ScalarIcon
+        :icon="showCollapsedItems ? 'ChevronDown' : 'ChevronRight'"
+        size="md"
+        thickness="1.75" />
+      <SchemaHeading
+        :name="name"
+        :value="(schemas as any)[name]" />
+      <Schema
+        v-if="showCollapsedItems"
+        :hideHeading="true"
+        noncollapsible
+        :value="(schemas as any)[name]" />
+      <!-- <SectionContent>
+        <SectionHeader :level="2">
+          <Anchor :id="getModelId(name)">
+            {{ (schemas as any)[name].title ?? name }}
+          </Anchor>
+        </SectionHeader>
+        <Schema
+          :name="name"
+          noncollapsible
+          :value="(schemas as any)[name]" />
+      </SectionContent> -->
+    </template>
+  </div>
+</template>

--- a/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
+++ b/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
@@ -1,15 +1,29 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components'
-import { ref } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 
+import { scrollToId } from '../../../helpers'
 import { useNavState } from '../../../hooks'
 import Anchor from '../../Anchor/Anchor.vue'
+import { Section } from '../../Section'
 import { Schema, SchemaHeading } from '../Schema'
 
-defineProps<{ name: string; schemas: Record<string, any> }>()
-const { getModelId } = useNavState()
+const props = defineProps<{ name: string; schemas: Record<string, any> }>()
+const { hash, getModelId } = useNavState()
 
 const showCollapsedItems = ref(false)
+
+watch(
+  hash,
+  async (id) => {
+    if (id === getModelId(props.name) && !showCollapsedItems.value) {
+      showCollapsedItems.value = true
+      await nextTick()
+      scrollToId(getModelId(props.name))
+    }
+  },
+  { immediate: true },
+)
 </script>
 <template>
   <div
@@ -30,11 +44,16 @@ const showCollapsedItems = ref(false)
             :value="(schemas as any)[name]" />
         </Anchor>
       </div>
-      <Schema
+      <Section
         v-if="showCollapsedItems"
-        :hideHeading="true"
-        noncollapsible
-        :value="(schemas as any)[name]" />
+        :id="getModelId(name)"
+        class="collapsed-model-section"
+        :label="name">
+        <Schema
+          :hideHeading="true"
+          noncollapsible
+          :value="(schemas as any)[name]" />
+      </Section>
     </template>
   </div>
 </template>
@@ -75,5 +94,9 @@ const showCollapsedItems = ref(false)
 }
 .collapsed-model .collapsed-model-trigger :deep(.anchor-copy) {
   line-height: 18.5px;
+}
+.collapsed-model-section {
+  padding: 0;
+  margin: 0;
 }
 </style>

--- a/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
+++ b/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
@@ -73,4 +73,7 @@ const showCollapsedItems = ref(false)
 .collapsed-model:hover .collapsed-model-trigger svg {
   color: var(--scalar-color-1);
 }
+.collapsed-model .collapsed-model-trigger :deep(.anchor-copy) {
+  line-height: 18.5px;
+}
 </style>

--- a/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
+++ b/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
@@ -36,8 +36,7 @@ watch(
         @click="showCollapsedItems = !showCollapsedItems">
         <ScalarIcon
           :icon="showCollapsedItems ? 'ChevronDown' : 'ChevronRight'"
-          size="md"
-          thickness="1.75" />
+          size="sm" />
         <Anchor :id="getModelId(name)">
           <SchemaHeading
             :name="name"

--- a/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
+++ b/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
@@ -15,10 +15,11 @@ const showCollapsedItems = ref(false)
   <div
     :id="getModelId(name)"
     class="collapsed-model"
-    :label="name"
-    @click="showCollapsedItems = !showCollapsedItems">
+    :label="name">
     <template v-if="(schemas as any)[name]">
-      <div class="collapsed-model-trigger">
+      <div
+        class="collapsed-model-trigger"
+        @click="showCollapsedItems = !showCollapsedItems">
         <ScalarIcon
           :icon="showCollapsedItems ? 'ChevronDown' : 'ChevronRight'"
           size="md"
@@ -51,6 +52,7 @@ const showCollapsedItems = ref(false)
   align-items: center;
   cursor: pointer;
   padding-top: 10px;
+  font-size: var(--scalar-font-size-3);
 }
 .collapsed-model .collapsed-model-trigger:after {
   content: '';

--- a/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
+++ b/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
@@ -3,6 +3,7 @@ import { ScalarIcon } from '@scalar/components'
 import { ref } from 'vue'
 
 import { useNavState } from '../../../hooks'
+import Anchor from '../../Anchor/Anchor.vue'
 import { Schema, SchemaHeading } from '../Schema'
 
 defineProps<{ name: string; schemas: Record<string, any> }>()
@@ -20,25 +21,16 @@ const showCollapsedItems = ref(false)
         :icon="showCollapsedItems ? 'ChevronDown' : 'ChevronRight'"
         size="md"
         thickness="1.75" />
-      <SchemaHeading
-        :name="name"
-        :value="(schemas as any)[name]" />
+      <Anchor :id="getModelId(name)">
+        <SchemaHeading
+          :name="name"
+          :value="(schemas as any)[name]" />
+      </Anchor>
       <Schema
         v-if="showCollapsedItems"
         :hideHeading="true"
         noncollapsible
         :value="(schemas as any)[name]" />
-      <!-- <SectionContent>
-        <SectionHeader :level="2">
-          <Anchor :id="getModelId(name)">
-            {{ (schemas as any)[name].title ?? name }}
-          </Anchor>
-        </SectionHeader>
-        <Schema
-          :name="name"
-          noncollapsible
-          :value="(schemas as any)[name]" />
-      </SectionContent> -->
     </template>
   </div>
 </template>

--- a/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
+++ b/packages/api-reference/src/components/Content/Models/CollapsedModel.vue
@@ -14,18 +14,21 @@ const showCollapsedItems = ref(false)
 <template>
   <div
     :id="getModelId(name)"
+    class="collapsed-model"
     :label="name"
     @click="showCollapsedItems = !showCollapsedItems">
     <template v-if="(schemas as any)[name]">
-      <ScalarIcon
-        :icon="showCollapsedItems ? 'ChevronDown' : 'ChevronRight'"
-        size="md"
-        thickness="1.75" />
-      <Anchor :id="getModelId(name)">
-        <SchemaHeading
-          :name="name"
-          :value="(schemas as any)[name]" />
-      </Anchor>
+      <div class="collapsed-model-trigger">
+        <ScalarIcon
+          :icon="showCollapsedItems ? 'ChevronDown' : 'ChevronRight'"
+          size="md"
+          thickness="1.75" />
+        <Anchor :id="getModelId(name)">
+          <SchemaHeading
+            :name="name"
+            :value="(schemas as any)[name]" />
+        </Anchor>
+      </div>
       <Schema
         v-if="showCollapsedItems"
         :hideHeading="true"
@@ -34,3 +37,38 @@ const showCollapsedItems = ref(false)
     </template>
   </div>
 </template>
+<style scoped>
+.collapsed-model {
+  padding: 0 0 10px;
+  border-top: var(--scalar-border-width) solid var(--scalar-border-color);
+  position: relative;
+}
+.collapsed-model:has(+ .show-more) {
+  border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
+}
+.collapsed-model .collapsed-model-trigger {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding-top: 10px;
+}
+.collapsed-model .collapsed-model-trigger:after {
+  content: '';
+  height: 10px;
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+}
+.collapsed-model .schema-card {
+  margin-top: 10px;
+}
+.collapsed-model-trigger svg {
+  color: var(--scalar-color-3);
+  position: absolute;
+  left: -18px;
+  margin-top: 1px;
+}
+.collapsed-model:hover .collapsed-model-trigger svg {
+  color: var(--scalar-color-1);
+}
+</style>

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -44,25 +44,28 @@ const models = computed(() => {
 </script>
 <template>
   <SectionContainer v-if="schemas">
-    <!-- Just a cheap trick to jump down to models -->
-    <Lazy
-      id="models"
-      :isLazy="false">
-      <div id="models" />
-    </Lazy>
-    <Lazy
-      v-for="(name, index) in models"
-      :id="getModelId(name)"
-      :key="name"
-      isLazy>
-      <CollapsedModel
-        :name="name"
-        :schemas="schemas" />
-      <ShowMoreButton
-        v-if="!showAllModels && index === models.length - 1"
-        :id="getModelId()"
-        class="something-special" />
-    </Lazy>
+    <Section>
+      <!-- Just a cheap trick to jump down to models -->
+      <SectionHeader :level="2">Models</SectionHeader>
+      <Lazy
+        id="models"
+        :isLazy="false">
+        <div id="models" />
+      </Lazy>
+      <Lazy
+        v-for="(name, index) in models"
+        :id="getModelId(name)"
+        :key="name"
+        isLazy>
+        <CollapsedModel
+          :name="name"
+          :schemas="schemas" />
+        <ShowMoreButton
+          v-if="!showAllModels && index === models.length - 1"
+          :id="getModelId()"
+          class="something-special" />
+      </Lazy>
+    </Section>
   </SectionContainer>
 </template>
 <style scoped>

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -22,12 +22,14 @@ const props = defineProps<{
     | unknown
 }>()
 
+const MAX_MODELS_INITIALLY_SHOWN = 10
+
 const { collapsedSidebarItems } = useSidebar()
 const { getModelId } = useNavState()
 
 const showAllModels = computed(
   () =>
-    Object.keys(props.schemas ?? {}).length <= 3 ||
+    Object.keys(props.schemas ?? {}).length <= MAX_MODELS_INITIALLY_SHOWN ||
     collapsedSidebarItems[getModelId()],
 )
 
@@ -38,8 +40,8 @@ const models = computed(() => {
     return allModels
   }
 
-  // return only first 3 models
-  return allModels.slice(0, 3)
+  // return only first MAX_MODELS_INITIALLY_SHOWN models
+  return allModels.slice(0, MAX_MODELS_INITIALLY_SHOWN)
 })
 </script>
 <template>

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -3,13 +3,7 @@ import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-parser'
 import { computed } from 'vue'
 
 import { useNavState, useSidebar } from '../../../hooks'
-import { Anchor } from '../../Anchor'
-import {
-  Section,
-  SectionContainer,
-  SectionContent,
-  SectionHeader,
-} from '../../Section'
+import { Section, SectionContainer, SectionHeader } from '../../Section'
 import ShowMoreButton from '../../ShowMoreButton.vue'
 import { Lazy } from '../Lazy'
 import CollapsedModel from './CollapsedModel.vue'
@@ -64,8 +58,7 @@ const models = computed(() => {
           :schemas="schemas" />
         <ShowMoreButton
           v-if="!showAllModels && index === models.length - 1"
-          :id="getModelId()"
-          class="something-special" />
+          :id="getModelId()" />
       </Lazy>
     </Section>
   </SectionContainer>

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -12,7 +12,7 @@ import {
 } from '../../Section'
 import ShowMoreButton from '../../ShowMoreButton.vue'
 import { Lazy } from '../Lazy'
-import { Schema } from '../Schema'
+import CollapsedModel from './CollapsedModel.vue'
 
 const props = defineProps<{
   schemas?:
@@ -55,29 +55,13 @@ const models = computed(() => {
       :id="getModelId(name)"
       :key="name"
       isLazy>
-      <Section
-        :id="getModelId(name)"
-        :label="name">
-        <template v-if="(schemas as any)[name]">
-          <SectionContent>
-            <SectionHeader :level="2">
-              <Anchor :id="getModelId(name)">
-                {{ (schemas as any)[name].title ?? name }}
-              </Anchor>
-            </SectionHeader>
-            <!-- Schema -->
-            <Schema
-              :name="name"
-              noncollapsible
-              :value="(schemas as any)[name]" />
-            <!-- Show More Button -->
-            <ShowMoreButton
-              v-if="!showAllModels && index === models.length - 1"
-              :id="getModelId()"
-              class="something-special" />
-          </SectionContent>
-        </template>
-      </Section>
+      <CollapsedModel
+        :name="name"
+        :schemas="schemas" />
+      <ShowMoreButton
+        v-if="!showAllModels && index === models.length - 1"
+        :id="getModelId()"
+        class="something-special" />
     </Lazy>
   </SectionContainer>
 </template>

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -86,8 +86,8 @@ const handleClick = (e: MouseEvent) =>
               v-if="shouldShowToggle"
               class="schema-card-title-icon"
               :class="{ 'schema-card-title-icon--open': open }"
-              icon="ChevronRight"
-              size="md" />
+              icon="Add"
+              size="xs" />
             <SchemaHeading
               :name="(value?.title ?? name) as string"
               :value="value" />
@@ -163,10 +163,9 @@ const handleClick = (e: MouseEvent) =>
 }
 
 .schema-card-title {
-  --schema-title-height: 38px;
   height: var(--schema-title-height);
 
-  padding: 10px 12px;
+  padding: 6px 10px;
 
   display: flex;
   align-items: center;
@@ -175,8 +174,6 @@ const handleClick = (e: MouseEvent) =>
   color: var(--scalar-color-2);
   font-weight: var(--scalar-semibold);
   font-size: var(--scalar-micro);
-  background: var(--scalar-background-1);
-  border-radius: var(--scalar-radius-lg);
   border-bottom: var(--scalar-border-width) solid transparent;
 }
 button.schema-card-title {
@@ -185,11 +182,8 @@ button.schema-card-title {
 button.schema-card-title:hover {
   color: var(--scalar-color-1);
 }
-.schema-card-title-icon {
-  margin-left: -4px;
-}
 .schema-card-title-icon--open {
-  transform: rotate(90deg);
+  transform: rotate(45deg);
 }
 .schema-properties-open > .schema-card-title {
   z-index: 1;
@@ -223,8 +217,14 @@ button.schema-card-title:hover {
 
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   border-radius: var(--scalar-radius-lg);
+  width: fit-content;
 }
-
+.schema-properties .schema-properties {
+  border-radius: 13.5px;
+}
+.schema-properties-open {
+  width: 100%;
+}
 .schema-card--compact {
   align-self: start;
 }

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -25,6 +25,7 @@ const props = withDefaults(
     compact?: boolean
     /** Shows a toggle to hide/show children */
     noncollapsible?: boolean
+    hideHeading?: boolean
   }>(),
   { level: 0 },
 )
@@ -58,7 +59,7 @@ const handleClick = (e: MouseEvent) =>
         class="schema-properties"
         :class="{ 'schema-properties-open': open }">
         <DisclosureButton
-          v-show="!(noncollapsible && compact)"
+          v-show="!hideHeading && !(noncollapsible && compact)"
           :as="noncollapsible ? 'div' : 'button'"
           class="schema-card-title"
           :class="{ 'schema-card-title--compact': compact }"

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -206,6 +206,9 @@ button.schema-card-title:hover {
 .schema-card-description + .schema-properties {
   width: fit-content;
 }
+.schema-card-description + .schema-properties {
+  margin-top: 12px;
+}
 .schema-properties-open.schema-properties,
 .schema-properties-open > .schema-card--open {
   width: 100%;

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -87,7 +87,8 @@ const handleClick = (e: MouseEvent) =>
               class="schema-card-title-icon"
               :class="{ 'schema-card-title-icon--open': open }"
               icon="Add"
-              size="xs" />
+              size="xs"
+              thickness="2.5" />
             <SchemaHeading
               :name="(value?.title ?? name) as string"
               :value="value" />
@@ -186,10 +187,6 @@ button.schema-card-title:hover {
   transform: rotate(45deg);
 }
 .schema-properties-open > .schema-card-title {
-  z-index: 1;
-  position: sticky;
-  top: var(--refs-header-height);
-
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
@@ -221,6 +218,9 @@ button.schema-card-title:hover {
 }
 .schema-properties .schema-properties {
   border-radius: 13.5px;
+}
+.schema-properties .schema-properties.schema-properties-open {
+  border-radius: 13.5px 13.5px var(--scalar-radius) var(--scalar-radius);
 }
 .schema-properties-open {
   width: 100%;

--- a/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
@@ -49,6 +49,6 @@ defineProps<{
 }
 .schema-type {
   font-family: var(--scalar-font-code);
-  font-size: var(--scalar-font-size-3);
+  color: var(--scalar-color-1);
 }
 </style>

--- a/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
@@ -45,8 +45,10 @@ defineProps<{
 /* Style the "icon" */
 .schema-type-icon {
   color: var(--scalar-color-1);
+  display: none;
 }
 .schema-type {
   font-family: var(--scalar-font-code);
+  font-size: var(--scalar-font-size-3);
 }
 </style>


### PR DESCRIPTION
Collapses and cleans up the models area, based off of #2833.

* Opens a model if you click on it in the sidebar
* Opens a model if you navigate to it via url
* Open a model if you navigate to it via search
* Highlights the model in the sidebar if it's visible and open

I also make the chevron a tiny bit smaller because it was running into the model heading.


https://github.com/user-attachments/assets/7244eff3-5d93-4202-8729-17f7aebd177d

