### PR TITLE
fix(api-client): command palette label

### DIFF
--- a/.changeset/clever-baboons-confess.md
+++ b/.changeset/clever-baboons-confess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: removes comamand palette command label + style fixtures

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -47,7 +47,7 @@ import {
 /** Available Commands for the Command Palette */
 const availableCommands = [
   {
-    label: 'Add to Request Sidebar',
+    label: '',
     commands: [
       {
         name: 'Create Request',

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -231,9 +231,9 @@ onBeforeUnmount(() => {
         class="bg-b-2 flex items-center rounded-md mb-2.5 pl-2 focus-within:bg-b-1 focus-within:shadow-border">
         <label for="commandmenu">
           <ScalarIcon
-            class="text-c-1 mr-2.5"
+            class="text-c-2 mr-2.5"
             icon="Search"
-            size="sm"
+            size="md"
             thickness="1.5" />
         </label>
         <input
@@ -277,7 +277,7 @@ onBeforeUnmount(() => {
           }"
           @click="executeCommand(command)">
           <ScalarIcon
-            class="text-c-1 mr-2.5"
+            class="text-c-2 mr-2.5"
             :icon="command.icon"
             size="md"
             thickness="1.5" />


### PR DESCRIPTION
this pr removes the command palette commands label as suggested by @marclave + increases search icon size to maintain icon alignment consistency, as seen below:

**before**
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/1dc126b8-5b0f-465d-adeb-d06e18f89bdd">

**after**
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/acde7cc0-82f0-4db0-89a8-5178e54c4fde">
