### PR TITLE
ci: switch working directory for aspnetcore-publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,15 +396,15 @@ jobs:
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Restore dependencies
-        working-directory: packages/scalar.aspnetcore
+        working-directory: packages/scalar.aspnetcore/src/Scalar.AspNetCore
         run: dotnet restore
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Pack Scalar.AspNetCore
-        working-directory: packages/scalar.aspnetcore
+        working-directory: packages/scalar.aspnetcore/src/Scalar.AspNetCore
         run: dotnet pack -c Release --no-restore --output nupkgs /p:Version=$VERSION
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Publish Scalar.AspNetCore
-        working-directory: packages/scalar.aspnetcore
+        working-directory: packages/scalar.aspnetcore/src/Scalar.AspNetCore
         run: dotnet nuget push nupkgs/*.nupkg -k ${{ secrets.NUGET_TOKEN }} -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
### Description

During the last release, I noticed [a warning](https://github.com/scalar/scalar/actions/runs/11149128322/job/30987323086#step:9:8) in the `aspnetcore-publish` job. I've updated the `working-directory` to target the .NET project instead of the .NET solution to get rid of the warning.