### PR TITLE
fix(api-client): adding default extra row on route change

### DIFF
--- a/.changeset/poor-moose-lick.md
+++ b/.changeset/poor-moose-lick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: add empty row on route change

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -385,6 +385,14 @@ watch(
     activeRequest.value?.method &&
       canMethodHaveBody(activeRequest.value.method) &&
       updateActiveBody(activeExampleContentType.value as Content)
+
+    // Add extra row on page route change as well
+    if (
+      ['multipartForm', 'formUrlEncoded'].includes(
+        activeExampleContentType.value as Content,
+      )
+    )
+      defaultRow()
   },
   { immediate: true },
 )


### PR DESCRIPTION
This PR ensures we add the extra empty row to forms in the client on route change. Previously we were doing it when the content type changed, but if it didn't change and it was a different route there would be no row added.