### PR TITLE
fix(docusaurus): remove headless ui on page change

### DIFF
--- a/.changeset/little-pets-approve.md
+++ b/.changeset/little-pets-approve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/docusaurus': patch
+---
+
+fix(docusaurus): remove headless ui on page change

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -221,7 +221,7 @@ module.exports = {
         'vue/max-lines-per-block': [
           'warn',
           {
-            script: 50,
+            script: 80,
             skipBlankLines: true,
           },
         ],

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -164,7 +164,7 @@ if (!specUrlElement && !specElement && !specScriptTag) {
   document.addEventListener(
     'scalar:reload-references',
     () => {
-      // Check if elemenet has been removed from dom, and re-add
+      // Check if element has been removed from dom, and re-add
       if (container && !document.body.contains(container)) {
         document.body.appendChild(container)
       }

--- a/packages/docusaurus/src/ScalarDocusaurusCommonJS.tsx
+++ b/packages/docusaurus/src/ScalarDocusaurusCommonJS.tsx
@@ -23,6 +23,9 @@ class ScalarDocusaurusCommonJS extends Component<Props> {
   }
 
   componentWillUnmount() {
+    // Clean up headless ui portal
+    const headless = document?.getElementById('headlessui-portal-root')
+    if (headless) headless.remove()
     this.observer?.disconnect()
   }
 


### PR DESCRIPTION
## Before

![Google Chrome-2024-09-04-14-51-34@2x](https://github.com/user-attachments/assets/10409c21-6a00-4914-b5fb-2fb73155307f)

## After

![Google Chrome-2024-09-04-14-50-26@2x](https://github.com/user-attachments/assets/10ce653f-5165-4103-a7ad-b0d4581693df)