### PR TITLE
fix(api-reference): render tags in tag group order if set

### DIFF
--- a/.changeset/happy-wolves-glow.md
+++ b/.changeset/happy-wolves-glow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): render tags in tag group order if set

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -69,7 +69,6 @@ const introCardsSlot = computed(() =>
     <slot
       v-else
       name="empty-state" />
-
     <template v-if="parsedSpec.tags">
       <template v-if="parsedSpec['x-tagGroups']">
         <TagList
@@ -78,7 +77,9 @@ const introCardsSlot = computed(() =>
           :layout="layout"
           :spec="parsedSpec"
           :tags="
-            parsedSpec.tags.filter((t) => tagGroup.tags.includes(t.name))
+            tagGroup.tags
+              .map((name) => parsedSpec.tags?.find((t) => t.name === name))
+              .filter((tag) => !!tag)
           " />
       </template>
       <TagList

--- a/packages/api-reference/src/components/Content/Tag/TagList.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagList.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import type { Spec, Tag as tagType } from '@scalar/types/legacy'
+import { computed } from 'vue'
+
+import { useNavState, useSidebar } from '../../../hooks'
+import { Lazy } from '../Lazy'
+import { Operation, OperationAccordion } from '../Operation'
+import { Tag, TagAccordion } from './'
+
+const props = defineProps<{
+  tags: tagType[]
+  spec: Spec
+  layout?: 'default' | 'accordion'
+}>()
+
+const { getOperationId, getTagId, hash } = useNavState()
+const { collapsedSidebarItems } = useSidebar()
+
+const tagLayout = computed<typeof Tag>(() =>
+  props.layout === 'accordion' ? TagAccordion : Tag,
+)
+
+const endpointLayout = computed<typeof Operation>(() =>
+  props.layout === 'accordion' ? OperationAccordion : Operation,
+)
+
+// If the first load is models, we do not lazy load tags/operations
+const isLazy = props.layout !== 'accordion' && !hash.value.startsWith('model')
+</script>
+<template>
+  <Lazy
+    v-for="tag in tags"
+    :id="getTagId(tag)"
+    :key="getTagId(tag)"
+    :isLazy="isLazy && !collapsedSidebarItems[getTagId(tag)]">
+    <Component
+      :is="tagLayout"
+      :id="getTagId(tag)"
+      :spec="spec"
+      :tag="tag">
+      <Lazy
+        v-for="(operation, operationIndex) in tag.operations"
+        :id="getOperationId(operation, tag)"
+        :key="`${operation.httpVerb}-${operation.operationId}`"
+        :isLazy="operationIndex > 0">
+        <Component
+          :is="endpointLayout"
+          :id="getOperationId(operation, tag)"
+          :operation="operation"
+          :tag="tag" />
+      </Lazy>
+    </Component>
+  </Lazy>
+</template>

--- a/packages/api-reference/src/components/Content/Tag/index.ts
+++ b/packages/api-reference/src/components/Content/Tag/index.ts
@@ -1,2 +1,3 @@
 export { default as Tag } from './Tag.vue'
 export { default as TagAccordion } from './TagAccordion.vue'
+export { default as TagList } from './TagList.vue'


### PR DESCRIPTION
Renders the tags based on the tag group configuration if one is set. I looked at adding the tag group titles but it seemed like maybe too much. We can add them though if we want.

Test file [tagGroups.yaml.zip](https://github.com/user-attachments/files/17302686/tagGroups.yaml.zip)
