### PR TITLE
feat(api-client-app): `scalar://` links

### DIFF
--- a/.changeset/dirty-months-jump.md
+++ b/.changeset/dirty-months-jump.md
@@ -1,0 +1,5 @@
+---
+'scalar-api-client': patch
+---
+
+feat: register as the default app for `scalar://` links

--- a/packages/api-client-app/open/index.html
+++ b/packages/api-client-app/open/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0" />
+    <title>Open in Scalar</title>
+  </head>
+
+  <body>
+    <ul>
+      <li>
+        <a href="https://scalar.com/download"> Download Scalar </a>
+      </li>
+      <li>
+        <button onClick="javascript:openAppLink()">Open in Scalar</button>
+      </li>
+    </ul>
+
+    <script>
+      /**
+       * Opens the URL passed as `?url=` query parameter in Scalar
+       */
+      function openAppLink() {
+        // Get the URL query parameters
+        const urlParams = new URLSearchParams(window.location.search)
+
+        // Get the `url` parameter
+        const url = urlParams.get('url')
+
+        if (!url) {
+          return
+        }
+
+        // Redirect
+        const target = `scalar://${encodeURIComponent(url)}`
+
+        console.log(`Opening ${target} …`)
+
+        window.location.href = target
+      }
+
+      // Open right-away
+      window.setTimeout(openAppLink, 100)
+    </script>
+  </body>
+</html>

--- a/packages/api-client-app/open/index.html
+++ b/packages/api-client-app/open/index.html
@@ -5,7 +5,15 @@
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Open in Scalar</title>
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="https://scalar.com/favicon.svg" />
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://scalar.com/favicon.png" />
   </head>
   <body>
     <div id="app"></div>

--- a/packages/api-client-app/open/index.html
+++ b/packages/api-client-app/open/index.html
@@ -5,44 +5,12 @@
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
-    <title>Open in Scalar</title>
+    <title>Document</title>
   </head>
-
   <body>
-    <ul>
-      <li>
-        <a href="https://scalar.com/download"> Download Scalar </a>
-      </li>
-      <li>
-        <button onClick="javascript:openAppLink()">Open in Scalar</button>
-      </li>
-    </ul>
-
-    <script>
-      /**
-       * Opens the URL passed as `?url=` query parameter in Scalar
-       */
-      function openAppLink() {
-        // Get the URL query parameters
-        const urlParams = new URLSearchParams(window.location.search)
-
-        // Get the `url` parameter
-        const url = urlParams.get('url')
-
-        if (!url) {
-          return
-        }
-
-        // Redirect
-        const target = `scalar://${encodeURIComponent(url)}`
-
-        console.log(`Opening ${target} …`)
-
-        window.location.href = target
-      }
-
-      // Open right-away
-      window.setTimeout(openAppLink, 100)
-    </script>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="src/main.ts"></script>
   </body>
 </html>

--- a/packages/api-client-app/open/src/components/App.vue
+++ b/packages/api-client-app/open/src/components/App.vue
@@ -1,0 +1,105 @@
+<script lang="ts" setup>
+import { ScalarButton, ScalarIcon } from '@scalar/components'
+import '@scalar/components/style.css'
+import '@scalar/themes/style.css'
+import { computed } from 'vue'
+
+/**
+ * Operating system of the user
+ */
+const platform = computed(() => {
+  const userAgent = navigator.userAgent.toLowerCase()
+
+  if (userAgent.includes('win')) return 'Windows'
+  if (userAgent.includes('mac')) return 'macOS'
+  if (userAgent.includes('linux')) return 'Linux'
+
+  return ''
+})
+
+/** Title (`title` query parameter) */
+const title = computed(() => {
+  const urlParams = new URLSearchParams(window.location.search)
+
+  // Get the `title` parameter
+  return urlParams.get('title')
+})
+
+/** App link (based on `url` parameter) */
+const scalarAppLink = computed(() => {
+  const urlParams = new URLSearchParams(window.location.search)
+
+  // Get the `url` parameter
+  const url = urlParams.get('url')
+
+  if (!url) {
+    return ''
+  }
+
+  // Redirect
+  const target = `scalar://${encodeURIComponent(url)}`
+
+  console.info(`Opening ${target} …`)
+
+  return target
+})
+
+/** Open the app */
+function openScalarApp() {
+  if (scalarAppLink.value) {
+    window.location.href = scalarAppLink.value
+  }
+}
+</script>
+
+<template>
+  <div class="scalar-app light-mode">
+    <div class="h-screen p-3 flex flex-col">
+      <header class="p-3">
+        <ScalarIcon
+          icon="Logo"
+          size="2xl" />
+      </header>
+      <main class="flex-1 flex items-center justify-center">
+        <div class="p-3 flex flex-col gap-2">
+          <div
+            v-if="title"
+            class="text-md font-bold p-3"
+            style="text-align: center">
+            {{ title }}
+          </div>
+          <ScalarButton
+            class="px-6 max-h-8 w-full gap-2 text-xs hover:bg-b-2"
+            size="md"
+            type="button"
+            variant="solid"
+            @click="openScalarApp">
+            <ScalarIcon
+              icon="Download"
+              size="md" />
+            Open in Scalar
+            <template v-if="platform"> for {{ platform }} </template>
+          </ScalarButton>
+          <ScalarButton
+            class="px-6 max-h-8 w-full gap-2 text-xs hover:bg-b-2"
+            size="md"
+            type="button"
+            variant="outlined">
+            <ScalarIcon
+              icon="Workspace"
+              size="md" />
+            View in the Browser
+          </ScalarButton>
+          <div class="text-sm py-4 text-center">
+            Don’t have the app?
+            <a
+              href="https://scalar.com/download"
+              target="_blank">
+              Download it for free
+            </a>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+</template>

--- a/packages/api-client-app/open/src/main.ts
+++ b/packages/api-client-app/open/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+
+import App from './components/App.vue'
+
+createApp(App).mount('#app')

--- a/packages/api-client-app/open/vite.config.ts
+++ b/packages/api-client-app/open/vite.config.ts
@@ -1,0 +1,6 @@
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [vue()],
+})

--- a/packages/api-client-app/package.json
+++ b/packages/api-client-app/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "build": "npm run types:check && electron-vite build",
     "dev": "electron-vite dev",
-    "dev:update": "electron-vite dev -- --runtime-simulate-updates=update-available",
     "dev:open": "cd open && vite",
+    "dev:update": "electron-vite dev -- --runtime-simulate-updates=update-available",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "preview": "electron-vite preview",
@@ -33,6 +33,8 @@
     "@electron-toolkit/preload": "^3.0.0",
     "@electron-toolkit/utils": "^3.0.0",
     "@scalar/api-client": "workspace:*",
+    "@scalar/components": "workspace:*",
+    "@scalar/themes": "workspace:*",
     "@todesktop/runtime": "^1.6.3",
     "electron-window-state": "^5.0.3",
     "fathom-client": "^3.7.2"

--- a/packages/api-client-app/package.json
+++ b/packages/api-client-app/package.json
@@ -14,6 +14,7 @@
     "build": "npm run types:check && electron-vite build",
     "dev": "electron-vite dev",
     "dev:update": "electron-vite dev -- --runtime-simulate-updates=update-available",
+    "dev:open": "cd open && vite",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "preview": "electron-vite preview",

--- a/packages/api-client-app/src/main/index.ts
+++ b/packages/api-client-app/src/main/index.ts
@@ -444,6 +444,7 @@ async function openAppLink(appLink?: string) {
   }
 
   // Fetch URL
+  console.log(`Fetching ${url} …`)
   const result = await fetch(url)
 
   // Error handling

--- a/packages/api-client-app/src/main/index.ts
+++ b/packages/api-client-app/src/main/index.ts
@@ -18,7 +18,14 @@ import icon from '../../build/icon.png?asset'
 
 const MODIFIED_HEADERS_KEY = 'X-Scalar-Modified-Headers'
 
-const gotTheLock = app.requestSingleInstanceLock()
+/**
+ * A strange way to have only one Window and handle app links
+ *
+ * @source https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app#windows-and-linux-code
+ */
+if (!app.requestSingleInstanceLock()) {
+  app.quit()
+}
 
 todesktop.init({
   updateReadyAction: {

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -46,16 +46,6 @@ window.electron.ipcRenderer?.on(
   },
 )
 
-// Open… menu
-window.electron.ipcRenderer?.on(
-  'importFile',
-  function (_: IpcRendererEvent, fileContent: string) {
-    if (fileContent) {
-      client.store.importSpecFile(fileContent)
-    }
-  },
-)
-
 // Drag and drop
 document.addEventListener('drop', drop)
 document.addEventListener('dragover', dragover)

--- a/packages/api-client-app/todesktop.json
+++ b/packages/api-client-app/todesktop.json
@@ -14,7 +14,9 @@
       "url": "https://scalar.com"
     },
     "dependencies": {
-      "@scalar/api-client": null
+      "@scalar/api-client": null,
+      "@scalar/themes": null,
+      "@scalar/components": null
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,9 +23,9 @@
   "scripts": {
     "@scalar/cli": "pnpm vite-node src/index.ts",
     "build": "scalar-build-rollup",
-    "test": "vitest",
     "link:cli": "pnpm run build && npm unlink -g @scalar/cli && npm link",
     "screenshot": "./scripts/take-screenshots.sh",
+    "test": "vitest",
     "types:build": "scalar-types-build",
     "types:check": "scalar-types-check"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,6 +693,12 @@ importers:
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@scalar/components':
+        specifier: workspace:*
+        version: link:../components
+      '@scalar/themes':
+        specifier: workspace:*
+        version: link:../themes
       '@todesktop/runtime':
         specifier: ^1.6.3
         version: 1.6.4
@@ -16287,8 +16293,8 @@ packages:
   vue-component-type-helpers@2.0.21:
     resolution: {integrity: sha512-3NaicyZ7N4B6cft4bfb7dOnPbE9CjLcx+6wZWAg5zwszfO4qXRh+U52dN5r5ZZfc6iMaxKCEcoH9CmxxoFZHLg==}
 
-  vue-component-type-helpers@2.0.29:
-    resolution: {integrity: sha512-58i+ZhUAUpwQ+9h5Hck0D+jr1qbYl4voRt5KffBx8qzELViQ4XdT/Tuo+mzq8u63teAG8K0lLaOiL5ofqW38rg==}
+  vue-component-type-helpers@2.1.2:
+    resolution: {integrity: sha512-URuxnrOhO9lUG4LOAapGWBaa/WOLDzzyAbL+uKZqT7RS+PFy0cdXI2mUSh7GaMts6vtHaeVbGk7trd0FPJi65Q==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -23710,7 +23716,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.31(typescript@5.5.2)
-      vue-component-type-helpers: 2.0.29
+      vue-component-type-helpers: 2.1.2
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -23727,7 +23733,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.31(typescript@5.5.2)
-      vue-component-type-helpers: 2.0.29
+      vue-component-type-helpers: 2.1.2
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -36858,7 +36864,7 @@ snapshots:
 
   vue-component-type-helpers@2.0.21: {}
 
-  vue-component-type-helpers@2.0.29: {}
+  vue-component-type-helpers@2.1.2: {}
 
   vue-demi@0.14.10(vue@3.4.31(typescript@5.5.2)):
     dependencies:


### PR DESCRIPTION
With this PR the app is registered as the default handler for `scalar://` protocol links, this allows to import an OpenAPI document through links.

Let’s say we’d love to import our Scalar Galaxy example:
`https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json`

We can encode the URI and prefix it with our protocol:
`scalar://${encodeURIComponent("https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json")}`

Which gives us this:
scalar://https%3A%2F%2Fcdn.jsdelivr.net%2Fnpm%2F%40scalar%2Fgalaxy%2Fdist%2Flatest.json

To test how this opens in the app, do the following:

1. `$ cd packages/api-client-app`
2. `$ pnpm dev`
3. `$ open scalar://https%3A%2F%2Fcdn.jsdelivr.net%2Fnpm%2F%40scalar%2Fgalaxy%2Fdist%2Flatest.json`

There’s also a simple HTML file that we’d eventually need to host somewhere, but more on this in a separate PR. :)