### PR TITLE
fix(api-client): uppercase method on request send, fix #3303

### DIFF
--- a/.changeset/two-tigers-enjoy.md
+++ b/.changeset/two-tigers-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: uppercase method on request send

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -369,7 +369,7 @@ export const createRequestOperation = <ResponseDataType = unknown>({
 
         const response = await fetch(proxiedUrl, {
           signal: controller.signal,
-          method: request.method,
+          method: request.method.toUpperCase(),
           body,
           headers,
         })


### PR DESCRIPTION
fixes https://github.com/scalar/scalar/issues/3303

as per https://www.rfc-editor.org/rfc/rfc7231#section-4.1


before:

```
curl 'https://sandbox.scalar.com/test' \
  -X 'patch' \
  -H 'accept: */*' \
  -H 'accept-language: en-US,en;q=0.9' \
  -H 'content-length: 0' \
  -H 'content-type: application/json' \
  -H 'origin: https://sandbox.scalar.com' \
  -H 'priority: u=1, i' \
  -H 'referer: https://sandbox.scalar.com/p/GcxDQ' \
  -H 'sec-ch-ua: "Google Chrome";v="129", "Not=A?Brand";v="8", "Chromium";v="129"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: same-origin' \
  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36'
```


after

```
curl 'https://sandbox.scalar.com/test' \
  -X 'PATCH' \
  -H 'accept: */*' \
  -H 'accept-language: en-US,en;q=0.9' \
  -H 'content-length: 0' \
  -H 'content-type: application/json' \
  -H 'origin: https://sandbox.scalar.com' \
  -H 'priority: u=1, i' \
  -H 'referer: https://sandbox.scalar.com/p/GcxDQ' \
  -H 'sec-ch-ua: "Google Chrome";v="129", "Not=A?Brand";v="8", "Chromium";v="129"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: same-origin' \
  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36'
```