### PR TITLE
feat(api-reference): allow to hide search

### DIFF
--- a/.changeset/ten-pets-return.md
+++ b/.changeset/ten-pets-return.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: allow to hide search sidebar

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -102,6 +102,18 @@ Whether to show the “Test Request” button
 }
 ```
 
+#### hideSearch?: boolean
+
+Whether to show the sidebar search bar
+
+`@default false`
+
+```js
+{
+  hideSearch: true
+}
+```
+
 #### darkMode?: boolean
 
 Whether dark mode is on or off initially (light mode)

--- a/packages/api-reference/src/components/DarkModeToggle/DarkModeIconToggle.vue
+++ b/packages/api-reference/src/components/DarkModeToggle/DarkModeIconToggle.vue
@@ -27,6 +27,7 @@ defineEmits<{
   color: var(--scalar-sidebar-color-2, var(--scalar-color-2));
   display: flex;
   align-items: center;
+  margin-left: auto;
 
   height: 24px;
   width: 24px;

--- a/packages/api-reference/src/components/Layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ClassicLayout.vue
@@ -36,6 +36,7 @@ const config = computed(() => ({ ...props.configuration, showSidebar: false }))
     <template #content-start="{ spec }">
       <ClassicHeader>
         <SearchButton
+          v-if="!props.configuration.hideSearch"
           class="t-doc__sidebar"
           :searchHotKey="config.searchHotKey"
           :spec="spec" />

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -54,7 +54,9 @@ watch(hash, (newHash, oldHash) => {
         v-model:open="isSidebarOpen" />
     </template>
     <template #sidebar-start="{ spec }">
-      <div class="scalar-api-references-standalone-search">
+      <div
+        v-if="!props.configuration.hideSearch"
+        class="scalar-api-references-standalone-search">
         <SearchButton
           :searchHotKey="props.configuration?.searchHotKey"
           :spec="spec" />

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -69,6 +69,12 @@ export type ReferenceConfiguration = {
    * @default: false
    */
   hideTestRequestButton?: boolean
+  /**
+   * Whether to show the sidebar search bar
+   *
+   * @default: false
+   */
+  hideSearch?: boolean
   /** Whether dark mode is on or off initially (light mode) */
   darkMode?: boolean
   /** forceDarkModeState makes it always this state no matter what*/


### PR DESCRIPTION
This PR is a proposal to introduce the `hideSearch` option to allow users to hide the search from api reference sidebar as requested in #2869.

**Preview**

```js
{
  hideSearch: true
}
```

<img width="891" alt="image" src="https://github.com/user-attachments/assets/aab61aaf-cb3f-483e-ba4d-74ebb3b7710c">
