### PR TITLE
fix(api-client): sidebar empty state

### DIFF
--- a/.changeset/tasty-timers-add.md
+++ b/.changeset/tasty-timers-add.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates empty sidebar content

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -204,8 +204,7 @@ onBeforeUnmount(() => {
           <div class="text-center text-balance text-sm mb-2 mt-2">
             <b class="font-medium">Let's Get Started</b>
             <p class="mt-2">
-              Create request, folder, collection or import OpenAPI, Postman or
-              Insomnia
+              Create request, folder, collection or import OpenAPI document
             </p>
           </div>
         </div>


### PR DESCRIPTION
this pr updates the empty sidebar item content introduced in #3279 to be re-introduced once their import is supported.