### PR TITLE
fix(api-client): command palette server collection

### DIFF
--- a/.changeset/new-chairs-allow.md
+++ b/.changeset/new-chairs-allow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates command palette server collection logic

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
@@ -24,6 +24,7 @@ const {
   activeWorkspaceCollections,
   collectionMutators,
   serverMutators,
+  events,
 } = useWorkspace()
 
 const url = ref('')
@@ -52,7 +53,10 @@ const handleSubmit = () => {
     return
   }
   const collectionUid = selectedCollection.value?.id
-  if (!collectionUid) return
+  if (!collectionUid) {
+    toast('Please select a collection before creating a server.', 'error')
+    return
+  }
 
   const server = serverMutators.add({ url: url.value }, collectionUid)
 
@@ -61,10 +65,14 @@ const handleSubmit = () => {
 
   emits('close')
 }
+
+const redirectToCreateCollection = () => {
+  events.commandPalette.emit({ commandName: 'Create Collection' })
+}
 </script>
 <template>
   <CommandActionForm
-    :disabled="!url.trim()"
+    :disabled="!url.trim() || !selectedCollection"
     @submit="handleSubmit">
     <CommandActionInput
       v-model="url"
@@ -76,6 +84,7 @@ const handleSubmit = () => {
         v-model="selectedCollection"
         :options="collections">
         <ScalarButton
+          v-if="collections.length > 0"
           class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
           variant="outlined">
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
@@ -85,6 +94,13 @@ const handleSubmit = () => {
             class="text-c-3"
             icon="ChevronDown"
             size="xs" />
+        </ScalarButton>
+        <ScalarButton
+          v-else
+          class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+          variant="outlined"
+          @click="redirectToCreateCollection">
+          <span class="text-c-1">Create Collection</span>
         </ScalarButton>
       </ScalarListbox>
     </template>

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -296,7 +296,7 @@ onBeforeUnmount(() => {
     <!-- Specific command palette -->
     <template v-else>
       <button
-        class="absolute p-0.75 hover:bg-b-3 rounded text-c-3 active:text-c-1 mr-1.5 my-1.5 z-1"
+        class="absolute p-0.75 hover:bg-b-3 rounded text-c-3 active:text-c-1 mr-1.5 my-1.25 z-1"
         type="button"
         @click="activeCommand = null">
         <ScalarIcon


### PR DESCRIPTION
this pr updates the command palette server collection dropdown displays and logic, in order to display a create collection button if no collection exists + updates the submit button state:

**before**
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/98f94c97-6a7b-481f-a9f3-2fbea682dbb8">

**after**
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/b0039ef7-6328-4f8c-9b63-266a9a392e3a">

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/6f031a7c-2306-40fb-a1df-03ecfd6bfc57">