### PR TITLE
fix(api-reference): duplicate download event listener

### DIFF
--- a/.changeset/great-singers-lay.md
+++ b/.changeset/great-singers-lay.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: download is triggered twice

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -16,6 +16,7 @@ import {
   onBeforeMount,
   onMounted,
   onServerPrefetch,
+  onUnmounted,
   provide,
   ref,
   useSSRContext,
@@ -172,6 +173,10 @@ const referenceSlotProps = computed<ReferenceSlotProps>(() => ({
   breadcrumb: breadcrumb.value,
   spec: props.parsedSpec,
 }))
+
+onUnmounted(() => {
+  downloadSpecBus.reset()
+})
 
 // Keep the parsed spec up to date
 watch(() => props.parsedSpec, setParsedSpec, { deep: true })


### PR DESCRIPTION
In some cases, the download was triggered twice. We register an event listener for the download, but we don’t unregister ist when the component is unmounted. This PR fixes it.