### PR TITLE
feat(api-client): response codeblock copy

### DIFF
--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -212,7 +212,8 @@ export default {
 }
 :deep(.cm-content) {
   font-family: var(--scalar-font-code);
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
+  padding: 8px 0;
 }
 /* Tooltip helper */
 :deep(.cm-tooltip) {
@@ -267,7 +268,7 @@ export default {
   background-color: var(--scalar-background-1);
   border-right: none;
   color: var(--scalar-color-3);
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   line-height: 1.44;
 }
 :deep(.cm-gutterElement) {

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -66,7 +66,7 @@ const dataUrl = computed<string>(() => {
     <div
       v-if="data"
       class="mx-1 border-1/2 flex flex-col rounded bg-b-1">
-      <div class="flex justify-between items-center border-b-1/2 p-1.5">
+      <div class="flex justify-between items-center border-b-1/2 px-3 py-1.5">
         <span class="text-xxs leading-3 font-code">
           {{ mimeType.essence }}
         </span>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { ScalarCodeBlock } from '@scalar/components'
 import { isJsonString } from '@scalar/oas-utils/helpers'
 import { type CodeMirrorLanguage, useCodeMirror } from '@scalar/use-codemirror'
 import { computed, ref, toRaw } from 'vue'
@@ -32,7 +33,9 @@ useCodeMirror({
 })
 </script>
 <template>
-  <div ref="codeMirrorRef" />
+  <ScalarCodeBlock
+    :content="content"
+    :lang="language" />
 </template>
 <style scoped>
 :deep(.cm-editor) {

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -37,7 +37,11 @@ const highlightedCode = computed(() => {
 const { copyToClipboard } = useClipboard()
 
 const isContentValid = computed(() => {
-  return props.content !== null && props.content !== 'null'
+  return (
+    props.content !== null &&
+    props.content !== 'null' &&
+    props.content !== '404 Not Found'
+  )
 })
 </script>
 <template>
@@ -62,6 +66,7 @@ const isContentValid = computed(() => {
 <style>
 @import '@scalar/code-highlight/css/code.css';
 .scalar-code-block {
+  background: inherit;
   position: relative;
   overflow: auto;
   padding: 0.5rem 0.5rem 0.5rem 0.75rem;


### PR DESCRIPTION
this pr adds copy capability to response code in api client as seen below:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/9c84a2fd-1d5b-4370-ba6e-b0025d4e6d55">
