### PR TITLE
fix(api-reference): lazy loading content jump

### DIFF
--- a/.changeset/hip-avocados-count.md
+++ b/.changeset/hip-avocados-count.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: lazyLoading content jump

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -72,16 +72,6 @@ const documentEl = ref<HTMLElement | null>(null)
 useResizeObserver(documentEl, (entries) => {
   elementHeight.value = entries[0].contentRect.height + 'px'
 })
-// Find scalar Y offset to support users who have tried to add their own headers
-const yPosition = ref(0)
-onMounted(() => {
-  const pbcr = documentEl.value?.parentElement?.getBoundingClientRect()
-  const bcr = documentEl.value?.getBoundingClientRect()
-  if (pbcr && bcr) {
-    const difference = bcr.top - pbcr.top
-    yPosition.value = difference < 2 ? 0 : difference
-  }
-})
 
 // Check for Obtrusive Scrollbars
 const obtrusiveScrollbars = computed(hasObtrusiveScrollbars)
@@ -125,6 +115,8 @@ const scrollToSection = async (id?: string) => {
   isIntersectionEnabled.value = true
 }
 
+const yPosition = ref(0)
+
 /**
  * Ensure we add our scalar wrapper class to the headless ui root
  * mounted is too late
@@ -132,10 +124,21 @@ const scrollToSection = async (id?: string) => {
 onBeforeMount(() => addScalarClassesToHeadless())
 
 onMounted(() => {
+  // Prevent the browser from restoring scroll position on refresh
+  history.scrollRestoration = 'manual'
+
   // Enable the spec download event bus
   downloadSpecBus.on(({ specTitle }) => {
     downloadSpecFile(props.rawSpec, specTitle)
   })
+
+  // Find scalar Y offset to support users who have tried to add their own headers
+  const pbcr = documentEl.value?.parentElement?.getBoundingClientRect()
+  const bcr = documentEl.value?.getBoundingClientRect()
+  if (pbcr && bcr) {
+    const difference = bcr.top - pbcr.top
+    yPosition.value = difference < 2 ? 0 : difference
+  }
 
   // This is what updates the hash ref from hash changes
   window.onhashchange = () =>


### PR DESCRIPTION
This one has been a little annoying and I could have sworn I fixed it before. Basically on initial load lazy loading works fine, BUT on subsequent loads there was a strange content jump happening. Turns out this was the browser remembering the scrollPosition, which we don't want as we manually handle it with lazy loading.

enter `history.scrollRestoration = 'manual'`

Before:

https://github.com/user-attachments/assets/b9d9c8d0-4d21-4f0d-b5f2-2d5edc9c7548



After:

https://github.com/user-attachments/assets/cacad2cd-801c-4a52-8888-0d3c11d12e30


