### PR TITLE
chore(api-client-app): deploy open electron app page

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -358,6 +358,44 @@ steps:
         '--service-account=$_SERVICE_ACCOUNT',
       ]
   # ---------------------------------------------------------------
+  # API Client App Open Page
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-open'
+    waitFor: ['push-base']
+    args:
+      [
+        'buildx',
+        'build',
+        '--build-arg',
+        'BASE_IMAGE=gcr.io/${_PROJECT_ID}/${_BASE_BUILDER}',
+        '-t',
+        'gcr.io/${_PROJECT_ID}/${_SERVICE_OPEN_ELECTRON}',
+        '-f',
+        './packages/api-client-app/Dockerfile',
+        '.',
+      ]
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'push-open'
+    waitFor: ['build-open']
+    args: ['push', 'gcr.io/${_PROJECT_ID}/${_SERVICE_OPEN_ELECTRON}']
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    waitFor: ['push-open']
+    args:
+      [
+        'run',
+        'deploy',
+        '$_SERVICE_OPEN_ELECTRON',
+        '--image=gcr.io/${_PROJECT_ID}/${_SERVICE_OPEN_ELECTRON}',
+        '--region=$_REGION',
+        '--platform=managed',
+        '--allow-unauthenticated',
+        '--execution-environment=gen2',
+        '--cpu=$_CPU',
+        '--memory=$_MEMORY',
+        '--service-account=$_SERVICE_ACCOUNT',
+      ]
+  # ---------------------------------------------------------------
   # Other Integration
   # - name: OTHER INTEGRATION
 # ---------------------------------------------------------------

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -369,7 +369,7 @@ steps:
         '--build-arg',
         'BASE_IMAGE=gcr.io/${_PROJECT_ID}/${_BASE_BUILDER}',
         '-t',
-        'gcr.io/${_PROJECT_ID}/${_SERVICE_OPEN_ELECTRON}',
+        'gcr.io/${_PROJECT_ID}/${_SERVICE_OPEN_API_CLIENT}',
         '-f',
         './packages/api-client-app/Dockerfile',
         '.',
@@ -377,7 +377,7 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     id: 'push-open'
     waitFor: ['build-open']
-    args: ['push', 'gcr.io/${_PROJECT_ID}/${_SERVICE_OPEN_ELECTRON}']
+    args: ['push', 'gcr.io/${_PROJECT_ID}/${_SERVICE_OPEN_API_CLIENT}']
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud
     waitFor: ['push-open']
@@ -385,8 +385,8 @@ steps:
       [
         'run',
         'deploy',
-        '$_SERVICE_OPEN_ELECTRON',
-        '--image=gcr.io/${_PROJECT_ID}/${_SERVICE_OPEN_ELECTRON}',
+        '$_SERVICE_OPEN_API_CLIENT',
+        '--image=gcr.io/${_PROJECT_ID}/${_SERVICE_OPEN_API_CLIENT}',
         '--region=$_REGION',
         '--platform=managed',
         '--allow-unauthenticated',

--- a/packages/api-client-app/Dockerfile
+++ b/packages/api-client-app/Dockerfile
@@ -1,0 +1,28 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS builder
+WORKDIR /app
+
+# Build the package
+RUN pnpm --filter scalar-api-client build:open
+
+FROM node:20-bullseye-slim AS runner
+# install simple http server for serving static content
+RUN npm install -g http-server
+
+ENV NODE_ENV=production
+
+# Use default non-root user from the node image
+USER node
+WORKDIR /app
+RUN chown node:node /app
+
+# Copy root node modules and any utilized packages
+COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/packages/components /app/packages/components
+COPY --from=builder /app/packages/themes /app/packages/themes
+COPY --from=builder /app/packages/api-client /app/packages/api-client
+COPY --from=builder /app/packages/api-client-app /app/packages/api-client-app
+WORKDIR /app/packages/api-client-app
+
+
+CMD ["http-server", "open/dist"]

--- a/packages/api-client-app/package.json
+++ b/packages/api-client-app/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "npm run types:check && electron-vite build",
+    "build:open": "cd open && vue-tsc --noEmit && vite build",
     "dev": "electron-vite dev",
     "dev:open": "cd open && vite",
     "dev:update": "electron-vite dev -- --runtime-simulate-updates=update-available",


### PR DESCRIPTION
We need an intermediate page before we open the Electron app from a link.

This PR deploys a simple vue app page to cloud run using cloud build

### TODO: 
- [ ] point it at `https://open.scalar.com/`
