### PR TITLE
Update package.json path export error

### DIFF
--- a/packages/hono-api-reference/package.json
+++ b/packages/hono-api-reference/package.json
@@ -29,6 +29,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
+      "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },


### PR DESCRIPTION
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /node_modules/@scalar/hono-api-reference/package.json

**Problem**
Currently, …

**Explanation**
This happens because …

**Solution**
With this PR …
