### PR TITLE
fix(api-client): duplicated path in send requests

### DIFF
--- a/.changeset/fair-snakes-hear.md
+++ b/.changeset/fair-snakes-hear.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: send request duplicated path

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -340,8 +340,11 @@ export const createRequestOperation = <ResponseDataType = unknown>({
 
           /** Finally we combine the two but make sure that we keep the path from server */
           const combinedURL = new URL(serverURL)
-          if (serverURL.pathname === '/') combinedURL.pathname = pathString
-          else combinedURL.pathname = serverURL.pathname + pathString
+          if (serverURL.pathname === '/') {
+            combinedURL.pathname = pathURL.pathname
+          } else {
+            combinedURL.pathname = serverURL.pathname
+          }
 
           // Combines all query params
           combinedURL.search = new URLSearchParams([


### PR DESCRIPTION
this pr is a first attempt regarding the duplicated path in send request function as seen below:

**before**
<img width="559" alt="image" src="https://github.com/user-attachments/assets/3691c407-c12a-43d2-9c3a-8e939a1afab8">

**after**
<img width="559" alt="image" src="https://github.com/user-attachments/assets/eec48d7c-e483-4d48-8f68-5b44c51480f9">
