### PR TITLE
chore: fix some linter warnings

### DIFF
--- a/examples/docusaurus/sidebars.ts
+++ b/examples/docusaurus/sidebars.ts
@@ -5,9 +5,9 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs'
  - create an ordered group of docs
  - render a sidebar for each doc of that group
  - provide next/previous navigation
-
+ 
  The sidebars can be generated from the filesystem, or explicitly defined here.
-
+ 
  Create as many sidebars as you want.
  */
 const sidebars: SidebarsConfig = {

--- a/packages/api-reference-editor/playground/main.ts
+++ b/packages/api-reference-editor/playground/main.ts
@@ -2,4 +2,4 @@ import { mountApiReferenceEditable } from '@/api-reference-editor'
 
 const el = document.getElementById('editor')
 
-const { mount } = mountApiReferenceEditable(el, {})
+mountApiReferenceEditable(el, {})

--- a/packages/api-reference/src/components/Content/Authentication/Authentication.stories.ts
+++ b/packages/api-reference/src/components/Content/Authentication/Authentication.stories.ts
@@ -44,7 +44,7 @@ export const NoAuthentication: Story = {
       },
       components: {
         securitySchemes: {
-          // @ts-expect error TODO
+          // @ts-expect-error TODO
           none: {},
         },
       },
@@ -63,7 +63,7 @@ export const BasicAuthentication: Story = {
       components: {
         securitySchemes: {
           basic: {
-            // @ts-expect error TODO
+            // @ts-expect-error TODO
             type: 'basic',
             description: 'Use HTTP **Basic** Auth.',
           },
@@ -162,10 +162,10 @@ export const MultipleMethods: Story = {
       },
       components: {
         securitySchemes: {
-          // @ts-expect error TODO
+          // @ts-expect-error TODO
           none: {},
           basic: {
-            // @ts-expect error TODO
+            // @ts-expect-error TODO
             type: 'basic',
             description: 'Use HTTP **Basic** Auth.',
           },
@@ -176,7 +176,7 @@ export const MultipleMethods: Story = {
           },
           oauth: {
             type: 'oauth2',
-            // @ts-expect error TODO
+            // @ts-expect-error TODO
             flow: 'accessCode',
             authorizationUrl: '',
             tokenUrl: '',

--- a/packages/api-reference/src/components/Content/Authentication/Authentication.stories.ts
+++ b/packages/api-reference/src/components/Content/Authentication/Authentication.stories.ts
@@ -44,7 +44,6 @@ export const NoAuthentication: Story = {
       },
       components: {
         securitySchemes: {
-          // @ts-expect-error TODO
           none: {},
         },
       },
@@ -63,7 +62,6 @@ export const BasicAuthentication: Story = {
       components: {
         securitySchemes: {
           basic: {
-            // @ts-expect-error TODO
             type: 'basic',
             description: 'Use HTTP **Basic** Auth.',
           },
@@ -162,10 +160,8 @@ export const MultipleMethods: Story = {
       },
       components: {
         securitySchemes: {
-          // @ts-expect-error TODO
           none: {},
           basic: {
-            // @ts-expect-error TODO
             type: 'basic',
             description: 'Use HTTP **Basic** Auth.',
           },
@@ -176,7 +172,6 @@ export const MultipleMethods: Story = {
           },
           oauth: {
             type: 'oauth2',
-            // @ts-expect-error TODO
             flow: 'accessCode',
             authorizationUrl: '',
             tokenUrl: '',

--- a/packages/api-reference/src/components/Content/Authentication/Authentication.stories.ts
+++ b/packages/api-reference/src/components/Content/Authentication/Authentication.stories.ts
@@ -44,7 +44,7 @@ export const NoAuthentication: Story = {
       },
       components: {
         securitySchemes: {
-          // @ts-ignore
+          // @ts-expect error TODO
           none: {},
         },
       },
@@ -63,7 +63,7 @@ export const BasicAuthentication: Story = {
       components: {
         securitySchemes: {
           basic: {
-            // @ts-ignore
+            // @ts-expect error TODO
             type: 'basic',
             description: 'Use HTTP **Basic** Auth.',
           },
@@ -162,10 +162,10 @@ export const MultipleMethods: Story = {
       },
       components: {
         securitySchemes: {
-          // @ts-ignore
+          // @ts-expect error TODO
           none: {},
           basic: {
-            // @ts-ignore
+            // @ts-expect error TODO
             type: 'basic',
             description: 'Use HTTP **Basic** Auth.',
           },
@@ -176,7 +176,7 @@ export const MultipleMethods: Story = {
           },
           oauth: {
             type: 'oauth2',
-            // @ts-ignore
+            // @ts-expect error TODO
             flow: 'accessCode',
             authorizationUrl: '',
             tokenUrl: '',

--- a/packages/api-reference/src/helpers/getExampleCode.test.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.test.ts
@@ -40,9 +40,9 @@ describe('getExampleCode', () => {
         method: 'POST',
         url: 'https://example.com',
       }),
-      // @ts-ignore
+      // @ts-expect error TODO
       'fantasy',
-      // @ts-ignore
+      // @ts-expect error TODO
       'blue',
     )
 

--- a/packages/api-reference/src/helpers/getExampleCode.test.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.test.ts
@@ -40,9 +40,9 @@ describe('getExampleCode', () => {
         method: 'POST',
         url: 'https://example.com',
       }),
-      // @ts-expect error TODO
+      // @ts-expect-error TODO
       'fantasy',
-      // @ts-expect error TODO
+      // @ts-expect-error TODO
       'blue',
     )
 

--- a/packages/api-reference/src/helpers/getExampleCode.test.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.test.ts
@@ -42,7 +42,6 @@ describe('getExampleCode', () => {
       }),
       // @ts-expect-error TODO
       'fantasy',
-      // @ts-expect-error TODO
       'blue',
     )
 

--- a/packages/api-reference/src/hooks/useReactiveSpec.test.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.test.ts
@@ -84,7 +84,7 @@ describe('useReactiveSpec', () => {
   }
 
   test('fetches JSON from an URL', async () => {
-    // @ts-expect error TODO
+    // @ts-expect-error TODO
     fetch.mockResolvedValue(createFetchResponse(basicSpecString))
 
     const { rawSpec } = useReactiveSpec({

--- a/packages/api-reference/src/hooks/useReactiveSpec.test.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.test.ts
@@ -84,7 +84,7 @@ describe('useReactiveSpec', () => {
   }
 
   test('fetches JSON from an URL', async () => {
-    // @ts-ignore
+    // @ts-expect error TODO
     fetch.mockResolvedValue(createFetchResponse(basicSpecString))
 
     const { rawSpec } = useReactiveSpec({

--- a/packages/api-reference/src/legacy/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-reference/src/legacy/helpers/getRequestFromAuthentication.test.ts
@@ -110,7 +110,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-ignore
+            // @ts-expect error TODO
             type: 'basic',
           },
         },
@@ -146,7 +146,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-ignore
+            // @ts-expect error TODO
             type: 'basic',
           },
         },
@@ -225,7 +225,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-ignore
+            // @ts-expect error TODO
             type: 'basic',
           },
         },
@@ -261,7 +261,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-ignore
+            // @ts-expect error TODO
             type: 'basic',
           },
         },
@@ -297,7 +297,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-ignore
+            // @ts-expect error TODO
             type: 'basic',
           },
         },
@@ -327,7 +327,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-ignore
+            // @ts-expect error TODO
             type: 'basic',
           },
         },
@@ -357,7 +357,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-ignore
+            // @ts-expect error TODO
             type: 'basic',
           },
         },
@@ -435,7 +435,7 @@ describe('getRequestFromAuthentication', () => {
           },
         },
         apiKey: {
-          // @ts-ignore
+          // @ts-expect error TODO
           token: null,
         },
       },

--- a/packages/api-reference/src/legacy/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-reference/src/legacy/helpers/getRequestFromAuthentication.test.ts
@@ -110,7 +110,6 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -146,7 +145,6 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -225,7 +223,6 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -261,7 +258,6 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -297,7 +293,6 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -327,7 +322,6 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -357,7 +351,6 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -435,7 +428,7 @@ describe('getRequestFromAuthentication', () => {
           },
         },
         apiKey: {
-          // @ts-expect-error TODO
+          // @ts-expect-error pass rubbish
           token: null,
         },
       },

--- a/packages/api-reference/src/legacy/helpers/getRequestFromAuthentication.test.ts
+++ b/packages/api-reference/src/legacy/helpers/getRequestFromAuthentication.test.ts
@@ -110,7 +110,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect error TODO
+            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -146,7 +146,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect error TODO
+            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -225,7 +225,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect error TODO
+            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -261,7 +261,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect error TODO
+            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -297,7 +297,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect error TODO
+            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -327,7 +327,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect error TODO
+            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -357,7 +357,7 @@ describe('getRequestFromAuthentication', () => {
         preferredSecurityScheme: 'basic',
         securitySchemes: {
           basic: {
-            // @ts-expect error TODO
+            // @ts-expect-error TODO
             type: 'basic',
           },
         },
@@ -435,7 +435,7 @@ describe('getRequestFromAuthentication', () => {
           },
         },
         apiKey: {
-          // @ts-expect error TODO
+          // @ts-expect-error TODO
           token: null,
         },
       },

--- a/packages/api-reference/src/legacy/helpers/normalizeHeaders.ts
+++ b/packages/api-reference/src/legacy/helpers/normalizeHeaders.ts
@@ -28,9 +28,9 @@ export const normalizeHeaders = (
     Object.entries(headers ?? {})
       .reverse() // Reverse to keep the last occurrence
       .filter(
-        ([key, _], index, arr) =>
+        ([key], index, arr) =>
           arr.findIndex(
-            ([k, __]) => normalizeHeaderName(k) === normalizeHeaderName(key),
+            ([k]) => normalizeHeaderName(k) === normalizeHeaderName(key),
           ) === index,
       )
       .reverse() // Reverse back to maintain original order

--- a/packages/echo-server/src/createEchoServer.test.ts
+++ b/packages/echo-server/src/createEchoServer.test.ts
@@ -6,7 +6,7 @@ const createEchoServerOnAnyPort = (): number => {
   const { listen } = createEchoServer()
   const instance = listen(0)
 
-  // @ts-ignore
+  // @ts-expect error TODO
   return Number(instance.address().port)
 }
 

--- a/packages/echo-server/src/createEchoServer.test.ts
+++ b/packages/echo-server/src/createEchoServer.test.ts
@@ -6,7 +6,7 @@ const createEchoServerOnAnyPort = (): number => {
   const { listen } = createEchoServer()
   const instance = listen(0)
 
-  // @ts-expect error TODO
+  // @ts-expect-error TODO
   return Number(instance.address().port)
 }
 

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -1,4 +1,6 @@
-import FastifyBasicAuth, { FastifyBasicAuthOptions } from '@fastify/basic-auth'
+import FastifyBasicAuth, {
+  type FastifyBasicAuthOptions,
+} from '@fastify/basic-auth'
 import Fastify from 'fastify'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/mock-server/tests/galaxy.test.ts
+++ b/packages/mock-server/tests/galaxy.test.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect error TODO
 import { describe, expect, it } from 'vitest'
 
 import galaxy from '../../galaxy/src/specifications/3.1.yaml?raw'

--- a/packages/mock-server/tests/galaxy.test.ts
+++ b/packages/mock-server/tests/galaxy.test.ts
@@ -1,4 +1,4 @@
-// @ts-expect error TODO
+// @ts-expect-error TODO
 import { describe, expect, it } from 'vitest'
 
 import galaxy from '../../galaxy/src/specifications/3.1.yaml?raw'

--- a/packages/nestjs-api-reference/src/nestJSApiReference.ts
+++ b/packages/nestjs-api-reference/src/nestJSApiReference.ts
@@ -1,7 +1,7 @@
 import type { ReferenceConfiguration } from '@scalar/api-reference'
 import type { Request, Response } from 'express'
-import { type FastifyRequest } from 'fastify'
-import { type ServerResponse } from 'http'
+import type { FastifyRequest } from 'fastify'
+import type { ServerResponse } from 'http'
 
 export type NestJSReferenceConfiguration = ReferenceConfiguration & {
   withFastify?: boolean

--- a/packages/openapi-parser/src/utils/betterAjvErrors/helpers.ts
+++ b/packages/openapi-parser/src/utils/betterAjvErrors/helpers.ts
@@ -133,7 +133,7 @@ export function createErrorInstances(root, options) {
 
 export default function prettify(ajvErrors, options) {
   const tree = makeTree(ajvErrors || [])
-  // @ts-ignore
+  // @ts-expect error TODO
   filterRedundantErrors(tree)
   return createErrorInstances(tree, options)
 }

--- a/packages/openapi-parser/src/utils/betterAjvErrors/helpers.ts
+++ b/packages/openapi-parser/src/utils/betterAjvErrors/helpers.ts
@@ -133,7 +133,7 @@ export function createErrorInstances(root, options) {
 
 export default function prettify(ajvErrors, options) {
   const tree = makeTree(ajvErrors || [])
-  // @ts-expect error TODO
+  // @ts-expect-error TODO
   filterRedundantErrors(tree)
   return createErrorInstances(tree, options)
 }

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/internalPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/internalPathItemRef.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, it } from 'vitest'
 
 import { validate } from '../../../../src'
 import internalPathItemRef from './internalPathItemRef.yaml?raw'
 
-describe('internalPathItemRef', () => {
+describe.todo('internalPathItemRef', () => {
   it('returns an error', async () => {
-    const result = await validate(internalPathItemRef)
+    await validate(internalPathItemRef)
 
     // expect(result.errors?.[0]?.message).toBe(`Can’t resolve URI: #/paths/test2`)
     // expect(result.errors?.length).toBe(1)

--- a/packages/ts-to-openapi/src/js-doc.ts
+++ b/packages/ts-to-openapi/src/js-doc.ts
@@ -1,4 +1,4 @@
-import { type JSDoc, type Node, getAllJSDocTags } from 'typescript'
+import type { JSDoc, Node } from 'typescript'
 
 /**
  * Extract items from jsDoc comments


### PR DESCRIPTION
This PR fixes just some linter warnings:

* ESLint fixes some things automatically
* replaced @ts-ignore with @ts-expect-error
* deleted some dead imports/variables