### PR TITLE
ci: skip update-contributors workflow on forks

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   update-readme:
     name: Update the README
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-readme:
     name: Update the README
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.repository_owner == 'scalar' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**Problem**
This workflow runs at 3pm also on forks, which can be annoying as the job will fail.
![image](https://github.com/user-attachments/assets/5d43626c-379c-41ae-91d3-9484d1bc6129)


**Solution**
This PR prevents the workflow from running on forks.
