### PR TITLE
chore: update fallback in the `CODEOWNERS` configuration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owner (overwritten by more specific entries)
-* @marclave
+* @hanspagel @amritk @geoffgscott
 
 # Root level code owners
 /.github @hanspagel


### PR DESCRIPTION
With the recent changes to the `CODEOWNERS` file I’ve seen more people reviewing PRs. I think it’s time for us to take over even more responsibility. 👀  This PR suggests to remove @marclave as the fallback code owner for every file that is not covered yet, replacing it with:

* me, @hanspagel 
* @amritk 
* @geoffgscott 

I think even without this configuration change we three are the ones who chime in when something is stuck or about to get stale. This change just makes it visible in the UI.

Let’s take the reviewing process to new heights and move even faster, with even less bugs. 🏄 