### PR TITLE
feat(fastify-api-reference): CORS headers for the OpenAPI documents

### DIFF
--- a/.changeset/slow-comics-melt.md
+++ b/.changeset/slow-comics-melt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+feat: add cors headers to OpenAPI documents

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -250,6 +250,8 @@ const fastifyApiReference = fp<
         return reply
           .header('Content-Type', `application/json`)
           .header('Content-Disposition', `filename=${filename}.json`)
+          .header('Access-Control-Allow-Origin', '*')
+          .header('Access-Control-Allow-Methods', '*')
           .send(json)
       },
     })
@@ -268,6 +270,8 @@ const fastifyApiReference = fp<
         return reply
           .header('Content-Type', `application/yaml`)
           .header('Content-Disposition', `filename=${filename}.yaml`)
+          .header('Access-Control-Allow-Origin', '*')
+          .header('Access-Control-Allow-Methods', '*')
           .send(yaml)
       },
     })


### PR DESCRIPTION
This PR adds `*` wildcard CORS headers to the OpenAPI documents our Fastify package is exposing.

Makes it easier to access them without a proxy. :)

Extracted from #3423.