### PR TITLE
chore(Scalar.AspNetCore): add @xC0dex as an additional code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,7 +28,7 @@
 # /packages/use-modal
 /packages/build-watch @geoffgscott
 /packages/nestjs-api-reference @marclave
-/packages/scalar.aspnetcore @marclave
+/packages/scalar.aspnetcore @xC0dex @marclave
 # /packages/use-toasts
 /packages/api-client-react @amritk
 /packages/cli @hanspagel


### PR DESCRIPTION
This is a suggestion to add @xC0dex as a code owner, so he’ll be auto-assigned for .NET PRs as a reviewer together with @marclave.