### PR TITLE
feat(api-reference): add `operationsSorter` to the configuration

### DIFF
--- a/.changeset/clean-zoos-battle.md
+++ b/.changeset/clean-zoos-battle.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: new `operationsSorter` option

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -347,6 +347,31 @@ Or specify a custom function to sort the tags.
 
 Learn more about Array sort functions: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
 
+#### operationsSorter?: 'alpha' | 'method' | ((a: TransformedOperation, b: TransformedOperation) => number)
+
+```js
+{
+  operationsSorter: 'alpha'
+}
+```
+
+Or specify a custom function to sort the operations.
+
+```js
+{
+  operationsSorter: (a, b) => {
+    const methodOrder = ['GET', 'POST', 'PUT', 'DELETE']
+    const methodComparison = methodOrder.indexOf(a.httpVerb) - methodOrder.indexOf(b.httpVerb)
+
+    if (methodComparison !== 0) {
+      return methodComparison
+    }
+
+    return a.path.localeCompare(b.path)
+  },
+}
+```
+
 #### theme?: string
 
 You don’t like the color scheme? We’ve prepared some themes for you:

--- a/packages/api-reference/.gitignore
+++ b/packages/api-reference/.gitignore
@@ -1,1 +1,3 @@
 /cdn
+
+coverage/

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -286,6 +286,7 @@ const fontsStyleTag = computed(
       <!-- Navigation tree / Table of Contents -->
       <div class="references-navigation-list">
         <Sidebar
+          :operationsSorter="configuration.operationsSorter"
           :parsedSpec="parsedSpec"
           :tagsSorter="configuration.tagsSorter">
           <template #sidebar-start>

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -3,14 +3,14 @@ import type { Spec } from '@scalar/types/legacy'
 import { onMounted, ref, watch } from 'vue'
 
 import { sleep } from '../../helpers'
-import { type TagsSorterOption, useNavState, useSidebar } from '../../hooks'
+import { type SorterOption, useNavState, useSidebar } from '../../hooks'
 import SidebarElement from './SidebarElement.vue'
 import SidebarGroup from './SidebarGroup.vue'
 
 const props = defineProps<
   {
     parsedSpec: Spec
-  } & TagsSorterOption
+  } & SorterOption
 >()
 
 const { hash, isIntersectionEnabled } = useNavState()
@@ -19,6 +19,7 @@ const { items, toggleCollapsedSidebarItem, collapsedSidebarItems } = useSidebar(
   {
     parsedSpec: props.parsedSpec,
     tagsSorter: props.tagsSorter,
+    operationsSorter: props.operationsSorter,
   },
 )
 

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -199,6 +199,13 @@ export type ReferenceConfiguration = {
    * Sort tags alphabetically or with a custom sort function
    */
   tagsSorter?: 'alpha' | ((a: Tag, b: Tag) => number)
+  /**
+   * Sort operations alphabetically, by method or with a custom sort function
+   */
+  operationsSorter?:
+    | 'alpha'
+    | 'method'
+    | ((a: TransformedOperation, b: TransformedOperation) => number)
 }
 
 export type Server = OpenAPIV3.ServerObject | OpenAPIV3_1.ServerObject


### PR DESCRIPTION
#3378 

tasks
- [x] add `operationsSorter`
- [x] add tests
- [x] add documentations