### PR TITLE
chore: remove parser release badge

### DIFF
--- a/packages/openapi-types/README.md
+++ b/packages/openapi-types/README.md
@@ -1,7 +1,6 @@
 # Scalar OpenAPI Types
 
 [![CI](https://github.com/scalar/openapi-parser/actions/workflows/ci.yml/badge.svg)](https://github.com/scalar/openapi-parser/actions/workflows/ci.yml)
-[![Release](https://github.com/scalar/openapi-parser/actions/workflows/release.yml/badge.svg)](https://github.com/scalar/openapi-parser/actions/workflows/release.yml)
 [![Contributors](https://img.shields.io/github/contributors/scalar/openapi-parser)](https://github.com/scalar/openapi-parser/graphs/contributors)
 [![GitHub License](https://img.shields.io/github/license/scalar/openapi-parser)](https://github.com/scalar/openapi-parser/blob/main/LICENSE)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)


### PR DESCRIPTION
I removed the release workflow from `scalar/openapi-parser`, but the `@scalar/openapi-types` package (which already lives here) points to the release workflow badge. Let’s remove this to make CI in main green again.