### PR TITLE
fix(Scalar.AspNetCore): typo in theme names

### DIFF
--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTheme.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTheme.cs
@@ -48,7 +48,7 @@ public enum ScalarTheme
     /// <summary>
     /// Blue Planet theme.
     /// </summary>
-    [Description("blueplanet")]
+    [Description("bluePlanet")]
     BluePlanet,
 
     /// <summary>
@@ -72,6 +72,6 @@ public enum ScalarTheme
     /// <summary>
     /// Deep Space theme.
     /// </summary>
-    [Description("deepspace")]
+    [Description("deepSpace")]
     DeepSpace
 }


### PR DESCRIPTION
### Description

This PR fixes two typos in the theme names.

Closes #3269 