### PR TITLE
chore: eslint script max lines

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -218,6 +218,13 @@ module.exports = {
           },
         ],
         'vue/custom-event-name-casing': ['error', 'camelCase'],
+        'vue/max-lines-per-block': [
+          'warn',
+          {
+            script: 50,
+            skipBlankLines: true,
+          },
+        ],
       },
     },
     /** Other rule overrides */


### PR DESCRIPTION
this pr adds max lines rules to the eslint config in order to prevent components from containing any significant amount of business logic. this aims to encourage the creation of helper files, so as to maintain an atomic approach to the functions written and tested in them.

```
  1:1  warning  Block has too many lines (79). Maximum allowed is 50  vue/max-lines-per-block

✖ 1 problem (0 errors, 1 warning)


│  package_format (skip) no matching staged files
┃  prettier ❯ 
```
