### PR TITLE
feat(api-client): remove tabs on client.scalar.com

### DIFF
--- a/.changeset/stupid-buckets-dress.md
+++ b/.changeset/stupid-buckets-dress.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat (api-client): remove tabs on client.scalar.com

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -69,6 +69,10 @@
       "import": "./dist/libs/event-busses/index.js",
       "types": "./dist/libs/event-busses/index.d.ts"
     },
+    "./layouts/Web": {
+      "import": "./dist/layouts/Web/index.js",
+      "types": "./dist/layouts/Web/index.d.ts"
+    },
     "./layouts/Modal": {
       "import": "./dist/layouts/Modal/index.js",
       "types": "./dist/layouts/Modal/index.d.ts"

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -45,9 +45,7 @@ const { isDark } = useDarkModeState()
 const workspaceStore = useWorkspace()
 
 // Ensure we add our scalar wrapper class to the headless ui root
-onBeforeMount(async () => {
-  addScalarClassesToHeadless()
-})
+onBeforeMount(() => addScalarClassesToHeadless())
 
 /** Handles the hotkey events, we will pass in custom hotkeys here */
 const handleKeyDown = (ev: KeyboardEvent) => handleHotKeyDown(ev, { hotKeys })

--- a/packages/api-client/src/layouts/App/hotkeys.ts
+++ b/packages/api-client/src/layouts/App/hotkeys.ts
@@ -1,0 +1,23 @@
+import type { HotKeyConfig } from '@scalar/oas-utils/entities/workspace'
+
+/**
+ * Default set of keybindings for the client app
+ */
+export const APP_HOTKEYS: HotKeyConfig = {
+  t: { event: 'addTopNav', modifiers: ['default'] },
+  w: { event: 'closeTopNav', modifiers: ['default'] },
+  ArrowLeft: { event: 'navigateTopNavLeft', modifiers: ['default', 'Alt'] },
+  ArrowRight: { event: 'navigateTopNavRight', modifiers: ['default', 'Alt'] },
+  l: { event: 'focusAddressBar', modifiers: ['default'] },
+  1: { event: 'jumpToTab', modifiers: ['default'] },
+  2: { event: 'jumpToTab', modifiers: ['default'] },
+  3: { event: 'jumpToTab', modifiers: ['default'] },
+  4: { event: 'jumpToTab', modifiers: ['default'] },
+  5: { event: 'jumpToTab', modifiers: ['default'] },
+  6: { event: 'jumpToTab', modifiers: ['default'] },
+  7: { event: 'jumpToTab', modifiers: ['default'] },
+  8: { event: 'jumpToTab', modifiers: ['default'] },
+  9: { event: 'jumpToLastTab', modifiers: ['default'] },
+  f: { event: 'focusRequestSearch', modifiers: ['default'] },
+  n: { event: 'openCommandPaletteRequest', modifiers: ['default'] },
+}

--- a/packages/api-client/src/layouts/Web/ApiClientWeb.vue
+++ b/packages/api-client/src/layouts/Web/ApiClientWeb.vue
@@ -29,9 +29,7 @@ const { isDark } = useDarkModeState()
 const workspaceStore = useWorkspace()
 
 // Ensure we add our scalar wrapper class to the headless ui root
-onBeforeMount(async () => {
-  addScalarClassesToHeadless()
-})
+onBeforeMount(() => addScalarClassesToHeadless())
 
 /** Handles the hotkey events, we will pass in custom hotkeys here */
 const handleKeyDown = (ev: KeyboardEvent) => handleHotKeyDown(ev)

--- a/packages/api-client/src/layouts/Web/ApiClientWeb.vue
+++ b/packages/api-client/src/layouts/Web/ApiClientWeb.vue
@@ -3,9 +3,8 @@ import { TheCommandPalette } from '@/components/CommandPalette'
 // TODO: Disabled until we polished the UI.
 // import { ImportCollectionListener } from '@/components/ImportCollection'
 import SideNav from '@/components/SideNav/SideNav.vue'
-import TopNav from '@/components/TopNav/TopNav.vue'
 import { useDarkModeState } from '@/hooks'
-import { DEFAULT_HOTKEYS, handleHotKeyDown } from '@/libs'
+import { handleHotKeyDown } from '@/libs'
 import { useWorkspace } from '@/store'
 import { addScalarClassesToHeadless } from '@scalar/components'
 import { getThemeStyles } from '@scalar/themes'
@@ -15,24 +14,9 @@ import {
   onBeforeMount,
   onBeforeUnmount,
   onMounted,
-  ref,
   watchEffect,
 } from 'vue'
 import { RouterView } from 'vue-router'
-
-import { APP_HOTKEYS } from './hotkeys'
-
-defineEmits<{
-  (e: 'newTab', item: { name: string; uid: string }): void
-}>()
-
-const hotKeys = { ...DEFAULT_HOTKEYS, ...APP_HOTKEYS }
-
-const newTab = ref<{ name: string; uid: string } | null>(null)
-
-const handleNewTab = (item: { name: string; uid: string }) => {
-  newTab.value = item
-}
 
 onMounted(() => {
   watchEffect(() => {
@@ -50,7 +34,7 @@ onBeforeMount(async () => {
 })
 
 /** Handles the hotkey events, we will pass in custom hotkeys here */
-const handleKeyDown = (ev: KeyboardEvent) => handleHotKeyDown(ev, { hotKeys })
+const handleKeyDown = (ev: KeyboardEvent) => handleHotKeyDown(ev)
 
 // Hotkey listeners
 onMounted(() => window.addEventListener('keydown', handleKeyDown))
@@ -69,7 +53,6 @@ const fontsStyleTag = computed(
   <!-- Listen for paste and drop events, and look for `url` query parameters to import collections -->
   <!-- <ImportCollectionListener> -->
   <div v-html="fontsStyleTag"></div>
-  <TopNav :openNewTab="newTab" />
 
   <!-- Ensure we have the workspace loaded from localStorage above -->
   <!-- min-h-0 is to allow scrolling of individual flex children -->
@@ -82,9 +65,7 @@ const fontsStyleTag = computed(
     <TheCommandPalette />
 
     <div class="flex flex-1 flex-col min-w-0 border-l-1/2 border-t-1/2">
-      <RouterView
-        v-slot="{ Component }"
-        @newTab="handleNewTab">
+      <RouterView v-slot="{ Component }">
         <keep-alive>
           <component :is="Component" />
         </keep-alive>

--- a/packages/api-client/src/layouts/Web/create-api-client-web.test.ts
+++ b/packages/api-client/src/layouts/Web/create-api-client-web.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { createApiClientWeb } from './create-api-client-web'
+
+describe('createApiClientWeb', () => {
+  it('renders something', async () => {
+    const element = document.createElement('div')
+    expect(element).not.toBeNull()
+
+    expect(element.innerHTML).not.toContain('Search commands')
+
+    createApiClientWeb(element, {
+      proxyUrl: 'https://proxy.scalar.com',
+    })
+
+    expect(element.innerHTML).toContain('Search commands')
+  })
+})

--- a/packages/api-client/src/layouts/Web/create-api-client-web.ts
+++ b/packages/api-client/src/layouts/Web/create-api-client-web.ts
@@ -1,0 +1,41 @@
+import { type ClientConfiguration, createApiClient } from '@/libs'
+import { router as _router, saveWorkspace } from '@/router'
+
+import ApiClientWeb from './ApiClientWeb.vue'
+
+/**
+ * Mount the API Client to a given element.
+ */
+export const createApiClientWeb = async (
+  /** Element to mount the references to */
+  el: HTMLElement | null,
+  /** Configuration object for API client */
+  configuration: ClientConfiguration = {},
+  /**
+   * Will attempt to mount the references immediately
+   * For SSR this may need to be blocked and done client side
+   */
+  mountOnInitialize = true,
+  /** Vue router to use */
+  router = _router,
+) => {
+  const client = createApiClient({
+    el,
+    appComponent: ApiClientWeb,
+    configuration: configuration,
+    mountOnInitialize,
+    router,
+  })
+
+  const { importSpecFile, importSpecFromUrl } = client.store
+  router.afterEach(saveWorkspace)
+
+  // Import the spec if needed
+  if (configuration.spec?.url) {
+    await importSpecFromUrl(configuration.spec.url, configuration.proxyUrl)
+  } else if (configuration.spec?.content) {
+    await importSpecFile(configuration.spec?.content)
+  }
+
+  return client
+}

--- a/packages/api-client/src/layouts/Web/index.ts
+++ b/packages/api-client/src/layouts/Web/index.ts
@@ -1,0 +1,2 @@
+export { default as ApiClientWeb } from './ApiClientWeb.vue'
+export * from './create-api-client-web'

--- a/packages/api-client/src/libs/event-busses/hot-keys-bus.ts
+++ b/packages/api-client/src/libs/event-busses/hot-keys-bus.ts
@@ -44,7 +44,6 @@ const inputHotkeys = [
  * Passing an empty object for hotkeys will disable them
  *
  * TODO we can add a merge or overwrite option
- * TODO need a way to switch between web + electron
  *
  * The modifier can be set by the user but defaults to ctrl for windows/linux and meta for macos
  *
@@ -56,22 +55,6 @@ export const DEFAULT_HOTKEYS: HotKeyConfig = {
   Escape: { event: 'closeModal' },
   b: { event: 'toggleSidebar', modifiers: ['default'] },
   k: { event: 'openCommandPalette', modifiers: ['default'] },
-  t: { event: 'addTopNav', modifiers: ['default'] },
-  w: { event: 'closeTopNav', modifiers: ['default'] },
-  ArrowLeft: { event: 'navigateTopNavLeft', modifiers: ['default', 'Alt'] },
-  ArrowRight: { event: 'navigateTopNavRight', modifiers: ['default', 'Alt'] },
-  l: { event: 'focusAddressBar', modifiers: ['default'] },
-  1: { event: 'jumpToTab', modifiers: ['default'] },
-  2: { event: 'jumpToTab', modifiers: ['default'] },
-  3: { event: 'jumpToTab', modifiers: ['default'] },
-  4: { event: 'jumpToTab', modifiers: ['default'] },
-  5: { event: 'jumpToTab', modifiers: ['default'] },
-  6: { event: 'jumpToTab', modifiers: ['default'] },
-  7: { event: 'jumpToTab', modifiers: ['default'] },
-  8: { event: 'jumpToTab', modifiers: ['default'] },
-  9: { event: 'jumpToLastTab', modifiers: ['default'] },
-  f: { event: 'focusRequestSearch', modifiers: ['default'] },
-  n: { event: 'openCommandPaletteRequest', modifiers: ['default'] },
 }
 
 /** Checks if we are in an "input" */

--- a/projects/client-scalar-com/src/main.ts
+++ b/projects/client-scalar-com/src/main.ts
@@ -1,6 +1,6 @@
-import { createApiClientApp } from '@scalar/api-client/layouts/App'
+import { createApiClientWeb } from '@scalar/api-client/layouts/Web'
 import '@scalar/api-client/style.css'
 
-createApiClientApp(document.getElementById('scalar-client'), {
+createApiClientWeb(document.getElementById('scalar-client'), {
   proxyUrl: 'https://proxy.scalar.com',
 })


### PR DESCRIPTION
After chatting with @marclave we decided to remove the tabs on `client.scalar.com` and only have them in the electron app similar to what linear does.

It made the most sense to me to split these into two packages one for the app and one for the web version.

## Web

https://github.com/user-attachments/assets/0d838c66-c5b1-4816-bf84-c7842537b7c2

## Desktop

https://github.com/user-attachments/assets/218c2dec-4dae-4e55-815e-7ae9163f17df

