### PR TITLE
chore: downgrade to `thollander/actions-comment-pull-request@v2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       - if: github.ref != 'refs/heads/main' && steps.deploy-client.outputs.deployment-url
         name: Add Cloudflare Preview URL to the PR
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
             **Cloudflare Preview for the API Client**
@@ -326,7 +326,7 @@ jobs:
             --filter @scalar-examples/web \
             --alias=${{env.DEPLOY_ID}}
       - name: Add Netlify Preview URL to the PR
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
             **Preview Examples**


### PR DESCRIPTION
v3 seems to add multiple comments instead of updating them. 👀 

More context in https://github.com/thollander/actions-comment-pull-request/issues/397

See #3468, doesn’t fix it though. There are still multiple preview links generated (at least for Netlify).