### PR TITLE
fix(api-client): environment dropdown

### DIFF
--- a/packages/api-client/src/libs/environment-parser.ts
+++ b/packages/api-client/src/libs/environment-parser.ts
@@ -14,6 +14,6 @@ export function parseEnvVariables(
         // Skip invalid environment editor JSON entries
       }
     }
-    return []
+    return [variable]
   })
 }

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -149,6 +149,7 @@ onMounted(setActiveEnvironment)
           <CodeInput
             v-if="activeEnvironmentID"
             class="pl-px pr-2 md:px-2 py-2.5"
+            language="json"
             lineNumbers
             :modelValue="environments[activeEnvironmentID].value"
             @update:modelValue="handleEnvironmentUpdate" />


### PR DESCRIPTION
this pr fixes the environment variable not being displayed in the dropdown + sets back the language to code input.

