### PR TITLE
chore: require some servers to be running for some test files

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -20,6 +20,13 @@ It’s worth to check the tests locally before sending contributions: `$ pnpm te
 
 If you want to add a test and only run your test file, you can filter the test suite like this: `$ pnpm test your-test`
 
+Some tests require an instance of `@scalar/proxy-server` and `@scalar/void-server`. Start them like so:
+
+```bash
+pnpm dev:void-server
+pnpm dev:proxy-server
+```
+
 ### Testing the CLI
 
 If you want to run the tests for the CLI, you’ll need to package first. The tests don’t use the source files, but the dist files.

--- a/packages/api-client/src/libs/sendRequest.test.ts
+++ b/packages/api-client/src/libs/sendRequest.test.ts
@@ -12,7 +12,7 @@ import {
   createRequestExample,
   createRequestExampleParameter,
 } from '@scalar/oas-utils/entities/workspace/spec'
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { sendRequest } from './sendRequest'
 
@@ -39,6 +39,44 @@ function createRequestExampleServer(metaRequestPayload: MetaRequestPayload) {
     server,
   }
 }
+
+beforeAll(async () => {
+  // Check whether the proxy-server is running
+  try {
+    const result = await fetch(`http://127.0.0.1:${PROXY_PORT}`)
+
+    if (result.ok) {
+      return
+    }
+  } catch (error) {
+    throw new Error(`
+
+[sendRequest.test.ts] Looks like you’re not running @scalar/proxy-server on <http://127.0.0.1:${PROXY_PORT}>, but it’s required for this test file.
+
+Try to run it like this:
+
+$ pnpm dev:proxy-server
+`)
+  }
+
+  // Check whether the void-server is running
+  try {
+    const result = await fetch(`http://127.0.0.1:${VOID_PORT}`)
+
+    if (result.ok) {
+      return
+    }
+  } catch (error) {
+    throw new Error(`
+
+[sendRequest.test.ts] Looks like you’re not running @scalar/void-server on <http://127.0.0.1:${VOID_PORT}>, but it’s required for this test file.
+
+Try to run it like this:
+
+$ pnpm dev:void-server
+`)
+  }
+})
 
 describe('sendRequest', () => {
   it('shows a warning when scalar_url is missing', async () => {

--- a/packages/api-client/src/libs/sendRequest.test.ts
+++ b/packages/api-client/src/libs/sendRequest.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it } from 'vitest'
 import { sendRequest } from './sendRequest'
 
 const PROXY_PORT = 5051
-const ECHO_PORT = 5052
+const VOID_PORT = 5052
 
 type MetaRequestPayload = {
   serverPayload?: ServerPayload
@@ -59,7 +59,7 @@ describe('sendRequest', () => {
 
   it('reaches the echo server *without* the proxy', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
+      serverPayload: { url: `http://127.0.0.1:${VOID_PORT}` },
     })
 
     const result = await sendRequest(
@@ -77,7 +77,7 @@ describe('sendRequest', () => {
 
   it('reaches the echo server *with* the proxy', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
+      serverPayload: { url: `http://127.0.0.1:${VOID_PORT}` },
     })
 
     const result = await sendRequest(
@@ -94,7 +94,7 @@ describe('sendRequest', () => {
 
   it('replaces variables in urls', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
+      serverPayload: { url: `http://127.0.0.1:${VOID_PORT}` },
       requestExamplePayload: {
         parameters: {
           path: [
@@ -118,7 +118,7 @@ describe('sendRequest', () => {
 
   it('sends query parameters', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
+      serverPayload: { url: `http://127.0.0.1:${VOID_PORT}` },
       requestExamplePayload: {
         parameters: {
           query: [
@@ -145,7 +145,7 @@ describe('sendRequest', () => {
 
   it('merges query parameters', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}?example=parameter` },
+      serverPayload: { url: `http://127.0.0.1:${VOID_PORT}?example=parameter` },
       requestPayload: { path: '' },
       requestExamplePayload: {
         parameters: {
@@ -176,7 +176,7 @@ describe('sendRequest', () => {
 
   it('works with no content', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}/204` },
+      serverPayload: { url: `http://127.0.0.1:${VOID_PORT}/204` },
     })
 
     const result = await sendRequest(
@@ -190,7 +190,7 @@ describe('sendRequest', () => {
 
   // it('adds cookies as headers', async () => {
   //   const { request, example, server } = createRequestExampleServer({
-  //     serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
+  //     serverPayload: { url: `http://127.0.0.1:${VOID_PORT}` },
   //     requestExamplePayload: {
   //       parameters: {
   //         cookies: [
@@ -219,7 +219,7 @@ describe('sendRequest', () => {
 
   // it('merges cookies', async () => {
   //   const { request, example, server } = createRequestExampleServer({
-  //     serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
+  //     serverPayload: { url: `http://127.0.0.1:${VOID_PORT}` },
   //     requestExamplePayload: {
   //       parameters: {
   //         cookies: [
@@ -254,7 +254,7 @@ describe('sendRequest', () => {
 
   it('skips the proxy for requests to localhost', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}/v1` },
+      serverPayload: { url: `http://127.0.0.1:${VOID_PORT}/v1` },
       requestPayload: { path: '' },
     })
 
@@ -288,7 +288,7 @@ describe('sendRequest', () => {
 
   it('keeps the trailing slash', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}/v1/` },
+      serverPayload: { url: `http://127.0.0.1:${VOID_PORT}/v1/` },
       requestPayload: { path: '' },
     })
 
@@ -306,7 +306,7 @@ describe('sendRequest', () => {
 
   it('sends a multipart/form-data request with string values', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
+      serverPayload: { url: `http://127.0.0.1:${VOID_PORT}` },
       requestPayload: { path: '', method: 'POST' },
       requestExamplePayload: {
         body: {
@@ -352,7 +352,7 @@ describe('sendRequest', () => {
    */
   it.todo('sends a multipart/form-data request with files', async () => {
     const { request, example, server } = createRequestExampleServer({
-      serverPayload: { url: `http://127.0.0.1:${ECHO_PORT}` },
+      serverPayload: { url: `http://127.0.0.1:${VOID_PORT}` },
       requestPayload: { path: '', method: 'POST' },
       requestExamplePayload: {
         body: {

--- a/packages/oas-utils/src/helpers/fetchSpecFromUrl.test.ts
+++ b/packages/oas-utils/src/helpers/fetchSpecFromUrl.test.ts
@@ -1,8 +1,28 @@
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { fetchSpecFromUrl } from './fetchSpecFromUrl'
 
 const PROXY_PORT = 5051
+
+beforeAll(async () => {
+  // Check whether the proxy-server is running
+  try {
+    const result = await fetch(`http://127.0.0.1:${PROXY_PORT}`)
+
+    if (result.ok) {
+      return
+    }
+  } catch (error) {
+    throw new Error(`
+
+[sendRequest.test.ts] Looks like you’re not running @scalar/proxy-server on <http://127.0.0.1:${PROXY_PORT}>, but it’s required for this test file.
+
+Try to run it like this:
+
+$ pnpm dev:proxy-server
+`)
+  }
+})
 
 describe('fetchSpecFromUrl', () => {
   it('fetches specifications (without a proxy)', async () => {


### PR DESCRIPTION
With this PR the contributing guide is updated to list the required servers (`@scalar/void-server` + `@scalar/proxy-server`) for a complete test run.

And with this PR, in the two test files that require them, we check whether they are running and throw a helpful error if they aren’t running already.