### PR TITLE
feat(api-client): request sidebar item modal style

### DIFF
--- a/.changeset/forty-yaks-remember.md
+++ b/.changeset/forty-yaks-remember.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: new modal layout

--- a/packages/api-client/src/components/Sidebar/Actions/DeleteSidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/Actions/DeleteSidebarListElement.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{
     @submit="emit('delete')">
     <p
       v-if="warningMessage"
-      class="text-c-3 font-medium text-xs mb-2">
+      class="leading-normal text-c-2 text-sm text-pretty">
       {{ warningMessage }}
     </p>
   </SidebarListElementForm>

--- a/packages/api-client/src/components/Sidebar/Actions/RenameSidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/Actions/RenameSidebarListElement.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import SidebarListElementForm from '@/components/Sidebar/Actions/SidebarListElementForm.vue'
+import { ScalarTextField } from '@scalar/components'
+import { ref } from 'vue'
+
+const props = defineProps<{
+  name: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'rename', newName: string): void
+}>()
+
+const newName = ref(props.name)
+</script>
+<template>
+  <SidebarListElementForm
+    @cancel="emit('close')"
+    @submit="emit('rename', newName)">
+    <ScalarTextField
+      v-model="newName"
+      autofocus />
+  </SidebarListElementForm>
+</template>

--- a/packages/api-client/src/components/Sidebar/Actions/SidebarListElementForm.vue
+++ b/packages/api-client/src/components/Sidebar/Actions/SidebarListElementForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarButton } from '@scalar/components'
+import { cva, cx } from 'cva'
 
 defineProps<{
   danger?: boolean
@@ -10,6 +11,16 @@ const emit = defineEmits<{
   (e: 'cancel'): void
   (e: 'submit'): void
 }>()
+
+const variants = cva({
+  base: 'gap-1.5 font-medium px-2.5 h-8 shadow-none focus:outline-none',
+  variants: {
+    danger: {
+      true: 'delete-warning-button',
+      false: '',
+    },
+  },
+})
 </script>
 <template>
   <form
@@ -17,29 +28,18 @@ const emit = defineEmits<{
     @submit.prevent="emit('submit')">
     <slot />
     <div class="flex justify-between">
-      <button
-        class="border text-left bg-b-1 focus:bg-b-2 hover:bg-b-2 rounded gap-1.5 px-2.5 py-1.5 focus:outline-none flex items-center cursor-pointer"
+      <ScalarButton
+        class="gap-1.5 px-2.5 h-8 shadow-none focus:outline-none flex items-center cursor-pointer"
         type="button"
+        variant="outlined"
         @click="emit('cancel')">
-        <ScalarIcon
-          class="inline-flex"
-          icon="Close"
-          size="sm"
-          thickness="1.75" />
         Cancel
-      </button>
-      <button
-        class="bg-red text-left focus:bg-b-2 hover:bg-b-2 rounded gap-1.5 px-2.5 py-1.5 focus:outline-none flex items-center cursor-pointer delete-warning-button"
-        :error="danger"
-        type="submit"
-        @click="emit('submit')">
-        <ScalarIcon
-          class="inline-flex"
-          icon="Delete"
-          size="sm"
-          thickness="1.5" />
-        {{ label ?? 'Submit' }}
-      </button>
+      </ScalarButton>
+      <ScalarButton
+        :class="cx(variants({ danger }))"
+        type="submit">
+        {{ label ?? 'Save' }}
+      </ScalarButton>
     </div>
   </form>
 </template>

--- a/packages/api-client/src/components/Sidebar/Actions/SidebarListElementForm.vue
+++ b/packages/api-client/src/components/Sidebar/Actions/SidebarListElementForm.vue
@@ -12,13 +12,13 @@ const emit = defineEmits<{
 }>()
 </script>
 <template>
-  <div
-    class="text-base"
+  <form
+    class="flex flex-col gap-4 text-base"
     @submit.prevent="emit('submit')">
     <slot />
-    <div>
+    <div class="flex justify-between">
       <button
-        class="w-full text-left focus:bg-b-2 hover:bg-b-2 rounded gap-1.5 px-2.5 py-1.5 focus:outline-none flex items-center cursor-pointer"
+        class="border text-left bg-b-1 focus:bg-b-2 hover:bg-b-2 rounded gap-1.5 px-2.5 py-1.5 focus:outline-none flex items-center cursor-pointer"
         type="button"
         @click="emit('cancel')">
         <ScalarIcon
@@ -29,7 +29,7 @@ const emit = defineEmits<{
         Cancel
       </button>
       <button
-        class="w-full text-left focus:bg-b-2 hover:bg-b-2 rounded gap-1.5 px-2.5 py-1.5 focus:outline-none flex items-center cursor-pointer delete-warning-button"
+        class="bg-red text-left focus:bg-b-2 hover:bg-b-2 rounded gap-1.5 px-2.5 py-1.5 focus:outline-none flex items-center cursor-pointer delete-warning-button"
         :error="danger"
         type="submit"
         @click="emit('submit')">
@@ -41,14 +41,15 @@ const emit = defineEmits<{
         {{ label ?? 'Submit' }}
       </button>
     </div>
-  </div>
+  </form>
 </template>
 <style scoped>
 .delete-warning-button {
+  background: color-mix(in srgb, var(--scalar-color-red), transparent 95%);
   color: var(--scalar-color-red);
 }
 .delete-warning-button:hover,
 .delete-warning-button:focus {
-  background: color-mix(in srgb, var(--scalar-color-red), transparent 95%);
+  background: color-mix(in srgb, var(--scalar-color-red), transparent 90%);
 }
 </style>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { HttpMethod } from '@/components/HttpMethod'
 import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
+import RenameSidebarListElement from '@/components/Sidebar/Actions/RenameSidebarListElement.vue'
 import { useSidebar } from '@/hooks'
 import { getModifiers } from '@/libs'
 import { commandPaletteBus } from '@/libs/event-busses'
@@ -11,7 +12,6 @@ import {
   ScalarContextMenu,
   ScalarIcon,
   ScalarModal,
-  ScalarTextField,
   useModal,
 } from '@scalar/components'
 import {
@@ -107,7 +107,7 @@ const item = computed<Item>(() => {
       resourceTitle: 'Collection',
       children: collection.children,
       warning:
-        'Warning: deleting this collection will delete all requests and tags as well',
+        'This cannot be undone. You’re about to delete the collection and all folders andrequests inside it.',
       rename: () =>
         collectionMutators.edit(collection.uid, 'info.title', tempName.value),
       delete: () =>
@@ -120,6 +120,8 @@ const item = computed<Item>(() => {
       entity: tag,
       resourceTitle: 'Tag',
       children: tag.children,
+      warning:
+        'This cannot be undone. You’re about to delete the tag and all requests inside it',
       rename: () => tagMutators.edit(tag.uid, 'name', tempName.value),
       delete: () => tagMutators.delete(tag, props.parentUids[0]),
     }
@@ -131,8 +133,7 @@ const item = computed<Item>(() => {
       method: request.method,
       entity: request,
       resourceTitle: 'Request',
-      warning:
-        'Warning: deleting this request will delete all examples as well',
+      warning: 'This cannot be undone. You’re about to delete the request.',
       children: request.examples,
       rename: () =>
         requestMutators.edit(request.uid, 'summary', tempName.value),
@@ -237,7 +238,8 @@ const tempName = ref('')
 const renameModal = useModal()
 const deleteModal = useModal()
 
-const handleItemRename = () => {
+const handleItemRename = (newName: string) => {
+  tempName.value = newName
   item.value.rename()
   renameModal.hide()
 }
@@ -459,24 +461,10 @@ function openCommandPaletteRequest() {
     :size="'xxs'"
     :state="renameModal"
     :title="`Rename ${item.resourceTitle}`">
-    <ScalarTextField
-      v-model="tempName"
-      :label="item.resourceTitle"
-      @keydown.prevent.enter="handleItemRename" />
-    <div class="flex gap-3">
-      <ScalarButton
-        class="flex-1"
-        variant="outlined"
-        @click="renameModal.hide()">
-        Cancel
-      </ScalarButton>
-      <ScalarButton
-        class="flex-1"
-        type="submit"
-        @click="handleItemRename">
-        Save
-      </ScalarButton>
-    </div>
+    <RenameSidebarListElement
+      :name="item.title"
+      @close="renameModal.hide()"
+      @rename="handleItemRename" />
   </ScalarModal>
 </template>
 

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -446,7 +446,7 @@ function openCommandPaletteRequest() {
     </Draggable>
   </div>
   <ScalarModal
-    :size="'sm'"
+    :size="'xxs'"
     :state="deleteModal"
     :title="`Delete ${item.resourceTitle}`">
     <DeleteSidebarListElement
@@ -456,6 +456,7 @@ function openCommandPaletteRequest() {
       @delete="handleItemDelete" />
   </ScalarModal>
   <ScalarModal
+    :size="'xxs'"
     :state="renameModal"
     :title="`Rename ${item.resourceTitle}`">
     <ScalarTextField


### PR DESCRIPTION
this pr adds consistency between delete/rename action modal style while updating the button position in order to fix ux risk of clicking to the wrong action due to call to action proximity.

tba: workspace modal actions

<details>
<summary>before</summary>
<img width="1026" alt="image" src="https://github.com/user-attachments/assets/94a3f028-4101-4be6-a870-4e4890ad0fae">

<img width="1026" alt="image" src="https://github.com/user-attachments/assets/2dba6eaf-368c-457d-8818-4c0e62839d76">
</details>

<details open>
<summary>after</summary>
<img width="1026" alt="image" src="https://github.com/user-attachments/assets/49cd37f6-e27c-42d6-b888-7978cfd29773">

<img width="1026" alt="image" src="https://github.com/user-attachments/assets/9a29060a-fd82-4989-8e95-4b19677d8aa1">
</details>