### PR TITLE
ci: run workflows on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
I don’t see a good reason why the CI workflows should only run on PRs against main.

Let us run them in all PRs!

Skipping the queue here to use it in some of the PRs we’re doing against our super huge PR.