### PR TITLE
fix: request example code works for some clients only, fix #3094

### DIFF
--- a/.changeset/dirty-crabs-give.md
+++ b/.changeset/dirty-crabs-give.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: request example code works for some examples only

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -178,16 +178,6 @@ onServerPrefetch(async () => {
   ctx!.payload.data[ssrStateKey] = await generateSnippet()
 })
 
-/** @hans TODO What is this doing? Computed properties should not be used as side effects  */
-computed(() => {
-  return getApiClientRequest({
-    serverState: serverState,
-    authenticationState: authenticationState,
-    operation: props.operation,
-    globalSecurity: getGlobalSecurity?.(),
-  })
-})
-
 /** Code language of the snippet */
 const language = computed(() => {
   const key =

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -149,13 +149,7 @@ async function generateSnippet() {
     ),
   )
 
-  const clientKey =
-    httpClient.clientKey === 'undici' ||
-    httpClient.clientKey === 'fetch' ||
-    httpClient.clientKey === 'ofetch'
-      ? httpClient.clientKey
-      : null
-
+  const clientKey = httpClient.clientKey
   const targetKey = httpClient.targetKey
 
   return (

--- a/packages/api-reference/src/helpers/getExampleCode.test.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.test.ts
@@ -4,7 +4,7 @@ import { createRequest } from './createRequest'
 import { getExampleCode } from './getExampleCode'
 
 describe('getExampleCode', () => {
-  it('generates a basic curl example (httpsnippet-lite)', async () => {
+  it('generates a basic shell/curl example (httpsnippet-lite)', async () => {
     const result = await getExampleCode(
       createRequest({
         method: 'POST',
@@ -19,7 +19,7 @@ describe('getExampleCode', () => {
     expect(result).toContain('--url https://example.com')
   })
 
-  it('generates a basic undici example (@scalar/snippetz)', async () => {
+  it('generates a basic node/undici example (@scalar/snippetz)', async () => {
     const result = await getExampleCode(
       createRequest({
         method: 'POST',
@@ -32,6 +32,41 @@ describe('getExampleCode', () => {
     expect(result).toContain(`import { request } from 'undici'`)
     expect(result).toContain(`'https://example.com'`)
     expect(result).toContain(`method: 'POST'`)
+  })
+
+  it('generates a basic javascript/jquery example (httpsnippet-lite)', async () => {
+    const result = await getExampleCode(
+      createRequest({
+        method: 'POST',
+        url: 'https://example.com',
+      }),
+      'javascript',
+      'jquery',
+    )
+
+    expect(result).toContain('$.ajax')
+  })
+
+  it('works with js and javascript (httpsnippet-lite)', async () => {
+    const result1 = await getExampleCode(
+      createRequest({
+        method: 'POST',
+        url: 'https://example.com',
+      }),
+      'js',
+      'jquery',
+    )
+
+    const result2 = await getExampleCode(
+      createRequest({
+        method: 'POST',
+        url: 'https://example.com',
+      }),
+      'javascript',
+      'jquery',
+    )
+
+    expect(result1).toBe(result2)
   })
 
   it('returns an empty string if passed rubbish', async () => {

--- a/packages/api-reference/src/helpers/getExampleCode.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.ts
@@ -22,7 +22,7 @@ export async function getExampleCode(
   client: ClientId,
 ) {
   // @scalar/snippetz
-  const snippetzTargetKey = target.replace('javascript', 'js')
+  const snippetzTargetKey = target
 
   if (snippetz().hasPlugin(snippetzTargetKey, client)) {
     return snippetz().print(
@@ -34,11 +34,17 @@ export async function getExampleCode(
 
   // httpsnippet-lite
   try {
+    const httpSnippetLiteTargetKey = target.replace(
+      'js',
+      'javascript',
+    ) as HttpSnippetLiteTargetId
+    const httpSnippetLiteClientKey = client as HttpSnippetLiteClientId
+
     // HTTPSnippet will return type string[] if passed input type HarEntry
     // Since we are passing type HarRequest output is a string
     const code = await new HTTPSnippet(request).convert(
-      target as HttpSnippetLiteTargetId,
-      client as HttpSnippetLiteClientId,
+      httpSnippetLiteTargetKey,
+      httpSnippetLiteClientKey,
     )
     if (typeof code === 'string') return code
   } catch (error) {


### PR DESCRIPTION
We broke the example code generation for most clients in #2995.

This PR fixes multiple issues causing the example code generation for most clients, and even deletes a dead code block.

We just didn’t pass the client id in some cases and we added an `js` alias to the `@scalar/snippetz` call, but not to the `httpsnippet-lite` call where it’s actually needed.