### PR TITLE
feat(api-client): disable sidebar resizing on small screens

### DIFF
--- a/.changeset/rich-pets-share.md
+++ b/.changeset/rich-pets-share.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat(api-client): disable sidebar resizing on small screens

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -140,7 +140,7 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
   <div
     v-if="activeRequest && activeExample"
     class="order-last lg:order-none lg:w-auto w-full">
-    <div class="m-auto flex basis-1/2 flex-row items-center">
+    <div class="m-auto flex flex-row items-center">
       <!-- Address Bar -->
       <Listbox
         v-slot="{ open }"

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -14,6 +14,8 @@ const props = withDefaults(
 )
 const { isReadOnly, sidebarWidth, setSidebarWidth } = useWorkspace()
 const isDragging = ref(false)
+
+const isNarrow = useMediaQuery('(max-width: 780px)')
 const sidebarRef = ref<HTMLElement | null>(null)
 const isMobile = useMediaQuery('(max-width: 800px)')
 
@@ -64,7 +66,7 @@ const startDrag = (event: MouseEvent) => {
     ref="sidebarRef"
     class="sidebar overflow-hidden relative flex flex-col flex-1 md:flex-none bg-b-1 md:border-b-0 md:border-r-1/2 min-w-full md:min-w-fit"
     :class="{ dragging: isDragging }"
-    :style="{ width: isMobile ? '100%' : sidebarWidth }">
+    :style="{ width: isNarrow ? '100%' : sidebarWidth }">
     <slot name="header" />
     <div
       v-if="!isReadOnly && title"
@@ -87,6 +89,7 @@ const startDrag = (event: MouseEvent) => {
       v-if="!isMobile"
       name="button" />
     <div
+      v-if="!isNarrow"
       class="resizer"
       @mousedown="startDrag"></div>
   </aside>

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -8,7 +8,6 @@ import {
   type Icon,
   ScalarContextMenu,
   ScalarDropdown,
-  ScalarDropdownDivider,
   ScalarDropdownItem,
   ScalarIcon,
 } from '@scalar/components'

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -149,8 +149,6 @@ onBeforeUnmount(() => executeRequestBus.off(executeRequest))
   }
   .sidebar-active-width {
     width: 100%;
-    border: 1px solid var(--scalar-border-color);
-    border-radius: var(--scalar-radius);
   }
 }
 .empty-sidebar-item:deep(.scalar-button) {


### PR DESCRIPTION
Based on chats with @cameronrohani this disables the resizing behaviour for the sidebar on small screen and makes the sidebar fill the viewport. We could also move the sidebar into a popover if that sort of overlay behavior if preferred.

Before / After:

https://github.com/user-attachments/assets/6c3de414-c617-4437-aa85-b1590a8fafca

