### PR TITLE
fix(api-client): arrays as query params

### DIFF
--- a/.changeset/breezy-moons-grab.md
+++ b/.changeset/breezy-moons-grab.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+avoid overwriting parameters in queries to support arrays as query params

--- a/packages/api-client/src/libs/send-request.test.ts
+++ b/packages/api-client/src/libs/send-request.test.ts
@@ -290,6 +290,40 @@ describe('sendRequest', () => {
     })
   })
 
+  it('sends query parameters as arrays', async () => {
+    const [error, requestOperation] = createRequestOperation<{
+      query: { foo: ['foo', 'bar'] }
+    }>(
+      createRequestPayload({
+        serverPayload: { url: VOID_URL },
+        requestExamplePayload: {
+          parameters: {
+            query: [
+              {
+                key: 'foo',
+                value: 'foo',
+                enabled: true,
+              },
+              {
+                key: 'foo',
+                value: 'bar',
+                enabled: true,
+              },
+            ],
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data.query).toMatchObject({
+      foo: ['foo', 'bar'],
+    })
+  })
+
   it('merges query parameters', async () => {
     const [error, requestOperation] = createRequestOperation<{
       query: { example: 'parameter'; foo: 'bar' }


### PR DESCRIPTION
**Problem**


Fix https://github.com/scalar/scalar/issues/3054

Before the fix proposal
![Screenshot 2024-09-06 at 11 34 56](https://github.com/user-attachments/assets/ad9e194c-58bc-42cc-8992-63997c585c96)


**Solution**
After the fix proposal
![Screenshot 2024-09-06 at 11 34 16](https://github.com/user-attachments/assets/11f28807-58ec-4b17-8f71-f35430f98624)


**Comments**
this is the first step in handling arrays. in the future, one might think of supporting other ways of defining arrays, e.g. https://swagger.io/docs/specification/serialization/

