### PR TITLE
docs: add image to GitHub contributor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,14 @@ We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/scalar>
 
 ### Contributors
 
-Contributions are welcome! Read the [`CONTRIBUTING`](https://github.com/scalar/scalar/blob/main/CONTRIBUTING) guide.
+Top 10 contributors September 2024.
+
+<img width="830" height="560" src="https://github.com/user-attachments/assets/09cf5d60-3bc7-432e-8356-1cec7c78e638">
 
 <br>
+<br>
+
+Top contributors all time.
 
 <!-- readme: collaborators,contributors -start -->
 <table>

--- a/README.md
+++ b/README.md
@@ -179,16 +179,18 @@ We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/scalar>
 
 <br>
 
-### Contributors
+### Contributions
 
-Top 10 contributors September 2024.
+Contributions are welcome! Read the [`CONTRIBUTING`](https://github.com/scalar/scalar/blob/main/CONTRIBUTING) guide.
+
+**Top 10 Contributors (September 2024)**
 
 <img width="830" height="560" src="https://github.com/user-attachments/assets/09cf5d60-3bc7-432e-8356-1cec7c78e638">
 
 <br>
 <br>
 
-Top contributors all time.
+**Top Contributors (All Time)**
 
 <!-- readme: collaborators,contributors -start -->
 <table>


### PR DESCRIPTION
adding a fun lil animation to the github readme 🤷 ...

you ever wonder what your top 10 GitHub contributors for september would look like projected on a pillar in a room in html/css in a foreignobject in a svg in a img in a readme.md file on your GitHub?


<img width="800" height="560" src="https://github.com/user-attachments/assets/2fffd34f-ba07-41be-8bd7-749e74cf6ca2">



<img width="983" alt="image" src="https://github.com/user-attachments/assets/0691b4bd-78ab-4343-9efa-681d5a71fb94">
