### PR TITLE
chore: update `@scalar/snippetz`

### DIFF
--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -67,7 +67,7 @@
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
     "@scalar/openapi-parser": "^0.7.2",
-    "@scalar/snippetz": "^0.1.6",
+    "@scalar/snippetz": "^0.2.0",
     "@scalar/themes": "workspace:*",
     "@scalar/types": "workspace:*",
     "@scalar/use-toasts": "workspace:*",

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -9,7 +9,7 @@ import {
 import { ScalarCodeBlock } from '@scalar/components'
 import { createHash, ssrState } from '@scalar/oas-utils/helpers'
 import { getRequestFromOperation } from '@scalar/oas-utils/spec-getters'
-import { snippetz } from '@scalar/snippetz'
+import { type TargetId, snippetz } from '@scalar/snippetz'
 import type {
   CustomRequestExample,
   ExampleRequestSSRKey,
@@ -139,12 +139,10 @@ async function generateSnippet() {
 
   const targetKey = httpClient.targetKey.replace('javascript', 'js')
 
-  if (
-    clientKey &&
-    snippetz().hasPlugin(targetKey, clientKey) &&
-    (targetKey === 'node' || targetKey === 'js')
-  ) {
-    return snippetz().print(targetKey, clientKey, request as any) ?? ''
+  if (clientKey && snippetz().hasPlugin(targetKey, clientKey)) {
+    return (
+      snippetz().print(targetKey as TargetId, clientKey, request as any) ?? ''
+    )
   }
 
   // Use httpsnippet-lite for other languages

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -832,8 +832,8 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2
       '@scalar/snippetz':
-        specifier: ^0.1.6
-        version: 0.1.6
+        specifier: ^0.2.0
+        version: 0.2.0
       '@scalar/themes':
         specifier: workspace:*
         version: link:../themes
@@ -5656,26 +5656,9 @@ packages:
     resolution: {integrity: sha512-kgzFox4KzC3NLrOZeT9m/iQ2VMNvL7JNz8ec+hz0sYulvMtYQ1qTqEyjQjALyCDzmzrSJA11Vg8JMMHDw3AA7A==}
     engines: {node: '>=18'}
 
-  '@scalar/snippetz-core@0.1.4':
-    resolution: {integrity: sha512-NMnDzl5dHgUj0k8ZtfssDfy6wv1wO/M+GhpdGr/4OH3m8UZB27CZ3hM7wXh+fm75hZO5XIBsANW20kJVnzpaHg==}
-
-  '@scalar/snippetz-plugin-js-fetch@0.1.1':
-    resolution: {integrity: sha512-9ODfi0OaEvZHdCe09c91eH1R5QPynL+FPxtYuK/9K5ElRE2NqxYysri9AsgOhr1Fqhpy5qKzDj4Gi5FHsJSGXw==}
-
-  '@scalar/snippetz-plugin-js-ofetch@0.1.1':
-    resolution: {integrity: sha512-fPIJlY4q1j5gbnsYSxix0IJ7hqcvm8Ly7iVoK66vaL738AIMiGZMhGKtLrTVPad77PimwO+jeq5iDIZ495UY7Q==}
-
-  '@scalar/snippetz-plugin-node-fetch@0.1.2':
-    resolution: {integrity: sha512-kD6erA6aAqjHkj+JrJQKqrqcH4fnCrLi2uYw16CmELIGtqVHFau7ew2c087y4OQTltdi5rEk2zj5zOBu9yaS3Q==}
-
-  '@scalar/snippetz-plugin-node-ofetch@0.1.1':
-    resolution: {integrity: sha512-9NpvdMKebg82FkVWoWyOxd1JXAB8KNxmrsFFwQKNjhAw0A5hjNR5oW9lD+FtB1Laupg2FNtw9dcCydnF+LcCWw==}
-
-  '@scalar/snippetz-plugin-node-undici@0.1.6':
-    resolution: {integrity: sha512-CivUl7wgZ6vlUb01FMdqOt/NVyOWqT0iHZRp5YlPp1pflXZLnAyi5antUTtBEUHUtHM2EO/WR7vx4kRsPcrgLg==}
-
-  '@scalar/snippetz@0.1.6':
-    resolution: {integrity: sha512-z3DEpT/FIZq9yeHL/tz2v6WvdHIiZ4uvK96RdeTPKUUJ0IXvA5vONG3PF5LE0Q/408PCzWsZpGs9f97ztaeJSQ==}
+  '@scalar/snippetz@0.2.0':
+    resolution: {integrity: sha512-Ayp5VS/wv1EYOCsN9hpmFUQpX+hCkbovTJPXOdPiDAsrGqPr9cY3uOa07tSi3eu2Fv5ceKaidP5hJP0fKnFjpw==}
+    engines: {node: '>=18'}
 
   '@segment/loosely-validate-event@2.0.0':
     resolution: {integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==}
@@ -22218,38 +22201,7 @@ snapshots:
       leven: 4.0.0
       yaml: 2.4.5
 
-  '@scalar/snippetz-core@0.1.4':
-    dependencies:
-      '@types/har-format': 1.2.15
-
-  '@scalar/snippetz-plugin-js-fetch@0.1.1':
-    dependencies:
-      '@scalar/snippetz-core': 0.1.4
-
-  '@scalar/snippetz-plugin-js-ofetch@0.1.1':
-    dependencies:
-      '@scalar/snippetz-core': 0.1.4
-
-  '@scalar/snippetz-plugin-node-fetch@0.1.2':
-    dependencies:
-      '@scalar/snippetz-core': 0.1.4
-
-  '@scalar/snippetz-plugin-node-ofetch@0.1.1':
-    dependencies:
-      '@scalar/snippetz-core': 0.1.4
-
-  '@scalar/snippetz-plugin-node-undici@0.1.6':
-    dependencies:
-      '@scalar/snippetz-core': 0.1.4
-
-  '@scalar/snippetz@0.1.6':
-    dependencies:
-      '@scalar/snippetz-core': 0.1.4
-      '@scalar/snippetz-plugin-js-fetch': 0.1.1
-      '@scalar/snippetz-plugin-js-ofetch': 0.1.1
-      '@scalar/snippetz-plugin-node-fetch': 0.1.2
-      '@scalar/snippetz-plugin-node-ofetch': 0.1.1
-      '@scalar/snippetz-plugin-node-undici': 0.1.6
+  '@scalar/snippetz@0.2.0': {}
 
   '@segment/loosely-validate-event@2.0.0':
     dependencies:


### PR DESCRIPTION
We made the @scalar/snippetz core and all plugins and everything just a single package, this was released as @scalar/snippetz@0.2.0.

See https://github.com/scalar/snippetz/pull/45

This PR updates to it. :)