### PR TITLE
fix: update galaxy dockerfile dependencies

### DIFF
--- a/packages/galaxy/Dockerfile
+++ b/packages/galaxy/Dockerfile
@@ -22,6 +22,7 @@ COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/packages/mock-server /app/packages/mock-server
 COPY --from=builder /app/packages/hono-api-reference /app/packages/hono-api-reference
 COPY --from=builder /app/packages/oas-utils /app/packages/oas-utils
+COPY --from=builder /app/packages/openapi-parser /app/packages/openapi-parser
 COPY --from=builder /app/packages/galaxy /app/packages/galaxy
 WORKDIR /app/packages/galaxy
 


### PR DESCRIPTION
Add the new workspace dependency, `openapi-parser` to the Dockefile
