### PR TITLE
fix(themes): remove variables from theme layer and move selection to default theme

### DIFF
--- a/.changeset/shaggy-steaks-enjoy.md
+++ b/.changeset/shaggy-steaks-enjoy.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/themes': patch
+---
+
+fix(themes): remove variables from theme layer and move selection to default (base) theme

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -54,19 +54,16 @@ const handleKeyDown = (ev: KeyboardEvent) => handleHotKeyDown(ev, { hotKeys })
 onMounted(() => window.addEventListener('keydown', handleKeyDown))
 onBeforeUnmount(() => window.removeEventListener('keydown', handleKeyDown))
 
-const fontsStyleTag = computed(
+const themeStyleTag = computed(
   () =>
     workspaceStore.activeWorkspace.value &&
-    `<style>
-  ${getThemeStyles(workspaceStore.activeWorkspace.value.themeId, {
-    fonts: true,
-  })}</style>`,
+    `<style>${getThemeStyles(workspaceStore.activeWorkspace.value.themeId)}</style>`,
 )
 </script>
 <template>
   <!-- Listen for paste and drop events, and look for `url` query parameters to import collections -->
   <!-- <ImportCollectionListener> -->
-  <div v-html="fontsStyleTag"></div>
+  <div v-html="themeStyleTag"></div>
   <TopNav :openNewTab="newTab" />
 
   <!-- Ensure we have the workspace loaded from localStorage above -->

--- a/packages/api-client/src/layouts/Web/ApiClientWeb.vue
+++ b/packages/api-client/src/layouts/Web/ApiClientWeb.vue
@@ -38,19 +38,16 @@ const handleKeyDown = (ev: KeyboardEvent) => handleHotKeyDown(ev)
 onMounted(() => window.addEventListener('keydown', handleKeyDown))
 onBeforeUnmount(() => window.removeEventListener('keydown', handleKeyDown))
 
-const fontsStyleTag = computed(
+const themeStyleTag = computed(
   () =>
     workspaceStore.activeWorkspace.value &&
-    `<style>
-  ${getThemeStyles(workspaceStore.activeWorkspace.value.themeId, {
-    fonts: true,
-  })}</style>`,
+    `<style>${getThemeStyles(workspaceStore.activeWorkspace.value.themeId)}</style>`,
 )
 </script>
 <template>
   <!-- Listen for paste and drop events, and look for `url` query parameters to import collections -->
   <!-- <ImportCollectionListener> -->
-  <div v-html="fontsStyleTag"></div>
+  <div v-html="themeStyleTag"></div>
 
   <!-- Ensure we have the workspace loaded from localStorage above -->
   <!-- min-h-0 is to allow scrolling of individual flex children -->

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -247,7 +247,7 @@ defaultOpenAllTags.value = props.configuration.defaultOpenAllTags ?? false
 
 useDeprecationWarnings(props.configuration)
 
-const fontsStyleTag = computed(
+const themeStyleTag = computed(
   () => `<style>
   ${getThemeStyles(props.configuration.theme, {
     fonts: props.configuration.withDefaultFonts,
@@ -255,7 +255,7 @@ const fontsStyleTag = computed(
 )
 </script>
 <template>
-  <div v-html="fontsStyleTag"></div>
+  <div v-html="themeStyleTag"></div>
   <div
     ref="documentEl"
     class="scalar-app scalar-api-reference references-layout"

--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -11,7 +11,6 @@ import moonTheme from './presets/moon.css?inline'
 import purpleTheme from './presets/purple.css?inline'
 import saturnTheme from './presets/saturn.css?inline'
 import solarizedTheme from './presets/solarized.css?inline'
-import baseVariables from './variables.css?inline'
 
 export { migrateThemeVariables } from './utilities/legacy'
 export { hasObtrusiveScrollbars } from './utilities/hasObtrusiveScrollbars'
@@ -112,14 +111,10 @@ export const getThemeById = (themeId?: ThemeId) => {
  * Get the theme and base variables for a given theme
  */
 export const getThemeStyles = (themeId?: ThemeId, opts?: GetThemeOpts) => {
-  const { variables = true, fonts = true, layer = 'scalar-theme' } = opts ?? {}
+  const { fonts = true, layer = 'scalar-theme' } = opts ?? {}
 
   // Combined theme, base variables and default fonts if configured
-  const styles = [
-    getThemeById(themeId),
-    variables ? baseVariables : '',
-    fonts ? defaultFonts : '',
-  ].join('')
+  const styles = [getThemeById(themeId), fonts ? defaultFonts : ''].join('')
 
   // Wrap the styles in a layer if configured
   if (layer) return `@layer ${layer} {\n${styles}}`

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -44,7 +44,16 @@
   --scalar-sidebar-search-color: var(--scalar-color-3);
   --scalar-sidebar-search-border-color: var(--scalar-border-color);
 }
-
+/* selection colors */
+.light-mode,
+.dark-mode {
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
+}
 /* advanced */
 .light-mode {
   --scalar-color-green: #069061;

--- a/packages/themes/src/variables.css
+++ b/packages/themes/src/variables.css
@@ -54,11 +54,9 @@
   color-scheme: dark;
   --scalar-scrollbar-color: rgba(255, 255, 255, 0.18);
   --scalar-scrollbar-color-active: rgba(255, 255, 255, 0.36);
-  --scalar-background-1: #0f0f0f;
   --scalar-button-1: rgba(255, 255, 255, 1);
   --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
   --scalar-button-1-color: black;
-  --scalar-color-1: #e7e7e7;
 
   --scalar-shadow-1: 0 1px 3px 0 rgb(0, 0, 0, 0.1);
   --scalar-shadow-2: rgba(15, 15, 15, 0.2) 0px 3px 6px,
@@ -70,23 +68,14 @@
   --scalar-sidebar-indent-border: transparent;
   --scalar-sidebar-indent-border-hover: transparent;
   --scalar-sidebar-indent-border-active: transparent;
-
-  --scalar-selection-background: color-mix(
-    in sRGB,
-    var(--scalar-color-1) 80%,
-    transparent
-  );
-  --scalar-selection-color: var(--scalar-background-1);
 }
 .light-mode {
   color-scheme: light;
   --scalar-scrollbar-color-active: rgba(0, 0, 0, 0.36);
   --scalar-scrollbar-color: rgba(0, 0, 0, 0.18);
-  --scalar-background-1: #fff;
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
   --scalar-button-1-color: rgba(255, 255, 255, 0.9);
-  --scalar-color-1: #2a2f45;
 
   --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
   --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
@@ -98,13 +87,6 @@
   --scalar-sidebar-indent-border: transparent;
   --scalar-sidebar-indent-border-hover: transparent;
   --scalar-sidebar-indent-border-active: transparent;
-
-  --scalar-selection-background: color-mix(
-    in sRGB,
-    var(--scalar-color-1) 80%,
-    transparent
-  );
-  --scalar-selection-color: var(--scalar-background-1);
 }
 /* On some browsers, the light color scheme takes precedence when the light mode is active */
 .light-mode .dark-mode {


### PR DESCRIPTION
Looks like we were injecting a copy of `variables.css` from `@scalar/themes` into the `scalar-theme` layer, we already import `variables.css` into the `scalar-base` layer as part of `@scalar/themes/style.css`.

It's important it's only in the `scalar-base` layer otherwise there's a risk of the default variables overriding theme variables (which is the issue in #3388). This updates the precedence to be:

1. Any user styles that they add to the page outside of a css layer
2. The theme injected into the `scalar-theme` css layer via [`getThemeStyles()`](https://github.com/scalar/scalar/blob/6279c5977c5067f21c61d4d91d7963f4a4b9a384/packages/themes/src/index.ts#L114) (includes any selection color overrides)
3. The variables & default (base) theme injected into the `scalar-base` css layer by importing [`@scalar/themes/style.css`](https://github.com/scalar/scalar/blob/6279c5977c5067f21c61d4d91d7963f4a4b9a384/packages/themes/src/style.css) (includes the default selection color configuration)



I also moved the base / default css variables for the selections into the default theme because they're more colors than root variables (they should work in either file now though). 

Fixes #3388

## Before

![Google Chrome-2024-10-07-13-55-04@2x](https://github.com/user-attachments/assets/cbf825c4-2d88-4b39-ad8f-b577644e9561)

## After

![Google Chrome-2024-10-07-13-29-32@2x](https://github.com/user-attachments/assets/9b56670a-2e43-4437-9230-ba9c7d7d9b5c)
