### PR TITLE
feat(api-client): added virtual text component and implement it for big responses

### DIFF
--- a/.changeset/neat-beers-dress.md
+++ b/.changeset/neat-beers-dress.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+'@scalar/oas-utils': patch
+---
+
+feat: added virtual text component

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -46,7 +46,7 @@ withDefaults(
         </div>
       </div>
     </DisclosureButton>
-    <DisclosurePanel class="rounded-b">
+    <DisclosurePanel class="rounded-b diclosure-panel">
       <slot :open="open" />
     </DisclosurePanel>
   </Disclosure>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -17,7 +17,7 @@ const textContent = computed(() => formatJsonOrYamlString(props.content))
 
     <div
       class="py-1.5 px-2.5 font-code text-xxs border-1/2 rounded-t border-b-0">
-      Response is too large for syntax highlighting
+      This response body is massive! Syntax highlighting won’t work here.
     </div>
 
     <ScalarVirtualText

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
   content: string
 }>()
 
-const textContent = computed(() => formatJsonOrYamlString(props.content || ''))
+const textContent = computed(() => formatJsonOrYamlString(props.content))
 </script>
 
 <template>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
+import { ScalarVirtualText } from '@scalar/components'
+import { formatJsonOrYamlString } from '@scalar/oas-utils/helpers'
+import { computed } from 'vue'
+
+const props = defineProps<{
+  content: string
+}>()
+
+const textContent = computed(() => formatJsonOrYamlString(props.content || ''))
+</script>
+
+<template>
+  <ViewLayoutCollapse class="response-body-virtual">
+    <template #title>Body</template>
+
+    <div
+      class="py-1.5 px-2.5 font-code text-xxs border-1/2 rounded-t border-b-0">
+      Response is too large for syntax highlighting
+    </div>
+
+    <ScalarVirtualText
+      containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1"
+      contentClass="hljs language-plaintext"
+      :lineHeight="20"
+      :text="textContent" />
+  </ViewLayoutCollapse>
+</template>
+
+<style>
+.response-body-virtual[data-headlessui-state='open'],
+.response-body-virtual[data-headlessui-state='open'] .diclosure-panel {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+</style>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -58,13 +58,15 @@ const sections = ['All', 'Cookies', 'Headers', 'Body']
 type ActiveSections = (typeof sections)[number]
 const activeSection = ref<ActiveSections>('All')
 
-/** Threshold for virtualizing text responses */
-const VIRTUALIZATION_THRESHOLD = 1000000
+/** Threshold for virtualizing text responses in characters */
+const VIRTUALIZATION_THRESHOLD = 5_000_000
 const shouldVirtualize = computed(
   () =>
     typeof props.response?.data === 'string' &&
     props.response.data.length > VIRTUALIZATION_THRESHOLD,
 )
+
+console.log(props.response?.data.length)
 </script>
 <template>
   <ViewLayoutSection>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -65,8 +65,6 @@ const shouldVirtualize = computed(
     typeof props.response?.data === 'string' &&
     props.response.data.length > VIRTUALIZATION_THRESHOLD,
 )
-
-console.log(props.response?.data.length)
 </script>
 <template>
   <ViewLayoutSection>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -59,7 +59,7 @@ type ActiveSections = (typeof sections)[number]
 const activeSection = ref<ActiveSections>('All')
 
 /** Threshold for virtualizing text responses */
-const VIRTUALIZATION_THRESHOLD = 100
+const VIRTUALIZATION_THRESHOLD = 1000000
 const shouldVirtualize = computed(
   () =>
     typeof props.response?.data === 'string' &&

--- a/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.spec.ts
+++ b/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.spec.ts
@@ -1,0 +1,114 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import ScalarVirtualText from './ScalarVirtualText.vue'
+
+describe('ScalarVirtualText', () => {
+  it('renders properly with default props', () => {
+    const wrapper = mount(ScalarVirtualText, {
+      props: {
+        text: 'Hello\nWorld',
+      },
+    })
+
+    expect(wrapper.find('.scalar-virtual-text').exists()).toBe(true)
+    expect(wrapper.find('.scalar-virtual-text-content').exists()).toBe(true)
+    expect(wrapper.findAll('.scalar-virtual-text-line')).toHaveLength(2)
+  })
+
+  it('applies custom classes', () => {
+    const wrapper = mount(ScalarVirtualText, {
+      props: {
+        text: 'Test',
+        containerClass: 'custom-container',
+        contentClass: 'custom-content',
+        lineClass: 'custom-line',
+      },
+    })
+
+    expect(wrapper.find('.scalar-virtual-text').classes()).toContain(
+      'custom-container',
+    )
+    expect(wrapper.find('.scalar-virtual-text-content').classes()).toContain(
+      'custom-content',
+    )
+    expect(wrapper.find('.scalar-virtual-text-line').classes()).toContain(
+      'custom-line',
+    )
+  })
+
+  it('respects custom line height', () => {
+    const wrapper = mount(ScalarVirtualText, {
+      props: {
+        text: 'Test',
+        lineHeight: 30,
+      },
+    })
+
+    const line = wrapper.find('.scalar-virtual-text-line')
+    expect(line.attributes('style')).toContain('height: 30px')
+    expect(line.attributes('style')).toContain('line-height: 30px')
+  })
+
+  it('handles empty text', () => {
+    const wrapper = mount(ScalarVirtualText, {
+      props: {
+        text: '',
+      },
+    })
+
+    expect(wrapper.findAll('.scalar-virtual-text-line')).toHaveLength(1)
+    expect(wrapper.find('.scalar-virtual-text-line').text()).toBe('')
+  })
+
+  it('updates visible lines on scroll', async () => {
+    const longText = Array(100).fill('Line').join('\n')
+    const wrapper = mount(ScalarVirtualText, {
+      props: {
+        text: longText,
+      },
+    })
+
+    const container = wrapper.find('.scalar-virtual-text')
+
+    // Mock the scrollTop and clientHeight
+    Object.defineProperty(container.element, 'scrollTop', {
+      value: 500,
+      writable: true,
+    })
+    Object.defineProperty(container.element, 'clientHeight', {
+      value: 200,
+      writable: true,
+    })
+
+    // Trigger scroll event
+    await container.trigger('scroll')
+
+    // Check if the content is translated
+    const content = wrapper.find('.scalar-virtual-text-content')
+    expect(content.attributes('style')).toContain('transform: translateY')
+  })
+
+  it('updates container height on window resize', async () => {
+    vi.spyOn(window, 'addEventListener')
+    vi.spyOn(window, 'removeEventListener')
+
+    const wrapper = mount(ScalarVirtualText, {
+      props: {
+        text: 'Test',
+      },
+    })
+
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function),
+    )
+
+    wrapper.unmount()
+
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function),
+    )
+  })
+})

--- a/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.stories.ts
+++ b/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.stories.ts
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+import ScalarVirtualText from './ScalarVirtualText.vue'
+
+const meta = {
+  component: ScalarVirtualText,
+  tags: ['autodocs'],
+  argTypes: {
+    text: { control: 'text' },
+    lineHeight: { control: 'number' },
+  },
+  render: (args) => ({
+    components: { ScalarVirtualText },
+    setup() {
+      return { args }
+    },
+    template: `
+      <div style="height: 300px; width: 400px; border: 1px solid #ccc;">
+        <ScalarVirtualText v-bind="args" />
+      </div>
+    `,
+  }),
+} satisfies Meta<typeof ScalarVirtualText>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Base: Story = {
+  args: {
+    text: `
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna 
+    aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur 
+    sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`.repeat(
+      200,
+    ),
+    lineHeight: 20,
+  },
+}

--- a/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.vue
+++ b/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.vue
@@ -94,10 +94,10 @@ watchEffect(() => {
 <template>
   <div
     ref="containerRef"
-    class="scalar-virtual-text relative h-full overflow-auto"
+    class="scalar-virtual-text relative overflow-auto"
     :class="containerClass"
     @scroll="handleScroll">
-    <div
+    <code
       ref="contentRef"
       class="scalar-virtual-text-content absolute"
       :class="contentClass"
@@ -105,7 +105,7 @@ watchEffect(() => {
       <div
         v-for="(line, index) in visibleLines"
         :key="visibleStartIndex + index"
-        class="scalar-virtual-text-line overflow-hidden whitespace-pre"
+        class="scalar-virtual-text-line"
         :class="lineClass"
         :style="{
           height: `${props.lineHeight}px`,
@@ -113,6 +113,6 @@ watchEffect(() => {
         }">
         {{ line }}
       </div>
-    </div>
+    </code>
   </div>
 </template>

--- a/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.vue
+++ b/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watchEffect } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    /** Text to display */
+    text: string
+    /**
+     * Height of each line
+     * @default 20
+     */
+    lineHeight?: number
+    containerClass?: string
+    contentClass?: string
+    lineClass?: string
+  }>(),
+  {
+    lineHeight: 20,
+    containerClass: '',
+    contentClass: '',
+    lineClass: '',
+  },
+)
+
+const containerRef = ref<HTMLElement | null>(null)
+const contentRef = ref<HTMLElement | null>(null)
+const scrollPosition = ref(0)
+const containerHeight = ref(0)
+
+/** Array of text broken into lines */
+const lines = computed(() => props.text.split('\n'))
+/**
+ * Total height of all lines combined
+ *
+ * TODO: there is a problem with this calculation which screws up the scrollbar a bit
+ */
+const totalHeight = computed(() => lines.value.length * props.lineHeight)
+
+/** Index of the first visible line */
+const visibleStartIndex = computed(() =>
+  Math.floor(scrollPosition.value / props.lineHeight),
+)
+
+/** Index of the last visible line */
+const visibleEndIndex = computed(() =>
+  Math.min(
+    Math.ceil(
+      (scrollPosition.value + containerHeight.value) / props.lineHeight,
+    ),
+    lines.value.length,
+  ),
+)
+
+/** Array of visible lines, including buffer for smooth scrolling */
+const visibleLines = computed(() => {
+  const buffer = 10
+  const start = Math.max(0, visibleStartIndex.value - buffer)
+  const end = Math.min(lines.value.length, visibleEndIndex.value + buffer)
+
+  return lines.value.slice(start, end)
+})
+
+/** Style object for the content container, controls "scrolling" */
+const contentStyle = computed(() => ({
+  height: `${totalHeight.value}px`,
+  transform: `translateY(${Math.max(0, visibleStartIndex.value - 10) * props.lineHeight}px)`,
+}))
+
+/** Updates the scroll position when the container is scrolled */
+const handleScroll = () =>
+  containerRef.value && (scrollPosition.value = containerRef.value.scrollTop)
+
+/** Updates the container height when the window is resized */
+const updateContainerHeight = () =>
+  containerRef.value &&
+  (containerHeight.value = containerRef.value.clientHeight)
+
+onMounted(() => {
+  updateContainerHeight()
+  window.addEventListener('resize', updateContainerHeight)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateContainerHeight)
+})
+
+watchEffect(() => {
+  if (!contentRef.value) return
+
+  contentRef.value.style.transform = `translateY(${Math.max(0, visibleStartIndex.value - 10) * props.lineHeight}px)`
+})
+</script>
+
+<template>
+  <div
+    ref="containerRef"
+    class="scalar-virtual-text relative h-full overflow-auto"
+    :class="containerClass"
+    @scroll="handleScroll">
+    <div
+      ref="contentRef"
+      class="scalar-virtual-text-content absolute"
+      :class="contentClass"
+      :style="contentStyle">
+      <div
+        v-for="(line, index) in visibleLines"
+        :key="visibleStartIndex + index"
+        class="scalar-virtual-text-line overflow-hidden whitespace-pre"
+        :class="lineClass"
+        :style="{
+          height: `${props.lineHeight}px`,
+          lineHeight: `${props.lineHeight}px`,
+        }">
+        {{ line }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/components/src/components/ScalarVirtualText/index.ts
+++ b/packages/components/src/components/ScalarVirtualText/index.ts
@@ -1,0 +1,1 @@
+export { default as ScalarVirtualText } from './ScalarVirtualText.vue'

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -33,6 +33,7 @@ import {
 } from './components/ScalarSearchResults'
 import { ScalarTextField } from './components/ScalarTextField'
 import { ScalarTooltip } from './components/ScalarTooltip'
+import { ScalarVirtualText } from './components/ScalarVirtualText'
 import './tailwind/tailwind.css'
 
 export * from './helpers'
@@ -59,6 +60,7 @@ export {
   ScalarSearchResultList,
   ScalarTextField,
   ScalarTooltip,
+  ScalarVirtualText,
   type Icon,
   type ScalarListboxOption,
   type ScalarComboboxOption,

--- a/packages/oas-utils/src/helpers/parse.ts
+++ b/packages/oas-utils/src/helpers/parse.ts
@@ -68,7 +68,7 @@ export const transformToJson = (value: string) => {
 export function formatJsonOrYamlString(value: string) {
   // If we don't start with a bracket assume yaml
   const trimmed = value.trim()
-  if (trimmed[0] !== '{') return value
+  if (trimmed[0] !== '{' && trimmed[0] !== '[') return value
 
   try {
     // JSON


### PR DESCRIPTION
We need a way to handle giant responses. Responses so big we can't even show them in plain text. So I added this virtual scroller.

Whats left (for a follow up PR):
- we need to play with the threshold to get it right
- also the scrollbar/height calculations don't quite work

test with `https://raw.githubusercontent.com/json-iterator/test-data/refs/heads/master/large-file.json`

Before:
browser crash
After:
![image](https://github.com/user-attachments/assets/451faa65-2d63-400b-bc88-be4bcf18b063)
