### PR TITLE
ci: deploy API client on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
   #
   deploy-api-client:
     # Only run this job for PRs from the same repository
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.ref == 'refs/heads/main' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-20.04
     needs: [build]
     strategy:


### PR DESCRIPTION
The API client doesn’t deploy on push to main anymore.

I’ve recently added a check to CI, whether it’s running in a fork or not. This is using the `github.event.pull_request`, but the `pull_request` event is not available in `main`, so the check fails.

This PR tries to fix it.

It‘ll still run for the main branch in forks, but we can deal with that in a separate PR.