### PR TITLE
chore: automatically add repository URL to every package.json

### DIFF
--- a/.changeset/wicked-dancers-share.md
+++ b/.changeset/wicked-dancers-share.md
@@ -1,0 +1,7 @@
+---
+'scalar-api-client': patch
+'@scalar/nextjs-openapi': patch
+'@scalar/snippetz': patch
+---
+
+fix: repository URL in package.json

--- a/examples/api-client/package.json
+++ b/examples/api-client/package.json
@@ -8,7 +8,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/scalar/scalar.git",
-    "directory": "examples/client"
+    "directory": "examples/api-client"
   },
   "version": "0.1.0",
   "private": true,

--- a/examples/cdn-api-reference/package.json
+++ b/examples/cdn-api-reference/package.json
@@ -4,6 +4,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/cdn-api-reference"
+  },
   "version": "0.0.1",
   "private": true,
   "engines": {

--- a/examples/docusaurus/package.json
+++ b/examples/docusaurus/package.json
@@ -4,6 +4,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/docusaurus"
+  },
   "version": "0.0.0",
   "private": true,
   "engines": {

--- a/examples/express-api-reference/package.json
+++ b/examples/express-api-reference/package.json
@@ -4,6 +4,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/express-api-reference"
+  },
   "version": "0.1.0",
   "private": true,
   "engines": {

--- a/examples/fastify-api-reference/package.json
+++ b/examples/fastify-api-reference/package.json
@@ -4,6 +4,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/fastify-api-reference"
+  },
   "version": "0.5.2",
   "private": true,
   "engines": {

--- a/examples/nestjs-api-reference-express/package.json
+++ b/examples/nestjs-api-reference-express/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/nestjs-api-reference-express"
+  },
   "version": "1.0.0",
   "private": true,
   "engines": {

--- a/examples/nestjs-api-reference-fastify/package.json
+++ b/examples/nestjs-api-reference-fastify/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/nestjs-api-reference-fastify"
+  },
   "version": "1.0.0",
   "private": true,
   "engines": {

--- a/examples/nextjs-api-reference/package.json
+++ b/examples/nextjs-api-reference/package.json
@@ -4,6 +4,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/nextjs-api-reference"
+  },
   "version": "0.1.0",
   "private": true,
   "engines": {

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -4,6 +4,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/react"
+  },
   "version": "0.0.0",
   "private": true,
   "engines": {

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -4,6 +4,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/ssg"
+  },
   "version": "0.1.0",
   "private": true,
   "engines": {

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -4,6 +4,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "examples/web"
+  },
   "version": "0.4.2",
   "private": true,
   "engines": {

--- a/packages/api-client-app/package.json
+++ b/packages/api-client-app/package.json
@@ -5,6 +5,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/api-client-app"
+  },
   "version": "0.1.33",
   "private": true,
   "engines": {

--- a/packages/nextjs-openapi/package.json
+++ b/packages/nextjs-openapi/package.json
@@ -8,7 +8,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/scalar/scalar.git",
-    "directory": "packages/types"
+    "directory": "packages/nextjs-openapi"
   },
   "keywords": [
     "typescript",

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -4,6 +4,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalar/scalar.git",
+    "directory": "packages/snippetz"
+  },
   "version": "0.2.1",
   "engines": {
     "node": ">=18"

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -134,7 +134,6 @@ async function formatPackage(filepath: string) {
 
   // Check whether the package.json needs to be updated
   if (JSON.stringify(data) !== JSON.stringify(formattedData)) {
-    printColor('green', `[${formattedData.name}] package.json formatted`)
     return
   }
 

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -120,10 +120,25 @@ async function formatPackage(filepath: string) {
     }
   })
 
-  if (JSON.stringify(data) !== JSON.stringify(formattedData)) {
-    printColor('green', `[${formattedData.name}] package.json formatted`)
+  // Repository URL
+  const directory = path.relative(
+    path.join(__dirname, '..'),
+    path.dirname(filepath),
+  )
+
+  formattedData['repository'] = {
+    type: 'git',
+    url: 'https://github.com/scalar/scalar.git',
+    directory,
   }
 
+  // Check whether the package.json needs to be updated
+  if (JSON.stringify(data) !== JSON.stringify(formattedData)) {
+    printColor('green', `[${formattedData.name}] package.json formatted`)
+    return
+  }
+
+  // Update the package.json
   await fs
     .writeFile(filepath, JSON.stringify(formattedData, null, 2) + '\n')
     .catch((err) => console.error(err))

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -133,7 +133,7 @@ async function formatPackage(filepath: string) {
   }
 
   // Check whether the package.json needs to be updated
-  if (JSON.stringify(data) !== JSON.stringify(formattedData)) {
+  if (JSON.stringify(data) === JSON.stringify(formattedData)) {
     return
   }
 

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -109,17 +109,6 @@ async function formatPackage(filepath: string) {
     }
   })
 
-  // Validate before sorting
-  // Check that required scripts are entered
-  validatePackageScripts(formattedData['scripts'], formattedData.name)
-
-  // Sort nested keys alphanumerically
-  sortKeys.forEach((key) => {
-    if (formattedData[key]) {
-      formattedData[key] = sortObjectKeys(formattedData[key])
-    }
-  })
-
   // Repository URL
   const directory = path.relative(
     path.join(__dirname, '..'),
@@ -131,6 +120,17 @@ async function formatPackage(filepath: string) {
     url: 'https://github.com/scalar/scalar.git',
     directory,
   }
+
+  // Validate before sorting
+  // Check that required scripts are entered
+  validatePackageScripts(formattedData['scripts'], formattedData.name)
+
+  // Sort nested keys alphanumerically
+  sortKeys.forEach((key) => {
+    if (formattedData[key]) {
+      formattedData[key] = sortObjectKeys(formattedData[key])
+    }
+  })
 
   // Check whether the package.json needs to be updated
   if (JSON.stringify(data) === JSON.stringify(formattedData)) {


### PR DESCRIPTION
Publishing fails because `@scalar/snippetz` doesn’t have the repository URL in the package.json.

With this PR the repository URL is automatically added with `pnpm format:packages` and the changes are already applied to all files.