### PR TITLE
feat(api-client): security schemes modal

### DIFF
--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/DeleteRequestAuthModal.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/DeleteRequestAuthModal.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { useWorkspace } from '@/store'
+import { ScalarButton, ScalarModal } from '@scalar/components'
+
+const props = defineProps<{
+  state: { open: boolean; show: () => void; hide: () => void }
+  scheme: { id: string; label: string } | undefined
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const { securitySchemes, securitySchemeMutators } = useWorkspace()
+
+const deleteScheme = () => {
+  securitySchemeMutators.delete(securitySchemes[props.scheme?.id])
+  emit('close')
+}
+</script>
+<template>
+  <ScalarModal
+    size="xxs"
+    :state="state"
+    title="Delete Security Scheme">
+    <p class="mb-4 leading-normal text-c-2 text-sm">
+      This cannot be undone. You’re about to delete the
+      {{ scheme?.label }} security scheme from the collection.
+    </p>
+    <div class="flex justify-between gap-2">
+      <ScalarButton
+        class="gap-1.5 px-3 h-8 shadow-none focus:outline-none flex items-center cursor-pointer"
+        type="button"
+        variant="outlined"
+        @click="emit('close')">
+        Cancel
+      </ScalarButton>
+      <ScalarButton
+        class="gap-1.5 px-3 h-8 shadow-none focus:outline-none flex items-center cursor-pointer"
+        type="submit"
+        @click="deleteScheme">
+        Delete {{ scheme?.label }}
+      </ScalarButton>
+    </div>
+  </ScalarModal>
+</template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -19,6 +19,7 @@ import {
 } from '@scalar/oas-utils/entities/spec'
 import { computed, ref, toRaw, watch } from 'vue'
 
+import DeleteRequestAuthModal from './DeleteRequestAuthModal.vue'
 import RequestAuthModal from './RequestAuthModal.vue'
 import RequestExampleAuth from './RequestExampleAuth.vue'
 
@@ -37,6 +38,8 @@ const {
 
 const comboboxRef = ref<typeof ScalarComboboxMultiselect | null>(null)
 const securitySchemeModal = useModal()
+const deleteSchemeModal = useModal()
+const selectedScheme = ref<{ id: string; label: string } | undefined>(undefined)
 
 /**
  * Available schemes that can be selected by a requestExample
@@ -116,6 +119,11 @@ watch(
   },
   { deep: true, immediate: true },
 )
+
+function handleDeleteScheme(option: { id: string; label: string }) {
+  selectedScheme.value = option
+  deleteSchemeModal.show()
+}
 </script>
 <template>
   <ViewLayoutCollapse
@@ -137,11 +145,13 @@ watch(
               ref="comboboxRef"
               class="text-xs w-full"
               fullWidth
+              isDeletable
               :modelValue="selectedAuth"
               multiple
               :options="schemeOptions"
               style="margin-left: 120px"
               teleport
+              @delete="handleDeleteScheme"
               @update:modelValue="updateSelectedAuth">
               <ScalarButton
                 class="h-auto py-0 px-0 text-c-2 hover:text-c-1 font-normal justify-start"
@@ -205,6 +215,10 @@ watch(
         :state="securitySchemeModal"
         @close="securitySchemeModal.hide()"
         @submit="updateSelectedAuth([...selectedAuth, { id: $event }])" />
+      <DeleteRequestAuthModal
+        :scheme="selectedScheme"
+        :state="deleteSchemeModal"
+        @close="deleteSchemeModal.hide()" />
     </form>
   </ViewLayoutCollapse>
 </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -10,6 +10,7 @@ import {
   ScalarButton,
   ScalarComboboxMultiselect,
   ScalarIcon,
+  useModal,
 } from '@scalar/components'
 import {
   type RequestExample,
@@ -18,6 +19,7 @@ import {
 } from '@scalar/oas-utils/entities/spec'
 import { computed, ref, toRaw, watch } from 'vue'
 
+import RequestAuthModal from './RequestAuthModal.vue'
 import RequestExampleAuth from './RequestExampleAuth.vue'
 
 defineProps<{
@@ -34,6 +36,7 @@ const {
 } = useWorkspace()
 
 const comboboxRef = ref<typeof ScalarComboboxMultiselect | null>(null)
+const securitySchemeModal = useModal()
 
 /**
  * Available schemes that can be selected by a requestExample
@@ -123,77 +126,86 @@ watch(
         {{ title }}
       </div>
     </template>
-    <DataTable
-      class="flex-1"
-      :columns="['']">
-      <DataTableRow>
-        <DataTableHeader
-          class="relative col-span-full cursor-pointer py-[0px] px-[0px] flex items-center">
-          <ScalarComboboxMultiselect
-            ref="comboboxRef"
-            class="text-xs w-full"
-            fullWidth
-            :modelValue="selectedAuth"
-            multiple
-            :options="schemeOptions"
-            style="margin-left: 120px"
-            teleport
-            @update:modelValue="updateSelectedAuth">
-            <ScalarButton
-              class="h-auto py-0 px-0 text-c-2 hover:text-c-1 font-normal justify-start"
+    <form>
+      <DataTable
+        class="flex-1"
+        :columns="['']">
+        <DataTableRow>
+          <DataTableHeader
+            class="relative col-span-full cursor-pointer py-[0px] px-[0px] flex items-center">
+            <ScalarComboboxMultiselect
+              ref="comboboxRef"
+              class="text-xs w-full"
               fullWidth
-              variant="ghost">
-              <div
-                class="text-c-2 h-8 flex min-w-[120px] items-center border-r-1/2 pr-0 pl-2">
-                Auth Type
-              </div>
-              <div
-                v-if="selectedAuth.length"
-                class="flex relative scroll-timeline-x w-full">
-                <div class="fade-left"></div>
-                <div class="flex flex-1 gap-0.75 mr-1.5 items-center">
-                  <span
-                    v-for="auth in selectedAuth"
-                    :key="auth.id"
-                    class="cm-pill flex items-center mx-0 h-fit">
-                    {{ auth.label }}
-                    <ScalarIcon
-                      class="ml-1 cursor-pointer text-c-3 hover:text-c-1"
-                      icon="Close"
-                      size="xs"
-                      @click.stop="unselectAuth(auth.id)" />
-                  </span>
-                </div>
-                <div class="fade-right"></div>
-              </div>
-              <div
-                v-else
-                class="pl-2">
-                None
-              </div>
-              <ScalarIcon
-                class="min-w-3 ml-auto mr-2.5"
-                icon="ChevronDown"
-                size="xs" />
-            </ScalarButton>
-            <template #actions>
+              :modelValue="selectedAuth"
+              multiple
+              :options="schemeOptions"
+              style="margin-left: 120px"
+              teleport
+              @update:modelValue="updateSelectedAuth">
               <ScalarButton
-                class="gap-1.5 font-normal h-auto justify-start px-2 py-1.5 text-c-1 text-xs hover:bg-b-2"
+                class="h-auto py-0 px-0 text-c-2 hover:text-c-1 font-normal justify-start"
                 fullWidth
                 variant="ghost">
-                <div class="flex items-center justify-center p-0.75 h-4 w-4">
-                  <ScalarIcon
-                    icon="Add"
-                    thickness="3" />
+                <div
+                  class="text-c-2 h-8 flex min-w-[120px] items-center border-r-1/2 pr-0 pl-2">
+                  Auth Type
                 </div>
-                Add Security Scheme
+                <div
+                  v-if="selectedAuth.length"
+                  class="flex relative scroll-timeline-x w-full">
+                  <div class="fade-left"></div>
+                  <div class="flex flex-1 gap-0.75 mr-1.5 items-center">
+                    <span
+                      v-for="auth in selectedAuth"
+                      :key="auth.id"
+                      class="cm-pill flex items-center mx-0 h-fit">
+                      {{ auth.label }}
+                      <ScalarIcon
+                        class="ml-1 cursor-pointer text-c-3 hover:text-c-1"
+                        icon="Close"
+                        size="xs"
+                        @click.stop="unselectAuth(auth.id)" />
+                    </span>
+                  </div>
+                  <div class="fade-right"></div>
+                </div>
+                <div
+                  v-else
+                  class="pl-2">
+                  None
+                </div>
+                <ScalarIcon
+                  class="min-w-3 ml-auto mr-2.5"
+                  icon="ChevronDown"
+                  size="xs" />
               </ScalarButton>
-            </template>
-          </ScalarComboboxMultiselect>
-        </DataTableHeader>
-      </DataTableRow>
-      <RequestExampleAuth />
-    </DataTable>
+              <template
+                v-if="!isReadOnly"
+                #actions>
+                <ScalarButton
+                  class="gap-1.5 font-normal h-auto justify-start px-2 py-1.5 text-c-1 text-xs hover:bg-b-2"
+                  fullWidth
+                  variant="ghost"
+                  @click="securitySchemeModal.show()">
+                  <div class="flex items-center justify-center p-0.75 h-4 w-4">
+                    <ScalarIcon
+                      icon="Add"
+                      thickness="3" />
+                  </div>
+                  Add Security Scheme
+                </ScalarButton>
+              </template>
+            </ScalarComboboxMultiselect>
+          </DataTableHeader>
+        </DataTableRow>
+        <RequestExampleAuth />
+      </DataTable>
+      <RequestAuthModal
+        :state="securitySchemeModal"
+        @close="securitySchemeModal.hide()"
+        @submit="updateSelectedAuth([...selectedAuth, { id: $event }])" />
+    </form>
   </ViewLayoutCollapse>
 </template>
 <style scoped>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -176,6 +176,19 @@ watch(
                 icon="ChevronDown"
                 size="xs" />
             </ScalarButton>
+            <template #actions>
+              <ScalarButton
+                class="gap-1.5 font-normal h-auto justify-start px-2 py-1.5 text-c-1 text-xs hover:bg-b-2"
+                fullWidth
+                variant="ghost">
+                <div class="flex items-center justify-center p-0.75 h-4 w-4">
+                  <ScalarIcon
+                    icon="Add"
+                    thickness="3" />
+                </div>
+                Add Security Scheme
+              </ScalarButton>
+            </template>
           </ScalarComboboxMultiselect>
         </DataTableHeader>
       </DataTableRow>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthModal.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthModal.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import { useWorkspace } from '@/store'
+import { ADD_AUTH_OPTIONS } from '@/views/Request/consts/new-auth-options'
+import {
+  ScalarButton,
+  ScalarIcon,
+  ScalarListbox,
+  ScalarModal,
+} from '@scalar/components'
+import type { SecurityScheme } from '@scalar/oas-utils/entities/spec'
+import { useToasts } from '@scalar/use-toasts'
+import { computed, ref, watch } from 'vue'
+
+const props = defineProps<{
+  state: { open: boolean; show: () => void; hide: () => void }
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'submit', id: string): void
+}>()
+
+const { toast } = useToasts()
+
+const newScheme = ref<{ id: string; label: string } | undefined>(undefined)
+const newFlow = ref<
+  | {
+      id: string
+      label: string
+      payload?: {
+        type?: string
+        flow?: { type: string }
+        in?: string
+        scheme?: string
+      }
+    }
+  | undefined
+>(undefined)
+
+const { securitySchemeMutators, activeCollection } = useWorkspace()
+
+const authTypes = computed(() =>
+  ADD_AUTH_OPTIONS.map((option) => ({
+    id: option.id,
+    label: option.label,
+  })),
+)
+
+const subOptions = computed(() => {
+  const selectedType = ADD_AUTH_OPTIONS.find(
+    (option) => option.label === newScheme.value?.label,
+  )
+  return selectedType ? selectedType.options : []
+})
+
+const addNewScheme = () => {
+  if (!newScheme.value || !newFlow.value) {
+    toast('Please select an auth type and option.', 'error')
+    return
+  }
+
+  const scheme = {
+    type: newFlow.value.payload?.type as SecurityScheme['type'],
+    nameKey: newFlow.value.label,
+    uid: newFlow.value.id,
+  } as SecurityScheme
+
+  if (newFlow.value.payload?.type === 'oauth2' && newFlow.value.payload.flow) {
+    ;(scheme as SecurityScheme & { flow: { type: string } }).flow = {
+      type: newFlow.value.payload.flow.type,
+    }
+  }
+
+  if (newFlow.value.payload?.type === 'apiKey' && newFlow.value.payload.in) {
+    ;(scheme as SecurityScheme & { in: string }).in = newFlow.value.payload.in
+  }
+
+  if (newFlow.value.payload?.type === 'http' && newFlow.value.payload.scheme) {
+    ;(scheme as SecurityScheme & { scheme: string }).scheme =
+      newFlow.value.payload.scheme
+  }
+
+  securitySchemeMutators.add(scheme, activeCollection.value?.uid || '')
+  emit('submit', scheme.uid)
+  emit('close')
+}
+
+// Reset second select values when the first select gets changed
+watch(newScheme, () => {
+  newFlow.value = undefined
+})
+
+// Reset select values when it gets closed
+watch(
+  () => props.state.open,
+  (newVal) => {
+    if (!newVal) {
+      newScheme.value = undefined
+      newFlow.value = undefined
+    }
+  },
+)
+
+const setPlaceholder = () => {
+  switch (newScheme.value?.id) {
+    case 'oauth2':
+      return 'Select Flow'
+    case 'http':
+      return 'Select Type'
+    case 'apiKey':
+      return 'Select Payload'
+    default:
+      return null
+  }
+}
+</script>
+<template>
+  <ScalarModal
+    size="xxs"
+    :state="state"
+    title="Security Scheme">
+    <div class="flex flex-col gap-2">
+      <ScalarListbox
+        v-model="newScheme"
+        :options="authTypes"
+        resize>
+        <ScalarButton
+          class="p-3 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+          variant="outlined">
+          <span :class="newScheme ? 'text-c-1' : 'text-c-3'">
+            {{ newScheme ? newScheme.label : 'Select Auth Type' }}
+          </span>
+          <ScalarIcon
+            class="ml-auto text-c-3"
+            icon="ChevronDown"
+            size="xs" />
+        </ScalarButton>
+      </ScalarListbox>
+      <div v-if="newScheme">
+        <ScalarListbox
+          v-model="newFlow"
+          :options="subOptions"
+          resize>
+          <ScalarButton
+            class="p-3 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+            variant="outlined">
+            <span :class="newFlow ? 'text-c-1' : 'text-c-3'">
+              {{ newFlow ? newFlow.label : setPlaceholder() }}
+            </span>
+            <ScalarIcon
+              class="ml-auto text-c-3"
+              icon="ChevronDown"
+              size="xs" />
+          </ScalarButton>
+        </ScalarListbox>
+      </div>
+      <div class="flex justify-between">
+        <ScalarButton
+          class="gap-1.5 px-3 h-8 shadow-none focus:outline-none flex items-center cursor-pointer"
+          type="button"
+          variant="outlined"
+          @click="emit('close')">
+          Cancel
+        </ScalarButton>
+        <ScalarButton
+          class="gap-1.5 px-3 h-8 shadow-none focus:outline-none flex items-center cursor-pointer"
+          :disabled="!newScheme || !newFlow"
+          type="submit"
+          @click="addNewScheme">
+          Add Security Scheme
+        </ScalarButton>
+      </div>
+    </div>
+  </ScalarModal>
+</template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestExampleAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestExampleAuth.vue
@@ -48,6 +48,7 @@ function updateExampleValue<T extends SecuritySchemeExampleValue>(
     <!-- Header -->
     <DataTableRow class="group/delete">
       <DataTableCell
+        v-if="security.length > 1"
         class="text-c-2 pl-2 text-xs font-medium flex items-center bg-b-2">
         {{ generateLabel(scheme) }}
       </DataTableCell>

--- a/packages/api-client/src/views/Request/consts/new-auth-options.ts
+++ b/packages/api-client/src/views/Request/consts/new-auth-options.ts
@@ -1,13 +1,14 @@
-import type { SecuritySchemePayload } from '@scalar/oas-utils/entities/workspace/security'
+import type { SecurityScheme } from '@scalar/oas-utils/entities/spec'
 import type { Entries } from 'type-fest'
 
 export type SecuritySchemeOption = {
   id: string
   label: string
-  payload?: SecuritySchemePayload
+  payload?: SecurityScheme
 }
 
 export type SecuritySchemeGroup = {
+  id: string
   label: string
   options: SecuritySchemeOption[]
 }
@@ -18,86 +19,111 @@ export type SecuritySchemeGroup = {
  * We store it as a dictionary first for quick lookups then convert to an array of options
  */
 export const ADD_AUTH_DICT = {
-  apiKeyCookie: {
-    label: 'API Key in Cookies',
-    payload: {
-      type: 'apiKey',
-      in: 'cookie',
-    },
-  },
-  apiKeyHeader: {
-    label: 'API Key in Headers',
-    payload: {
-      type: 'apiKey',
-      in: 'header',
-    },
-  },
-  apiKeyQuery: {
-    label: 'API Key in Query Params',
-    payload: {
-      type: 'apiKey',
-      in: 'query',
-    },
-  },
-  httpBasic: {
-    label: 'HTTP Basic',
-    payload: {
-      type: 'http',
-      scheme: 'basic',
-    },
-  },
-  httpBearer: {
-    label: 'HTTP Bearer',
-    payload: {
-      type: 'http',
-      scheme: 'bearer',
-    },
-  },
-  oauth2Implicit: {
-    label: 'Oauth2 Implicit Flow',
-    payload: {
-      type: 'oauth2',
-      flow: {
-        type: 'implicit',
+  apiKey: {
+    label: 'API Key',
+    options: [
+      {
+        id: 'apiKeyCookie',
+        label: 'API Key in Cookies',
+        payload: {
+          type: 'apiKey',
+          in: 'cookie',
+        },
       },
-    },
-  },
-  oauth2Password: {
-    label: 'Oauth2 Password Flow',
-    payload: {
-      type: 'oauth2',
-      flow: {
-        type: 'password',
+      {
+        id: 'apiKeyHeader',
+        label: 'API Key in Headers',
+        payload: {
+          type: 'apiKey',
+          in: 'header',
+        },
       },
-    },
-  },
-  oauth2ClientCredentials: {
-    label: 'Oauth2 Client Credentials',
-    payload: {
-      type: 'oauth2',
-      flow: {
-        type: 'clientCredentials',
+      {
+        id: 'apiKeyQuery',
+        label: 'API Key in Query Params',
+        payload: {
+          type: 'apiKey',
+          in: 'query',
+        },
       },
-    },
+    ],
   },
-  oauth2AuthorizationFlow: {
-    label: 'Oauth2 Authorization Code',
-    payload: {
-      type: 'oauth2',
-      flow: {
-        type: 'authorizationCode',
+  http: {
+    label: 'HTTP',
+    options: [
+      {
+        id: 'httpBasic',
+        label: 'HTTP Basic',
+        payload: {
+          type: 'http',
+          scheme: 'basic',
+        },
       },
-    },
+      {
+        id: 'httpBearer',
+        label: 'HTTP Bearer',
+        payload: {
+          type: 'http',
+          scheme: 'bearer',
+        },
+      },
+    ],
+  },
+  oauth2: {
+    label: 'OAuth2',
+    options: [
+      {
+        id: 'oauth2Implicit',
+        label: 'Oauth2 Implicit Flow',
+        payload: {
+          type: 'oauth2',
+          flow: {
+            type: 'implicit',
+          },
+        },
+      },
+      {
+        id: 'oauth2Password',
+        label: 'Oauth2 Password Flow',
+        payload: {
+          type: 'oauth2',
+          flow: {
+            type: 'password',
+          },
+        },
+      },
+      {
+        id: 'oauth2ClientCredentials',
+        label: 'Oauth2 Client Credentials',
+        payload: {
+          type: 'oauth2',
+          flow: {
+            type: 'clientCredentials',
+          },
+        },
+      },
+      {
+        id: 'oauth2AuthorizationFlow',
+        label: 'Oauth2 Authorization Code',
+        payload: {
+          type: 'oauth2',
+          flow: {
+            type: 'authorizationCode',
+          },
+        },
+      },
+    ],
   },
 } as const
 
 const entries = Object.entries(ADD_AUTH_DICT) as Entries<typeof ADD_AUTH_DICT>
 
 /** Options for the dropdown to add new auth */
-export const ADD_AUTH_OPTIONS: SecuritySchemeOption[] = entries.map(
+export const ADD_AUTH_OPTIONS: SecuritySchemeGroup[] = entries.map(
   ([id, value]) =>
     ({
       id,
-      ...value,
-    }) as const,
+      label: value.label,
+      options: [...(value.options as unknown as SecuritySchemeOption[])],
+    }) as SecuritySchemeGroup,
 )

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
@@ -11,11 +11,13 @@ defineProps<
     options: Option[] | OptionGroup[]
     modelValue?: Option[]
     placeholder?: string
+    isDeletable?: boolean
   } & Omit<FloatingOptions, 'middleware'>
 >()
 
 defineEmits<{
   (e: 'update:modelValue', v: Option[]): void
+  (e: 'delete', option: Option): void
 }>()
 
 /** Propagate up the popover ref */
@@ -35,11 +37,13 @@ defineExpose({ comboboxPopoverRef })
       <div class="divide-1 divide-y">
         <ComboboxOptions
           v-if="options && options.length"
+          :isDeletable="isDeletable"
           :modelValue="modelValue"
           multiselect
           :open="open"
           :options="options"
           :placeholder="placeholder"
+          @delete="(option: Option) => $emit('delete', option)"
           @update:modelValue="(v) => $emit('update:modelValue', v)" />
         <div
           v-if="$slots.actions"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
@@ -32,13 +32,21 @@ defineExpose({ comboboxPopoverRef })
     :teleport="teleport">
     <slot />
     <template #popover="{ open }">
-      <ComboboxOptions
-        :modelValue="modelValue"
-        multiselect
-        :open="open"
-        :options="options"
-        :placeholder="placeholder"
-        @update:modelValue="(v) => $emit('update:modelValue', v)" />
+      <div class="divide-1 divide-y">
+        <ComboboxOptions
+          v-if="options && options.length"
+          :modelValue="modelValue"
+          multiselect
+          :open="open"
+          :options="options"
+          :placeholder="placeholder"
+          @update:modelValue="(v) => $emit('update:modelValue', v)" />
+        <div
+          v-if="$slots.actions"
+          class="p-0.75">
+          <slot name="actions" />
+        </div>
+      </div>
     </template>
   </ComboboxPopover>
 </template>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
@@ -6,6 +6,7 @@ defineProps<{
   active?: boolean
   selected?: boolean
   style?: 'radio' | 'checkbox'
+  isDeletable?: boolean
 }>()
 
 const variants = cva({
@@ -25,7 +26,7 @@ const variants = cva({
 })
 </script>
 <template>
-  <li :class="cx(variants({ active, selected }))">
+  <li :class="cx(variants({ active, selected }), 'group')">
     <div
       class="flex size-4 items-center justify-center p-0.75 group-hover:shadow-border"
       :class="[
@@ -39,5 +40,12 @@ const variants = cva({
         thickness="2.5" />
     </div>
     <span class="inline-block min-w-0 flex-1 truncate text-c-1"><slot /></span>
+    <ScalarIcon
+      v-if="isDeletable"
+      class="text-c-2 opacity-0 group-hover:opacity-100"
+      icon="Delete"
+      size="md"
+      thickness="1.5"
+      @click.stop="$emit('delete')" />
   </li>
 </template>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -12,10 +12,12 @@ const props = defineProps<{
   placeholder?: string
   open?: boolean
   multiselect?: boolean
+  isDeletable?: boolean
 }>()
 
 const emit = defineEmits<{
   (e: 'update:modelValue', v: Option[]): void
+  (e: 'delete', option: Option): void
 }>()
 
 defineOptions({ inheritAttrs: false })
@@ -132,9 +134,11 @@ function moveActive(dir: 1 | -1) {
         <ComboboxOption
           v-if="group.options.some((o) => o.id === option.id)"
           :active="active?.id === option.id"
+          :isDeletable="isDeletable"
           :selected="selected.some((o) => o.id === option.id)"
           :style="multiselect ? 'checkbox' : 'radio'"
           @click="toggleSelected(option)"
+          @delete="$emit('delete', option)"
           @mousedown.prevent
           @mouseenter="active = option">
           {{ option.label }}

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -50,7 +50,7 @@ const modal = cva({
 const body = cva({
   base: [
     'scalar-modal-body',
-    'relative m-1 max-h-[calc(100dvh-240px)] overflow-y-auto rounded-lg bg-b-1 p-3',
+    'relative m-1 max-h-[calc(100dvh-240px)] rounded-lg bg-b-1 p-3',
   ].join(' '),
   variants: {
     variant: {


### PR DESCRIPTION
this pr adds security scheme button creation to auth combobox along auth modal in order to add security scheme to a collection:

https://github.com/user-attachments/assets/d43f9c1a-7e7c-4e23-b3dd-58d42e9a0d8a

some more refactor and polish to be added as i started by duplicating const type and flows but we might want to re-use `new-auth-options` ones.