### PR TITLE
style(api-client): gap between sidebar entries

### DIFF
--- a/.changeset/shy-bobcats-try.md
+++ b/.changeset/shy-bobcats-try.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: updates sidenav gap and sidehelp hover

--- a/packages/api-client/src/components/SideNav/SideHelp.vue
+++ b/packages/api-client/src/components/SideNav/SideHelp.vue
@@ -10,7 +10,7 @@ import {
     class="max-w-[150px]"
     :placement="'top-end'">
     <button
-      class="min-w-[37px] max-w-[37px] hover:bg-b-3 flex items-center justify-center rounded-lg p-[7px] text-c-3 focus:text-c-1 scalar-app-nav-padding"
+      class="min-w-[37px] max-w-[37px] hover:bg-b-2 flex items-center justify-center rounded-lg p-[7px] text-c-3 focus:text-c-1 scalar-app-nav-padding"
       type="button">
       <ScalarIcon
         icon="Help"

--- a/packages/api-client/src/components/SideNav/SideNav.vue
+++ b/packages/api-client/src/components/SideNav/SideNav.vue
@@ -28,7 +28,7 @@ const { currentRoute } = useRouter()
         </SideNavLink>
       </li>
     </ul>
-    <ul class="mt-auto flex flex-col py-0.5">
+    <ul class="mt-auto flex flex-col gap-1.5 py-0.5">
       <li class="flex items-center no-drag-region">
         <SideNavLink
           :active="currentRoute.name === 'settings'"


### PR DESCRIPTION
this pr adds gap to sidenav components and updates the hover color on sidehelp:

**before**
<img width="407" alt="image" src="https://github.com/user-attachments/assets/625a11ad-e360-41bf-b646-23ab03328528">

**after**
<img width="407" alt="image" src="https://github.com/user-attachments/assets/6df38e46-103a-42d3-b5e0-216047501cea">
