### PR TITLE
fix(api-client): cm focused selection colors

### DIFF
--- a/.changeset/happy-eels-glow.md
+++ b/.changeset/happy-eels-glow.md
@@ -1,0 +1,6 @@
+---
+'@scalar/use-codemirror': patch
+'@scalar/api-client': patch
+---
+
+fix: sets focused selection color variables

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -337,4 +337,8 @@ export default {
   border-radius: var(--scalar-radius);
   color: var(--scalar-color-1);
 }
+.cm-focused .cm-content ::selection {
+  background: var(--scalar-selection-background) !important;
+  color: var(--scalar-selection-color);
+}
 </style>

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -318,6 +318,10 @@ function getCodeMirrorExtensions({
         border: 'none',
         fontFamily: 'var(--scalar-font)',
       },
+      '.cm-line::selection': {
+        background: 'var(--scalar-selection-background) !important',
+        color: 'var(--scalar-selection-color)',
+      },
     }),
     // Listen to updates
     EditorView.updateListener.of((v) => {


### PR DESCRIPTION
this pr fixes the code mirror selection color mismatch caught by @hwkr by setting the introduced variables in #3283:

**before**
<img width="716" alt="image" src="https://github.com/user-attachments/assets/295f19e9-45e5-41f1-9b9a-f679b92c79f9">

**after**
<img width="716" alt="image" src="https://github.com/user-attachments/assets/5957be83-fe2e-4323-9110-b6095a223d21">
