### PR TITLE
fix(api-client): scope api client draggable styles

### DIFF
--- a/.changeset/lemon-dryers-kick.md
+++ b/.changeset/lemon-dryers-kick.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/draggable': patch
+---
+
+fix(api-client): scope api client draggable styles

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -84,7 +84,7 @@ const startDrag = (event: MouseEvent) => {
       @mousedown="startDrag"></div>
   </aside>
 </template>
-<style>
+<style scoped>
 .sidebar-height {
   min-height: calc(100% - 50px);
 }

--- a/packages/draggable/src/Draggable.vue
+++ b/packages/draggable/src/Draggable.vue
@@ -182,7 +182,7 @@ defineExpose({
   </div>
 </template>
 
-<style>
+<style scoped>
 .dragover-asChild,
 .dragover-above,
 .dragover-below {


### PR DESCRIPTION
These should be scoped so they don't leak out of the client. I tested it and everything still seems to be working fine but another test wouldn't hurt 🙏 

