### PR TITLE
fix(api-reference): show path and test request when hiddenClients is true

### DIFF
--- a/.changeset/friendly-rocks-wait.md
+++ b/.changeset/friendly-rocks-wait.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): show path and test request when hiddenClients is true

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -6,19 +6,17 @@ const { availableTargets, httpTargetTitle, httpClientTitle } =
   useHttpClientStore()
 </script>
 <template>
-  <div>
-    <template v-if="availableTargets.length">
-      <div class="client-libraries-heading">Client Libraries</div>
-      <div>
-        <ClientSelector />
-      </div>
-      <div
-        class="selected-client card-footer"
-        muted>
-        {{ httpClientTitle }}
-        {{ httpTargetTitle }}
-      </div>
-    </template>
+  <div v-if="availableTargets.length">
+    <div class="client-libraries-heading">Client Libraries</div>
+    <div>
+      <ClientSelector />
+    </div>
+    <div
+      class="selected-client card-footer"
+      muted>
+      {{ httpClientTitle }}
+      {{ httpTargetTitle }}
+    </div>
   </div>
 </template>
 <style scoped>

--- a/packages/api-reference/src/components/Content/Operation/Operation.vue
+++ b/packages/api-reference/src/components/Content/Operation/Operation.vue
@@ -40,7 +40,9 @@ defineProps<{
         </SectionColumn>
         <SectionColumn>
           <div class="examples">
-            <ExampleRequest :operation="operation">
+            <ExampleRequest
+              fallback
+              :operation="operation">
               <template #header>
                 <EndpointPath
                   class="example-path"

--- a/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
+++ b/packages/api-reference/src/components/Content/Operation/OperationAccordion.vue
@@ -193,7 +193,8 @@ console.log(!getHideTestRequestButton?.())
 
 .endpoint-content {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-auto-columns: 1fr;
+  grid-auto-flow: column;
   gap: 9px;
   padding: 9px;
 }

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -33,7 +33,6 @@ import {
 import { HttpMethod } from '../../components/HttpMethod'
 import {
   GLOBAL_SECURITY_SYMBOL,
-  getApiClientRequest,
   getExampleCode,
   getHarRequest,
 } from '../../helpers'
@@ -43,6 +42,8 @@ import TextSelect from './TextSelect.vue'
 
 const props = defineProps<{
   operation: TransformedOperation
+  /** Show a simplified card if no example are available */
+  fallback?: boolean
 }>()
 
 const ssrHash = createHash(
@@ -308,6 +309,20 @@ function updateHttpClient(value: string) {
       <slot name="footer" />
     </CardFooter>
   </Card>
+  <Card
+    v-else-if="fallback"
+    class="dark-mode">
+    <CardContent class="request-card-simple">
+      <div class="request-header">
+        <HttpMethod
+          as="span"
+          class="request-method"
+          :method="operation.httpVerb" />
+        <slot name="header" />
+      </div>
+      <slot name="footer" />
+    </CardContent>
+  </Card>
 </template>
 <style scoped>
 .request {
@@ -343,6 +358,15 @@ function updateHttpClient(value: string) {
 .request-editor-section {
   display: flex;
   flex: 1;
+}
+.request-card-simple {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 8px 8px 8px 12px;
+
+  font-size: var(--scalar-small);
 }
 .code-snippet {
   display: flex;


### PR DESCRIPTION
Cleans up the UI when there aren't any clients / example so we still show a path and the test request button.

Fixes #3380 

## Before / After

<img width="400" alt="Google Chrome-2024-10-07-22-32-41@2x" src="https://github.com/user-attachments/assets/d91c39bf-af2f-4bcf-8638-eaab2a052a06">
<img width="400" alt="Google Chrome-2024-10-07-21-50-11@2x" src="https://github.com/user-attachments/assets/744d9cbe-b97f-428a-9c0c-a23a32bb36e1">

<img width="400" alt="Google Chrome-2024-10-07-22-32-47@2x" src="https://github.com/user-attachments/assets/1ead4b63-9a9b-4ff3-8751-c93c571a8a44">
<img width="400" alt="Google Chrome-2024-10-07-22-23-43@2x" src="https://github.com/user-attachments/assets/4b656a4d-d3e3-48fa-9866-e0b88ceed106">

<img width="400" alt="Google Chrome-2024-10-07-22-32-55@2x" src="https://github.com/user-attachments/assets/465d2571-8ece-4ef6-95f3-7318886b5d7c">
<img width="400" alt="Google Chrome-2024-10-07-22-29-07@2x" src="https://github.com/user-attachments/assets/51b6f867-6edd-47f4-90b0-a6c2a3716a22">



