### PR TITLE
fix(api-client):  add back content header

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -155,6 +155,7 @@
     "@types/js-cookie": "^3.0.6",
     "@types/whatwg-mimetype": "^3.0.2",
     "@vitejs/plugin-vue": "^5.0.4",
+    "@vue/test-utils": "^2.4.1",
     "autoprefixer": "^10.4.19",
     "jsdom": "^22.1.0",
     "postcss": "^8.4.38",

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -48,8 +48,14 @@ function createFetchHeaders(example: RequestExample, env: object) {
   const headers: NonNullable<RequestInit['headers']> = {}
 
   example.parameters.headers.forEach((h) => {
-    if (h.enabled)
-      headers[h.key.toLowerCase()] = replaceTemplateVariables(h.value, env)
+    const lowerCaseKey = h.key.toLowerCase()
+
+    // Ensure we remove the mutlipart/form-data header so fetch can properly set boundaries
+    if (
+      h.enabled &&
+      (lowerCaseKey !== 'content-type' || h.value !== 'multipart/form-data')
+    )
+      headers[lowerCaseKey] = replaceTemplateVariables(h.value, env)
   })
 
   return headers

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
@@ -1,0 +1,163 @@
+import { useWorkspace } from '@/store'
+import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import { mount } from '@vue/test-utils'
+import {
+  type Mock,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import RequestBody from './RequestBody.vue'
+
+// Mock the useWorkspace hook
+vi.mock('@/store', () => ({
+  useWorkspace: vi.fn(),
+}))
+
+describe('RequestBody.vue', () => {
+  const props = { props: { title: 'Body' } }
+  const mockActiveRequest = { value: { uid: 'mockRequestUid' } }
+  const mockActiveExample: { value: Partial<RequestExample> } = {
+    value: {
+      uid: 'mockExampleUid',
+      body: {
+        activeBody: 'raw',
+      },
+    },
+  }
+  const mockRequestExampleMutators = {
+    edit: vi.fn(),
+  }
+
+  // Mock our request + example
+  beforeEach(() => {
+    ;(useWorkspace as Mock).mockReturnValue({
+      activeRequest: mockActiveRequest,
+      activeExample: mockActiveExample,
+      requestExampleMutators: mockRequestExampleMutators,
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders correctly with no body', async () => {
+    const wrapper = mount(RequestBody, props)
+    expect(wrapper.text()).toContain('No Body')
+    wrapper.unmount()
+  })
+
+  it('renders with multipart form', async () => {
+    mockActiveExample.value.body = {
+      activeBody: 'formData',
+      formData: {
+        encoding: 'form-data',
+        value: [],
+      },
+    }
+    const wrapper = mount(RequestBody, props)
+
+    expect(wrapper.text()).toContain('Multipart Form')
+    wrapper.unmount()
+  })
+
+  it('renders with url encoded form', async () => {
+    // @ts-expect-error TODO: figure out how vue utils handles unwrapping refs
+    mockActiveExample.body = mockActiveExample.value.body = {
+      activeBody: 'formData',
+      formData: {
+        encoding: 'urlencoded',
+        value: [],
+      },
+    }
+    const wrapper = mount(RequestBody, props)
+
+    expect(wrapper.text()).toContain('Form URL Encoded')
+    wrapper.unmount()
+  })
+
+  it('renders with binary file', async () => {
+    mockActiveExample.value.body = {
+      activeBody: 'binary',
+    }
+    const wrapper = mount(RequestBody, props)
+
+    expect(wrapper.text()).toContain('Binary File')
+    wrapper.unmount()
+  })
+
+  it('renders with json', async () => {
+    mockActiveExample.value.body = {
+      activeBody: 'raw',
+      raw: {
+        encoding: 'json',
+        value: '',
+      },
+    }
+    const wrapper = mount(RequestBody, props)
+
+    expect(wrapper.text()).toContain('JSON')
+    wrapper.unmount()
+  })
+
+  it('renders with xml', async () => {
+    mockActiveExample.value.body = {
+      activeBody: 'raw',
+      raw: {
+        encoding: 'xml',
+        value: '',
+      },
+    }
+    const wrapper = mount(RequestBody, props)
+
+    expect(wrapper.text()).toContain('XML')
+    wrapper.unmount()
+  })
+
+  it('renders with yaml', async () => {
+    mockActiveExample.value.body = {
+      activeBody: 'raw',
+      raw: {
+        encoding: 'yaml',
+        value: '',
+      },
+    }
+    const wrapper = mount(RequestBody, props)
+
+    expect(wrapper.text()).toContain('YAML')
+    wrapper.unmount()
+  })
+
+  it('renders with edn', async () => {
+    mockActiveExample.value.body = {
+      activeBody: 'raw',
+      raw: {
+        encoding: 'edn',
+        value: '',
+      },
+    }
+    const wrapper = mount(RequestBody, props)
+
+    expect(wrapper.text()).toContain('EDN')
+    wrapper.unmount()
+  })
+
+  it('renders with other', async () => {
+    mockActiveExample.value.body = {
+      activeBody: 'raw',
+      raw: {
+        encoding: 'html',
+        value: '',
+      },
+    }
+    const wrapper = mount(RequestBody, props)
+
+    expect(wrapper.text()).toContain('Other')
+    wrapper.unmount()
+  })
+})

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -8,6 +8,7 @@ import { useFileDialog } from '@/hooks'
 import { useWorkspace } from '@/store'
 import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
 import { requestExampleParametersSchema } from '@scalar/oas-utils/entities/spec'
+import { canMethodHaveBody } from '@scalar/oas-utils/helpers'
 import type { CodeMirrorLanguage } from '@scalar/use-codemirror'
 import type { Entries } from 'type-fest'
 import { computed, nextTick, ref, watch } from 'vue'
@@ -367,7 +368,16 @@ watch(
   selectedContentType,
   (val) => {
     if (['multipartForm', 'formUrlEncoded'].includes(val?.id)) defaultRow()
-    console.log('triggered')
+  },
+  { immediate: true },
+)
+
+watch(
+  () => activeExample.value?.uid,
+  () => {
+    activeRequest.value?.method &&
+      canMethodHaveBody(activeRequest.value.method) &&
+      updateActiveBody(activeExampleContentType.value as Content)
   },
   { immediate: true },
 )

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -124,7 +124,6 @@ const updateRequestNameHandler = (event: Event) => {
           (activeSection === 'All' || activeSection === 'Body') &&
           canMethodHaveBody(activeRequest.method)
         "
-        body="foo"
         title="Body" />
     </div>
   </ViewLayoutSection>

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -46,6 +46,7 @@ export const exampleRequestBodyEncoding = [
   'yaml',
   'edn',
 ] as const
+export type BodyEncoding = (typeof exampleRequestBodyEncoding)[number]
 
 export const exampleRequestBodySchema = z.object({
   raw: z
@@ -67,7 +68,6 @@ export const exampleRequestBodySchema = z.object({
     .union([z.literal('raw'), z.literal('formData'), z.literal('binary')])
     .default('raw'),
 })
-
 export type ExampleRequestBody = z.infer<typeof exampleRequestBodySchema>
 
 export const requestExampleSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 12.3.2(typescript@5.5.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
+        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -663,6 +663,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
         version: 5.0.5(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))(vue@3.4.31(typescript@5.5.2))
+      '@vue/test-utils':
+        specifier: ^2.4.1
+        version: 2.4.6
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.19(postcss@8.4.38)
@@ -31015,7 +31018,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -31046,7 +31049,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -33732,7 +33735,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
 
   postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.39):
     dependencies:
@@ -36437,7 +36440,7 @@ snapshots:
       '@swc/core': 1.5.29(@swc/helpers@0.5.5)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2):
+  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11


### PR DESCRIPTION
Closes #3157, #3142

- fixed not being able to select different body content types
- added tests for body content types
- added back in the magic content header
- made content header set correctly when switching examples