### PR TITLE
chore: Add Nuget to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
       interval: 'daily'
     # This will disable updates, but still create PRs for security updates.
     open-pull-requests-limit: 0
+  - package-ecosystem: 'nuget'
+    directory: '/packages/scalar.aspnetcore'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
### Description

This PR adds the NuGet package manager to the dependabot configuration. The `Scalar.AspNetCore` project itself has only one dependency, but the demo and test projects have some more. I think weekly updates are fine as the dependencies are not crucial.