### PR TITLE
fix(api-client): add correct version number in ascii preview

### DIFF
--- a/.changeset/good-rabbits-invite.md
+++ b/.changeset/good-rabbits-invite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: add proper scalar version in ascii preview

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -11,6 +11,8 @@ import {
 import { useWorkspace } from '@/store'
 import { onBeforeUnmount, onMounted } from 'vue'
 
+import { version } from '../../../../package.json'
+
 const { isReadOnly, activeWorkspace } = useWorkspace()
 
 const openCommandPaletteRequest = () => {
@@ -31,13 +33,13 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
       <div
         v-if="!activeWorkspace.isReadOnly"
         class="scalar-version-number">
-        Scalar V1.0.6 <b>Alpha</b> Release
+        Scalar V{{ version }} <b>Beta</b> Release
         <div class="mt-1">
           <a
             href="https://github.com/scalar/scalar/issues/2669"
-            target="_blank"
-            >Roadmap</a
-          >
+            target="_blank">
+            Roadmap
+          </a>
         </div>
       </div>
       <ScalarAsciiArt

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -11,8 +11,6 @@ import {
 import { useWorkspace } from '@/store'
 import { onBeforeUnmount, onMounted } from 'vue'
 
-import { version } from '../../../../package.json'
-
 const { isReadOnly, activeWorkspace } = useWorkspace()
 
 const openCommandPaletteRequest = () => {
@@ -22,6 +20,8 @@ const openCommandPaletteRequest = () => {
 const handleHotKey = (event: HotKeyEvents) => {
   if (event.openCommandPaletteRequest) openCommandPaletteRequest()
 }
+
+const packageVersion = PACKAGE_VERSION
 
 onMounted(() => hotKeyBus.on(handleHotKey))
 onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
@@ -33,7 +33,7 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
       <div
         v-if="!activeWorkspace.isReadOnly"
         class="scalar-version-number">
-        Scalar V{{ version }} <b>Beta</b> Release
+        Scalar V{{ packageVersion }} <b>Beta</b> Release
         <div class="mt-1">
           <a
             href="https://github.com/scalar/scalar/issues/2669"

--- a/packages/api-client/src/vite-env.d.ts
+++ b/packages/api-client/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/** The version number taken from the package.json */
+declare const PACKAGE_VERSION: string

--- a/packages/api-client/vite.config.ts
+++ b/packages/api-client/vite.config.ts
@@ -10,6 +10,9 @@ import svgLoader from 'vite-svg-loader'
 
 export default defineConfig({
   plugins: [vue(), svgLoader(), ViteWatchWorkspace()],
+  define: {
+    PACKAGE_VERSION: JSON.stringify(process.env.npm_package_version),
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
before:
<img width="340" alt="image" src="https://github.com/user-attachments/assets/342dd794-e068-4001-b9d0-71b902dc8ea4">


after:
<img width="289" alt="image" src="https://github.com/user-attachments/assets/e27d0495-a87c-4b77-afd2-73a3e70a4ae0">
