### PR TITLE
feat(api-client): address bar http methods

### DIFF
--- a/packages/api-client/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/api-client/src/components/HttpMethod/HttpMethod.vue
@@ -22,6 +22,7 @@ const method = computed(() => getHttpMethodInfo(props.method))
 const methodOptions = Object.entries(REQUEST_METHODS).map(([id]) => ({
   id: id as RequestMethod,
   label: id.charAt(0) + id.toLowerCase().slice(1),
+  color: getHttpMethodInfo(id).color,
 }))
 const selectedMethod = computed({
   get: () => methodOptions.find(({ id }) => id === props.method),
@@ -49,6 +50,7 @@ const httpLabel = computed(() => method.value.short)
   <ScalarListbox
     v-if="isEditable"
     v-model="selectedMethod"
+    class="mt-1 font-code uppercase"
     :options="methodOptions">
     <div
       class="h-full"

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -97,9 +97,11 @@ const variants = cva({
                   icon="Checkmark"
                   thickness="2.5" />
               </div>
-              <span class="inline-block min-w-0 flex-1 truncate text-c-1">{{
-                option.label
-              }}</span>
+              <span
+                class="inline-block min-w-0 flex-1 truncate"
+                :class="option.color ? option.color : 'text-c-1'">
+                {{ option.label }}
+              </span>
             </li>
           </ListboxOption>
           <div

--- a/packages/oas-utils/src/helpers/httpMethods.ts
+++ b/packages/oas-utils/src/helpers/httpMethods.ts
@@ -1,5 +1,9 @@
 import type { RequestMethod } from '@/entities/spec/requests'
 
+/**
+ * HTTP methods in a specific order
+ * Do not change the order
+ */
 export const REQUEST_METHODS: {
   [x in RequestMethod]: {
     short: string
@@ -7,35 +11,10 @@ export const REQUEST_METHODS: {
     backgroundColor: string
   }
 } = {
-  connect: {
-    short: 'CONN',
-    color: 'text-c-2',
-    backgroundColor: 'bg-c-2',
-  },
-  delete: {
-    short: 'DEL',
-    color: 'text-red',
-    backgroundColor: 'bg-red',
-  },
   get: {
     short: 'GET',
     color: 'text-blue',
     backgroundColor: 'bg-blue',
-  },
-  head: {
-    short: 'HEAD',
-    color: 'text-scalar-c-2',
-    backgroundColor: 'bg-c-2',
-  },
-  options: {
-    short: 'OPTS',
-    color: 'text-purple',
-    backgroundColor: 'bg-purple',
-  },
-  patch: {
-    short: 'PATCH',
-    color: 'text-yellow',
-    backgroundColor: 'bg-yellow',
   },
   post: {
     short: 'POST',
@@ -46,6 +25,31 @@ export const REQUEST_METHODS: {
     short: 'PUT',
     color: 'text-orange',
     backgroundColor: 'bg-orange',
+  },
+  patch: {
+    short: 'PATCH',
+    color: 'text-yellow',
+    backgroundColor: 'bg-yellow',
+  },
+  delete: {
+    short: 'DEL',
+    color: 'text-red',
+    backgroundColor: 'bg-red',
+  },
+  options: {
+    short: 'OPTS',
+    color: 'text-purple',
+    backgroundColor: 'bg-purple',
+  },
+  head: {
+    short: 'HEAD',
+    color: 'text-scalar-c-2',
+    backgroundColor: 'bg-c-2',
+  },
+  connect: {
+    short: 'CONN',
+    color: 'text-c-2',
+    backgroundColor: 'bg-c-2',
   },
   trace: {
     short: 'TRACE',


### PR DESCRIPTION
this pr updates http methods style and ordering in the address bar:

**before**
<img width="892" alt="image" src="https://github.com/user-attachments/assets/094be912-bddb-4e48-8e48-de75e20812a0">

**after**
<img width="892" alt="image" src="https://github.com/user-attachments/assets/7d2aa15c-be06-4a77-8c93-301796e6763c">
