### PR TITLE
feat(api-client): performance upgrades

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -45,6 +45,10 @@
       "import": "./dist/views/Request/libs/index.js",
       "types": "./dist/views/Request/libs/index.d.ts"
     },
+    "./views/Request/libs/event-busses": {
+      "import": "./dist/views/Request/libs/event-busses/index.js",
+      "types": "./dist/views/Request/libs/event-busses/index.d.ts"
+    },
     "./views/Request/consts": {
       "import": "./dist/views/Request/consts/index.js",
       "types": "./dist/views/Request/consts/index.d.ts"

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -6,6 +6,7 @@ import SidebarButton from '@/components/Sidebar/SidebarButton.vue'
 import { useSidebar } from '@/hooks'
 import { type HotKeyEvents, commandPaletteBus, hotKeyBus } from '@/libs'
 import { useWorkspace } from '@/store'
+import RequestSidebarItemMenu from '@/views/Request/RequestSidebarItemMenu.vue'
 import { dragHandlerFactory } from '@/views/Request/handle-drag'
 import {
   ScalarIcon,
@@ -13,7 +14,7 @@ import {
   ScalarSearchResultItem,
   ScalarSearchResultList,
 } from '@scalar/components'
-import { onBeforeUnmount, onMounted, watch } from 'vue'
+import { onBeforeMount, onBeforeUnmount, onMounted, watch } from 'vue'
 
 import RequestSidebarItem from './RequestSidebarItem.vue'
 import { WorkspaceDropdown } from './components'
@@ -34,6 +35,7 @@ const {
   activeRequest,
   activeWorkspaceRequests,
   findRequestParents,
+  isReadOnly,
 } = workspaceContext
 
 const { handleDragEnd, isDroppable } = dragHandlerFactory(workspaceContext)
@@ -80,8 +82,11 @@ const handleHotKey = (event: HotKeyEvents) => {
   }
 }
 
+onBeforeMount(() => console.time('sidebar'))
+
 onMounted(() => {
   hotKeyBus.on(handleHotKey)
+  setTimeout(() => console.timeEnd('sidebar'), 0)
 })
 
 /**
@@ -186,6 +191,9 @@ onBeforeUnmount(() => {
       </SidebarButton>
     </template>
   </Sidebar>
+
+  <!-- Menu -->
+  <RequestSidebarItemMenu v-if="!isReadOnly" />
 </template>
 <style scoped>
 .search-button-fade {

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -229,6 +229,7 @@ function openCommandPaletteRequest() {
   })
 }
 </script>
+
 <template>
   <div
     class="relative flex flex-row"

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -1,36 +1,24 @@
 <script setup lang="ts">
 import { HttpMethod } from '@/components/HttpMethod'
-import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
-import RenameSidebarListElement from '@/components/Sidebar/Actions/RenameSidebarListElement.vue'
 import { useSidebar } from '@/hooks'
 import { getModifiers } from '@/libs'
 import { commandPaletteBus } from '@/libs/event-busses'
 import { PathId } from '@/router'
 import { useWorkspace } from '@/store'
 import {
-  ScalarButton,
-  ScalarContextMenu,
-  ScalarIcon,
-  ScalarModal,
-  useModal,
-} from '@scalar/components'
+  type Item,
+  requestSidebarMenuBus,
+} from '@/views/Request/libs/event-busses'
+import { ScalarButton, ScalarIcon } from '@scalar/components'
 import {
   Draggable,
   type DraggableProps,
   type DraggingItem,
   type HoveredItem,
 } from '@scalar/draggable'
-import type {
-  Collection,
-  Request,
-  RequestExample,
-  RequestMethod,
-  Tag,
-} from '@scalar/oas-utils/entities/spec'
+import type { Request } from '@scalar/oas-utils/entities/spec'
 import { computed, ref } from 'vue'
-import { RouterLink, useRouter } from 'vue-router'
-
-import RequestSidebarItemMenu from './RequestSidebarItemMenu.vue'
+import { RouterLink } from 'vue-router'
 
 const props = withDefaults(
   defineProps<{
@@ -78,20 +66,7 @@ const {
   requestExampleMutators,
   router,
 } = useWorkspace()
-const { replace } = useRouter()
 const { collapsedSidebarFolders, toggleSidebarFolder } = useSidebar()
-
-type Item = {
-  title: string
-  entity: Collection | Tag | Request | RequestExample
-  resourceTitle: string
-  children: string[]
-  method?: RequestMethod
-  link?: string
-  warning?: string
-  rename: () => void
-  delete: () => void
-}
 
 /** Normalize properties across different types for easy consumption */
 const item = computed<Item>(() => {
@@ -108,8 +83,8 @@ const item = computed<Item>(() => {
       children: collection.children,
       warning:
         'This cannot be undone. You’re about to delete the collection and all folders andrequests inside it.',
-      rename: () =>
-        collectionMutators.edit(collection.uid, 'info.title', tempName.value),
+      rename: (name: string) =>
+        collectionMutators.edit(collection.uid, 'info.title', name),
       delete: () =>
         collectionMutators.delete(collection, activeWorkspace.value),
     }
@@ -122,7 +97,7 @@ const item = computed<Item>(() => {
       children: tag.children,
       warning:
         'This cannot be undone. You’re about to delete the tag and all requests inside it',
-      rename: () => tagMutators.edit(tag.uid, 'name', tempName.value),
+      rename: (name: string) => tagMutators.edit(tag.uid, 'name', name),
       delete: () => tagMutators.delete(tag, props.parentUids[0]),
     }
 
@@ -135,8 +110,8 @@ const item = computed<Item>(() => {
       resourceTitle: 'Request',
       warning: 'This cannot be undone. You’re about to delete the request.',
       children: request.examples,
-      rename: () =>
-        requestMutators.edit(request.uid, 'summary', tempName.value),
+      rename: (name: string) =>
+        requestMutators.edit(request.uid, 'summary', name),
       delete: () => requestMutators.delete(request, props.parentUids[0]),
     }
 
@@ -147,8 +122,8 @@ const item = computed<Item>(() => {
     entity: requestExample,
     resourceTitle: 'Example',
     children: [],
-    rename: () =>
-      requestExampleMutators.edit(requestExample.uid, 'name', tempName.value),
+    rename: (name: string) =>
+      requestExampleMutators.edit(requestExample.uid, 'name', name),
     delete: () => requestExampleMutators.delete(requestExample),
   }
 })
@@ -234,32 +209,6 @@ const _isDroppable = (draggingItem: DraggingItem, hoveredItem: HoveredItem) => {
   return true
 }
 
-const tempName = ref('')
-const renameModal = useModal()
-const deleteModal = useModal()
-
-const handleItemRename = (newName: string) => {
-  tempName.value = newName
-  item.value.rename()
-  renameModal.hide()
-}
-
-const openRenameModal = () => {
-  tempName.value = item.value.title || ''
-  renameModal.show()
-}
-
-/** Delete with redirect for both requests and requestExamples */
-const handleItemDelete = () => {
-  item.value.delete()
-
-  if (activeRouterParams.value[PathId.Request] === props.uid)
-    replace(`/workspace/${activeWorkspace.value.uid}/request/default`)
-
-  if (activeRouterParams.value[PathId.Examples] === props.uid)
-    replace(`/workspace/${activeWorkspace.value}/request/default`)
-}
-
 const handleNavigation = (event: KeyboardEvent, _item: Item) => {
   if (event) {
     const modifier = getModifiers(['default'])
@@ -308,120 +257,112 @@ function openCommandPaletteRequest() {
         @click.prevent="
           (event: KeyboardEvent) => handleNavigation(event, item)
         ">
-        <ScalarContextMenu :disabled="isReadOnly">
-          <template #trigger>
-            <div
-              class="group relative flex min-h-8 cursor-pointer flex-row items-start justify-between gap-2 py-1.5 pr-2 rounded editable-sidebar-hover w-full"
-              :class="[
-                highlightClasses,
-                isExactActive || isDefaultActive
-                  ? 'bg-sidebar-active-b text-sidebar-active-c transition-none'
-                  : 'text-sidebar-c-2',
-              ]"
-              tabindex="0">
-              <span
-                class="line-clamp-3 z-10 font-medium w-full pl-2 word-break-break-word"
-                :class="{
-                  'editable-sidebar-hover-item': !isReadOnly,
-                }">
-                {{ item.title }}
-              </span>
-              <div class="flex flex-row gap-1 items-center">
-                <!-- Menu -->
-                <div class="relative">
-                  <RequestSidebarItemMenu
-                    v-if="!isReadOnly"
-                    :item="item.entity"
-                    :parentUids="parentUids"
-                    :resourceTitle="item.resourceTitle"
-                    @delete="deleteModal.show()"
-                    @rename="openRenameModal" />
-                </div>
-                <span class="flex items-start">
-                  &hairsp;
-                  <HttpMethod
-                    v-if="item.method"
-                    class="font-bold"
-                    :method="item.method" />
-                </span>
-              </div>
+        <div
+          class="group relative flex min-h-8 cursor-pointer flex-row items-start justify-between gap-2 py-1.5 pr-2 rounded editable-sidebar-hover w-full"
+          :class="[
+            highlightClasses,
+            isExactActive || isDefaultActive
+              ? 'bg-sidebar-active-b text-sidebar-active-c transition-none'
+              : 'text-sidebar-c-2',
+          ]"
+          tabindex="0">
+          <span
+            class="line-clamp-3 z-10 font-medium w-full pl-2 word-break-break-word"
+            :class="{
+              'editable-sidebar-hover-item': !isReadOnly,
+            }">
+            {{ item.title }}
+          </span>
+          <div class="flex flex-row gap-1 items-center">
+            <!-- Menu -->
+            <div class="relative">
+              <ScalarButton
+                v-if="!isReadOnly"
+                class="px-0.5 py-0 z-10 hover:bg-b-3 hidden group-hover:flex ui-open:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
+                size="sm"
+                type="button"
+                variant="ghost"
+                @click.stop.prevent="
+                  (ev) =>
+                    requestSidebarMenuBus.emit({
+                      item,
+                      parentUids,
+                      targetRef: ev.currentTarget,
+                    })
+                ">
+                <ScalarIcon
+                  icon="Ellipses"
+                  size="sm" />
+              </ScalarButton>
             </div>
-          </template>
-          <template #content>
-            <RequestSidebarItemMenu
-              :item="item.entity"
-              :parentUids="parentUids"
-              :resourceTitle="item.resourceTitle"
-              static
-              @delete="deleteModal.show()"
-              @rename="openRenameModal" />
-          </template>
-        </ScalarContextMenu>
+            <span class="flex items-start">
+              &hairsp;
+              <HttpMethod
+                v-if="item.method"
+                class="font-bold"
+                :method="item.method" />
+            </span>
+          </div>
+        </div>
       </RouterLink>
 
       <!-- Collection/Folder -->
-      <ScalarContextMenu
+      <button
         v-else-if="!isReadOnly || parentUids.length"
-        :disabled="isReadOnly || isDraftCollection">
-        >
-        <template #trigger>
-          <button
-            class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5 z-[1]"
-            :class="highlightClasses"
-            type="button"
-            @click="toggleSidebarFolder(item.entity.uid)">
-            <span
-              class="z-10 flex h-5 items-center justify-center max-w-[14px]">
-              <slot name="leftIcon">
-                <div
-                  :class="{
-                    'rotate-90': collapsedSidebarFolders[item.entity.uid],
-                  }">
-                  <ScalarIcon
-                    class="text-c-3 text-sm"
-                    icon="ChevronRight"
-                    size="sm"
-                    thickness="2.5" />
-                </div>
-              </slot>
-              &hairsp;
-            </span>
+        class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5 z-[1]"
+        :class="highlightClasses"
+        :disabled="isReadOnly"
+        type="button"
+        @click="toggleSidebarFolder(item.entity.uid)">
+        <span class="z-10 flex h-5 items-center justify-center max-w-[14px]">
+          <slot name="leftIcon">
             <div
-              class="flex flex-1 flex-row justify-between editable-sidebar-hover">
-              <span
-                class="line-clamp-3 z-10 font-medium text-left w-full word-break-break-word"
-                :class="{
-                  'editable-sidebar-hover-item': !isReadOnly,
-                }">
-                {{ item.title }}
-              </span>
-              <div class="relative flex h-fit">
-                <RequestSidebarItemMenu
-                  v-if="!isReadOnly && !isDraftCollection"
-                  :item="item.entity"
-                  :parentUids="parentUids"
-                  :resourceTitle="item.resourceTitle"
-                  @delete="deleteModal.show()"
-                  @rename="openRenameModal" />
-                <span>&hairsp;</span>
-              </div>
+              :class="{
+                'rotate-90': collapsedSidebarFolders[item.entity.uid],
+              }">
+              <ScalarIcon
+                class="text-c-3 text-sm"
+                icon="ChevronRight"
+                size="sm"
+                thickness="2.5" />
             </div>
-          </button>
-        </template>
-        <template #content>
-          <RequestSidebarItemMenu
-            v-if="!isReadOnly && !isDraftCollection"
-            :item="item.entity"
-            :parentUids="parentUids"
-            :resourceTitle="item.resourceTitle"
-            static
-            @delete="deleteModal.show()"
-            @rename="openRenameModal" />
-        </template>
-      </ScalarContextMenu>
+          </slot>
+          &hairsp;
+        </span>
+        <div
+          class="flex flex-1 flex-row justify-between editable-sidebar-hover">
+          <span
+            class="line-clamp-3 z-10 font-medium text-left w-full word-break-break-word"
+            :class="{
+              'editable-sidebar-hover-item': !isReadOnly,
+            }">
+            {{ item.title }}
+          </span>
+          <div class="relative flex h-fit">
+            <ScalarButton
+              v-if="!isReadOnly && !isDraftCollection"
+              class="px-0.5 py-0 z-10 hover:bg-b-3 hidden group-hover:flex ui-open:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
+              size="sm"
+              variant="ghost"
+              @click.stop.prevent="
+                (ev) =>
+                  requestSidebarMenuBus.emit({
+                    item,
+                    parentUids,
+                    targetRef: ev.currentTarget,
+                  })
+              ">
+              <ScalarIcon
+                icon="Ellipses"
+                size="sm" />
+            </ScalarButton>
+            <span>&hairsp;</span>
+          </div>
+        </div>
+      </button>
 
       <!-- Children -->
-      <div v-show="showChildren">
+      <div v-if="showChildren">
         <!-- We never want to show the first example -->
         <RequestSidebarItem
           v-for="childUid in item.children"
@@ -447,25 +388,6 @@ function openCommandPaletteRequest() {
       </div>
     </Draggable>
   </div>
-  <ScalarModal
-    :size="'xxs'"
-    :state="deleteModal"
-    :title="`Delete ${item.resourceTitle}`">
-    <DeleteSidebarListElement
-      :variableName="item.title"
-      :warningMessage="item.warning"
-      @close="deleteModal.hide()"
-      @delete="handleItemDelete" />
-  </ScalarModal>
-  <ScalarModal
-    :size="'xxs'"
-    :state="renameModal"
-    :title="`Rename ${item.resourceTitle}`">
-    <RenameSidebarListElement
-      :name="item.title"
-      @close="renameModal.hide()"
-      @rename="handleItemRename" />
-  </ScalarModal>
 </template>
 
 <style>

--- a/packages/api-client/src/views/Request/libs/event-busses/index.ts
+++ b/packages/api-client/src/views/Request/libs/event-busses/index.ts
@@ -1,0 +1,1 @@
+export * from './request-sidebar-menu-bus'

--- a/packages/api-client/src/views/Request/libs/event-busses/request-sidebar-menu-bus.ts
+++ b/packages/api-client/src/views/Request/libs/event-busses/request-sidebar-menu-bus.ts
@@ -1,0 +1,37 @@
+import type {
+  Collection,
+  Request,
+  RequestExample,
+  RequestMethod,
+  Tag,
+} from '@scalar/oas-utils/entities/spec'
+import { type EventBusKey, useEventBus } from '@vueuse/core'
+import type { Ref } from 'vue'
+
+export type Item = {
+  title: string
+  entity: Collection | Tag | Request | RequestExample
+  resourceTitle: string
+  children: string[]
+  method?: RequestMethod
+  link?: string
+  warning?: string
+  rename: (name: string) => void
+  delete: () => void
+}
+
+export type RequestSidebarMenuBusEvent = {
+  /** The resource which we are opening the menu for */
+  item: Item
+  /** Array of parentUids used when nesting in the sidemenu */
+  parentUids: string[]
+  /** Target ref from the button which triggered the menu for positioning */
+  targetRef: Ref<HTMLButtonElement>
+}
+const RequestSidebarMenuBusKey: EventBusKey<RequestSidebarMenuBusEvent> =
+  Symbol()
+
+/**
+ * Event bus for openening the sidebar menu
+ */
+export const requestSidebarMenuBus = useEventBus(RequestSidebarMenuBusKey)

--- a/packages/api-client/src/views/Request/libs/event-busses/request-sidebar-menu-bus.ts
+++ b/packages/api-client/src/views/Request/libs/event-busses/request-sidebar-menu-bus.ts
@@ -6,7 +6,6 @@ import type {
   Tag,
 } from '@scalar/oas-utils/entities/spec'
 import { type EventBusKey, useEventBus } from '@vueuse/core'
-import type { Ref } from 'vue'
 
 export type Item = {
   title: string
@@ -26,7 +25,7 @@ export type RequestSidebarMenuBusEvent = {
   /** Array of parentUids used when nesting in the sidemenu */
   parentUids: string[]
   /** Target ref from the button which triggered the menu for positioning */
-  targetRef: Ref<HTMLButtonElement>
+  targetRef: HTMLButtonElement
 }
 const RequestSidebarMenuBusKey: EventBusKey<RequestSidebarMenuBusEvent> =
   Symbol()

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -24,7 +24,7 @@ defineOptions({ inheritAttrs: false })
       :targetRef="targetRef"
       :teleport="teleport">
       <MenuButton
-        v-if="!static && !targetRef"
+        v-if="!static"
         as="template">
         <slot />
       </MenuButton>

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -21,9 +21,10 @@ defineOptions({ inheritAttrs: false })
       :isOpen="static ? staticOpen : open ?? isOpen"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
+      :targetRef="targetRef"
       :teleport="teleport">
       <MenuButton
-        v-if="!static"
+        v-if="!static && !targetRef"
         as="template">
         <slot />
       </MenuButton>

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -36,7 +36,11 @@ const wrapperRef: Ref<HTMLElement | null> = ref(null)
 
 /** Fallback to div wrapper if a button element is not provided */
 const targetRef = computed(
-  () => (wrapperRef.value?.children?.[0] || wrapperRef.value) ?? undefined,
+  () =>
+    (props.targetRef?.value ||
+      wrapperRef.value?.children?.[0] ||
+      wrapperRef.value) ??
+    undefined,
 )
 
 const targetSize = useResizeWithTarget(targetRef, {

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -37,9 +37,7 @@ const wrapperRef: Ref<HTMLElement | null> = ref(null)
 /** Fallback to div wrapper if a button element is not provided */
 const targetRef = computed(
   () =>
-    (props.targetRef?.value ||
-      wrapperRef.value?.children?.[0] ||
-      wrapperRef.value) ??
+    (props.targetRef || wrapperRef.value?.children?.[0] || wrapperRef.value) ??
     undefined,
 )
 

--- a/packages/components/src/components/ScalarFloating/types.ts
+++ b/packages/components/src/components/ScalarFloating/types.ts
@@ -1,4 +1,5 @@
 import type { Middleware, Placement } from '@floating-ui/vue'
+import type { Ref } from 'vue'
 
 export type FloatingOptions = {
   /**
@@ -11,6 +12,11 @@ export type FloatingOptions = {
    * If enabled it will set `width` slot prop of the floating slot
    */
   resize?: boolean
+  /**
+   * Override the targetRef, useful if we are not passing a button
+   * into the slot but is controlled from an external button
+   */
+  targetRef?: Ref<HTMLElement | null>
   /**
    * Floating UI Middleware to be passed to Floating UI
    * @see https://floating-ui.com/docs/computePosition#middleware

--- a/packages/components/src/components/ScalarFloating/types.ts
+++ b/packages/components/src/components/ScalarFloating/types.ts
@@ -16,7 +16,7 @@ export type FloatingOptions = {
    * Override the targetRef, useful if we are not passing a button
    * into the slot but is controlled from an external button
    */
-  targetRef?: Ref<HTMLElement | null>
+  targetRef?: HTMLElement
   /**
    * Floating UI Middleware to be passed to Floating UI
    * @see https://floating-ui.com/docs/computePosition#middleware


### PR DESCRIPTION
This improves the load time of the api-client by about 25x when looking at big specs. This was caused by the context menu + menu + modals in every instance of the sidebar items. We should aim to keep looping items as lean as we can!

Before:
`sidebar load time: 2629.917236328125 ms`

After:
`sidebar load time: 110.170166015625 ms`

@antlio I had to remove the context menu because I couldn't figure out how to pull it out of the `ReqeuestSidebarItem` and into the parent. Maybe you can help with that. 

TODO:

- [ ] accessibility/focus with arrow keys
- [ ] close menu when clicking anywhere
- [ ] Still need to figure out why the menu jumps (due to the button disapearing)
- [ ] switch the bus to a ref and use the menu button wrapper

![image](https://github.com/user-attachments/assets/594d0217-34af-417a-9d46-5a7c1e019fc3)


