### PR TITLE
fix(cli): init test deletes `scalar.config.json`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "@scalar/cli": "pnpm vite-node src/index.ts",
     "build": "scalar-build-rollup",
+    "test": "vitest",
     "link:cli": "pnpm run build && npm unlink -g @scalar/cli && npm link",
     "screenshot": "./scripts/take-screenshots.sh",
     "types:build": "scalar-types-build",

--- a/packages/cli/src/commands/format/format.test.ts
+++ b/packages/cli/src/commands/format/format.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 import { ScalarCli } from '../../../tests/invoke-cli'
@@ -12,13 +13,14 @@ describe('format', () => {
     const notWellFormatted = '{"foo":    "bar"}'
 
     // Create JSON file
-    const jsonFile = './packages/cli/src/commands/format/temp.json'
+    const jsonFile = fileURLToPath(new URL('./temp.json', import.meta.url))
+
     fs.writeFileSync(jsonFile, notWellFormatted)
 
     // Format
     const [exitCode, logs] = ScalarCli()
       .setCwd(path.resolve('./'))
-      .invoke(['format', './packages/cli/src/commands/format/temp.json'])
+      .invoke(['format', jsonFile])
 
     // Output
     logs.should.contain('File formatted')
@@ -40,13 +42,14 @@ describe('format', () => {
     const notWellFormatted = 'openapi:      3.1.0'
 
     // Create JSON file
-    const yamlFile = './packages/cli/src/commands/format/temp.yaml'
+    const yamlFile = fileURLToPath(new URL('./temp.yaml', import.meta.url))
+
     fs.writeFileSync(yamlFile, notWellFormatted)
 
     // Format
     const [exitCode, logs] = ScalarCli()
       .setCwd(path.resolve('./'))
-      .invoke(['format', './packages/cli/src/commands/format/temp.yaml'])
+      .invoke(['format', yamlFile])
 
     // Output
     logs.should.contain('File formatted')

--- a/packages/cli/src/commands/init/init.test.ts
+++ b/packages/cli/src/commands/init/init.test.ts
@@ -1,14 +1,23 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 import { ScalarCli } from '../../../tests/invoke-cli'
 
+const cwd = fileURLToPath(new URL('./', import.meta.url))
+
+const configFile = fileURLToPath(
+  new URL('./scalar.config.json', import.meta.url),
+)
+
+const openApiDocument = fileURLToPath(
+  new URL('../validate/valid.json', import.meta.url),
+)
+
 describe('init', () => {
   it('creates a config file', () => {
     // Delete config file if it exists
-    const configFile = './scalar.config.json'
-
     if (fs.existsSync(configFile)) {
       fs.unlinkSync(configFile)
     }
@@ -18,11 +27,11 @@ describe('init', () => {
 
     // Create config file
     const [exitCode, logs] = ScalarCli()
-      .setCwd(path.resolve('./'))
+      .setCwd(cwd)
       .invoke([
         'init',
         '--file',
-        './packages/cli/src/commands/validate/valid.json',
+        openApiDocument,
         '--force',
         '--subdomain',
         'foobar.apidocumentation.com',
@@ -30,20 +39,18 @@ describe('init', () => {
 
     // Output
     logs.should.contain(`"subdomain": "foobar.apidocumentation.com"`)
-    logs.should.contain(
-      `"path": "./packages/cli/src/commands/validate/valid.json"`,
-    )
+    logs.should.contain(`"path": "${openApiDocument}"`)
 
     // File exists
+    console.log(configFile)
+
     expect(fs.existsSync(configFile)).toBe(true)
-    expect(fs.readFileSync(configFile, 'utf-8')).toContain(
-      './packages/cli/src/commands/validate/valid.json',
-    )
+    expect(fs.readFileSync(configFile, 'utf-8')).toContain(openApiDocument)
     expect(JSON.parse(fs.readFileSync(configFile, 'utf-8'))).toMatchObject({
       references: [
         {
           name: 'API Reference',
-          path: './packages/cli/src/commands/validate/valid.json',
+          path: openApiDocument,
         },
       ],
     })

--- a/packages/cli/src/commands/validate/validate.test.ts
+++ b/packages/cli/src/commands/validate/validate.test.ts
@@ -1,31 +1,38 @@
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 import { ScalarCli } from '../../../tests/invoke-cli'
 
 describe('validate', () => {
   it('validates the given json file', () => {
+    const file = fileURLToPath(new URL('./valid.json', import.meta.url))
+
     const [exitCode, logs] = ScalarCli()
       .setCwd(path.resolve('./'))
-      .invoke(['validate', './packages/cli/src/commands/validate/valid.json'])
+      .invoke(['validate', file])
 
     logs.should.contain('OpenAPI 3.1')
     expect(exitCode).toBe(0)
   })
 
   it('validates the given yaml file', () => {
+    const file = fileURLToPath(new URL('./valid.yaml', import.meta.url))
+
     const [exitCode, logs] = ScalarCli()
       .setCwd(path.resolve('./'))
-      .invoke(['validate', './packages/cli/src/commands/validate/valid.yaml'])
+      .invoke(['validate', file])
 
     logs.should.contain('OpenAPI 3.1')
     expect(exitCode).toBe(0)
   })
 
   it('shows errors for invalid file', () => {
+    const file = fileURLToPath(new URL('./invalid.json', import.meta.url))
+
     const [exitCode, logs] = ScalarCli()
       .setCwd(path.resolve('./'))
-      .invoke(['validate', './packages/cli/src/commands/validate/invalid.json'])
+      .invoke(['validate', file])
 
     logs.should.contain(
       'Can’t find supported Swagger/OpenAPI version in specification, version must be a string.',


### PR DESCRIPTION
The `scalar init` test deleted the `scalar.config.json` in root.

This PR makes all CLI tests use files inside the CLI directory.

This is also great, because you can run `pnpm test` in the package folder again. :)