### PR TITLE
fix(api-client): allow to add servers in read only mode

### DIFF
--- a/.changeset/empty-snails-vanish.md
+++ b/.changeset/empty-snails-vanish.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: force show servers when not in read only mode

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -68,6 +68,7 @@ const serverUrlWithoutTrailingSlash = computed(() => {
 <template>
   <ScalarDropdown
     v-if="
+      !isReadOnly ||
       (requestServerOptions && requestServerOptions?.length > 1) ||
       (collectionServerOptions && collectionServerOptions?.length > 1)
     "


### PR DESCRIPTION
**Problem**
Currently, you couldn't see the add servers if there was only 1 server in the address bar

**Solution**
With this PR we bypass this logic and show all options when in the api client
