### PR TITLE
fix(api-client): sidebar cta position

### DIFF
--- a/.changeset/proud-meals-return.md
+++ b/.changeset/proud-meals-return.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates sidebar call to action position

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -85,9 +85,11 @@ const startDrag = (event: MouseEvent) => {
       }">
       <slot name="content" />
     </div>
-    <slot
+    <div
       v-if="!isMobile"
-      name="button" />
+      class="relative z-10 pt-0 md:px-2.5 md:pb-2.5 -translate-y-full w-[inherit] has-[.empty-sidebar-item]:border-t-1/2">
+      <slot name="button" />
+    </div>
     <div
       v-if="!isNarrow"
       class="resizer"

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -194,10 +194,8 @@ onBeforeUnmount(() => {
     </template>
     <template #button>
       <div
-        class="relative z-10 pt-0 md:px-2.5 md:pb-2.5 -translate-y-full w-[inherit]"
         :class="{
           'empty-sidebar-item': activeWorkspaceRequests.length <= 1,
-          'border-t-1/2': activeWorkspaceRequests.length <= 1,
         }">
         <div class="empty-sidebar-item-content px-2.5 py-2.5">
           <div class="w-[60px] h-[68px] m-auto rabbit-ascii mt-2 relative">


### PR DESCRIPTION
this pr fixes the sidebar call to action position that is not visually accessible from cookies, anvironment views:

**before**
<img width="352" alt="image" src="https://github.com/user-attachments/assets/e12ec345-e4d5-48d8-b979-b222b42756c9">

**after**
<img width="352" alt="image" src="https://github.com/user-attachments/assets/ef7e97d9-9ff9-41b0-9b1e-933f2461081b">
