### PR TITLE
feat(api-reference): pass selected server to API client

### DIFF
--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -344,12 +344,27 @@ export const createWorkspaceStore = (router: Router, persistData = true) => {
     requestExampleMutators.delete(requestExample.uid)
   }
 
+  const withActiveServer = (requestExample: RequestExample): RequestExample => {
+    if (!activeServer.value) {
+      return requestExample
+    }
+
+    const replaceDoubleCurlyBraces = /{{(.*?)}}/g
+    requestExample.url = requestExample.url.replace(
+      replaceDoubleCurlyBraces,
+      `{{${activeServer.value.url}}}`,
+    )
+
+    return requestExample
+  }
+
   /** Currently active example OR the first one */
-  const activeExample = computed(
-    () =>
+  const activeExample = computed(() => {
+    return withActiveServer(
       requestExamples[activeRouterParams.value[PathId.Examples]] ??
-      requestExamples[activeRequest.value?.childUids[0] ?? ''],
-  )
+        requestExamples[activeRequest.value?.childUids[0] ?? ''],
+    )
+  })
 
   // ---------------------------------------------------------------------------
   // REQUEST HISTORY


### PR DESCRIPTION
- This PR set the selected server in api-reference to api-client

**Problem**
Currently, api-reference does not preserve the selected server in the main page to the `Test Request` modal. This is to set the `active server` url in the api-client

**Solution**
When retreiving the `activeExample` from workspace, set the activeServer url in the example url



https://github.com/user-attachments/assets/ace85b01-d6fa-4e0e-bb4e-2871d295ca44

