### PR TITLE
fix: autoprefixer warnings, fix #3003

### DIFF
--- a/.changeset/weak-ties-rescue.md
+++ b/.changeset/weak-ties-rescue.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/components': patch
+'@scalar/use-toasts': patch
+---
+
+fix: autprefixer warnings

--- a/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
+++ b/packages/api-reference/src/components/Content/Operation/PathResponses/PathResponses.vue
@@ -203,7 +203,7 @@ const showSchema = ref(false)
   border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 .response-example-selector {
-  align-self: start;
+  align-self: flex-start;
   margin: -4px;
 }
 .response-description {

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -226,7 +226,7 @@ button.schema-card-title:hover {
   width: 100%;
 }
 .schema-card--compact {
-  align-self: start;
+  align-self: flex-start;
 }
 
 .schema-card--compact.schema-card--open {

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -82,7 +82,7 @@ const isContentValid = computed(() => {
 .scalar-code-copy {
   display: flex;
   align-items: start;
-  justify-content: end;
+  justify-content: flex-end;
 
   position: sticky;
   inset: 0;

--- a/packages/use-toasts/src/components/ScalarToasts.vue
+++ b/packages/use-toasts/src/components/ScalarToasts.vue
@@ -50,7 +50,7 @@ initializeToasts((message, level = 'info', options: ToastOptions = {}) => {
   box-shadow: var(--scalar-shadow-2);
 }
 .scalar-toaster [data-sonner-toast] [data-icon] {
-  align-self: start;
+  align-self: flex-start;
   position: relative;
   top: 2px;
 }


### PR DESCRIPTION
This replaces some CSS values with mixed support with alternative values.

While they behave [slightly different according to MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content#flex-start), I couldn’t spot any difference in our use case.

See #3003