### PR TITLE
fix(components): inactive url in markdown example

### DIFF
--- a/packages/components/src/components/ScalarMarkdown/test.md
+++ b/packages/components/src/components/ScalarMarkdown/test.md
@@ -29,7 +29,7 @@ Readability, however, is emphasized above all else. A Markdown-formatted
 document should be publishable as-is, as plain text, without looking
 like it's been marked up with tags or formatting instructions. While
 Markdown's syntax has been influenced by several existing text-to-HTML
-filters -- including [Setext](http://docutils.sourceforge.net/mirror/setext.html), [atx](http://www.aaronsw.com/2002/atx/), [Textile](http://textism.com/tools/textile/), [reStructuredText](http://docutils.sourceforge.net/rst.html),
+filters -- including [Setext](http://docutils.sourceforge.net/mirror/setext.html), [Textile](http://textism.com/tools/textile/), [reStructuredText](http://docutils.sourceforge.net/rst.html),
 [Grutatext](http://www.triptico.com/software/grutatxt.html), and [EtText](http://ettext.taint.org/doc/) -- the single biggest source of
 inspiration for Markdown's syntax is the format of plain text email.
 


### PR DESCRIPTION
This URL is breaking the Markdown Link check in CI.

We miss you Aaron 🥹