### PR TITLE
chore(oas-utils): `getExampleFromSchema` performance improvements

### DIFF
--- a/.changeset/sharp-walls-bathe.md
+++ b/.changeset/sharp-walls-bathe.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+chore: improve performance of getExampleFromSchema

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponse.vue
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponse.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { ScalarCodeBlock } from '@scalar/components'
-import { prettyPrintJson } from '@scalar/oas-utils/helpers'
 import { getExampleFromSchema } from '@scalar/oas-utils/spec-getters'
 import type { OpenAPI } from '@scalar/openapi-types'
 
@@ -13,7 +12,7 @@ defineProps<{
   <template v-if="response?.example">
     <ScalarCodeBlock
       class="bg-b-2"
-      :content="prettyPrintJson(response?.example)"
+      :content="response?.example"
       lang="json" />
   </template>
   <!-- Schema -->
@@ -21,12 +20,10 @@ defineProps<{
     <ScalarCodeBlock
       class="bg-b-2"
       :content="
-        prettyPrintJson(
-          getExampleFromSchema(response?.schema, {
-            emptyString: '…',
-            mode: 'read',
-          }),
-        )
+        getExampleFromSchema(response?.schema, {
+          emptyString: '…',
+          mode: 'read',
+        })
       "
       lang="json" />
   </template>

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -934,7 +934,17 @@ describe('getExampleFromSchema', () => {
           foobar: {
             foobar: {
               foobar: {
-                foobar: '[Circular Reference]',
+                foobar: {
+                  foobar: {
+                    foobar: {
+                      foobar: {
+                        foobar: {
+                          foobar: '[Circular Reference]',
+                        },
+                      },
+                    },
+                  },
+                },
               },
             },
           },

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -340,7 +340,7 @@ export const getExampleFromSchema = (
   }
 
   // Warn if the type is unknown …
-  console.warn(`[getExampleFromSchema] Unknown property type "${schema.type}".`)
+  // console.warn(`[getExampleFromSchema] Unknown property type "${schema.type}".`)
 
   // … and just return null for now.
   return null

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -87,13 +87,11 @@ export const getExampleFromSchema = (
   // But if `emptyString` is  set, we do want to see some values.
   const makeUpRandomData = !!options?.emptyString
 
-  // Check if the property is read-only
-  if (options?.mode === 'write' && schema.readOnly) {
-    return undefined
-  }
-
-  // Check if the property is write-only
-  if (options?.mode === 'read' && schema.writeOnly) {
+  // Check if the property is read-only/write-only
+  if (
+    (options?.mode === 'write' && schema.readOnly) ||
+    (options?.mode === 'read' && schema.writeOnly)
+  ) {
     return undefined
   }
 

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -1,42 +1,42 @@
 /** Hard limit for rendering circular references */
 const MAX_LEVELS_DEEP = 10
 
+const genericExampleValues: Record<string, string> = {
+  // 'date-time': '1970-01-01T00:00:00Z',
+  'date-time': new Date().toISOString(),
+  // 'date': '1970-01-01',
+  'date': new Date().toISOString().split('T')[0],
+  'email': 'hello@example.com',
+  'hostname': 'example.com',
+  // https://tools.ietf.org/html/rfc6531#section-3.3
+  'idn-email': 'jane.doe@example.com',
+  // https://tools.ietf.org/html/rfc5890#section-2.3.2.3
+  'idn-hostname': 'example.com',
+  'ipv4': '127.0.0.1',
+  'ipv6': '51d4:7fab:bfbf:b7d7:b2cb:d4b4:3dad:d998',
+  'iri-reference': '/entitiy/1',
+  // https://tools.ietf.org/html/rfc3987
+  'iri': 'https://example.com/entity/123',
+  'json-pointer': '/nested/objects',
+  'password': 'super-secret',
+  'regex': '/[a-z]/',
+  // https://tools.ietf.org/html/draft-handrews-relative-json-pointer-01
+  'relative-json-pointer': '1/nested/objects',
+  // full-time in https://tools.ietf.org/html/rfc3339#section-5.6
+  // 'time': '00:00:00Z',
+  'time': new Date().toISOString().split('T')[1].split('.')[0],
+  // either a URI or relative-reference https://tools.ietf.org/html/rfc3986#section-4.1
+  'uri-reference': '../folder',
+  'uri-template': 'https://example.com/{id}',
+  'uri': 'https://example.com',
+  'uuid': '123e4567-e89b-12d3-a456-426614174000',
+}
+
 /**
  * We can use the `format` to generate some random values.
  */
 function guessFromFormat(schema: Record<string, any>, fallback: string = '') {
-  const exampleValues: Record<string, string> = {
-    // 'date-time': '1970-01-01T00:00:00Z',
-    'date-time': new Date().toISOString(),
-    // 'date': '1970-01-01',
-    'date': new Date().toISOString().split('T')[0],
-    'email': 'hello@example.com',
-    'hostname': 'example.com',
-    // https://tools.ietf.org/html/rfc6531#section-3.3
-    'idn-email': 'jane.doe@example.com',
-    // https://tools.ietf.org/html/rfc5890#section-2.3.2.3
-    'idn-hostname': 'example.com',
-    'ipv4': '127.0.0.1',
-    'ipv6': '51d4:7fab:bfbf:b7d7:b2cb:d4b4:3dad:d998',
-    'iri-reference': '/entitiy/1',
-    // https://tools.ietf.org/html/rfc3987
-    'iri': 'https://example.com/entity/123',
-    'json-pointer': '/nested/objects',
-    'password': 'super-secret',
-    'regex': '/[a-z]/',
-    // https://tools.ietf.org/html/draft-handrews-relative-json-pointer-01
-    'relative-json-pointer': '1/nested/objects',
-    // full-time in https://tools.ietf.org/html/rfc3339#section-5.6
-    // 'time': '00:00:00Z',
-    'time': new Date().toISOString().split('T')[1].split('.')[0],
-    // either a URI or relative-reference https://tools.ietf.org/html/rfc3986#section-4.1
-    'uri-reference': '../folder',
-    'uri-template': 'https://example.com/{id}',
-    'uri': 'https://example.com',
-    'uuid': '123e4567-e89b-12d3-a456-426614174000',
-  }
-
-  return exampleValues[schema.format] ?? fallback
+  return genericExampleValues[schema.format] ?? fallback
 }
 
 /**

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -126,7 +126,7 @@ export const getExampleFromSchema = (
   }
 
   // enum: [ 'available', 'pending', 'sold' ]
-  if (schema.enum !== undefined) {
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
     return schema.enum[0]
   }
 

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -156,24 +156,30 @@ export const getExampleFromSchema = (
 
     // Regular properties
     if (schema.properties !== undefined) {
-      Object.keys(schema.properties).forEach((propertyName: string) => {
-        const property = schema.properties[propertyName]
-        const propertyXmlTagName = options?.xml ? property.xml?.name : undefined
-
-        response[propertyXmlTagName ?? propertyName] = getExampleFromSchema(
-          property,
-          options,
-          level + 1,
-          schema,
-          propertyName,
-        )
-
+      for (const propertyName in schema.properties) {
         if (
-          typeof response[propertyXmlTagName ?? propertyName] === 'undefined'
+          Object.prototype.hasOwnProperty.call(schema.properties, propertyName)
         ) {
-          delete response[propertyXmlTagName ?? propertyName]
+          const property = schema.properties[propertyName]
+          const propertyXmlTagName = options?.xml
+            ? property.xml?.name
+            : undefined
+
+          response[propertyXmlTagName ?? propertyName] = getExampleFromSchema(
+            property,
+            options,
+            level + 1,
+            schema,
+            propertyName,
+          )
+
+          if (
+            typeof response[propertyXmlTagName ?? propertyName] === 'undefined'
+          ) {
+            delete response[propertyXmlTagName ?? propertyName]
+          }
         }
-      })
+      }
     }
 
     // Additional properties

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -1,5 +1,5 @@
 /** Hard limit for rendering circular references */
-const MAX_LEVELS_DEEP = 5
+const MAX_LEVELS_DEEP = 10
 
 /**
  * We can use the `format` to generate some random values.


### PR DESCRIPTION
I’m playing around with a huge OpenAPI document with huge schemas. Find the screenshot of a perf profile for opening a tag. The big blue box is `getExampleFromSchema` taking more than 1s:

![image](https://github.com/user-attachments/assets/b7df966c-3216-4421-b8dc-65afec02c4c0)

This PR tries to improve the performance and the results are amazing: The new implementation is 1.000× faster than what we had before.

<img width="1318" alt="Screenshot 2024-10-02 at 12 54 46" src="https://github.com/user-attachments/assets/ec57ef0b-7061-42c3-aac4-3850a10667b2">