### PR TITLE
feat(api-reference): adds favicon configuration

### DIFF
--- a/.changeset/tame-melons-thank.md
+++ b/.changeset/tame-melons-thank.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: adds favicon configuration

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -190,6 +190,16 @@ You can pass information to the config object to configure meta information out 
 }
 ```
 
+#### favicon?: string
+
+You can specify the path to a favicon to be used for the documentation.
+
+```js
+{
+  favicon: '/favicon.svg'
+}
+```
+
 #### defaultHttpClient?: HttpClientState
 
 By default, we’re using Shell/curl as the default HTTP client. Or, if that’s disabled (through `hiddenClients`), we’re just using the first available HTTP client.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -3,6 +3,7 @@ import { useAuthenticationStore } from '#legacy'
 import { migrateThemeVariables } from '@scalar/themes'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import { useSeoMeta } from '@unhead/vue'
+import { useFavicon } from '@vueuse/core'
 import { computed, toRef, watch } from 'vue'
 
 import { useDarkModeState, useReactiveSpec } from '../hooks'
@@ -86,6 +87,9 @@ const { parsedSpec, rawSpec } = useReactiveSpec({
   proxy: toRef(() => configuration.value.proxy || ''),
   specConfig: toRef(() => configuration.value.spec || {}),
 })
+
+const favicon = computed(() => configuration.value.favicon)
+useFavicon(favicon)
 </script>
 <template>
   <!-- Inject any custom CSS directly into a style tag -->

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -109,6 +109,13 @@ export type ReferenceConfiguration = {
    */
   metaData?: UseSeoMetaInput
   /**
+   * Path to a favicon image
+   *
+   * @default undefined
+   * @example '/favicon.svg'
+   */
+  favicon?: string
+  /**
    * List of httpsnippet clients to hide from the clients menu
    * By default hides Unirest, pass `[]` to show all clients
    */


### PR DESCRIPTION
this pr adds favicon configuration for api reference as highlighted in #2637:

**Preview**

```js
{
  favicon: 'path/to/favicon.svg'
}
```

<img width="591" alt="image" src="https://github.com/user-attachments/assets/8fdb7f23-2ae4-4d16-a2a0-8ce5db00d89b">
