### PR TITLE
chore(nestjs-api-reference, express-api-reference): move `@scalar/api-reference` and `express` from `dependencies` to `devDependencies`

### DIFF
--- a/.changeset/nasty-penguins-argue.md
+++ b/.changeset/nasty-penguins-argue.md
@@ -1,0 +1,6 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/nestjs-api-reference': patch
+---
+
+chore: move `express` and `@scalar/api-reference` to `devDependencies`

--- a/packages/express-api-reference/package.json
+++ b/packages/express-api-reference/package.json
@@ -40,6 +40,7 @@
     "dist"
   ],
   "module": "dist/index.js",
+  "dependencies": {},
   "devDependencies": {
     "@scalar/api-reference": "workspace:*",
     "@types/express": "^4.17.21",

--- a/packages/express-api-reference/package.json
+++ b/packages/express-api-reference/package.json
@@ -40,12 +40,10 @@
     "dist"
   ],
   "module": "dist/index.js",
-  "dependencies": {
-    "@scalar/api-reference": "workspace:*",
-    "express": "^4.19.2"
-  },
   "devDependencies": {
+    "@scalar/api-reference": "workspace:*",
     "@types/express": "^4.17.21",
+    "express": "^4.19.2",
     "tsup": "^7.2.0",
     "vite": "^5.2.10",
     "vitest": "^1.6.0"

--- a/packages/express-api-reference/package.json
+++ b/packages/express-api-reference/package.json
@@ -40,7 +40,9 @@
     "dist"
   ],
   "module": "dist/index.js",
-  "dependencies": {},
+  "dependencies": {
+    "@scalar/types": "workspace:*"
+  },
   "devDependencies": {
     "@scalar/api-reference": "workspace:*",
     "@types/express": "^4.17.21",

--- a/packages/express-api-reference/src/expressApiReference.ts
+++ b/packages/express-api-reference/src/expressApiReference.ts
@@ -1,4 +1,4 @@
-import type { ReferenceConfiguration } from '@scalar/api-reference'
+import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import type { Request, Response } from 'express'
 
 export type ApiReferenceOptions = ReferenceConfiguration & {

--- a/packages/nestjs-api-reference/package.json
+++ b/packages/nestjs-api-reference/package.json
@@ -40,12 +40,10 @@
     "dist"
   ],
   "module": "dist/index.js",
-  "dependencies": {
-    "@scalar/api-reference": "workspace:*",
-    "express": "^4.19.2"
-  },
   "devDependencies": {
+    "@scalar/api-reference": "workspace:*",
     "@types/express": "^4.17.21",
+    "express": "^4.19.2",
     "fastify": "^4.26.2",
     "tsup": "^7.2.0",
     "vite": "^5.2.10",

--- a/packages/nestjs-api-reference/package.json
+++ b/packages/nestjs-api-reference/package.json
@@ -40,6 +40,7 @@
     "dist"
   ],
   "module": "dist/index.js",
+  "dependencies": {},
   "devDependencies": {
     "@scalar/api-reference": "workspace:*",
     "@types/express": "^4.17.21",

--- a/packages/nestjs-api-reference/package.json
+++ b/packages/nestjs-api-reference/package.json
@@ -40,7 +40,9 @@
     "dist"
   ],
   "module": "dist/index.js",
-  "dependencies": {},
+  "dependencies": {
+    "@scalar/types": "workspace:*"
+  },
   "devDependencies": {
     "@scalar/api-reference": "workspace:*",
     "@types/express": "^4.17.21",

--- a/packages/nestjs-api-reference/src/nestJSApiReference.ts
+++ b/packages/nestjs-api-reference/src/nestJSApiReference.ts
@@ -1,4 +1,4 @@
-import type { ReferenceConfiguration } from '@scalar/api-reference'
+import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import type { Request, Response } from 'express'
 import type { FastifyRequest } from 'fastify'
 import type { ServerResponse } from 'http'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 12.3.2(typescript@5.5.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+        version: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -1630,17 +1630,16 @@ importers:
         version: 20.14.10
 
   packages/nestjs-api-reference:
-    dependencies:
+    devDependencies:
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../api-reference
-      express:
-        specifier: ^4.19.2
-        version: 4.19.2
-    devDependencies:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
+      express:
+        specifier: ^4.19.2
+        version: 4.19.2
       fastify:
         specifier: ^4.26.2
         version: 4.28.0
@@ -31018,7 +31017,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -31049,7 +31048,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -33735,7 +33734,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2)
 
   postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.39):
     dependencies:
@@ -36440,7 +36439,7 @@ snapshots:
       '@swc/core': 1.5.29(@swc/helpers@0.5.5)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.5.2):
+  ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1473,6 +1473,10 @@ importers:
         version: 1.6.0(@types/node@20.14.10)(jsdom@24.1.0)(terser@5.31.2)
 
   packages/express-api-reference:
+    dependencies:
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       '@scalar/api-reference':
         specifier: workspace:*
@@ -1629,6 +1633,10 @@ importers:
         version: 20.14.10
 
   packages/nestjs-api-reference:
+    dependencies:
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       '@scalar/api-reference':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1473,17 +1473,16 @@ importers:
         version: 1.6.0(@types/node@20.14.10)(jsdom@24.1.0)(terser@5.31.2)
 
   packages/express-api-reference:
-    dependencies:
+    devDependencies:
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../api-reference
-      express:
-        specifier: ^4.19.2
-        version: 4.19.2
-    devDependencies:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
+      express:
+        specifier: ^4.19.2
+        version: 4.19.2
       tsup:
         specifier: ^7.2.0
         version: 7.3.0(@swc/core@1.5.29)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.5.2))(typescript@5.5.2)


### PR DESCRIPTION
closes #3159
closes #3187

In `@scalar/nestjs-api-reference` and `@scalar/express-api-reference`, `@scalar/api-reference` and `express` should be listed under `devDependencies` to avoid including them in built package. Check above issues for details.