### PR TITLE
feat(openapi-parser): upgrade Swagger 2.0 formData parameters, see #3205

### DIFF
--- a/.changeset/fresh-rivers-brush.md
+++ b/.changeset/fresh-rivers-brush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+feat: upgrade Swagger 2.0 formData parameters

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -344,4 +344,53 @@ describe('upgradeFromTwoToThree', () => {
 
     expect(result.paths['/planets'].get.produces).toBeUndefined()
   })
+
+  it('migrates formData', async () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      paths: {
+        '/planets': {
+          get: {
+            description:
+              'Returns all planets from the system that the user has access to',
+            parameters: [
+              {
+                name: 'additionalMetadata',
+                in: 'formData',
+                description: 'Additional data to pass to server',
+                required: false,
+                type: 'string',
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    expect(result.paths).toStrictEqual({
+      '/planets': {
+        get: {
+          description:
+            'Returns all planets from the system that the user has access to',
+          requestBody: {
+            content: {
+              'application/x-www-form-urlencoded': {
+                schema: {
+                  properties: {
+                    additionalMetadata: {
+                      description: 'Additional data to pass to server',
+                      type: 'string',
+                    },
+                  },
+                  type: 'object',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.paths['/planets'].get.produces).toBeUndefined()
+  })
 })

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -358,7 +358,7 @@ describe('upgradeFromTwoToThree', () => {
                 name: 'additionalMetadata',
                 in: 'formData',
                 description: 'Additional data to pass to server',
-                required: false,
+                required: true,
                 type: 'string',
               },
             ],
@@ -376,6 +376,7 @@ describe('upgradeFromTwoToThree', () => {
             content: {
               'application/x-www-form-urlencoded': {
                 schema: {
+                  required: ['additionalMetadata'],
                   properties: {
                     additionalMetadata: {
                       description: 'Additional data to pass to server',

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -115,6 +115,46 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
               )
 
               delete operationItem.consumes
+
+              // formData parameters
+              const formDataParameters = operationItem.parameters.filter(
+                (parameter: OpenAPIV2.ParameterObject) =>
+                  parameter.in === 'formData',
+              )
+
+              if (formDataParameters.length > 0) {
+                if (typeof operationItem.requestBody !== 'object') {
+                  operationItem.requestBody = {}
+                }
+
+                if (typeof operationItem.requestBody.content !== 'object') {
+                  operationItem.requestBody.content = {}
+                }
+
+                operationItem.requestBody.content[
+                  'application/x-www-form-urlencoded'
+                ] = {
+                  schema: {
+                    type: 'object',
+                    properties: {},
+                  },
+                }
+
+                for (const param of formDataParameters) {
+                  operationItem.requestBody.content[
+                    'application/x-www-form-urlencoded'
+                  ].schema.properties[param.name] = {
+                    type: param.type,
+                    description: param.description,
+                  }
+                }
+
+                // Remove formData parameters from the parameters array
+                operationItem.parameters = operationItem.parameters.filter(
+                  (parameter: OpenAPIV2.ParameterObject) =>
+                    parameter.in !== 'formData',
+                )
+              }
             }
 
             // Responses

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -137,6 +137,7 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
                   schema: {
                     type: 'object',
                     properties: {},
+                    required: [], // Initialize required array
                   },
                 }
 
@@ -146,6 +147,13 @@ export function upgradeFromTwoToThree(specification: AnyObject) {
                   ].schema.properties[param.name] = {
                     type: param.type,
                     description: param.description,
+                  }
+
+                  // Add to required array if param is required
+                  if (param.required) {
+                    operationItem.requestBody.content[
+                      'application/x-www-form-urlencoded'
+                    ].schema.required.push(param.name)
                   }
                 }
 


### PR DESCRIPTION
OpenAPI 3.x doesn’t have `formData` parameters anymore, so let’s add them to the request body on `upgrade()` instead. :)

See #3205 for more context.

We don't show the form data parameters in the API client, though: #3222