### PR TITLE
feat(api-client): request and response section

### DIFF
--- a/.changeset/nine-beers-sip.md
+++ b/.changeset/nine-beers-sip.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: updates request and response section order and naming

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -16,17 +16,17 @@ const { activeRequest, activeExample, isReadOnly, requestMutators } =
 
 const sections = computed(() => {
   const allSections = new Set([
+    'All',
     'Query',
     'Auth',
-    'Request',
+    'Variables',
     'Cookies',
     'Headers',
     'Body',
-    'All',
   ])
 
   if (!activeExample.value?.parameters.path.length)
-    allSections.delete('Request')
+    allSections.delete('Variables')
   if (!canMethodHaveBody(activeRequest.value?.method ?? 'get'))
     allSections.delete('Body')
   if (isAuthHidden.value) allSections.delete('Auth')
@@ -101,7 +101,7 @@ const updateRequestNameHandler = (event: Event) => {
         title="Authentication" />
       <RequestPathParams
         v-show="
-          (activeSection === 'All' || activeSection === 'Request') &&
+          (activeSection === 'All' || activeSection === 'Variables') &&
           activeExample?.parameters?.path?.length
         "
         paramKey="path"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -53,7 +53,7 @@ const responseCookies = computed(
     }) ?? [],
 )
 
-const sections = ['Cookies', 'Headers', 'Body', 'All']
+const sections = ['All', 'Cookies', 'Headers', 'Body']
 type ActiveSections = (typeof sections)[number]
 
 const activeSection = ref<ActiveSections>('All')


### PR DESCRIPTION
this pr updates the request and response section order and naming as seen below:
- `all` displayed first
- `variables` for path variables section instead of request

**before**
<img width="1120" alt="image" src="https://github.com/user-attachments/assets/092a272b-1c42-4a5d-b0d4-9e8169800208">


**after**
<img width="1120" alt="image" src="https://github.com/user-attachments/assets/c1b1d8bd-0ea6-4d25-b9fc-70c0f616b6dc">
