### PR TITLE
fix(api-reference): empty server variable value

### DIFF
--- a/.changeset/little-worms-beg.md
+++ b/.changeset/little-worms-beg.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/oas-utils': patch
+---
+
+fix: displays variable in curly braces when empty

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -148,10 +148,12 @@ async function generateSnippet() {
   // Use httpsnippet-lite for other languages
   try {
     const snippet = new HTTPSnippet(request)
-    return (await snippet.convert(
+    const result = await snippet.convert(
       httpClient.targetKey,
       httpClient.clientKey,
-    )) as string
+    )
+
+    return decodeURIComponent(result as string)
   } catch (e) {
     console.error('[ExampleRequest]', e)
     return ''

--- a/packages/oas-utils/src/helpers/replaceVariables.test.ts
+++ b/packages/oas-utils/src/helpers/replaceVariables.test.ts
@@ -26,4 +26,13 @@ describe('replaceVariables', () => {
       ),
     ).toMatchObject('foo<span>foo</span>foo')
   })
+
+  it('returns variable in curly braces when value is empty', () => {
+    const template = 'http://{host}:{port}/api'
+    const variables = { host: 'localhost', port: '' }
+
+    const result = replaceVariables(template, variables)
+
+    expect(result).toBe('http://localhost:{port}/api')
+  })
 })

--- a/packages/oas-utils/src/helpers/replaceVariables.ts
+++ b/packages/oas-utils/src/helpers/replaceVariables.ts
@@ -15,7 +15,7 @@ export function replaceVariables(
     if (typeof variablesOrCallback === 'function') {
       return variablesOrCallback(match)
     } else {
-      return variablesOrCallback[match]?.toString()
+      return variablesOrCallback[match]?.toString() || `{${match}}`
     }
   }
 


### PR DESCRIPTION
this pr fixes #2244 as seen below:

**before**
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/c4334acf-3fdc-42eb-b11f-73d60378638c">

**after**
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/c375ee4c-2c02-4a84-a334-08a5fa891fe6">
