### PR TITLE
fix: remove trailing slash in examples and in client for server

### DIFF
--- a/.changeset/famous-trainers-shake.md
+++ b/.changeset/famous-trainers-shake.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: remove trailing slash in examples and in client for server

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -57,16 +57,23 @@ const handleAddServer = () =>
   commandPaletteBus.emit({
     commandName: 'Add Server',
   })
+
+const serverUrlWithoutTrailingSlash = computed(() => {
+  return activeServer.value?.url?.replace(/\/$/, '') ?? ''
+})
 </script>
 <template>
   <ScalarDropdown
-    v-if="requestServerOptions?.length || collectionServerOptions?.length"
+    v-if="
+      (requestServerOptions && requestServerOptions?.length > 1) ||
+      (collectionServerOptions && collectionServerOptions?.length > 1)
+    "
     teleport=".scalar-client">
     <button
       class="font-code lg:text-sm text-xs whitespace-nowrap border border-b-3 border-solid rounded px-1.5 py-0.5 text-c-2 z-[1]"
       type="button"
       @click.stop>
-      {{ activeServer?.url }}
+      {{ serverUrlWithoutTrailingSlash }}
     </button>
     <template #items>
       <!-- Request -->
@@ -92,7 +99,6 @@ const handleAddServer = () =>
         :key="serverOption.id"
         :serverOption="serverOption"
         type="collection" />
-
       <!-- Add Server -->
       <template v-if="!isReadOnly">
         <ScalarDropdownDivider />
@@ -112,8 +118,8 @@ const handleAddServer = () =>
     </template>
   </ScalarDropdown>
   <div
-    v-else-if="activeServer?.url"
+    v-else-if="serverUrlWithoutTrailingSlash"
     class="flex whitespace-nowrap items-center font-code lg:text-sm text-xs">
-    {{ activeServer.url }}
+    {{ serverUrlWithoutTrailingSlash }}
   </div>
 </template>

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -59,7 +59,10 @@ const handleAddServer = () =>
   })
 
 const serverUrlWithoutTrailingSlash = computed(() => {
-  return activeServer.value?.url?.replace(/\/$/, '') ?? ''
+  if (activeServer.value?.url?.endsWith('/')) {
+    return activeServer.value.url.slice(0, -1)
+  }
+  return activeServer.value?.url || ''
 })
 </script>
 <template>

--- a/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
@@ -5,8 +5,12 @@ import { replaceVariables } from '@scalar/oas-utils/helpers'
  * Get the URL from the server state.
  */
 export function getUrlFromServerState(state: ServerState) {
-  // Get the selected server
+  // Get the selected server and remove trailing slash
   const server = state?.servers?.[state.selectedServer ?? 0]
+
+  if (server?.url?.endsWith('/')) {
+    server.url = server.url.slice(0, -1)
+  }
 
   // Replace variables: {protocol}://{host}:{port}/{basePath}
   const url =


### PR DESCRIPTION
**Problem**
Currently we have `//` if a server has a trailing slash

**Solution**
(we remove it from rendering :) )
