### PR TITLE
chore(types): add point to declaration file

### DIFF
--- a/.changeset/chilly-cycles-refuse.md
+++ b/.changeset/chilly-cycles-refuse.md
@@ -1,0 +1,5 @@
+---
+'@scalar/types': patch
+---
+
+chore: add point to declaration file

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -28,6 +28,7 @@
     "types:check": "scalar-types-check"
   },
   "type": "module",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,1 @@
-export {}
+export * from './legacy'


### PR DESCRIPTION
I tried updating this package, [elysia-swagger](https://github.com/elysiajs/elysia-swagger), to use @scalar/types, but there was an error about a missing declaration file. This PR will fix that.