### PR TITLE
fix(api-reference): server description color style

### DIFF
--- a/.changeset/dry-kings-drum.md
+++ b/.changeset/dry-kings-drum.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: server description color style

--- a/packages/api-reference/src/features/BaseUrl/ServerForm.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerForm.vue
@@ -96,6 +96,8 @@ const server = computed(() => props.servers?.[selectedRef.value])
 .description {
   padding: 6px 12px;
   font-size: var(--scalar-small);
+  font-weight: var(--scalar-semibold);
+  color: var(--scalar-color-3);
 }
 .description :deep(.markdown) {
   font-size: var(--scalar-micro);


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/ff104f94-03ac-4c03-8929-77e53990d7b5

After:

https://github.com/user-attachments/assets/75c8fddf-67ef-4529-8586-0986cd87f13f

