### PR TITLE
style: don't make the path variable italic

### DIFF
--- a/.changeset/silly-lions-heal.md
+++ b/.changeset/silly-lions-heal.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+style: no italic for the path variable

--- a/packages/api-reference/src/components/Content/Operation/Operation.vue
+++ b/packages/api-reference/src/components/Content/Operation/Operation.vue
@@ -75,5 +75,6 @@ defineProps<{
 }
 .example-path :deep(em) {
   color: var(--scalar-color-1);
+  font-style: normal;
 }
 </style>


### PR DESCRIPTION
I don’t think it was intentional to have the path variable italic, so this PR makes it `font-style: normal` again:

**Before**
<img width="458" alt="Screenshot 2024-09-02 at 15 22 51" src="https://github.com/user-attachments/assets/8c06c18b-1c3d-4286-92c3-42265ad05ca7">

**After**
<img width="357" alt="Screenshot 2024-09-02 at 15 22 59" src="https://github.com/user-attachments/assets/57ec3896-ad1f-4fab-9fc0-8aba7b3c09c8">