### PR TITLE
feat(openapi-parser): upgrade Swagger 2.0 securityDefinitions

### DIFF
--- a/.changeset/grumpy-feet-beam.md
+++ b/.changeset/grumpy-feet-beam.md
@@ -1,0 +1,6 @@
+---
+'@scalar/openapi-parser': patch
+'@scalar/api-reference': patch
+---
+
+feat: upgrade Swagger 2.0 securityDefinitions


### PR DESCRIPTION
With this PR Swagger 2.0 securityDefinitions are upgraded to the OpenAPI 3.0 structure, too.

Example: https://petstore.swagger.io/v2/swagger.json (breaks the API client without the PR)