### PR TITLE
fix(themes): reset

### DIFF
--- a/.changeset/thirty-paws-sleep.md
+++ b/.changeset/thirty-paws-sleep.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix: removes focus visible style from reset

--- a/packages/themes/src/reset.css
+++ b/packages/themes/src/reset.css
@@ -73,12 +73,6 @@
   textarea {
     border-radius: var(--scalar-radius);
     border-width: 1px;
-
-    /** @see https://tailwindcss.com/docs/ring-width#focus-rings */
-    &:focus-visible {
-      box-shadow: var(--tw-ring-inset) 0 0 0
-        calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-    }
   }
 
   input::placeholder,


### PR DESCRIPTION
this pr removes the focus visible style added in the theme reset stylesheet in #3435 in order to fix ui focus issue, while we found another better approach to it.

**before**
in reference
<img width="762" alt="image" src="https://github.com/user-attachments/assets/59bf5b04-8066-4637-8a60-730ea3283a17">

in api client
<img width="762" alt="image" src="https://github.com/user-attachments/assets/ff5ab547-a6e1-4f02-a20f-b3eacf7d1ae0">


**after**
in reference
<img width="762" alt="image" src="https://github.com/user-attachments/assets/f9bf4ce5-25d9-4242-a251-1ff507834167">

in api client
<img width="762" alt="image" src="https://github.com/user-attachments/assets/093cb351-9a05-457b-9b67-092e0b4e4c56">
