### PR TITLE
fix(api-client): remove servers dropdown if empty

### DIFF
--- a/.changeset/silent-ladybugs-matter.md
+++ b/.changeset/silent-ladybugs-matter.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: removed showing servers dropdown if empty

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -68,7 +68,6 @@ const serverUrlWithoutTrailingSlash = computed(() => {
 <template>
   <ScalarDropdown
     v-if="
-      !isReadOnly ||
       (requestServerOptions && requestServerOptions?.length > 1) ||
       (collectionServerOptions && collectionServerOptions?.length > 1)
     "


### PR DESCRIPTION
We showed the server dropdown even if empty to allow adding servers in #3297, but this leaves an empty gap:

![image](https://github.com/user-attachments/assets/e2292cbc-2b34-45e8-b5fd-a764f8943f77)

This reverts that change and you can just add servers from the command palette 
