### PR TITLE
fix(api-client): request header

### DIFF
--- a/.changeset/blue-moons-dream.md
+++ b/.changeset/blue-moons-dream.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: request header style

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -68,19 +68,24 @@ const updateRequestNameHandler = (event: Event) => {
         icon="ExternalLink"
         size="sm"
         thickness="2.5" />
-      <div class="flex-1 flex items-center pointer-events-none">
+      <div class="flex-1 flex gap-1 items-center pointer-events-none">
         Request
         <label
           v-if="!isReadOnly"
           class="absolute w-full h-full top-0 left-0 pointer-events-auto opacity-0 cursor-text"
           for="requestname"></label>
         <input
+          v-if="!isReadOnly"
           id="requestname"
-          class="pl-1 outline-none border-0 text-c-2 rounded pointer-events-auto relative w-full"
-          :disabled="isReadOnly"
+          class="outline-none border-0 text-c-2 rounded pointer-events-auto relative w-full"
           placeholder="Request Name"
           :value="activeRequest?.summary"
           @input="updateRequestNameHandler" />
+        <span
+          v-else
+          class="text-c-2">
+          {{ activeRequest?.summary }}
+        </span>
       </div>
       <ContextBar
         :activeSection="activeSection"


### PR DESCRIPTION
this pr favors span markup over input in the api client request header on read only mode to avoid style issue:

**before**
<img width="693" alt="image" src="https://github.com/user-attachments/assets/cfadef5c-92d3-441f-9d32-9f101c50a4a1">

**after**
<img width="689" alt="image" src="https://github.com/user-attachments/assets/5b738ebc-5571-4756-87ec-e065e6020735">