### PR TITLE
fix: sidebar indent lines and stroke thickness

### DIFF
--- a/.changeset/calm-coats-hammer.md
+++ b/.changeset/calm-coats-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sidebar indent lines + icon stroke thickness

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -52,33 +52,33 @@ const themeStyleTag = computed(
 </script>
 <template>
   <!-- Listen for paste and drop events, and look for `url` query parameters to import collections -->
-  <ImportCollectionListener>
-    <div v-html="themeStyleTag"></div>
-    <TopNav :openNewTab="newTab" />
+  <!-- <ImportCollectionListener> -->
+  <div v-html="themeStyleTag"></div>
+  <TopNav :openNewTab="newTab" />
 
-    <!-- Ensure we have the workspace loaded from localStorage above -->
-    <!-- min-h-0 is to allow scrolling of individual flex children -->
-    <main
-      v-if="workspaceStore.activeWorkspace.value?.uid"
-      class="flex min-h-0 flex-1">
-      <SideNav />
+  <!-- Ensure we have the workspace loaded from localStorage above -->
+  <!-- min-h-0 is to allow scrolling of individual flex children -->
+  <main
+    v-if="workspaceStore.activeWorkspace.value?.uid"
+    class="flex min-h-0 flex-1">
+    <SideNav />
 
-      <!-- Popup command palette to add resources from anywhere -->
-      <TheCommandPalette />
+    <!-- Popup command palette to add resources from anywhere -->
+    <TheCommandPalette />
 
-      <div class="flex flex-1 flex-col min-w-0 border-l-1/2 border-t-1/2">
-        <RouterView
-          v-slot="{ Component }"
-          @newTab="handleNewTab">
-          <keep-alive>
-            <component :is="Component" />
-          </keep-alive>
-        </RouterView>
-      </div>
-    </main>
+    <div class="flex flex-1 flex-col min-w-0 border-l-1/2 border-t-1/2">
+      <RouterView
+        v-slot="{ Component }"
+        @newTab="handleNewTab">
+        <keep-alive>
+          <component :is="Component" />
+        </keep-alive>
+      </RouterView>
+    </div>
+  </main>
 
-    <ScalarToasts />
-  </ImportCollectionListener>
+  <ScalarToasts />
+  <!-- </ImportCollectionListener> -->
 </template>
 <style>
 @import '@scalar/components/style.css';

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { TheCommandPalette } from '@/components/CommandPalette'
 // TODO: Disabled until we polished the UI.
-// import { ImportCollectionListener } from '@/components/ImportCollection'
+import { ImportCollectionListener } from '@/components/ImportCollection'
 import SideNav from '@/components/SideNav/SideNav.vue'
 import TopNav from '@/components/TopNav/TopNav.vue'
 import { useDarkModeState } from '@/hooks'
@@ -52,33 +52,33 @@ const themeStyleTag = computed(
 </script>
 <template>
   <!-- Listen for paste and drop events, and look for `url` query parameters to import collections -->
-  <!-- <ImportCollectionListener> -->
-  <div v-html="themeStyleTag"></div>
-  <TopNav :openNewTab="newTab" />
+  <ImportCollectionListener>
+    <div v-html="themeStyleTag"></div>
+    <TopNav :openNewTab="newTab" />
 
-  <!-- Ensure we have the workspace loaded from localStorage above -->
-  <!-- min-h-0 is to allow scrolling of individual flex children -->
-  <main
-    v-if="workspaceStore.activeWorkspace.value?.uid"
-    class="flex min-h-0 flex-1">
-    <SideNav />
+    <!-- Ensure we have the workspace loaded from localStorage above -->
+    <!-- min-h-0 is to allow scrolling of individual flex children -->
+    <main
+      v-if="workspaceStore.activeWorkspace.value?.uid"
+      class="flex min-h-0 flex-1">
+      <SideNav />
 
-    <!-- Popup command palette to add resources from anywhere -->
-    <TheCommandPalette />
+      <!-- Popup command palette to add resources from anywhere -->
+      <TheCommandPalette />
 
-    <div class="flex flex-1 flex-col min-w-0 border-l-1/2 border-t-1/2">
-      <RouterView
-        v-slot="{ Component }"
-        @newTab="handleNewTab">
-        <keep-alive>
-          <component :is="Component" />
-        </keep-alive>
-      </RouterView>
-    </div>
-  </main>
+      <div class="flex flex-1 flex-col min-w-0 border-l-1/2 border-t-1/2">
+        <RouterView
+          v-slot="{ Component }"
+          @newTab="handleNewTab">
+          <keep-alive>
+            <component :is="Component" />
+          </keep-alive>
+        </RouterView>
+      </div>
+    </main>
 
-  <ScalarToasts />
-  <!-- </ImportCollectionListener> -->
+    <ScalarToasts />
+  </ImportCollectionListener>
 </template>
 <style>
 @import '@scalar/components/style.css';

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { TheCommandPalette } from '@/components/CommandPalette'
 // TODO: Disabled until we polished the UI.
-import { ImportCollectionListener } from '@/components/ImportCollection'
+// import { ImportCollectionListener } from '@/components/ImportCollection'
 import SideNav from '@/components/SideNav/SideNav.vue'
 import TopNav from '@/components/TopNav/TopNav.vue'
 import { useDarkModeState } from '@/hooks'

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -111,7 +111,7 @@ onMounted(() => {
               </button>
               <div
                 v-show="showChildren(domain)"
-                class="before:bg-b-3 before:absolute before:left-[calc(1rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
                 <div
                   v-for="(cookieList, path) in paths"
                   :key="path">
@@ -131,7 +131,7 @@ onMounted(() => {
                   </button>
                   <div
                     v-show="showChildren(domain + path)"
-                    class="before:bg-b-3 before:absolute before:left-[calc(1.75rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                    class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1.75rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
                     <SidebarListElement
                       v-for="cookie in cookieList"
                       :key="cookie.uid"

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -117,7 +117,7 @@ onBeforeUnmount(() => {
         class="min-h-11 xl:min-h-header xl:py-2.5 py-1 px-2.5 border-b-1/2" />
     </template>
     <template #content>
-      <div class="search-button-fade sticky px-3 py-2.5 top-0 z-1">
+      <div class="search-button-fade sticky px-3 py-2.5 top-0 z-10">
         <ScalarSearchInput
           ref="searchInputRef"
           v-model="searchText"
@@ -174,10 +174,10 @@ onBeforeUnmount(() => {
                 v-if="collection.info?.title === 'Drafts'"
                 class="text-sidebar-c-2 group-hover:hidden"
                 icon="Scribble"
-                thickness="2.5" />
+                thickness="2.25" />
               <LibraryIcon
                 v-else
-                class="text-sidebar-c-2 size-3.5 stroke-[2.5] group-hover:hidden"
+                class="text-sidebar-c-2 size-3.5 stroke-[2.25] group-hover:hidden"
                 :src="
                   collection['x-scalar-icon'] || 'interface-content-folder'
                 " />
@@ -188,7 +188,8 @@ onBeforeUnmount(() => {
                 <ScalarIcon
                   class="text-c-3 hidden text-sm group-hover:block"
                   icon="ChevronRight"
-                  size="sm" />
+                  size="sm"
+                  thickness="2.5" />
               </div>
             </template>
           </RequestSidebarItem>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -241,7 +241,7 @@ function openCommandPaletteRequest() {
     :class="[
       (isReadOnly && parentUids.length > 1) ||
       (!isReadOnly && parentUids.length)
-        ? 'before:bg-b-3 before:absolute before:left-[calc(.75rem_+_.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 indent-border-line-offset'
+        ? 'before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(.75rem_+_.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 indent-border-line-offset'
         : '',
     ]">
     <Draggable


### PR DESCRIPTION
add back sidebar indent lines + make stroke width of chevrons + icons feel more 1:1

after:
<img width="337" alt="image" src="https://github.com/user-attachments/assets/6245575a-5169-41e7-b81f-ae6a1de3e8a9">

before:
<img width="316" alt="image" src="https://github.com/user-attachments/assets/b2b78707-ca89-4450-b39a-7946bcf3b14a">
