### PR TITLE
fix(docusaurus): improve docusaurus memory issues

### DIFF
--- a/.changeset/little-pets-approve.md
+++ b/.changeset/little-pets-approve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/docusaurus': patch
+---
+
+fix(docusaurus): improve docusaurus memory issues

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -221,7 +221,7 @@ module.exports = {
         'vue/max-lines-per-block': [
           'warn',
           {
-            script: 50,
+            script: 80,
             skipBlankLines: true,
           },
         ],

--- a/examples/docusaurus/docusaurus.config.ts
+++ b/examples/docusaurus/docusaurus.config.ts
@@ -92,7 +92,7 @@ const config: Config = {
             content: `{
   "openapi": "3.1.0",
   "info": {
-    "title": "Hello World",
+    "title": "JSON Docs",
     "version": "1.0.0"
   },
   "paths": {}
@@ -111,7 +111,7 @@ const config: Config = {
           spec: {
             content: `openapi: 3.1.0
 info:
-  title: Hello World
+  title: YAML Docs
   version: 1.0.0
 paths: {}
 `,

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -164,7 +164,7 @@ if (!specUrlElement && !specElement && !specScriptTag) {
   document.addEventListener(
     'scalar:reload-references',
     () => {
-      // Check if elemenet has been removed from dom, and re-add
+      // Check if element has been removed from dom, and re-add
       if (container && !document.body.contains(container)) {
         document.body.appendChild(container)
       }

--- a/packages/docusaurus/src/ScalarDocusaurusCommonJS.tsx
+++ b/packages/docusaurus/src/ScalarDocusaurusCommonJS.tsx
@@ -23,9 +23,8 @@ class ScalarDocusaurusCommonJS extends Component<Props> {
   }
 
   componentWillUnmount() {
-    // Clean up headless ui portal
-    const headless = document?.getElementById('headlessui-portal-root')
-    if (headless) headless.remove()
+    // Clean up app
+    document.dispatchEvent(new Event('scalar:destroy-references'))
     this.observer?.disconnect()
   }
 
@@ -39,50 +38,68 @@ class ScalarDocusaurusCommonJS extends Component<Props> {
           this.props.route.configuration &&
           !document.getElementById('api-reference')
         ) {
-          const config = this.props.route.configuration
+          console.log(`Loading Scalar script...`)
+          // Deep copy the configuration
+          const config = JSON.parse(
+            JSON.stringify(this.props.route.configuration),
+          )
 
-          // Execute content function if it exists
-          if (typeof config.spec?.content === 'function') {
-            config.spec.content = config.spec.content()
-          }
-
-          // Convert the document to a string
-          const documentString = config?.spec?.content
-            ? typeof config?.spec?.content === 'string'
-              ? config.spec.content
-              : JSON.stringify(config.spec.content)
-            : ''
-
-          // Delete content from configuration
-          if (config?.spec?.content) {
-            delete config.spec.content
-          }
-
-          // Convert the configuration to a string
-          const configString = JSON.stringify(config ?? {})
-            .split('"')
-            .join('&quot;')
-
-          // Create and append a script element with the configuration and the content
+          // Create and append a script element to mount the Scalar app
           const apiReferenceScript = document.createElement('script')
           apiReferenceScript.id = 'api-reference'
           apiReferenceScript.type = 'application/json'
-          apiReferenceScript.dataset.configuration = configString
-          apiReferenceScript.innerHTML = documentString
 
           container.appendChild(apiReferenceScript)
 
-          // Creating and appending the script element
-          const script = document.createElement('script')
-          script.src = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
-          script.async = true
-          script.onload = () => {
-            console.log('Script loaded successfully')
+          // Check if we've already loaded the Scalar script
+          const loaded = document.body.getAttribute('data-scalar-loaded')
+
+          if (loaded) {
+            console.log(`Scalar script already loaded, reloading app `)
+            document.dispatchEvent(new Event('scalar:reload-references'))
+            document.dispatchEvent(
+              new CustomEvent('scalar:update-references-config', {
+                detail: { configuration: config },
+              }),
+            )
+          } else {
+            // Execute content function if it exists
+            if (typeof config.spec?.content === 'function') {
+              config.spec.content = config.spec.content()
+            }
+
+            // Convert the document to a string
+            const documentString = config?.spec?.content
+              ? typeof config?.spec?.content === 'string'
+                ? config.spec.content
+                : JSON.stringify(config.spec.content)
+              : ''
+
+            // Delete content from configuration
+            if (config?.spec?.content) {
+              delete config.spec.content
+            }
+
+            // Convert the configuration to a string
+            const configString = JSON.stringify(config ?? {})
+              .split('"')
+              .join('&quot;')
+            apiReferenceScript.dataset.configuration = configString
+            apiReferenceScript.innerHTML = documentString
+
+            // Creating and appending the script element
+            const script = document.createElement('script')
+            script.src = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+            script.async = true
+            script.onload = () => {
+              console.log('Scalar script loaded successfully')
+              document.body.setAttribute('data-scalar-loaded', 'true')
+            }
+            script.onerror = (error) => {
+              console.error('Error loading Scalar script:', error)
+            }
+            container.appendChild(script)
           }
-          script.onerror = (error) => {
-            console.error('Error loading script:', error)
-          }
-          container.appendChild(script)
 
           // Stop observing once the container is found and script is added
           this.observer?.disconnect()

--- a/packages/docusaurus/src/ScalarDocusaurusCommonJS.tsx
+++ b/packages/docusaurus/src/ScalarDocusaurusCommonJS.tsx
@@ -23,6 +23,9 @@ class ScalarDocusaurusCommonJS extends Component<Props> {
   }
 
   componentWillUnmount() {
+    // Clean up headless ui portal
+    const headless = document?.getElementById('headlessui-portal-root')
+    if (headless) headless.remove()
     this.observer?.disconnect()
   }
 


### PR DESCRIPTION
While not solving every issue this PR does improve the memory performance and DOM performance of the Scalar Docusaurus integration. Things it does do:

- Unmounts and removes the app when switching away from Scalar Docs in Docusaurus
- Checks to see if the Scalar CDN script has been loaded already rather than fetch a new copy every time
- Deletes the old configuration when refreshing the config (which hopefully will allow the browser to free up that memory)

Because our Docusaurus integration uses the CDN version of the app we will need to make sure we publish the new `standalone.js` before releasing the Docusaurus update (or at the same time?). I think we should be safe to publish the changes to `standalone.js` on their own, the only functionality change should be that the `scalar:reload-references` event will now try to mount to `script#api-reference` rather than always remounting to body.

I'm not sure if this is how we want to tackle all this @hanspagel @amritk feel free to weigh in. 

## Before

https://github.com/user-attachments/assets/8831f3fb-6c34-46b1-8294-2beb3594c45f

## After

https://github.com/user-attachments/assets/9da942f9-32ca-44ad-90d9-283c69cae833

