### PR TITLE
chore: remove max-lines-per-block rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -219,13 +219,6 @@ module.exports = {
           },
         ],
         'vue/custom-event-name-casing': ['error', 'camelCase'],
-        'vue/max-lines-per-block': [
-          'warn',
-          {
-            script: 150,
-            skipBlankLines: true,
-          },
-        ],
       },
     },
     /** Other rule overrides */


### PR DESCRIPTION
I’d love to have less lines in Vue components, but the rule doesn’t work well in practice. It just adds squiggly lines to the whole file and instead of nudging me to refactor the component it just makes me close it faster. Also, red squiggly lines are really hard to spot then.

So let’s make our components have less lines, but let’s also remove this rule for now!