### PR TITLE
ci: don’t run jobs with secrets in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   todesktop-release:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-20.04
     needs: [build, test]
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   todesktop-release:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-20.04
     needs: [build, test]
     strategy:
@@ -246,6 +245,8 @@ jobs:
           ./packages/void-server
 
   deploy-api-client:
+    # Only run this job for PRs from the same repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-20.04
     needs: [build]
     strategy:
@@ -294,7 +295,8 @@ jobs:
           comment_tag: 'cloudflare-preview'
 
   deploy-examples:
-    if: github.ref != 'refs/heads/main'
+    # Only run this job for PRs from the same repository, not for pushes to main
+    if: github.ref != 'refs/heads/main' && github.event.pull_request.head.repo.full_name == github.repository
     needs: [build]
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
For security reasons secrets aren’t available in PRs coming from forks.

Let’s skip steps that require secrets, so they don’t fail for external contributions.

<img width="917" alt="Screenshot 2024-09-30 at 15 06 54" src="https://github.com/user-attachments/assets/deb5d71b-097b-45eb-a32e-5d7944398e77">
