### PR TITLE
fix(api-client): too many z-index layers

### DIFF
--- a/.changeset/fresh-frogs-thank.md
+++ b/.changeset/fresh-frogs-thank.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: too many z-index layers

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -152,7 +152,7 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
             { 'border-transparent overflow-visible rounded-b-none': open },
           ]">
           <div
-            class="pointer-events-none absolute left-0 top-0 z-10 block h-full w-full overflow-hidden">
+            class="pointer-events-none absolute left-0 top-0 block h-full w-full overflow-hidden">
             <div
               class="bg-mix-transparent bg-mix-amount-90 absolute left-0 top-0 h-full w-full"
               :class="getBackgroundColor()"
@@ -191,14 +191,14 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
 
           <AddressBarHistory :open="open" />
           <ScalarButton
-            class="relative h-auto shrink-0 gap-1 overflow-hidden pl-2 pr-2.5 py-1 z-[1] font-bold"
+            class="relative h-auto shrink-0 gap-1 overflow-hidden pl-2 pr-2.5 py-1 font-bold"
             :disabled="isRequesting"
             @click="handleExecuteRequest">
             <ScalarIcon
-              class="relative z-10 shrink-0 fill-current"
+              class="relative shrink-0 fill-current"
               icon="Play"
               size="xs" />
-            <span class="text-xxs relative z-10 lg:flex hidden">Send</span>
+            <span class="text-xxs relative lg:flex hidden">Send</span>
           </ScalarButton>
         </div>
       </Listbox>
@@ -270,7 +270,6 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
   animation-duration: 1ms;
   animation-direction: reverse;
   animation-timeline: --scroll-timeline;
-  z-index: 1;
   pointer-events: none;
 }
 .fade-left {

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -70,7 +70,7 @@ function handleHistoryClick(historicalRequest: RequestEvent) {
   <!-- History shadow and placement-->
   <div
     :class="[
-      'absolute bg-white left-0 top-8 w-full rounded-lg before:pointer-events-none before:absolute before:left-0 before:-top-8 before:h-[calc(100%+32px)] before:w-full before:rounded-lg z-50',
+      'absolute bg-white left-0 top-8 w-full rounded-lg before:pointer-events-none before:absolute before:left-0 before:-top-8 before:h-[calc(100%+32px)] before:w-full before:rounded-lg z-context',
       { 'before:shadow-lg': open },
     ]">
     <!-- History Item -->

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -73,7 +73,7 @@ const serverUrlWithoutTrailingSlash = computed(() => {
     "
     teleport=".scalar-client">
     <button
-      class="font-code lg:text-sm text-xs whitespace-nowrap border border-b-3 border-solid rounded px-1.5 py-0.5 text-c-2 z-[1]"
+      class="font-code lg:text-sm text-xs whitespace-nowrap border border-b-3 border-solid rounded px-1.5 py-0.5 text-c-2"
       type="button"
       @click.stop>
       {{ serverUrlWithoutTrailingSlash }}

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -246,7 +246,6 @@ export default {
 }
 :deep(.cm-tooltip-autocomplete ul) {
   padding: 6px !important;
-  z-index: 10000;
   position: relative;
 }
 :deep(.cm-tooltip-autocomplete ul li:hover) {

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -219,12 +219,12 @@ onBeforeUnmount(() => {
 <template>
   <div
     v-show="modalState.open"
-    class="commandmenu-clickout"
+    class="commandmenu-clickout z-overlay"
     @click="closeHandler()"></div>
 
   <div
     v-show="modalState.open"
-    class="commandmenu custom-scroll">
+    class="commandmenu z-overlay custom-scroll">
     <!-- Default palette (command list) -->
     <template v-if="!activeCommand">
       <div
@@ -294,7 +294,7 @@ onBeforeUnmount(() => {
     <!-- Specific command palette -->
     <template v-else>
       <button
-        class="absolute p-0.75 hover:bg-b-3 rounded text-c-3 active:text-c-1 mr-1.5 my-1.5 z-10"
+        class="absolute p-0.75 hover:bg-b-3 rounded text-c-3 active:text-c-1 mr-1.5 my-1.5 z-1"
         type="button"
         @click="activeCommand = null">
         <ScalarIcon
@@ -322,12 +322,10 @@ onBeforeUnmount(() => {
   padding: 6px;
   margin: 12px;
   position: fixed;
-  z-index: 10;
   left: 50%;
   top: 150px;
   opacity: 0;
   transform: translate3d(-50%, 10px, 0);
-  z-index: 100;
   animation: fadeincommandmenu ease-in-out 0.3s forwards;
   animation-delay: 0.1s;
 }
@@ -339,7 +337,6 @@ onBeforeUnmount(() => {
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 100;
   cursor: pointer;
 }
 @keyframes fadeincommand {

--- a/packages/api-client/src/components/ContextBar.vue
+++ b/packages/api-client/src/components/ContextBar.vue
@@ -51,7 +51,6 @@ defineEmits<{
   padding-left: 24px;
   position: absolute;
   right: 0;
-  z-index: 100;
   transition: width 0s ease-in-out 0.2s;
   overflow: hidden;
 }

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -119,7 +119,6 @@ const startDrag = (event: MouseEvent) => {
   bottom: 0;
   border-right: 2px solid transparent;
   transition: border-right-color 0.3s;
-  z-index: 100;
 }
 .resizer:hover,
 .dragging .resizer {
@@ -134,6 +133,5 @@ const startDrag = (event: MouseEvent) => {
   position: absolute;
   width: 100%;
   height: 100%;
-  z-index: 99;
 }
 </style>

--- a/packages/api-client/src/components/ViewLayout/ViewLayout.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex flex-col min-h-0 flex-1 xl:overflow-hidden md:flex-row leading-3 z-0">
+    class="flex flex-col min-h-0 flex-1 xl:overflow-hidden md:flex-row leading-3">
     <slot />
   </div>
 </template>

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -9,7 +9,7 @@ const id = nanoid()
     class="flex xl:min-w-0 xl:flex-1 flex-col xl:custom-scroll bg-b-1">
     <div
       :id="id"
-      class="xl:min-h-header flex items-center border-b-1/2 p-2 md:px-4 md:py-2.5 xl:px-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 z-20 rounded-t xl:rounded-none">
+      class="xl:min-h-header flex items-center border-b-1/2 p-2 md:px-4 md:py-2.5 xl:px-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 rounded-t xl:rounded-none">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -70,7 +70,7 @@ const themeStyleTag = computed(
   <!-- min-h-0 is to allow scrolling of individual flex children -->
   <main
     v-if="workspaceStore.activeWorkspace.value?.uid"
-    class="flex min-h-0 flex-1 z-0">
+    class="flex min-h-0 flex-1">
     <SideNav />
 
     <!-- Popup command palette to add resources from anywhere -->

--- a/packages/api-client/src/layouts/Modal/ApiClientModal.vue
+++ b/packages/api-client/src/layouts/Modal/ApiClientModal.vue
@@ -44,12 +44,12 @@ onBeforeUnmount(() => {
   <div
     v-show="modalState.open"
     class="scalar">
-    <div className="scalar-container">
+    <div className="scalar-container z-overlay">
       <div className="scalar-app scalar-client scalar-app-layout">
         <RouterView key="$route.fullPath" />
       </div>
       <div
-        class="scalar-app-exit"
+        class="scalar-app-exit -z-1"
         @click="modalState.hide()"></div>
     </div>
   </div>

--- a/packages/api-client/src/layouts/Modal/ApiClientModal.vue
+++ b/packages/api-client/src/layouts/Modal/ApiClientModal.vue
@@ -74,7 +74,6 @@ onBeforeUnmount(() => {
   margin: auto;
   opacity: 0;
   animation: scalarapiclientfadein 0.35s forwards;
-  z-index: 1002;
   position: relative;
   overflow: hidden;
   border-radius: 8px;
@@ -95,7 +94,6 @@ onBeforeUnmount(() => {
   height: 100vh;
   background: #00000038;
   transition: all 0.3s ease-in-out;
-  z-index: 1000;
   cursor: pointer;
   animation: scalardrawerexitfadein 0.35s forwards;
 }
@@ -136,7 +134,6 @@ onBeforeUnmount(() => {
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 1001;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -111,7 +111,7 @@ onMounted(() => {
               </button>
               <div
                 v-show="showChildren(domain)"
-                class="before:bg-b-3 before:absolute before:left-[calc(1rem_-_1.5px)] before:top-0 before:z-10 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                class="before:bg-b-3 before:absolute before:left-[calc(1rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
                 <div
                   v-for="(cookieList, path) in paths"
                   :key="path">
@@ -131,7 +131,7 @@ onMounted(() => {
                   </button>
                   <div
                     v-show="showChildren(domain + path)"
-                    class="before:bg-b-3 before:absolute before:left-[calc(1.75rem_-_1.5px)] before:top-0 before:z-10 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                    class="before:bg-b-3 before:absolute before:left-[calc(1.75rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
                     <SidebarListElement
                       v-for="cookie in cookieList"
                       :key="cookie.uid"

--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -74,7 +74,7 @@ onClickOutside(
 <template>
   <ScalarDropdown
     ref="dropdownRef"
-    class="mt-2 z-10 min-w-60 rounded border bg-b-1 p-1 w-fit"
+    class="mt-2 min-w-60 rounded border bg-b-1 p-1 w-fit"
     static
     :staticOpen="isOpen"
     :style="{

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -261,7 +261,6 @@ function handleDeleteScheme(option: { id: string; label: string }) {
   animation-timeline: --scroll-timeline;
   min-height: 24px;
   pointer-events: none;
-  z-index: 1;
 }
 .fade-left {
   background: linear-gradient(

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -32,7 +32,7 @@ const hasItemProperties = computed(
     </template>
     <template #content>
       <div
-        class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
+        class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 p-2 text-xxs leading-5 text-c-1">
         <div
           v-if="hasItemProperties"
           class="flex items-center text-c-2">

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -114,7 +114,7 @@ onBeforeUnmount(() => {
         class="xl:min-h-header xl:py-2.5 py-1 px-2.5 border-b-1/2" />
     </template>
     <template #content>
-      <div class="search-button-fade sticky px-3 py-2.5 top-0 z-50">
+      <div class="search-button-fade sticky px-3 py-2.5 top-0 z-1">
         <ScalarSearchInput
           ref="searchInputRef"
           v-model="searchText"

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -241,7 +241,7 @@ function openCommandPaletteRequest() {
     :class="[
       (isReadOnly && parentUids.length > 1) ||
       (!isReadOnly && parentUids.length)
-        ? 'before:bg-b-3 before:absolute before:left-[calc(.75rem_+_.5px)] before:top-0 before:z-10 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 indent-border-line-offset'
+        ? 'before:bg-b-3 before:absolute before:left-[calc(.75rem_+_.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 indent-border-line-offset'
         : '',
     ]">
     <Draggable
@@ -273,7 +273,7 @@ function openCommandPaletteRequest() {
           ]"
           tabindex="0">
           <span
-            class="line-clamp-3 z-10 font-medium w-full pl-2 word-break-break-word"
+            class="line-clamp-3 font-medium w-full pl-2 word-break-break-word"
             :class="{
               'editable-sidebar-hover-item': !isReadOnly,
             }">
@@ -284,7 +284,7 @@ function openCommandPaletteRequest() {
             <div class="relative">
               <ScalarButton
                 v-if="!isReadOnly"
-                class="px-0.5 py-0 z-10 hover:bg-b-3 hidden group-hover:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
+                class="px-0.5 py-0 hover:bg-b-3 hidden group-hover:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
                 :class="{
                   flex:
                     menuItem?.item?.entity.uid === item.entity.uid &&
@@ -321,11 +321,11 @@ function openCommandPaletteRequest() {
       <!-- Collection/Folder -->
       <button
         v-else-if="!isReadOnly || parentUids.length"
-        class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5 z-[1]"
+        class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded p-1.5"
         :class="highlightClasses"
         type="button"
         @click="toggleSidebarFolder(item.entity.uid)">
-        <span class="z-10 flex h-5 items-center justify-center max-w-[14px]">
+        <span class="flex h-5 items-center justify-center max-w-[14px]">
           <slot name="leftIcon">
             <div
               :class="{
@@ -343,7 +343,7 @@ function openCommandPaletteRequest() {
         <div
           class="flex flex-1 flex-row justify-between editable-sidebar-hover">
           <span
-            class="line-clamp-3 z-10 font-medium text-left w-full word-break-break-word"
+            class="line-clamp-3 font-medium text-left w-full word-break-break-word"
             :class="{
               'editable-sidebar-hover-item': !isReadOnly,
             }">
@@ -352,7 +352,7 @@ function openCommandPaletteRequest() {
           <div class="relative flex h-fit">
             <ScalarButton
               v-if="!isReadOnly && !isDraftCollection"
-              class="px-0.5 py-0 z-10 hover:bg-b-3 hidden group-hover:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
+              class="px-0.5 py-0 hover:bg-b-3 hidden group-hover:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
               :class="{
                 flex:
                   menuItem.item?.entity.uid === item.entity.uid &&

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseLoadingOverlay.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseLoadingOverlay.vue
@@ -24,7 +24,7 @@ requestStatusBus.on((status) => {
   <Transition>
     <div
       v-if="loading.isLoading"
-      class="absolute inset-0 bg-b-1 z-10 flex flex-col gap-6 items-center justify-center">
+      class="absolute inset-0 bg-b-1 flex flex-col gap-6 items-center justify-center">
       <ScalarLoading
         class="text-c-3"
         :loadingState="loading"


### PR DESCRIPTION
I faced a z-index issue in another branch, so I tried to debug it and found a lot of z-index layers throughout the API client. Some in Tailwind, some in CSS, some even conflicting with eachother.

I tried removing all and it didn’t look too bad, so @hwkr added a Tailwind config and reintroduced a z-index where actually needed.

We should test this thoroughly, though. I might have missed places where we need to add it again. Can you all help me with that? 👀 Just leave a screenshot here and we’ll fix it.