### PR TITLE
feat: getExampleFromSchema can generate examples for anyOf schemas, fix #2417

### DIFF
--- a/.changeset/thick-monkeys-shout.md
+++ b/.changeset/thick-monkeys-shout.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+Generate examples for schemas with `anyOf` defined when `type` is not defined

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -328,6 +328,48 @@ describe('getExampleFromSchema', () => {
     ).toMatchObject({ foo: 1 })
   })
 
+  it('uses the first example in object anyOf when type is not defined', () => {
+    expect(
+      getExampleFromSchema({
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              foo: { type: 'number' },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              bar: { type: 'string' },
+            },
+          },
+        ],
+      }),
+    ).toMatchObject({ foo: 1 })
+  })
+
+  it('uses the first example in object oneOf when type is not defined', () => {
+    expect(
+      getExampleFromSchema({
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              foo: { type: 'number' },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              bar: { type: 'string' },
+            },
+          },
+        ],
+      }),
+    ).toMatchObject({ foo: 1 })
+  })
+
   it('uses all examples in object allOf', () => {
     expect(
       getExampleFromSchema({

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -125,7 +125,12 @@ export const getExampleFromSchema = (
   }
 
   // Check if the property is required
-  const isObjectOrArray = schema.type === 'object' || schema.type === 'array'
+  const isObjectOrArray =
+    schema.type === 'object' ||
+    schema.type === 'array' ||
+    !!schema.allOf?.at?.(0) ||
+    !!schema.anyOf?.at?.(0) ||
+    !!schema.oneOf?.at?.(0)
   if (!isObjectOrArray && options?.omitEmptyAndOptionalProperties === true) {
     const isRequired =
       schema.required === true ||

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -275,10 +275,11 @@ export const getExampleFromSchema = (
     return exampleValues[schema.type]
   }
 
-  // Check if property has the `oneOf` key
-  if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) {
-    // Get the first item from the `oneOf` array
-    const firstOneOfItem = schema.oneOf[0]
+  const discriminateSchema = schema.oneOf || schema.anyOf
+  // Check if property has the `oneOf` | `anyOf` key
+  if (Array.isArray(discriminateSchema) && discriminateSchema.length > 0) {
+    // Get the first item from the `oneOf` | `anyOf` array
+    const firstOneOfItem = discriminateSchema[0]
 
     // Return an example for the first item
     return getExampleFromSchema(firstOneOfItem, options, level + 1)


### PR DESCRIPTION
**Problem**
Examples are not generated for schemas with `anyOf` when `type` is not defined on the object

Currently, I used some auto gen tools to generate json schemas, and it creates unions with `anyOf` instead of `oneOf`
Examples are generated fine for `oneOf` schemas, but the `anyOf` case is completely ignored

**Solution**
With this PR, I create an implementation for the `anyOf` that is similar to the `oneOf`'s implementation
