### PR TITLE
fix(object-utils): setNested doesn’t work with arrays

### DIFF
--- a/packages/object-utils/src/nested/nested.test.ts
+++ b/packages/object-utils/src/nested/nested.test.ts
@@ -20,6 +20,24 @@ const nestedObj = {
   },
 }
 
+const request = {
+  tags: ['Planets'],
+  summary: 'Get a planet',
+  description:
+    'You’ll better learn a little bit more about the planets. It might come in handy once space travel is available for everyone.',
+  operationId: 'getPlanet',
+  security: [{}],
+  parameters: [
+    {
+      in: 'path',
+      name: 'planetId',
+      required: true,
+      deprecated: false,
+      schema: { type: 'integer', format: 'int64', examples: [1] },
+    },
+  ],
+}
+
 describe('Set a nested value', () => {
   test('Basic nested set', () => {
     const baseObj = clone(nestedObj)
@@ -48,6 +66,16 @@ describe('Set a nested value', () => {
 
     setNestedValue(baseObj, 'c.2', { name: 'asda' })
     copy.c[2] = { name: 'asda' }
+
+    expect(baseObj).toEqual(copy)
+  })
+
+  test('Nested array replacement on request parameters', () => {
+    const baseObj = clone(request)
+    const copy = clone(request)
+
+    setNestedValue(baseObj, 'parameters.0.schema.examples.0', 122)
+    copy.parameters[0].schema.examples[0] = 122
 
     expect(baseObj).toEqual(copy)
   })

--- a/packages/object-utils/src/nested/nested.ts
+++ b/packages/object-utils/src/nested/nested.ts
@@ -244,11 +244,10 @@ export function setNestedValue<T, P extends Path<T>>(
   value: PathValue<T, P>,
 ) {
   const keys = path.split('.')
-  const lastKey = keys.at(-1)
 
   // Loop over to get the nested object reference. Then assign the value to it
-  keys.reduce((acc, current) => {
-    if (current === lastKey) acc[current] = value
+  keys.reduce((acc, current, idx) => {
+    if (idx === keys.length - 1) acc[current] = value
 
     return acc[current]
   }, obj as any)


### PR DESCRIPTION
There was a critical logic error in determining the end state for nested setting. This corrects the logic. 