### PR TITLE
chore: add missing npm scripts

### DIFF
--- a/examples/api-client/package.json
+++ b/examples/api-client/package.json
@@ -19,6 +19,8 @@
     "build": "vite build",
     "deploy": "pnpm run build && wrangler pages deploy ./dist --project-name=client",
     "dev": "vite",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "preview": "pnpm run build && wrangler pages dev ./dist",
     "test:unit": "vitest",
     "types:check": "vue-tsc --build --force"

--- a/examples/docusaurus/package.json
+++ b/examples/docusaurus/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.3.2",
     "@docusaurus/preset-classic": "^3.3.2",
+    "@docusaurus/theme-classic": "^3.5.2",
     "@mdx-js/react": "^3.0.0",
     "@scalar/docusaurus": "workspace:*",
     "clsx": "^2.0.0",

--- a/examples/docusaurus/package.json
+++ b/examples/docusaurus/package.json
@@ -20,9 +20,11 @@
     "deploy": "docusaurus deploy",
     "dev": "docusaurus start --port=5063 --no-open",
     "docusaurus": "docusaurus",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "serve": "docusaurus serve",
     "swizzle": "docusaurus swizzle",
-    "typecheck": "tsc",
+    "types:check": "tsc",
     "write-heading-ids": "docusaurus write-heading-ids",
     "write-translations": "docusaurus write-translations"
   },

--- a/examples/express-api-reference/package.json
+++ b/examples/express-api-reference/package.json
@@ -20,7 +20,7 @@
     "docker:build": "build --platform=linux/amd64 -t ${image_name} --build-arg=\"BASE_IMAGE=scalar-base\" -f ./examples/express-api-reference/Dockerfile .",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
-    "types:check": "scalar-types-check-vue"
+    "types:check": "scalar-types-check"
   },
   "type": "module",
   "dependencies": {

--- a/examples/express-api-reference/package.json
+++ b/examples/express-api-reference/package.json
@@ -17,7 +17,10 @@
   "scripts": {
     "build": "tsc --p tsconfig.json && tsc-alias -p tsconfig.json",
     "dev": "nodemon --exec \"vite-node src/index.ts\" --ext ts --quiet --watch ../../packages/express-api-reference --watch ./",
-    "docker:build": "build --platform=linux/amd64 -t ${image_name} --build-arg=\"BASE_IMAGE=scalar-base\" -f ./examples/express-api-reference/Dockerfile ."
+    "docker:build": "build --platform=linux/amd64 -t ${image_name} --build-arg=\"BASE_IMAGE=scalar-base\" -f ./examples/express-api-reference/Dockerfile .",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
+    "types:check": "scalar-types-check-vue"
   },
   "type": "module",
   "dependencies": {
@@ -26,6 +29,7 @@
     "swagger-jsdoc": "^6.2.8"
   },
   "devDependencies": {
+    "@scalar/build-tooling": "workspace:*",
     "@types/express": "^4.17.21",
     "@types/swagger-jsdoc": "^6.0.3",
     "vite": "^5.2.10"

--- a/examples/fastify-api-reference/package.json
+++ b/examples/fastify-api-reference/package.json
@@ -18,6 +18,8 @@
     "build": "tsc --p tsconfig.json && tsc-alias -p tsconfig.json",
     "dev": "nodemon --exec \"vite-node src/index.ts\" --ext ts --quiet --watch ../../packages/fastify-api-reference --watch ./",
     "docker:build": "build --platform=linux/amd64 -t ${image_name} --build-arg=\"BASE_IMAGE=scalar-base\" -f ./examples/fastify-api-reference/Dockerfile .",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "types:check": "tsc --noEmit --skipLibCheck"
   },
   "type": "module",

--- a/examples/nestjs-api-reference-express/package.json
+++ b/examples/nestjs-api-reference-express/package.json
@@ -19,7 +19,8 @@
     "build": "nest build",
     "dev": "nest start",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "start:debug": "nest start --debug --watch",
     "start:dev": "nest start --watch",
     "start:prod": "node dist/main",
@@ -27,7 +28,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/jest/bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "types:check": "tsc --noEmit"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/examples/nestjs-api-reference-fastify/package.json
+++ b/examples/nestjs-api-reference-fastify/package.json
@@ -19,7 +19,8 @@
     "build": "nest build",
     "dev": "nest start",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "start:debug": "nest start --debug --watch",
     "start:dev": "nest start --watch",
     "start:prod": "node dist/main",
@@ -27,7 +28,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/jest/bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "types:check": "tsc --noEmit"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/examples/nextjs-api-reference/.eslintrc.cjs
+++ b/examples/nextjs-api-reference/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs', 'plugin:@next/next/recommended'],
+}

--- a/examples/nextjs-api-reference/package.json
+++ b/examples/nextjs-api-reference/package.json
@@ -18,8 +18,10 @@
     "build": "next build",
     "dev": "next dev -p 5058",
     "docker:build": "build --platform=linux/amd64 -t ${image_name} --build-arg=\"BASE_IMAGE=scalar-base\" -f ./examples/nextjs-api-reference/Dockerfile .",
-    "lint": "next lint",
-    "start": "next start"
+    "lint:check": "next lint",
+    "lint:fix": "next lint --fix",
+    "start": "next start",
+    "types:check": "tsc --noEmit"
   },
   "type": "module",
   "dependencies": {
@@ -30,6 +32,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@next/eslint-plugin-next": "^14.2.11",
     "@types/node": "^20.14.10",
     "@types/react": "^18.2.60",
     "@types/react-dom": "^18.2.19"

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -17,7 +17,10 @@
   "scripts": {
     "build": "vue-tsc && vite-ssg build",
     "dev": "vite",
-    "preview": "vite preview"
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
+    "preview": "vite preview",
+    "types:check": "scalar-types-check-vue"
   },
   "type": "module",
   "dependencies": {
@@ -27,6 +30,7 @@
     "vue": "^3.4.29"
   },
   "devDependencies": {
+    "@scalar/build-tooling": "workspace:*",
     "@vitejs/plugin-vue": "^5.0.4",
     "vite": "^5.2.10",
     "vite-ssg": "^0.23.6"

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -17,8 +17,8 @@
   "scripts": {
     "build": "vue-tsc && vite build",
     "dev": "vite",
-    "lint": "eslint \"src/**/*.{js,vue}\"",
-    "lint:fix": "eslint \"src/**/*.{js,vue}\" --fix",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "preview": "vite preview",
     "types:check": "vue-tsc --noEmit --skipLibCheck --composite false"
   },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "test:e2e:local": "pnpm --filter playwright test:e2e local",
     "test:e2e:themes": "pnpm --filter playwright test:e2e themes",
     "test:e2e:nuxt": "pnpm --filter playwright test:e2e nuxt",
-    "types:check": "turbo --concurrency=100 types:check",
+    "types:check": "turbo --concurrency=8 types:check",
     "bootstrap:package": "vite-node scripts/bootstrap-package/bootstrap-package.ts",
     "markdown:check": "remark --frail ."
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "root",
   "type": "module",
+  "version": "1.0.0",
+  "private": true,
   "engines": {
     "pnpm": "^9.1.0"
   },
@@ -41,7 +43,6 @@
     "vue-eslint-parser": "^9.4.2",
     "vue-tsc": "^2.0.26"
   },
-  "private": true,
   "scripts": {
     "build": "turbo build",
     "build:docker-base": "docker build -t scalar-base -f ./tooling/base-docker-builder/Dockerfile .",

--- a/packages/api-client-app/package.json
+++ b/packages/api-client-app/package.json
@@ -21,8 +21,6 @@
     "dev": "electron-vite dev",
     "dev:open": "cd open && vite",
     "dev:update": "electron-vite dev -- --runtime-simulate-updates=update-available",
-    "lint:check": "eslint .",
-    "lint:fix": "eslint .  --fix",
     "preview": "electron-vite preview",
     "test": "vitest",
     "todesktop:build": "npm run build && todesktop build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,8 @@
     "@scalar/cli": "pnpm vite-node src/index.ts",
     "build": "scalar-build-rollup",
     "link:cli": "pnpm run build && npm unlink -g @scalar/cli && npm link",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "screenshot": "./scripts/take-screenshots.sh",
     "test": "vitest",
     "types:build": "scalar-types-build",

--- a/packages/express-api-reference/package.json
+++ b/packages/express-api-reference/package.json
@@ -16,7 +16,10 @@
   },
   "scripts": {
     "build": "tsup ./src/index.ts --format esm,cjs --dts",
-    "test": "vitest run"
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
+    "test": "vitest run",
+    "types:check": "tsc --noEmit"
   },
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/hono-api-reference/package.json
+++ b/packages/hono-api-reference/package.json
@@ -19,6 +19,8 @@
     "dev": "nodemon --exec \"vite-node playground/index.ts\" --ext ts --quiet --watch ./",
     "docker:build": "docker buildx build --platform=linux/amd64 -t scalar-hono-reference --build-arg=\"BASE_IMAGE=scalar-base\" .",
     "docker:run": "docker run -t scalar-hono-reference",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "test": "vitest",
     "types:build": "scalar-types-build",
     "types:check": "scalar-types-check"

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -23,6 +23,8 @@
   "scripts": {
     "build": "scalar-build-rollup",
     "dev": "nodemon --exec \"vite-node playground/index.ts\" --ext ts --quiet",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "test": "vitest",
     "types:build": "scalar-types-build",
     "types:check": "scalar-types-check"

--- a/packages/nestjs-api-reference/package.json
+++ b/packages/nestjs-api-reference/package.json
@@ -16,7 +16,10 @@
   },
   "scripts": {
     "build": "tsup ./src/index.ts --format esm,cjs --dts",
-    "test": "vitest run"
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
+    "test": "vitest run",
+    "types:check": "tsc --noEmit"
   },
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -15,6 +15,8 @@
   },
   "scripts": {
     "build": "scalar-build-rollup",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "test": "vitest",
     "types:build": "scalar-types-build",
     "types:check": "scalar-types-check"

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -22,6 +22,8 @@
   "scripts": {
     "build": "scalar-build-rollup",
     "dev": "nodemon --exec \"vite-node playground/index.ts\" --ext ts --quiet",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint .  --fix",
     "test": "vitest",
     "types:build": "scalar-types-build",
     "types:check": "scalar-types-check"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
         specifier: ^6.2.8
         version: 6.2.8(openapi-types@12.1.3)
     devDependencies:
+      '@scalar/build-tooling':
+        specifier: workspace:*
+        version: link:../../packages/build-tooling
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
@@ -419,6 +422,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@next/eslint-plugin-next':
+        specifier: ^14.2.11
+        version: 14.2.11
       '@types/node':
         specifier: ^20.14.10
         version: 20.14.10
@@ -508,6 +514,9 @@ importers:
         specifier: ^3.4.29
         version: 3.4.31(typescript@5.5.2)
     devDependencies:
+      '@scalar/build-tooling':
+        specifier: workspace:*
+        version: link:../../packages/build-tooling
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
         version: 5.0.5(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))(vue@3.4.31(typescript@5.5.2))
@@ -4845,6 +4854,9 @@ packages:
 
   '@next/env@14.2.5':
     resolution: {integrity: sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==}
+
+  '@next/eslint-plugin-next@14.2.11':
+    resolution: {integrity: sha512-7mw+xW7Y03Ph4NTCcAzYe+vu4BNjEHZUfZayyF3Y1D9RX6c5NIe25m1grHEAkyUuaqjRxOYhnCNeglOkIqLkBA==}
 
   '@next/swc-darwin-arm64@14.2.5':
     resolution: {integrity: sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==}
@@ -21408,6 +21420,10 @@ snapshots:
       urlpattern-polyfill: 8.0.2
 
   '@next/env@14.2.5': {}
+
+  '@next/eslint-plugin-next@14.2.11':
+    dependencies:
+      glob: 10.3.10
 
   '@next/swc-darwin-arm64@14.2.5':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@docusaurus/preset-classic':
         specifier: ^3.3.2
         version: 3.4.0(@algolia/client-search@4.23.3)(@swc/core@1.5.29)(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(typescript@5.5.2)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-classic':
+        specifier: ^3.5.2
+        version: 3.5.2(@swc/core@1.5.29)(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.0.1(@types/react@18.3.3)(react@18.3.1)
@@ -3305,16 +3308,40 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@docusaurus/core@3.5.2':
+    resolution: {integrity: sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==}
+    engines: {node: '>=18.0'}
+    hasBin: true
+    peerDependencies:
+      '@mdx-js/react': ^3.0.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@docusaurus/cssnano-preset@3.4.0':
     resolution: {integrity: sha512-qwLFSz6v/pZHy/UP32IrprmH5ORce86BGtN0eBtG75PpzQJAzp9gefspox+s8IEOr0oZKuQ/nhzZ3xwyc3jYJQ==}
+    engines: {node: '>=18.0'}
+
+  '@docusaurus/cssnano-preset@3.5.2':
+    resolution: {integrity: sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==}
     engines: {node: '>=18.0'}
 
   '@docusaurus/logger@3.4.0':
     resolution: {integrity: sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==}
     engines: {node: '>=18.0'}
 
+  '@docusaurus/logger@3.5.2':
+    resolution: {integrity: sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==}
+    engines: {node: '>=18.0'}
+
   '@docusaurus/mdx-loader@3.4.0':
     resolution: {integrity: sha512-kSSbrrk4nTjf4d+wtBA9H+FGauf2gCax89kV8SUSJu3qaTdSIKdWERlngsiHaCFgZ7laTJ8a67UFf+xlFPtuTw==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@docusaurus/mdx-loader@3.5.2':
+    resolution: {integrity: sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
@@ -3326,10 +3353,24 @@ packages:
       react: '*'
       react-dom: '*'
 
+  '@docusaurus/module-type-aliases@3.5.2':
+    resolution: {integrity: sha512-Z+Xu3+2rvKef/YKTMxZHsEXp1y92ac0ngjDiExRdqGTmEKtCUpkbNYH8v5eXo5Ls+dnW88n6WTa+Q54kLOkwPg==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
   '@docusaurus/plugin-content-blog@3.4.0':
     resolution: {integrity: sha512-vv6ZAj78ibR5Jh7XBUT4ndIjmlAxkijM3Sx5MAAzC1gyv0vupDQNhzuFg1USQmQVj3P5I6bquk12etPV3LJ+Xw==}
     engines: {node: '>=18.0'}
     peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@docusaurus/plugin-content-blog@3.5.2':
+    resolution: {integrity: sha512-R7ghWnMvjSf+aeNDH0K4fjyQnt5L0KzUEnUhmf1e3jZrv3wogeytZNN6n7X8yHcMsuZHPOrctQhXWnmxu+IRRg==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/plugin-content-docs': '*'
       react: ^18.0.0
       react-dom: ^18.0.0
 
@@ -3340,8 +3381,22 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@docusaurus/plugin-content-docs@3.5.2':
+    resolution: {integrity: sha512-Bt+OXn/CPtVqM3Di44vHjE7rPCEsRCB/DMo2qoOuozB9f7+lsdrHvD0QCHdBs0uhz6deYJDppAr2VgqybKPlVQ==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@docusaurus/plugin-content-pages@3.4.0':
     resolution: {integrity: sha512-h2+VN/0JjpR8fIkDEAoadNjfR3oLzB+v1qSXbIAKjQ46JAHx3X22n9nqS+BWSQnTnp1AjkjSvZyJMekmcwxzxg==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@docusaurus/plugin-content-pages@3.5.2':
+    resolution: {integrity: sha512-WzhHjNpoQAUz/ueO10cnundRz+VUtkjFhhaQ9jApyv1a46FPURO4cef89pyNIOMny1fjDz/NUN2z6Yi+5WUrCw==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0
@@ -3401,10 +3456,25 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@docusaurus/theme-classic@3.5.2':
+    resolution: {integrity: sha512-XRpinSix3NBv95Rk7xeMF9k4safMkwnpSgThn0UNQNumKvmcIYjfkwfh2BhwYh/BxMXQHJ/PdmNh22TQFpIaYg==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@docusaurus/theme-common@3.4.0':
     resolution: {integrity: sha512-0A27alXuv7ZdCg28oPE8nH/Iz73/IUejVaCazqu9elS4ypjiLhK3KfzdSQBnL/g7YfHSlymZKdiOHEo8fJ0qMA==}
     engines: {node: '>=18.0'}
     peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@docusaurus/theme-common@3.5.2':
+    resolution: {integrity: sha512-QXqlm9S6x9Ibwjs7I2yEDgsCocp708DrCrgHgKwg2n2AY0YQ6IjU0gAK35lHRLOvAoJUfCKpQAwUykB0R7+Eew==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/plugin-content-docs': '*'
       react: ^18.0.0
       react-dom: ^18.0.0
 
@@ -3419,11 +3489,21 @@ packages:
     resolution: {integrity: sha512-zSxCSpmQCCdQU5Q4CnX/ID8CSUUI3fvmq4hU/GNP/XoAWtXo9SAVnM3TzpU8Gb//H3WCsT8mJcTfyOk3d9ftNg==}
     engines: {node: '>=18.0'}
 
+  '@docusaurus/theme-translations@3.5.2':
+    resolution: {integrity: sha512-GPZLcu4aT1EmqSTmbdpVrDENGR2yObFEX8ssEFYTCiAIVc0EihNSdOIBTazUvgNqwvnoU1A8vIs1xyzc3LITTw==}
+    engines: {node: '>=18.0'}
+
   '@docusaurus/tsconfig@3.4.0':
     resolution: {integrity: sha512-0qENiJ+TRaeTzcg4olrnh0BQ7eCxTgbYWBnWUeQDc84UYkt/T3pDNnm3SiQkqPb+YQ1qtYFlC0RriAElclo8Dg==}
 
   '@docusaurus/types@3.4.0':
     resolution: {integrity: sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@docusaurus/types@3.5.2':
+    resolution: {integrity: sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
@@ -3437,12 +3517,34 @@ packages:
       '@docusaurus/types':
         optional: true
 
+  '@docusaurus/utils-common@3.5.2':
+    resolution: {integrity: sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/types': '*'
+    peerDependenciesMeta:
+      '@docusaurus/types':
+        optional: true
+
   '@docusaurus/utils-validation@3.4.0':
     resolution: {integrity: sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==}
     engines: {node: '>=18.0'}
 
+  '@docusaurus/utils-validation@3.5.2':
+    resolution: {integrity: sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==}
+    engines: {node: '>=18.0'}
+
   '@docusaurus/utils@3.4.0':
     resolution: {integrity: sha512-fRwnu3L3nnWaXOgs88BVBmG1yGjcQqZNHG+vInhEa2Sz2oQB+ZjbEMO5Rh9ePFpZ0YDiDUhpaVjwmS+AU2F14g==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/types': '*'
+    peerDependenciesMeta:
+      '@docusaurus/types':
+        optional: true
+
+  '@docusaurus/utils@3.5.2':
+    resolution: {integrity: sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==}
     engines: {node: '>=18.0'}
     peerDependencies:
       '@docusaurus/types': '*'
@@ -10708,6 +10810,10 @@ packages:
     resolution: {integrity: sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==}
     engines: {node: '>=12'}
 
+  infima@0.2.0-alpha.44:
+    resolution: {integrity: sha512-tuRkUSO/lB3rEhLJk25atwAjgLuzq070+pOW8XcvpHky/YbENnRRdPd85IBkyeTgttmOy5ah+yHYsK1HhUd4lQ==}
+    engines: {node: '>=12'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -17458,7 +17564,7 @@ snapshots:
     dependencies:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -17797,7 +17903,7 @@ snapshots:
 
   '@babel/plugin-transform-class-properties@7.24.7':
     dependencies:
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -17821,9 +17927,9 @@ snapshots:
 
   '@babel/plugin-transform-class-static-block@7.24.7':
     dependencies:
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.8)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -18228,7 +18334,7 @@ snapshots:
 
   '@babel/plugin-transform-private-methods@7.24.7':
     dependencies:
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -18253,9 +18359,9 @@ snapshots:
   '@babel/plugin-transform-private-property-in-object@7.24.7':
     dependencies:
       '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.8)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -18393,6 +18499,18 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.7)
       babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.7)
       babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-runtime@7.24.7(@babel/core@7.24.8)':
+    dependencies:
+      '@babel/core': 7.24.8
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.8)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.8)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.8)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -18535,81 +18653,81 @@ snapshots:
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-validator-option': 7.24.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.8)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.8)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.8)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.8)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.8)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.8)
-      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.7)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.7)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-class-properties': 7.24.7
       '@babel/plugin-transform-class-static-block': 7.24.7
-      '@babel/plugin-transform-classes': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-destructuring': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-classes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-destructuring': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-modules-amd': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-modules-systemjs': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-modules-umd': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-private-methods': 7.24.7
       '@babel/plugin-transform-private-property-in-object': 7.24.7
-      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-typeof-symbol': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.8)
-      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.8)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.8)
-      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.8)
+      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-typeof-symbol': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.7)
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.7)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.7)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.7)
       core-js-compat: 3.37.1
       semver: 6.3.1
     transitivePeerDependencies:
@@ -19362,7 +19480,106 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
+  '@docusaurus/core@3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)':
+    dependencies:
+      '@babel/core': 7.24.8
+      '@babel/generator': 7.24.8
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.8)
+      '@babel/plugin-transform-runtime': 7.24.7(@babel/core@7.24.8)
+      '@babel/preset-env': 7.24.7(@babel/core@7.24.8)
+      '@babel/preset-react': 7.24.7(@babel/core@7.24.8)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.8)
+      '@babel/runtime': 7.24.7
+      '@babel/runtime-corejs3': 7.24.7
+      '@babel/traverse': 7.24.8
+      '@docusaurus/cssnano-preset': 3.5.2
+      '@docusaurus/logger': 3.5.2
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@mdx-js/react': 3.0.1(@types/react@18.3.3)(react@18.3.1)
+      autoprefixer: 10.4.19(postcss@8.4.39)
+      babel-loader: 9.1.3(@babel/core@7.24.8)(webpack@5.92.0(@swc/core@1.5.29))
+      babel-plugin-dynamic-import-node: 2.3.3
+      boxen: 6.2.1
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      clean-css: 5.3.3
+      cli-table3: 0.6.5
+      combine-promises: 1.2.0
+      commander: 5.1.0
+      copy-webpack-plugin: 11.0.0(webpack@5.92.0(@swc/core@1.5.29))
+      core-js: 3.37.1
+      css-loader: 6.11.0(webpack@5.92.0(@swc/core@1.5.29))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.92.0(@swc/core@1.5.29))
+      cssnano: 6.1.2(postcss@8.4.39)
+      del: 6.1.1
+      detect-port: 1.6.1
+      escape-html: 1.0.3
+      eta: 2.2.0
+      eval: 0.1.8
+      file-loader: 6.2.0(webpack@5.92.0(@swc/core@1.5.29))
+      fs-extra: 11.2.0
+      html-minifier-terser: 7.2.0
+      html-tags: 3.3.1
+      html-webpack-plugin: 5.6.0(webpack@5.92.0(@swc/core@1.5.29))
+      leven: 3.1.0
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.9.0(webpack@5.92.0(@swc/core@1.5.29))
+      p-map: 4.0.0
+      postcss: 8.4.39
+      postcss-loader: 7.3.4(postcss@8.4.39)(typescript@5.5.2)(webpack@5.92.0(@swc/core@1.5.29))
+      prompts: 2.4.2
+      react: 18.3.1
+      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.5.2)(vue-template-compiler@2.7.16)(webpack@5.92.0(@swc/core@1.5.29))
+      react-dom: 18.3.1(react@18.3.1)
+      react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.92.0(@swc/core@1.5.29))
+      react-router: 5.3.4(react@18.3.1)
+      react-router-config: 5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1)
+      react-router-dom: 5.3.4(react@18.3.1)
+      rtl-detect: 1.1.2
+      semver: 7.6.3
+      serve-handler: 6.1.5
+      shelljs: 0.8.5
+      terser-webpack-plugin: 5.3.10(@swc/core@1.5.29)(webpack@5.92.0(@swc/core@1.5.29))
+      tslib: 2.6.3
+      update-notifier: 6.0.2
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.92.0(@swc/core@1.5.29)))(webpack@5.92.0(@swc/core@1.5.29))
+      webpack: 5.92.0(@swc/core@1.5.29)
+      webpack-bundle-analyzer: 4.10.2
+      webpack-dev-server: 4.15.2(webpack@5.92.0(@swc/core@1.5.29))
+      webpack-merge: 5.10.0
+      webpackbar: 5.0.2(webpack@5.92.0(@swc/core@1.5.29))
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+
   '@docusaurus/cssnano-preset@3.4.0':
+    dependencies:
+      cssnano-preset-advanced: 6.1.2(postcss@8.4.39)
+      postcss: 8.4.39
+      postcss-sort-media-queries: 5.2.0(postcss@8.4.39)
+      tslib: 2.6.3
+
+  '@docusaurus/cssnano-preset@3.5.2':
     dependencies:
       cssnano-preset-advanced: 6.1.2(postcss@8.4.39)
       postcss: 8.4.39
@@ -19374,11 +19591,53 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.6.3
 
+  '@docusaurus/logger@3.5.2':
+    dependencies:
+      chalk: 4.1.2
+      tslib: 2.6.3
+
   '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)':
     dependencies:
       '@docusaurus/logger': 3.4.0
       '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
       '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@mdx-js/mdx': 3.0.1
+      '@slorber/remark-comment': 1.0.0
+      escape-html: 1.0.3
+      estree-util-value-to-estree: 3.1.1
+      file-loader: 6.2.0(webpack@5.92.0(@swc/core@1.5.29))
+      fs-extra: 11.2.0
+      image-size: 1.1.1
+      mdast-util-mdx: 3.0.0
+      mdast-util-to-string: 4.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      rehype-raw: 7.0.0
+      remark-directive: 3.0.0
+      remark-emoji: 4.0.1
+      remark-frontmatter: 5.0.0
+      remark-gfm: 4.0.0
+      stringify-object: 3.3.0
+      tslib: 2.6.3
+      unified: 11.0.4
+      unist-util-visit: 5.0.0
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.92.0(@swc/core@1.5.29)))(webpack@5.92.0(@swc/core@1.5.29))
+      vfile: 6.0.1
+      webpack: 5.92.0(@swc/core@1.5.29)
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - typescript
+      - uglify-js
+      - webpack-cli
+
+  '@docusaurus/mdx-loader@3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)':
+    dependencies:
+      '@docusaurus/logger': 3.5.2
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
       '@mdx-js/mdx': 3.0.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -19429,6 +19688,24 @@ snapshots:
       - uglify-js
       - webpack-cli
 
+  '@docusaurus/module-type-aliases@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@docusaurus/types': 3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/history': 4.7.11
+      '@types/react': 18.3.3
+      '@types/react-router-config': 5.0.11
+      '@types/react-router-dom': 5.3.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-helmet-async: 2.0.5(react@18.3.1)
+      react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - uglify-js
+      - webpack-cli
+
   '@docusaurus/plugin-content-blog@3.4.0(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)':
     dependencies:
       '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
@@ -19451,6 +19728,48 @@ snapshots:
       utility-types: 3.11.0
       webpack: 5.92.0(@swc/core@1.5.29)
     transitivePeerDependencies:
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+
+  '@docusaurus/plugin-content-blog@3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16))(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)':
+    dependencies:
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
+      '@docusaurus/logger': 3.5.2
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16))(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
+      '@docusaurus/types': 3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      cheerio: 1.0.0-rc.12
+      feed: 4.2.2
+      fs-extra: 11.2.0
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reading-time: 1.5.0
+      srcset: 4.0.0
+      tslib: 2.6.3
+      unist-util-visit: 5.0.0
+      utility-types: 3.11.0
+      webpack: 5.92.0(@swc/core@1.5.29)
+    transitivePeerDependencies:
+      - '@mdx-js/react'
       - '@parcel/css'
       - '@rspack/core'
       - '@swc/core'
@@ -19506,6 +19825,46 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
+  '@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)':
+    dependencies:
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
+      '@docusaurus/logger': 3.5.2
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
+      '@docusaurus/module-type-aliases': 3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16))(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
+      '@docusaurus/types': 3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@types/react-router-config': 5.0.11
+      combine-promises: 1.2.0
+      fs-extra: 11.2.0
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.6.3
+      utility-types: 3.11.0
+      webpack: 5.92.0(@swc/core@1.5.29)
+    transitivePeerDependencies:
+      - '@mdx-js/react'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+
   '@docusaurus/plugin-content-pages@3.4.0(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)':
     dependencies:
       '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
@@ -19519,6 +19878,37 @@ snapshots:
       tslib: 2.6.3
       webpack: 5.92.0(@swc/core@1.5.29)
     transitivePeerDependencies:
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+
+  '@docusaurus/plugin-content-pages@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)':
+    dependencies:
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
+      '@docusaurus/types': 3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      fs-extra: 11.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.6.3
+      webpack: 5.92.0(@swc/core@1.5.29)
+    transitivePeerDependencies:
+      - '@mdx-js/react'
       - '@parcel/css'
       - '@rspack/core'
       - '@swc/core'
@@ -19765,6 +20155,54 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
+  '@docusaurus/theme-classic@3.5.2(@swc/core@1.5.29)(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)':
+    dependencies:
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
+      '@docusaurus/module-type-aliases': 3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16))(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-pages': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16))(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
+      '@docusaurus/theme-translations': 3.5.2
+      '@docusaurus/types': 3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@mdx-js/react': 3.0.1(@types/react@18.3.3)(react@18.3.1)
+      clsx: 2.1.1
+      copy-text-to-clipboard: 3.2.0
+      infima: 0.2.0-alpha.44
+      lodash: 4.17.21
+      nprogress: 0.2.0
+      postcss: 8.4.39
+      prism-react-renderer: 2.3.1(react@18.3.1)
+      prismjs: 1.29.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router-dom: 5.3.4(react@18.3.1)
+      rtlcss: 4.1.1
+      tslib: 2.6.3
+      utility-types: 3.11.0
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@types/react'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+
   '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)':
     dependencies:
       '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
@@ -19801,6 +20239,32 @@ snapshots:
       - uglify-js
       - utf-8-validate
       - vue-template-compiler
+      - webpack-cli
+
+  '@docusaurus/theme-common@3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16))(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)':
+    dependencies:
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
+      '@docusaurus/module-type-aliases': 3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.2)(vue-template-compiler@2.7.16)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@types/history': 4.7.11
+      '@types/react': 18.3.3
+      '@types/react-router-config': 5.0.11
+      clsx: 2.1.1
+      parse-numeric-range: 1.3.0
+      prism-react-renderer: 2.3.1(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.6.3
+      utility-types: 3.11.0
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - typescript
+      - uglify-js
       - webpack-cli
 
   '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@4.23.3)(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.14.0)(typescript@5.5.2)(vue-template-compiler@2.7.16)':
@@ -19850,9 +20314,34 @@ snapshots:
       fs-extra: 11.2.0
       tslib: 2.6.3
 
+  '@docusaurus/theme-translations@3.5.2':
+    dependencies:
+      fs-extra: 11.2.0
+      tslib: 2.6.3
+
   '@docusaurus/tsconfig@3.4.0': {}
 
   '@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@mdx-js/mdx': 3.0.1
+      '@types/history': 4.7.11
+      '@types/react': 18.3.3
+      commander: 5.1.0
+      joi: 17.13.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      utility-types: 3.11.0
+      webpack: 5.92.0(@swc/core@1.5.29)
+      webpack-merge: 5.10.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - uglify-js
+      - webpack-cli
+
+  '@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@mdx-js/mdx': 3.0.1
       '@types/history': 4.7.11
@@ -19878,11 +20367,36 @@ snapshots:
     optionalDependencies:
       '@docusaurus/types': 3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
+  '@docusaurus/utils-common@3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      tslib: 2.6.3
+    optionalDependencies:
+      '@docusaurus/types': 3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
   '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)':
     dependencies:
       '@docusaurus/logger': 3.4.0
       '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      fs-extra: 11.2.0
+      joi: 17.13.1
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - typescript
+      - uglify-js
+      - webpack-cli
+
+  '@docusaurus/utils-validation@3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)':
+    dependencies:
+      '@docusaurus/logger': 3.5.2
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       fs-extra: 11.2.0
       joi: 17.13.1
       js-yaml: 4.1.0
@@ -19921,6 +20435,38 @@ snapshots:
       webpack: 5.92.0(@swc/core@1.5.29)
     optionalDependencies:
       '@docusaurus/types': 3.4.0(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - typescript
+      - uglify-js
+      - webpack-cli
+
+  '@docusaurus/utils@3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.5.2)':
+    dependencies:
+      '@docusaurus/logger': 3.5.2
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@svgr/webpack': 8.1.0(typescript@5.5.2)
+      escape-string-regexp: 4.0.0
+      file-loader: 6.2.0(webpack@5.92.0(@swc/core@1.5.29))
+      fs-extra: 11.2.0
+      github-slugger: 1.5.0
+      globby: 11.1.0
+      gray-matter: 4.0.3
+      jiti: 1.21.6
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      micromatch: 4.0.7
+      prompts: 2.4.2
+      resolve-pathname: 3.0.0
+      shelljs: 0.8.5
+      tslib: 2.6.3
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.92.0(@swc/core@1.5.29)))(webpack@5.92.0(@swc/core@1.5.29))
+      utility-types: 3.11.0
+      webpack: 5.92.0(@swc/core@1.5.29)
+    optionalDependencies:
+      '@docusaurus/types': 3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -25870,6 +26416,13 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.92.0(@swc/core@1.5.29)
 
+  babel-loader@9.1.3(@babel/core@7.24.8)(webpack@5.92.0(@swc/core@1.5.29)):
+    dependencies:
+      '@babel/core': 7.24.8
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.92.0(@swc/core@1.5.29)
+
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
       object.assign: 4.1.5
@@ -29786,6 +30339,8 @@ snapshots:
   indent-string@5.0.0: {}
 
   infima@0.2.0-alpha.43: {}
+
+  infima@0.2.0-alpha.44: {}
 
   inflight@1.0.6:
     dependencies:

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -18,6 +18,15 @@ type PackageType = 'examples' | 'packages'
  * Sorts, defaults and overrides keys as specified in the definitions below
  */
 
+/** While we strive to make everything ESM, we just accept that some packages aren’t ESM. */
+const NO_MODULE_PACKAGES = [
+  'scalar-api-client',
+  '@scalar/docusaurus',
+  '@scalar-examples/docusaurus',
+  '@scalar-examples/nestjs-api-reference-express',
+  '@scalar-examples/nestjs-api-reference-fastify',
+]
+
 /** List of keys to sort and format */
 const restrictedKeys = [
   'name',
@@ -72,10 +81,10 @@ async function formatPackage(filepath: string) {
 
   const data = JSON.parse(file)
 
-  if (data.type !== 'module') {
+  if (data.type !== 'module' && !NO_MODULE_PACKAGES.includes(data.name)) {
     printColor(
       'brightRed',
-      `Package ${data.name} must be an ESM module with "type"="module"`,
+      `Package ${data.name} must be an ECMAScript module with "type": "module"`,
     )
   }
   if (


### PR DESCRIPTION
The `format:packages` script showed a whole bunch of warnings and errors for missing npm scripts (mostly lint:check, lint:fix, types:check) and some packages not being ESM.

This PR fixes all of them.