### PR TITLE
style(api-client): enhances responsiveness

### DIFF
--- a/.changeset/kind-monkeys-clap.md
+++ b/.changeset/kind-monkeys-clap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: enhances responsiveness

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -40,7 +40,8 @@ const envs = computed(() => [
         class="font-normal h-auto justify-start py-1.5 px-1.5 text-c-1 hover:bg-b-2 text-c-2 w-fit"
         fullWidth
         variant="ghost">
-        <h2 class="font-medium m-0 text-sm flex gap-1.5 items-center">
+        <h2
+          class="font-medium m-0 text-sm flex gap-1.5 items-center whitespace-nowrap">
           {{ activeEnvironment?.name ?? 'No Environment' }}
           <ScalarIcon
             class="size-3"

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -70,7 +70,7 @@ const startDrag = (event: MouseEvent) => {
     <slot name="header" />
     <div
       v-if="!isReadOnly && title"
-      class="xl:min-h-header flex items-center justify-between border-b-1/2 p-2 md:px-4 md:py-2.5 text-sm">
+      class="min-h-11 xl:min-h-header flex items-center justify-between border-b-1/2 px-3 py-1.5 md:px-4 md:py-2.5 text-sm">
       <h2 class="font-medium m-0 text-sm whitespace-nowrap">
         {{ title }}
       </h2>

--- a/packages/api-client/src/components/Sidebar/SidebarButton.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarButton.vue
@@ -12,7 +12,7 @@ const handleClick = () => {
 </script>
 <template>
   <ScalarButton
-    class="bg-b-1 text-c-1 hover:bg-b-2 group relative w-full border-1/2 px-2 py-1 md:p-1.5 h-auto"
+    class="bg-b-1 text-c-1 hover:bg-b-2 group relative w-auto md:w-full border-1/2 px-2 py-1 md:p-1.5 h-auto"
     icon="Plus"
     variant="outlined"
     @click="handleClick">

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -226,8 +226,18 @@ onBeforeUnmount(() => hotKeyBus.off(handleHotKey))
     transparent
   );
   padding-left: 52px;
-  padding-right: 10px;
+  padding-right: 4px;
   position: relative;
+}
+@screen lg {
+  .t-app__top-nav {
+    padding-right: 6px;
+  }
+}
+@screen lg {
+  .t-app__top-nav {
+    padding-right: 10px;
+  }
 }
 .t-app__top-nav-draggable {
   -webkit-app-region: drag;

--- a/packages/api-client/src/components/ViewLayout/ViewLayout.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex flex-col min-h-0 flex-1 xl:overflow-hidden md:flex-row leading-3">
+    class="divide-y md:divide-y-0 divide-1 flex flex-col min-h-0 flex-1 xl:overflow-hidden md:flex-row leading-3">
     <slot />
   </div>
 </template>

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="border-t-1/2 md:border-t-0 divide divide-y xl:divide-y-0 xl:divide-x-1/2 flex xl:flex-row flex-col custom-scroll pr-0 rounded">
+    class="border-t-1/2 md:border-t-0 divide divide-y xl:divide-y-0 xl:divide-x-1/2 flex xl:flex-row flex-col custom-scroll pr-0">
     <slot />
   </div>
 </template>

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -6,10 +6,10 @@ const id = nanoid()
 <template>
   <section
     :aria-labelledby="id"
-    class="flex xl:min-w-0 xl:flex-1 flex-col xl:custom-scroll bg-b-1">
+    class="flex h-full xl:min-w-0 xl:flex-1 flex-col xl:custom-scroll bg-b-1">
     <div
       :id="id"
-      class="xl:min-h-header flex items-center border-b-1/2 p-2 md:px-4 md:py-2.5 xl:px-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 rounded-t xl:rounded-none">
+      class="min-h-11 xl:min-h-header flex items-center border-b-1/2 px-3.5 py-2 md:px-4 md:py-2.5 xl:px-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 xl:rounded-none">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -111,7 +111,7 @@ onBeforeUnmount(() => {
       v-if="!isReadonly"
       #header>
       <WorkspaceDropdown
-        class="xl:min-h-header xl:py-2.5 py-1 px-2.5 border-b-1/2" />
+        class="min-h-11 xl:min-h-header xl:py-2.5 py-1 px-2.5 border-b-1/2" />
     </template>
     <template #content>
       <div class="search-button-fade sticky px-3 py-2.5 top-0 z-1">

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -17,7 +17,7 @@ defineEmits<{
 </script>
 <template>
   <div
-    class="lg:min-h-header flex items-center w-full justify-center p-1 flex-wrap t-app__top-container border-b-1/2">
+    class="lg:min-h-header flex items-center w-full justify-center p-2 pt-1 lg:p-2 lg:p-1 flex-wrap t-app__top-container md:border-b-1/2">
     <div
       class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-0.5 lg:flex-1 w-6/12">
       <SidebarToggle


### PR DESCRIPTION
this pr updates style in api client in order to fixes and enhances responsiveness glitches such as
- view header button width
- alignments
- double borders
- border radiuses

as seen below:

**before**
<img width="493" alt="image" src="https://github.com/user-attachments/assets/b662a57d-677d-4b1d-a75d-c8d18850c768">

<img width="493" alt="image" src="https://github.com/user-attachments/assets/09366f57-2e60-468a-b03f-34c89eecec83">

<img width="493" alt="image" src="https://github.com/user-attachments/assets/a5bfeeb2-4d74-433e-9da8-065c48de4e16">

**after**
<img width="493" alt="image" src="https://github.com/user-attachments/assets/9f8a38a7-d95e-49ee-a70e-0053fc009001">

<img width="493" alt="image" src="https://github.com/user-attachments/assets/6e51415e-ca17-4f56-b408-538b799b1ba3">

<img width="493" alt="image" src="https://github.com/user-attachments/assets/249b236a-b21e-4d05-85c2-6b038beb1282">