### PR TITLE
fix(api-client): path regex helper

### DIFF
--- a/.changeset/early-geese-impress.md
+++ b/.changeset/early-geese-impress.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+fix: adds path regex helper

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -3,6 +3,7 @@ import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useWorkspace } from '@/store'
 import RequestTable from '@/views/Request/RequestSection/RequestTable.vue'
 import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import { pathRegex } from '@scalar/oas-utils/helpers'
 import { computed, watch } from 'vue'
 
 const props = defineProps<{
@@ -71,8 +72,7 @@ const setPathVariable = (url: string) => {
   if (!activeExample.value) return
 
   /** matching regex for nested curly braces {value} */
-  const pathVariables =
-    url.match(/{([^{}]+)}/g)?.map((v) => v.slice(1, -1)) || []
+  const pathVariables = url.match(pathRegex)?.map((v) => v.slice(1, -1)) || []
   const parameters = activeExample.value.parameters[props.paramKey]
 
   const paramMap = new Map(parameters.map((param) => [param.key, param]))

--- a/packages/oas-utils/src/helpers/regexHelpers.ts
+++ b/packages/oas-utils/src/helpers/regexHelpers.ts
@@ -1,1 +1,2 @@
 export const variableRegex = /{{((?:[^{}]|{[^{}]*})*)}}/g
+export const pathRegex = /(?<!{){([^{}]+)}(?!})/g


### PR DESCRIPTION
this pr fixes the current path variable regex that display also the request path table for environment variables by setting up a path regex helper.