### PR TITLE
fix(api-client): hide modal event

### DIFF
--- a/.changeset/silent-rats-bathe.md
+++ b/.changeset/silent-rats-bathe.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: hide modal event typo

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -109,7 +109,7 @@ onBeforeUnmount(() => executeRequestBus.off(executeRequest))
     <RequestSubpageHeader
       v-model="showSideBar"
       :isReadonly="activeWorkspace.isReadOnly"
-      @hideModel="() => modalState.hide()" />
+      @hideModal="() => modalState.hide()" />
     <ViewLayout>
       <RequestSidebar
         :isReadonly="activeWorkspace.isReadOnly"


### PR DESCRIPTION
this pr fixes a typo in the hide event modal in order to re-enable modal closing on button click from a reference.