### PR TITLE
feat(api-client): add web app playground

### DIFF
--- a/.changeset/rude-berries-hunt.md
+++ b/.changeset/rude-berries-hunt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds api client web playground

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "dev:client": "turbo dev --filter client-scalar-com",
     "dev:components": "turbo dev --filter @scalar/components",
     "dev:modal": "turbo playground:modal --filter @scalar/api-client",
+    "dev:web-app": "turbo playground:web --filter @scalar/api-client",
     "dev:nuxt": "turbo dev --filter @scalar/nuxt",
     "dev:proxy-server": "pnpm --filter @scalar-examples/proxy-server dev",
     "dev:reference": "turbo dev --filter @scalar/api-reference",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "clean:dist": "find . -name dist -type d -exec rm -rf {} \\;",
     "clean:turbo": "find . -name .turbo -type d -exec rm -rf {} \\;",
     "dev": "turbo dev --concurrency=100 --filter './examples/*' --filter=@scalar/nuxt --filter=@scalar/draggable --filter @scalar/components --filter @scalar/api-client --filter @scalar/nextjs-openapi",
-    "dev:app": "turbo dev --filter @scalar/api-client",
+    "dev:app": "turbo dev --filter scalar-api-client",
     "dev:client": "turbo dev --filter client-scalar-com",
     "dev:components": "turbo dev --filter @scalar/components",
     "dev:modal": "turbo playground:modal --filter @scalar/api-client",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -29,6 +29,7 @@
     "lint:fix": "eslint .  --fix",
     "playground:app": "vite ./playground/app -c ./vite.config.ts",
     "playground:modal": "vite ./playground/modal -c ./vite.config.ts",
+    "playground:web": "vite ./playground/web -c ./vite.config.ts",
     "preview": "vite preview",
     "test": "vitest",
     "types:build": "vue-tsc -p tsconfig.build.json",

--- a/packages/api-client/playground/web/index.html
+++ b/packages/api-client/playground/web/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/vite.svg" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0" />
+    <title>Scalar API Client Web</title>
+  </head>
+  <body>
+    <div
+      id="scalar-client"
+      class="scalar-app scalar-client" />
+    <script
+      type="module"
+      src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/api-client/playground/web/main.ts
+++ b/packages/api-client/playground/web/main.ts
@@ -1,0 +1,6 @@
+import { createApiClientWeb } from '@scalar/api-client/layouts/Web'
+import '@scalar/api-client/style.css'
+
+createApiClientWeb(document.getElementById('scalar-client'), {
+  proxyUrl: 'https://proxy.scalar.com',
+})

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,11 @@
       "persistent": true,
       "dependsOn": ["^build"]
     },
+    "playground:web": {
+      "cache": false,
+      "persistent": true,
+      "dependsOn": ["^build"]
+    },
     "types:check": {}
   }
 }


### PR DESCRIPTION
this pr adds and updates:
- `pnpm dev:web-app` that open the api client web version
- `pnpm dev:app` that open the api client app version

to do so a web app playground has been added in order to use the api client web component that has been introduced in #3351 to reflect the web usage locally.

**why**
currently when using `pnpm dev:app`, the api client launch the app version that does not reflect the web usage.
