### PR TITLE
feat(api-client): handle file download with filename in response

### DIFF
--- a/.changeset/late-chairs-scream.md
+++ b/.changeset/late-chairs-scream.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: download response with filename

--- a/packages/api-client/src/libs/extractAttachmentFilename.test.ts
+++ b/packages/api-client/src/libs/extractAttachmentFilename.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractFilename } from './extractAttachmentFilename'
+
+describe('extractFileName', () => {
+  it('should return empty filename when Content-Disposition is empty', () => {
+    const result = extractFilename('')
+    expect(result).toEqual('')
+  })
+
+  it('should extract filename from Content-Disposition with quotes', () => {
+    const contentDisposition = 'attachment; filename="example.txt"'
+    const result = extractFilename(contentDisposition)
+    expect(result).toEqual('example.txt')
+  })
+
+  it('should extract filename from Content-Disposition without quotes', () => {
+    const contentDisposition = 'attachment; filename=example.txt'
+    const result = extractFilename(contentDisposition)
+    expect(result).toEqual('example.txt')
+  })
+
+  it('should trim spaces around filename', () => {
+    const contentDisposition = 'attachment; filename=   example.txt   '
+    const result = extractFilename(contentDisposition)
+    expect(result).toEqual('example.txt')
+  })
+
+  it('should extract filename from Content-Disposition with spaces', () => {
+    const contentDisposition = 'attachment; filename="example 123.txt"'
+    const result = extractFilename(contentDisposition)
+    expect(result).toEqual('example 123.txt')
+  })
+
+  it('should return empty filename when filename is not present', () => {
+    const contentDisposition = 'attachment'
+    const result = extractFilename(contentDisposition)
+    expect(result).toEqual('')
+  })
+
+  it('should handle filenames with special characters', () => {
+    const contentDisposition =
+      'attachment; filename="file-with-#-characters.pdf"'
+    const result = extractFilename(contentDisposition)
+    expect(result).toEqual('file-with-#-characters.pdf')
+  })
+
+  it('should handle encoded filenames', () => {
+    const contentDisposition =
+      'attachment; filename=%E0%B8%AA%E0%B8%A7%E0%B8%B1%E0%B8%AA%E0%B8%94%E0%B8%B5.pdf'
+    const result = extractFilename(contentDisposition)
+    expect(result).toEqual('สวัสดี.pdf')
+  })
+})

--- a/packages/api-client/src/libs/extractAttachmentFilename.ts
+++ b/packages/api-client/src/libs/extractAttachmentFilename.ts
@@ -1,0 +1,24 @@
+const decodeURIComponentSafe = (str: string) => {
+  try {
+    return decodeURIComponent(str)
+  } catch (e) {
+    return str
+  }
+}
+
+export function extractFilename(contentDisposition: string) {
+  let filename = ''
+
+  if (contentDisposition) {
+    const fileNameMatch = contentDisposition.match(
+      /filename\s*=\s*"?([^";]+)"?/,
+    )
+
+    if (fileNameMatch && fileNameMatch.length === 2) {
+      // Decode filename
+      filename = decodeURIComponentSafe(fileNameMatch[1].trim())
+    }
+  }
+
+  return filename
+}

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
+import { extractFilename } from '@/libs/extractAttachmentFilename'
 import { mediaTypes } from '@/views/Request/consts'
 import { computed, ref } from 'vue'
 import MIMEType from 'whatwg-mimetype'
@@ -36,6 +37,14 @@ const mimeType = computed(() => {
   return new MIMEType(contentType)
 })
 
+const attachmentFilename = computed(() => {
+  const value =
+    props.headers.find(
+      (header) => header.name.toLowerCase() === 'content-disposition',
+    )?.value ?? ''
+  return extractFilename(value)
+})
+
 const mediaConfig = computed(() => mediaTypes[mimeType.value.essence])
 
 const dataUrl = computed<string>(() => {
@@ -60,6 +69,7 @@ const dataUrl = computed<string>(() => {
       v-if="data && dataUrl"
       #actions>
       <ResponseBodyDownload
+        :filename="attachmentFilename"
         :href="dataUrl"
         :type="mimeType.essence" />
     </template>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
@@ -6,16 +6,18 @@ import { computed } from 'vue'
 const props = defineProps<{
   href: string
   type?: string
+  filename?: string
 }>()
 
-const extension = computed(
-  () => mediaTypes[props.type ?? '']?.extension ?? '.unknown',
-)
+const filenameExtension = computed(() => {
+  const extension = mediaTypes[props.type ?? '']?.extension ?? '.unknown'
+  return props.filename ? props.filename : `response${extension}`
+})
 </script>
 <template>
   <a
     class="flex gap-1 text-c-3 text-xxs no-underline items-center hover:bg-b-3 rounded py-0.5 px-1.5"
-    :download="`response${extension}`"
+    :download="`${filenameExtension}`"
     :href="href"
     @click.stop>
     <ScalarIcon


### PR DESCRIPTION
This update adds the capability to download a file response with the correct filename extracted from the response headers. The feature ensures that when a file is downloaded via the API client, the filename is properly set according to the content disposition, providing a more user-friendly experience.

before

https://github.com/user-attachments/assets/368e48c7-cc04-403e-809b-19e3fa890c23

after

https://github.com/user-attachments/assets/938de78d-e0b8-498b-a94f-a16485653b00

