### PR TITLE
chore: add siteMeta

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1,4 +1,8 @@
 {
+  "siteMeta": {
+    "title": "Scalar Documentation",
+    "description": "Guides for Scalar, covering your favorite frameworks, languages and use cases."
+  },
   "publishOnMerge": true,
   "subdomain": "guides",
   "customDomain": "guides.scalar.com",


### PR DESCRIPTION
Let’s use a custom page title and description for <https://guides.scalar.com>