### PR TITLE
ci: the Netlify deployment should wait for the initial build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
 
   deploy-examples:
     if: github.ref != 'refs/heads/main'
-    name: Examples deploy preview
+    needs: [build]
     runs-on: ubuntu-20.04
     strategy:
       matrix:


### PR DESCRIPTION
Oops, I forgot to add `'build'` as an requirement for the Netlify deploy step.

Not a problem, but it can’t leverage the build cache if it starts before the cache is filled.