### PR TITLE
fix(api-reference): placeholders in the license header not replaced

### DIFF
--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -11,7 +11,7 @@ import { name, version } from './package.json'
 
 function replaceVariables(template: string, variables: Record<string, string>) {
   return Object.entries(variables).reduce((content, [key, value]) => {
-    return content.replace(new RegExp(`\\$\\{${key}\\}`, 'g'), value)
+    return content.replace(new RegExp(`\\{\\{ ${key} \\}\\}`, 'g'), value)
   }, template)
 }
 


### PR DESCRIPTION
**Problem**
While playing around with #2918, I found that the placeholders in [the license header](https://github.com/scalar/scalar/blob/main/packages/api-reference/license-banner-template.txt) were not correctly replaced.

**Solution**
This PR fixes the regular expressions to match the placeholder's format.
