### PR TITLE
feat(api-client): performance upgrades for sidebar

### DIFF
--- a/.changeset/brown-peaches-bathe.md
+++ b/.changeset/brown-peaches-bathe.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+chore: performance upgrades for api client sidebar

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -41,6 +41,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./views/Request/types": {
+      "import": "./dist/views/Request/types/index.js",
+      "types": "./dist/views/Request/types/index.d.ts"
+    },
     "./views/Request/libs": {
       "import": "./dist/views/Request/libs/index.js",
       "types": "./dist/views/Request/libs/index.d.ts"

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -163,11 +163,18 @@ const addRow = () => {
   })
   const newParams = [...formParams.value, newParam]
 
-  requestExampleMutators.edit(
-    activeExample.value.uid,
-    'body.formData.value',
-    newParams,
-  )
+  // Ensure we have formData
+  if (activeExample.value.body.formData)
+    requestExampleMutators.edit(
+      activeExample.value.uid,
+      'body.formData.value',
+      newParams,
+    )
+  else
+    requestExampleMutators.edit(activeExample.value.uid, 'body.formData', {
+      value: newParams,
+      encoding: 'form-data',
+    })
 }
 
 /** Enable and disables the row */

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -1,36 +1,21 @@
 <script setup lang="ts">
 import { HttpMethod } from '@/components/HttpMethod'
-import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
-import RenameSidebarListElement from '@/components/Sidebar/Actions/RenameSidebarListElement.vue'
 import { useSidebar } from '@/hooks'
 import { getModifiers } from '@/libs'
 import { commandPaletteBus } from '@/libs/event-busses'
 import { PathId } from '@/router'
 import { useWorkspace } from '@/store'
-import {
-  ScalarButton,
-  ScalarContextMenu,
-  ScalarIcon,
-  ScalarModal,
-  useModal,
-} from '@scalar/components'
+import type { SidebarItem, SidebarMenuItem } from '@/views/Request/types'
+import { ScalarButton, ScalarIcon } from '@scalar/components'
 import {
   Draggable,
   type DraggableProps,
   type DraggingItem,
   type HoveredItem,
 } from '@scalar/draggable'
-import type {
-  Collection,
-  Request,
-  RequestExample,
-  RequestMethod,
-  Tag,
-} from '@scalar/oas-utils/entities/spec'
+import type { Request } from '@scalar/oas-utils/entities/spec'
 import { computed, ref } from 'vue'
-import { RouterLink, useRouter } from 'vue-router'
-
-import RequestSidebarItemMenu from './RequestSidebarItemMenu.vue'
+import { RouterLink } from 'vue-router'
 
 const props = withDefaults(
   defineProps<{
@@ -50,6 +35,8 @@ const props = withDefaults(
     parentUids: string[]
     /** uid of a Collection, Tag, Request or RequestExample */
     uid: string
+    /** To keep track of the menu being open */
+    menuItem: SidebarMenuItem
   }>(),
   { isDraggable: false, isDroppable: false, isChild: false },
 )
@@ -57,6 +44,7 @@ const props = withDefaults(
 const emit = defineEmits<{
   onDragEnd: [draggingItem: DraggingItem, hoveredItem: HoveredItem]
   newTab: [name: string, uid: string]
+  openMenu: [menuItem: SidebarMenuItem]
 }>()
 
 defineSlots<{
@@ -78,23 +66,10 @@ const {
   requestExampleMutators,
   router,
 } = useWorkspace()
-const { replace } = useRouter()
 const { collapsedSidebarFolders, toggleSidebarFolder } = useSidebar()
 
-type Item = {
-  title: string
-  entity: Collection | Tag | Request | RequestExample
-  resourceTitle: string
-  children: string[]
-  method?: RequestMethod
-  link?: string
-  warning?: string
-  rename: () => void
-  delete: () => void
-}
-
 /** Normalize properties across different types for easy consumption */
-const item = computed<Item>(() => {
+const item = computed<SidebarItem>(() => {
   const collection = collections[props.uid]
   const tag = tags[props.uid]
   const request = requests[props.uid]
@@ -108,8 +83,8 @@ const item = computed<Item>(() => {
       children: collection.children,
       warning:
         'This cannot be undone. You’re about to delete the collection and all folders andrequests inside it.',
-      rename: () =>
-        collectionMutators.edit(collection.uid, 'info.title', tempName.value),
+      rename: (name: string) =>
+        collectionMutators.edit(collection.uid, 'info.title', name),
       delete: () =>
         collectionMutators.delete(collection, activeWorkspace.value),
     }
@@ -122,7 +97,7 @@ const item = computed<Item>(() => {
       children: tag.children,
       warning:
         'This cannot be undone. You’re about to delete the tag and all requests inside it',
-      rename: () => tagMutators.edit(tag.uid, 'name', tempName.value),
+      rename: (name: string) => tagMutators.edit(tag.uid, 'name', name),
       delete: () => tagMutators.delete(tag, props.parentUids[0]),
     }
 
@@ -135,8 +110,8 @@ const item = computed<Item>(() => {
       resourceTitle: 'Request',
       warning: 'This cannot be undone. You’re about to delete the request.',
       children: request.examples,
-      rename: () =>
-        requestMutators.edit(request.uid, 'summary', tempName.value),
+      rename: (name: string) =>
+        requestMutators.edit(request.uid, 'summary', name),
       delete: () => requestMutators.delete(request, props.parentUids[0]),
     }
 
@@ -147,8 +122,8 @@ const item = computed<Item>(() => {
     entity: requestExample,
     resourceTitle: 'Example',
     children: [],
-    rename: () =>
-      requestExampleMutators.edit(requestExample.uid, 'name', tempName.value),
+    rename: (name: string) =>
+      requestExampleMutators.edit(requestExample.uid, 'name', name),
     delete: () => requestExampleMutators.delete(requestExample),
   }
 })
@@ -234,33 +209,7 @@ const _isDroppable = (draggingItem: DraggingItem, hoveredItem: HoveredItem) => {
   return true
 }
 
-const tempName = ref('')
-const renameModal = useModal()
-const deleteModal = useModal()
-
-const handleItemRename = (newName: string) => {
-  tempName.value = newName
-  item.value.rename()
-  renameModal.hide()
-}
-
-const openRenameModal = () => {
-  tempName.value = item.value.title || ''
-  renameModal.show()
-}
-
-/** Delete with redirect for both requests and requestExamples */
-const handleItemDelete = () => {
-  item.value.delete()
-
-  if (activeRouterParams.value[PathId.Request] === props.uid)
-    replace(`/workspace/${activeWorkspace.value.uid}/request/default`)
-
-  if (activeRouterParams.value[PathId.Examples] === props.uid)
-    replace(`/workspace/${activeWorkspace.value}/request/default`)
-}
-
-const handleNavigation = (event: KeyboardEvent, _item: Item) => {
+const handleNavigation = (event: KeyboardEvent, _item: SidebarItem) => {
   if (event) {
     const modifier = getModifiers(['default'])
     const isModifierPressed = modifier.some((key) => event[key])
@@ -280,6 +229,7 @@ function openCommandPaletteRequest() {
   })
 }
 </script>
+
 <template>
   <div
     class="relative flex flex-row"
@@ -308,130 +258,130 @@ function openCommandPaletteRequest() {
         @click.prevent="
           (event: KeyboardEvent) => handleNavigation(event, item)
         ">
-        <ScalarContextMenu :disabled="isReadOnly">
-          <template #trigger>
-            <div
-              class="group relative flex min-h-8 cursor-pointer flex-row items-start justify-between gap-2 py-1.5 pr-2 rounded editable-sidebar-hover w-full"
-              :class="[
-                highlightClasses,
-                isExactActive || isDefaultActive
-                  ? 'bg-sidebar-active-b text-sidebar-active-c transition-none'
-                  : 'text-sidebar-c-2',
-              ]"
-              tabindex="0">
-              <span
-                class="line-clamp-3 z-10 font-medium w-full pl-2 word-break-break-word"
+        <div
+          class="group relative flex min-h-8 cursor-pointer flex-row items-start justify-between gap-2 py-1.5 pr-2 rounded editable-sidebar-hover w-full"
+          :class="[
+            highlightClasses,
+            isExactActive || isDefaultActive
+              ? 'bg-sidebar-active-b text-sidebar-active-c transition-none'
+              : 'text-sidebar-c-2',
+          ]"
+          tabindex="0">
+          <span
+            class="line-clamp-3 z-10 font-medium w-full pl-2 word-break-break-word"
+            :class="{
+              'editable-sidebar-hover-item': !isReadOnly,
+            }">
+            {{ item.title }}
+          </span>
+          <div class="flex flex-row gap-1 items-center">
+            <!-- Menu -->
+            <div class="relative">
+              <ScalarButton
+                v-if="!isReadOnly"
+                class="px-0.5 py-0 z-10 hover:bg-b-3 hidden group-hover:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
                 :class="{
-                  'editable-sidebar-hover-item': !isReadOnly,
-                }">
-                {{ item.title }}
-              </span>
-              <div class="flex flex-row gap-1 items-center">
-                <!-- Menu -->
-                <div class="relative">
-                  <RequestSidebarItemMenu
-                    v-if="!isReadOnly"
-                    :item="item.entity"
-                    :parentUids="parentUids"
-                    :resourceTitle="item.resourceTitle"
-                    @delete="deleteModal.show()"
-                    @rename="openRenameModal" />
-                </div>
-                <span class="flex items-start">
-                  &hairsp;
-                  <HttpMethod
-                    v-if="item.method"
-                    class="font-bold"
-                    :method="item.method" />
-                </span>
-              </div>
+                  flex: menuItem?.item?.entity.uid === item.entity.uid,
+                }"
+                size="sm"
+                type="button"
+                variant="ghost"
+                @click.stop.prevent="
+                  (ev) =>
+                    $emit('openMenu', {
+                      item,
+                      parentUids,
+                      targetRef: ev.currentTarget.parentNode,
+                      open: true,
+                    })
+                ">
+                <ScalarIcon
+                  icon="Ellipses"
+                  size="sm" />
+              </ScalarButton>
             </div>
-          </template>
-          <template #content>
-            <RequestSidebarItemMenu
-              :item="item.entity"
-              :parentUids="parentUids"
-              :resourceTitle="item.resourceTitle"
-              static
-              @delete="deleteModal.show()"
-              @rename="openRenameModal" />
-          </template>
-        </ScalarContextMenu>
+            <span class="flex items-start">
+              &hairsp;
+              <HttpMethod
+                v-if="item.method"
+                class="font-bold"
+                :method="item.method" />
+            </span>
+          </div>
+        </div>
       </RouterLink>
 
       <!-- Collection/Folder -->
-      <ScalarContextMenu
+      <button
         v-else-if="!isReadOnly || parentUids.length"
-        :disabled="isReadOnly || isDraftCollection">
-        >
-        <template #trigger>
-          <button
-            class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5 z-[1]"
-            :class="highlightClasses"
-            type="button"
-            @click="toggleSidebarFolder(item.entity.uid)">
-            <span
-              class="z-10 flex h-5 items-center justify-center max-w-[14px]">
-              <slot name="leftIcon">
-                <div
-                  :class="{
-                    'rotate-90': collapsedSidebarFolders[item.entity.uid],
-                  }">
-                  <ScalarIcon
-                    class="text-c-3 text-sm"
-                    icon="ChevronRight"
-                    size="sm"
-                    thickness="2.5" />
-                </div>
-              </slot>
-              &hairsp;
-            </span>
+        class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5 z-[1]"
+        :class="highlightClasses"
+        :disabled="isReadOnly"
+        type="button"
+        @click="toggleSidebarFolder(item.entity.uid)">
+        <span class="z-10 flex h-5 items-center justify-center max-w-[14px]">
+          <slot name="leftIcon">
             <div
-              class="flex flex-1 flex-row justify-between editable-sidebar-hover">
-              <span
-                class="line-clamp-3 z-10 font-medium text-left w-full word-break-break-word"
-                :class="{
-                  'editable-sidebar-hover-item': !isReadOnly,
-                }">
-                {{ item.title }}
-              </span>
-              <div class="relative flex h-fit">
-                <RequestSidebarItemMenu
-                  v-if="!isReadOnly && !isDraftCollection"
-                  :item="item.entity"
-                  :parentUids="parentUids"
-                  :resourceTitle="item.resourceTitle"
-                  @delete="deleteModal.show()"
-                  @rename="openRenameModal" />
-                <span>&hairsp;</span>
-              </div>
+              :class="{
+                'rotate-90': collapsedSidebarFolders[item.entity.uid],
+              }">
+              <ScalarIcon
+                class="text-c-3 text-sm"
+                icon="ChevronRight"
+                size="sm"
+                thickness="2.5" />
             </div>
-          </button>
-        </template>
-        <template #content>
-          <RequestSidebarItemMenu
-            v-if="!isReadOnly && !isDraftCollection"
-            :item="item.entity"
-            :parentUids="parentUids"
-            :resourceTitle="item.resourceTitle"
-            static
-            @delete="deleteModal.show()"
-            @rename="openRenameModal" />
-        </template>
-      </ScalarContextMenu>
+          </slot>
+          &hairsp;
+        </span>
+        <div
+          class="flex flex-1 flex-row justify-between editable-sidebar-hover">
+          <span
+            class="line-clamp-3 z-10 font-medium text-left w-full word-break-break-word"
+            :class="{
+              'editable-sidebar-hover-item': !isReadOnly,
+            }">
+            {{ item.title }}
+          </span>
+          <div class="relative flex h-fit">
+            <ScalarButton
+              v-if="!isReadOnly && !isDraftCollection"
+              class="px-0.5 py-0 z-10 hover:bg-b-3 hidden group-hover:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
+              :class="{ flex: menuItem.item?.entity.uid === item.entity.uid }"
+              size="sm"
+              variant="ghost"
+              @click.stop.prevent="
+                (ev) =>
+                  $emit('openMenu', {
+                    item,
+                    parentUids,
+                    targetRef: ev.currentTarget.parentNode,
+                    open: true,
+                  })
+              ">
+              <ScalarIcon
+                icon="Ellipses"
+                size="sm" />
+            </ScalarButton>
+            <span>&hairsp;</span>
+          </div>
+        </div>
+      </button>
 
       <!-- Children -->
-      <div v-show="showChildren">
+      <div v-if="showChildren">
         <!-- We never want to show the first example -->
         <RequestSidebarItem
           v-for="childUid in item.children"
           :key="childUid"
           :isDraggable="!requestExamples[childUid]"
           :isDroppable="_isDroppable"
+          :menuItem="menuItem"
           :parentUids="[...parentUids, uid]"
           :uid="childUid"
           @newTab="(name, uid) => $emit('newTab', name, uid)"
-          @onDragEnd="(...args) => $emit('onDragEnd', ...args)" />
+          @onDragEnd="(...args) => $emit('onDragEnd', ...args)"
+          @openMenu="(item) => $emit('openMenu', item)" />
         <ScalarButton
           v-if="item.children.length === 0"
           class="mb-[.5px] flex gap-1.5 h-8 text-c-1 py-0 justify-start text-xs w-full hover:bg-b-2"
@@ -447,25 +397,6 @@ function openCommandPaletteRequest() {
       </div>
     </Draggable>
   </div>
-  <ScalarModal
-    :size="'xxs'"
-    :state="deleteModal"
-    :title="`Delete ${item.resourceTitle}`">
-    <DeleteSidebarListElement
-      :variableName="item.title"
-      :warningMessage="item.warning"
-      @close="deleteModal.hide()"
-      @delete="handleItemDelete" />
-  </ScalarModal>
-  <ScalarModal
-    :size="'xxs'"
-    :state="renameModal"
-    :title="`Rename ${item.resourceTitle}`">
-    <RenameSidebarListElement
-      :name="item.title"
-      @close="renameModal.hide()"
-      @rename="handleItemRename" />
-  </ScalarModal>
 </template>
 
 <style>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -281,7 +281,9 @@ function openCommandPaletteRequest() {
                 v-if="!isReadOnly"
                 class="px-0.5 py-0 z-10 hover:bg-b-3 hidden group-hover:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
                 :class="{
-                  flex: menuItem?.item?.entity.uid === item.entity.uid,
+                  flex:
+                    menuItem?.item?.entity.uid === item.entity.uid &&
+                    menuItem.open,
                 }"
                 size="sm"
                 type="button"
@@ -347,7 +349,11 @@ function openCommandPaletteRequest() {
             <ScalarButton
               v-if="!isReadOnly && !isDraftCollection"
               class="px-0.5 py-0 z-10 hover:bg-b-3 hidden group-hover:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
-              :class="{ flex: menuItem.item?.entity.uid === item.entity.uid }"
+              :class="{
+                flex:
+                  menuItem.item?.entity.uid === item.entity.uid &&
+                  menuItem.open,
+              }"
               size="sm"
               variant="ghost"
               @click.stop.prevent="

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -12,7 +12,7 @@ import {
   ScalarModal,
   useModal,
 } from '@scalar/components'
-import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 const props = defineProps<{ menuItem: SidebarMenuItem }>()
@@ -38,7 +38,6 @@ const handleAddExample = () =>
   })
 
 const openRenameModal = () => {
-  console.log('opening')
   tempName.value = props.menuItem.item?.title || ''
   renameModal.show()
 }
@@ -65,13 +64,10 @@ const handleItemDelete = () => {
     replace(`/workspace/${activeWorkspace.value}/request/default`)
 }
 
-// Manually focus the popup
+// Manually focus the popup - not pretty but it works
 const menuRef = ref<typeof ScalarDropdown | null>(null)
 watch([() => props.menuItem.open, menuRef], async ([open]) => {
-  if (open && menuRef.value) {
-    await nextTick()
-    menuRef.value.$parent.$el.focus()
-  }
+  if (open && menuRef.value?.$parent?.$el) menuRef.value.$parent.$el.focus()
 })
 
 // Close menu on click becuse headless dont seem to work

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -1,72 +1,87 @@
 <script setup lang="ts">
+import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
+import RenameSidebarListElement from '@/components/Sidebar/Actions/RenameSidebarListElement.vue'
 import { commandPaletteBus } from '@/libs/event-busses'
+import { PathId } from '@/router'
+import { useWorkspace } from '@/store'
+import type { SidebarMenuItem } from '@/views/Request/types'
 import {
-  ScalarButton,
   ScalarDropdown,
   ScalarDropdownItem,
   ScalarIcon,
+  ScalarModal,
+  useModal,
 } from '@scalar/components'
-import type {
-  Collection,
-  Request,
-  RequestExample,
-  Tag,
-} from '@scalar/oas-utils/entities/spec'
-import { computed } from 'vue'
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 
-const props = withDefaults(
-  defineProps<{
-    /** Both inidicate the level and provide a way to traverse upwards */
-    item: Collection | Tag | Request | RequestExample
-    resourceTitle: string
-    static?: boolean
-  }>(),
-  { static: false },
-)
+const props = defineProps<{ menuItem: SidebarMenuItem }>()
 
 const emit = defineEmits<{
-  (event: 'delete'): void
-  (event: 'rename'): void
+  closeMenu: []
 }>()
+
+const { replace } = useRouter()
+const { activeWorkspace, activeRouterParams } = useWorkspace()
+
+const tempName = ref('')
+const renameModal = useModal()
+const deleteModal = useModal()
 
 /** Add example */
 const handleAddExample = () =>
   commandPaletteBus.emit({
     commandName: 'Add Example',
     metaData: {
-      itemUid: props.item.uid,
+      itemUid: props.menuItem.item?.entity.uid,
     },
   })
 
-const isRequest = computed(() => 'summary' in props.item)
+const openRenameModal = () => {
+  console.log('opening')
+  tempName.value = props.menuItem.item?.title || ''
+  renameModal.show()
+}
+
+const handleItemRename = (newName: string) => {
+  tempName.value = newName
+  props.menuItem.item?.rename(newName)
+  renameModal.hide()
+}
+
+/** Delete with redirect for both requests and requestExamples */
+const handleItemDelete = () => {
+  props.menuItem.item?.delete()
+
+  if (
+    activeRouterParams.value[PathId.Request] === props.menuItem.item?.entity.uid
+  )
+    replace(`/workspace/${activeWorkspace.value.uid}/request/default`)
+
+  if (
+    activeRouterParams.value[PathId.Examples] ===
+    props.menuItem.item?.entity.uid
+  )
+    replace(`/workspace/${activeWorkspace.value}/request/default`)
+}
+
+// Close menu on click becuse headless dont seem to work
+const globalClickListener = () => emit('closeMenu')
+onMounted(() => window.addEventListener('click', globalClickListener))
+onBeforeUnmount(() => window.removeEventListener('click', globalClickListener))
 </script>
 
 <template>
   <ScalarDropdown
-    :static="static"
-    :teleport="!static">
-    <ScalarButton
-      class="px-0.5 py-0 z-10 hover:bg-b-3 hidden group-hover:flex ui-open:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
-      size="sm"
-      variant="ghost"
-      @click="
-        (ev) => {
-          // We must stop propagation on folders and collections to prevent them from toggling
-          if (
-            props.resourceTitle === 'Collection' ||
-            props.resourceTitle === 'Folder'
-          )
-            ev.stopPropagation()
-        }
-      ">
-      <ScalarIcon
-        icon="Ellipses"
-        size="sm" />
-    </ScalarButton>
+    v-if="menuItem.targetRef && menuItem.open"
+    ref="ref"
+    static
+    :targetRef="menuItem.targetRef"
+    teleport>
     <template #items>
       <!-- Add example -->
       <ScalarDropdownItem
-        v-if="isRequest"
+        v-if="menuItem.item?.entity.type === 'request'"
         class="flex gap-2"
         @click="handleAddExample">
         <ScalarIcon
@@ -80,7 +95,7 @@ const isRequest = computed(() => 'summary' in props.item)
       <!-- Rename -->
       <ScalarDropdownItem
         class="flex gap-2"
-        @click="emit('rename')">
+        @click="openRenameModal">
         <ScalarIcon
           class="inline-flex"
           icon="Edit"
@@ -105,7 +120,7 @@ const isRequest = computed(() => 'summary' in props.item)
       <!-- Delete -->
       <ScalarDropdownItem
         class="flex gap-2"
-        @click="emit('delete')">
+        @click="deleteModal.show()">
         <ScalarIcon
           class="inline-flex"
           icon="Delete"
@@ -115,6 +130,27 @@ const isRequest = computed(() => 'summary' in props.item)
       </ScalarDropdownItem>
     </template>
   </ScalarDropdown>
+
+  <!-- Modals -->
+  <ScalarModal
+    :size="'xxs'"
+    :state="deleteModal"
+    :title="`Delete ${menuItem.item?.resourceTitle}`">
+    <DeleteSidebarListElement
+      :variableName="menuItem.item?.title ?? ''"
+      :warningMessage="menuItem.item?.warning"
+      @close="deleteModal.hide()"
+      @delete="handleItemDelete" />
+  </ScalarModal>
+  <ScalarModal
+    :size="'xxs'"
+    :state="renameModal"
+    :title="`Rename ${menuItem.item?.resourceTitle}`">
+    <RenameSidebarListElement
+      :name="menuItem.item?.title ?? ''"
+      @close="renameModal.hide()"
+      @rename="handleItemRename" />
+  </ScalarModal>
 </template>
 <style scoped>
 .ellipsis-position {

--- a/packages/api-client/src/views/Request/types/index.ts
+++ b/packages/api-client/src/views/Request/types/index.ts
@@ -1,0 +1,1 @@
+export * from './sidebar-item'

--- a/packages/api-client/src/views/Request/types/sidebar-item.ts
+++ b/packages/api-client/src/views/Request/types/sidebar-item.ts
@@ -1,0 +1,30 @@
+import type {
+  Collection,
+  Request,
+  RequestExample,
+  RequestMethod,
+  Tag,
+} from '@scalar/oas-utils/entities/spec'
+
+export type SidebarItem = {
+  title: string
+  entity: Collection | Tag | Request | RequestExample
+  resourceTitle: string
+  children: string[]
+  method?: RequestMethod
+  link?: string
+  warning?: string
+  rename: (name: string) => void
+  delete: () => void
+}
+
+export type SidebarMenuItem = {
+  /** The resource which we are opening the menu for */
+  item?: SidebarItem
+  /** Array of parentUids used when nesting in the sidemenu */
+  parentUids?: string[]
+  /** Target ref from the button which triggered the menu for positioning */
+  targetRef?: HTMLButtonElement
+  /** Controls wether the menu is open or not */
+  open: boolean
+}

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -21,6 +21,7 @@ defineOptions({ inheritAttrs: false })
       :isOpen="static ? staticOpen : open ?? isOpen"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
+      :targetRef="targetRef"
       :teleport="teleport">
       <MenuButton
         v-if="!static"

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -36,7 +36,9 @@ const wrapperRef: Ref<HTMLElement | null> = ref(null)
 
 /** Fallback to div wrapper if a button element is not provided */
 const targetRef = computed(
-  () => (wrapperRef.value?.children?.[0] || wrapperRef.value) ?? undefined,
+  () =>
+    (props.targetRef || wrapperRef.value?.children?.[0] || wrapperRef.value) ??
+    undefined,
 )
 
 const targetSize = useResizeWithTarget(targetRef, {

--- a/packages/components/src/components/ScalarFloating/types.ts
+++ b/packages/components/src/components/ScalarFloating/types.ts
@@ -1,4 +1,5 @@
 import type { Middleware, Placement } from '@floating-ui/vue'
+import type { Ref } from 'vue'
 
 export type FloatingOptions = {
   /**
@@ -11,6 +12,11 @@ export type FloatingOptions = {
    * If enabled it will set `width` slot prop of the floating slot
    */
   resize?: boolean
+  /**
+   * Override the targetRef, useful if we are not passing a button
+   * into the slot but is controlled from an external button
+   */
+  targetRef?: HTMLElement
   /**
    * Floating UI Middleware to be passed to Floating UI
    * @see https://floating-ui.com/docs/computePosition#middleware


### PR DESCRIPTION
This improves the load time of the api-client by about 25x when looking at big specs. This was caused by the context menu + menu + modals in every instance of the sidebar items. We should aim to keep looping items as lean as we can!

Before:
sidebar load time: 2629.917236328125 ms

After:
sidebar load time: 110.170166015625 ms

@antlio I had to remove the context menu because I couldn't figure out how to pull it out of the ReqeuestSidebarItem and into the parent. Maybe you can help with that.

TODO:

- [x] accessibility/focus with arrow keys
- [x] close menu when clicking anywhere
- [x] close menu when hitting escape
- [x] Still need to figure out why the menu jumps (due to the button disapearing)
- [x] switch the bus to a ref and use the menu button wrapper
