### PR TITLE
fix(api-reference): anchor offset

### DIFF
--- a/.changeset/green-adults-crash.md
+++ b/.changeset/green-adults-crash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: anchor models and webhooks offset

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -44,13 +44,14 @@ const models = computed(() => {
 })
 </script>
 <template>
-  <SectionContainer v-if="schemas">
+  <SectionContainer
+    v-if="schemas"
+    id="models">
     <Section>
       <SectionHeader :level="2">Models</SectionHeader>
       <Lazy
         id="models"
         :isLazy="false">
-        <div id="models" />
       </Lazy>
       <div
         class="models-list"

--- a/packages/api-reference/src/components/Content/Webhooks/Webhooks.vue
+++ b/packages/api-reference/src/components/Content/Webhooks/Webhooks.vue
@@ -43,13 +43,14 @@ const webhooksFiltered = computed(() => {
 })
 </script>
 <template>
-  <SectionContainer v-if="webhookKeys.length">
+  <SectionContainer
+    v-if="webhookKeys.length"
+    id="webhooks">
     <Section>
       <SectionHeader :level="2">Webhooks</SectionHeader>
       <Lazy
         id="webhooks"
         :isLazy="false">
-        <div id="webhooks" />
       </Lazy>
       <div
         class="webhooks-list"

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -94,5 +94,6 @@ watch(
 .collapsible-section-content {
   padding: 0;
   margin: 0;
+  scroll-margin-top: 140px;
 }
 </style>


### PR DESCRIPTION
this pr moves id to section markup level for model and webhook components in order to fix anchor offset issue as seen below:

**before**

https://github.com/user-attachments/assets/7a82f0a7-2ba1-40cd-86c1-84408164c80a

**after**

https://github.com/user-attachments/assets/46bd3508-1e62-479f-993a-0d470575cdb3



