### PR TITLE
fix(api-client): lower syntax highlighting threshold on responseBody

### DIFF
--- a/.changeset/pink-cats-push.md
+++ b/.changeset/pink-cats-push.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: lower syntax highlighting response threshold

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -77,11 +77,6 @@
       "types": "./dist/libs/importers/index.d.ts",
       "default": "./dist/libs/importers/index.js"
     },
-    "./libs/event-busses": {
-      "import": "./dist/libs/event-busses/index.js",
-      "types": "./dist/libs/event-busses/index.d.ts",
-      "default": "./dist/libs/event-busses/index.js"
-    },
     "./layouts/Web": {
       "import": "./dist/layouts/Web/index.js",
       "types": "./dist/layouts/Web/index.d.ts",

--- a/packages/api-client/src/libs/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/create-request-operation.test.ts
@@ -141,7 +141,7 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/api/example',
       body: '',
@@ -160,7 +160,7 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/me',
       body: '',
@@ -179,7 +179,7 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/',
       body: '',
@@ -199,7 +199,7 @@ describe('create-request-operation', () => {
     expect(requestError).toBe(null)
     expect(result?.response.data).not.toContain('ECONNREFUSED')
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/',
     })
@@ -218,7 +218,7 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/',
     })
@@ -255,16 +255,14 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/example',
     })
   })
 
   it('sends query parameters', async () => {
-    const [error, requestOperation] = createRequestOperation<{
-      query: { foo: 'bar' }
-    }>(
+    const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: { url: VOID_URL },
         requestExamplePayload: {
@@ -285,11 +283,14 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data.query).toMatchObject({
-      foo: 'bar',
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
+      query: {
+        foo: 'bar',
+      },
     })
   })
 
+  // TODO: We can’t access the fetch configuration as of now. We could return them, though.
   it.skip('uses uppercase request method', async () => {
     const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
@@ -307,7 +308,7 @@ describe('create-request-operation', () => {
       await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'POST',
     })
     expect(fetchOptions).toMatchObject({
@@ -317,9 +318,7 @@ describe('create-request-operation', () => {
   })
 
   it('sends query parameters as arrays', async () => {
-    const [error, requestOperation] = createRequestOperation<{
-      query: { foo: ['foo', 'bar'] }
-    }>(
+    const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: { url: VOID_URL },
         requestExamplePayload: {
@@ -345,15 +344,13 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data.query).toMatchObject({
+    expect(JSON.parse(result?.response.data as string).query).toMatchObject({
       foo: ['foo', 'bar'],
     })
   })
 
   it('merges query parameters', async () => {
-    const [error, requestOperation] = createRequestOperation<{
-      query: { example: 'parameter'; foo: 'bar' }
-    }>(
+    const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: {
           url: `${VOID_URL}/api?orange=apple`,
@@ -379,17 +376,15 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data.query).toStrictEqual({
+    expect(JSON.parse(result?.response.data as string).query).toStrictEqual({
       example: 'parameter',
       foo: 'bar',
       orange: 'apple',
     })
   })
 
-  it('doesnt have any query parameters', async () => {
-    const [error, requestOperation] = createRequestOperation<{
-      query: { example: 'parameter'; foo: 'bar' }
-    }>(
+  it('doesn’t have any query parameters', async () => {
+    const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: {
           url: VOID_URL,
@@ -401,13 +396,11 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data.query).toStrictEqual({})
+    expect(JSON.parse(result?.response.data as string).query).toStrictEqual({})
   })
 
   it('should ignore query parameters with empty values', async () => {
-    const [error, requestOperation] = createRequestOperation<{
-      query: { example: 'parameter'; foo: 'bar' }
-    }>(
+    const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: {
           url: VOID_URL,
@@ -430,7 +423,7 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data.query).toStrictEqual({})
+    expect(JSON.parse(result?.response.data as string).query).toStrictEqual({})
   })
 
   it('works with no content', async () => {
@@ -458,7 +451,7 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/v1',
     })
@@ -475,7 +468,7 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/v1/',
     })
@@ -508,7 +501,7 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'POST',
       path: '/',
       body: {
@@ -563,7 +556,7 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'POST',
       path: '/',
       body: {

--- a/packages/api-client/src/libs/decode-buffer.test.ts
+++ b/packages/api-client/src/libs/decode-buffer.test.ts
@@ -7,7 +7,7 @@ describe('decode-buffer', () => {
     const jsonData = JSON.stringify({ key: 'value' })
     const buffer = new TextEncoder().encode(jsonData)
     const result = decodeBuffer(buffer, 'application/json')
-    expect(result).toEqual({ key: 'value' })
+    expect(result).toEqual(JSON.stringify({ key: 'value' }))
   })
 
   it('decodes text content', () => {

--- a/packages/api-client/src/libs/decode-buffer.test.ts
+++ b/packages/api-client/src/libs/decode-buffer.test.ts
@@ -21,7 +21,7 @@ describe('decode-buffer', () => {
     const binaryData = new Uint8Array([1, 2, 3, 4])
     const result = decodeBuffer(binaryData.buffer, 'application/octet-stream')
     expect(result).toBeInstanceOf(Blob)
-    expect(result.type).toBe('application/octet-stream')
+    expect((result as Blob).type).toBe('application/octet-stream')
   })
 
   it('uses the charset parameter for text decoding', () => {

--- a/packages/api-client/src/libs/send-request.test.ts
+++ b/packages/api-client/src/libs/send-request.test.ts
@@ -100,7 +100,7 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toContain(
+    expect(result?.response.data as string).toContain(
       'The `scalar_url` query parameter is required.',
     )
   })
@@ -141,7 +141,7 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/api/example',
       body: '',
@@ -160,7 +160,7 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/me',
       body: '',
@@ -179,7 +179,7 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/',
       body: '',
@@ -197,9 +197,11 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).not.toContain('ECONNREFUSED')
+    expect(JSON.parse(result?.response.data as string)).not.toContain(
+      'ECONNREFUSED',
+    )
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/',
     })
@@ -218,7 +220,7 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/',
     })
@@ -255,16 +257,14 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/example',
     })
   })
 
   it('sends query parameters', async () => {
-    const [error, requestOperation] = createRequestOperation<{
-      query: { foo: 'bar' }
-    }>(
+    const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: { url: VOID_URL },
         requestExamplePayload: {
@@ -285,15 +285,13 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data.query).toMatchObject({
+    expect(JSON.parse(result?.response.data as string).query).toMatchObject({
       foo: 'bar',
     })
   })
 
   it('sends query parameters as arrays', async () => {
-    const [error, requestOperation] = createRequestOperation<{
-      query: { foo: ['foo', 'bar'] }
-    }>(
+    const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: { url: VOID_URL },
         requestExamplePayload: {
@@ -319,15 +317,15 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data.query).toMatchObject({
-      foo: ['foo', 'bar'],
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
+      query: {
+        foo: ['foo', 'bar'],
+      },
     })
   })
 
   it('merges query parameters', async () => {
-    const [error, requestOperation] = createRequestOperation<{
-      query: { example: 'parameter'; foo: 'bar' }
-    }>(
+    const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: {
           url: `${VOID_URL}/api?orange=apple`,
@@ -353,17 +351,17 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data.query).toStrictEqual({
-      example: 'parameter',
-      foo: 'bar',
-      orange: 'apple',
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
+      query: {
+        example: 'parameter',
+        foo: 'bar',
+        orange: 'apple',
+      },
     })
   })
 
   it('doesnt have any query parameters', async () => {
-    const [error, requestOperation] = createRequestOperation<{
-      query: { example: 'parameter'; foo: 'bar' }
-    }>(
+    const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: {
           url: VOID_URL,
@@ -375,13 +373,13 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data.query).toStrictEqual({})
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
+      query: {},
+    })
   })
 
   it('should ignore query parameters with empty values', async () => {
-    const [error, requestOperation] = createRequestOperation<{
-      query: { example: 'parameter'; foo: 'bar' }
-    }>(
+    const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: {
           url: VOID_URL,
@@ -404,7 +402,7 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data.query).toStrictEqual({})
+    expect(JSON.parse(result?.response.data as string).query).toStrictEqual({})
   })
 
   it('works with no content', async () => {
@@ -432,7 +430,7 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/v1',
     })
@@ -449,7 +447,7 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/v1/',
     })
@@ -482,7 +480,7 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'POST',
       path: '/',
       body: {
@@ -537,7 +535,7 @@ describe('sendRequest', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(result?.response.data).toMatchObject({
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'POST',
       path: '/',
       body: {

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -58,12 +58,10 @@ const sections = ['All', 'Cookies', 'Headers', 'Body']
 type ActiveSections = (typeof sections)[number]
 const activeSection = ref<ActiveSections>('All')
 
-/** Threshold for virtualizing text responses in characters */
-const VIRTUALIZATION_THRESHOLD = 5_000_000
+/** Threshold for virtualizing response bodies in bytes */
+const VIRTUALIZATION_THRESHOLD = 20_000
 const shouldVirtualize = computed(
-  () =>
-    typeof props.response?.data === 'string' &&
-    props.response.data.length > VIRTUALIZATION_THRESHOLD,
+  () => (props.response?.size ?? 0) > VIRTUALIZATION_THRESHOLD,
 )
 </script>
 <template>

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -22,10 +22,7 @@ export const requestMethods = [
 export type RequestMethod = (typeof requestMethods)[number]
 
 /** A single set of populated values for a sent request */
-export type ResponseInstance<ResponseDataType = unknown> = Omit<
-  Response,
-  'headers'
-> & {
+export type ResponseInstance = Omit<Response, 'headers'> & {
   /** Store headers as an object to match what we had with axios */
   headers: Record<string, string>
   /** Keys of headers which set cookies */
@@ -33,7 +30,9 @@ export type ResponseInstance<ResponseDataType = unknown> = Omit<
   /** Time in ms the request took */
   duration: number
   /** The response data */
-  data: ResponseDataType
+  data: string | Blob
+  /** The response size in bytes */
+  size: number
   /** The response status */
   status: number
   /** The response method */


### PR DESCRIPTION
Fixes #3467

Switched the unit of measurement to bytes and dropped the threshold to 20k. Lets see how this does.

Also removed some Json parsing since it was redundant. Will fix up the tests