### PR TITLE
fix(next-openapi): remove ts config from playground

### DIFF
--- a/packages/nextjs-openapi/playground/next.config.js
+++ b/packages/nextjs-openapi/playground/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  redirects: () => [
+    {
+      source: '/',
+      destination: '/openapi',
+      permanent: true,
+    },
+  ],
+  output: 'standalone',
+}
+
+export default nextConfig

--- a/packages/nextjs-openapi/playground/next.config.ts
+++ b/packages/nextjs-openapi/playground/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  /* config options here */
-}
-
-export default nextConfig


### PR DESCRIPTION
Apparently next doesn't support a typescript config (but it works?) 