### PR TITLE
fix(api-reference): search results scroll to wrong position

### DIFF
--- a/.changeset/stupid-bananas-begin.md
+++ b/.changeset/stupid-bananas-begin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: search results scroll to wrong position

--- a/packages/api-reference/src/features/Search/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/SearchModal.vue
@@ -66,14 +66,46 @@ const tagRegex = /#(tag\/[^/]*)/
 
 // Ensure we open the section
 function onSearchResultClick(entry: FuseResult<FuseData>) {
+  // Determine the parent ID for sidebar navigation
   let parentId = 'models'
   const tagMatch = entry.item.href.match(tagRegex)
 
   if (tagMatch?.length && tagMatch.length > 1) {
     parentId = tagMatch[1]
   }
+  // Expand the corresponding sidebar item
   setCollapsedSidebarItem(parentId, true)
-  props.modalState.hide()
+
+  // Extract the target ID from the href
+  const targetId = entry.item.href.replace('#', '')
+
+  let observer: MutationObserver | null = null
+
+  // Function to execute when the target element appears
+  const onElementAppears = () => {
+    window.location.href = getFullUrlFromHash(entry.item.href)
+    props.modalState.hide()
+    if (observer) {
+      observer.disconnect()
+    }
+  }
+
+  // Check if the target element already exists
+  if (document.getElementById(targetId)) {
+    onElementAppears()
+  } else {
+    // If not, set up an observer to wait for it
+    observer = new MutationObserver(() => {
+      if (document.getElementById(targetId)) {
+        onElementAppears()
+      }
+    })
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    })
+  }
 }
 
 // given just a #hash-name, we grab the full URL to be explicit to


### PR DESCRIPTION
**Problem**
when using search function inside of the references there is a race condition that causes the search to sometimes not jump to the correct endpoint the first time it is searched, highlighed in this [issue](https://github.com/scalar/scalar/issues/2741)

**Solution**
This PR changes the function `onSearchResultClick` inside of `SearchModal.vue` Now it uses a `MutationObserver` to wait until the target section is loaded in the DOM before navigating to it. This ensures that the docs scroll to the correct section right away when a user clicks a search result.
