### PR TITLE
test(Scalar.AspNetCore): Increase Code Coverage

### DIFF
--- a/packages/scalar.aspnetcore/README.md
+++ b/packages/scalar.aspnetcore/README.md
@@ -6,7 +6,7 @@
 
 This .NET package `Scalar.AspNetCore` provides an easy way to render beautiful API references based on OpenAPI/Swagger documents.
 
-Made possible by the wonderful work of [@captainsafia](https://github.com/captainsafia) on [building the integration and docs written](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/aspnetcore-openapi?view=aspnetcore-9.0&tabs=visual-studio#using-scalar-for-interactive-api-documentation) for the Scalar & .NET integration. Thanks to [@xC0dex](https://github.com/xC0dex) for making it awesome.
+Made possible by the wonderful work of [@captainsafia](https://github.com/captainsafia) on [building the integration and docs written](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/using-openapi-documents?view=aspnetcore-9.0#use-scalar-for-interactive-api-documentation) for the Scalar & .NET integration. Thanks to [@xC0dex](https://github.com/xC0dex) for making it awesome.
 
 ![dotnet](./dotnet.jpg)
 

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class ScalarEndpointRouteBuilderExtensions
 
         if (!options.EndpointPathPrefix.Contains(DocumentName))
         {
-            throw new ArgumentException($"`EndpointPathPrefix` must define `{DocumentName}`.");
+            throw new ArgumentException($"'EndpointPathPrefix' must define '{DocumentName}'.");
         }
         var configuration = JsonSerializer.Serialize(options.ToScalarConfiguration(), ScalaConfigurationSerializerContext.Default.ScalarConfiguration);
 

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -54,13 +54,13 @@ internal static class ScalarOptionsMapper
         };
     }
 
-    private static Dictionary<string, string[]>? GetHiddenClients(ScalarOptions options)
+    private static Dictionary<string, IEnumerable<string>>? GetHiddenClients(ScalarOptions options)
     {
         var targets = ProcessOptions(options);
 
         return targets?.ToDictionary(k =>
                 k.Key.ToStringFast(),
-            k => k.Value.Select(v => v.ToStringFast()).ToArray()
+            k => k.Value.Select(v => v.ToStringFast())
         );
     }
 

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -2,7 +2,7 @@ namespace Scalar.AspNetCore;
 
 internal static class ScalarOptionsMapper
 {
-    private static readonly Dictionary<ScalarTarget, ScalarClient[]> ClientOptions = new()
+    internal static readonly Dictionary<ScalarTarget, ScalarClient[]> ClientOptions = new()
     {
         { ScalarTarget.C, [ScalarClient.Libcurl] },
         { ScalarTarget.Clojure, [ScalarClient.CljHttp] },

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
@@ -34,7 +34,7 @@ internal sealed class ScalarConfiguration
 
     public required DefaultHttpClient? DefaultHttpClient { get; init; }
 
-    public required IDictionary<string, string[]>? HiddenClients { get; init; }
+    public required IDictionary<string, IEnumerable<string>>? HiddenClients { get; init; }
 
     public required ScalarAuthenticationOptions? Authentication { get; init; }
 

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -79,7 +79,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
     }
 
     [Fact]
-    public async Task MapScalarApiReference_ShouldHandleCustom_WhenSpecified()
+    public async Task MapScalarApiReference_ShouldHandleCustomEndpointPath_WhenSpecified()
     {
         // Arrange
         var client = factory.WithWebHostBuilder(builder =>
@@ -95,5 +95,24 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+    
+    [Fact]
+    public void MapScalarApiReference_ShouldThrowException_WhenDocumentNameNotSpecified()
+    {
+        // Arrange
+        var tmpFactory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.Configure<ScalarOptions>(options => options.EndpointPathPrefix = "/custom-path");
+            });
+        });
+
+        // Act
+        var act = () => tmpFactory.CreateClient(); // CreateClient starts the app
+        
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("'EndpointPathPrefix' must define '{documentName}'.");
     }
 }

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -3,13 +3,15 @@ namespace Scalar.AspNetCore.Tests;
 public class ScalarOptionsExtensionsTests
 {
     [Fact]
-    public void Do()
+    public void Extensions_ShouldSetAllPropertiesCorrectly()
     {
         // Arrange
         var options = new ScalarOptions();
 
         // Act
         options
+            .WithTitle("My title")
+            .WithEndpointPrefix("/docs/{documentName}")
             .WithModels(false)
             .WithDownloadButton(false)
             .WithTestRequestButton(false)
@@ -34,10 +36,13 @@ public class ScalarOptionsExtensionsTests
             .WithDarkModeToggle(false)
             .WithForceThemeMode(ThemeMode.Light)
             .WithTagSorter(TagSorter.Alpha)
+            .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
             .AddServer("https://example.com")
             .AddServer(new ScalarServer("https://example.org", "My other server"));
 
         // Assert
+        options.Title.Should().Be("My title");
+        options.EndpointPathPrefix.Should().Be("/docs/{documentName}");
         options.HideModels.Should().BeTrue();
         options.HideDownloadButton.Should().BeTrue();
         options.HideTestRequestButton.Should().BeTrue();
@@ -58,6 +63,8 @@ public class ScalarOptionsExtensionsTests
         options.CustomCss.Should().Be("*{}");
         options.HideDarkModeToggle.Should().BeTrue();
         options.ForceThemeMode.Should().Be(ThemeMode.Light);
+        options.DefaultHttpClient.Key.Should().Be(ScalarTarget.CSharp);
+        options.DefaultHttpClient.Value.Should().Be(ScalarClient.HttpClient);
         options.Servers.Should().HaveCount(2);
         options.Servers.Should().ContainSingle(x => x.Url == "https://example.com");
         options.Servers.Should().ContainSingle(x => x.Url == "https://example.org" && x.Description == "My other server");

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -96,4 +96,75 @@ public class ScalarOptionsMapperTests
         configuration.TagSorter.Should().Be(TagSorter.Alpha.ToStringFast());
         configuration.Theme.Should().Be(ScalarTheme.Saturn.ToStringFast());
     }
+
+    [Fact]
+    public void GetHiddenClients_ShouldReturnNull_WhenEnabledTargetsAndEnabledClientsAreEmpty()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        var hiddenClients = options.ToScalarConfiguration().HiddenClients;
+
+        // Assert
+        hiddenClients.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetHiddenClients_ShouldReturnAllClients_WhenHiddenClientsIsTrue()
+    {
+        // Arrange
+        var options = new ScalarOptions { HiddenClients = true };
+
+        // Act
+        var hiddenClients = options.ToScalarConfiguration().HiddenClients;
+
+        // Assert
+        hiddenClients.Should().ContainKeys(ScalarOptionsMapper.ClientOptions.Keys.Select(x => x.ToStringFast()));
+    }
+
+    [Fact]
+    public void GetHiddenClients_ShouldReturnFilteredClients_WhenEnabledTargetsIsNotEmpty()
+    {
+        // Arrange
+        var options = new ScalarOptions { EnabledTargets = [ScalarTarget.CSharp] };
+
+        // Act
+        var hiddenClients = options.ToScalarConfiguration().HiddenClients;
+
+        // Assert
+        hiddenClients.Should().HaveCount(ScalarOptionsMapper.ClientOptions.Count - 1);
+        hiddenClients.Should().NotContainKey(ScalarTarget.CSharp.ToStringFast());
+    }
+
+    [Fact]
+    public void GetHiddenClients_ShouldReturnFilteredClients_WhenEnabledClientsIsNotEmpty()
+    {
+        // Arrange
+        var options = new ScalarOptions { EnabledClients = [ScalarClient.HttpClient, ScalarClient.Python3] };
+
+        // Act
+        var hiddenClients = options.ToScalarConfiguration().HiddenClients;
+
+        // Assert
+        hiddenClients.Should().HaveCount(ScalarOptionsMapper.ClientOptions.Count);
+        hiddenClients.Should().ContainKey(ScalarTarget.CSharp.ToStringFast())
+            .WhoseValue.Should().ContainSingle().Which.Should().Be(ScalarClient.RestSharp.ToStringFast());
+        hiddenClients.Should().ContainKey(ScalarTarget.Python.ToStringFast())
+            .WhoseValue.Should().ContainSingle().Which.Should().Be(ScalarClient.Requests.ToStringFast());
+    }
+
+    [Fact]
+    public void GetHiddenClients_ShouldNotReturnTarget_WhenAllClientsAreEnabled()
+    {
+        // Arrange
+        var options = new ScalarOptions { EnabledClients = [ScalarClient.OkHttp] }; // All Kotlin clients are enabled
+
+        // Act
+        var hiddenClients = options.ToScalarConfiguration().HiddenClients;
+
+        // Assert
+        hiddenClients.Should().HaveCount(ScalarOptionsMapper.ClientOptions.Count - 1);
+        hiddenClients.Should().NotContainKey(ScalarTarget.Kotlin.ToStringFast());
+    }
 }

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -1,0 +1,99 @@
+namespace Scalar.AspNetCore.Tests;
+
+public class ScalarOptionsMapperTests
+{
+    [Fact]
+    public void ToConfiguration_ShouldReturnCorrectDefaultConfiguration()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        var configuration = options.ToScalarConfiguration();
+
+        // Assert
+        configuration.Proxy.Should().BeNull();
+        configuration.ShowSidebar.Should().BeTrue();
+        configuration.HideModels.Should().BeFalse();
+        configuration.HideDownloadButton.Should().BeFalse();
+        configuration.HideTestRequestButton.Should().BeFalse();
+        configuration.DarkMode.Should().BeTrue();
+        configuration.ForceDarkModeState.Should().BeNull();
+        configuration.HideDarkModeToggle.Should().BeFalse();
+        configuration.CustomCss.Should().BeNull();
+        configuration.SearchHotKey.Should().BeNull();
+        configuration.Servers.Should().BeNull();
+        configuration.Metadata.Should().BeNull();
+        configuration.DefaultHttpClient!.TargetKey.Should().Be(ScalarTarget.Shell.ToStringFast());
+        configuration.DefaultHttpClient!.ClientKey.Should().Be(ScalarClient.Curl.ToStringFast());
+        configuration.HiddenClients.Should().BeNull();
+        configuration.Authentication.Should().BeNull();
+        configuration.WithDefaultFonts.Should().BeTrue();
+        configuration.DefaultOpenAllTags.Should().BeFalse();
+        configuration.TagSorter.Should().BeNull();
+        configuration.Theme.Should().Be(ScalarTheme.Purple.ToStringFast());
+    }
+
+    [Fact]
+    public void ToConfiguration_ShouldReturnCorrectCustomConfiguration()
+    {
+        // Arrange
+        var options = new ScalarOptions
+        {
+            ProxyUrl = "http://localhost:8080",
+            ShowSidebar = false,
+            HideModels = true,
+            HideDownloadButton = true,
+            HideTestRequestButton = true,
+            DarkMode = false,
+            ForceThemeMode = ThemeMode.Light,
+            HideDarkModeToggle = true,
+            CustomCss = "*{}",
+            SearchHotKey = "o",
+            Theme = ScalarTheme.Saturn,
+            Servers = [new ScalarServer("https://example.com")],
+            Metadata = new Dictionary<string, string> { ["key"] = "value" },
+            DefaultHttpClient = new KeyValuePair<ScalarTarget, ScalarClient>(ScalarTarget.CSharp, ScalarClient.HttpClient),
+            HiddenClients = true,
+            Authentication = new ScalarAuthenticationOptions
+            {
+                PreferredSecurityScheme = "my-scheme",
+                ApiKey = new ApiKeyOptions
+                {
+                    Token = "my-token"
+                }
+            },
+            DefaultFonts = false,
+            DefaultOpenAllTags = true,
+            TagSorter = TagSorter.Alpha
+        };
+
+        // Act
+        var configuration = options.ToScalarConfiguration();
+
+        // Assert
+        configuration.Proxy.Should().Be("http://localhost:8080");
+        configuration.ShowSidebar.Should().BeFalse();
+        configuration.HideModels.Should().BeTrue();
+        configuration.HideDownloadButton.Should().BeTrue();
+        configuration.HideTestRequestButton.Should().BeTrue();
+        configuration.DarkMode.Should().BeFalse();
+        configuration.ForceDarkModeState.Should().Be(ThemeMode.Light.ToStringFast());
+        configuration.HideDarkModeToggle.Should().BeTrue();
+        configuration.CustomCss.Should().Be("*{}");
+        configuration.SearchHotKey.Should().Be("o");
+        configuration.Servers.Should().ContainSingle().Which.Url.Should().Be("https://example.com");
+        configuration.Metadata.Should().ContainKey("key").WhoseValue.Should().Be("value");
+        configuration.DefaultHttpClient!.TargetKey.Should().Be(ScalarTarget.CSharp.ToStringFast());
+        configuration.DefaultHttpClient!.ClientKey.Should().Be(ScalarClient.HttpClient.ToStringFast());
+        configuration.HiddenClients.Should().ContainKeys(ScalarOptionsMapper.ClientOptions.Keys.Select(x => x.ToStringFast()));
+        configuration.Authentication.Should().NotBeNull();
+        configuration.Authentication!.PreferredSecurityScheme.Should().Be("my-scheme");
+        configuration.Authentication.ApiKey.Should().NotBeNull();
+        configuration.Authentication.ApiKey!.Token.Should().Be("my-token");
+        configuration.WithDefaultFonts.Should().BeFalse();
+        configuration.DefaultOpenAllTags.Should().BeTrue();
+        configuration.TagSorter.Should().Be(TagSorter.Alpha.ToStringFast());
+        configuration.Theme.Should().Be(ScalarTheme.Saturn.ToStringFast());
+    }
+}


### PR DESCRIPTION
### Description

This PR increases the code coverage of the `Scalar.AspNetCore` to 💯%.
![image](https://github.com/user-attachments/assets/479fe072-aea1-4589-aeff-871a7e4657dd)

I also updated one link in the Readme to target the correct docs.
