### PR TITLE
fix(api-client): add missing securityDefinitions check on import

### DIFF
--- a/.changeset/smooth-windows-remain.md
+++ b/.changeset/smooth-windows-remain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: add missing securityDefinitions check on import

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -114,7 +114,8 @@ export async function importSpecToWorkspace(
   // ---------------------------------------------------------------------------
   // SECURITY HANDLING
 
-  const security = schema.components?.securitySchemes ?? {}
+  const security =
+    schema.components?.securitySchemes ?? schema?.securityDefinitions ?? {}
 
   const securitySchemes = (Object.entries(security) as Entries<typeof security>)
     .map?.(([nameKey, s]) => {


### PR DESCRIPTION
**Problem**
Currently when you import `"swagger": "2.0",` and using `securityDefinitions`, it breaks our client 😨 

**Solution**
With this PR we check for that field on import 😎 

https://petstore.swagger.io/v2/swagger.json

test that spec on https://client.scalar.com vs our preview 😎 


**edit** Amrit brought up that we need to handle this in the upgrade actually 🤯 