### PR TITLE
chore: make `@scalar/config` package public

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,7 +12,6 @@
   },
   "keywords": [],
   "version": "0.1.0",
-  "private": true,
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
The CLI is broken, because we didn’t publish the `@scalar/config` package, let’s fix this. :)

I published manually to fix the CLI, this PR sets it to public for future releases.