### PR TITLE
chore(openapi-parser): use common TSConfig

### DIFF
--- a/packages/openapi-parser/tsconfig.json
+++ b/packages/openapi-parser/tsconfig.json
@@ -1,33 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "ES2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    "module": "ESNext" /* Specify what module code is generated. */,
-    "moduleResolution": "Bundler",
-    // Required for isolated module compilation (ESBuild)
-    "isolatedModules": true,
-    // Support proper ESM builds
-    "esModuleInterop": true,
-    // Ensure that casing is correct in imports.
-    "forceConsistentCasingInFileNames": true,
-    "strict": false,
-    "strictNullChecks": false,
-    "resolveJsonModule": true,
-    "skipLibCheck": true
-  },
-  "include": [
-    "src/**/*",
-    "tests/**/*",
-    "**/*.json",
-    "**/*.yaml",
-    "rollup.config.ts"
-  ],
-  "exclude": ["dist", "node_modules", "**/dist", "**/node_modules"],
-  // Required for path rewrites
-  "ts-node": {
-    "require": ["tsconfig-paths/register"]
-  },
-  // Required for path aliasing
-  "tsc-alias": {
-    "resolveFullPaths": true
-  }
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "include": ["src", "rollup.config.ts"]
 }


### PR DESCRIPTION
Breaking the openapi parser migration to standard build tooling into multiple smaller PRs for testing tree shaking at each step. This PR only updates the`tsconfig` to use the standard base tsconfig for the workspace. 

Code changes will be necessary but many will be fixed when the [dynamic typings](https://github.com/scalar/scalar/pull/3028) are merged. 
