### PR TITLE
feat(void-server): respond with no content on `/204`

### DIFF
--- a/.changeset/swift-rings-chew.md
+++ b/.changeset/swift-rings-chew.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+feat: respond with no content for /204

--- a/packages/api-client/src/libs/sendRequest.test.ts
+++ b/packages/api-client/src/libs/sendRequest.test.ts
@@ -172,6 +172,20 @@ describe('sendRequest', () => {
     })
   })
 
+  it('works with no content', async () => {
+    const { request, example, server } = createRequestExampleServer({
+      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}/204` },
+    })
+
+    const result = await sendRequest(
+      request,
+      example,
+      server?.url + request.path,
+    )
+
+    expect(result?.response?.data).toBe('')
+  })
+
   // it('adds cookies as headers', async () => {
   //   const { request, example, server } = createRequestExampleServer({
   //     serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -247,6 +247,15 @@ describe('createVoidServer', () => {
     expect(await response.text()).toBe('Not Found')
   })
 
+  it('returns no content for 204', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/204')
+
+    expect(response.status).toBe(204)
+    expect(await response.text()).toBe('')
+  })
+
   it('returns 500', async () => {
     const server = await createVoidServer()
 

--- a/packages/void-server/src/createVoidServer.ts
+++ b/packages/void-server/src/createVoidServer.ts
@@ -33,6 +33,13 @@ export async function createVoidServer() {
     return c.text(errors?.[status] ?? 'Unknown Error')
   })
 
+  // No content
+  app.all('/:status{204}', async (c: Context) => {
+    console.info(`${c.req.method} ${c.req.path}`)
+
+    return c.body(null, 204)
+  })
+
   // Return content based on the file extension
   app.all('/:filename{.+\\.(html|xml|json|zip)$}', async (c: Context) => {
     console.info(`${c.req.method} ${c.req.path}`)


### PR DESCRIPTION
I’m just debugging an issue with a 204 No Content response, and added this to `@scalar/void-server`:

When requesting `/204`, it responds with status 204 and an empty body.

We already have similar responses, e.g. for error codes: https://void.scalar.com/404