### PR TITLE
fix(client-scalar-com): favicon does not show

### DIFF
--- a/projects/client-scalar-com/index.html
+++ b/projects/client-scalar-com/index.html
@@ -5,17 +5,17 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="https://www.scalar.com/favicon.svg" />
+      href="https://scalar.com/favicon.svg" />
     <link
       rel="icon"
       type="image/png"
-      href="https://www.scalar.com/favicon.png" />
+      href="https://scalar.com/favicon.png" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://www.scalar.com https://cdn.usefathom.com; media-src 'self' data: blob:; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://scalar.com https://www.scalar.com https://cdn.usefathom.com; media-src 'self' data: blob:; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
     <title>Scalar API Client</title>
     <script
       src="https://cdn.usefathom.com/script.js"


### PR DESCRIPTION
The favicon doesn’t show on <https://client.scalar.com>.

Looks like we switched from `scalar.com` to `www.scalar.com` and back to `scalar.com`. This PR updates the Content Security Policy to allow both, and points to the non-www URL (which is the current default).