### PR TITLE
fix(api-client): add Content-Security-Policy to client.scalar.com

### DIFF
--- a/.changeset/old-olives-itch.md
+++ b/.changeset/old-olives-itch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): add Content-Security-Policy to client.scalar.com

--- a/examples/api-client/index.html
+++ b/examples/api-client/index.html
@@ -8,6 +8,9 @@
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com; media-src 'self' data: blob:; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
     <title>Scalar API Client</title>
     <script
       src="https://cdn.usefathom.com/script.js"

--- a/packages/api-client-app/src/renderer/index.html
+++ b/packages/api-client-app/src/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' blob:; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com; font-src https://fonts.scalar.com" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com; media-src 'self' data: blob:; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
   </head>
 
   <body>


### PR DESCRIPTION
Turns out blob urls in object (or iframe) tags are executed in the same origin context as the host page which means they're vulnerable to XSS injection. 

I updated our `Content-Security-Policy` for the app and set a `Content-Security-Policy` for examples/api-client (which seems to be used for client.scalar.com) to not allow scripts from blobs. This prevents scripts from running in html previews and in svgs when they're opened in a new tab via right click → "Open Image in New Tab"

Fixes #3286 

## `Content-Security-Policy` Before / After

https://github.com/user-attachments/assets/08340b65-70d8-4f69-b6ce-d5fd8aa40128

https://github.com/user-attachments/assets/0590325e-6a5e-4976-8dc4-1dd15c0a4a30

