### PR TITLE
fix: logo light/dark mode

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -89,8 +89,8 @@
   "references": [],
   "siteConfig": {
     "logo": {
-      "darkMode": "https://scalar.com/logo-dark.svg",
-      "lightMode": "https://scalar.com/logo-light.svg"
+      "darkMode": "https://scalar.com/logo-light.svg",
+      "lightMode": "https://scalar.com/logo-dark.svg"
     },
     "footer": ""
   }


### PR DESCRIPTION
I think we need to swap the logos.

Currently, it looks like this:

<img width="334" alt="Screenshot 2024-09-06 at 15 21 20" src="https://github.com/user-attachments/assets/940a07be-ee3e-406c-b628-8472f244dcc7">

<img width="314" alt="Screenshot 2024-09-06 at 15 21 16" src="https://github.com/user-attachments/assets/29421042-d3e6-4fbb-9319-303bae29ebb3">
