### PR TITLE
chore(api-client): remove unused code

### DIFF
--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -77,7 +77,7 @@ const dataUrl = computed<string>(() => {
       <ResponseBodyRaw
         v-if="mediaConfig?.raw && showRaw"
         :key="dataUrl"
-        :data="data"
+        :content="data"
         :language="mediaConfig.language" />
       <ResponseBodyPreview
         v-if="mediaConfig?.preview && showPreview"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
 import { ScalarCodeBlock } from '@scalar/components'
-import { isJsonString } from '@scalar/oas-utils/helpers'
 import { type CodeMirrorLanguage, useCodeMirror } from '@scalar/use-codemirror'
-import { computed, ref, toRaw } from 'vue'
+import { ref } from 'vue'
 
 const props = defineProps<{
   data: any
@@ -11,30 +10,17 @@ const props = defineProps<{
 
 const codeMirrorRef = ref<HTMLDivElement | null>(null)
 
-// Pretty print JSON
-const content = computed<string>(() => {
-  // Format JSON
-  const value = props.data
-  // Format JSON
-  if (value && isJsonString(value)) {
-    return JSON.stringify(JSON.parse(value as string), null, 2)
-  } else if (value && typeof toRaw(value) === 'object') {
-    return JSON.stringify(value, null, 2)
-  }
-  return value
-})
-
 useCodeMirror({
   codeMirrorRef,
   readOnly: true,
   lineNumbers: true,
-  content,
+  content: props.data,
   language: props.language,
 })
 </script>
 <template>
   <ScalarCodeBlock
-    :content="content"
+    :content="data"
     :lang="language" />
 </template>
 <style scoped>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
@@ -4,7 +4,7 @@ import { type CodeMirrorLanguage, useCodeMirror } from '@scalar/use-codemirror'
 import { ref } from 'vue'
 
 const props = defineProps<{
-  data: any
+  content: any
   language?: CodeMirrorLanguage
 }>()
 
@@ -14,13 +14,13 @@ useCodeMirror({
   codeMirrorRef,
   readOnly: true,
   lineNumbers: true,
-  content: props.data,
+  content: props.content,
   language: props.language,
 })
 </script>
 <template>
   <ScalarCodeBlock
-    :content="data"
+    :content="content"
     :lang="language" />
 </template>
 <style scoped>


### PR DESCRIPTION
I saw some code to format the raw response body in the API client. But it’s passed to `ScalarCodeBlock` anyway, and this component is already formatting the content (pretty printing JSON).