### PR TITLE
feat(openapi-parser): self reference the document

### DIFF
--- a/.changeset/khaki-cheetahs-doubt.md
+++ b/.changeset/khaki-cheetahs-doubt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+feat: self reference the document

--- a/packages/openapi-parser/src/utils/resolveReferences.test.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.test.ts
@@ -647,4 +647,48 @@ describe('resolveReferences', () => {
     // Resolve the *path* from the given file
     expect(schema.components.schemas.Upload.allOf[0].title).toBe('Coordinates')
   })
+
+  it('resolves reference to self by filename', async () => {
+    const filesystem = [
+      {
+        dir: '/Foobar',
+        isEntrypoint: true,
+        references: [],
+        filename: 'openapi.json',
+        specification: {
+          openapi: '3.1.0',
+          info: {},
+          paths: {
+            '/foobar': {
+              post: {
+                requestBody: {
+                  $ref: 'openapi.json#/components/requestBodies/Foobar',
+                },
+              },
+            },
+          },
+          components: {
+            requestBodies: {
+              Foobar: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                      example: 'foobar',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    ]
+
+    const { schema } = resolveReferences(filesystem)
+    expect(
+      schema.paths['/foobar'].post.requestBody.content['application/json']
+        .schema.example,
+    ).toBe('foobar')
+  })
 })

--- a/packages/openapi-parser/src/utils/resolveReferences.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.ts
@@ -183,7 +183,7 @@ function resolveUri(
   const [prefix, path] = uri.split('#', 2)
 
   // External references
-  if (prefix && prefix != file.filename) {
+  if (prefix && prefix !== file.filename) {
     const externalReference = filesystem.find((entry) => {
       return entry.filename === prefix
     })

--- a/packages/openapi-parser/src/utils/resolveReferences.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.ts
@@ -183,7 +183,7 @@ function resolveUri(
   const [prefix, path] = uri.split('#', 2)
 
   // External references
-  if (prefix) {
+  if (prefix && prefix != file.filename) {
     const externalReference = filesystem.find((entry) => {
       return entry.filename === prefix
     })

--- a/packages/openapi-parser/src/utils/resolveReferences.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.ts
@@ -182,8 +182,11 @@ function resolveUri(
   // Understand the URI
   const [prefix, path] = uri.split('#', 2)
 
+  /** Check whether the file is pointing to itself */
+  const isDifferentFile = prefix !== file.filename
+
   // External references
-  if (prefix && prefix !== file.filename) {
+  if (prefix && isDifferentFile) {
     const externalReference = filesystem.find((entry) => {
       return entry.filename === prefix
     })


### PR DESCRIPTION
**Problem**
Currently, openapi-parser does not support self references in `$ref` properties  e.g. openapi.json cannot reference an object with `./openapi.json#/parameters/Parameter` (I think it gets stuck in a loop of circular references). Whilst this is a bit of a weird way of doing a reference, I don't believe it's against the spec (https://json-schema.org/draft/2020-12/json-schema-core#ref) and I've come across a few instances of this in the [Azure API spec](https://github.com/Azure/azure-rest-api-specs/blob/ad60d7f8eba124edc6999677c55aba2184e303b0/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2016-10-10/apimanagement.json#L49).

**Solution**
This PR adds a simple check during reference resolution to see if the reference prefix matches the current filename. This doesn't account for all scenarios atm. e.g.  `../parentfolder/openapi.json#/parameters/Parameter` 
