### PR TITLE
fix(api-client): don't error if there aren't any collections

### DIFF
--- a/.changeset/slow-bees-fix.md
+++ b/.changeset/slow-bees-fix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): don't error if there aren't any collections

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -207,7 +207,7 @@ export const createWorkspaceStore = (
       )
 
     const fallbackUid =
-      activeWorkspace.value.collections[0] ?? collections[0].uid
+      activeWorkspace.value.collections[0] ?? collections[0]?.uid
 
     return collections[fallbackUid]
   })


### PR DESCRIPTION
This seems to be causing issues in the guides because it sometimes clears the contents of the spec, you can test it by setting `content: ''` in the example.

## Before

<img width="1512" alt="Google Chrome-2024-10-02-17-02-32@2x" src="https://github.com/user-attachments/assets/dd1f27e4-e112-4232-a8dd-01220b86f338">

## After

<img width="1511" alt="Google Chrome-2024-10-02-17-20-07@2x" src="https://github.com/user-attachments/assets/6fc6e3fc-edcc-4829-82a2-6f6752aafd49">
