### PR TITLE
fix(api-client): environment wording

### DIFF
--- a/.changeset/nasty-bats-mate.md
+++ b/.changeset/nasty-bats-mate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: strip variable from functio name and cta

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -22,7 +22,7 @@ const activeEnvironmentID = ref<string | null>(null)
 const nameInputRef = ref<HTMLInputElement | null>(null)
 const isEditingName = ref(false)
 
-function addEnvironmentVariable() {
+function addEnvironment() {
   const environment = {
     name: 'New Environment',
     uid: nanoid(),
@@ -43,7 +43,7 @@ function handleEnvironmentUpdate(raw: string) {
   }
 }
 
-const removeEnvironmentVariable = (uid: string) => {
+const removeEnvironment = (uid: string) => {
   environmentMutators.delete(uid)
   if (activeEnvironmentID.value === uid) {
     activeEnvironmentID.value = null
@@ -109,13 +109,13 @@ onMounted(setActiveEnvironment)
                 }"
                 :warningMessage="`Are you sure you want to delete this environment?`"
                 @click="activeEnvironmentID = environment.uid"
-                @delete="removeEnvironmentVariable(environment.uid)" />
+                @delete="removeEnvironment(environment.uid)" />
             </SidebarList>
           </div>
         </template>
         <template #button>
-          <SidebarButton :click="addEnvironmentVariable">
-            <template #title>Add Environment Variable</template>
+          <SidebarButton :click="addEnvironment">
+            <template #title>Add Environment</template>
           </SidebarButton>
         </template>
       </Sidebar>


### PR DESCRIPTION
this pr removes variable wording from function and call to action to reflect better actions as spotted by @hanspagel :

**before**
<img width="906" alt="image" src="https://github.com/user-attachments/assets/a67b1c9a-b13b-4c18-ab2b-0bb42535ee29">

**after**
<img width="906" alt="image" src="https://github.com/user-attachments/assets/f0b5f5c0-c729-4c7d-9c98-46c867c1f686">
