### PR TITLE
fix(api-client-app): images from fathom are blocked

### DIFF
--- a/.changeset/many-hotels-camp.md
+++ b/.changeset/many-hotels-camp.md
@@ -1,0 +1,5 @@
+---
+'scalar-api-client': patch
+---
+
+fix: allow to load images from fathom

--- a/packages/api-client-app/src/renderer/index.html
+++ b/packages/api-client-app/src/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' blob:; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://cdn.usefathom.com; font-src https://fonts.scalar.com" />
+      content="default-src 'self' blob:; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com; font-src https://fonts.scalar.com" />
   </head>
 
   <body>

--- a/packages/api-client-app/src/renderer/index.html
+++ b/packages/api-client-app/src/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' blob:; connect-src *; script-src 'self' https://cdn.usefathom.com/script.js; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com/script.js; font-src https://fonts.scalar.com" />
+      content="default-src 'self' blob:; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://cdn.usefathom.com; font-src https://fonts.scalar.com" />
   </head>
 
   <body>

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -40,7 +40,7 @@ if (window.electron) {
   trackEvent(`launch: ${os}`)
 
   // Hook into the router
-  router.beforeEach((route) => {
+  router.afterEach((route) => {
     if (typeof route.name !== 'string') {
       return
     }

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -12,16 +12,16 @@ const client = await createApiClientApp(
   createWebHashRouter(),
 )
 
-/**
- * Fathom Analytics offers simple & privacy-first tracking
- * @see https://usefathom.com/
- */
-load('EUNBEXQC', {
-  spa: 'auto',
-})
-
-// Track the launch event
+// Anonymous tracking
 if (window.electron) {
+  /**
+   * Fathom Analytics offers simple & privacy-first tracking
+   * @see https://usefathom.com/
+   */
+  load('EUNBEXQC', {
+    spa: 'auto',
+  })
+
   const { platform } = window.electron.process
 
   const os =


### PR DESCRIPTION
Currently, we block any images loaded from fathom. This PR adds to the content security policy to allow images to be fetched from fathom.

It also scopes the tracking to just Electron, and not client.scalar.com.