### PR TITLE
fix(api-references): selected server doesn’t update the API client, fix #2830

### DIFF
--- a/.changeset/eleven-tigers-mix.md
+++ b/.changeset/eleven-tigers-mix.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix(api-references): sync selected server state with api client modal

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -11,7 +11,7 @@ import type {
   SpecConfiguration,
 } from '@scalar/types/legacy'
 import type { LiteralUnion } from 'type-fest'
-import { type Component, createApp } from 'vue'
+import { type Component, createApp, watch } from 'vue'
 import type { Router } from 'vue-router'
 
 /** Configuration options for the Scalar API client */
@@ -188,6 +188,16 @@ export const createApiClient = ({
           'selectedServerUid',
           server.uid,
         )
+    },
+    /** Update the currently selected server via URL */
+    onUpdateServer: (callback: (url: string) => void) => {
+      watch(
+        () => activeCollection.value?.selectedServerUid,
+        (uid) => {
+          const server = Object.values(servers).find((s) => s.uid === uid)
+          if (server?.url) callback(server.url)
+        },
+      )
     },
     /**
      * Update the auth values, we currently don't change the auth selection

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -51,7 +51,6 @@ onMounted(async () => {
   onUpdateServer((url) => {
     if (!server.servers) return
     const index = server.servers.findIndex((s) => s.url === url)
-    console.log('Set server', index, url)
     if (index >= 0) setServer({ selectedServer: index })
   })
 

--- a/packages/api-reference/src/components/ApiClientModal.vue
+++ b/packages/api-reference/src/components/ApiClientModal.vue
@@ -16,20 +16,27 @@ const props = defineProps<{
 const el = ref<HTMLDivElement | null>(null)
 const client = ref<ApiClient | null>(null)
 
-const { server } = useServerStore()
+const { server, setServer } = useServerStore()
 
 onMounted(async () => {
   if (!el.value) return
 
   const { createApiClientModal } = await import('@scalar/api-client')
 
-  const { app, open, updateAuth, modalState, updateSpec, updateServer } =
-    await createApiClientModal(el.value, {
-      spec: props.spec ?? {},
-      preferredSecurityScheme: props.preferredSecurityScheme,
-      proxyUrl: props.proxyUrl,
-      servers: props.servers,
-    })
+  const {
+    app,
+    open,
+    updateAuth,
+    modalState,
+    updateSpec,
+    updateServer,
+    onUpdateServer,
+  } = await createApiClientModal(el.value, {
+    spec: props.spec ?? {},
+    preferredSecurityScheme: props.preferredSecurityScheme,
+    proxyUrl: props.proxyUrl,
+    servers: props.servers,
+  })
 
   client.value = {
     // @ts-expect-error not sure what the beef with app is, possible router related
@@ -39,6 +46,14 @@ onMounted(async () => {
   }
 
   modalStateBus.emit(modalState)
+
+  // Update the references server when the client server changes
+  onUpdateServer((url) => {
+    if (!server.servers) return
+    const index = server.servers.findIndex((s) => s.url === url)
+    console.log('Set server', index, url)
+    if (index >= 0) setServer({ selectedServer: index })
+  })
 
   // Event bus to listen to apiClient events
   apiClientBus.on((event) => {

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
 import { useServerStore } from '#legacy'
 import type { Server, Spec } from '@scalar/types/legacy'
-import { ref, toRef, watch } from 'vue'
+import { computed, toRef } from 'vue'
 
 import ServerForm from './ServerForm.vue'
+import type { ServerVariableValues } from './types'
 
 const props = defineProps<{
   /**
@@ -30,38 +31,19 @@ const { server: serverState, setServer } = useServerStore({
   servers,
 })
 
-// Keep the selected item in sync with the store
-const selected = ref<number>(0)
+const selected = computed<number>({
+  get: () => serverState.selectedServer || 0,
+  set: (i) => setServer({ selectedServer: i }),
+})
 
-watch(
-  selected,
-  () =>
-    setServer({
-      selectedServer: selected.value,
-    }),
-  {
-    immediate: true,
-  },
-)
-
-function onUpdateVariable(name: string, value: string) {
-  setServer({
-    variables: {
-      ...serverState.variables,
-      [name]: value,
-    },
-  })
-}
+const variables = computed<ServerVariableValues>({
+  get: () => serverState.variables,
+  set: (v) => setServer({ variables: v }),
+})
 </script>
 <template>
   <ServerForm
-    :selected="selected"
-    :servers="serverState.servers as Server[]"
-    :variables="serverState.variables"
-    @update:selected="
-      (value) => {
-        selected = value
-      }
-    "
-    @update:variable="onUpdateVariable" />
+    v-model:selected="selected"
+    v-model:variables="variables"
+    :servers="serverState.servers as Server[]" />
 </template>

--- a/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
@@ -10,11 +10,11 @@ import { computed } from 'vue'
 
 const props = defineProps<{
   options: Server[]
-  value: number
+  modelValue: number
 }>()
 
 const emit = defineEmits<{
-  (e: 'change', v: string): void
+  (e: 'update:modelValue', v: number): void
 }>()
 
 const options = computed<ScalarListboxOption[]>(() =>
@@ -25,8 +25,10 @@ const options = computed<ScalarListboxOption[]>(() =>
 )
 
 const selected = computed<ScalarListboxOption | undefined>({
-  get: () => options.value?.find((opt) => opt.id === props.value.toString()),
-  set: (opt?: ScalarListboxOption) => emit('change', opt?.id ?? ''),
+  get: () =>
+    options.value?.find((opt) => opt.id === props.modelValue.toString()),
+  set: (opt?: ScalarListboxOption) =>
+    emit('update:modelValue', parseInt(opt?.id ?? '', 10)),
 })
 </script>
 <template>


### PR DESCRIPTION
Synchronizes the selected server in the references with the selected server in the api client.

I'm not sure if this is the preferred callback pattern but I did my best to keep it simple and clean up the server selector a little bit. I wasn't sure how to set up variables to test that part @hanspagel?

## Before / After

https://github.com/user-attachments/assets/f2e6cbbc-e4a0-4eca-bfb7-a9e329528ad6

