### PR TITLE
chore: remove user without write permission from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,7 +31,7 @@
 # /packages/use-modal
 /packages/build-watch @geoffgscott
 /packages/nestjs-api-reference @marclave
-/packages/scalar.aspnetcore @xC0dex @marclave
+/packages/scalar.aspnetcore @marclave
 # /packages/use-toasts
 /packages/api-client-react @amritk
 /packages/cli @hanspagel


### PR DESCRIPTION
Looks like you can’t have users without full write permission in the `CODEOWNERS` file, sorry @xC0dex. :(

I need to find another way to automatically assign you as a reviewer.