### PR TITLE
feat: render deeply nested schemas, fix #2337

### DIFF
--- a/.changeset/smooth-ties-dress.md
+++ b/.changeset/smooth-ties-dress.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/oas-utils': patch
+---
+
+feat: render deeply nested schemas, but not circular references

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -892,17 +892,7 @@ describe('getExampleFromSchema', () => {
           foobar: {
             foobar: {
               foobar: {
-                foobar: {
-                  foobar: {
-                    foobar: {
-                      foobar: {
-                        foobar: {
-                          foobar: null,
-                        },
-                      },
-                    },
-                  },
-                },
+                foobar: '[Circular Reference]',
               },
             },
           },

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -873,4 +873,41 @@ describe('getExampleFromSchema', () => {
       c: true,
     })
   })
+
+  it('deals with circular references', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        foobar: {},
+      },
+    }
+
+    // Create a circular reference
+    schema.properties.foobar = schema
+
+    // 10 levels deep, that’s enough. It should return null then.
+    expect(getExampleFromSchema(schema)).toStrictEqual({
+      foobar: {
+        foobar: {
+          foobar: {
+            foobar: {
+              foobar: {
+                foobar: {
+                  foobar: {
+                    foobar: {
+                      foobar: {
+                        foobar: {
+                          foobar: null,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
 })

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -1,3 +1,6 @@
+/** Hard limit to prevent infinite recursion due to circular references */
+const MAX_LEVELS_DEEP = 10
+
 /**
  * We can use the `format` to generate some random values.
  */
@@ -71,7 +74,7 @@ export const getExampleFromSchema = (
   name?: string,
 ): any => {
   // Break an infinite loop
-  if (level > 5) {
+  if (level > MAX_LEVELS_DEEP) {
     return null
   }
 

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -1,5 +1,5 @@
-/** Hard limit to prevent infinite recursion due to circular references */
-const MAX_LEVELS_DEEP = 10
+/** Hard limit for rendering circular references */
+const MAX_LEVELS_DEEP = 5
 
 /**
  * We can use the `format` to generate some random values.
@@ -73,9 +73,14 @@ export const getExampleFromSchema = (
   parentSchema?: Record<string, any>,
   name?: string,
 ): any => {
-  // Break an infinite loop
-  if (level > MAX_LEVELS_DEEP) {
-    return null
+  // Check whether it’s a circular reference
+  if (level === MAX_LEVELS_DEEP + 1) {
+    try {
+      // Fails if it contains a circular reference
+      JSON.stringify(schema)
+    } catch {
+      return '[Circular Reference]'
+    }
   }
 
   // Sometimes, we just want the structure and no values.


### PR DESCRIPTION
Currently, we just don’t render schemas more than 5 levels deep.

This PR renders deeply nested schemas, no matter how deeply they are nested.

But circular references are detected and only the first five levels are rendered in that case.

See #2337 for more context.