### PR TITLE
feat(api-client): sets initial security scheme in the client 

### DIFF
--- a/.changeset/light-brooms-roll.md
+++ b/.changeset/light-brooms-roll.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: added setting of initial security schemes in the client

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
@@ -36,13 +36,15 @@ export const createApiClientModal = async (
     await importSpecFromUrl(
       configuration.spec.url,
       configuration.proxyUrl,
-      configuration?.servers,
+      configuration.servers,
+      configuration.initialScheme,
     )
   else if (configuration.spec?.content)
     await importSpecFile(
       configuration.spec?.content,
       undefined,
       configuration?.servers,
+      configuration.initialScheme,
     )
 
   return client

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
@@ -37,14 +37,14 @@ export const createApiClientModal = async (
       configuration.spec.url,
       configuration.proxyUrl,
       configuration.servers,
-      configuration.initialScheme,
+      configuration.preferredSecurityScheme,
     )
   else if (configuration.spec?.content)
     await importSpecFile(
       configuration.spec?.content,
       undefined,
       configuration?.servers,
-      configuration.initialScheme,
+      configuration.preferredSecurityScheme,
     )
 
   return client

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -5,57 +5,24 @@ import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { LS_KEYS, objectMerge } from '@scalar/oas-utils/helpers'
 import { DATA_VERSION, DATA_VERSION_LS_LEY } from '@scalar/oas-utils/migrations'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
-import type { ThemeId } from '@scalar/themes'
-import type { Spec, SpecConfiguration } from '@scalar/types/legacy'
+import type {
+  AuthenticationState,
+  ReferenceConfiguration,
+  SpecConfiguration,
+} from '@scalar/types/legacy'
 import type { LiteralUnion } from 'type-fest'
 import { type Component, createApp } from 'vue'
 import type { Router } from 'vue-router'
 
 /** Configuration options for the Scalar API client */
 export type ClientConfiguration = {
-  /** The Swagger/OpenAPI spec to render */
-  spec?: SpecConfiguration
-  /** Pass in a proxy to the API client */
-  proxyUrl?: string
-  /** Pass in a theme API client */
-  themeId?: ThemeId
-  /** Whether to show the sidebar */
-  showSidebar?: boolean
-  /** The initially selected security scheme */
-  initialScheme?: string | null
-  /** override the initial servers */
-  servers?: Spec['servers']
-  /** Whether dark mode is on or off initially (light mode) */
-  // darkMode?: boolean
-  /** Key used with CTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k) */
-  searchHotKey?:
-    | 'a'
-    | 'b'
-    | 'c'
-    | 'd'
-    | 'e'
-    | 'f'
-    | 'g'
-    | 'h'
-    | 'i'
-    | 'j'
-    | 'k'
-    | 'l'
-    | 'm'
-    | 'n'
-    | 'o'
-    | 'p'
-    | 'q'
-    | 'r'
-    | 's'
-    | 't'
-    | 'u'
-    | 'v'
-    | 'w'
-    | 'x'
-    | 'y'
-    | 'z'
-}
+  proxyUrl?: ReferenceConfiguration['proxy']
+  themeId?: ReferenceConfiguration['theme']
+  preferredSecurityScheme?: AuthenticationState['preferredSecurityScheme']
+} & Pick<
+  ReferenceConfiguration,
+  'spec' | 'showSidebar' | 'servers' | 'searchHotKey'
+>
 
 export type OpenClientPayload = {
   path: string

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -21,6 +21,8 @@ export type ClientConfiguration = {
   themeId?: ThemeId
   /** Whether to show the sidebar */
   showSidebar?: boolean
+  /** The initially selected security scheme */
+  initialScheme?: string | null
   /** override the initial servers */
   servers?: Spec['servers']
   /** Whether dark mode is on or off initially (light mode) */

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -1,3 +1,4 @@
+import type { ClientConfiguration } from '@/libs'
 import type { StoreContext } from '@/store/store-context'
 import { fetchSpecFromUrl } from '@scalar/oas-utils/helpers'
 import { importSpecToWorkspace } from '@scalar/oas-utils/transforms'
@@ -24,6 +25,7 @@ export function importSpecFileFactory({
      * attach those as needed to entities below
      */
     overloadServers?: Spec['servers'],
+    initialScheme?: ClientConfiguration['initialScheme'],
   ) => {
     const spec = toRaw(_spec)
 
@@ -31,7 +33,7 @@ export function importSpecFileFactory({
     if (overloadServers?.length && typeof spec === 'object')
       spec.servers = overloadServers
 
-    const workspaceEntities = await importSpecToWorkspace(spec)
+    const workspaceEntities = await importSpecToWorkspace(spec, initialScheme)
 
     if (workspaceEntities.error) {
       console.group('IMPORT ERRORS')
@@ -64,10 +66,11 @@ export function importSpecFileFactory({
     url: string,
     proxy?: string,
     overloadServers?: Spec['servers'],
+    initialScheme?: ClientConfiguration['initialScheme'],
   ) {
     try {
       const spec = await fetchSpecFromUrl(url, proxy)
-      await importSpecFile(spec, undefined, overloadServers)
+      await importSpecFile(spec, undefined, overloadServers, initialScheme)
     } catch (error) {
       console.error('Failed to fetch spec from URL:', error)
     }

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -25,7 +25,7 @@ export function importSpecFileFactory({
      * attach those as needed to entities below
      */
     overloadServers?: Spec['servers'],
-    initialScheme?: ClientConfiguration['initialScheme'],
+    preferredSecurityScheme?: ClientConfiguration['preferredSecurityScheme'],
   ) => {
     const spec = toRaw(_spec)
 
@@ -33,7 +33,10 @@ export function importSpecFileFactory({
     if (overloadServers?.length && typeof spec === 'object')
       spec.servers = overloadServers
 
-    const workspaceEntities = await importSpecToWorkspace(spec, initialScheme)
+    const workspaceEntities = await importSpecToWorkspace(
+      spec,
+      preferredSecurityScheme,
+    )
 
     if (workspaceEntities.error) {
       console.group('IMPORT ERRORS')
@@ -66,11 +69,16 @@ export function importSpecFileFactory({
     url: string,
     proxy?: string,
     overloadServers?: Spec['servers'],
-    initialScheme?: ClientConfiguration['initialScheme'],
+    preferredSecurityScheme?: ClientConfiguration['preferredSecurityScheme'],
   ) {
     try {
       const spec = await fetchSpecFromUrl(url, proxy)
-      await importSpecFile(spec, undefined, overloadServers, initialScheme)
+      await importSpecFile(
+        spec,
+        undefined,
+        overloadServers,
+        preferredSecurityScheme,
+      )
     } catch (error) {
       console.error('Failed to fetch spec from URL:', error)
     }

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -26,7 +26,7 @@ onMounted(async () => {
   const { app, open, updateAuth, modalState, updateSpec, updateServer } =
     await createApiClientModal(el.value, {
       spec: props.spec ?? {},
-      initialScheme: props.preferredSecurityScheme,
+      preferredSecurityScheme: props.preferredSecurityScheme,
       proxyUrl: props.proxyUrl,
       servers: props.servers,
     })

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -8,6 +8,7 @@ import { apiClientBus, modalStateBus } from './api-client-bus'
 
 const props = defineProps<{
   proxyUrl?: string
+  preferredSecurityScheme?: string | null
   spec?: SpecConfiguration
   servers?: Spec['servers']
 }>()
@@ -25,6 +26,7 @@ onMounted(async () => {
   const { app, open, updateAuth, modalState, updateSpec, updateServer } =
     await createApiClientModal(el.value, {
       spec: props.spec ?? {},
+      initialScheme: props.preferredSecurityScheme,
       proxyUrl: props.proxyUrl,
       servers: props.servers,
     })

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -353,6 +353,9 @@ const fontsStyleTag = computed(
     <!-- REST API Client Overlay -->
     <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withDefaultFonts: false` -->
     <ApiClientModal
+      :preferredSecurityScheme="
+        configuration.authentication?.preferredSecurityScheme
+      "
       :proxyUrl="configuration.proxy"
       :servers="configuration.servers"
       :spec="configuration.spec" />

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -22,6 +22,7 @@ import { schemaModel } from '@/helpers/schema-model'
 import { keysOf } from '@scalar/object-utils/arrays'
 import { dereference, load, upgrade } from '@scalar/openapi-parser'
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { AuthenticationState } from '@scalar/types/legacy'
 import type { UnknownObject } from '@scalar/types/utils'
 import type { Entries } from 'type-fest'
 
@@ -65,7 +66,7 @@ const convertOauth2Flows = (
  */
 export async function importSpecToWorkspace(
   spec: string | UnknownObject,
-  initialScheme?: string | null,
+  preferredSecurityScheme?: AuthenticationState['preferredSecurityScheme'],
 ): Promise<
   | {
       error: false
@@ -191,8 +192,9 @@ export async function importSpecToWorkspace(
         // Set the initially selected security scheme
         if (securityRequirements.length) {
           const name =
-            initialScheme && securityRequirements.includes(initialScheme ?? '')
-              ? initialScheme
+            preferredSecurityScheme &&
+            securityRequirements.includes(preferredSecurityScheme ?? '')
+              ? preferredSecurityScheme
               : securityRequirements[0]
           const uid = securitySchemeMap[name]
           selectedSecuritySchemeUids = [uid]


### PR DESCRIPTION
Since security schemes are selected per request, it isn't so easy to change the currently selected scheme from the references. HOWEVER we can set the scheme on initialization!

closes #3264