### PR TITLE
style(api-client): icon library stroke

### DIFF
--- a/.changeset/moody-owls-dance.md
+++ b/.changeset/moody-owls-dance.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: increases icon library usage stroke

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteCollection.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteCollection.vue
@@ -54,7 +54,7 @@ const handleSubmit = () => {
           class="aspect-square px-0 h-auto"
           variant="outlined">
           <LibraryIcon
-            class="size-4 text-c-2"
+            class="size-4 text-c-2 stroke-2"
             :src="collectionIcon" />
         </ScalarButton>
       </IconSelector>

--- a/packages/api-client/src/components/IconSelector.vue
+++ b/packages/api-client/src/components/IconSelector.vue
@@ -33,7 +33,7 @@ const value = computed<string>({
         class="flex flex-col">
         <div class="flex text-sm">
           <RadioGroupLabel class="text-c-2 py-1 px-1">
-            <slot name="title">Select an icon...</slot>
+            <slot name="title">Select an icon</slot>
           </RadioGroupLabel>
         </div>
         <ul
@@ -48,7 +48,9 @@ const value = computed<string>({
             <RadioGroupLabel class="sr-only">
               {{ icon.src.replaceAll('-', ' ') }} Icon
             </RadioGroupLabel>
-            <LibraryIcon :src="icon.src" />
+            <LibraryIcon
+              class="stroke-2"
+              :src="icon.src" />
           </RadioGroupOption>
         </ul>
       </RadioGroup>

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -164,7 +164,7 @@ onBeforeUnmount(() => {
             @openMenu="(item) => Object.assign(menuItem, item)">
             <template #leftIcon>
               <LibraryIcon
-                class="text-sidebar-c-2 size-3.5 group-hover:hidden"
+                class="text-sidebar-c-2 size-3.5 stroke-[2.5] group-hover:hidden"
                 :src="
                   collection['x-scalar-icon'] || 'interface-content-folder'
                 " />


### PR DESCRIPTION
this pr increases icon library icon usage stroke to maintain icon / text consistency as suggested by @cameronrohani  in sidebar, command palette:

**before**
<img width="1443" alt="image" src="https://github.com/user-attachments/assets/f78365f6-2153-4be1-897d-8513d4cdf175">


**after**
<img width="1443" alt="image" src="https://github.com/user-attachments/assets/f8f5f522-0d4e-4998-aa01-0246c22e5424">
