### PR TITLE
feat(api-reference): allow to hide the “Test Request” button

### DIFF
--- a/.changeset/chilly-cycles-breathe.md
+++ b/.changeset/chilly-cycles-breathe.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: allow to hide the Test Request button

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -80,13 +80,25 @@ Whether models (`components.schemas` or `definitions`) should be shown in the si
 
 #### hideDownloadButton?: boolean
 
-Whether to show the "Download OpenAPI Specification" button
+Whether to show the “Download OpenAPI Document” button
 
 `@default false`
 
 ```js
 {
   hideDownloadButton: true
+}
+```
+
+#### hideTestRequestButton?: boolean
+
+Whether to show the “Test Request” button
+
+`@default false`
+
+```js
+{
+  hideTestRequestButton: true
 }
 ```
 

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -25,6 +25,7 @@ import {
 import {
   GLOBAL_SECURITY_SYMBOL,
   HIDE_DOWNLOAD_BUTTON_SYMBOL,
+  HIDE_TEST_REQUEST_BUTTON_SYMBOL,
   OPENAPI_DOCUMENT_URL_SYMBOL,
   downloadSpecBus,
   downloadSpecFile,
@@ -234,6 +235,10 @@ provide(GLOBAL_SECURITY_SYMBOL, () => props.parsedSpec.security)
 provide(
   HIDE_DOWNLOAD_BUTTON_SYMBOL,
   () => props.configuration.hideDownloadButton,
+)
+provide(
+  HIDE_TEST_REQUEST_BUTTON_SYMBOL,
+  () => props.configuration.hideTestRequestButton,
 )
 provide(OPENAPI_DOCUMENT_URL_SYMBOL, () => props.configuration.spec?.url)
 

--- a/packages/api-reference/src/components/Content/Operation/TestRequestButton.vue
+++ b/packages/api-reference/src/components/Content/Operation/TestRequestButton.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components'
 import type { TransformedOperation } from '@scalar/types/legacy'
+import { inject } from 'vue'
 
+import { HIDE_TEST_REQUEST_BUTTON_SYMBOL } from '../../../helpers'
 import { apiClientBus } from '../../api-client-bus'
 
 defineProps<{
   operation: TransformedOperation
 }>()
+
+const getHideTestRequestButton = inject(HIDE_TEST_REQUEST_BUTTON_SYMBOL)
 </script>
 <template>
   <button
+    v-if="getHideTestRequestButton?.() !== true"
     class="show-api-client-button"
     :method="operation.httpVerb"
     type="button"
@@ -26,6 +31,7 @@ defineProps<{
       size="sm" />
     <span>Test Request</span>
   </button>
+  <template v-else>&nbsp;</template>
 </template>
 <style scoped>
 .show-api-client-button {

--- a/packages/api-reference/src/helpers/provideSymbols.ts
+++ b/packages/api-reference/src/helpers/provideSymbols.ts
@@ -15,6 +15,10 @@ export const HIDE_DOWNLOAD_BUTTON_SYMBOL = Symbol() as InjectionKey<
   () => boolean | undefined
 >
 
+export const HIDE_TEST_REQUEST_BUTTON_SYMBOL = Symbol() as InjectionKey<
+  () => boolean | undefined
+>
+
 export const OPENAPI_DOCUMENT_URL_SYMBOL = Symbol() as InjectionKey<
   () => string | undefined
 >

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -58,11 +58,17 @@ export type ReferenceConfiguration = {
    */
   hideModels?: boolean
   /**
-   * Whether to show the "Download OpenAPI Specification" button
+   * Whether to show the “Download OpenAPI Document” button
    *
    * @default false
    */
   hideDownloadButton?: boolean
+  /**
+   * Whether to show the “Test Request” button
+   *
+   * @default: false
+   */
+  hideTestRequestButton?: boolean
   /** Whether dark mode is on or off initially (light mode) */
   darkMode?: boolean
   /** forceDarkModeState makes it always this state no matter what*/


### PR DESCRIPTION
Every now and them [someone asks to disable the “Test Request” button](https://github.com/scalar/scalar/discussions/3005), which launches the embedded API client. Currently, people just hide it with CSS or even use alternatives, just because they can’t disable it. 

This PR introduces the `hideTestRequestButton` option to allow users to hide the button.

I’ve kept the footer of the card, because otherwise we’d need the logic to disable the button in the parent component, and these are 3 different components. Keeping the footer was way easier, so I went with this solution.

**Preview**

```js
{
  hideTestRequestButton: true
}
```

<img width="683" alt="Screenshot 2024-09-02 at 15 23 55" src="https://github.com/user-attachments/assets/5377720a-99b6-4ea3-9e3c-da7eb9c2cc46">
