### PR TITLE
fix(api-client): Basic Auth header format for empty passwords

### DIFF
--- a/.changeset/plenty-dancers-breathe.md
+++ b/.changeset/plenty-dancers-breathe.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: Basic Auth should still include a colon after the username  
+

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -309,7 +309,7 @@ export const createRequestOperation = <ResponseDataType = unknown>({
         if (scheme.scheme === 'basic') {
           const username = replaceTemplateVariables(exampleAuth.username, env)
           const password = replaceTemplateVariables(exampleAuth.password, env)
-          const value = password ? `${username}:${password}` : username
+          const value = `${username}:${password}`
 
           headers['Authorization'] = `Basic ${btoa(value)}`
         } else {


### PR DESCRIPTION
fixes #3124 

This PR addresses an issue with Basic Authentication header formatting when the password is empty. According to [RFC 7617](https://datatracker.ietf.org/doc/html/rfc7617), the Basic Auth header must include the colon `(:)` separator between the username and password, even if the password is empty.

- Ensured that the username:password format is maintained by appending a colon after the username, even when the password is empty.

This change ensures compliance with the Basic Auth standard and prevents potential authorization issues when no password is supplied.
