### PR TITLE
fix(api-client): skip empty value of query parameters

### DIFF
--- a/.changeset/fast-pandas-shake.md
+++ b/.changeset/fast-pandas-shake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: skip empty value of query parameters

--- a/packages/api-client/src/libs/send-request.test.ts
+++ b/packages/api-client/src/libs/send-request.test.ts
@@ -378,6 +378,35 @@ describe('sendRequest', () => {
     expect(result?.response.data.query).toStrictEqual({})
   })
 
+  it('should ignore query parameters with empty values', async () => {
+    const [error, requestOperation] = createRequestOperation<{
+      query: { example: 'parameter'; foo: 'bar' }
+    }>(
+      createRequestPayload({
+        serverPayload: {
+          url: VOID_URL,
+        },
+        requestExamplePayload: {
+          parameters: {
+            query: [
+              {
+                key: 'foo',
+                value: '',
+                enabled: true,
+              },
+            ],
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data.query).toStrictEqual({})
+  })
+
   it('works with no content', async () => {
     const [error, requestOperation] = createRequestOperation(
       createRequestPayload({

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -65,7 +65,8 @@ function createFetchHeaders(example: RequestExample, env: object) {
 function createFetchQueryParams(example: RequestExample, env: object) {
   const params = new URLSearchParams()
   example.parameters.query.forEach((p) => {
-    if (p.enabled) params.append(p.key, replaceTemplateVariables(p.value, env))
+    if (p.enabled && p.value)
+      params.append(p.key, replaceTemplateVariables(p.value, env))
   })
 
   return params


### PR DESCRIPTION
**Problem**
Currently, query parameters are populated even when their values are empty, leading to incorrect or unnecessary parameters being included in the request. This can cause issues when the backend expects non-empty values for certain query parameters.

**Solution**
With this PR, the logic has been updated to skip query parameters with empty values. Now, only enabled query parameters with non-empty values will be appended to the request, ensuring that the resulting query string is correct and avoids sending unnecessary parameters.
