### PR TITLE
chore(nextjs-api-reference): fix import of ReferenceConfiguration

### DIFF
--- a/.changeset/empty-coins-love.md
+++ b/.changeset/empty-coins-love.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nextjs-api-reference': patch
+---
+
+chore: fix import of ReferenceConfiguration

--- a/packages/nextjs-api-reference/src/ApiReference.ts
+++ b/packages/nextjs-api-reference/src/ApiReference.ts
@@ -1,4 +1,4 @@
-import type { ReferenceConfiguration } from '@scalar/api-reference'
+import type { ReferenceConfiguration } from '@scalar/types/legacy'
 
 import { nextjsThemeCss } from './theme'
 


### PR DESCRIPTION
fixes #3190 