### PR TITLE
style(api-client): updates overall alignments

### DIFF
--- a/.changeset/smart-sloths-pump.md
+++ b/.changeset/smart-sloths-pump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: updates overall alignments

--- a/packages/api-client/src/components/ContextBar.vue
+++ b/packages/api-client/src/components/ContextBar.vue
@@ -47,7 +47,7 @@ defineEmits<{
 }
 .filter-hover {
   height: 100%;
-  padding-right: 48px;
+  padding-right: 42px;
   padding-left: 24px;
   position: absolute;
   right: 0;

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -43,9 +43,9 @@ const envs = computed(() => [
         <h2 class="font-medium m-0 text-sm flex gap-1.5 items-center">
           {{ activeEnvironment?.name ?? 'No Environment' }}
           <ScalarIcon
-            class="size-2.5"
+            class="size-3"
             icon="ChevronDown"
-            thickness="3.5" />
+            thickness="3" />
         </h2>
       </ScalarButton>
       <!-- Workspace list -->

--- a/packages/api-client/src/components/SideNav/SideNav.vue
+++ b/packages/api-client/src/components/SideNav/SideNav.vue
@@ -28,7 +28,7 @@ const { currentRoute } = useRouter()
         </SideNavLink>
       </li>
     </ul>
-    <ul class="mt-auto flex flex-col py-1.5">
+    <ul class="mt-auto flex flex-col py-0.5">
       <li class="flex items-center no-drag-region">
         <SideHelp />
       </li>

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -207,7 +207,7 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
           @newTab="addNavItem" />
       </template>
       <button
-        class="text-c-3 hover:bg-b-3 p-1.5 rounded-lg webkit-app-no-drag"
+        class="text-c-3 hover:bg-b-3 p-1.5 rounded webkit-app-no-drag"
         type="button"
         @click="addNavItem">
         <ScalarIcon
@@ -221,7 +221,7 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
 <style scoped>
 .t-app__top-nav {
   padding-left: 52px;
-  padding-right: 9px;
+  padding-right: 10px;
   position: relative;
 }
 .t-app__top-nav-draggable {

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -20,7 +20,7 @@ withDefaults(
     class="focus-within:bg-b-2 ui-not-open:hover:bg-b-2 focus-within:text-c-1 text-c-2 rounded request-item ui-not-open:bg-transparent ui-open:pb-1 ui-open:mb-3 ui-not-open:mb-0 ui-not-open:pb-0"
     :defaultOpen="defaultOpen">
     <DisclosureButton
-      class="hover:text-c-1 group flex w-full items-center gap-1.5 overflow-hidden py-1.5 text-sm font-medium px-1.5">
+      class="hover:text-c-1 group flex w-full items-center gap-2.5 overflow-hidden py-1.5 text-sm font-medium px-1.5">
       <ScalarIcon
         class="text-c-3 group-hover:text-c-1 ui-open:rotate-90 ui-not-open:rotate-0"
         icon="ChevronRight"

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -93,7 +93,7 @@ const updateRequestNameHandler = (event: Event) => {
         @setActiveSection="activeSection = $event" />
     </template>
     <div
-      class="request-section-content custom-scroll flex flex-1 flex-col px-2 xl:px-5 py-2.5">
+      class="request-section-content custom-scroll flex flex-1 flex-col px-2 xl:px-4 py-2.5">
       <RequestAuth
         v-show="
           !isAuthHidden && (activeSection === 'All' || activeSection === 'Auth')

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -32,7 +32,7 @@ defineEmits<{
     </div>
     <AddressBar />
     <div
-      class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-0.5 lg:flex-1 justify-end w-6/12">
+      class="flex flex-row items-center gap-1 lg:px-2.5 lg:mb-0 mb-0.5 lg:flex-1 justify-end w-6/12">
       <EnvironmentSelector v-if="!isReadonly" />
       <!-- TODO: There should be an `ìsModal` flag instead -->
       <button

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -86,9 +86,9 @@ const deleteWorkspace = async () => {
               {{ activeWorkspace.name }}
             </h2>
             <ScalarIcon
-              class="size-2.5"
+              class="size-3"
               icon="ChevronDown"
-              thickness="3.5" />
+              thickness="3" />
           </div>
         </ScalarButton>
 


### PR DESCRIPTION
overall style OCD pr:

<table>
<thead>
<td align="center">
Top Right Buttons
</td>
</thead>
<tbody>
<td>
<table>
<thead>
<td>Before</td>
<td>After</td>
</thead>
<tbody>
<td>
<img width="325" alt="image" src="https://github.com/user-attachments/assets/19014718-46a2-4b7b-ad6c-0a0dda17b6d1">
</td>
<td>
<img width="325" alt="image" src="https://github.com/user-attachments/assets/9c988a31-c30e-48d7-86c4-e00acc583fdf">
</td>
</tbody>
</table>
</td>
</tbody>
</table>

<table>
<thead>
<td align="center">
Sidenav Toggle
</td>
</thead>
<tbody>
<td>
<table>
<thead>
<td>Before</td>
<td>After</td>
</thead>
<tbody>
<td>
<img width="325" alt="image" src="https://github.com/user-attachments/assets/a6b27ef4-d2e7-48c3-bd1a-04881c861a32">
</td>
<td>
<img width="325" alt="image" src="https://github.com/user-attachments/assets/0205670e-fe8e-483f-b4e8-e178e78de9bd">
</td>
</tbody>
</table>
</td>
</tbody>
</table>


<table>
<thead>
<td align="center">
Section + Subsections
</td>
</thead>
<tbody>
<td>
<table>
<thead>
<td>Before</td>
<td>After</td>
</thead>
<tbody>
<td>
<img width="325" alt="image" src="https://github.com/user-attachments/assets/e3ed1814-2866-45cc-ac44-14d89d6a492d">
</td>
<td>
<img width="325" alt="image" src="https://github.com/user-attachments/assets/ac740fe0-6748-4f5c-b5d8-281abcd1b1ae">
</td>
</tbody>
</table>
</td>
</tbody>
</table>