### PR TITLE
fix(fastify-api-reference): does not work with `ignoreTrailingSlash: true`

### DIFF
--- a/.changeset/wise-doors-hide.md
+++ b/.changeset/wise-doors-hide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: doesn’t work with ignoreTrailingSlash: true

--- a/examples/fastify-api-reference/src/index.ts
+++ b/examples/fastify-api-reference/src/index.ts
@@ -5,6 +5,7 @@ import Fastify from 'fastify'
 // Init Fastify
 const fastify = Fastify({
   logger: false,
+  // ignoreTrailingSlash: true,
 })
 
 // Register Swagger

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -42,9 +42,32 @@ function exampleSpec() {
 }
 
 describe('fastifyApiReference', () => {
-  it('returns 200 OK for the HTML', async () => {
+  it('returns 200 OK for the HTML and redirects to the route with a trailing slash', async () => {
     const fastify = Fastify({
       logger: false,
+    })
+
+    await fastify.register(fastifyApiReference, {
+      routePrefix: '/reference',
+      configuration: {
+        spec: { url: '/openapi.json' },
+      },
+    })
+
+    const address = await fastify.listen({ port: 0 })
+    const response = await fetch(`${address}/reference`, { redirect: 'manual' })
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/reference/')
+
+    const finalResponse = await fetch(`${address}/reference/`)
+    expect(finalResponse.status).toBe(200)
+  })
+
+  it('works with ignoreTrailingSlash', async () => {
+    const fastify = Fastify({
+      logger: false,
+      ignoreTrailingSlash: true,
     })
 
     await fastify.register(fastifyApiReference, {


### PR DESCRIPTION
Currently, our Fastify integration throws an error if `ignoreTrailingSlash` is set to `true`.

If this is set, Fastify registers both versions of a route (with and without a trailing slash), which we do too. So it correctly throws an error, because the route is already registered.

This PR should fix it. :)

Fixes #3408