### PR TITLE
fix(api-client): sidebar folder toggle

### DIFF
--- a/.changeset/slimy-birds-check.md
+++ b/.changeset/slimy-birds-check.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: enables sidebar item toggle on readonly

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -318,7 +318,6 @@ function openCommandPaletteRequest() {
         v-else-if="!isReadOnly || parentUids.length"
         class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5 z-[1]"
         :class="highlightClasses"
-        :disabled="isReadOnly"
         type="button"
         @click="toggleSidebarFolder(item.entity.uid)">
         <span class="z-10 flex h-5 items-center justify-center max-w-[14px]">


### PR DESCRIPTION
this pr enables back the sidebar item being disabled from a reference client, unless it was meant to be.