### PR TITLE
feat(galaxy): add variables to the second server, see #3317

### DIFF
--- a/.changeset/afraid-guests-vanish.md
+++ b/.changeset/afraid-guests-vanish.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat: add variables to the second server

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -50,8 +50,16 @@ info:
     email: marc@scalar.com
 servers:
   - url: https://galaxy.scalar.com
-  - url: https://void.scalar.com
+  - url: '{protocol}://void.scalar.com/{path}'
     description: Responds with your request data
+    variables:
+      protocol:
+        default: https
+        enum:
+          - http
+          - https
+      path:
+        default: ''
 security:
   - bearerAuth: []
   - basicAuth: []


### PR DESCRIPTION
This PR adds variables to the second server of our OpenAPI example, great do debug #3317.