### PR TITLE
fix(api-client): add collection.info.version optional

### DIFF
--- a/.changeset/yellow-singers-count.md
+++ b/.changeset/yellow-singers-count.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: make collection.info.version optional

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -57,7 +57,7 @@ export const oasInfoSchema = z.object({
    * REQUIRED. The version of the OpenAPI document (which is distinct from the OpenAPI
    * Specification version or the API implementation version).
    */
-  version: z.string().default('0.0.1'),
+  version: z.string().optional().default('0.0.1'),
 })
 
 /**

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -57,7 +57,7 @@ export const oasInfoSchema = z.object({
    * REQUIRED. The version of the OpenAPI document (which is distinct from the OpenAPI
    * Specification version or the API implementation version).
    */
-  version: z.string().optional().default('0.0.1'),
+  version: z.string().optional().default('1.0'),
 })
 
 /**


### PR DESCRIPTION
fix #3463 
Turns out we already had a default, was just missing optional()