### PR TITLE
chore: remove changeset codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,9 @@
 # Documentation
 /documentation/* @hanspagel
 
+# Changesets
+/.changeset/*
+
 # Packages
 /packages/api-client @amritk
 /packages/api-reference-editor @geoffgscott


### PR DESCRIPTION
I think right now we're always adding all the default codeowners on every PR that includes a changeset (which most of them do) which I don't think is what we want?