### PR TITLE
fix(api-client): request sidebar menu actions

### DIFF
--- a/.changeset/dull-owls-brake.md
+++ b/.changeset/dull-owls-brake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: request sidebar item ellipsis menu events

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -393,7 +393,9 @@ const handleNavigation = (event: KeyboardEvent, item: typeof props.item) => {
                   "
                   :item="item"
                   :parentUids="parentUids"
-                  :resourceTitle="resourceTitle" />
+                  :resourceTitle="resourceTitle"
+                  @delete="deleteModal.show()"
+                  @rename="openRenameModal" />
                 <span>&hairsp;</span>
               </div>
             </div>


### PR DESCRIPTION
this pr brings back events in the ellipsis menu that have been omitted, in order to be able to display action modal again from the ellipsis menu actions (spotted by @hanspagel):

<img width="565" alt="image" src="https://github.com/user-attachments/assets/10c9a812-c975-438d-bec3-883d3dca1d75">
