### PR TITLE
fix: `File` is not defined (Node 18) DOC-2222

### DIFF
--- a/.changeset/fluffy-eagles-do.md
+++ b/.changeset/fluffy-eagles-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: File is not defined

--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -125,9 +125,12 @@ export const sendRequest = async (
   let data: FormData | string | File | null = null
 
   if (example.body.activeBody === 'binary' && example.body.binary) {
-    headers['Content-Type'] = example.body.binary.type
+    if (example.body.binary.type) {
+      headers['Content-Type'] = example.body.binary.type
+    }
     headers['Content-Disposition'] =
       `attachment; filename="${example.body.binary.name}"`
+    // @ts-expect-error Would be rad to have access to the File type in Node 18, but we that’s not the case.
     data = example.body.binary
   } else if (example.body.activeBody === 'raw' && example.body.raw.value) {
     data = example.body.raw.value

--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -159,7 +159,7 @@ export const sendRequest = async (
             if (formParam.file) {
               bodyFormData.append(
                 formParam.key,
-                formParam.file as any,
+                formParam.file,
                 formParam.file.name,
               )
             } else if (formParam.value !== undefined) {
@@ -290,10 +290,7 @@ export const sendRequest = async (
   }
 
   if (data) {
-    // WARNING: this casting is necessary because
-    // the custom defined FileType has ReadableStream<Uint8Array>
-    // Whereas RequestInit is expecting ReadableStream<unknown>
-    config.body = data as RequestInit['body']
+    config.body = data
   }
 
   // Start timer to get response duration

--- a/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
@@ -69,7 +69,13 @@ const requestExampleSchema = z.object({
           value: requestExampleParametersSchema.array().default([]),
         })
         .default({}),
-      binary: z.instanceof(File).optional(),
+      binary: z
+        .object({
+          name: z.string(),
+          type: z.string(),
+          size: z.number(),
+        })
+        .optional(),
       activeBody: z
         .union([z.literal('raw'), z.literal('formData'), z.literal('binary')])
         .default('raw'),

--- a/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
@@ -11,7 +11,7 @@ export const blobSchema = z.object({
     .function()
     .args(z.number().optional(), z.number().optional(), z.string().optional())
     .returns(z.any()), // Returns a Blob (any type for now)
-  stream: z.function().returns(z.instanceof(ReadableStream)), // Returns a ReadableStream of Uint8Array
+  stream: z.function().returns(z.instanceof(ReadableStream<Uint8Array>)), // Returns a ReadableStream of Uint8Array
   text: z.function().returns(z.promise(z.string())), // Returns a Promise of string
 })
 

--- a/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
@@ -6,6 +6,7 @@ const requestExampleParametersSchema = z.object({
   key: z.string().default(''),
   value: z.union([z.string(), z.number()]).transform(String).default(''),
   enabled: z.boolean().default(true),
+  // TODO: Lacking the `File` type in Node 18 here, but it would still be cool to be more specific than just using `any`.
   file: z.any().optional(),
   description: z.string().optional(),
   /** Params are linked to parents such as path params and global headers/cookies */
@@ -71,9 +72,10 @@ const requestExampleSchema = z.object({
         .default({}),
       binary: z
         .object({
-          name: z.string(),
+          name: z.string().optional(),
           type: z.string(),
           size: z.number(),
+          lastModified: z.number(),
         })
         .optional(),
       activeBody: z

--- a/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/workspace/spec/request-examples.ts
@@ -2,12 +2,34 @@ import { nanoidSchema } from '@/entities/workspace/shared'
 import { deepMerge } from '@scalar/object-utils/merge'
 import { z } from 'zod'
 
+// Define the Blob schema
+export const blobSchema = z.object({
+  size: z.number().nonnegative('Blob size must be a non-negative number').int(), // Size of the Blob
+  type: z.string(), // MIME type of the Blob
+  arrayBuffer: z.function().returns(z.promise(z.instanceof(ArrayBuffer))), // Returns a Promise of ArrayBuffer
+  slice: z
+    .function()
+    .args(z.number().optional(), z.number().optional(), z.string().optional())
+    .returns(z.any()), // Returns a Blob (any type for now)
+  stream: z.function().returns(z.instanceof(ReadableStream)), // Returns a ReadableStream of Uint8Array
+  text: z.function().returns(z.promise(z.string())), // Returns a Promise of string
+})
+
+const fileSchema = z
+  .object({
+    name: z.string(),
+    lastModified: z.number(),
+    webkitRelativePath: z.string(),
+  })
+  .extend(blobSchema.shape)
+
+export type FileType = z.infer<typeof fileSchema>
+
 const requestExampleParametersSchema = z.object({
   key: z.string().default(''),
   value: z.union([z.string(), z.number()]).transform(String).default(''),
   enabled: z.boolean().default(true),
-  // TODO: Lacking the `File` type in Node 18 here, but it would still be cool to be more specific than just using `any`.
-  file: z.any().optional(),
+  file: fileSchema.optional(),
   description: z.string().optional(),
   /** Params are linked to parents such as path params and global headers/cookies */
   refUid: nanoidSchema.optional(),
@@ -70,14 +92,7 @@ const requestExampleSchema = z.object({
           value: requestExampleParametersSchema.array().default([]),
         })
         .default({}),
-      binary: z
-        .object({
-          name: z.string().optional(),
-          type: z.string(),
-          size: z.number(),
-          lastModified: z.number(),
-        })
-        .optional(),
+      binary: fileSchema.optional(),
       activeBody: z
         .union([z.literal('raw'), z.literal('formData'), z.literal('binary')])
         .default('raw'),


### PR DESCRIPTION
The `File` type is not available in Node 18, so let’s use this object as a workaround.