### PR TITLE
feat(nextjs-api-reference): pin cdn version

### DIFF
--- a/.changeset/odd-spoons-learn.md
+++ b/.changeset/odd-spoons-learn.md
@@ -1,0 +1,7 @@
+---
+"@scalar/hono-api-reference": patch
+"@scalar/nestjs-api-reference": patch
+"@scalar/nextjs-api-reference": patch
+---
+
+feat: pin cdn version in integrations

--- a/packages/hono-api-reference/README.md
+++ b/packages/hono-api-reference/README.md
@@ -32,7 +32,7 @@ app.get(
 )
 ```
 
-The Hono middleware takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/tree/main/packages/api-reference#props) in the core package README.
+The Hono middleware takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/blob/main/documentation/configuration.md) in the core package README.
 
 ### Themes
 
@@ -74,13 +74,15 @@ app.get(
 
 You can use a custom CDN ，default is `https://cdn.jsdelivr.net/npm/@scalar/api-reference`.
 
+You can also pin the CDN to a specific version by specifying it in the CDN string like `https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.28`
+
 ```ts
 import { apiReference } from '@scalar/hono-api-reference'
 
 app.use(
   '/reference',
   apiReference({
-    cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+    cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
     spec: {
       content: OpenApiSpecification,
     },

--- a/packages/hono-api-reference/README.md
+++ b/packages/hono-api-reference/README.md
@@ -76,6 +76,8 @@ You can use a custom CDN ，default is `https://cdn.jsdelivr.net/npm/@scalar/api
 
 You can also pin the CDN to a specific version by specifying it in the CDN string like `https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.28`
 
+You can find all available CDN versions [here](https://www.jsdelivr.com/package/npm/@scalar/api-reference?tab=files)
+
 ```ts
 import { apiReference } from '@scalar/hono-api-reference'
 

--- a/packages/hono-api-reference/src/honoApiReference.test.ts
+++ b/packages/hono-api-reference/src/honoApiReference.test.ts
@@ -31,4 +31,17 @@ describe('javascript', () => {
       }).toString(),
     ).toContain('script src="https://custom.example.com/cdn/@scalar/galaxy"')
   })
+
+  it('pins the CDN to a specified version', () => {
+    expect(
+      javascript({
+        spec: {
+          url,
+        },
+        cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.0',
+      }).toString(),
+    ).toContain(
+      'script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.0"',
+    )
+  })
 })

--- a/packages/nestjs-api-reference/README.md
+++ b/packages/nestjs-api-reference/README.md
@@ -86,13 +86,17 @@ app.use(
 
 You can use a custom CDN ，default is `https://cdn.jsdelivr.net/npm/@scalar/api-reference`.
 
+You can also pin the CDN to a specific version by specifying it in the CDN string like `https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.28`
+
+You can find all available CDN versions [here](https://www.jsdelivr.com/package/npm/@scalar/api-reference?tab=files)
+
 ```ts
 import { apiReference } from '@scalar/nestjs-api-reference'
 
 app.use(
   '/reference',
   apiReference({
-    cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+    cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
     spec: {
       content: OpenApiSpecification,
     },

--- a/packages/nextjs-api-reference/README.md
+++ b/packages/nextjs-api-reference/README.md
@@ -84,3 +84,25 @@ export default function References() {
   )
 }
 ```
+
+### Specific CDN version
+
+By default, this integration will use the latest version of the `@scalar/api-reference`.
+
+You can also pin the CDN to a specific version by specifying it in the CDN string like `https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.28`
+
+You can find all available CDN versions [here](https://www.jsdelivr.com/package/npm/@scalar/api-reference?tab=files)
+
+```ts
+// app/reference/route.ts
+import { ApiReference } from '@scalar/nextjs-api-reference'
+
+const config = {
+  spec: {
+    url: '/openapi.json',
+  },
+  cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
+}
+
+export const GET = ApiReference(config)
+```

--- a/packages/nextjs-api-reference/src/ApiReference.ts
+++ b/packages/nextjs-api-reference/src/ApiReference.ts
@@ -2,6 +2,10 @@ import type { ReferenceConfiguration } from '@scalar/types/legacy'
 
 import { nextjsThemeCss } from './theme'
 
+export type ApiReferenceOptions = ReferenceConfiguration & {
+  cdn?: string
+}
+
 /**
  * Next.js adapter for an Api Reference
  *
@@ -10,7 +14,7 @@ import { nextjsThemeCss } from './theme'
  * @params config - the Api Reference config object
  * @params options - reserved for future use to add customization to the response
  */
-export const ApiReference = (config: ReferenceConfiguration) => {
+export const ApiReference = (config: ApiReferenceOptions) => {
   // If no spec is passed, show a warning.
   if (!config.spec?.content && !config.spec?.url) {
     throw new Error(
@@ -40,6 +44,11 @@ export const ApiReference = (config: ReferenceConfiguration) => {
     config.customCss = nextjsThemeCss
   }
 
+  // Check the config for a custom CDN string or set to default
+  const cdnString = config?.cdn
+    ? config.cdn
+    : 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest'
+
   // Convert the configuration to a string
   const configString = JSON.stringify(config ?? {})
     .split('"')
@@ -62,7 +71,7 @@ export const ApiReference = (config: ReferenceConfiguration) => {
       data-configuration="${configString}">
       ${documentString}
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script src="${cdnString}"></script>
   </body>
 </html>
       `,


### PR DESCRIPTION
This PR updates the configuration to allow the user to specify the `@scalar/api-reference` CDN version in the `next-js` integration. It also adds documentation for pinning the version in other integrations.

Maybe we add the cdn url as an option in the universal configuration object?

It was proposed to add an option in vite config to pin the versions but I'm not seeing any specific advantages over specifying the version in the script tag
