### PR TITLE
fix(api-client): requests with relative server URLs fail

### DIFF
--- a/packages/api-client/src/libs/sendRequest.ts
+++ b/packages/api-client/src/libs/sendRequest.ts
@@ -204,12 +204,12 @@ export const sendRequest = async (
     }
 
     try {
-      new URL(rawUrl)
+      new URL(rawUrl, typeof window !== "undefined" ? window.location.origin : undefined)
     } catch (error) {
       throw new Error(ERRORS.INVALID_URL)
     }
 
-    const origin = new URL(rawUrl).host
+    const origin = new URL(rawUrl, typeof window !== "undefined" ? window.location.origin : undefined).host
     Object.keys(workspaceCookies).forEach((key) => {
       const c = workspaceCookies[key]
       if (!c.domain) return


### PR DESCRIPTION
**Problem**
Currently, when using FastAPI with a [root path](https://fastapi.tiangolo.com/advanced/behind-a-proxy/?h=root+path#providing-the-root_path), the server section in the OpenAPI file contains relative URLs. The Scalar interface seems to support relative URLs up to the point of sending a request, where it crashes: `Error: The URL seems to be invalid. Try adding a valid URL.`

**Solution**
With this PR, the request is sent using `window.location.origin` as the default base URL. In the case where the OpenAPI spec contains a full URL, this argument is ignored.
