### PR TITLE
fix(api-client-app): invalid pageview url

### DIFF
--- a/.changeset/mean-icons-rescue.md
+++ b/.changeset/mean-icons-rescue.md
@@ -1,0 +1,5 @@
+---
+'scalar-api-client': patch
+---
+
+fix: invalid pageview url

--- a/packages/api-client-app/src/renderer/src/main.ts
+++ b/packages/api-client-app/src/renderer/src/main.ts
@@ -46,8 +46,8 @@ if (window.electron) {
     }
 
     trackPageview({
-      // We don’t need to know the route, the name of the route is enough.
-      url: `${os}/${route.name}`,
+      // We don’t need to know the path, the name of the route is enough.
+      url: `https://scalar-${os}/${route.name}`,
     })
   })
 }


### PR DESCRIPTION
Turns out we’ve used an invalid URL for the pageviews, which worked locally, but not in the build - for some reason.