### PR TITLE
fix: css missing comma

### DIFF
--- a/.changeset/slow-spoons-pump.md
+++ b/.changeset/slow-spoons-pump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: css missing comma

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -451,7 +451,7 @@ const fontsStyleTag = computed(
   position: sticky;
   top: var(--refs-header-height);
   height: calc(100dvh - var(--refs-header-height));
-  background: var(--scalar-sidebar-background-1 var(--scalar-background-1));
+  background: var(--scalar-sidebar-background-1, var(--scalar-background-1));
   overflow-y: auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Previously chrome might have been ignoring this bad css rule, but fixed!