### PR TITLE
fix(api-client): address bar input long content

### DIFF
--- a/.changeset/tender-moose-fix.md
+++ b/.changeset/tender-moose-fix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: code input content height

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -221,6 +221,7 @@ export default {
 :deep(.cm-content) {
   font-family: var(--scalar-font-code);
   font-size: var(--scalar-small);
+  max-height: 20px;
   padding: 8px 0;
 }
 /* Tooltip helper */


### PR DESCRIPTION
this pr fixes #3227 by adding input content max height:

<img width="1467" alt="image" src="https://github.com/user-attachments/assets/d77a7ec1-95fa-4ff9-b867-6ed7baf3fa73">
