### PR TITLE
fix(client.scalar.com): add missing favicon to client.scalar.com

### DIFF
--- a/examples/api-client/index.html
+++ b/examples/api-client/index.html
@@ -5,17 +5,17 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="https://www.scalar.com/favicon.svg" />
+      href="https://scalar.com/favicon.svg" />
     <link
       rel="icon"
       type="image/png"
-      href="https://www.scalar.com/favicon.png" />
+      href="https://scalar.com/favicon.png" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com; media-src 'self' data: blob:; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://scalar.com https://cdn.usefathom.com; media-src 'self' data: blob:; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
     <title>Scalar API Client</title>
     <script
       src="https://cdn.usefathom.com/script.js"

--- a/examples/api-client/index.html
+++ b/examples/api-client/index.html
@@ -5,17 +5,17 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="https://scalar.com/favicon.svg" />
+      href="https://www.scalar.com/favicon.svg" />
     <link
       rel="icon"
       type="image/png"
-      href="https://scalar.com/favicon.png" />
+      href="https://www.scalar.com/favicon.png" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://scalar.com https://cdn.usefathom.com; media-src 'self' data: blob:; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://www.scalar.com https://cdn.usefathom.com; media-src 'self' data: blob:; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
     <title>Scalar API Client</title>
     <script
       src="https://cdn.usefathom.com/script.js"

--- a/examples/api-client/index.html
+++ b/examples/api-client/index.html
@@ -4,7 +4,12 @@
     <meta charset="UTF-8" />
     <link
       rel="icon"
-      href="/favicon.ico" />
+      type="image/svg+xml"
+      href="https://www.scalar.com/favicon.svg" />
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://www.scalar.com/favicon.png" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
now we have a favicon for https://client.scalar.com