### PR TITLE
fix(api-client): address bar http methods

### DIFF
--- a/.changeset/hungry-rules-stare.md
+++ b/.changeset/hungry-rules-stare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: teleports http methods dropdown

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -162,6 +162,7 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
               :isEditable="!isReadOnly"
               isSquare
               :method="activeRequest.method"
+              teleport=".scalar-client"
               @change="updateRequestMethod" />
           </div>
           <div

--- a/packages/api-client/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/api-client/src/components/HttpMethod/HttpMethod.vue
@@ -50,7 +50,7 @@ const httpLabel = computed(() => method.value.short)
   <ScalarListbox
     v-if="isEditable"
     v-model="selectedMethod"
-    class="mt-1 font-code uppercase"
+    class="mt-1 font-code text-sm uppercase"
     :options="methodOptions">
     <div
       class="h-full"


### PR DESCRIPTION
this pr fixes the visibility of the address bar http methods dropdown introduced in #3194.