### PR TITLE
fix(api-reference): show examples in models section

### DIFF
--- a/.changeset/clean-buckets-perform.md
+++ b/.changeset/clean-buckets-perform.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: support for multiple examples in schemas

--- a/.changeset/late-shirts-shave.md
+++ b/.changeset/late-shirts-shave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat(galaxy): add multiple examples to request body and schema

--- a/.changeset/nasty-cups-live.md
+++ b/.changeset/nasty-cups-live.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): show examples in models section

--- a/.changeset/pretty-trains-do.md
+++ b/.changeset/pretty-trains-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat: add multiple examples to some schemas

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -112,6 +112,26 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
         value.example || value?.items.example
       }}</code>
     </div>
+    <template
+      v-if="
+        value?.examples &&
+        typeof value.examples === 'object' &&
+        Object.keys(value.examples).length > 0
+      ">
+      <div class="property-example custom-scroll">
+        <span class="property-example-label">
+          {{
+            Object.keys(value.examples).length === 1 ? 'Example' : 'Examples'
+          }}
+        </span>
+        <code
+          v-for="(example, key) in value.examples"
+          :key="key"
+          class="property-example-value">
+          {{ example }}
+        </code>
+      </div>
+    </template>
     <!-- Enum -->
     <div
       v-if="getEnumFromValue(value)?.length > 1"
@@ -252,10 +272,8 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 .property-example {
   display: flex;
   flex-direction: column;
-  gap: 6px;
 
   margin-top: 6px;
-  padding: 6px;
 
   max-height: calc(((var(--full-height) - var(--refs-header-height))) / 2);
 
@@ -268,10 +286,14 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 .property-example-label {
   font-weight: var(--scalar-semibold);
   color: var(--scalar-color-3);
+
+  padding: 6px;
 }
 .property-example-value {
   font-family: var(--scalar-font-code);
   white-space: pre;
+  padding: 6px;
+  border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 
 .property-rule {

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -266,6 +266,17 @@ paths:
           application/json:
             schema:
               '$ref': '#/components/schemas/NewUser'
+            examples:
+              Marc:
+                value:
+                  name: Marc
+                  email: marc@scalar.com
+                  password: i-love-scalar
+              Cam:
+                value:
+                  name: Cam
+                  email: cam@scalar.com
+                  password: scalar-is-cool
       responses:
         '201':
           description: Created
@@ -424,17 +435,20 @@ components:
         name:
           type: string
           examples:
-            - Marc
+            - Hans
+            - Brynn
         email:
           type: string
           format: email
           examples:
-            - marc@scalar.com
+            - hans@scalar.com
+            - brynn@scalar.com
         password:
           type: string
           minLength: 8
           examples:
             - i-love-scalar
+            - scalar-is-cool
     User:
       type: object
       required:


### PR DESCRIPTION
Shows all the schema example values in the "Models" section again when the `examples` keyword is used (e.g. an array of examples). It sounds like OAS 3.1 has introduced the ability to add multiple examples to a schema as part of its alignment with JSON schema which only [allows an array of examples](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-9.5). 

I also added some additional example data to Scalar Galaxy with multiple examples.

<img width="1536" alt="Google Chrome-2024-09-25-18-08-06@2x" src="https://github.com/user-attachments/assets/5fed796e-681c-4ede-99a8-55d905e44bd1">

![Google Chrome-2024-09-25-18-16-57@2x](https://github.com/user-attachments/assets/38ce6c03-4a75-4538-8c55-acd30dfd4c75)
