### PR TITLE
fix(themes): selection color variables to presets

### DIFF
--- a/.changeset/thick-experts-behave.md
+++ b/.changeset/thick-experts-behave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix: moves selection color variables to presets

--- a/packages/themes/src/presets/alternate.css
+++ b/packages/themes/src/presets/alternate.css
@@ -18,6 +18,13 @@
   --scalar-background-accent: var(--scalar-background-3);
 
   --scalar-border-color: rgba(0, 0, 0, 0.1);
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 .dark-mode {
   --scalar-background-1: #131313;
@@ -33,6 +40,13 @@
   --scalar-background-accent: var(--scalar-background-3);
 
   --scalar-border-color: rgba(255, 255, 255, 0.1);
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
@@ -100,4 +114,9 @@
   --scalar-color-blue: var(--scalar-color-1);
   --scalar-color-orange: var(--scalar-color-1);
   --scalar-color-purple: var(--scalar-color-1);
+}
+/* High contrast custom selection */
+*::selection {
+  background: var(--scalar-selection-background);
+  color: var(--scalar-selection-color);
 }

--- a/packages/themes/src/presets/bluePlanet.css
+++ b/packages/themes/src/presets/bluePlanet.css
@@ -66,6 +66,13 @@
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
   --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 .dark-mode {
   --scalar-color-green: rgba(69, 255, 165, 0.823);
@@ -78,6 +85,13 @@
   --scalar-button-1: rgba(255, 255, 255, 1);
   --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
   --scalar-button-1-color: black;
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 /* Custom theme */
 /* Document header */
@@ -179,4 +193,9 @@
   --scalar-background-1: #fff;
   --scalar-background-2: #fff;
   --scalar-background-3: #fff;
+}
+/* High contrast custom selection */
+*::selection {
+  background: var(--scalar-selection-background);
+  color: var(--scalar-selection-color);
 }

--- a/packages/themes/src/presets/deepSpace.css
+++ b/packages/themes/src/presets/deepSpace.css
@@ -16,6 +16,13 @@
 
   --scalar-border-color: rgb(228, 228, 231);
   --scalar-code-language-color-supersede: var(--scalar-color-1);
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 .dark-mode {
   --scalar-color-1: #fafafa;
@@ -30,6 +37,13 @@
 
   --scalar-border-color: rgba(255, 255, 255, 0.16);
   --scalar-code-language-color-supersede: var(--scalar-color-1);
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 
 /* Document Sidebar */
@@ -187,4 +201,9 @@
   background-size: 200px 200px;
   mask-image: radial-gradient(ellipse at 100% 0%, black 40%, transparent 70%);
   opacity: 0.2;
+}
+/* High contrast custom selection */
+*::selection {
+  background: var(--scalar-selection-background);
+  color: var(--scalar-selection-color);
 }

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -11,6 +11,13 @@
 
   --scalar-color-accent: #0099ff;
   --scalar-border-color: #dfdfdf;
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 .dark-mode {
   --scalar-background-1: #0f0f0f;
@@ -25,6 +32,13 @@
   --scalar-background-accent: #3ea6ff1f;
 
   --scalar-border-color: #2d2d2d;
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
@@ -69,4 +83,9 @@
   --scalar-button-1: rgba(255, 255, 255, 1);
   --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
   --scalar-button-1-color: black;
+}
+/* High contrast custom selection */
+*::selection {
+  background: var(--scalar-selection-background);
+  color: var(--scalar-selection-color);
 }

--- a/packages/themes/src/presets/kepler.css
+++ b/packages/themes/src/presets/kepler.css
@@ -13,6 +13,13 @@
   --scalar-border-color: rgba(0, 0, 0, 0.1);
 
   --scalar-code-language-color-supersede: var(--scalar-color-3);
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 .dark-mode {
   --scalar-color-1: #f7f8f8;
@@ -27,6 +34,13 @@
 
   --scalar-border-color: #313245;
   --scalar-code-language-color-supersede: var(--scalar-color-3);
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar {
@@ -147,4 +161,9 @@
     transparent
   );
   height: 100vh;
+}
+/* High contrast custom selection */
+*::selection {
+  background: var(--scalar-selection-background);
+  color: var(--scalar-selection-color);
 }

--- a/packages/themes/src/presets/mars.css
+++ b/packages/themes/src/presets/mars.css
@@ -139,3 +139,8 @@
 .light-mode .section-flare {
   display: none;
 }
+/* High contrast custom selection */
+*::selection {
+  background: var(--scalar-selection-background);
+  color: var(--scalar-selection-color);
+}

--- a/packages/themes/src/presets/moon.css
+++ b/packages/themes/src/presets/moon.css
@@ -29,6 +29,13 @@
   --scalar-color-blue: #1d4ed8;
   --scalar-color-orange: #c2410c;
   --scalar-color-purple: #6d28d9;
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 
 .dark-mode {
@@ -62,6 +69,13 @@
   --scalar-color-blue: #4eb3ec;
   --scalar-color-orange: #ff8d4d;
   --scalar-color-purple: #b191f9;
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 
 /* Sidebar */
@@ -91,4 +105,9 @@
   --scalar-sidebar-search-background: var(--scalar-background-3);
   --scalar-sidebar-search-border-color: var(--scalar-sidebar-search-background);
   --scalar-sidebar-search--color: var(--scalar-color-3);
+}
+/* High contrast custom selection */
+*::selection {
+  background: var(--scalar-selection-background);
+  color: var(--scalar-selection-color);
 }

--- a/packages/themes/src/presets/purple.css
+++ b/packages/themes/src/presets/purple.css
@@ -12,6 +12,13 @@
   --scalar-background-accent: #5469d41f;
 
   --scalar-border-color: rgba(215, 215, 206, 0.68);
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 .dark-mode {
   --scalar-background-1: #15171c;
@@ -26,6 +33,13 @@
   --scalar-background-accent: #5469d41f;
 
   --scalar-border-color: rgba(255, 255, 255, 0.18);
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
@@ -70,4 +84,9 @@
   --scalar-button-1: rgba(255, 255, 255, 1);
   --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
   --scalar-button-1-color: black;
+}
+/* High contrast custom selection */
+*::selection {
+  background: var(--scalar-selection-background);
+  color: var(--scalar-selection-color);
 }

--- a/packages/themes/src/presets/saturn.css
+++ b/packages/themes/src/presets/saturn.css
@@ -11,6 +11,13 @@
 
   --scalar-color-accent: #1763a6;
   --scalar-background-accent: #1f648e1f;
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 .dark-mode {
   --scalar-background-1: #09090b;
@@ -24,6 +31,13 @@
 
   --scalar-color-accent: #4eb3ec;
   --scalar-background-accent: #8ab4f81f;
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
@@ -86,4 +100,9 @@
   );
   -webkit-background-clip: text;
   background-clip: text;
+}
+/* High contrast custom selection */
+*::selection {
+  background: var(--scalar-selection-background);
+  color: var(--scalar-selection-color);
 }

--- a/packages/themes/src/presets/solarized.css
+++ b/packages/themes/src/presets/solarized.css
@@ -29,6 +29,13 @@
   --scalar-color-blue: #1d4ed8;
   --scalar-color-orange: #c2410c;
   --scalar-color-purple: #6d28d9;
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 
 .dark-mode {
@@ -62,6 +69,13 @@
   --scalar-color-blue: #4eb3ec;
   --scalar-color-orange: #ff8d4d;
   --scalar-color-purple: #b191f9;
+
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
 }
 
 /* Sidebar */
@@ -91,4 +105,9 @@
   --scalar-sidebar-search-background: var(--scalar-background-2);
   --scalar-sidebar-search-border-color: var(--scalar-sidebar-search-background);
   --scalar-sidebar-search--color: var(--scalar-color-3);
+}
+/* High contrast custom selection */
+*::selection {
+  background: var(--scalar-selection-background);
+  color: var(--scalar-selection-color);
 }

--- a/packages/themes/src/variables.css
+++ b/packages/themes/src/variables.css
@@ -54,7 +54,6 @@
   color-scheme: dark;
   --scalar-scrollbar-color: rgba(255, 255, 255, 0.18);
   --scalar-scrollbar-color-active: rgba(255, 255, 255, 0.36);
-  --scalar-background-1: #0f0f0f;
   --scalar-button-1: rgba(255, 255, 255, 1);
   --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
   --scalar-button-1-color: black;
@@ -70,19 +69,11 @@
   --scalar-sidebar-indent-border: transparent;
   --scalar-sidebar-indent-border-hover: transparent;
   --scalar-sidebar-indent-border-active: transparent;
-
-  --scalar-selection-background: color-mix(
-    in sRGB,
-    var(--scalar-color-1) 80%,
-    transparent
-  );
-  --scalar-selection-color: var(--scalar-background-1);
 }
 .light-mode {
   color-scheme: light;
   --scalar-scrollbar-color-active: rgba(0, 0, 0, 0.36);
   --scalar-scrollbar-color: rgba(0, 0, 0, 0.18);
-  --scalar-background-1: #fff;
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
   --scalar-button-1-color: rgba(255, 255, 255, 0.9);
@@ -98,13 +89,6 @@
   --scalar-sidebar-indent-border: transparent;
   --scalar-sidebar-indent-border-hover: transparent;
   --scalar-sidebar-indent-border-active: transparent;
-
-  --scalar-selection-background: color-mix(
-    in sRGB,
-    var(--scalar-color-1) 80%,
-    transparent
-  );
-  --scalar-selection-color: var(--scalar-background-1);
 }
 /* On some browsers, the light color scheme takes precedence when the light mode is active */
 .light-mode .dark-mode {
@@ -123,9 +107,4 @@
     --scalar-heading-1: 24px;
     --scalar-page-description: 20px;
   }
-}
-/* High contrast custom selection */
-*::selection {
-  background: var(--scalar-selection-background);
-  color: var(--scalar-selection-color);
 }


### PR DESCRIPTION
this pr moves back the selection color variables to presets in order to avoid adding background variable at the variables level that breaks theming, fixes #3388 