### PR TITLE
fix(api-client): address typo style

### DIFF
--- a/.changeset/unlucky-mice-film.md
+++ b/.changeset/unlucky-mice-film.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: address bar style and error typo

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -304,12 +304,6 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
 .codemirror-bg-switcher {
   --scalar-background-1: var(--scalar-background-2);
 }
-.addressbar-bg-states :deep(.adressbar-history-button:hover) {
-  background: var(--scalar-background-3);
-}
-.addressbar-bg-states:focus-within :deep(.adressbar-history-button:hover) {
-  background: var(--scalar-background-2);
-}
 .addressbar-bg-states:focus-within .codemirror-bg-switcher {
   --scalar-background-1: var(--scalar-background-1);
 }

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -147,9 +147,8 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
         v-model="selectedRequest">
         <div
           :class="[
-            'addressbar-bg-states text-xxs relative flex w-full lg:min-w-[720px] lg:max-w-[720px] order-last lg:order-none flex-1 flex-row items-stretch rounded-lg border-1/2 p-[3px]',
-            { 'rounded-b-none': open },
-            { 'border-transparent': open },
+            'addressbar-bg-states text-xxs relative flex w-full lg:min-w-[720px] lg:max-w-[720px] order-last overflow-hidden lg:order-none flex-1 flex-row items-stretch rounded-lg border-1/2 p-[3px]',
+            { 'border-transparent overflow-visible rounded-b-none': open },
           ]">
           <div
             class="pointer-events-none absolute left-0 top-0 z-10 block h-full w-full overflow-hidden">

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -60,7 +60,7 @@ function handleHistoryClick(historicalRequest: RequestEvent) {
   <!-- History -->
   <ListboxButton
     v-if="history?.length"
-    class="adressbar-history-button mr-1 rounded p-1.5 text-c-3 focus:text-c-1">
+    class="addressbar-history-button mr-1 rounded-lg p-1.5 text-c-3 focus:text-c-1">
     <ScalarIcon
       icon="History"
       size="sm"
@@ -70,12 +70,12 @@ function handleHistoryClick(historicalRequest: RequestEvent) {
   <!-- History shadow and placement-->
   <div
     :class="[
-      'absolute left-0 top-[33px] w-full rounded before:pointer-events-none before:absolute before:left-0 before:top-[-33px] before:h-[calc(100%+33px)] before:w-full before:rounded z-50',
+      'absolute bg-white left-0 top-8 w-full rounded-lg before:pointer-events-none before:absolute before:left-0 before:-top-8 before:h-[calc(100%+32px)] before:w-full before:rounded-lg z-50',
       { 'before:shadow-lg': open },
     ]">
     <!-- History Item -->
     <ListboxOptions
-      class="bg-b-1 custom-scroll bg-mix-transparent bg-mix-amount-30 max-h-[300px] rounded-b p-[3px] pt-0 backdrop-blur grid grid-cols-[44px,1fr,repeat(3,auto)] items-center">
+      class="bg-b-1 border-t custom-scroll max-h-[300px] rounded-b-lg p-[3px] grid grid-cols-[44px,1fr,repeat(3,auto)] items-center">
       <ListboxOption
         v-for="(entry, index) in history"
         :key="index"
@@ -102,3 +102,11 @@ function handleHistoryClick(historicalRequest: RequestEvent) {
     </ListboxOptions>
   </div>
 </template>
+<style scoped>
+.addressbar-history-button:hover {
+  background: var(--scalar-background-3);
+}
+.addressbar-history-button:focus-within {
+  background: var(--scalar-background-2);
+}
+</style>

--- a/packages/api-client/src/libs/errors.ts
+++ b/packages/api-client/src/libs/errors.ts
@@ -8,7 +8,7 @@ export const ERRORS = {
     'File uploads are not saved in history, you must re-upload the file.',
   REQUEST_ABORTED: 'The request has been cancelled',
   REQUEST_FAILED: 'An error occurred while making the request',
-  URL_EMPTY: 'The adress bar seems to be empty. Try adding an URL.',
+  URL_EMPTY: 'The address bar input seems to be empty. Try adding a URL.',
 } as const
 
 /** Normalizes caught error into an error instance */


### PR DESCRIPTION
this pr fixes address bar empty url typo + adds style enhancements and loading overflow:

**before**
<img width="962" alt="image" src="https://github.com/user-attachments/assets/9567d5dc-548d-422a-a6cf-5b668021443c">

**after**
<img width="962" alt="image" src="https://github.com/user-attachments/assets/d8e902dd-afbc-4fd3-bc46-385661180e4e">
