### PR TITLE
fix(api-client): disable object preview due to blob XSS vulnerability

### DIFF
--- a/.changeset/old-olives-itch.md
+++ b/.changeset/old-olives-itch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): disable object preview due to blob XSS vulnerability

--- a/examples/api-client/index.html
+++ b/examples/api-client/index.html
@@ -8,6 +8,9 @@
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com; media-src 'self' data: blob:; font-src https://fonts.scalar.com" />
     <title>Scalar API Client</title>
     <script
       src="https://cdn.usefathom.com/script.js"

--- a/packages/api-client-app/src/renderer/index.html
+++ b/packages/api-client-app/src/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' blob:; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com; font-src https://fonts.scalar.com" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com; media-src 'self' data: blob:; font-src https://fonts.scalar.com" />
   </head>
 
   <body>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyPreview.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyPreview.vue
@@ -50,12 +50,6 @@ watch(
         :src="src"
         :type="type" />
     </audio>
-    <object
-      v-else
-      class="w-full aspect-[4/3]"
-      :data="src"
-      :type="type"
-      @error="error = true" />
   </div>
   <ResponseBodyInfo v-else>Preview unavailable</ResponseBodyInfo>
 </template>

--- a/packages/api-client/src/views/Request/consts/mediaTypes.ts
+++ b/packages/api-client/src/views/Request/consts/mediaTypes.ts
@@ -1,6 +1,6 @@
 import type { CodeMirrorLanguage } from '@scalar/use-codemirror'
 
-export type MediaPreview = 'object' | 'image' | 'video' | 'audio'
+export type MediaPreview = 'image' | 'video' | 'audio'
 
 export type MediaConfig = {
   preview?: MediaPreview
@@ -26,7 +26,7 @@ export const mediaTypes: { [type: string]: MediaConfig | undefined } = {
   'application/msword': { extension: '.doc' },
   'application/octet-stream': { extension: '.bin' },
   'application/ogg': { extension: '.ogx' },
-  'application/pdf': { extension: '.pdf', preview: 'object' },
+  'application/pdf': { extension: '.pdf' },
   'application/rtf': { extension: '.rtf', raw: true },
   'application/vnd.amazon.ebook': { extension: '.azw' },
   'application/vnd.apple.installer+xml': {
@@ -103,7 +103,6 @@ export const mediaTypes: { [type: string]: MediaConfig | undefined } = {
     extension: '.html',
     raw: true,
     language: 'html',
-    preview: 'object',
   },
   'text/javascript': { extension: '.js', raw: true },
   'text/plain': { extension: '.txt', raw: true },


### PR DESCRIPTION
Turns out `blob` urls in `object` (or `iframe`) tags are executed in the same origin context as the host page which means they're vulnerable to XSS injection. This disables the object preview (which is used for html and pdf previews) for the time being until we can preview them safely. The `svg` preview should still be safe though since it's rendered with an `<img>`.

I also updated our `Content-Security-Policy` for the app and for `examples/api-client` (which seems to be used for `client.scalar.com`) to not allow scripts from blobs and to only allow blobs to be used for `<img>` and media tags (`<video>` and `<audio>`). This prevents scripts from running in svgs when they're opened in a new tab via right click → "Open Image in New Tab"

## `Content-Security-Policy` Before / After

https://github.com/user-attachments/assets/0590325e-6a5e-4976-8dc4-1dd15c0a4a30

