### PR TITLE
chore: update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ Ready? [Create your account on scalar.com](https://scalar.com).
 
 ## Projects
 
-| Project                                                            | Description            |
-| ------------------------------------------------------------------ | ---------------------- |
-| [Scalar API Client](packages/api-client/README.md)                 | API client             |
-| [Scalar CLI](packages/cli/README.md)                               | Command-line interface |
-| [Scalar Galaxy](packages/galaxy/README.md)                         | OpenAPI Example        |
-| [Scalar Play Button](packages/play-button/README.md)               | Quick API Client Embed |
-| [Scalar Mock Server](packages/mock-server/README.md)               | OpenAPI Mock Server    |
-| [Scalar Void Server](packages/void-server/README.md)               | HTTP Request Mirror    |
-| [Scalar Open API Parser](https://github.com/scalar/openapi-parser) | OpenAPI SDK            |
-| [Scalar Sandbox](https://sandbox.scalar.com/)                      | Online OpenAPI Editor  |
+| Project                                                  | Description            |
+| -------------------------------------------------------- | ---------------------- |
+| [Scalar API Client](packages/api-client/README.md)       | API client             |
+| [Scalar CLI](packages/cli/README.md)                     | Command-line interface |
+| [Scalar Galaxy](packages/galaxy/README.md)               | OpenAPI Example        |
+| [Scalar Play Button](packages/play-button/README.md)     | Quick API Client Embed |
+| [Scalar Mock Server](packages/mock-server/README.md)     | OpenAPI Mock Server    |
+| [Scalar Void Server](packages/void-server/README.md)     | HTTP Request Mirror    |
+| [Scalar Open API Parser](packages/void-server/README.md) | OpenAPI SDK            |
+| [Scalar Sandbox](https://sandbox.scalar.com/)            | Online OpenAPI Editor  |
 
 ## Documentation
 

--- a/packages/openapi-parser/README.md
+++ b/packages/openapi-parser/README.md
@@ -240,10 +240,6 @@ Thanks a ton for all the help and inspiration:
 - You could consider this package the modern successor of [@apidevtools/swagger-parser](https://github.com/APIDevTools/swagger-parser), we even test against it to make sure we’re getting the same results (where intended).
 - We stole a lot of example specification from [@mermade](https://github.com/mermade) to test against.
 
-## Contributions
-
-Contributions are welcome! Read [`CONTRIBUTING`](https://github.com/scalar/openapi-parser/blob/main/CONTRIBUTING).
-
 ## License
 
 The source code in this repository is licensed under [MIT](https://github.com/scalar/openapi-parser/blob/main/LICENSE).


### PR DESCRIPTION
I’ve found some (now) outdated links to the openapi-parser repository, let’s fix this.