### PR TITLE
fix(api-client): address bar placeholder

### DIFF
--- a/.changeset/unlucky-fireants-sneeze.md
+++ b/.changeset/unlucky-fireants-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: displays address bar placeholder according to active server

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -22,6 +22,7 @@ import AddressBarServers from './AddressBarServer.vue'
 const {
   activeRequest,
   activeExample,
+  activeServer,
   isReadOnly,
   requestMutators,
   requestHistory,
@@ -181,7 +182,7 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
               disableTabIndent
               :emitOnBlur="false"
               :modelValue="activeRequest.path"
-              placeholder="Enter URL to get started"
+              :placeholder="activeServer ? '' : 'Enter URL to get started'"
               server
               @submit="handleExecuteRequest"
               @update:modelValue="updateRequestPath" />


### PR DESCRIPTION
this pr updates placeholder display according to active server presence:

**before**
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/2b0d9da4-0065-413d-842b-795c4a7c43c9">

**after**
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/cedccbc8-82f2-4695-93b2-de0ce45d5b19">
