### PR TITLE
fix(openapi-parser): `upgrade` doesn’t return OpenAPI 3.1 type

### DIFF
--- a/.changeset/slimy-actors-invent.md
+++ b/.changeset/slimy-actors-invent.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: upgrade returns correct OpenAPI document version type

--- a/packages/openapi-parser/src/types/index.ts
+++ b/packages/openapi-parser/src/types/index.ts
@@ -17,8 +17,8 @@ export type ValidateResult = {
   schema?: OpenAPI.Document
 }
 
-export type UpgradeResult = {
-  specification: OpenAPI.Document
+export type UpgradeResult<T extends OpenAPI.Document = OpenAPI.Document> = {
+  specification: T
   version: string
 }
 

--- a/packages/openapi-parser/src/utils/upgrade.test-d.ts
+++ b/packages/openapi-parser/src/utils/upgrade.test-d.ts
@@ -1,0 +1,19 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { describe, expectTypeOf, it } from 'vitest'
+
+import { upgrade } from './index'
+
+describe('OpenAPI', () => {
+  it('narrows it down to OpenAPI 3.1', () => {
+    const { specification } = upgrade({
+      openapi: '3.0.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {},
+    })
+
+    expectTypeOf(specification).toMatchTypeOf<OpenAPIV3_1.Document>()
+  })
+})

--- a/packages/openapi-parser/src/utils/upgrade.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { AnyObject } from '../types'
+import { makeFilesystem } from './makeFilesystem'
 import { upgrade } from './upgrade'
 
 describe('upgrade', () => {
@@ -12,7 +13,7 @@ describe('upgrade', () => {
         version: '1.0.0',
       },
       paths: {},
-    }) as AnyObject
+    })
 
     expect(specification.swagger).toBe('2.0')
   })
@@ -25,7 +26,7 @@ describe('upgrade', () => {
         version: '1.0.0',
       },
       paths: {},
-    }) as AnyObject
+    })
 
     expect(specification.openapi).toBe('3.1.0')
   })
@@ -38,7 +39,22 @@ describe('upgrade', () => {
         version: '1.0.0',
       },
       paths: {},
-    }) as AnyObject
+    })
+
+    expect(specification.openapi).toBe('3.1.0')
+  })
+
+  it('works with a filesystem', async () => {
+    const { specification } = upgrade(
+      makeFilesystem({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {},
+      }),
+    )
 
     expect(specification.openapi).toBe('3.1.0')
   })

--- a/packages/openapi-parser/src/utils/upgrade.ts
+++ b/packages/openapi-parser/src/utils/upgrade.ts
@@ -1,3 +1,5 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
 import type { AnyObject, Filesystem, UpgradeResult } from '../types'
 import { getEntrypoint } from './getEntrypoint'
 import { makeFilesystem } from './makeFilesystem'
@@ -8,20 +10,20 @@ import { upgradeFromTwoToThree } from './upgradeFromTwoToThree'
  * Upgrade specification to OpenAPI 3.1.0
  */
 export function upgrade(
-  specification: AnyObject | Filesystem,
+  value: string | AnyObject | Filesystem,
   _options?: AnyObject,
-): UpgradeResult {
+): UpgradeResult<OpenAPIV3_1.Document> {
   const upgraders = [upgradeFromTwoToThree, upgradeFromThreeToThreeOne]
 
   // TODO: Run upgrade over the whole filesystem
   const result = upgraders.reduce(
     (currentSpecification, upgrader) => upgrader(currentSpecification),
-    getEntrypoint(makeFilesystem(specification)).specification,
-  )
+    getEntrypoint(makeFilesystem(value)).specification,
+  ) as OpenAPIV3_1.Document
 
   return {
     specification: result,
     // TODO: Make dynamic
     version: '3.1',
-  }
+  } as UpgradeResult<OpenAPIV3_1.Document>
 }


### PR DESCRIPTION
Currently, the `upgrade` function returns the `OpenAPI.Document` type.

We can narrow this down, because we know the version number, though.

With this PR the `upgrade` function (used on it’s own) returns the `OpenAPIV3_1.Document` type.