### PR TITLE
feat(api-reference): multipart and url encoded request data, fix #2902, fix #1451

### DIFF
--- a/.changeset/curly-moose-confess.md
+++ b/.changeset/curly-moose-confess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: request bodies for multipart form data and url encoded form data

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -24,7 +24,7 @@ describe('getExampleFromSchema', () => {
       getExampleFromSchema({
         enum: ['available', 'pending', 'sold'],
       }),
-    ).toMatchObject('available')
+    ).toBe('available')
   })
 
   it('uses empty quotes as a fallback for strings', () => {
@@ -32,7 +32,7 @@ describe('getExampleFromSchema', () => {
       getExampleFromSchema({
         type: 'string',
       }),
-    ).toMatchObject('')
+    ).toBe('')
   })
 
   it('only includes required attributes and attributes with example values', () => {
@@ -79,7 +79,7 @@ describe('getExampleFromSchema', () => {
       getExampleFromSchema({
         type: ['string', 'number'],
       }),
-    ).toMatchObject('')
+    ).toBe('')
   })
 
   it('uses null for nullable union types', () => {
@@ -187,7 +187,7 @@ describe('getExampleFromSchema', () => {
           emptyString: '…',
         },
       ),
-    ).toMatchObject('…')
+    ).toBe('…')
   })
 
   it('returns emails as an example value', () => {
@@ -416,7 +416,7 @@ describe('getExampleFromSchema', () => {
       default: 'BAD_REQUEST_EXCEPTION',
     }
 
-    expect(getExampleFromSchema(schema)).toMatchObject('BAD_REQUEST_EXCEPTION')
+    expect(getExampleFromSchema(schema)).toBe('BAD_REQUEST_EXCEPTION')
   })
 
   it('uses 1 as the default for a number', () => {
@@ -625,7 +625,7 @@ describe('getExampleFromSchema', () => {
           },
         ],
       }),
-    ).toMatchObject('')
+    ).toBe('')
   })
 
   it('works with allOf', () => {
@@ -637,7 +637,7 @@ describe('getExampleFromSchema', () => {
           },
         ],
       }),
-    ).toMatchObject('')
+    ).toBe('')
   })
 
   it('uses all schemas in allOf', () => {
@@ -682,7 +682,7 @@ describe('getExampleFromSchema', () => {
         example: 'foobar',
         readOnly: true,
       }),
-    ).toMatchObject('foobar')
+    ).toBe('foobar')
   })
 
   it('returns readOnly attributes in read mode', () => {
@@ -696,7 +696,7 @@ describe('getExampleFromSchema', () => {
           mode: 'read',
         },
       ),
-    ).toMatchObject('foobar')
+    ).toBe('foobar')
   })
 
   it('doesn’t return readOnly attributes in write mode', () => {
@@ -719,7 +719,7 @@ describe('getExampleFromSchema', () => {
         example: 'foobar',
         writeOnly: true,
       }),
-    ).toMatchObject('foobar')
+    ).toBe('foobar')
   })
 
   it('returns writeOnly attributes in write mode', () => {
@@ -733,7 +733,7 @@ describe('getExampleFromSchema', () => {
           mode: 'write',
         },
       ),
-    ).toMatchObject('foobar')
+    ).toBe('foobar')
   })
 
   it('doesn’t return writeOnly attributes in read mode', () => {

--- a/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.test.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.test.ts
@@ -242,4 +242,46 @@ describe('getRequestBodyFromOperation', () => {
       text: JSON.stringify(expectedResult, null, 2),
     })
   })
+
+  it('adds parameters from a requestBody schema', () => {
+    const request = getRequestBodyFromOperation({
+      httpVerb: 'POST',
+      path: '/foobar',
+      information: {
+        requestBody: {
+          content: {
+            'application/x-www-form-urlencoded': {
+              schema: {
+                type: 'object',
+                properties: {
+                  id: {
+                    type: 'integer',
+                    example: 1,
+                  },
+                  name: {
+                    type: 'string',
+                    example: 'foobar',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(request?.postData).toMatchObject({
+      mimeType: 'application/x-www-form-urlencoded',
+      params: [
+        {
+          name: 'id',
+          value: 1,
+        },
+        {
+          name: 'name',
+          value: 'foobar',
+        },
+      ],
+    })
+  })
 })

--- a/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.ts
@@ -11,7 +11,7 @@ import { getParametersFromOperation } from './getParametersFromOperation'
  * that represent the key-value pairs of the object.
  */
 function getParamsFromObject(
-  obj: any,
+  obj: AnyObject,
   prefix = '',
 ): {
   name: string

--- a/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.ts
@@ -6,6 +6,8 @@ import { prettyPrintJson } from '../helpers/prettyPrintJson'
 import { getExampleFromSchema } from './getExampleFromSchema'
 import { getParametersFromOperation } from './getParametersFromOperation'
 
+type AnyObject = Record<string, any>
+
 /**
  * Transform the object into a nested array of objects
  * that represent the key-value pairs of the object.


### PR DESCRIPTION
Long overdue! This PR adds support for request bodies with the `application/x-www-form-urlencode` and `multipart/form-data` content types. :)

See #2902 for more context.