### PR TITLE
fix: logo url in oss-pledge.json

### DIFF
--- a/oss-pledge.json
+++ b/oss-pledge.json
@@ -1,7 +1,7 @@
 {
   "description": "Scalar builds open-source tools for APIs, with first class OpenAPI support.",
   "name": "Scalar",
-  "urlSquareLogoWithBackground": "https://github.com/organizations/scalar/settings/profile",
+  "urlSquareLogoWithBackground": "https://avatars.githubusercontent.com/u/301879?s=200&v=4",
   "urlLearnMore": "https://scalar.com/blog/oss-pledge-2024",
   "annualReports": [
     {


### PR DESCRIPTION
**Problem**
Currently, the URL for the Scalar logo for the Open Source Pledge profile is bad.

**Solution**
With this PR, the URL magically becomes good. 😄