### PR TITLE
fix(Scalar.AspNetCore): ForceThemeMode is null by default

### DIFF
--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -66,7 +66,7 @@ public sealed class ScalarOptions
     /// ForceDarkModeState makes it always this state no matter what <c>'dark' | 'light'</c>.
     /// </summary>
     /// <value>The default value is <c>null</c>.</value>
-    public ThemeMode? ForceThemeMode { get; set; } = ThemeMode.Light;
+    public ThemeMode? ForceThemeMode { get; set; }
 
     /// <summary>
     /// Whether to hide the dark mode toggle.


### PR DESCRIPTION
**Problem**
The `ForceThemeMode` property was set to `ThemeMode.Light` by default, which caused properties like `DarkMode` to have no effect.

**Solution**
The default value is now `null` as intended.

Closes #3156
