### PR TITLE
chore: switch from `yaml` to `js-yaml`

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -167,6 +167,7 @@
     "cva": "1.0.0-beta.1",
     "fuse.js": "^7.0.0",
     "js-cookie": "^3.0.5",
+    "js-yaml": "^4.1.0",
     "nanoid": "^5.0.7",
     "pretty-bytes": "^6.1.1",
     "pretty-ms": "^8.0.0",
@@ -174,7 +175,6 @@
     "vue": "^3.5.12",
     "vue-router": "^4.3.0",
     "whatwg-mimetype": "^4.0.0",
-    "yaml": "^2.4.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -181,6 +181,7 @@
     "@scalar/build-tooling": "workspace:*",
     "@types/content-type": "^1.1.8",
     "@types/js-cookie": "^3.0.6",
+    "@types/js-yaml": "^4.0.9",
     "@types/shell-quote": "^1.7.5",
     "@types/whatwg-mimetype": "^3.0.2",
     "@vitejs/plugin-vue": "^5.0.4",

--- a/packages/api-client/src/components/ImportCollection/utils/getOpenApiDocumentVersion.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/getOpenApiDocumentVersion.ts
@@ -1,5 +1,6 @@
 import { isDocument } from '@/components/ImportCollection/utils/isDocument'
-import { parse } from 'yaml'
+// @ts-ignore
+import { load } from 'js-yaml'
 
 /**
  * Get the Swagger/OpenAPI version and format from the given string
@@ -26,7 +27,7 @@ export function getOpenApiDocumentVersion(input: string | null) {
   }
 
   try {
-    const result = parse(input ?? '')
+    const result = load(input ?? '')
 
     if (typeof result?.openapi === 'string') {
       return `OpenAPI ${result.openapi} YAML`

--- a/packages/api-client/src/components/ImportCollection/utils/getOpenApiDocumentVersion.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/getOpenApiDocumentVersion.ts
@@ -1,5 +1,4 @@
 import { isDocument } from '@/components/ImportCollection/utils/isDocument'
-// @ts-ignore
 import { load } from 'js-yaml'
 
 /**

--- a/packages/api-reference/src/hooks/useReactiveSpec.test.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.test.ts
@@ -283,6 +283,6 @@ describe('useParser', () => {
     // Sleep for 10ms to wait for the parser to finish
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(specErrors.value).toContain('YAMLParseError')
+    expect(specErrors.value).toContain('YAMLException')
   })
 })

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -51,6 +51,7 @@
     "@fastify/swagger": "^8.10.1",
     "@scalar/api-reference": "workspace:*",
     "@scalar/openapi-parser": "workspace:*",
+    "@types/js-yaml": "^4.0.9",
     "@vitest/coverage-v8": "^1.6.0",
     "fastify": "^4.26.2",
     "github-slugger": "^2.0.0",

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -54,13 +54,13 @@
     "@vitest/coverage-v8": "^1.6.0",
     "fastify": "^4.26.2",
     "github-slugger": "^2.0.0",
+    "js-yaml": "^4.1.0",
     "magic-string": "^0.30.8",
     "rollup-plugin-node-externals": "^7.1.2",
     "terser": "^5.30.0",
     "vite": "^5.2.10",
     "vite-plugin-static-copy": "^1.0.2",
     "vitest": "^1.6.0",
-    "vue": "^3.5.12",
-    "yaml": "^2.4.5"
+    "vue": "^3.5.12"
   }
 }

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -4,7 +4,6 @@ import FastifyBasicAuth, {
 import fastifySwagger from '@fastify/swagger'
 import type { OpenAPI } from '@scalar/types/legacy'
 import Fastify from 'fastify'
-// @ts-ignore
 import { load } from 'js-yaml'
 import { beforeEach, describe, expect, it } from 'vitest'
 

--- a/packages/fastify-api-reference/src/fastifyApiReference.test.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.test.ts
@@ -4,8 +4,9 @@ import FastifyBasicAuth, {
 import fastifySwagger from '@fastify/swagger'
 import type { OpenAPI } from '@scalar/types/legacy'
 import Fastify from 'fastify'
+// @ts-ignore
+import { load } from 'js-yaml'
 import { beforeEach, describe, expect, it } from 'vitest'
-import YAML from 'yaml'
 
 import fastifyApiReference from './index'
 
@@ -215,7 +216,7 @@ describe('fastifyApiReference', () => {
               `${address}/reference${endpoints.yaml}`,
             )
             expect(response.status).toBe(200)
-            expect(YAML.parse(await response.text())).toEqual(spec)
+            expect(load(await response.text())).toEqual(spec)
           })
         })
       })

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -118,9 +118,9 @@
     "@scalar/themes": "workspace:*",
     "@scalar/types": "workspace:*",
     "flatted": "^3.3.1",
+    "js-yaml": "^4.1.0",
     "microdiff": "^1.4.0",
     "nanoid": "^5.0.7",
-    "yaml": "^2.4.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -127,6 +127,7 @@
     "@scalar/build-tooling": "workspace:*",
     "@scalar/openapi-parser": "workspace:*",
     "@scalar/openapi-types": "workspace:*",
+    "@types/js-yaml": "^4.0.9",
     "rollup": "^4.16.4",
     "type-fest": "^4.20.0",
     "vite": "^5.2.10",

--- a/packages/oas-utils/src/helpers/parse.ts
+++ b/packages/oas-utils/src/helpers/parse.ts
@@ -1,5 +1,4 @@
 import type { UnknownObject } from '@scalar/types/utils'
-// @ts-ignore
 import { dump, load } from 'js-yaml'
 
 type PrimitiveOrObject = object | string | null | number | boolean | undefined

--- a/packages/oas-utils/src/helpers/parse.ts
+++ b/packages/oas-utils/src/helpers/parse.ts
@@ -1,5 +1,6 @@
 import type { UnknownObject } from '@scalar/types/utils'
-import { parse, stringify } from 'yaml'
+// @ts-ignore
+import { dump, load } from 'js-yaml'
 
 type PrimitiveOrObject = object | string | null | number | boolean | undefined
 
@@ -7,7 +8,7 @@ type PrimitiveOrObject = object | string | null | number | boolean | undefined
 export const yaml = {
   /** Parse and throw if the return value is not an object */
   parse: (val: string) => {
-    const yamlObject = parse(val)
+    const yamlObject = load(val)
     if (typeof yamlObject !== 'object') throw Error('Invalid YAML object')
     return yamlObject as UnknownObject
   },
@@ -22,7 +23,7 @@ export const yaml = {
       return typeof fallback === 'function' ? fallback(err) : fallback
     }
   },
-  stringify,
+  dump,
 }
 
 /** JSON handling with optional safeparse */

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -56,9 +56,9 @@
     "ajv": "^8.17.1",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",
+    "js-yaml": "^4.1.0",
     "jsonpointer": "^5.0.1",
-    "leven": "^4.0.0",
-    "yaml": "^2.4.5"
+    "leven": "^4.0.0"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -68,6 +68,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@scalar/openapi-types": "workspace:*",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.14.10",
     "glob": "^10.3.10",
     "json-to-ast": "^2.1.0",

--- a/packages/openapi-parser/rollup.config.ts
+++ b/packages/openapi-parser/rollup.config.ts
@@ -65,7 +65,7 @@ const config: RollupOptions[] = [
       'ajv/dist/2020',
       'ajv-draft-04',
       'ajv-formats',
-      'yaml',
+      'js-yaml',
       '@scalar/openapi-types',
     ],
     treeshake: {

--- a/packages/openapi-parser/src/utils/isYaml.ts
+++ b/packages/openapi-parser/src/utils/isYaml.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { load } from 'js-yaml'
 
 export function isYaml(value: string) {

--- a/packages/openapi-parser/src/utils/isYaml.ts
+++ b/packages/openapi-parser/src/utils/isYaml.ts
@@ -1,4 +1,5 @@
-import { parse } from 'yaml'
+// @ts-ignore
+import { load } from 'js-yaml'
 
 export function isYaml(value: string) {
   // Line breaks
@@ -7,8 +8,8 @@ export function isYaml(value: string) {
   }
 
   try {
-    parse(value, {
-      maxAliasCount: 10000,
+    load(value, {
+      // maxAliasCount: 10000,
     })
 
     return true

--- a/packages/openapi-parser/src/utils/load/load.test.ts
+++ b/packages/openapi-parser/src/utils/load/load.test.ts
@@ -1,6 +1,7 @@
+// @ts-ignore
+import { dump } from 'js-yaml'
 import path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { stringify } from 'yaml'
 
 import { getEntrypoint } from '../getEntrypoint'
 import { load } from './load'
@@ -67,7 +68,7 @@ describe('load', async () => {
 
   it('loads YAML string', async () => {
     const { filesystem } = await load(
-      stringify({
+      dump({
         openapi: '3.1.0',
         info: {
           title: 'Hello World',
@@ -147,7 +148,7 @@ describe('load', async () => {
     // @ts-expect-error
     fetch.mockResolvedValue({
       text: async () =>
-        stringify({
+        dump({
           openapi: '3.1.0',
           info: {
             title: 'Hello World',
@@ -264,7 +265,7 @@ describe('load', async () => {
         return Promise.resolve({
           text: () =>
             Promise.resolve(
-              stringify({
+              dump({
                 openapi: '3.1.0',
                 info: {
                   title: 'Hello World',
@@ -351,7 +352,7 @@ describe('load', async () => {
     })
 
     const { filesystem } = await load(
-      stringify({
+      dump({
         openapi: '3.1.0',
         info: {
           title: 'Hello World',

--- a/packages/openapi-parser/src/utils/load/load.test.ts
+++ b/packages/openapi-parser/src/utils/load/load.test.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { dump } from 'js-yaml'
 import path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'

--- a/packages/openapi-parser/src/utils/normalize.ts
+++ b/packages/openapi-parser/src/utils/normalize.ts
@@ -1,4 +1,5 @@
-import { parse } from 'yaml'
+// @ts-ignore
+import { load } from 'js-yaml'
 
 import type { AnyObject, Filesystem } from '../types'
 import { isFilesystem } from './isFilesystem'
@@ -18,8 +19,8 @@ export function normalize(
     try {
       return JSON.parse(specification)
     } catch (error) {
-      return parse(specification, {
-        maxAliasCount: 10000,
+      return load(specification, {
+        // maxAliasCount: 10000,
       })
     }
   }

--- a/packages/openapi-parser/src/utils/normalize.ts
+++ b/packages/openapi-parser/src/utils/normalize.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { load } from 'js-yaml'
 
 import type { AnyObject, Filesystem } from '../types'

--- a/packages/openapi-parser/src/utils/openapi/openapi.test.ts
+++ b/packages/openapi-parser/src/utils/openapi/openapi.test.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { dump } from 'js-yaml'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'

--- a/packages/openapi-parser/src/utils/openapi/openapi.test.ts
+++ b/packages/openapi-parser/src/utils/openapi/openapi.test.ts
@@ -1,6 +1,7 @@
+// @ts-ignore
+import { dump } from 'js-yaml'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { stringify } from 'yaml'
 
 import { readFiles } from '../load/plugins/readFiles'
 import { openapi } from './openapi'
@@ -252,7 +253,7 @@ describe('pipeline', () => {
   it('toYaml', async () => {
     const result = await openapi().load(example).toYaml()
 
-    expect(result).toBe(stringify(example))
+    expect(result).toBe(dump(example))
   })
 
   it('dereference', async () => {

--- a/packages/openapi-parser/src/utils/toYaml.ts
+++ b/packages/openapi-parser/src/utils/toYaml.ts
@@ -1,5 +1,6 @@
-import { stringify } from 'yaml'
+// @ts-ignore
+import { dump } from 'js-yaml'
 
 import type { AnyObject } from '../types'
 
-export const toYaml = (value: AnyObject) => stringify(value)
+export const toYaml = (value: AnyObject) => dump(value)

--- a/packages/openapi-parser/src/utils/toYaml.ts
+++ b/packages/openapi-parser/src/utils/toYaml.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { dump } from 'js-yaml'
 
 import type { AnyObject } from '../types'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,6 +598,9 @@ importers:
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7
@@ -619,9 +622,6 @@ importers:
       whatwg-mimetype:
         specifier: ^4.0.0
         version: 4.0.0
-      yaml:
-        specifier: ^2.4.5
-        version: 2.4.5
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1539,6 +1539,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       magic-string:
         specifier: ^0.30.8
         version: 0.30.10
@@ -1560,9 +1563,6 @@ importers:
       vue:
         specifier: ^3.5.12
         version: 3.5.12(typescript@5.6.2)
-      yaml:
-        specifier: ^2.4.5
-        version: 2.4.5
 
   packages/galaxy:
     devDependencies:
@@ -1825,15 +1825,15 @@ importers:
       flatted:
         specifier: ^3.3.1
         version: 3.3.1
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       microdiff:
         specifier: ^1.4.0
         version: 1.4.0
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7
-      yaml:
-        specifier: ^2.4.5
-        version: 2.4.5
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1893,15 +1893,15 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       jsonpointer:
         specifier: ^5.0.1
         version: 5.0.1
       leven:
         specifier: ^4.0.0
         version: 4.0.0
-      yaml:
-        specifier: ^2.4.5
-        version: 2.4.5
     devDependencies:
       '@apidevtools/swagger-parser':
         specifier: ^10.1.0
@@ -25449,7 +25449,7 @@ snapshots:
       '@vue/shared': 3.4.29
       entities: 4.5.0
       estree-walker: 2.0.2
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   '@vue/compiler-core@3.4.31':
     dependencies:
@@ -25457,7 +25457,7 @@ snapshots:
       '@vue/shared': 3.4.31
       entities: 4.5.0
       estree-walker: 2.0.2
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   '@vue/compiler-core@3.5.12':
     dependencies:
@@ -25465,7 +25465,7 @@ snapshots:
       '@vue/shared': 3.5.12
       entities: 4.5.0
       estree-walker: 2.0.2
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   '@vue/compiler-dom@3.4.31':
     dependencies:
@@ -25487,7 +25487,7 @@ snapshots:
       estree-walker: 2.0.2
       magic-string: 0.30.10
       postcss: 8.4.39
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.12':
     dependencies:
@@ -25499,7 +25499,7 @@ snapshots:
       estree-walker: 2.0.2
       magic-string: 0.30.12
       postcss: 8.4.47
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.4.31':
     dependencies:
@@ -27306,12 +27306,12 @@ snapshots:
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   css-tree@2.3.1:
     dependencies:
       mdn-data: 2.0.30
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   css-what@6.1.0: {}
 
@@ -31658,7 +31658,7 @@ snapshots:
     dependencies:
       '@babel/parser': 7.24.8
       '@babel/types': 7.24.7
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   make-dir@2.1.0:
     dependencies:
@@ -33827,7 +33827,7 @@ snapshots:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.1.0
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   postcss@8.4.38:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,6 +635,9 @@ importers:
       '@types/js-cookie':
         specifier: ^3.0.6
         version: 3.0.6
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/shell-quote':
         specifier: ^1.7.5
         version: 1.7.5
@@ -1530,6 +1533,9 @@ importers:
       '@scalar/openapi-parser':
         specifier: workspace:*
         version: link:../openapi-parser
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@vitest/coverage-v8':
         specifier: ^1.6.0
         version: 1.6.0(vitest@1.6.0(@types/node@20.14.10)(jsdom@24.1.0)(terser@5.31.1))
@@ -1844,6 +1850,9 @@ importers:
       '@scalar/openapi-parser':
         specifier: workspace:*
         version: link:../openapi-parser
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       rollup:
         specifier: ^4.16.4
         version: 4.18.0
@@ -1924,6 +1933,9 @@ importers:
       '@scalar/openapi-types':
         specifier: workspace:*
         version: link:../openapi-types
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^20.14.10
         version: 20.14.10
@@ -6852,6 +6864,9 @@ packages:
 
   '@types/js-cookie@3.0.6':
     resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
@@ -24716,6 +24731,8 @@ snapshots:
       pretty-format: 29.7.0
 
   '@types/js-cookie@3.0.6': {}
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/jsdom@21.1.7':
     dependencies:


### PR DESCRIPTION
WIP

Looks like switching from `yaml` to `js-yaml` could save 70 kB.