### PR TITLE
feat: Add new configuration options and docs

### DIFF
--- a/packages/scalar.aspnetcore/SacalarClients.cs
+++ b/packages/scalar.aspnetcore/SacalarClients.cs
@@ -1,0 +1,131 @@
+﻿namespace Scalar.AspNetCore;
+
+public static class ScalarClients
+{
+    public static class C
+    {
+        public const string KEY = "c";
+        public const string LIBCURL = "libcurl";
+    }
+
+    public static class Clojure
+    {
+        public const string KEY = "clojure";
+        public const string CLJ_HTTP = "clj_http";
+    }
+
+    public static class CSharp
+    {
+        public const string KEY = "csharp";
+        public const string HTTPCLIENT = "httpclient";
+        public const string RESTSHARP = "restsharp";
+    }
+
+    public static class Go
+    {
+        public const string KEY = "go";
+        public const string NATIVE = "native";
+    }
+
+    public static class Http
+    {
+        public const string KEY = "http";
+        public const string HTTP1_1 = "http1.1";
+    }
+
+    public static class Java
+    {
+        public const string KEY = "java";
+        public const string ASYNCHTTP = "asynchttp";
+        public const string NETHTTP = "nethttp";
+        public const string OKHTTP = "okhttp";
+        public const string UNIREST = "unirest";
+    }
+
+    public static class JavaScript
+    {
+        public const string KEY = "javascript";
+        public const string XHR = "xhr";
+        public const string AXIOS = "axios";
+        public const string FETCH = "fetch";
+        public const string JQUERY = "jquery";
+    }
+
+    public static class Kotlin
+    {
+        public const string KEY = "kotlin";
+        public const string OKHTTP = "okhttp";
+    }
+
+    public static class Node
+    {
+        public const string KEY = "node";
+        public const string UNDICI = "undici";
+        public const string NATIVE = "native";
+        public const string REQUEST = "request";
+        public const string UNIREST = "unirest";
+        public const string AXIOS = "axios";
+        public const string FETCH = "fetch";
+    }
+
+    public static class ObjC
+    {
+        public const string KEY = "objc";
+        public const string NSURLSESSION = "nsurlsession";
+    }
+
+    public static class OCaml
+    {
+        public const string KEY = "ocaml";
+        public const string COHTTP = "cohttp";
+    }
+
+    public static class PHP
+    {
+        public const string KEY = "php";
+        public const string CURL = "curl";
+        public const string GUZZLE = "guzzle";
+        public const string HTTP1 = "http1";
+        public const string HTTP2 = "http2";
+    }
+
+    public static class PowerShell
+    {
+        public const string KEY = "powershell";
+        public const string WEBREQUEST = "webrequest";
+        public const string RESTMETHOD = "restmethod";
+    }
+
+    public static class Python
+    {
+        public const string KEY = "python";
+        public const string PYTHON3 = "python3";
+        public const string REQUESTS = "requests";
+    }
+
+    public static class R
+    {
+        public const string KEY = "r";
+        public const string HTTR = "httr";
+    }
+
+    public static class Ruby
+    {
+        public const string KEY = "ruby";
+        public const string NATIVE = "native";
+    }
+
+    public static class Shell
+    {
+        public const string KEY = "shell";
+        public const string CURL = "curl";
+        public const string HTTPIE = "httpie";
+        public const string WGET = "wget";
+    }
+
+    public static class Swift
+    {
+        public const string KEY = "swift";
+        public const string NSURLSESSION = "nsurlsession";
+    }
+}

--- a/packages/scalar.aspnetcore/SacalarClients.cs
+++ b/packages/scalar.aspnetcore/SacalarClients.cs
@@ -1,131 +1,65 @@
-﻿namespace Scalar.AspNetCore;
+﻿using System.ComponentModel;
 
-public static class ScalarClients
+namespace Scalar.AspNetCore;
+
+public enum ScalarClients
 {
-    public static class C
-    {
-        public const string KEY = "c";
-        public const string LIBCURL = "libcurl";
-    }
-
-    public static class Clojure
-    {
-        public const string KEY = "clojure";
-        public const string CLJ_HTTP = "clj_http";
-    }
-
-    public static class CSharp
-    {
-        public const string KEY = "csharp";
-        public const string HTTPCLIENT = "httpclient";
-        public const string RESTSHARP = "restsharp";
-    }
-
-    public static class Go
-    {
-        public const string KEY = "go";
-        public const string NATIVE = "native";
-    }
-
-    public static class Http
-    {
-        public const string KEY = "http";
-        public const string HTTP1_1 = "http1.1";
-    }
-
-    public static class Java
-    {
-        public const string KEY = "java";
-        public const string ASYNCHTTP = "asynchttp";
-        public const string NETHTTP = "nethttp";
-        public const string OKHTTP = "okhttp";
-        public const string UNIREST = "unirest";
-    }
-
-    public static class JavaScript
-    {
-        public const string KEY = "javascript";
-        public const string XHR = "xhr";
-        public const string AXIOS = "axios";
-        public const string FETCH = "fetch";
-        public const string JQUERY = "jquery";
-    }
-
-    public static class Kotlin
-    {
-        public const string KEY = "kotlin";
-        public const string OKHTTP = "okhttp";
-    }
-
-    public static class Node
-    {
-        public const string KEY = "node";
-        public const string UNDICI = "undici";
-        public const string NATIVE = "native";
-        public const string REQUEST = "request";
-        public const string UNIREST = "unirest";
-        public const string AXIOS = "axios";
-        public const string FETCH = "fetch";
-    }
-
-    public static class ObjC
-    {
-        public const string KEY = "objc";
-        public const string NSURLSESSION = "nsurlsession";
-    }
-
-    public static class OCaml
-    {
-        public const string KEY = "ocaml";
-        public const string COHTTP = "cohttp";
-    }
-
-    public static class PHP
-    {
-        public const string KEY = "php";
-        public const string CURL = "curl";
-        public const string GUZZLE = "guzzle";
-        public const string HTTP1 = "http1";
-        public const string HTTP2 = "http2";
-    }
-
-    public static class PowerShell
-    {
-        public const string KEY = "powershell";
-        public const string WEBREQUEST = "webrequest";
-        public const string RESTMETHOD = "restmethod";
-    }
-
-    public static class Python
-    {
-        public const string KEY = "python";
-        public const string PYTHON3 = "python3";
-        public const string REQUESTS = "requests";
-    }
-
-    public static class R
-    {
-        public const string KEY = "r";
-        public const string HTTR = "httr";
-    }
-
-    public static class Ruby
-    {
-        public const string KEY = "ruby";
-        public const string NATIVE = "native";
-    }
-
-    public static class Shell
-    {
-        public const string KEY = "shell";
-        public const string CURL = "curl";
-        public const string HTTPIE = "httpie";
-        public const string WGET = "wget";
-    }
-
-    public static class Swift
-    {
-        public const string KEY = "swift";
-        public const string NSURLSESSION = "nsurlsession";
-    }
+    [Description("libcurl")]
+    LIBCURL,
+    [Description("clj_http")]
+    CLJ_HTTP,
+    [Description("httpclient")]
+    HTTPCLIENT,
+    [Description("restsharp")]
+    RESTSHARP,
+    [Description("native")]
+    NATIVE,
+    [Description("http1.1")]
+    HTTP1_1,
+    [Description("asynchttp")]
+    ASYNCHTTP,
+    [Description("nethttp")]
+    NETHTTP,
+    [Description("okhttp")]
+    OKHTTP,
+    [Description("unirest")]
+    UNIREST,
+    [Description("xhr")]
+    XHR,
+    [Description("axios")]
+    AXIOS,
+    [Description("fetch")]
+    FETCH,
+    [Description("jquery")]
+    JQUERY,
+    [Description("undici")]
+    UNDICI,
+    [Description("request")]
+    REQUEST,
+    [Description("nsurlsession")]
+    NSURLSESSION,
+    [Description("cohttp")]
+    COHTTP,
+    [Description("curl")]
+    CURL,
+    [Description("guzzle")]
+    GUZZLE,
+    [Description("http1")]
+    HTTP1,
+    [Description("http2")]
+    HTTP2,
+    [Description("webrequest")]
+    WEBREQUEST,
+    [Description("restmethod")]
+    RESTMETHOD,
+    [Description("python3")]
+    PYTHON3,
+    [Description("requests")]
+    REQUESTS,
+    [Description("httr")]
+    HTTR,
+    [Description("httpie")]
+    HTTPIE,
+    [Description("wget")]
+    WGET
 }

--- a/packages/scalar.aspnetcore/ScalaConfiguration.cs
+++ b/packages/scalar.aspnetcore/ScalaConfiguration.cs
@@ -1,0 +1,83 @@
+﻿using static Scalar.AspNetCore.ScalarClients;
+
+namespace Scalar.AspNetCore;
+
+internal class ScalaConfiguration
+{
+    public string Theme { get; init; } = "purple";
+    public bool ShowSideBar { get; init; } = true;
+    public bool HideModels { get; set; } = false;
+    public bool HideDownloadButton { get; init; } = false;
+    public bool DarkMode { get; init; } = true;
+    public bool HideDarkModeToggle { get; set; } = false;
+    public bool DefaultOpenAllTags { get; set; } = false;
+    public bool WithDefaultFonts { get; init; } = true;
+
+    public string? ForceDarkModeState { get; set; }
+    public string? CustomCss { get; init; }
+    public string? SearchHotkey { get; init; }
+    public string[] HiddenClients { get; init; } = Array.Empty<string>();
+    public Dictionary<string, string>? Metadata { get; init; }
+    public ScalarAuthenticationOptions? Authentication { get; init; }
+    public ScalarDefaultHttpClient? DefaultHttpClient { get; init; }
+
+    public ScalaConfiguration(ScalarOptions options)
+    {
+        Theme = options.Theme.ToString().ToLower();
+        DarkMode = options.DarkMode;
+        HideModels = options.HideModels;
+        HideDarkModeToggle = options.HideDarkModeToggle;
+        HideDownloadButton = options.HideDownloadButton;
+        DefaultOpenAllTags = options.DefaultOpenAllTags;
+        ForceDarkModeState = options.ForceDarkModeState;
+        ShowSideBar = options.ShowSideBar;
+        WithDefaultFonts = options.WithDefaultFonts;
+        CustomCss = options.CustomCss;
+        SearchHotkey = options.SearchHotkey;
+        DefaultHttpClient = options.DefaultHttpClient;
+        Metadata = options.Metadata.Any() ? options.Metadata : null;
+        Authentication = options.Authentication.Enabled ? options.Authentication : null;
+        HiddenClients = GetHiddenClients(options);
+    }
+
+    private string[] GetHiddenClients(ScalarOptions options)
+    {
+        var clients = GetAllClientKeys();
+
+        if (options.HiddenClients)
+            return clients;
+
+        if (!options.EnabledClients.Any())
+            return Array.Empty<string>();
+
+        return clients
+            .Except(options.EnabledClients)
+            .ToArray();
+    }
+
+    private string[] GetAllClientKeys()
+    {
+        var options = new List<string>
+        {
+            Clojure.CLJ_HTTP,
+            CSharp.HTTPCLIENT, CSharp.RESTSHARP,
+            Go.NATIVE,
+            Http.HTTP1_1,
+            Java.ASYNCHTTP, Java.NETHTTP, Java.OKHTTP, Java.UNIREST,
+            JavaScript.XHR, JavaScript.AXIOS, JavaScript.FETCH, JavaScript.JQUERY,
+            Kotlin.OKHTTP,
+            Node.UNDICI, Node.NATIVE, Node.REQUEST, Node.UNIREST, Node.AXIOS, Node.FETCH,
+            ObjC.NSURLSESSION,
+            OCaml.COHTTP,
+            PHP.CURL, PHP.GUZZLE, PHP.HTTP1, PHP.HTTP2,
+            PowerShell.WEBREQUEST, PowerShell.RESTMETHOD,
+            Python.PYTHON3, Python.REQUESTS,
+            R.HTTR,
+            Ruby.NATIVE,
+            Shell.CURL, Shell.HTTPIE, Shell.WGET,
+            Swift.NSURLSESSION
+        };
+
+        return options.Distinct().ToArray();
+    }
+}

--- a/packages/scalar.aspnetcore/Scalar.AspNetCore.cs
+++ b/packages/scalar.aspnetcore/Scalar.AspNetCore.cs
@@ -3,16 +3,12 @@ using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Scalar.AspNetCore
 {
     public static class OpenApiEndpointRouteBuilderExtensions
     {
-        public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints)
-        {
-            return endpoints.MapScalarApiReference(_ => { });
-        }
+        private const string DOCUMENT_NAME = "{documentName}";
 
         private static readonly JsonSerializerOptions JsonSerializerOptions = new()
         {
@@ -21,41 +17,46 @@ namespace Scalar.AspNetCore
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
 
-        public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints,
-            Action<ScalarOptions> configureOptions)
+        public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints)
+        {
+            return endpoints.MapScalarApiReference(_ => { });
+        }
+        public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, Action<ScalarOptions> configureOptions)
         {
             var options = new ScalarOptions();
             configureOptions(options);
 
-            var configurationJson = JsonSerializer.Serialize(options, JsonSerializerOptions);
+            if (!options.EndpointPathPrefix.Contains(DOCUMENT_NAME))
+                throw new ArgumentException($"`EndpointPathPrefix` must define `{DOCUMENT_NAME}`.");
 
-            return endpoints.MapGet(options.EndpointPathPrefix + "/{documentName}", (string documentName) =>
-                {
-                    var title = options.Title ?? $"Scalar API Reference -- {documentName}";
-                    var dataUrl = options.DataUrlFunc is not null ? options.DataUrlFunc(documentName) : $"/openapi/{documentName}.json";
-                    return Results.Content(
-                        $$"""
-                          <!doctype html>
-                          <html>
-                          <head>
-                              <title>{{title}}</title>
-                              <meta charset="utf-8" />
-                              <meta name="viewport" content="width=device-width, initial-scale=1" />
-                          </head>
-                          <body>
-                              <script id="api-reference" data-url="{{dataUrl}}"></script>
-                              <script>
-                              var configuration = {{configurationJson}}
+            return endpoints.MapGet(options.EndpointPathPrefix, (string documentName) =>
+            {
+                var title = options.Title.Replace(DOCUMENT_NAME, documentName);
+                var dataUrl = options.SetDataUrl?.Invoke(documentName) ?? $"/openapi/{documentName}.json";
+                var configuration = JsonSerializer.Serialize(new ScalaConfiguration(options), JsonSerializerOptions);
 
-                              document.getElementById('api-reference').dataset.configuration =
-                                  JSON.stringify(configuration)
-                              </script>
-                              <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-                          </body>
-                          </html>
-                          """, "text/html");
-                })
-                .ExcludeFromDescription();
+                return Results.Content(
+                    $$"""
+                        <!doctype html>
+                        <html>
+                        <head>
+                            <title>{{title}}</title>
+                            <meta charset="utf-8" />
+                            <meta name="viewport" content="width=device-width, initial-scale=1" />
+                        </head>
+                        <body>
+                            <script id="api-reference" data-url="{{dataUrl}}"></script>
+                            <script>
+                            var configuration = {{configuration}}
+
+                            document.getElementById('api-reference').dataset.configuration = JSON.stringify(configuration)
+                            </script>
+                            <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+                        </body>
+                        </html>
+                        """, "text/html");
+            })
+            .ExcludeFromDescription();
         }
     }
 }

--- a/packages/scalar.aspnetcore/Scalar.AspNetCore.csproj
+++ b/packages/scalar.aspnetcore/Scalar.AspNetCore.csproj
@@ -1,10 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.1.0</Version>
+		<Version>1.2.0</Version>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/packages/scalar.aspnetcore/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/ScalarOptions.cs
@@ -1,56 +1,202 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
 namespace Scalar.AspNetCore;
 
 public class ScalarOptions
 {
-    [JsonIgnore]
-    public string EndpointPathPrefix { get; set; } = "/scalar";
+    /// <summary>
+    /// Metadata title
+    /// </summary>
+    /// <value>The default value is <c>'Scalar API Reference -- {documentName}'</c>.</value>
+    /// <remarks>You can use {documentName}, and it will be replaced by the version number.</remarks>
+    public string Title { get; set; } = "Scalar API Reference -- {documentName}";
 
-    [JsonIgnore]
-    public string? Title { get; set; }
+    /// <summary>
+    /// Path prefix to access the documentation.
+    /// </summary>
+    /// <value>The default value is <c>'/scalar/{documentName}'</c>.</value>
+    /// <remarks>You can use {documentName}, and it will be replaced by the version number.</remarks>
+    public string EndpointPathPrefix { get; set; } = "/scalar/{documentName}";
 
-    public string Theme { get; set; } = "purple";
+    /// <summary>
+    /// Whether the sidebar should be shown.
+    /// </summary>
+    /// <value>The default value is <c>true</c>.</value>
+    public bool ShowSideBar { get; set; } = true;
 
-    public bool? DarkMode { get; set; }
-    public bool? HideDownloadButton { get; set; }
-    public bool? ShowSideBar { get; set; }
+    /// <summary>
+    /// Whether models (components.schemas or definitions) should be shown in the sidebar, search and content.
+    /// </summary>
+    /// <value>The default value is <c>false</c>.</value>
+    public bool HideModels { get; set; } = false;
 
-    public bool? WithDefaultFonts { get; set; }
+    /// <summary>
+    /// Whether to show the "Download OpenAPI Specification" button
+    /// </summary>
+    /// <value>The default value is <c>false</c>.</value>
+    public bool HideDownloadButton { get; set; } = false;
 
-    public string? Layout { get; set; }
+    /// <summary>
+    /// Whether dark mode is on or off initially (light mode)
+    /// </summary>
+    /// <value>The default value is <c>true</c>.</value>
+    public bool DarkMode { get; set; } = true;
 
+    /// <summary>
+    /// ForceDarkModeState makes it always this state no matter what <c>'dark' | 'light'</c>
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public string? ForceDarkModeState { get; set; }
+
+    /// <summary>
+    /// Whether to show the dark mode toggle
+    /// </summary>
+    /// <value>The default value is <c>false</c>.</value>
+    public bool HideDarkModeToggle { get; set; } = false;
+
+    /// <summary>
+    /// You can pass custom CSS directly to the component.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
     public string? CustomCss { get; set; }
 
+    /// <summary>
+    /// Key used with CTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k)
+    /// </summary>
+    /// <value>The default value is <c>k</c>.</value>
     public string? SearchHotkey { get; set; }
 
-    public Dictionary<string, string>? Metadata { get; set; }
+    /// <summary>
+    /// Set color theme.
+    /// </summary>
+    /// <value>The default value is Set <see cref="ScalarThemes.PURPLE"/>.</value>
+    /// <remarks>Select your preferred <see cref="ScalarThemes.PURPLE">ScalarTheme</see>.</remarks>
+    public ScalarThemes Theme { get; set; } = ScalarThemes.PURPLE;
 
-    public ScalarAuthenticationOptions? Authentication { get; set; }
+    /// <summary>
+    /// By default we’re using Inter and JetBrains Mono, served by Google Fonts.
+    /// </summary>
+    /// <value>The default value is <c>true</c>.</value>
+    /// <remarks>If you use a different font or just don’t want to use Google Fonts, pass withDefaultFonts: false to the configuration.</remarks>
+    public bool WithDefaultFonts { get; set; } = true;
+
+    /// <summary>
+    /// By default we only open the relevant tag based on the url.
+    /// </summary>
+    /// <value>The default value is <c>false</c>.</value>
+    /// <remarks>if you want all the tags open by default then set this configuration option.</remarks>
+    public bool DefaultOpenAllTags { get; set; } = false;
+
+    /// <summary>
+    /// You can pass an array of httpsnippet clients to hide from the clients menu.
+    /// </summary>
+    /// <value>The default value is <c>false</c>.</value>
+    public bool HiddenClients { get; set; } = false;
+
+    /// <summary>
+    /// You can pass an array of HTTPSnippet clients that you want to display in the clients menu.
+    /// </summary>
+    /// <value>The default value is <see cref="Array.Empty"/>.</value>
+    /// <remarks>If an empty array is sent, all options will be displayed.</remarks>
+    public string[] EnabledClients { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// You can pass information to the config object to configure meta information out of the box.
+    /// </summary>
+    public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// To make authentication easier you can prefill the credentials for your users
+    /// </summary>
+    public ScalarAuthenticationOptions Authentication { get; set; } = new ScalarAuthenticationOptions();
+
+    /// <summary>
+    /// By default, we’re using Shell/curl as the default HTTP client. Or, if that’s disabled (through hiddenClients), we’re just using the first available HTTP client.
+    /// You can explicitly set the default HTTP client.
+    /// </summary>
+    public ScalarDefaultHttpClient DefaultHttpClient { get; set; } = new ScalarDefaultHttpClient();
 
     /// <summary>
     /// Provides a function for setting the data URL for the API reference
     /// given the document name.
     /// </summary>
-    public Func<string, string>? DataUrlFunc { get; set; }
+    public Func<string, string>? SetDataUrl { get; set; }        
 }
 
+/// <summary>
+/// To make authentication easier you can prefill the credentials for your users
+/// </summary>
 public class ScalarAuthenticationOptions
 {
-    public string? PreferredSecurityScheme { get; set; }
+    private const string NONE_SCHEME = "none";
 
-    public ScalarAuthenticationApiKey? ApiKey { get; set; }
+    /// <summary>
+    /// The OpenAPI file has keys for all security schemes
+    /// </summary>
+    public string PreferredSecurityScheme { get; } = string.Empty;
+    public bool Enabled => PreferredSecurityScheme.ToLower() != NONE_SCHEME;
+
+    internal ScalarAuthenticationOptions()
+    {
+        PreferredSecurityScheme = NONE_SCHEME;
+    }
+
+    internal ScalarAuthenticationOptions(string preferredSecurityScheme)
+    {
+        PreferredSecurityScheme = preferredSecurityScheme;
+    }
 }
 
-public class ScalarAuthenticationoAuth2
+public sealed class ScalarAuthenticationCustomOptions : ScalarAuthenticationOptions
 {
-    public string? ClientId { get; set; }
+    public ScalarAuthenticationApiKey ApiKey { get; }
 
-    public List<string>? Scopes { get; set; }
+    public ScalarAuthenticationCustomOptions(string scheme, string token) : base(scheme) 
+    { 
+        ApiKey = new ScalarAuthenticationApiKey(token);
+    }
 }
 
-public class ScalarAuthenticationApiKey
+public sealed class ScalarAuthenticationoAuth2Options : ScalarAuthenticationOptions
 {
-    public string? Token { get; set; }
+    public ScalarAuthenticationoAuth2 OAuth2 { get; }
+
+    public ScalarAuthenticationoAuth2Options(string clientId, params string[] scopes) : base("oauth2")
+    {
+        OAuth2 = new ScalarAuthenticationoAuth2(clientId, scopes);
+    }
+}
+
+public sealed class ScalarAuthenticationApiKey
+{
+    public string Token { get; set; } = string.Empty;
+
+    public ScalarAuthenticationApiKey(string token)
+    {
+        Token = token;
+    }
+}
+
+public sealed class ScalarAuthenticationoAuth2
+{
+    public string ClientId { get; } = string.Empty;
+    public string[] Scopes { get; } = Array.Empty<string>();
+
+    public ScalarAuthenticationoAuth2(string clientId, params string[] scopes)
+    {
+        ClientId = clientId;
+        Scopes = scopes;
+    }
+}
+
+public sealed class ScalarDefaultHttpClient
+{
+    /// <summary>
+    /// Default display target
+    /// </summary>
+    /// <value>The default value is <see cref="ScalarClients.Shell.KEY"/>.</value>
+    public string TargetKey { get; set; } = ScalarClients.Shell.KEY;
+    /// <summary>
+    /// Default display client
+    /// </summary>
+    /// <value>The default value is <see cref="ScalarClients.Shell.CURL"/>.</value>
+    public string ClientKey { get; set; } = ScalarClients.Shell.CURL;
 }

--- a/packages/scalar.aspnetcore/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/ScalarOptions.cs
@@ -96,7 +96,14 @@ public class ScalarOptions
     /// </summary>
     /// <value>The default value is <see cref="Array.Empty"/>.</value>
     /// <remarks>If an empty array is sent, all options will be displayed.</remarks>
-    public string[] EnabledClients { get; set; } = Array.Empty<string>();
+    public ScalarClients[] EnabledClients { get; set; } = Array.Empty<ScalarClients>();
+
+    /// <summary>
+    /// You can pass an array of HTTPSnippet tarjets that you want to display in the clients menu.
+    /// </summary>
+    /// <value>The default value is <see cref="Array.Empty"/>.</value>
+    /// <remarks>If an empty array is sent, all options will be displayed.</remarks>
+    public ScalarTargets[] EnabledTargets { get; set; } = Array.Empty<ScalarTargets>();
 
     /// <summary>
     /// You can pass information to the config object to configure meta information out of the box.
@@ -192,11 +199,11 @@ public sealed class ScalarDefaultHttpClient
     /// <summary>
     /// Default display target
     /// </summary>
-    /// <value>The default value is <see cref="ScalarClients.Shell.KEY"/>.</value>
-    public string TargetKey { get; set; } = ScalarClients.Shell.KEY;
+    /// <value>The default value is <see cref="ScalarTargets.Shell"/>.</value>
+    public ScalarTargets TargetKey { get; set; } = ScalarTargets.Shell;
     /// <summary>
     /// Default display client
     /// </summary>
-    /// <value>The default value is <see cref="ScalarClients.Shell.CURL"/>.</value>
-    public string ClientKey { get; set; } = ScalarClients.Shell.CURL;
+    /// <value>The default value is <see cref="ScalarClients.CURL"/>.</value>
+    public ScalarClients ClientKey { get; set; } = ScalarClients.CURL;
 }

--- a/packages/scalar.aspnetcore/ScalarTargets.cs
+++ b/packages/scalar.aspnetcore/ScalarTargets.cs
@@ -1,0 +1,43 @@
+﻿using System.ComponentModel;
+
+namespace Scalar.AspNetCore;
+
+public enum ScalarTargets
+{
+    C,
+    Clojure,
+    CSharp,
+    Go,
+    Http,
+    Java,
+    JavaScript,
+    Kotlin,
+    Node,
+    ObjC,
+    OCaml,
+    PHP,
+    PowerShell,
+    Python,
+    R,
+    Ruby,
+    Shell,
+    Swift,
+}
+
+internal static class Extensions
+{
+    static public string GetDescription(this Enum enumValue)
+    {
+        var field = enumValue.GetType().GetField(enumValue.ToString());
+        if (field == null)
+            return enumValue.ToString();
+
+        var attributes = field.GetCustomAttributes(typeof(DescriptionAttribute), false);
+        if (Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute)) is DescriptionAttribute attribute)
+        {
+            return attribute.Description;
+        }
+
+        return enumValue.ToString();
+    }
+}

--- a/packages/scalar.aspnetcore/ScalarThemes.cs
+++ b/packages/scalar.aspnetcore/ScalarThemes.cs
@@ -1,0 +1,16 @@
+﻿namespace Scalar.AspNetCore;
+
+public enum ScalarThemes
+{
+    NONE,
+    ALTERNATE,
+    DEFAULT,
+    MOON,
+    PURPLE,
+    SOLARIZED,
+    BLUEPLANET,
+    SATURN,
+    KEPLER,
+    MARS,
+    DEEPSPACE
+}


### PR DESCRIPTION
Some missing configurations have been added to the AspNetCore SDK, and documentation has been updated.

**Added options:** 
- HideModels
- ForceDarkModeState
- HideDarkModeToggle
- DefaultOpenAllTags
- DefaultHttpClient
- HiddenClients - Left as a bool for easier configuration.

**New Features:** 
- **EnabledClients** and **EnabledTargets**: Allow filtering ONLY the ones you want to show. These options override the HiddenClients array with the opposite options.
- **Authentication**: Improved class relationships.
- **Theme**, **Clients** and **Targets** are available as enum options.
- Add documentation options
