### PR TITLE
chore: remove credentials min length error

### DIFF
--- a/packages/code-highlight/src/code/highlight.ts
+++ b/packages/code-highlight/src/code/highlight.ts
@@ -24,12 +24,11 @@ export function syntaxHighlight(
       ? [options.maskCredentials]
       : (options?.maskCredentials ?? [])
   ).filter((c) => {
+    // Credentials must be at least 3 characters to mask.
     if (c.length < 3) {
-      console.error(
-        `Codeblock credentials must be at least 3 characters to mask. Will not mask "${c}"`,
-      )
       return false
     }
+
     return true
   })
 


### PR DESCRIPTION
There’s an error in the console when the auth credentials are shorter than 3 characters. It’s saying that we won’t mask the credentials in that case.

I can’t think of any scenario where 2 characters are confidential anyway and no one will notice when it’s in the browser console, I think we can remove it.