### PR TITLE
fix(api-client): removes duplicated utility class in request header

### DIFF
--- a/.changeset/big-candles-hammer.md
+++ b/.changeset/big-candles-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: removes duplicated utility class in request header

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -17,7 +17,7 @@ defineEmits<{
 </script>
 <template>
   <div
-    class="lg:min-h-header flex items-center w-full justify-center p-2 pt-1 lg:p-2 lg:p-1 flex-wrap t-app__top-container md:border-b-1/2">
+    class="lg:min-h-header flex items-center w-full justify-center p-2 pt-1 lg:p-1 flex-wrap t-app__top-container md:border-b-1/2">
     <div
       class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-0.5 lg:flex-1 w-6/12">
       <SidebarToggle


### PR DESCRIPTION
this pr fixes a duplicated utility class introduced after a rebase:

**before**
<img width="604" alt="image" src="https://github.com/user-attachments/assets/6d2e0b46-a2d7-46ec-b48d-53e501c21c4c">

**after
<img width="604" alt="image" src="https://github.com/user-attachments/assets/630d637d-e61a-4588-84a4-d6973d37d920">
