### PR TITLE
fix: authentication form submitted on enter, fix #2917

### DIFF
--- a/.changeset/witty-beers-cough.md
+++ b/.changeset/witty-beers-cough.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: authentication form submits on enter

--- a/packages/api-reference/src/legacy/components/SecurityScheme.vue
+++ b/packages/api-reference/src/legacy/components/SecurityScheme.vue
@@ -229,7 +229,9 @@ const startAuthentication = (url: string) => {
 }
 </script>
 <template>
-  <CardForm v-if="value && value?.type">
+  <CardForm
+    v-if="value && value?.type"
+    @submit.prevent>
     <!-- API Key -->
     <CardFormTextInput
       v-if="value.type === 'apiKey'"


### PR DESCRIPTION
Currently, the authentication form is submitted when hitting enter in an input field. This reloads the page and added information is lost.

With this PR the submit of this form is prevented, we don’t want to submit the form anyway.