### PR TITLE
feat(fastify-api-reference): use relative URL for fetching spec

### DIFF
--- a/.changeset/gentle-dolls-agree.md
+++ b/.changeset/gentle-dolls-agree.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+feat(fastify-api-reference): use relative URL for fetching spec from Fastify

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -306,7 +306,8 @@ const fastifyApiReference = fp<
           configuration = {
             ...configuration,
             spec: {
-              url: openApiSpecUrlJson,
+              // Use a relative URL in case we're proxied
+              url: `.${getOpenApiDocumentEndpoints(options.openApiDocumentEndpoints).json}`,
             },
           }
         }


### PR DESCRIPTION
This should solve @mcollina's issue with hosting Scalar via Fastify at a nested / proxied URL. Instead setting the spec URL to be absolute based on the route prefix (e.g. `/reference/openapi.json`) we assume it's relative to the current page (e.g. `./openapi.json`) which it should be since we host the file there ourselves when we register the plugin.

@hanspagel let me know if you see any issues with resolving it like this.

The test repo I was using was https://github.com/mcollina/scalar-fastify-proxy. Fyi @mcollina as far as I can tell setting `publicPath: './'` wasn't actually doing anything since it's no longer used by the integration. 
