### PR TITLE
feat(api-client): style context bar revert

### DIFF
--- a/.changeset/wild-timers-design.md
+++ b/.changeset/wild-timers-design.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+style: sets context bar back to previous position

--- a/packages/api-client/src/components/ContextBar.vue
+++ b/packages/api-client/src/components/ContextBar.vue
@@ -10,13 +10,13 @@ defineEmits<{
 </script>
 <template>
   <div
-    class="fade-request-section-content sticky top-0 z-10 pointer-events-none pr-1">
+    class="fade-request-section-content sticky top-0 z-10 pointer-events-none">
     <div
-      class="request-section-content request-section-content-filter bg-b-1 text-c-3 bg-b-1 hidden xl:flex justify-center rounded gap-[1px] pointer-events-auto">
+      class="request-section-content request-section-content-filter bg-b-1 border-1/2 text-c-3 bg-b-1 mb-2.5 hidden xl:flex justify-center rounded p-[1.5px] text-xs gap-[1.5px] pointer-events-auto">
       <button
         v-for="section in sections"
         :key="section"
-        class="hover:bg-b-2 w-full rounded px-1.5 py-1 text-center font-medium"
+        class="hover:bg-b-2 w-full rounded p-1 text-center font-medium"
         :class="[
           activeSection === section
             ? 'bg-b-2 text-c-1  pointer-events-none'

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -87,13 +87,13 @@ const updateRequestNameHandler = (event: Event) => {
           {{ activeRequest?.summary }}
         </span>
       </div>
+    </template>
+    <div
+      class="request-section-content custom-scroll flex flex-1 flex-col px-2 xl:px-5 py-2.5">
       <ContextBar
         :activeSection="activeSection"
         :sections="sections"
         @setActiveSection="activeSection = $event" />
-    </template>
-    <div
-      class="request-section-content custom-scroll flex flex-1 flex-col px-2 xl:px-5 py-2.5">
       <RequestAuth
         v-show="
           !isAuthHidden && (activeSection === 'All' || activeSection === 'Auth')

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -72,10 +72,6 @@ const activeSection = ref<ActiveSections>('All')
           v-if="response"
           :response="response" />
       </div>
-      <ContextBar
-        :activeSection="activeSection"
-        :sections="sections"
-        @setActiveSection="activeSection = $event" />
     </template>
     <div
       class="custom-scroll relative flex flex-1 flex-col px-2 xl:px-4 py-2.5">
@@ -83,6 +79,10 @@ const activeSection = ref<ActiveSections>('All')
         <ResponseEmpty />
       </template>
       <template v-else>
+        <ContextBar
+          :activeSection="activeSection"
+          :sections="sections"
+          @setActiveSection="activeSection = $event" />
         <ResponseCookies
           v-if="activeSection === 'All' || activeSection === 'Cookies'"
           :cookies="responseCookies" />

--- a/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
+++ b/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
@@ -34,7 +34,7 @@ const variants = cva({
   base: 'flex items-center rounded border bg-b-1 text-sm font-medium',
   variants: {
     sidebar: {
-      true: 'gap-1.5 p-1.5',
+      true: 'h-8 gap-1.5 px-1.5 ',
       false: 'h-10 p-3',
     },
   },


### PR DESCRIPTION
this pr sets context bar back to its previous position to maintain readability:

**before**
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/0cac5263-5964-46df-aa78-65022a5204e8">

**after** 
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/757db2e1-0623-4721-895a-568e84f56af8">
