### PR TITLE
feat(themes): make base dark mode colors opaque

### DIFF
--- a/.changeset/kind-grapes-lick.md
+++ b/.changeset/kind-grapes-lick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+feat(themes): make base dark mode colors opaque

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -10,21 +10,21 @@
   --scalar-color-3: #8e8e8e;
 
   --scalar-color-accent: #0099ff;
-  --scalar-border-color: rgba(0, 0, 0, 0.1);
+  --scalar-border-color: #dfdfdf;
 }
 .dark-mode {
   --scalar-background-1: #0f0f0f;
   --scalar-background-2: #1a1a1a;
   --scalar-background-3: #272727;
 
-  --scalar-color-1: rgba(255, 255, 255, 0.9);
-  --scalar-color-2: rgba(255, 255, 255, 0.62);
-  --scalar-color-3: rgba(255, 255, 255, 0.44);
+  --scalar-color-1: #e7e7e7;
+  --scalar-color-2: #a4a4a4;
+  --scalar-color-3: #797979;
 
   --scalar-color-accent: #3ea6ff;
   --scalar-background-accent: #3ea6ff1f;
 
-  --scalar-border-color: rgba(255, 255, 255, 0.1);
+  --scalar-border-color: #2d2d2d;
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,


### PR DESCRIPTION
This fixes some issues with transparent theme colors sometimes causing inconsistent layering when placed over each other. 

For example icons that use a fill and an outline (main / this PR): 

<img width="375" alt="Google Chrome-2024-09-06-14-08-43@2x" src="https://github.com/user-attachments/assets/8cef639f-4be1-4f12-989e-c7b91e8395b9">
<img width="375" alt="Google Chrome-2024-09-06-14-08-50@2x" src="https://github.com/user-attachments/assets/191eafbc-a04c-4cfd-8adb-c7c6a66e31a6">

This PR updates all of the base colors in the default theme (colors 1 through 3 and the border color) to be opaque. I can also update the rest of the themes and colors to all be opaque if that's something we want as well.

In order to match the existing look of the app I adjusted the border color slightly to be slightly darker in light mode and slightly lightly in dark mode. I think the change is pretty subtle?

## Before / Afters

These screenshots can be used to compare the before after if you don't feel like checking out the PR: [ComparisonScreenshots.zip](https://github.com/user-attachments/files/16912988/ComparisonScreenshots.zip)

This shows the references introduction card which is a good example of the border colors overlayed on several different background colors.

![Google Chrome-2024-09-06-13-56-34](https://github.com/user-attachments/assets/f48f06f1-4762-4e90-9001-d9f58b4c5d1f)

![Google Chrome-2024-09-06-13-58-20](https://github.com/user-attachments/assets/9ded80eb-12f7-443c-943b-357be4ec8e05)

Here you can see a bunch of the pages one after the other:

https://github.com/user-attachments/assets/152cde2b-2020-45ce-85ce-22b39e11f313


