### PR TITLE
feat(void-server): query parameter arrays

### DIFF
--- a/.changeset/five-ways-argue.md
+++ b/.changeset/five-ways-argue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+feat: query parameter arrays

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -63,6 +63,16 @@ describe('createVoidServer', () => {
     })
   })
 
+  it('returns the query string', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/?foo=bar&foo=bar')
+
+    expect(await response.json()).toMatchObject({
+      queryString: '?foo=bar&foo=bar',
+    })
+  })
+
   it('returns the JSON body', async () => {
     const server = await createVoidServer()
 

--- a/packages/void-server/src/createVoidServer.test.ts
+++ b/packages/void-server/src/createVoidServer.test.ts
@@ -63,13 +63,16 @@ describe('createVoidServer', () => {
     })
   })
 
-  it('returns the query string', async () => {
+  it('deals with array query parameters', async () => {
     const server = await createVoidServer()
 
-    const response = await server.request('/?foo=bar&foo=bar')
+    const response = await server.request('/?foo=foo&foo=bar&example=value')
 
     expect(await response.json()).toMatchObject({
-      queryString: '?foo=bar&foo=bar',
+      query: {
+        foo: ['foo', 'bar'],
+        example: 'value',
+      },
     })
   })
 

--- a/packages/void-server/src/utils/getRequestData.ts
+++ b/packages/void-server/src/utils/getRequestData.ts
@@ -43,6 +43,10 @@ export async function getRequestData(c: Context) {
 
   const cookies = getCookie(c)
 
+  const url = new URL(c.req.url)
+
+  const queryString = url.search
+
   return {
     method: c.req.method,
     path: c.req.path,
@@ -50,6 +54,7 @@ export async function getRequestData(c: Context) {
     ...authentication,
     cookies,
     query: c.req.query(),
+    queryString,
     body: body,
   }
 }

--- a/packages/void-server/src/utils/getRequestData.ts
+++ b/packages/void-server/src/utils/getRequestData.ts
@@ -43,9 +43,18 @@ export async function getRequestData(c: Context) {
 
   const cookies = getCookie(c)
 
-  const url = new URL(c.req.url)
+  // Get all query parameters as array
+  const query: Record<string, string | string[] | undefined> = c.req.queries()
 
-  const queryString = url.search
+  // Some query parameters are arrays, some are single values.
+  Object.keys(query).forEach((key) => {
+    query[key] =
+      query?.[key] && query?.[key]?.length > 1
+        ? // Array
+          query[key]
+        : // Single value
+          c.req.query(key)
+  })
 
   return {
     method: c.req.method,
@@ -53,8 +62,7 @@ export async function getRequestData(c: Context) {
     headers,
     ...authentication,
     cookies,
-    query: c.req.query(),
-    queryString,
+    query,
     body: body,
   }
 }


### PR DESCRIPTION
I was reviewing #3055 and noticed `@scalar/void-server` only returns the first value for query parameter arrays.

This PR adds support for arrays:

**Request**
```bash
GET /?foo=foo&foo=bar&example=value
```

**Response**
```js
{
    query: {
      foo: ['foo', 'bar'],
      example: 'value',
    },
  }
```