### PR TITLE
fix(api-reference): OAuth authorization code flow rendering

### DIFF
--- a/.changeset/empty-donkeys-tan.md
+++ b/.changeset/empty-donkeys-tan.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat: add oauth code authorization

--- a/.changeset/lemon-shoes-judge.md
+++ b/.changeset/lemon-shoes-judge.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: show oauth code authorization

--- a/packages/api-reference/src/legacy/components/SecurityScheme.vue
+++ b/packages/api-reference/src/legacy/components/SecurityScheme.vue
@@ -463,13 +463,15 @@ const startAuthentication = (url: string) => {
                 value !== undefined &&
                 Object.entries(
                   (value as any).flows.implicit?.scopes ??
-                    (value as any).flows.password!.scopes,
+                    (value as any).flows.password?.scopes ??
+                    (value as any).flows.authorizationCode?.scopes,
                 ).length > 0
               "
               v-model:selected="oauth2SelectedScopes"
               :scopes="
                 (value as any).flows.implicit?.scopes ??
-                (value as any).flows.password!.scopes
+                (value as any).flows.password?.scopes ??
+                (value as any).flows.authorizationCode?.scopes
               " />
             <button
               class="cardform-auth-button"

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -375,6 +375,12 @@ components:
           scopes:
             write:planets: modify planets in your account
             read:planets: read your planets
+        authorizationCode:
+          authorizationUrl: https://galaxy.scalar.com/oauth/authorize
+          tokenUrl: https://galaxy.scalar.com/oauth/token
+          scopes:
+            write:planets: modify planets in your account
+            read:planets: read your planets
   parameters:
     planetId:
       name: planetId


### PR DESCRIPTION
## Problem
The reference currently doesn't support the OAuth Authorization Code flow due to an issue in the `SecurityScheme.vue` component. The password flow scopes have a non-null assertion, which prevents the Authorization Code flow from being rendered properly. This issue was reported in #1960.

## Solution
This PR modifies the `SecurityScheme.vue` component to correctly support the Authorization Code flow. Additionally, it adds an Authorization Code flow example to the galaxy spec for testing and demonstration purposes.

## Changes
- Updated `SecurityScheme.vue` to handle Authorization Code flow rendering
- Added Authorization Code flow example to the galaxy spec
- Removed unnecessary non-null assertion for password flow scopes

## Visual Comparison

### Before:
![Before changes](https://github.com/user-attachments/assets/4e06f8a7-8725-45b5-981e-ec70108ff154)

### After:
![After changes](https://github.com/user-attachments/assets/0fd6d086-d85a-45b7-a5a5-6624f87b1a78)

## Related Issues
- Fixes #1960: OAuth Authorization Code bug

## Testing
- Verified that the Authorization Code flow now renders correctly
- Ensured that existing functionality for other OAuth flows remains intact
- Tested with the updated galaxy spec example

## Additional Notes
This change resolves a long-standing issue that has affected users trying to implement OAuth Authorization Code flow. It should significantly improve the usability of the client for OAuth 2.0 implementations.