### PR TITLE
chore(api-client): remove defineProps import

### DIFF
--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useWorkspace } from '@/store'
 import { useMediaQuery } from '@vueuse/core'
-import { defineProps, ref } from 'vue'
+import { ref } from 'vue'
 
 const props = withDefaults(
   defineProps<{


### PR DESCRIPTION
> [@vue/compiler-sfc] `defineProps` is a compiler macro and no longer needs to be imported.