### PR TITLE
fix(object-utils): setNested function doesn’t work with nested arrays

### DIFF
--- a/.changeset/large-cows-hammer.md
+++ b/.changeset/large-cows-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/object-utils': patch
+---
+
+fix: setNestedValue function and also add new pathParsing funciton

--- a/packages/object-utils/src/nested/nested.test.ts
+++ b/packages/object-utils/src/nested/nested.test.ts
@@ -1,7 +1,7 @@
 import { clone } from '@/clone'
 import { describe, expect, test } from 'vitest'
 
-import { setNestedValue } from './nested'
+import { parseTypedPath, setNestedValue } from './nested'
 
 const nestedObj = {
   a: {
@@ -21,12 +21,22 @@ const nestedObj = {
 }
 
 const request = {
+  tags: ['Planets'],
+  summary: 'Get a planet',
+  description:
+    'You’ll better learn a little bit more about the planets. It might come in handy once space travel is available for everyone.',
+  operationId: 'getPlanet',
+  security: [{}],
   parameters: [
     {
+      in: 'path',
+      name: 'planetId',
+      required: true,
+      deprecated: false,
       schema: { type: 'integer', format: 'int64', examples: [1] },
     },
   ],
-}
+} as const
 
 describe('Set a nested value', () => {
   test('Basic nested set', () => {
@@ -68,5 +78,15 @@ describe('Set a nested value', () => {
     copy.c[2] = { name: 'asda' }
 
     expect(baseObj).toEqual(copy)
+  })
+
+  test('Parse a path', () => {
+    expect(parseTypedPath(request, 'parameters.0.schema.examples.0')).toEqual(
+      'parameters.0.schema.examples.0',
+    )
+  })
+
+  test('Parse an invalid path', () => {
+    expect(parseTypedPath(request, 'parameters.stuff.others')).toBeNull()
   })
 })

--- a/packages/object-utils/src/nested/nested.test.ts
+++ b/packages/object-utils/src/nested/nested.test.ts
@@ -20,6 +20,14 @@ const nestedObj = {
   },
 }
 
+const request = {
+  parameters: [
+    {
+      schema: { type: 'integer', format: 'int64', examples: [1] },
+    },
+  ],
+}
+
 describe('Set a nested value', () => {
   test('Basic nested set', () => {
     const baseObj = clone(nestedObj)
@@ -38,6 +46,16 @@ describe('Set a nested value', () => {
 
     setNestedValue(baseObj, 'c.1.name', 'three')
     copy.c[1].name = 'three'
+
+    expect(baseObj).toEqual(copy)
+  })
+
+  test('Nested array replacement on request parameters', () => {
+    const baseObj = clone(request)
+    const copy = clone(request)
+
+    setNestedValue(baseObj, 'parameters.0.schema.examples.0', 122)
+    copy.parameters[0].schema.examples[0] = 122
 
     expect(baseObj).toEqual(copy)
   })

--- a/packages/object-utils/src/nested/nested.test.ts
+++ b/packages/object-utils/src/nested/nested.test.ts
@@ -36,7 +36,7 @@ const request = {
       schema: { type: 'integer', format: 'int64', examples: [1] },
     },
   ],
-} as const
+}
 
 describe('Set a nested value', () => {
   test('Basic nested set', () => {

--- a/packages/object-utils/src/nested/nested.test.ts
+++ b/packages/object-utils/src/nested/nested.test.ts
@@ -1,7 +1,8 @@
 import { clone } from '@/clone'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, expectTypeOf, test } from 'vitest'
 
 import { parseTypedPath, setNestedValue } from './nested'
+import type { ParsePathResult } from './nested'
 
 const nestedObj = {
   a: {
@@ -88,5 +89,32 @@ describe('Set a nested value', () => {
 
   test('Parse an invalid path', () => {
     expect(parseTypedPath(request, 'parameters.stuff.others')).toBeNull()
+  })
+})
+
+describe('ParsePathResult type tests', () => {
+  test('Valid nested path', () => {
+    type Result = ParsePathResult<typeof nestedObj, 'a.aa'>
+    expectTypeOf<Result>().toEqualTypeOf<'a.aa'>()
+  })
+
+  test('Valid array path', () => {
+    type Result = ParsePathResult<typeof nestedObj, 'c.0.name'>
+    expectTypeOf<Result>().toEqualTypeOf<'c.0.name'>()
+  })
+
+  test('Invalid path', () => {
+    type Result = ParsePathResult<typeof nestedObj, 'a.nonexistent'>
+    expectTypeOf<Result>().toEqualTypeOf<null>()
+  })
+
+  test('Partial valid path', () => {
+    type Result = ParsePathResult<typeof nestedObj, 'a.aa.nonexistent'>
+    expectTypeOf<Result>().toEqualTypeOf<null>()
+  })
+
+  test('Deep nested path', () => {
+    type Result = ParsePathResult<typeof nestedObj, 'd.da.daa.daaa'>
+    expectTypeOf<Result>().toEqualTypeOf<'d.da.daa.daaa'>()
   })
 })

--- a/packages/object-utils/src/nested/nested.ts
+++ b/packages/object-utils/src/nested/nested.ts
@@ -244,15 +244,26 @@ export function setNestedValue<T, P extends Path<T>>(
   value: PathValue<T, P>,
 ) {
   const keys = path.split('.')
-  const lastKey = keys.at(-1)
+  let current: any = obj
+  const lastIndex = keys.length - 1
 
-  // Loop over to get the nested object reference. Then assign the value to it
-  keys.reduce((acc, current) => {
-    if (current === lastKey) acc[current] = value
+  for (let i = 0; i < lastIndex; i++) {
+    const key = keys[i]
+    const nextKey = keys[i + 1]
+    const isNextKeyNumeric = /^\d+$/.test(nextKey)
 
-    return acc[current]
-  }, obj as any)
+    if (current[key] === undefined) {
+      current[key] = isNextKeyNumeric ? [] : {}
+    } else if (Array.isArray(current[key]) !== isNextKeyNumeric) {
+      throw new Error(
+        `Type mismatch at '${keys.slice(0, i + 1).join('.')}': expected ${isNextKeyNumeric ? 'array' : 'object'}`,
+      )
+    }
 
+    current = current[key]
+  }
+
+  current[keys[lastIndex]] = value
   return obj
 }
 

--- a/packages/object-utils/src/nested/nested.ts
+++ b/packages/object-utils/src/nested/nested.ts
@@ -300,7 +300,7 @@ export function getNestedValue<T, P extends Path<T>>(obj: T, path: P) {
 export const parseTypedPath = <T, P extends string>(
   obj: T,
   path: P,
-): ParsePathResult<T, P> => {
+): ParsePathResult<T, P> | null => {
   const keys = path.split('.')
   let current: any = obj
 
@@ -309,12 +309,12 @@ export const parseTypedPath = <T, P extends string>(
 
     if (current === undefined || current === null) {
       console.error(`Cannot access ${key} of undefined or null`)
-      return null as ParsePathResult<T, P>
+      return null
     }
 
     if (!(key in current)) {
       console.error(`Invalid key: ${key}`)
-      return null as ParsePathResult<T, P>
+      return null
     }
     current = current[key]
   }


### PR DESCRIPTION
The `setNestedValue` function didn't work for the test case I added (required for live sync). I got claude to fix it 

Also added a path parsing function which will be used to type the diffs in live sync

Also checked a benchmark and perf has slightly improved + we can remove some extra code with this one when working with formData
```ts
setNestedValue (shallow) x 37,805,234 ops/sec ±6.51% (60 runs sampled)
setNestedValueOld (shallow) x 25,364,159 ops/sec ±4.34% (72 runs sampled)
setNestedValue (deep) x 16,101,160 ops/sec ±3.30% (75 runs sampled)
setNestedValueOld (deep) x 12,860,047 ops/sec ±2.91% (75 runs sampled)
Fastest is setNestedValue (shallow)
```