### PR TITLE
chore(openapi-parser): make `examples` in schemas an array on upgrade, fix #3373

### DIFF
--- a/.changeset/gentle-years-teach.md
+++ b/.changeset/gentle-years-teach.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+chore: make examples an array if it’s in a schema

--- a/packages/openapi-parser/src/utils/traverse.ts
+++ b/packages/openapi-parser/src/utils/traverse.ts
@@ -5,7 +5,7 @@ import type { AnyObject } from '../types'
  */
 export function traverse(
   specification: AnyObject,
-  transform: (specification: AnyObject, path: string[]) => AnyObject,
+  transform: (specification: AnyObject, path?: string[]) => AnyObject,
   path: string[] = [],
 ) {
   const result: AnyObject = {}

--- a/packages/openapi-parser/src/utils/traverse.ts
+++ b/packages/openapi-parser/src/utils/traverse.ts
@@ -5,25 +5,26 @@ import type { AnyObject } from '../types'
  */
 export function traverse(
   specification: AnyObject,
-  transform: (specification: AnyObject) => AnyObject,
+  transform: (specification: AnyObject, path: string[]) => AnyObject,
+  path: string[] = [],
 ) {
   const result: AnyObject = {}
 
   for (const [key, value] of Object.entries(specification)) {
+    const currentPath = [...path, key]
     if (Array.isArray(value)) {
-      result[key] = value.map((item) => {
+      result[key] = value.map((item, index) => {
         if (typeof item === 'object' && item !== null) {
-          return traverse(item, transform)
+          return traverse(item, transform, [...currentPath, index.toString()])
         }
-
         return item
       })
     } else if (typeof value === 'object' && value !== null) {
-      result[key] = traverse(value, transform)
+      result[key] = traverse(value, transform, currentPath)
     } else {
       result[key] = value
     }
   }
 
-  return transform(result)
+  return transform(result, path)
 }

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
@@ -1,255 +1,115 @@
 import { describe, expect, it } from 'vitest'
 
-import { upgradeFromThreeToThreeOne } from './upgradeFromThreeToThreeOne'
+import {
+  isSchemaPath,
+  upgradeFromThreeToThreeOne,
+} from './upgradeFromThreeToThreeOne'
 
-describe('version', () => {
-  it('doesn’t modify Swagger 2.0 files', async () => {
-    const result = upgradeFromThreeToThreeOne({
-      swagger: '2.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {},
-    })
-
-    expect(result.swagger).toBe('2.0')
+describe('isSchemaPath', () => {
+  it('correctly identifies schema paths', () => {
+    expect(isSchemaPath(['components', 'schemas', 'User'])).toBe(true)
+    expect(
+      isSchemaPath([
+        'paths',
+        '/users',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+      ]),
+    ).toBe(true)
+    expect(
+      isSchemaPath([
+        'paths',
+        '/users',
+        'post',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+      ]),
+    ).toBe(true)
+    expect(
+      isSchemaPath(['components', 'schemas', 'User', 'properties', 'address']),
+    ).toBe(true)
+    expect(isSchemaPath(['components', 'schemas', 'User', 'allOf', '0'])).toBe(
+      true,
+    )
+    expect(
+      isSchemaPath(['paths', '/users', 'get', 'parameters', '0', 'schema']),
+    ).toBe(true)
   })
 
-  it('changes the version to from 3.0.0 to 3.1.0', async () => {
-    const result = upgradeFromThreeToThreeOne({
-      openapi: '3.0.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {},
-    })
-
-    expect(result.openapi).toBe('3.1.0')
-  })
-
-  it('changes the version to 3.0.3 to 3.1.0', async () => {
-    const result = upgradeFromThreeToThreeOne({
-      openapi: '3.0.3',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {},
-    })
-
-    expect(result.openapi).toBe('3.1.0')
+  it('correctly identifies non-schema paths', () => {
+    expect(isSchemaPath(['info'])).toBe(false)
+    expect(isSchemaPath(['paths', '/users', 'get', 'summary'])).toBe(false)
+    expect(isSchemaPath(['components', 'parameters', 'userId'])).toBe(false)
   })
 })
 
-describe('nullable types', () => {
-  it('migrates nullable types', async () => {
-    const result = upgradeFromThreeToThreeOne({
-      openapi: '3.0.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {
-        '/test': {
-          get: {
-            responses: {
-              '200': {
-                description: 'foobar',
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'string',
-                      nullable: true,
-                    },
-                  },
-                },
-              },
-            },
-          },
+describe('upgradeFromThreeToThreeOne', () => {
+  describe('version', () => {
+    it('doesn’t modify Swagger 2.0 files', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        swagger: '2.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
         },
-      },
+        paths: {},
+      })
+
+      expect(result.swagger).toBe('2.0')
     })
 
-    expect(
-      result.paths['/test'].get.responses['200'].content['application/json']
-        .schema,
-    ).toEqual({
-      type: ['null', 'string'],
-    })
-  })
-})
-
-describe('exclusiveMinimum and exclusiveMaximum', () => {
-  it('migrate exclusiveMinimum and exclusiveMaximum', async () => {
-    const result = upgradeFromThreeToThreeOne({
-      openapi: '3.0.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {
-        '/test': {
-          get: {
-            responses: {
-              '200': {
-                description: 'foobar',
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'integer',
-                      minimum: 1,
-                      exclusiveMinimum: true,
-                      maximum: 100,
-                      exclusiveMaximum: true,
-                    },
-                  },
-                },
-              },
-            },
-          },
+    it('changes the version to from 3.0.0 to 3.1.0', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
         },
-      },
+        paths: {},
+      })
+
+      expect(result.openapi).toBe('3.1.0')
     })
 
-    expect(
-      result.paths['/test'].get.responses['200'].content['application/json']
-        .schema,
-    ).toEqual({
-      type: 'integer',
-      exclusiveMinimum: 1,
-      exclusiveMaximum: 100,
-    })
-  })
-})
-
-describe('use examples not example', () => {
-  it('migrates example to examples', async () => {
-    const result = upgradeFromThreeToThreeOne({
-      openapi: '3.0.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {
-        '/test': {
-          get: {
-            responses: {
-              '200': {
-                description: 'foobar',
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'integer',
-                      example: 1,
-                    },
-                  },
-                },
-              },
-            },
-          },
+    it('changes the version to 3.0.3 to 3.1.0', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.3',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
         },
-      },
-    })
+        paths: {},
+      })
 
-    expect(
-      result.paths['/test'].get.responses['200'].content['application/json']
-        .schema,
-    ).toEqual({
-      type: 'integer',
-      examples: {
-        default: 1,
-      },
-    })
-  })
-})
-
-describe('describing File Upload Payloads ', () => {
-  it('remove schema for file uploads', async () => {
-    const result = upgradeFromThreeToThreeOne({
-      openapi: '3.0.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {
-        '/test': {
-          get: {
-            requestBody: {
-              content: {
-                'application/octet-stream': {
-                  schema: {
-                    type: 'string',
-                    format: 'binary',
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    })
-
-    expect(
-      result.paths['/test'].get.requestBody.content['application/octet-stream'],
-    ).toEqual({})
-  })
-
-  it('migrates base64 format to contentEncoding', async () => {
-    const result = upgradeFromThreeToThreeOne({
-      openapi: '3.0.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {
-        '/test': {
-          get: {
-            requestBody: {
-              content: {
-                'application/octet-stream': {
-                  schema: {
-                    type: 'string',
-                    format: 'base64',
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    })
-
-    expect(
-      result.paths['/test'].get.requestBody.content['application/octet-stream'],
-    ).toEqual({
-      schema: {
-        type: 'string',
-        contentEncoding: 'base64',
-      },
+      expect(result.openapi).toBe('3.1.0')
     })
   })
 
-  it('migrates binary format for multipart file uploads', async () => {
-    const result = upgradeFromThreeToThreeOne({
-      openapi: '3.0.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {
-        '/test': {
-          get: {
-            requestBody: {
-              content: {
-                'multipart/form-data': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      fileName: {
+  describe('nullable types', () => {
+    it('migrates nullable types', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/test': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'foobar',
+                  content: {
+                    'application/json': {
+                      schema: {
                         type: 'string',
-                        format: 'binary',
+                        nullable: true,
                       },
                     },
                   },
@@ -258,36 +118,227 @@ describe('describing File Upload Payloads ', () => {
             },
           },
         },
-      },
-    })
+      })
 
-    expect(
-      result.paths['/test'].get.requestBody.content['multipart/form-data'],
-    ).toEqual({
-      schema: {
-        type: 'object',
-        properties: {
-          fileName: {
-            type: 'string',
-            contentEncoding: 'application/octet-stream',
-          },
-        },
-      },
+      expect(
+        result.paths['/test'].get.responses['200'].content['application/json']
+          .schema,
+      ).toEqual({
+        type: ['null', 'string'],
+      })
     })
   })
-})
 
-describe.skip('declaring $schema', () => {
-  it('adds a $schema', async () => {
-    const result = upgradeFromThreeToThreeOne({
-      openapi: '3.0.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {},
+  describe('exclusiveMinimum and exclusiveMaximum', () => {
+    it('migrate exclusiveMinimum and exclusiveMaximum', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/test': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'foobar',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'integer',
+                        minimum: 1,
+                        exclusiveMinimum: true,
+                        maximum: 100,
+                        exclusiveMaximum: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(
+        result.paths['/test'].get.responses['200'].content['application/json']
+          .schema,
+      ).toEqual({
+        type: 'integer',
+        exclusiveMinimum: 1,
+        exclusiveMaximum: 100,
+      })
+    })
+  })
+
+  describe('use examples not example in schemas', () => {
+    it('migrates example to examples', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/test': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'foobar',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'integer',
+                        example: 1,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(
+        result.paths['/test'].get.responses['200'].content['application/json']
+          .schema,
+      ).toEqual({
+        type: 'integer',
+        examples: [1],
+      })
+    })
+  })
+
+  describe('describing File Upload Payloads ', () => {
+    it('remove schema for file uploads', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/test': {
+            get: {
+              requestBody: {
+                content: {
+                  'application/octet-stream': {
+                    schema: {
+                      type: 'string',
+                      format: 'binary',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(
+        result.paths['/test'].get.requestBody.content[
+          'application/octet-stream'
+        ],
+      ).toEqual({})
     })
 
-    expect(result.$schema).toBe('http://json-schema.org/draft-07/schema#')
+    it('migrates base64 format to contentEncoding', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/test': {
+            get: {
+              requestBody: {
+                content: {
+                  'application/octet-stream': {
+                    schema: {
+                      type: 'string',
+                      format: 'base64',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(
+        result.paths['/test'].get.requestBody.content[
+          'application/octet-stream'
+        ],
+      ).toEqual({
+        schema: {
+          type: 'string',
+          contentEncoding: 'base64',
+        },
+      })
+    })
+
+    it('migrates binary format for multipart file uploads', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/test': {
+            get: {
+              requestBody: {
+                content: {
+                  'multipart/form-data': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        fileName: {
+                          type: 'string',
+                          format: 'binary',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(
+        result.paths['/test'].get.requestBody.content['multipart/form-data'],
+      ).toEqual({
+        schema: {
+          type: 'object',
+          properties: {
+            fileName: {
+              type: 'string',
+              contentEncoding: 'application/octet-stream',
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe.skip('declaring $schema', () => {
+    it('adds a $schema', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {},
+      })
+
+      expect(result.$schema).toBe('http://json-schema.org/draft-07/schema#')
+    })
   })
 })

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -7,7 +7,7 @@ import { traverse } from './traverse'
  * https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0
  */
 export function upgradeFromThreeToThreeOne(originalSpecification: AnyObject) {
-  let specification = structuredClone(originalSpecification)
+  let specification = originalSpecification
 
   // Version
   if (specification.openapi?.startsWith('3.0')) {


### PR DESCRIPTION
Currently, when upgrading an OpenAPI document to 3.1, we’re transforming all `example` attributes to an `examples` object. For schemas, it’s more common to use arrays.

With this PR we’re transforming them to arrays, and not to objects anymore (for schemas only).

Note: Probably easier to review the commits, than just the changed files.

See #3373