### PR TITLE
feat(api-client): command palette navigation

### DIFF
--- a/.changeset/olive-roses-cough.md
+++ b/.changeset/olive-roses-cough.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/themes': patch
+---
+
+feat: enhances command palette navigation and style

--- a/packages/api-client/src/components/CommandPalette/CommandActionForm.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandActionForm.vue
@@ -8,6 +8,7 @@ defineProps<{
 defineEmits<{
   (event: 'submit'): void
   (event: 'cancel'): void
+  (event: 'back', e: KeyboardEvent): void
 }>()
 </script>
 <template>

--- a/packages/api-client/src/components/CommandPalette/CommandActionInput.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandActionInput.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'update:modelValue', v: string): void
+  (e: 'onDelete', event: KeyboardEvent): void
 }>()
 
 defineOptions({ inheritAttrs: false })
@@ -21,6 +22,11 @@ const model = computed<string>({
   get: () => props.modelValue ?? '',
   set: (v) => emit('update:modelValue', v),
 })
+
+const handleBack = (event: KeyboardEvent) => {
+  if (model.value !== '') return
+  emit('onDelete', event)
+}
 </script>
 <template>
   <label
@@ -34,5 +40,6 @@ const model = computed<string>({
     class="border-transparent outline-none w-full pl-8 text-sm min-h-8 py-1.5"
     data-form-type="other"
     data-lpignore="true"
-    v-bind="$attrs" />
+    v-bind="$attrs"
+    @keydown.delete.stop="handleBack($event)" />
 </template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteCollection.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteCollection.vue
@@ -11,6 +11,7 @@ import CommandActionInput from './CommandActionInput.vue'
 
 const emits = defineEmits<{
   (event: 'close'): void
+  (event: 'back', e: KeyboardEvent): void
 }>()
 
 const { activeWorkspace, collectionMutators } = useWorkspace()
@@ -45,7 +46,8 @@ const handleSubmit = () => {
     <CommandActionInput
       v-model="collectionName"
       label="Collection Name"
-      placeholder="Collection Name" />
+      placeholder="Collection Name"
+      @onDelete="emits('back', $event)" />
     <template #options>
       <IconSelector
         v-model="collectionIcon"

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -22,6 +22,7 @@ const props = defineProps<{
 
 const emits = defineEmits<{
   (event: 'close'): void
+  (event: 'back', e: KeyboardEvent): void
 }>()
 
 const { push } = useRouter()
@@ -69,7 +70,8 @@ const handleSubmit = () => {
     <CommandActionInput
       v-model="exampleName"
       label="Example Name"
-      placeholder="Example Name" />
+      placeholder="Example Name"
+      @onDelete="emits('back', $event)" />
     <template #options>
       <ScalarDropdown
         placement="bottom"

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
@@ -10,6 +10,7 @@ import CommandActionInput from './CommandActionInput.vue'
 
 const emits = defineEmits<{
   (event: 'close'): void
+  (event: 'back', e: KeyboardEvent): void
 }>()
 
 const { activeWorkspace, importSpecFile, importSpecFromUrl } = useWorkspace()
@@ -59,7 +60,8 @@ const handleSubmit = async () => {
     <CommandActionInput
       v-model="specUrl"
       label="Paste Swagger File URL"
-      placeholder="Paste Swagger File URL" />
+      placeholder="Paste Swagger File URL"
+      @onDelete="emits('back', $event)" />
     <template #options>
       <ScalarButton
         class="p-2 max-h-8 gap-1 text-xs hover:bg-b-2 relative"

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
@@ -24,6 +24,7 @@ const props = defineProps<{
 
 const emits = defineEmits<{
   (event: 'close'): void
+  (event: 'back', e: KeyboardEvent): void
 }>()
 
 const { push } = useRouter()
@@ -123,7 +124,8 @@ const handleSubmit = () => {
     <CommandActionInput
       v-model="requestName"
       label="Request Name"
-      placeholder="Request Name" />
+      placeholder="Request Name"
+      @onDelete="emits('back', $event)" />
     <template #options>
       <div class="flex gap-2">
         <HttpMethod

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
@@ -14,6 +14,7 @@ import CommandActionInput from './CommandActionInput.vue'
 
 const emits = defineEmits<{
   (event: 'close'): void
+  (event: 'back', e: KeyboardEvent): void
 }>()
 
 const { toast } = useToasts()
@@ -68,7 +69,8 @@ const handleSubmit = () => {
     <CommandActionInput
       v-model="url"
       label="Server URL"
-      placeholder="Server URL" />
+      placeholder="Server URL"
+      @onDelete="emits('back', $event)" />
     <template #options>
       <ScalarListbox
         v-model="selectedCollection"

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
@@ -14,6 +14,7 @@ import CommandActionInput from './CommandActionInput.vue'
 
 const emits = defineEmits<{
   (event: 'close'): void
+  (event: 'back', e: KeyboardEvent): void
 }>()
 
 const { activeWorkspaceCollections, activeCollection, tagMutators } =
@@ -57,7 +58,8 @@ const handleSubmit = () => {
     <CommandActionInput
       v-model="name"
       label="Tag Name"
-      placeholder="Tag Name" />
+      placeholder="Tag Name"
+      @onDelete="emits('back', $event)" />
     <template #options>
       <ScalarListbox
         v-model="selectedCollection"

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteWorkspace.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteWorkspace.vue
@@ -9,6 +9,7 @@ import CommandActionInput from './CommandActionInput.vue'
 
 const emits = defineEmits<{
   (event: 'close'): void
+  (event: 'back', e: KeyboardEvent): void
 }>()
 
 const { push } = useRouter()
@@ -36,7 +37,8 @@ const handleSubmit = () => {
     <CommandActionInput
       v-model="workspaceName"
       label="Workspace Name"
-      placeholder="Workspace Name" />
+      placeholder="Workspace Name"
+      @onDelete="emits('back', $event)" />
     <template #submit>Create Workspace</template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -34,7 +34,7 @@ export type CommandNames = keyof typeof PaletteComponents
 
 <script setup lang="ts">
 import { ScalarIcon, useModal } from '@scalar/components'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 import {
@@ -125,6 +125,14 @@ const closeHandler = () => {
   selectedSearchResult.value = -1
 }
 
+/** Reset state on back */
+const backHandler = () => {
+  // Prevent delete event from removing query command character
+  event.preventDefault()
+  activeCommand.value = null
+  nextTick(() => commandInputRef.value?.focus())
+}
+
 /** Handle execution of the command, some have routes while others show another palette */
 const executeCommand = (
   command: (typeof availableCommands)[number]['commands'][number],
@@ -152,6 +160,13 @@ const openCommandPalette = ({
   // Need nextTick to focus after a click since focus goes to the button
   nextTick(() => commandInputRef.value?.focus())
 }
+
+/** Focus on first result when conducting a search */
+watch(commandQuery, (newQuery) => {
+  if (newQuery && searchResultsWithPlaceholderResults.value.length > 0) {
+    selectedSearchResult.value = 0
+  }
+})
 
 /** Handle up and down arrow keys in the menu */
 const handleArrowKey = (direction: 'up' | 'down', ev: KeyboardEvent) => {
@@ -207,7 +222,7 @@ onBeforeUnmount(() => {
 
   <div
     v-show="modalState.open"
-    class="commandmenu">
+    class="commandmenu custom-scroll">
     <!-- Default palette (command list) -->
     <template v-if="!activeCommand">
       <div
@@ -298,6 +313,7 @@ onBeforeUnmount(() => {
   box-shadow: var(--scalar-shadow-2);
   border-radius: var(--scalar-radius-lg);
   background-color: var(--scalar-background-1);
+  max-height: 50dvh;
   width: 100%;
   max-width: 580px;
   padding: 6px 12px 12px 12px;

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -126,9 +126,11 @@ const closeHandler = () => {
 }
 
 /** Reset state on back */
-const backHandler = () => {
+const backHandler = (event: KeyboardEvent) => {
   // Prevent delete event from removing query command character
-  event.preventDefault()
+  if (commandQuery.value !== '') {
+    event?.preventDefault()
+  }
   activeCommand.value = null
   nextTick(() => commandInputRef.value?.focus())
 }
@@ -303,6 +305,7 @@ onBeforeUnmount(() => {
       <component
         :is="PaletteComponents[activeCommand]"
         v-bind="metaData ? { metaData: metaData } : {}"
+        @back="backHandler($event)"
         @close="closeHandler" />
     </template>
   </div>

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -184,7 +184,7 @@ const handleArrowKey = (direction: 'up' | 'down', ev: KeyboardEvent) => {
 
   commandRefs.value[selectedSearchResult.value]?.scrollIntoView({
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   })
 }
 
@@ -228,7 +228,7 @@ onBeforeUnmount(() => {
     <!-- Default palette (command list) -->
     <template v-if="!activeCommand">
       <div
-        class="bg-b-2 flex items-center rounded mb-2 pl-2 focus-within:bg-b-1 focus-within:shadow-border">
+        class="bg-b-2 flex items-center rounded-md mb-2.5 pl-2 focus-within:bg-b-1 focus-within:shadow-border">
         <label for="commandmenu">
           <ScalarIcon
             class="text-c-1 mr-2.5"
@@ -258,7 +258,7 @@ onBeforeUnmount(() => {
               command.name.toLowerCase().includes(commandQuery.toLowerCase()),
             ).length > 0
           "
-          class="text-c-3 font-medium text-xs mt-2">
+          class="text-c-3 font-medium text-xs px-2 mb-1 mt-2">
           {{ group.label }}
         </div>
         <div
@@ -319,7 +319,7 @@ onBeforeUnmount(() => {
   max-height: 50dvh;
   width: 100%;
   max-width: 580px;
-  padding: 6px 12px 12px 12px;
+  padding: 6px;
   margin: 12px;
   position: fixed;
   z-index: 10;

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -287,7 +287,7 @@ onBeforeUnmount(() => {
       </button>
       <component
         :is="PaletteComponents[activeCommand]"
-        :metaData="metaData"
+        v-bind="metaData ? { metaData: metaData } : {}"
         @close="closeHandler" />
     </template>
   </div>

--- a/packages/themes/src/variables.css
+++ b/packages/themes/src/variables.css
@@ -60,7 +60,7 @@
 
   --scalar-shadow-1: 0 1px 3px 0 rgb(0, 0, 0, 0.1);
   --scalar-shadow-2: rgba(15, 15, 15, 0.2) 0px 3px 6px,
-    rgba(15, 15, 15, 0.4) 0px 9px 24px, 0 0 0 1px rgba(255, 255, 255, 0.1);
+    rgba(15, 15, 15, 0.4) 0px 9px 24px, 0 0 0 1px var(--scalar-border-color);
 
   --scalar-lifted-brightness: 1.45;
   --scalar-backdrop-brightness: 0.5;


### PR DESCRIPTION
this pr adds the following enhancements:
- focus on first result when conducting command search
- return on global menu on delete key from a command
- enhances styles and fix border opacity

https://github.com/user-attachments/assets/3435ca91-ddd7-4fc8-83b9-061d4bb9e1c2

