### PR TITLE
feat(object-utils): new debounce function without dependencies

### DIFF
--- a/.changeset/weak-terms-reply.md
+++ b/.changeset/weak-terms-reply.md
@@ -1,0 +1,5 @@
+---
+"@scalar/object-utils": patch
+---
+
+feat(object-utils): new debounce function without dependencies

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -69,7 +69,6 @@
   ],
   "module": "dist/index.js",
   "dependencies": {
-    "@vueuse/core": "^10.10.0",
     "flatted": "^3.3.1",
     "just-clone": "^6.2.0",
     "ts-deepmerge": "^7.0.1"

--- a/packages/object-utils/src/mutator-record/debounce.test.ts
+++ b/packages/object-utils/src/mutator-record/debounce.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { debounce } from './debounce'
+
+describe('Functions are debounced', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('Debounce function', () => {
+    const func = vi.fn()
+    const debouncedFunc = debounce(func, 1000)
+
+    // Call it immediately
+    debouncedFunc()
+    expect(func).toHaveBeenCalledTimes(0) // func not called
+
+    // Call it several times with 500ms between each call
+    for (let i = 0; i < 10; i++) {
+      vi.advanceTimersByTime(500)
+      debouncedFunc()
+    }
+    expect(func).toHaveBeenCalledTimes(0) // func not called
+
+    // wait 1000ms
+    vi.advanceTimersByTime(1000)
+    expect(func).toHaveBeenCalledTimes(1) // func called
+  })
+
+  test('Debounce function with max wait', () => {
+    const func = vi.fn()
+    const debouncedFunc = debounce(func, 1000, { maxWait: 2000 })
+
+    // Call it immediately
+    debouncedFunc()
+    expect(func).toHaveBeenCalledTimes(0) // func not called
+
+    // Call it several times with 500ms between each call
+    for (let i = 0; i < 10; i++) {
+      vi.advanceTimersByTime(500)
+      debouncedFunc()
+    }
+    expect(func).toHaveBeenCalledTimes(2) // func is called twice because max wait is reached every 4 x 500ms
+  })
+})

--- a/packages/object-utils/src/mutator-record/debounce.ts
+++ b/packages/object-utils/src/mutator-record/debounce.ts
@@ -1,0 +1,34 @@
+type CallbackFunction = (...args: any[]) => any
+
+/**
+ * Dependency-less debounce function with max wait
+ *
+ * @param fn - any function to debounce
+ * @param wait - time in ms to wait after function call to invoke function
+ * @param {number} maxWait - time in ms to wait after function call to invoke function even if it's still being called
+ */
+export function debounce<T extends CallbackFunction>(
+  fn: T,
+  wait: number,
+  { maxWait }: { maxWait?: number } = {},
+): (...args: any[]) => void {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let maxTimer: ReturnType<typeof setTimeout> | null = null
+
+  return function (this: any, ...args: any[]) {
+    if (timer) clearTimeout(timer)
+
+    timer = setTimeout(() => {
+      maxTimer !== null ? clearTimeout(maxTimer) : null
+      maxTimer = null
+      fn.apply(this, args)
+    }, wait)
+
+    if (maxWait && !maxTimer)
+      maxTimer = setTimeout(() => {
+        timer !== null ? clearTimeout(timer) : null
+        maxTimer = null
+        fn.apply(this, args)
+      }, maxWait)
+  }
+}

--- a/packages/object-utils/src/mutator-record/debounce.ts
+++ b/packages/object-utils/src/mutator-record/debounce.ts
@@ -2,6 +2,7 @@ type CallbackFunction = (...args: any[]) => any
 
 /**
  * Dependency-less debounce function with max wait
+ * derived from @url https://dev.to/cantem/how-to-write-a-debounce-function-1bdf
  *
  * @param fn - any function to debounce
  * @param wait - time in ms to wait after function call to invoke function

--- a/packages/object-utils/src/mutator-record/handlers.ts
+++ b/packages/object-utils/src/mutator-record/handlers.ts
@@ -1,8 +1,8 @@
 import { Mutation } from '@/mutator-record/mutations'
 import type { Path, PathValue } from '@/nested'
-import { useDebounceFn } from '@vueuse/core'
 import { stringify } from 'flatted'
 
+import { debounce } from './debounce'
 import { LS_CONFIG } from './local-storage'
 
 const MAX_MUTATION_RECORDS = 500
@@ -29,7 +29,7 @@ export function mutationFactory<
 
   /** Triggers on any changes so we can save to localStorage */
   const onChange = localStorageKey
-    ? useDebounceFn(
+    ? debounce(
         () => localStorage.setItem(localStorageKey, stringify(entityMap)),
         LS_CONFIG.DEBOUNCE_MS,
         { maxWait: LS_CONFIG.MAX_WAIT_MS },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1859,9 +1859,6 @@ importers:
 
   packages/object-utils:
     dependencies:
-      '@vueuse/core':
-        specifier: ^10.10.0
-        version: 10.11.0(vue@3.4.31(typescript@5.6.2))
       flatted:
         specifier: ^3.3.1
         version: 3.3.1


### PR DESCRIPTION
Currently, the `object-utils` package depends on `@vueuse/core` for its `useDebounceFn` 

This PR removes the dependency, `@vueuse/core`, from `@scalar/object-utils` by creating a new dependency-less debounce function for use with mutations.
