### PR TITLE
fix(fastify-api-reference): JS can’t be fetched in proxied environments

### DIFF
--- a/.changeset/chatty-trainers-cover.md
+++ b/.changeset/chatty-trainers-cover.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: JS can't be fetched in proxied environments

--- a/.changeset/slimy-carrots-shop.md
+++ b/.changeset/slimy-carrots-shop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+chore!: mark `publicPath` as deprecated, remove it from the configuration

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -53,7 +53,6 @@
     "@scalar/openapi-parser": "workspace:*",
     "@vitest/coverage-v8": "^1.6.0",
     "fastify": "^4.26.2",
-    "fastify-list-routes": "^1.0.0",
     "github-slugger": "^2.0.0",
     "magic-string": "^0.30.8",
     "rollup-plugin-node-externals": "^7.1.2",

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@fastify/basic-auth": "^5.1.1",
+    "@fastify/http-proxy": "^9.0.0",
     "@fastify/swagger": "^8.10.1",
     "@scalar/api-reference": "workspace:*",
     "@scalar/openapi-parser": "workspace:*",

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -53,6 +53,7 @@
     "@scalar/openapi-parser": "workspace:*",
     "@vitest/coverage-v8": "^1.6.0",
     "fastify": "^4.26.2",
+    "fastify-list-routes": "^1.0.0",
     "github-slugger": "^2.0.0",
     "magic-string": "^0.30.8",
     "rollup-plugin-node-externals": "^7.1.2",

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -213,9 +213,7 @@ describe('fastifyApiReference', () => {
 
     const address = await fastify.listen({ port: 0 })
     const response = await fetch(`${address}/reference`)
-    expect(await response.text()).toContain(
-      '/reference/@scalar/fastify-api-reference/js/browser.js',
-    )
+    expect(await response.text()).toContain('/reference/js/scalar.js')
   })
 
   it('prefixes the JS url', async () => {
@@ -233,9 +231,7 @@ describe('fastifyApiReference', () => {
 
     const address = await fastify.listen({ port: 0 })
     const response = await fetch(`${address}/reference`)
-    expect(await response.text()).toContain(
-      '/foobar/reference/@scalar/fastify-api-reference/js/browser.js',
-    )
+    expect(await response.text()).toContain('/foobar/reference/js/scalar.js')
   })
 
   describe('has the spec URL', () => {
@@ -345,9 +341,7 @@ describe('fastifyApiReference', () => {
 
     const address = await fastify.listen({ port: 0 })
     const response = await fetch(`${address}/reference`)
-    expect(await response.text()).toContain(
-      '/reference/@scalar/fastify-api-reference/js/browser.js',
-    )
+    expect(await response.text()).toContain('/reference/js/scalar.js')
   })
 
   it('returns 401 Unauthorized for requests without authentication', async () => {
@@ -369,9 +363,7 @@ describe('fastifyApiReference', () => {
     let response = await fetch(`${address}/reference`)
     expect(response.status).toBe(401)
 
-    response = await fetch(
-      `${address}/reference/@scalar/fastify-api-reference/js/browser.js`,
-    )
+    response = await fetch(`${address}/reference/js/scalar.js`)
     expect(response.status).toBe(401)
   })
 
@@ -398,14 +390,11 @@ describe('fastifyApiReference', () => {
     })
     expect(response.status).toBe(200)
 
-    response = await fetch(
-      `${address}/reference/@scalar/fastify-api-reference/js/browser.js`,
-      {
-        headers: {
-          authorization: basicAuthEncode('admin', 'admin'),
-        },
+    response = await fetch(`${address}/reference/js/scalar.js`, {
+      headers: {
+        authorization: basicAuthEncode('admin', 'admin'),
       },
-    )
+    })
     expect(response.status).toBe(200)
   })
 })

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -213,25 +213,7 @@ describe('fastifyApiReference', () => {
 
     const address = await fastify.listen({ port: 0 })
     const response = await fetch(`${address}/reference`)
-    expect(await response.text()).toContain('/reference/js/scalar.js')
-  })
-
-  it('prefixes the JS url', async () => {
-    const fastify = Fastify({
-      logger: false,
-    })
-
-    await fastify.register(fastifyApiReference, {
-      routePrefix: '/reference',
-      publicPath: '/foobar',
-      configuration: {
-        spec: { url: '/openapi.json' },
-      },
-    })
-
-    const address = await fastify.listen({ port: 0 })
-    const response = await fetch(`${address}/reference`)
-    expect(await response.text()).toContain('/foobar/reference/js/scalar.js')
+    expect(await response.text()).toContain('js/scalar.js')
   })
 
   describe('has the spec URL', () => {
@@ -326,22 +308,6 @@ describe('fastifyApiReference', () => {
     const response = await fetch(`${address}/reference`)
     expect(response.headers.has('content-type')).toBe(true)
     expect(response.headers.get('content-type')).toContain('text/html')
-  })
-
-  it('has the JS url with default routePrefix', async () => {
-    const fastify = Fastify({
-      logger: false,
-    })
-
-    await fastify.register(fastifyApiReference, {
-      configuration: {
-        spec: { url: '/openapi.json' },
-      },
-    })
-
-    const address = await fastify.listen({ port: 0 })
-    const response = await fetch(`${address}/reference`)
-    expect(await response.text()).toContain('/reference/js/scalar.js')
   })
 
   it('returns 401 Unauthorized for requests without authentication', async () => {

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -1,80 +1,19 @@
 import { openapi } from '@scalar/openapi-parser'
 import { fetchUrls } from '@scalar/openapi-parser/plugins/fetch-urls'
-import type { OpenAPI, ReferenceConfiguration } from '@scalar/types/legacy'
+import type { OpenAPI } from '@scalar/types/legacy'
 import type {
   FastifyBaseLogger,
   FastifyTypeProviderDefault,
   RawServerDefault,
-  onRequestHookHandler,
-  preHandlerHookHandler,
 } from 'fastify'
 import fp from 'fastify-plugin'
 import { slug } from 'github-slugger'
 
+import type {
+  FastifyApiReferenceHooksOptions,
+  FastifyApiReferenceOptions,
+} from './types'
 import { getJavaScriptFile } from './utils'
-
-export type FastifyApiReferenceOptions = {
-  /**
-   * If you’re prefixing Fastify with a path, you can set it here.
-   * It’ll be added to the JavaScript URL and the route.
-   *
-   * Example: `${publicPath}${routePrefix}/@scalar/fastify-api-reference/js/browser.js`
-   */
-  publicPath?: string
-  /**
-   * Prefix the route with a path. This is where the API Reference will be available.
-   *
-   * @default '/reference'
-   */
-  routePrefix?: `/${string}`
-  /**
-   * Set where the OpenAPI specification is exposed under `${routePrefix}`.
-   *
-   * The specification is always available on these endpoints, parsed by `@scalar/openapi-parser`.
-   *
-   * The specification is sourced from, in order of precedence:
-   * - `configuration.spec.content`
-   * - `configuration.spec.url` – fetched via `@scalar/openapi-parser/plugins/fetch-urls`
-   * - `@fastify/swagger` – if `configuration.spec` is not provided
-   *
-   * These endpoints can be used to fetch the OpenAPI specification for your own programmatic use.
-   *
-   * @default{ json: '/openapi.json', yaml: '/openapi.yaml' }
-   */
-  openApiDocumentEndpoints?: {
-    /**
-     * Set where the OpenAPI specification is exposed under `${routePrefix}`, in JSON format.
-     *
-     * With the default value, the endpoint is: `${publicPath}${routePrefix}/openapi.json`
-     *
-     * @default '/openapi.json'
-     */
-    json?: `/${string}`
-    /**
-     * Set where the OpenAPI specification is exposed under `${routePrefix}`, in YAML format.
-     *
-     * With the default value, the endpoint is: `${publicPath}${routePrefix}/openapi.yaml`
-     *
-     * @default '/openapi.yaml'
-     */
-    yaml?: `/${string}`
-  }
-  /**
-   * The universal configuration object for @scalar/api-reference.
-   *
-   * Read more: https://github.com/scalar/scalar
-   */
-  configuration?: ReferenceConfiguration
-  /**
-   * The hooks for the API Reference.
-   */
-  hooks?: FastifyApiReferenceHooksOptions
-}
-
-export type FastifyApiReferenceHooksOptions = Partial<{
-  onRequest?: onRequestHookHandler
-  preHandler?: preHandlerHookHandler
-}>
 
 // This Schema is used to hide the route from the documentation.
 // https://github.com/fastify/fastify-swagger#hide-a-route

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -38,8 +38,8 @@ const getOpenApiDocumentEndpoints = (
 
 const RELATIVE_JAVASCRIPT_PATH = 'js/scalar.js'
 
-const getJavaScriptUrl = (routePrefix?: string, publicPath?: string) =>
-  `${publicPath ?? ''}${getRoutePrefix(routePrefix)}/${RELATIVE_JAVASCRIPT_PATH}`.replace(
+const getJavaScriptUrl = (routePrefix?: string) =>
+  `${getRoutePrefix(routePrefix)}/${RELATIVE_JAVASCRIPT_PATH}`.replace(
     /\/\//g,
     '/',
   )

--- a/packages/fastify-api-reference/src/index.ts
+++ b/packages/fastify-api-reference/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from './fastifyApiReference'
+export * from './types'

--- a/packages/fastify-api-reference/src/proxy.test.ts
+++ b/packages/fastify-api-reference/src/proxy.test.ts
@@ -1,0 +1,41 @@
+import HttpProxy from '@fastify/http-proxy'
+import Fastify from 'fastify'
+import { describe, expect, it } from 'vitest'
+
+import Scalar from './index'
+
+describe('fastifyApiReference', () => {
+  it('returns 200 OK for the HTML', async () => {
+    const origin = Fastify({
+      logger: false,
+    })
+
+    await origin.register(Scalar, {
+      routePrefix: '/documentation',
+      publicPath: './',
+      configuration: {
+        spec: { url: '/openapi.json' },
+      },
+    })
+
+    origin.get('/origin', async (request, reply) => {
+      return { origin: 'origin' }
+    })
+
+    const originAddress = await origin.listen({ port: 0 })
+    const originResponse = await fetch(`${originAddress}/documentation`)
+
+    expect(originResponse.status).toBe(200)
+
+    const proxy = Fastify({ logger: { name: 'proxy' } })
+    proxy.register(HttpProxy, {
+      upstream: originAddress,
+      prefix: '/proxy',
+    })
+
+    const proxyAddress = await proxy.listen({ port: 0 })
+    const proxyResponse = await fetch(`${proxyAddress}/documentation`)
+
+    expect(proxyResponse.status).toBe(200)
+  })
+})

--- a/packages/fastify-api-reference/src/proxy.test.ts
+++ b/packages/fastify-api-reference/src/proxy.test.ts
@@ -1,25 +1,24 @@
 import HttpProxy from '@fastify/http-proxy'
 import Fastify from 'fastify'
+import ListRoutes from 'fastify-list-routes'
 import { describe, expect, it } from 'vitest'
 
 import Scalar from './index'
 
 describe('fastifyApiReference', () => {
   it('returns 200 OK for the HTML', async () => {
+    // Origin
     const origin = Fastify({
       logger: false,
     })
 
+    await origin.register(ListRoutes, { colors: true })
+
     await origin.register(Scalar, {
       routePrefix: '/documentation',
-      publicPath: './',
       configuration: {
         spec: { url: '/openapi.json' },
       },
-    })
-
-    origin.get('/origin', async (request, reply) => {
-      return { origin: 'origin' }
     })
 
     const originAddress = await origin.listen({ port: 0 })
@@ -27,15 +26,37 @@ describe('fastifyApiReference', () => {
 
     expect(originResponse.status).toBe(200)
 
-    const proxy = Fastify({ logger: { name: 'proxy' } })
-    proxy.register(HttpProxy, {
+    // Proxy
+    const proxy = Fastify({
+      logger: false,
+    })
+
+    await proxy.register(ListRoutes, { colors: true })
+
+    await proxy.register(HttpProxy, {
       upstream: originAddress,
       prefix: '/proxy',
     })
 
     const proxyAddress = await proxy.listen({ port: 0 })
-    const proxyResponse = await fetch(`${proxyAddress}/documentation`)
+    const proxyResponse = await fetch(`${proxyAddress}/proxy/documentation`)
 
     expect(proxyResponse.status).toBe(200)
+
+    // Redirect
+    expect(proxyResponse.redirected).toBe(true)
+
+    const resolvedUrl = new URL(proxyResponse.url)
+    const resolvedPath = resolvedUrl.pathname
+    expect(resolvedPath).toBe('/proxy/documentation/')
+
+    // JavaScript
+    const proxyResponseBody = await proxyResponse.text()
+    expect(proxyResponseBody).toContain('src="js/scalar.js"')
+
+    const assetResponse = await fetch(
+      `${proxyAddress}${resolvedPath}js/scalar.js`,
+    )
+    expect(assetResponse.status).toBe(200)
   })
 })

--- a/packages/fastify-api-reference/src/proxy.test.ts
+++ b/packages/fastify-api-reference/src/proxy.test.ts
@@ -1,6 +1,5 @@
 import HttpProxy from '@fastify/http-proxy'
 import Fastify from 'fastify'
-import ListRoutes from 'fastify-list-routes'
 import { describe, expect, it } from 'vitest'
 
 import Scalar from './index'
@@ -11,8 +10,6 @@ describe('fastifyApiReference', () => {
     const origin = Fastify({
       logger: false,
     })
-
-    await origin.register(ListRoutes, { colors: true })
 
     await origin.register(Scalar, {
       routePrefix: '/documentation',
@@ -30,8 +27,6 @@ describe('fastifyApiReference', () => {
     const proxy = Fastify({
       logger: false,
     })
-
-    await proxy.register(ListRoutes, { colors: true })
 
     await proxy.register(HttpProxy, {
       upstream: originAddress,

--- a/packages/fastify-api-reference/src/types.ts
+++ b/packages/fastify-api-reference/src/types.ts
@@ -1,0 +1,65 @@
+import type { ReferenceConfiguration } from '@scalar/types/legacy'
+import type { onRequestHookHandler, preHandlerHookHandler } from 'fastify'
+
+export type FastifyApiReferenceOptions = {
+  /**
+   * If you’re prefixing Fastify with a path, you can set it here.
+   * It’ll be added to the JavaScript URL and the route.
+   *
+   * Example: `${publicPath}${routePrefix}/@scalar/fastify-api-reference/js/browser.js`
+   */
+  publicPath?: string
+  /**
+   * Prefix the route with a path. This is where the API Reference will be available.
+   *
+   * @default '/reference'
+   */
+  routePrefix?: `/${string}`
+  /**
+   * Set where the OpenAPI specification is exposed under `${routePrefix}`.
+   *
+   * The specification is always available on these endpoints, parsed by `@scalar/openapi-parser`.
+   *
+   * The specification is sourced from, in order of precedence:
+   * - `configuration.spec.content`
+   * - `configuration.spec.url` – fetched via `@scalar/openapi-parser/plugins/fetch-urls`
+   * - `@fastify/swagger` – if `configuration.spec` is not provided
+   *
+   * These endpoints can be used to fetch the OpenAPI specification for your own programmatic use.
+   *
+   * @default{ json: '/openapi.json', yaml: '/openapi.yaml' }
+   */
+  openApiDocumentEndpoints?: {
+    /**
+     * Set where the OpenAPI specification is exposed under `${routePrefix}`, in JSON format.
+     *
+     * With the default value, the endpoint is: `${publicPath}${routePrefix}/openapi.json`
+     *
+     * @default '/openapi.json'
+     */
+    json?: `/${string}`
+    /**
+     * Set where the OpenAPI specification is exposed under `${routePrefix}`, in YAML format.
+     *
+     * With the default value, the endpoint is: `${publicPath}${routePrefix}/openapi.yaml`
+     *
+     * @default '/openapi.yaml'
+     */
+    yaml?: `/${string}`
+  }
+  /**
+   * The universal configuration object for @scalar/api-reference.
+   *
+   * Read more: https://github.com/scalar/scalar
+   */
+  configuration?: ReferenceConfiguration
+  /**
+   * The hooks for the API Reference.
+   */
+  hooks?: FastifyApiReferenceHooksOptions
+}
+
+export type FastifyApiReferenceHooksOptions = Partial<{
+  onRequest?: onRequestHookHandler
+  preHandler?: preHandlerHookHandler
+}>

--- a/packages/fastify-api-reference/src/types.ts
+++ b/packages/fastify-api-reference/src/types.ts
@@ -6,7 +6,7 @@ export type FastifyApiReferenceOptions = {
    * If you’re prefixing Fastify with a path, you can set it here.
    * It’ll be added to the JavaScript URL and the route.
    *
-   * Example: `${publicPath}${routePrefix}/@scalar/fastify-api-reference/js/browser.js`
+   * Example: `${publicPath}${routePrefix}/js/scalar.js`
    */
   publicPath?: string
   /**

--- a/packages/fastify-api-reference/src/types.ts
+++ b/packages/fastify-api-reference/src/types.ts
@@ -7,6 +7,7 @@ export type FastifyApiReferenceOptions = {
    * It’ll be added to the JavaScript URL and the route.
    *
    * Example: `${publicPath}${routePrefix}/js/scalar.js`
+   * @deprecated We don't use this anymore.
    */
   publicPath?: string
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 12.3.2(typescript@5.6.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
+        version: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -1527,9 +1527,6 @@ importers:
       fastify:
         specifier: ^4.26.2
         version: 4.28.0
-      fastify-list-routes:
-        specifier: ^1.0.0
-        version: 1.0.0
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -9873,9 +9870,6 @@ packages:
   fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
     hasBin: true
-
-  fastify-list-routes@1.0.0:
-    resolution: {integrity: sha512-1ayHJiHW54yDlyRTUwEmIB0kH1eFd29I6uIp3/23n8rbGCKwqQzTLKUxHTpmlSN2FG2ceQIrh5HRaNUh1m0ZAA==}
 
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
@@ -29149,10 +29143,6 @@ snapshots:
     dependencies:
       strnum: 1.0.5
 
-  fastify-list-routes@1.0.0:
-    dependencies:
-      fastify-plugin: 4.5.1
-
   fastify-plugin@4.5.1: {}
 
   fastify@4.27.0:
@@ -31120,7 +31110,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -31151,7 +31141,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -33837,7 +33827,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
 
   postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.39):
     dependencies:
@@ -36542,7 +36532,7 @@ snapshots:
       '@swc/core': 1.5.29(@swc/helpers@0.5.5)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2):
+  ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 12.3.2(typescript@5.6.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
+        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -1527,6 +1527,9 @@ importers:
       fastify:
         specifier: ^4.26.2
         version: 4.28.0
+      fastify-list-routes:
+        specifier: ^1.0.0
+        version: 1.0.0
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -9870,6 +9873,9 @@ packages:
   fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
     hasBin: true
+
+  fastify-list-routes@1.0.0:
+    resolution: {integrity: sha512-1ayHJiHW54yDlyRTUwEmIB0kH1eFd29I6uIp3/23n8rbGCKwqQzTLKUxHTpmlSN2FG2ceQIrh5HRaNUh1m0ZAA==}
 
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
@@ -29143,6 +29149,10 @@ snapshots:
     dependencies:
       strnum: 1.0.5
 
+  fastify-list-routes@1.0.0:
+    dependencies:
+      fastify-plugin: 4.5.1
+
   fastify-plugin@4.5.1: {}
 
   fastify@4.27.0:
@@ -31110,7 +31120,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -31141,7 +31151,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -33827,7 +33837,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
 
   postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.39):
     dependencies:
@@ -36532,7 +36542,7 @@ snapshots:
       '@swc/core': 1.5.29(@swc/helpers@0.5.5)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2):
+  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,82 +284,6 @@ importers:
         version: 10.3.2(@swc/cli@0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0))(@swc/core@1.5.29(@swc/helpers@0.5.5))
       '@nestjs/schematics':
         specifier: ^10.0.1
-        version: 10.1.1(chokidar@3.6.0)(typescript@5.6.2)
-      '@nestjs/testing':
-        specifier: ^10.0.0
-        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9))
-      '@swc/cli':
-        specifier: ^0.1.62
-        version: 0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0)
-      '@swc/core':
-        specifier: ^1.3.64
-        version: 1.5.29(@swc/helpers@0.5.5)
-      '@types/jest':
-        specifier: ^29.5.2
-        version: 29.5.12
-      '@types/node':
-        specifier: ^20.14.10
-        version: 20.14.10
-      '@types/supertest':
-        specifier: ^2.0.12
-        version: 2.0.16
-      '@typescript-eslint/parser':
-        specifier: ^6.21.0
-        version: 6.21.0(eslint@8.57.0)(typescript@5.6.2)
-      eslint-config-prettier:
-        specifier: ^9.1.0
-        version: 9.1.0(eslint@8.57.0)
-      eslint-plugin-prettier:
-        specifier: ^5.1.3
-        version: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.2)
-      jest:
-        specifier: ^29.5.0
-        version: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2))
-      prettier:
-        specifier: ^3.2.5
-        version: 3.3.2
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
-      supertest:
-        specifier: ^6.3.3
-        version: 6.3.4
-      ts-jest:
-        specifier: ^29.1.0
-        version: 29.1.4(@babel/core@7.24.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.8))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)))(typescript@5.6.2)
-      ts-loader:
-        specifier: ^9.4.3
-        version: 9.5.1(typescript@5.6.2)(webpack@5.92.0(@swc/core@1.5.29(@swc/helpers@0.5.5)))
-
-  examples/nestjs-api-reference-fastify:
-    dependencies:
-      '@nestjs/common':
-        specifier: ^10.3.8
-        version: 10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/core':
-        specifier: ^10.3.8
-        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/platform-fastify':
-        specifier: ^10.3.8
-        version: 10.3.9(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))
-      '@nestjs/swagger':
-        specifier: ^7.3.1
-        version: 7.3.1(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)
-      '@scalar/nestjs-api-reference':
-        specifier: workspace:*
-        version: link:../../packages/nestjs-api-reference
-      reflect-metadata:
-        specifier: ^0.1.13
-        version: 0.1.14
-      rxjs:
-        specifier: ^7.8.1
-        version: 7.8.1
-    devDependencies:
-      '@nestjs/cli':
-        specifier: ^10.0.1
-        version: 10.3.2(@swc/cli@0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0))(@swc/core@1.5.29(@swc/helpers@0.5.5))
-      '@nestjs/schematics':
-        specifier: ^10.0.1
         version: 10.1.1(chokidar@3.6.0)(typescript@5.3.3)
       '@nestjs/testing':
         specifier: ^10.0.0
@@ -406,6 +330,82 @@ importers:
       ts-loader:
         specifier: ^9.4.3
         version: 9.5.1(typescript@5.3.3)(webpack@5.90.1(@swc/core@1.5.29(@swc/helpers@0.5.5)))
+
+  examples/nestjs-api-reference-fastify:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^10.3.8
+        version: 10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/core':
+        specifier: ^10.3.8
+        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/platform-fastify':
+        specifier: ^10.3.8
+        version: 10.3.9(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))
+      '@nestjs/swagger':
+        specifier: ^7.3.1
+        version: 7.3.1(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)
+      '@scalar/nestjs-api-reference':
+        specifier: workspace:*
+        version: link:../../packages/nestjs-api-reference
+      reflect-metadata:
+        specifier: ^0.1.13
+        version: 0.1.14
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
+    devDependencies:
+      '@nestjs/cli':
+        specifier: ^10.0.1
+        version: 10.3.2(@swc/cli@0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0))(@swc/core@1.5.29(@swc/helpers@0.5.5))
+      '@nestjs/schematics':
+        specifier: ^10.0.1
+        version: 10.1.1(chokidar@3.6.0)(typescript@5.6.2)
+      '@nestjs/testing':
+        specifier: ^10.0.0
+        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9))
+      '@swc/cli':
+        specifier: ^0.1.62
+        version: 0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0)
+      '@swc/core':
+        specifier: ^1.3.64
+        version: 1.5.29(@swc/helpers@0.5.5)
+      '@types/jest':
+        specifier: ^29.5.2
+        version: 29.5.12
+      '@types/node':
+        specifier: ^20.14.10
+        version: 20.14.10
+      '@types/supertest':
+        specifier: ^2.0.12
+        version: 2.0.16
+      '@typescript-eslint/parser':
+        specifier: ^6.21.0
+        version: 6.21.0(eslint@8.57.0)(typescript@5.6.2)
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.0)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.2)
+      jest:
+        specifier: ^29.5.0
+        version: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2))
+      prettier:
+        specifier: ^3.2.5
+        version: 3.3.2
+      source-map-support:
+        specifier: ^0.5.21
+        version: 0.5.21
+      supertest:
+        specifier: ^6.3.3
+        version: 6.3.4
+      ts-jest:
+        specifier: ^29.1.0
+        version: 29.1.4(@babel/core@7.24.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.8))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)))(typescript@5.6.2)
+      ts-loader:
+        specifier: ^9.4.3
+        version: 9.5.1(typescript@5.6.2)(webpack@5.92.0(@swc/core@1.5.29(@swc/helpers@0.5.5)))
 
   examples/nextjs-api-reference:
     dependencies:
@@ -1509,6 +1509,9 @@ importers:
       '@fastify/basic-auth':
         specifier: ^5.1.1
         version: 5.1.1
+      '@fastify/http-proxy':
+        specifier: ^9.0.0
+        version: 9.5.0
       '@fastify/swagger':
         specifier: ^8.10.1
         version: 8.14.0
@@ -4361,11 +4364,17 @@ packages:
   '@fastify/formbody@7.4.0':
     resolution: {integrity: sha512-H3C6h1GN56/SMrZS8N2vCT2cZr7mIHzBHzOBa5OPpjfB/D6FzP9mMpE02ZzrFX0ANeh0BAJdoXKOF2e7IbV+Og==}
 
+  '@fastify/http-proxy@9.5.0':
+    resolution: {integrity: sha512-1iqIdV10d5k9YtfHq9ylX5zt1NiM50fG+rIX40qt00R694sqWso3ukyTFZVk33SDoSiBW8roB7n11RUVUoN+Ag==}
+
   '@fastify/merge-json-schemas@0.1.1':
     resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
 
   '@fastify/middie@8.3.1':
     resolution: {integrity: sha512-qrQ8U3iCdjNum3+omnIvAyz21ifFx+Pp5jYW7PJJ7b9ueKTCPXsH6vEvaZQrjEZvOpTnWte+CswfBODWD0NqYQ==}
+
+  '@fastify/reply-from@9.8.0':
+    resolution: {integrity: sha512-bPNVaFhEeNI0Lyl6404YZaPFokudCplidE3QoOcr78yOy6H9sYw97p5KPYvY/NJNUHfFtvxOaSAHnK+YSiv/Mg==}
 
   '@fastify/send@2.1.0':
     resolution: {integrity: sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==}
@@ -20981,6 +20990,16 @@ snapshots:
       fast-querystring: 1.1.2
       fastify-plugin: 4.5.1
 
+  '@fastify/http-proxy@9.5.0':
+    dependencies:
+      '@fastify/reply-from': 9.8.0
+      fast-querystring: 1.1.2
+      fastify-plugin: 4.5.1
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@fastify/merge-json-schemas@0.1.1':
     dependencies:
       fast-deep-equal: 3.1.3
@@ -20991,6 +21010,16 @@ snapshots:
       fastify-plugin: 4.5.1
       path-to-regexp: 6.2.2
       reusify: 1.0.4
+
+  '@fastify/reply-from@9.8.0':
+    dependencies:
+      '@fastify/error': 3.4.1
+      end-of-stream: 1.4.4
+      fast-content-type-parse: 1.1.0
+      fast-querystring: 1.1.2
+      fastify-plugin: 4.5.1
+      toad-cache: 3.7.0
+      undici: 5.28.4
 
   '@fastify/send@2.1.0':
     dependencies:


### PR DESCRIPTION
When Fastify is proxied with a route prefix, we can't rely on the configured route prefix that our integration has. The URL that we requested the JS from was invalid in those cases.

With this PR we’re making the JS asset path relative, which requires to access the reference with a trailing slash.

I registered a new route (depending on the configuration) e.g. `/reference`, which redirects to `/reference/`. This makes the browser request the JS with the `/reference/` prefix instead of just `/`.

This PR also includes the following unrelated changes (sorry):
* The `publicPath` prefix wasn’t really implemented, so I marked it as deprecated and deleted the relevant code. I’m not sure why this was in there. 👀 
* `/reference/@scalar/fastify-api-reference/js/browser.js` -> `/reference/js/scalar.js` (having `scalar.js` in the network panel is better than `browser.js`)
* Types are moved to a separate file