### PR TITLE
feat(api-client): squiggly icon for drafts

### DIFF
--- a/.changeset/fresh-experts-crash.md
+++ b/.changeset/fresh-experts-crash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: sets draft collection icon

--- a/.changeset/kind-llamas-drum.md
+++ b/.changeset/kind-llamas-drum.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: adds scribble icon

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -166,7 +166,13 @@ onBeforeUnmount(() => {
             @onDragEnd="handleDragEnd"
             @openMenu="(item) => Object.assign(menuItem, item)">
             <template #leftIcon>
+              <ScalarIcon
+                v-if="collection.info?.title === 'Drafts'"
+                class="text-sidebar-c-2 group-hover:hidden"
+                icon="Scribble"
+                thickness="2.5" />
               <LibraryIcon
+                v-else
                 class="text-sidebar-c-2 size-3.5 stroke-[2.5] group-hover:hidden"
                 :src="
                   collection['x-scalar-icon'] || 'interface-content-folder'

--- a/packages/components/src/components/ScalarIcon/icons/Scribble.svg
+++ b/packages/components/src/components/ScalarIcon/icons/Scribble.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 15c1.895 3 3.79 4 6.632 4 2.842 0 6.631-3 6.631-7s-2.842-7-5.684-7-4.737 1.5-4.737 4 1.895 5 5.684 5c3.79 0 7.966-2.453 9.474-5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/components/src/components/ScalarIcon/icons/icons.ts
+++ b/packages/components/src/components/ScalarIcon/icons/icons.ts
@@ -63,6 +63,7 @@ export const ICONS = [
   'Play',
   'Refresh',
   'Roadmap',
+  'Scribble',
   'Search',
   'Server',
   'Show',


### PR DESCRIPTION
this pr adds draft collection a scribble icon as suggested by @cameronrohani 

<img width="645" alt="image" src="https://github.com/user-attachments/assets/238a71dc-f1f0-465d-82a1-172f9d8c816e">
