### PR TITLE
feat(api-client): adds safe parsing after migration

### DIFF
--- a/.changeset/heavy-mayflies-lay.md
+++ b/.changeset/heavy-mayflies-lay.md
@@ -1,0 +1,7 @@
+---
+'@scalar/object-utils': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: adds safe-parsing to the end of the migration

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -15,7 +15,7 @@ import {
   ScalarSearchResultItem,
   ScalarSearchResultList,
 } from '@scalar/components'
-import { onBeforeMount, onBeforeUnmount, onMounted, reactive, watch } from 'vue'
+import { onBeforeUnmount, onMounted, reactive, watch } from 'vue'
 
 import RequestSidebarItem from './RequestSidebarItem.vue'
 import { WorkspaceDropdown } from './components'
@@ -86,12 +86,7 @@ const handleHotKey = (event: HotKeyEvents) => {
   }
 }
 
-onBeforeMount(() => console.time('sidebar'))
-
-onMounted(() => {
-  hotKeyBus.on(handleHotKey)
-  setTimeout(() => console.timeEnd('sidebar'), 0)
-})
+onMounted(() => hotKeyBus.on(handleHotKey))
 
 /**
  * Need to manually remove listener on unmount due to vueuse memory leak

--- a/packages/oas-utils/src/migrations/local-storage.ts
+++ b/packages/oas-utils/src/migrations/local-storage.ts
@@ -28,7 +28,7 @@ export const getLocalStorageVersion = (): string => {
     const [collection] = Object.values(
       parse(collectionStr) ?? {},
     ) as v_2_1_0.Collection[]
-    if (collection.type === 'collection') return '2.1.0'
+    if (collection?.type === 'collection') return '2.1.0'
 
     if (dataVersion) return dataVersion
     return '0.0.0'

--- a/packages/object-utils/src/mutator-record/handlers.ts
+++ b/packages/object-utils/src/mutator-record/handlers.ts
@@ -43,14 +43,6 @@ export function mutationFactory<
     onChange()
   }
 
-  /**
-   * Loads localStorage data into the mutator after migration
-   */
-  const loadLocalStorage = (instances: T[]) => {
-    // TODO: Validation should be provided for each entity
-    instances.forEach(add)
-  }
-
   return {
     /** Adds a new item to the record of tracked items and creates a new mutation tracking instance */
     add,
@@ -93,7 +85,6 @@ export function mutationFactory<
       mutator?.redo()
       onChange()
     },
-    loadLocalStorage,
   }
 }
 


### PR DESCRIPTION
closes #3208 

This PR: 
- fixes the bug that Hans encountered
- adds safe parsing after the migration is done to prevent any further breaking of the app in the case of a bad migration