### PR TITLE
fix(api-reference): operation accordion test icon

### DIFF
--- a/.changeset/breezy-shoes-deliver.md
+++ b/.changeset/breezy-shoes-deliver.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: hide test icon in operation accordion

--- a/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
+++ b/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
@@ -5,8 +5,10 @@ import {
   ScalarMarkdown,
 } from '@scalar/components'
 import type { TransformedOperation } from '@scalar/types/legacy'
+import { inject } from 'vue'
 
 import { ExampleRequest } from '../../../features/ExampleRequest'
+import { HIDE_TEST_REQUEST_BUTTON_SYMBOL } from '../../../helpers'
 import { useClipboard } from '../../../hooks'
 import { Anchor } from '../../Anchor'
 import { HttpMethod } from '../../HttpMethod'
@@ -22,6 +24,9 @@ defineProps<{
 }>()
 
 const { copyToClipboard } = useClipboard()
+const getHideTestRequestButton = inject(HIDE_TEST_REQUEST_BUTTON_SYMBOL)
+
+console.log(!getHideTestRequestButton?.())
 </script>
 <template>
   <SectionAccordion
@@ -55,7 +60,7 @@ const { copyToClipboard } = useClipboard()
         v-if="active"
         :operation="operation" />
       <ScalarIcon
-        v-else
+        v-else-if="!getHideTestRequestButton?.()"
         class="endpoint-try-hint"
         icon="Play"
         thickness="1.75px" />


### PR DESCRIPTION
this pr hides the test icon in classic layout api reference when `hideTestRequestButton` is enabled introduced in #3016:

**before**
<img width="1026" alt="image" src="https://github.com/user-attachments/assets/a4a026eb-979e-4721-b95b-ec5a00a117e0">

**after**
<img width="1026" alt="image" src="https://github.com/user-attachments/assets/28b43c92-b491-41d2-b94a-9da8f4348750">