### PR TITLE
chore(api-client): add more tests

### DIFF
--- a/.changeset/moody-kiwis-learn.md
+++ b/.changeset/moody-kiwis-learn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: header names can have leading/trailing whitespaces

--- a/examples/api-client/vite.config.ts.js
+++ b/examples/api-client/vite.config.ts.js
@@ -1,0 +1,20 @@
+// vite.config.ts
+import vue from '@vitejs/plugin-vue'
+import { URL, fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+
+const vite_config_default = defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(
+        new URL(
+          './src',
+          'file:///Users/hanspagel/Documents/Projects/scalar/examples/api-client/vite.config.ts',
+        ),
+      ),
+    },
+  },
+})
+export { vite_config_default as default }
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImltcG9ydCB2dWUgZnJvbSAnQHZpdGVqcy9wbHVnaW4tdnVlJ1xuaW1wb3J0IHsgVVJMLCBmaWxlVVJMVG9QYXRoIH0gZnJvbSAnbm9kZTp1cmwnXG5pbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd2aXRlJ1xuXG4vLyBodHRwczovL3ZpdGVqcy5kZXYvY29uZmlnL1xuZXhwb3J0IGRlZmF1bHQgZGVmaW5lQ29uZmlnKHtcbiAgcGx1Z2luczogW3Z1ZSgpXSxcbiAgcmVzb2x2ZToge1xuICAgIGFsaWFzOiB7XG4gICAgICAnQCc6IGZpbGVVUkxUb1BhdGgobmV3IFVSTCgnLi9zcmMnLCBcImZpbGU6Ly8vVXNlcnMvaGFuc3BhZ2VsL0RvY3VtZW50cy9Qcm9qZWN0cy9zY2FsYXIvZXhhbXBsZXMvYXBpLWNsaWVudC92aXRlLmNvbmZpZy50c1wiKSksXG4gICAgfSxcbiAgfSxcbn0pXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQUE7QUFDQTtBQUNBO0FBR0EsSUFBTyxzQkFBUSxhQUFhO0FBQUEsRUFDMUIsU0FBUyxDQUFDO0FBQUEsRUFDVixTQUFTO0FBQUEsSUFDUCxPQUFPO0FBQUEsTUFDTCxLQUFLLGNBQWMsSUFBSSxJQUFJLFNBQVM7QUFBQTtBQUFBO0FBQUE7IiwKICAibmFtZXMiOiBbXQp9Cg==

--- a/packages/api-client/src/libs/create-fetch-body.test.ts
+++ b/packages/api-client/src/libs/create-fetch-body.test.ts
@@ -1,0 +1,35 @@
+import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import { describe, expect, it } from 'vitest'
+
+import { createFetchBody } from './send-request'
+
+describe('create-fetch-body', () => {
+  it('should handle request method in lowercase', () => {
+    const example: RequestExample = {
+      uid: 'random-uid',
+      name: 'foo',
+      requestUid: 'other-random-uid',
+      type: 'requestExample',
+      body: {
+        activeBody: 'raw',
+        raw: {
+          value: 'hello world',
+          encoding: 'text',
+        },
+      },
+      parameters: {
+        headers: [],
+        query: [],
+        path: [],
+        cookies: [],
+      },
+    }
+
+    const result = createFetchBody('post', example)
+
+    expect(result).toEqual({
+      body: 'hello world',
+      contentType: 'text',
+    })
+  })
+})

--- a/packages/api-client/src/libs/create-fetch-body.test.ts
+++ b/packages/api-client/src/libs/create-fetch-body.test.ts
@@ -25,7 +25,7 @@ describe('create-fetch-body', () => {
       },
     }
 
-    const result = createFetchBody('post', example)
+    const result = createFetchBody('post', example, {})
 
     expect(result).toEqual({
       body: 'hello world',

--- a/packages/api-client/src/libs/create-fetch-headers.test.ts
+++ b/packages/api-client/src/libs/create-fetch-headers.test.ts
@@ -43,7 +43,7 @@ describe('createFetchHeaders', () => {
       },
     }
 
-    const result = createFetchHeaders(example)
+    const result = createFetchHeaders(example, {})
 
     expect(result).toStrictEqual({
       'x-custom-header': 'custom value',
@@ -60,7 +60,7 @@ describe('createFetchHeaders', () => {
       },
     }
 
-    const result = createFetchHeaders(example)
+    const result = createFetchHeaders(example, {})
 
     expect(result).toStrictEqual({})
   })
@@ -78,7 +78,7 @@ describe('createFetchHeaders', () => {
       },
     }
 
-    const result = createFetchHeaders(example)
+    const result = createFetchHeaders(example, {})
 
     expect(result).toStrictEqual({
       'x-strange-header': 'MixedCaseValue',
@@ -107,7 +107,7 @@ describe('createFetchHeaders', () => {
       },
     }
 
-    const result = createFetchHeaders(example)
+    const result = createFetchHeaders(example, {})
 
     expect(result).toStrictEqual({
       'x-trailing-space': 'value with space ',
@@ -136,7 +136,7 @@ describe('createFetchHeaders', () => {
       },
     }
 
-    const result = createFetchHeaders(example)
+    const result = createFetchHeaders(example, {})
 
     expect(result).toStrictEqual({
       'x-trailing-space-header': 'value',

--- a/packages/api-client/src/libs/create-fetch-headers.test.ts
+++ b/packages/api-client/src/libs/create-fetch-headers.test.ts
@@ -1,0 +1,146 @@
+import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import { describe, expect, it } from 'vitest'
+
+import { createFetchHeaders } from './send-request'
+
+describe('createFetchHeaders', () => {
+  it('creates headers from enabled parameters', () => {
+    const example: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        path: [],
+        query: [],
+        cookies: [],
+        headers: [
+          { key: 'Authorization', value: 'Bearer {{token}}', enabled: true },
+          { key: 'Content-Type', value: 'application/json', enabled: true },
+          { key: 'X-Custom-Header', value: 'custom value', enabled: true },
+          { key: 'Disabled-Header', value: 'disabled', enabled: false },
+        ],
+      },
+    }
+
+    const env = { token: '12345' }
+
+    const result = createFetchHeaders(example, env)
+
+    expect(result).toStrictEqual({
+      'authorization': 'Bearer 12345',
+      'content-type': 'application/json',
+      'x-custom-header': 'custom value',
+    })
+  })
+
+  it('doesn’t include multipart/form-data Content-Type header', () => {
+    const example: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        path: [],
+        query: [],
+        cookies: [],
+        headers: [
+          { key: 'Content-Type', value: 'multipart/form-data', enabled: true },
+          { key: 'X-Custom-Header', value: 'custom value', enabled: true },
+        ],
+      },
+    }
+
+    const result = createFetchHeaders(example)
+
+    expect(result).toStrictEqual({
+      'x-custom-header': 'custom value',
+    })
+  })
+
+  it('handles empty parameters', () => {
+    const example: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        path: [],
+        query: [],
+        cookies: [],
+        headers: [],
+      },
+    }
+
+    const result = createFetchHeaders(example)
+
+    expect(result).toStrictEqual({})
+  })
+
+  it('handles headers with mixed case characters', () => {
+    const example: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        path: [],
+        query: [],
+        cookies: [],
+        headers: [
+          { key: 'X-sTrAnGe-HeAdEr', value: 'MixedCaseValue', enabled: true },
+          { key: 'NoRmAl-HeAdEr', value: 'NormalValue', enabled: true },
+        ],
+      },
+    }
+
+    const result = createFetchHeaders(example)
+
+    expect(result).toStrictEqual({
+      'x-strange-header': 'MixedCaseValue',
+      'normal-header': 'NormalValue',
+    })
+  })
+
+  it('handles headers with trailing spaces', () => {
+    const example: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        path: [],
+        query: [],
+        cookies: [],
+        headers: [
+          {
+            key: 'X-Trailing-Space',
+            value: 'value with space ',
+            enabled: true,
+          },
+          {
+            key: 'X-No-Trailing-Space',
+            value: 'value without space',
+            enabled: true,
+          },
+        ],
+      },
+    }
+
+    const result = createFetchHeaders(example)
+
+    expect(result).toStrictEqual({
+      'x-trailing-space': 'value with space ',
+      'x-no-trailing-space': 'value without space',
+    })
+  })
+
+  it('handles headers with trailing spaces in the header name', () => {
+    const example: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        path: [],
+        query: [],
+        cookies: [],
+        headers: [
+          {
+            key: 'X-Trailing-Space-Header ',
+            value: 'value',
+            enabled: true,
+          },
+          {
+            key: 'X-Normal-Header',
+            value: 'normal value',
+            enabled: true,
+          },
+        ],
+      },
+    }
+
+    const result = createFetchHeaders(example)
+
+    expect(result).toStrictEqual({
+      'x-trailing-space-header': 'value',
+      'x-normal-header': 'normal value',
+    })
+  })
+})

--- a/packages/api-client/src/libs/create-fetch-query-params.test.ts
+++ b/packages/api-client/src/libs/create-fetch-query-params.test.ts
@@ -18,7 +18,7 @@ describe('create-fetch-query-params', () => {
       },
     }
 
-    const result = createFetchQueryParams(requestExample)
+    const result = createFetchQueryParams(requestExample, {})
 
     expect(result.toString()).toEqual('page=1&limit=10&search=John')
   })
@@ -37,7 +37,7 @@ describe('create-fetch-query-params', () => {
       },
     }
 
-    const result = createFetchQueryParams(requestExample)
+    const result = createFetchQueryParams(requestExample, {})
 
     expect(result.toString()).toEqual('color=red&color=blue&size=large')
   })
@@ -52,7 +52,7 @@ describe('create-fetch-query-params', () => {
       },
     }
 
-    const result = createFetchQueryParams(requestExample)
+    const result = createFetchQueryParams(requestExample, {})
 
     expect(result.toString()).toEqual('')
     expect(result).toBeInstanceOf(URLSearchParams)

--- a/packages/api-client/src/libs/create-fetch-query-params.test.ts
+++ b/packages/api-client/src/libs/create-fetch-query-params.test.ts
@@ -1,0 +1,61 @@
+import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import { describe, expect, it } from 'vitest'
+
+import { createFetchQueryParams } from './send-request'
+
+describe('create-fetch-query-params', () => {
+  it('creates query paramer from an example', () => {
+    const requestExample: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        headers: [],
+        path: [],
+        cookies: [],
+        query: [
+          { key: 'page', value: '1', enabled: true },
+          { key: 'limit', value: '10', enabled: true },
+          { key: 'search', value: 'John', enabled: true },
+        ],
+      },
+    }
+
+    const result = createFetchQueryParams(requestExample)
+
+    expect(result.toString()).toEqual('page=1&limit=10&search=John')
+  })
+
+  it('handles array parameters (same name multiple times)', () => {
+    const requestExample: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        headers: [],
+        path: [],
+        cookies: [],
+        query: [
+          { key: 'color', value: 'red', enabled: true },
+          { key: 'color', value: 'blue', enabled: true },
+          { key: 'size', value: 'large', enabled: true },
+        ],
+      },
+    }
+
+    const result = createFetchQueryParams(requestExample)
+
+    expect(result.toString()).toEqual('color=red&color=blue&size=large')
+  })
+
+  it('returns empty URLSearchParams when no query parameters are provided', () => {
+    const requestExample: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        headers: [],
+        path: [],
+        cookies: [],
+        query: [],
+      },
+    }
+
+    const result = createFetchQueryParams(requestExample)
+
+    expect(result.toString()).toEqual('')
+    expect(result).toBeInstanceOf(URLSearchParams)
+    expect([...result.entries()]).toHaveLength(0)
+  })
+})

--- a/packages/api-client/src/libs/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/create-request-operation.test.ts
@@ -302,6 +302,7 @@ describe('create-request-operation', () => {
     )
     if (error) throw error
 
+    // @ts-expect-error Not added yet
     const [requestError, result, fetchOptions] =
       await requestOperation.sendRequest()
 

--- a/packages/api-client/src/libs/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/create-request-operation.test.ts
@@ -1,0 +1,582 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { createRequestOperation } from '@/libs'
+import {
+  type RequestExamplePayload,
+  type RequestPayload,
+  type ServerPayload,
+  createExampleFromRequest,
+  requestExampleSchema,
+  requestSchema,
+  serverSchema,
+} from '@scalar/oas-utils/entities/spec'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+const PROXY_PORT = 5051
+const VOID_PORT = 5052
+const PROXY_URL = `http://127.0.0.1:${PROXY_PORT}`
+const VOID_URL = `http://127.0.0.1:${VOID_PORT}`
+
+type MetaRequestPayload = {
+  serverPayload?: ServerPayload
+  requestPayload?: RequestPayload
+  requestExamplePayload?: RequestExamplePayload
+  proxy?: string
+}
+
+/** Creates the payload for createRequestOperation */
+const createRequestPayload = (metaRequestPayload: MetaRequestPayload = {}) => {
+  const request = requestSchema.parse(metaRequestPayload.requestPayload ?? {})
+  const server = serverSchema.parse(metaRequestPayload.serverPayload ?? {})
+  let example = createExampleFromRequest(request, 'example')
+
+  // Overwrite any example properties
+  if (metaRequestPayload.requestExamplePayload)
+    example = requestExampleSchema.parse({
+      ...example,
+      ...metaRequestPayload.requestExamplePayload,
+    })
+
+  return {
+    auth: {},
+    request,
+    environment: {},
+    globalCookies: [],
+    example,
+    server,
+    proxy: metaRequestPayload.proxy,
+    securitySchemes: {},
+  }
+}
+
+beforeAll(async () => {
+  // Check whether the proxy-server is running
+  try {
+    const result = await fetch(PROXY_URL)
+
+    if (result.ok) {
+      return
+    }
+  } catch (error) {
+    throw new Error(`
+
+[sendRequest.test.ts] Looks like you’re not running @scalar/proxy-server on <http://127.0.0.1:${PROXY_PORT}>, but it’s required for this test file.
+
+Try to run it like this:
+
+$ pnpm dev:proxy-server
+`)
+  }
+
+  // Check whether the void-server is running
+  try {
+    const result = await fetch(VOID_URL)
+
+    if (result.ok) {
+      return
+    }
+  } catch (error) {
+    throw new Error(`
+
+[sendRequest.test.ts] Looks like you’re not running @scalar/void-server on <http://127.0.0.1:${VOID_PORT}>, but it’s required for this test file.
+
+Try to run it like this:
+
+$ pnpm dev:void-server
+`)
+  }
+})
+
+describe('create-request-operation', () => {
+  it('shows a warning when scalar_url is missing', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: PROXY_URL },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toContain(
+      'The `scalar_url` query parameter is required.',
+    )
+  })
+
+  it('builds a request with a relative server url', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: `/api` },
+        requestPayload: {
+          path: '/{path}',
+          parameters: [
+            {
+              in: 'path',
+              name: 'path',
+            },
+          ],
+        },
+        requestExamplePayload: {
+          parameters: {
+            path: [
+              {
+                key: 'path',
+                value: 'example',
+                enabled: true,
+              },
+            ],
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    // Mock the origin to make the relative request work
+    vi.spyOn(window, 'location', 'get').mockReturnValue({
+      ...window.location,
+      origin: VOID_URL,
+    })
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'GET',
+      path: '/api/example',
+      body: '',
+    })
+  })
+
+  it('builds a request with no server and a path', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        requestPayload: {
+          path: 'https://void.scalar.com/me',
+        },
+      }),
+    )
+    if (error) throw error
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'GET',
+      path: '/me',
+      body: '',
+    })
+  })
+
+  it('builds a request with no server and no path', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        requestPayload: {
+          path: 'https://void.scalar.com',
+        },
+      }),
+    )
+    if (error) throw error
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'GET',
+      path: '/',
+      body: '',
+    })
+  })
+
+  it('reaches the echo server *without* the proxy', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: VOID_URL },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).not.toContain('ECONNREFUSED')
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'GET',
+      path: '/',
+    })
+  })
+
+  // TODO: this doesn't actually hit the proxy due to 127.0.0.1
+  it('reaches the echo server *with* the proxy', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: VOID_URL },
+        proxy: PROXY_URL,
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'GET',
+      path: '/',
+    })
+  })
+
+  it('replaces variables in urls', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: VOID_URL },
+        requestPayload: {
+          path: '/{path}',
+          parameters: [
+            {
+              in: 'path',
+              name: 'path',
+            },
+          ],
+        },
+        requestExamplePayload: {
+          parameters: {
+            path: [
+              {
+                key: 'path',
+                value: 'example',
+                enabled: true,
+              },
+            ],
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'GET',
+      path: '/example',
+    })
+  })
+
+  it('sends query parameters', async () => {
+    const [error, requestOperation] = createRequestOperation<{
+      query: { foo: 'bar' }
+    }>(
+      createRequestPayload({
+        serverPayload: { url: VOID_URL },
+        requestExamplePayload: {
+          parameters: {
+            query: [
+              {
+                key: 'foo',
+                value: 'bar',
+                enabled: true,
+              },
+            ],
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data.query).toMatchObject({
+      foo: 'bar',
+    })
+  })
+
+  it.skip('uses uppercase request method', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: VOID_URL },
+        requestPayload: {
+          // Lowercase method
+          method: 'post',
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result, fetchOptions] =
+      await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'POST',
+    })
+    expect(fetchOptions).toMatchObject({
+      // Uppercase method
+      method: 'POST',
+    })
+  })
+
+  it('sends query parameters as arrays', async () => {
+    const [error, requestOperation] = createRequestOperation<{
+      query: { foo: ['foo', 'bar'] }
+    }>(
+      createRequestPayload({
+        serverPayload: { url: VOID_URL },
+        requestExamplePayload: {
+          parameters: {
+            query: [
+              {
+                key: 'foo',
+                value: 'foo',
+                enabled: true,
+              },
+              {
+                key: 'foo',
+                value: 'bar',
+                enabled: true,
+              },
+            ],
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data.query).toMatchObject({
+      foo: ['foo', 'bar'],
+    })
+  })
+
+  it('merges query parameters', async () => {
+    const [error, requestOperation] = createRequestOperation<{
+      query: { example: 'parameter'; foo: 'bar' }
+    }>(
+      createRequestPayload({
+        serverPayload: {
+          url: `${VOID_URL}/api?orange=apple`,
+        },
+        requestPayload: {
+          path: '?example=parameter',
+        },
+        requestExamplePayload: {
+          parameters: {
+            query: [
+              {
+                key: 'foo',
+                value: 'bar',
+                enabled: true,
+              },
+            ],
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data.query).toStrictEqual({
+      example: 'parameter',
+      foo: 'bar',
+      orange: 'apple',
+    })
+  })
+
+  it('doesnt have any query parameters', async () => {
+    const [error, requestOperation] = createRequestOperation<{
+      query: { example: 'parameter'; foo: 'bar' }
+    }>(
+      createRequestPayload({
+        serverPayload: {
+          url: VOID_URL,
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data.query).toStrictEqual({})
+  })
+
+  it('should ignore query parameters with empty values', async () => {
+    const [error, requestOperation] = createRequestOperation<{
+      query: { example: 'parameter'; foo: 'bar' }
+    }>(
+      createRequestPayload({
+        serverPayload: {
+          url: VOID_URL,
+        },
+        requestExamplePayload: {
+          parameters: {
+            query: [
+              {
+                key: 'foo',
+                value: '',
+                enabled: true,
+              },
+            ],
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data.query).toStrictEqual({})
+  })
+
+  it('works with no content', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: `${VOID_URL}/204` },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toBe('')
+  })
+
+  it('skips the proxy for requests to 127.0.0.1 (localhost)', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: `http://127.0.0.1:${VOID_PORT}/v1` },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'GET',
+      path: '/v1',
+    })
+  })
+
+  it('keeps the trailing slash', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: `${VOID_URL}/v1/` },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'GET',
+      path: '/v1/',
+    })
+  })
+
+  it('sends a multipart/form-data request with string values', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: VOID_URL },
+        requestPayload: { path: '', method: 'post' },
+        requestExamplePayload: {
+          body: {
+            activeBody: 'formData',
+            formData: {
+              encoding: 'form-data',
+              value: [
+                {
+                  key: 'name',
+                  value: 'John Doe',
+                  enabled: true,
+                },
+              ],
+            },
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'POST',
+      path: '/',
+      body: {
+        name: 'John Doe',
+      },
+    })
+  })
+
+  /**
+   * If we pass FormData with a file to fetch(), it seems to switch to a streaming mode and
+   * the void-server doesn't receive the body properly.
+   * It does work on other echo servers such as https://echo.free.beeceptor.com
+   *
+   * It’s not clear to me, whether we need to make the void-server handle that, or
+   * if we should disable the streaming, or
+   * if there’s another way to test this properly.
+   *
+   * - @hanspagel
+   */
+  it.todo('sends a multipart/form-data request with files', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: VOID_URL },
+        requestPayload: { path: '', method: 'post' },
+        requestExamplePayload: {
+          body: {
+            activeBody: 'formData',
+            formData: {
+              encoding: 'form-data',
+              value: [
+                {
+                  key: 'file',
+                  file: new File(['hello'], 'hello.txt', {
+                    type: 'text/plain',
+                  }),
+                  enabled: true,
+                },
+                {
+                  key: 'image',
+                  file: new File(['hello'], 'hello.png', { type: 'image/png' }),
+                  value: 'ignore me',
+                  enabled: true,
+                },
+              ],
+            },
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(result?.response.data).toMatchObject({
+      method: 'POST',
+      path: '/',
+      body: {
+        file: {
+          name: 'hello.txt',
+          sizeInBytes: 5,
+          type: 'text/plain',
+        },
+        image: {
+          name: 'hello.png',
+          sizeInBytes: 5,
+          type: 'image/png',
+        },
+      },
+    })
+  })
+})

--- a/packages/api-client/src/libs/decode-buffer.test.ts
+++ b/packages/api-client/src/libs/decode-buffer.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodeBuffer } from './send-request'
+
+describe('decode-buffer', () => {
+  it('decodes JSON content', () => {
+    const jsonData = JSON.stringify({ key: 'value' })
+    const buffer = new TextEncoder().encode(jsonData)
+    const result = decodeBuffer(buffer, 'application/json')
+    expect(result).toEqual({ key: 'value' })
+  })
+
+  it('decodes text content', () => {
+    const textData = 'Hello, world!'
+    const buffer = new TextEncoder().encode(textData)
+    const result = decodeBuffer(buffer, 'text/plain')
+    expect(result).toBe('Hello, world!')
+  })
+
+  it('returns a Blob for binary content', () => {
+    const binaryData = new Uint8Array([1, 2, 3, 4])
+    const result = decodeBuffer(binaryData.buffer, 'application/octet-stream')
+    expect(result).toBeInstanceOf(Blob)
+    expect(result.type).toBe('application/octet-stream')
+  })
+
+  it('uses the charset parameter for text decoding', () => {
+    const textData = 'こんにちは'
+    const buffer = new TextEncoder().encode(textData)
+    const result = decodeBuffer(buffer, 'text/plain; charset=utf-8')
+    expect(result).toBe('こんにちは')
+  })
+})

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -44,7 +44,10 @@ export function decodeBuffer(buffer: ArrayBuffer, contentType: string) {
 }
 
 /** Populate the headers from enabled parameters */
-export function createFetchHeaders(example: RequestExample, env: object) {
+export function createFetchHeaders(
+  example: Pick<RequestExample, 'parameters'>,
+  env: object,
+) {
   const headers: NonNullable<RequestInit['headers']> = {}
 
   example.parameters.headers.forEach((h) => {
@@ -62,7 +65,10 @@ export function createFetchHeaders(example: RequestExample, env: object) {
 }
 
 /** Populate the query parameters from the example  */
-export function createFetchQueryParams(example: RequestExample, env: object) {
+export function createFetchQueryParams(
+  example: Pick<RequestExample, 'parameters'>,
+  env: object,
+) {
   const params = new URLSearchParams()
   example.parameters.query.forEach((p) => {
     if (p.enabled && p.value)

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -23,7 +23,7 @@ import MimeTypeParser from 'whatwg-mimetype'
 
 // TODO: This should return `unknown` to acknowledge we don’t know type, shouldn’t it?
 /** Decode the buffer according to its content-type */
-function decodeBuffer(buffer: ArrayBuffer, contentType: string) {
+export function decodeBuffer(buffer: ArrayBuffer, contentType: string) {
   const mimeType = new MimeTypeParser(contentType)
 
   if (textMediaTypes.includes(mimeType.essence)) {
@@ -44,11 +44,11 @@ function decodeBuffer(buffer: ArrayBuffer, contentType: string) {
 }
 
 /** Populate the headers from enabled parameters */
-function createFetchHeaders(example: RequestExample, env: object) {
+export function createFetchHeaders(example: RequestExample, env: object) {
   const headers: NonNullable<RequestInit['headers']> = {}
 
   example.parameters.headers.forEach((h) => {
-    const lowerCaseKey = h.key.toLowerCase()
+    const lowerCaseKey = h.key.trim().toLowerCase()
 
     // Ensure we remove the mutlipart/form-data header so fetch can properly set boundaries
     if (
@@ -62,7 +62,7 @@ function createFetchHeaders(example: RequestExample, env: object) {
 }
 
 /** Populate the query parameters from the example  */
-function createFetchQueryParams(example: RequestExample, env: object) {
+export function createFetchQueryParams(example: RequestExample, env: object) {
   const params = new URLSearchParams()
   example.parameters.query.forEach((p) => {
     if (p.enabled && p.value)
@@ -73,7 +73,7 @@ function createFetchQueryParams(example: RequestExample, env: object) {
 }
 
 /** Set all cookie params and workspace level cookies that are applicable */
-function setRequestCookies({
+export function setRequestCookies({
   example,
   env,
   globalCookies,
@@ -156,7 +156,7 @@ function setRequestCookies({
  * TODO: Should we be setting the content type headers here?
  * If so we must allow the user to override the content type header
  */
-function createFetchBody(
+export function createFetchBody(
   method: RequestMethod,
   example: RequestExample,
   env: object,


### PR DESCRIPTION
This PR adds a few more tests around `createRequestOperation` and the used helpers.

Just one code change: We’re trimming whitespace from the header name now.

Note: I’ve also added one to test for the uppercase request method added in #3305, but I didn’t enable it, because it requires more code changes. Will ff with a separate PR.