### PR TITLE
feat(api-client): track active workspace in local storage

### DIFF
--- a/.changeset/twelve-penguins-end.md
+++ b/.changeset/twelve-penguins-end.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat(api-client): track active workspace in local storage

--- a/packages/api-client/src/layouts/App/create-api-client-app.ts
+++ b/packages/api-client/src/layouts/App/create-api-client-app.ts
@@ -1,5 +1,5 @@
 import { type ClientConfiguration, createApiClient } from '@/libs'
-import { router as _router } from '@/router'
+import { router as _router, saveWorkspace } from '@/router'
 
 import ApiClientApp from './ApiClientApp.vue'
 
@@ -28,6 +28,7 @@ export const createApiClientApp = async (
   })
 
   const { importSpecFile, importSpecFromUrl } = client.store
+  router.afterEach(saveWorkspace)
 
   // Import the spec if needed
   if (configuration.spec?.url) {

--- a/packages/api-client/src/router.ts
+++ b/packages/api-client/src/router.ts
@@ -1,4 +1,5 @@
 import {
+  type RouteLocationNormalized,
   type RouteRecordRaw,
   createMemoryHistory,
   createRouter,
@@ -59,11 +60,11 @@ export const modalRoutes = [
 const routes = [
   {
     path: '/',
-    redirect: '/workspace/default/request/default',
+    redirect: redirectToDefaultWorkspace,
   },
   {
     path: '/workspace',
-    redirect: '/workspace/default/request/default',
+    redirect: redirectToDefaultWorkspace,
   },
   {
     path: `/workspace/:${PathId.Workspace}`,
@@ -147,6 +148,21 @@ export const createModalRouter = () =>
     history: createMemoryHistory(),
     routes: modalRoutes,
   })
+
+/** Tracks the active workspace in localstorage for when the client reloads */
+const WORKSPACE_KEY = 'activeWorkspace' as const
+
+/** Save the active workspace in localstorage for when the client reloads */
+export function saveWorkspace(to: RouteLocationNormalized) {
+  const workspace = to.params[PathId.Workspace]
+  if (workspace) localStorage.setItem(WORKSPACE_KEY, `${workspace}`)
+}
+
+/** Redirect to the saved workspace or the default workspace */
+export function redirectToDefaultWorkspace() {
+  const workspace = localStorage.getItem(WORKSPACE_KEY) ?? 'default'
+  return `/workspace/${workspace}/request/default`
+}
 
 /** If we try to navigate to a entity UID that does not exist then we fallback to the default */
 export function fallbackMissingParams(


### PR DESCRIPTION
I tried this a few different ways but this seemed to be the simplest and most robust. Persists the most recent active workspace `uid` so that we can go to it when we load `/`.

Client Web:

https://github.com/user-attachments/assets/5fef215e-f953-4e25-8f1f-f9f773c597eb

Client App:

https://github.com/user-attachments/assets/92d22c16-57b9-495f-ae91-73ce581ce7a3

