### PR TITLE
chore: nuget security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,6 @@ updates:
   - package-ecosystem: 'nuget'
     directory: '/packages/scalar.aspnetcore'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
+    # This will disable updates, but still create PRs for security updates.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
I love dependabot, but let’s limit it to nuget security updates for now. :)