### PR TITLE
feat(openapi-parser): upgrade from Swagger 2.0

### DIFF
--- a/.changeset/clean-melons-wait.md
+++ b/.changeset/clean-melons-wait.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+feat: upgrade from Swagger 2.0 (experimental)

--- a/packages/openapi-parser/README.md
+++ b/packages/openapi-parser/README.md
@@ -90,7 +90,7 @@ There’s an `upgrade` command to upgrade all your OpenAPI specifications to the
 import { upgrade } from '@scalar/openapi-parser'
 
 const { specification } = upgrade({
-  openapi: '3.0.0',
+  swagger: 2.0,
   info: {
     title: 'Hello World',
     version: '1.0.0',

--- a/packages/openapi-parser/README.md
+++ b/packages/openapi-parser/README.md
@@ -90,7 +90,7 @@ There’s an `upgrade` command to upgrade all your OpenAPI specifications to the
 import { upgrade } from '@scalar/openapi-parser'
 
 const { specification } = upgrade({
-  swagger: 2.0,
+  swagger: '2.0',
   info: {
     title: 'Hello World',
     version: '1.0.0',

--- a/packages/openapi-parser/README.md
+++ b/packages/openapi-parser/README.md
@@ -84,7 +84,7 @@ const { specification } = filter(specification, (schema) => !schema?.['x-interna
 
 There’s an `upgrade` command to upgrade all your OpenAPI specifications to the latest OpenAPI version.
 
-> ⚠️ Currently, only an upgrade from OpenAPI 3.0 to OpenAPI 3.1 is supported. Swagger 2.0 is not supported (yet).
+> ⚠️ The upgrade from Swagger 2.0 is still experimental and probably lacks features.
 
 ```ts
 import { upgrade } from '@scalar/openapi-parser'

--- a/packages/openapi-parser/src/utils/upgrade.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade.test.ts
@@ -5,7 +5,7 @@ import { makeFilesystem } from './makeFilesystem'
 import { upgrade } from './upgrade'
 
 describe('upgrade', () => {
-  it('doesn’t modify Swagger 2.0 files', async () => {
+  it('upgrades documents from Swagger 2.0 to OpenAPI 3.1', async () => {
     const { specification } = upgrade({
       swagger: '2.0',
       info: {
@@ -15,7 +15,8 @@ describe('upgrade', () => {
       paths: {},
     })
 
-    expect(specification.swagger).toBe('2.0')
+    expect(specification.swagger).toBeUndefined()
+    expect(specification.openapi).toBe('3.1.0')
   })
 
   it('changes the version to from 3.0.0 to 3.1.0', async () => {

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -2,9 +2,6 @@ import { describe, expect, it } from 'vitest'
 
 import { upgradeFromTwoToThree } from './upgradeFromTwoToThree'
 
-// TODO:
-// * Update refs, e.g. #/definitions/Planet to #/components/schemas/Planet
-
 describe('upgradeFromTwoToThree', () => {
   it('changes the version to from 3.0.0 to 3.1.0', async () => {
     const result = upgradeFromTwoToThree({
@@ -85,6 +82,37 @@ describe('upgradeFromTwoToThree', () => {
     })
 
     expect(result.definitions).toBeUndefined()
+  })
+
+  it('rewrites $refs to definitions', async () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      paths: {
+        '/planets': {
+          get: {
+            responses: {
+              '200': {
+                schema: {
+                  $ref: '#/definitions/Planet',
+                },
+              },
+            },
+          },
+        },
+      },
+      definitions: {
+        Planet: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+      },
+    })
+    expect(
+      result.paths['/planets'].get.responses['200'].content['application/json']
+        .schema.$ref,
+    ).toBe('#/components/schemas/Planet')
   })
 
   it('transforms responses', async () => {

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -52,4 +52,36 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.schemes).toBeUndefined()
     expect(result.host).toBeUndefined()
   })
+
+  // Moves definitions to components
+  it('moves definitions to components', async () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      definitions: {
+        Category: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'integer',
+              format: 'int64',
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.components?.schemas).toStrictEqual({
+      Category: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'integer',
+            format: 'int64',
+          },
+        },
+      },
+    })
+
+    expect(result.definitions).toBeUndefined()
+  })
 })

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import { upgradeFromTwoToThree } from './upgradeFromTwoToThree'
 
-describe.skip('version', () => {
-  it('doesn’t modify Swagger 2.0 files', async () => {
+describe('upgradeFromTwoToThree', () => {
+  it('changes the version to from 3.0.0 to 3.1.0', async () => {
     const result = upgradeFromTwoToThree({
       swagger: '2.0',
       info: {
@@ -13,6 +13,7 @@ describe.skip('version', () => {
       paths: {},
     })
 
-    expect(result.openapi).toBe('3.0.0')
+    expect(result.openapi).toBe('3.0.3')
+    expect(result.swagger).toBeUndefined()
   })
 })

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -16,4 +16,40 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.openapi).toBe('3.0.3')
     expect(result.swagger).toBeUndefined()
   })
+
+  it('upgrades URLs to new server syntax', async () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      basePath: '/v1',
+      schemes: ['http'],
+      host: 'api.example.com',
+    })
+
+    expect(result.servers).toStrictEqual([
+      {
+        url: 'http://api.example.com/v1',
+      },
+    ])
+
+    expect(result.basePath).toBeUndefined()
+    expect(result.schemes).toBeUndefined()
+    expect(result.host).toBeUndefined()
+  })
+
+  it('upgrades host to new server syntax', async () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      host: 'api.example.com',
+    })
+
+    expect(result.servers).toStrictEqual([
+      {
+        url: 'http://api.example.com',
+      },
+    ])
+
+    expect(result.basePath).toBeUndefined()
+    expect(result.schemes).toBeUndefined()
+    expect(result.host).toBeUndefined()
+  })
 })

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -53,7 +53,6 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.host).toBeUndefined()
   })
 
-  // Moves definitions to components
   it('moves definitions to components', async () => {
     const result = upgradeFromTwoToThree({
       swagger: '2.0',
@@ -83,5 +82,125 @@ describe('upgradeFromTwoToThree', () => {
     })
 
     expect(result.definitions).toBeUndefined()
+  })
+
+  it('transforms paths', async () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      paths: {
+        '/pets': {
+          get: {
+            description:
+              'Returns all pets from the system that the user has access to',
+            produces: ['application/json', 'application/xml'],
+            responses: {
+              '200': {
+                description: 'A list of pets.',
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/definitions/pet',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.paths).toStrictEqual({
+      '/pets': {
+        get: {
+          description:
+            'Returns all pets from the system that the user has access to',
+          responses: {
+            '200': {
+              description: 'A list of pets.',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/definitions/pet',
+                    },
+                  },
+                },
+                'application/xml': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/definitions/pet',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.paths['/pets'].get.produces).toBeUndefined()
+  })
+
+  it('uses global produces for responses', async () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      produces: ['application/json', 'application/xml'],
+      paths: {
+        '/pets': {
+          get: {
+            description:
+              'Returns all pets from the system that the user has access to',
+            responses: {
+              '200': {
+                description: 'A list of pets.',
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/definitions/pet',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.paths).toStrictEqual({
+      '/pets': {
+        get: {
+          description:
+            'Returns all pets from the system that the user has access to',
+          responses: {
+            '200': {
+              description: 'A list of pets.',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/definitions/pet',
+                    },
+                  },
+                },
+                'application/xml': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/definitions/pet',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.paths['/pets'].get.produces).toBeUndefined()
   })
 })

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import { upgradeFromTwoToThree } from './upgradeFromTwoToThree'
 
+// TODO:
+// * Update refs, e.g. #/definitions/Planet to #/components/schemas/Planet
+
 describe('upgradeFromTwoToThree', () => {
   it('changes the version to from 3.0.0 to 3.1.0', async () => {
     const result = upgradeFromTwoToThree({
@@ -84,22 +87,22 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.definitions).toBeUndefined()
   })
 
-  it('transforms paths', async () => {
+  it('transforms responses', async () => {
     const result = upgradeFromTwoToThree({
       swagger: '2.0',
       paths: {
-        '/pets': {
+        '/planets': {
           get: {
             description:
-              'Returns all pets from the system that the user has access to',
+              'Returns all planets from the system that the user has access to',
             produces: ['application/json', 'application/xml'],
             responses: {
               '200': {
-                description: 'A list of pets.',
+                description: 'A list of planets.',
                 schema: {
                   type: 'array',
                   items: {
-                    $ref: '#/definitions/pet',
+                    $ref: '#/definitions/planet',
                   },
                 },
               },
@@ -110,19 +113,19 @@ describe('upgradeFromTwoToThree', () => {
     })
 
     expect(result.paths).toStrictEqual({
-      '/pets': {
+      '/planets': {
         get: {
           description:
-            'Returns all pets from the system that the user has access to',
+            'Returns all planets from the system that the user has access to',
           responses: {
             '200': {
-              description: 'A list of pets.',
+              description: 'A list of planets.',
               content: {
                 'application/json': {
                   schema: {
                     type: 'array',
                     items: {
-                      $ref: '#/definitions/pet',
+                      $ref: '#/definitions/planet',
                     },
                   },
                 },
@@ -130,7 +133,7 @@ describe('upgradeFromTwoToThree', () => {
                   schema: {
                     type: 'array',
                     items: {
-                      $ref: '#/definitions/pet',
+                      $ref: '#/definitions/planet',
                     },
                   },
                 },
@@ -141,7 +144,7 @@ describe('upgradeFromTwoToThree', () => {
       },
     })
 
-    expect(result.paths['/pets'].get.produces).toBeUndefined()
+    expect(result.paths['/planets'].get.produces).toBeUndefined()
   })
 
   it('uses global produces for responses', async () => {
@@ -149,17 +152,17 @@ describe('upgradeFromTwoToThree', () => {
       swagger: '2.0',
       produces: ['application/json', 'application/xml'],
       paths: {
-        '/pets': {
+        '/planets': {
           get: {
             description:
-              'Returns all pets from the system that the user has access to',
+              'Returns all planets from the system that the user has access to',
             responses: {
               '200': {
-                description: 'A list of pets.',
+                description: 'A list of planets.',
                 schema: {
                   type: 'array',
                   items: {
-                    $ref: '#/definitions/pet',
+                    $ref: '#/definitions/Planet',
                   },
                 },
               },
@@ -170,19 +173,19 @@ describe('upgradeFromTwoToThree', () => {
     })
 
     expect(result.paths).toStrictEqual({
-      '/pets': {
+      '/planets': {
         get: {
           description:
-            'Returns all pets from the system that the user has access to',
+            'Returns all planets from the system that the user has access to',
           responses: {
             '200': {
-              description: 'A list of pets.',
+              description: 'A list of planets.',
               content: {
                 'application/json': {
                   schema: {
                     type: 'array',
                     items: {
-                      $ref: '#/definitions/pet',
+                      $ref: '#/definitions/Planet',
                     },
                   },
                 },
@@ -190,7 +193,7 @@ describe('upgradeFromTwoToThree', () => {
                   schema: {
                     type: 'array',
                     items: {
-                      $ref: '#/definitions/pet',
+                      $ref: '#/definitions/Planet',
                     },
                   },
                 },
@@ -201,6 +204,116 @@ describe('upgradeFromTwoToThree', () => {
       },
     })
 
-    expect(result.paths['/pets'].get.produces).toBeUndefined()
+    expect(result.paths['/planets'].get.produces).toBeUndefined()
+  })
+
+  it('transforms requestBody', async () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+
+      paths: {
+        '/planets': {
+          get: {
+            description:
+              'Returns all planets from the system that the user has access to',
+            consumes: ['application/json', 'application/xml'],
+            parameters: [
+              {
+                in: 'body',
+                name: 'body',
+                description:
+                  'Planet object that needs to be added to the store',
+                required: true,
+                schema: {
+                  $ref: '#/definitions/Planet',
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    expect(result.paths).toStrictEqual({
+      '/planets': {
+        get: {
+          description:
+            'Returns all planets from the system that the user has access to',
+          requestBody: {
+            description: 'Planet object that needs to be added to the store',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/definitions/Planet',
+                },
+              },
+              'application/xml': {
+                schema: {
+                  $ref: '#/definitions/Planet',
+                },
+              },
+            },
+            required: true,
+          },
+        },
+      },
+    })
+
+    expect(result.paths['/planets'].get.produces).toBeUndefined()
+  })
+
+  it('uses global consumes for requestBody', async () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      produces: ['application/json', 'application/xml'],
+      paths: {
+        '/planets': {
+          get: {
+            description:
+              'Returns all planets from the system that the user has access to',
+            consumes: ['application/json', 'application/xml'],
+            parameters: [
+              {
+                in: 'body',
+                name: 'body',
+                description:
+                  'Planet object that needs to be added to the store',
+                required: true,
+                schema: {
+                  $ref: '#/definitions/Planet',
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    expect(result.paths).toStrictEqual({
+      '/planets': {
+        get: {
+          description:
+            'Returns all planets from the system that the user has access to',
+          requestBody: {
+            description: 'Planet object that needs to be added to the store',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/definitions/Planet',
+                },
+              },
+              'application/xml': {
+                schema: {
+                  $ref: '#/definitions/Planet',
+                },
+              },
+            },
+            required: true,
+          },
+        },
+      },
+    })
+
+    expect(result.paths['/planets'].get.produces).toBeUndefined()
   })
 })

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -23,13 +23,24 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
       ? specification.schemes
       : ['http']
 
-    specification.servers = schemes.map((scheme) => ({
+    specification.servers = schemes.map((scheme: string[]) => ({
       url: `${scheme}://${specification.host}${specification.basePath ?? ''}`,
     }))
 
     delete specification.basePath
     delete specification.schemes
     delete specification.host
+  }
+
+  // Schemas
+  if (specification.definitions) {
+    if (typeof specification.components !== 'object') {
+      specification.components = {}
+    }
+
+    specification.components.schemas = specification.definitions
+
+    delete specification.definitions
   }
 
   return specification as OpenAPIV3.Document

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -18,6 +18,10 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
     return specification
   }
 
+  console.warn(
+    `[upgradeFromTwoToThree] The upgrade from Swagger 2.0 to OpenAPI 3.0 documents is experimental and lacks features.`,
+  )
+
   // Servers
   if (specification.host) {
     const schemes = specification.schemes?.length

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -1,6 +1,7 @@
 import type { OpenAPIV2, OpenAPIV3 } from '@scalar/openapi-types'
 
 import type { AnyObject } from '../types'
+import { traverse } from './traverse'
 
 /**
  * Upgrade Swagger 2.0 to OpenAPI 3.0
@@ -41,6 +42,18 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
     specification.components.schemas = specification.definitions
 
     delete specification.definitions
+
+    // Rewrite $refs to definitions
+    specification = traverse(specification, (schema) => {
+      if (schema.$ref?.startsWith('#/definitions/')) {
+        schema.$ref = schema.$ref.replace(
+          /^#\/definitions\//,
+          '#/components/schemas/',
+        )
+      }
+
+      return schema
+    })
   }
 
   // Paths

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -53,6 +53,7 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
           if (Object.hasOwn(pathItem, method)) {
             const operationItem = pathItem[method]
 
+            // Responses
             if (operationItem.responses) {
               for (const response in operationItem.responses) {
                 if (Object.hasOwn(operationItem.responses, response)) {

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -17,5 +17,20 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
     return specification
   }
 
+  // Servers
+  if (specification.host) {
+    const schemes = specification.schemes?.length
+      ? specification.schemes
+      : ['http']
+
+    specification.servers = schemes.map((scheme) => ({
+      url: `${scheme}://${specification.host}${specification.basePath ?? ''}`,
+    }))
+
+    delete specification.basePath
+    delete specification.schemes
+    delete specification.host
+  }
+
   return specification as OpenAPIV3.Document
 }

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -1,3 +1,5 @@
+import type { OpenAPIV3 } from '@scalar/openapi-types'
+
 import type { AnyObject } from '../types'
 
 /**
@@ -6,6 +8,14 @@ import type { AnyObject } from '../types'
  * https://swagger.io/blog/news/whats-new-in-openapi-3-0/
  */
 export function upgradeFromTwoToThree(specification: AnyObject) {
-  // TODO: Implement
-  return specification
+  // Version
+  if (specification.swagger?.startsWith('2.0')) {
+    specification.openapi = '3.0.3'
+    delete specification.swagger
+  } else {
+    // Skip if it’s something else than 3.0.x
+    return specification
+  }
+
+  return specification as OpenAPIV3.Document
 }

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -43,5 +43,47 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
     delete specification.definitions
   }
 
+  // Paths
+  if (specification.paths) {
+    for (const path in specification.paths) {
+      if (Object.hasOwn(specification.paths, path)) {
+        const pathItem = specification.paths[path]
+
+        for (const method in pathItem) {
+          if (Object.hasOwn(pathItem, method)) {
+            const operationItem = pathItem[method]
+
+            if (operationItem.responses) {
+              for (const response in operationItem.responses) {
+                if (Object.hasOwn(operationItem.responses, response)) {
+                  const responseItem = operationItem.responses[response]
+
+                  if (responseItem.schema) {
+                    const produces = specification.produces ??
+                      operationItem.produces ?? ['application/json']
+
+                    for (const type of produces) {
+                      if (typeof responseItem.content !== 'object') {
+                        responseItem.content = {}
+                      }
+
+                      responseItem.content[type] = {
+                        schema: responseItem.schema,
+                      }
+                    }
+
+                    delete responseItem.schema
+                  }
+                }
+              }
+            }
+
+            delete operationItem.produces
+          }
+        }
+      }
+    }
+  }
+
   return specification as OpenAPIV3.Document
 }

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -1,4 +1,4 @@
-import type { OpenAPIV3 } from '@scalar/openapi-types'
+import type { OpenAPIV2, OpenAPIV3 } from '@scalar/openapi-types'
 
 import type { AnyObject } from '../types'
 
@@ -53,6 +53,53 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
           if (Object.hasOwn(pathItem, method)) {
             const operationItem = pathItem[method]
 
+            // Request bodies
+            if (operationItem.parameters) {
+              const bodyParameter = structuredClone(
+                operationItem.parameters.find(
+                  (parameter: OpenAPIV3.ParameterObject) =>
+                    parameter.in === 'body',
+                ) ?? {},
+              )
+
+              if (bodyParameter && Object.keys(bodyParameter).length) {
+                delete bodyParameter.name
+                delete bodyParameter.in
+
+                const consumes = specification.consumes ??
+                  operationItem.consumes ?? ['application/json']
+
+                if (typeof operationItem.requestBody !== 'object') {
+                  operationItem.requestBody = {}
+                }
+
+                if (typeof operationItem.requestBody.content !== 'object') {
+                  operationItem.requestBody.content = {}
+                }
+
+                const { schema, ...requestBody } = bodyParameter
+
+                operationItem.requestBody = {
+                  ...operationItem.requestBody,
+                  ...requestBody,
+                }
+
+                for (const type of consumes) {
+                  operationItem.requestBody.content[type] = {
+                    schema: schema,
+                  }
+                }
+              }
+
+              // Delete body parameter
+              operationItem.parameters = operationItem.parameters.filter(
+                (parameter: OpenAPIV2.ParameterObject) =>
+                  parameter.in !== 'body',
+              )
+
+              delete operationItem.consumes
+            }
+
             // Responses
             if (operationItem.responses) {
               for (const response in operationItem.responses) {
@@ -63,11 +110,11 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
                     const produces = specification.produces ??
                       operationItem.produces ?? ['application/json']
 
-                    for (const type of produces) {
-                      if (typeof responseItem.content !== 'object') {
-                        responseItem.content = {}
-                      }
+                    if (typeof responseItem.content !== 'object') {
+                      responseItem.content = {}
+                    }
 
+                    for (const type of produces) {
                       responseItem.content[type] = {
                         schema: responseItem.schema,
                       }
@@ -80,6 +127,11 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
             }
 
             delete operationItem.produces
+
+            // Delete empty parameters
+            if (operationItem.parameters?.length === 0) {
+              delete operationItem.parameters
+            }
           }
         }
       }


### PR DESCRIPTION
I’d consider it experimental and it lacks features (e.g. support security schemes), but it’s a start:

```ts
import { upgrade } from '@scalar/openapi-parser'

const { specification } = upgrade({
  swagger: 2.0,
  info: {
    title: 'Hello World',
    version: '1.0.0',
  },
  basePath: '/v1',
  schemes: ['http'],
  host: 'api.example.com',    
  paths: {},
})

// Output:
//
// {
//   openapi: '3.1.0',
//   info: {
//     title: 'Hello World',
//     version: '1.0.0',
//   },
//   servers: [
//     {
//       url: 'http://api.example.com/v1',
//     },
//   ],
//   paths: {},
// }  
```