### PR TITLE
style(api-reference): search modal deprecated endpoint

### DIFF
--- a/.changeset/search-modal-deprecated-endpoint.md
+++ b/.changeset/search-modal-deprecated-endpoint.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+style(api-reference): search modal deprecated endpoint

--- a/packages/api-reference/src/features/Search/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/SearchModal.vue
@@ -109,7 +109,10 @@ function getFullUrlFromHash(href: string) {
         :icon="ENTRY_ICONS[entry.item.type]"
         @click="onSearchResultClick(entry)"
         @focus="selectedSearchResult = index">
-        {{ entry.item.title }}
+        <span
+          :class="{ deprecated: entry.item.operation?.information?.deprecated }"
+          >{{ entry.item.title }}</span
+        >
         <template
           v-if="
             (entry.item.httpVerb || entry.item.path) &&
@@ -158,5 +161,8 @@ a {
   font-weight: var(--scalar-semibold);
   display: flex;
   gap: 12px;
+}
+.deprecated {
+  text-decoration: line-through;
 }
 </style>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/42a45310-c40d-4a93-8382-c5b5001c22ce)

After:
![image](https://github.com/user-attachments/assets/5acd4233-58cd-4064-acf8-db141eb68999)

