### PR TITLE
fix(api-reference): incorrect example for schemas with anyOf, fix #2218

### DIFF
--- a/.changeset/selfish-ladybugs-pretend.md
+++ b/.changeset/selfish-ladybugs-pretend.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: incorrect example for schemas with anyOf

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -834,4 +834,43 @@ describe('getExampleFromSchema', () => {
       },
     })
   })
+
+  it('works with anyOf', () => {
+    expect(
+      getExampleFromSchema({
+        title: 'Foo',
+        type: 'object',
+        anyOf: [
+          {
+            type: 'object',
+            required: ['a'],
+            properties: {
+              a: {
+                type: 'integer',
+                format: 'int32',
+              },
+            },
+          },
+          {
+            type: 'object',
+            required: ['b'],
+            properties: {
+              b: {
+                type: 'string',
+              },
+            },
+          },
+        ],
+        required: ['c'],
+        properties: {
+          c: {
+            type: 'boolean',
+          },
+        },
+      }),
+    ).toStrictEqual({
+      a: 1,
+      c: true,
+    })
+  })
 })

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -186,16 +186,12 @@ export const getExampleFromSchema = (
     if (schema.anyOf !== undefined) {
       Object.assign(
         response,
-        getExampleFromSchema(schema.anyOf[0]),
-        options,
-        level + 1,
+        getExampleFromSchema(schema.anyOf[0], options, level + 1),
       )
     } else if (schema.oneOf !== undefined) {
       Object.assign(
         response,
-        getExampleFromSchema(schema.oneOf[0]),
-        options,
-        level + 1,
+        getExampleFromSchema(schema.oneOf[0], options, level + 1),
       )
     } else if (schema.allOf !== undefined) {
       Object.assign(


### PR DESCRIPTION
I’ve had a nasty typo: Instead of passing options to `getExampleFromSchema` I just merged the options with the result. 🙈 

This PR fixes it and adds a basic test for schemas containing `anyOf`.

See #2218