### PR TITLE
style(api-client): layout responsiveness

### DIFF
--- a/packages/api-client/src/components/DataTable/DataTable.vue
+++ b/packages/api-client/src/components/DataTable/DataTable.vue
@@ -7,7 +7,7 @@ defineProps<{
 </script>
 <template>
   <div
-    class="border-1/2 rounded mx-1 bg-b-1"
+    class="border-1/2 rounded bg-b-1 md:mx-1"
     :class="scroll ? 'overflow-x-auto custom-scroll' : 'overflow-visible'">
     <table
       class="grid auto-rows-auto min-h-8 mb-0"

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -19,7 +19,7 @@ defineProps<{
         v-else
         name="title" />
     </template>
-    <div class="custom-scroll flex flex-1 flex-col gap-1.5 px-5 py-5">
+    <div class="custom-scroll flex flex-1 flex-col gap-1.5 p-2 md:p-5">
       <DataTable
         v-if="Object.keys(data).length > 0"
         :columns="['']">

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useWorkspace } from '@/store'
+import { useMediaQuery } from '@vueuse/core'
 import { defineProps, ref } from 'vue'
 
 const props = withDefaults(
@@ -14,6 +15,7 @@ const props = withDefaults(
 const { isReadOnly, sidebarWidth, setSidebarWidth } = useWorkspace()
 const isDragging = ref(false)
 const sidebarRef = ref<HTMLElement | null>(null)
+const isMobile = useMediaQuery('(max-width: 800px)')
 
 const startDrag = (event: MouseEvent) => {
   event.preventDefault()
@@ -60,25 +62,30 @@ const startDrag = (event: MouseEvent) => {
   <aside
     v-show="props.showSideBar"
     ref="sidebarRef"
-    class="sidebar overflow-hidden relative flex flex-col border-r-1/2 bg-b-1"
+    class="sidebar overflow-hidden relative flex flex-col flex-1 md:flex-none bg-b-1 md:border-b-0 md:border-r-1/2 min-w-full md:min-w-fit"
     :class="{ dragging: isDragging }"
-    :style="{ width: sidebarWidth }">
+    :style="{ width: isMobile ? '100%' : sidebarWidth }">
     <slot name="header" />
     <div
       v-if="!isReadOnly && title"
-      class="xl:min-h-header py-2.5 flex items-center border-b-1/2 px-4 text-sm">
+      class="xl:min-h-header flex items-center justify-between border-b-1/2 p-2 md:px-4 md:py-2.5 text-sm">
       <h2 class="font-medium m-0 text-sm whitespace-nowrap">
         {{ title }}
       </h2>
+      <slot
+        v-if="isMobile"
+        name="button" />
     </div>
     <div
-      class="custom-scroll sidebar-height"
+      class="custom-scroll sidebar-height pb-0 md:pb-[42px]"
       :class="{
         'sidebar-mask': !isReadOnly,
       }">
       <slot name="content" />
     </div>
-    <slot name="button" />
+    <slot
+      v-if="!isMobile"
+      name="button" />
     <div
       class="resizer"
       @mousedown="startDrag"></div>
@@ -88,14 +95,15 @@ const startDrag = (event: MouseEvent) => {
 .sidebar-height {
   min-height: calc(100% - 50px);
 }
-.sidebar-mask {
-  padding-bottom: 42px;
-  mask-image: linear-gradient(
-    0,
-    transparent 0,
-    transparent 40px,
-    var(--scalar-background-2) 60px
-  );
+@screen md {
+  .sidebar-mask {
+    mask-image: linear-gradient(
+      0,
+      transparent 0,
+      transparent 40px,
+      var(--scalar-background-2) 60px
+    );
+  }
 }
 .resizer {
   width: 5px;

--- a/packages/api-client/src/components/Sidebar/SidebarButton.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarButton.vue
@@ -11,15 +11,15 @@ const handleClick = () => {
 }
 </script>
 <template>
-  <div class="fixed relative bottom-[42px] z-10 flex px-2.5 pb-2 pt-0">
+  <div class="fixed relative z-10 pt-0 md:px-2.5 md:pb-2 md:bottom-[42px]">
     <ScalarButton
-      class="bg-b-1 text-c-1 hover:bg-b-2 group relative w-full border-1/2 p-1.5 h-auto"
+      class="bg-b-1 text-c-1 hover:bg-b-2 group relative w-full border-1/2 px-2 py-1 md:p-1.5 h-auto"
       icon="Plus"
       variant="outlined"
       @click="handleClick">
       <slot name="title" />
       <ScalarHotkey
-        class="absolute right-2 group-hover:opacity-80 text-c-2 add-item-hotkey"
+        class="hidden md:block absolute right-2 group-hover:opacity-80 text-c-2 add-item-hotkey"
         hotkey="K"
         @hotkeyPressed="handleClick" />
     </ScalarButton>

--- a/packages/api-client/src/components/SubpageHeader.vue
+++ b/packages/api-client/src/components/SubpageHeader.vue
@@ -8,7 +8,7 @@ const currentRoute = useRoute()
   <div
     class="flex flex-1 flex-col rounded pt-0 h-full bg-b-1 relative border-1/2 rounded mr-1.5 mb-1.5 overflow-hidden">
     <div
-      class="lg:min-h-header items-center w-full p-1 t-app__top-container flex items-center border-b-1/2">
+      class="hidden md:flex lg:min-h-header items-center w-full p-1 t-app__top-container items-center border-b-1/2">
       <router-link
         class="text-c-2 text-sm font-medium ml-1 flex items-center p-1.5 hover:bg-b-2 rounded cursor-pointer gap-0.5 active:text-c-1 no-underline dark:hover:bg-b-2"
         :to="`/workspace/${currentRoute.params.workspace}/request/default`">

--- a/packages/api-client/src/components/ViewLayout/ViewLayout.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayout.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="flex min-h-0 flex-1 xl:overflow-hidden leading-3 z-0">
+  <div
+    class="flex flex-col min-h-0 flex-1 xl:overflow-hidden md:flex-row leading-3 z-0">
     <slot />
   </div>
 </template>

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="divide divide-y xl:divide-y-0 xl:divide-x-1/2 flex xl:flex-row flex-col custom-scroll rounded">
+    class="border-t-1/2 md:border-t-0 divide divide-y xl:divide-y-0 xl:divide-x-1/2 flex xl:flex-row flex-col custom-scroll pr-0 rounded">
     <slot />
   </div>
 </template>

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -9,7 +9,7 @@ const id = nanoid()
     class="flex xl:min-w-0 xl:flex-1 flex-col xl:custom-scroll bg-b-1">
     <div
       :id="id"
-      class="xl:min-h-header py-2.5 flex items-center border-b-1/2 px-4 xl:pl-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 z-20 rounded-t xl:rounded-none">
+      class="xl:min-h-header flex items-center border-b-1/2 p-2 md:px-4 md:py-2.5 xl:pl-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 z-20 rounded-t xl:rounded-none">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -36,7 +36,7 @@ const updateCookie = (key: any, value: any) => {
           for="cookiename"></label>
         <input
           id="cookiename"
-          class="pl-1 outline-none border-0 text-c-2 rounded pointer-events-auto relative w-full"
+          class="md:pl-1 outline-none border-0 text-c-2 rounded pointer-events-auto relative w-full"
           placeholder="Cookie Name"
           :value="activeCookie.name"
           @input="

--- a/packages/api-client/src/views/Cookies/CookieRaw.vue
+++ b/packages/api-client/src/views/Cookies/CookieRaw.vue
@@ -12,7 +12,7 @@ const { cookies, activeCookieId } = useWorkspace()
     </template>
     <template v-if="activeCookieId && cookies[activeCookieId]">
       <CodeInput
-        class="px-2 py-2.5"
+        class="pl-px pr-2 md:px-2 py-2.5"
         lineNumbers
         modelValue="" />
     </template>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -150,7 +150,7 @@ onMounted(setActiveEnvironment)
           </template>
           <CodeInput
             v-if="activeEnvironmentID"
-            class="px-2 py-2.5"
+            class="pl-px pr-2 md:px-2 py-2.5"
             lineNumbers
             :modelValue="environments[activeEnvironmentID].value"
             @update:modelValue="handleEnvironmentUpdate" />


### PR DESCRIPTION
this pr updates layout responsiveness to reach a good enough on mobile, to be enhanced later on:

**before**
<img width="640" alt="image" src="https://github.com/user-attachments/assets/7ed5f4d7-51e7-4e9f-8ed0-d4926156e436">

**after**
<img width="640" alt="image" src="https://github.com/user-attachments/assets/4e70e3dd-9b19-4b6e-8f42-882decdeedd3">
