### PR TITLE
feat(api-client): create custom workspace selector

### DIFF
--- a/.changeset/breezy-numbers-jam.md
+++ b/.changeset/breezy-numbers-jam.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+feat(api-client): create custom workspace selector

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
@@ -14,8 +14,8 @@ import { normalize } from '@scalar/openapi-parser'
 import type { OpenAPI } from '@scalar/openapi-types'
 import { computed, watch } from 'vue'
 
-import { WorkspaceDropdown } from '../../views/Request/components'
 import ImportNowButton from './ImportNowButton.vue'
+import WorkspaceSelector from './WorkspaceSelector.vue'
 
 // import OpenAppButton from './OpenAppButton.vue'
 
@@ -133,7 +133,7 @@ watch(
         <!-- Select the workspace -->
         <div class="flex justify-center">
           <div class="inline-block py-1 px-4">
-            <WorkspaceDropdown />
+            <WorkspaceSelector />
           </div>
         </div>
       </div>
@@ -153,8 +153,8 @@ watch(
               Download Scalar App
             </a>
             <br />
-            Offline First - Open Source</span
-          >
+            Offline First - Open Source
+          </span>
         </div>
       </div>
     </div>

--- a/packages/api-client/src/components/ImportCollection/ImportNowButton.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportNowButton.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { isUrl } from '@/components/ImportCollection/utils/isUrl'
 import { useWorkspace } from '@/store'
-import { ScalarButton, ScalarIcon } from '@scalar/components'
+import { ScalarButton } from '@scalar/components'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
 import { useRouter } from 'vue-router'

--- a/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
+++ b/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { useWorkspace } from '@/store'
+import {
+  ScalarButton,
+  ScalarDropdown,
+  ScalarDropdownDivider,
+  ScalarDropdownItem,
+  ScalarIcon,
+  ScalarModal,
+  useModal,
+} from '@scalar/components'
+import { useToasts } from '@scalar/use-toasts'
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const { activeWorkspace, workspaces, workspaceMutators } = useWorkspace()
+const { push } = useRouter()
+
+const modal = useModal()
+const { toast } = useToasts()
+const workspaceName = ref('')
+
+const updateSelected = (uid: string) => {
+  if (uid === activeWorkspace.value.uid) return
+  push(`/workspace/${uid}`)
+}
+
+const handleCreateWorkspace = () => {
+  if (!workspaceName.value.trim()) {
+    toast('Please enter a name before creating a workspace.', 'error')
+    return
+  }
+
+  const workspace = workspaceMutators.add({
+    name: workspaceName.value,
+  })
+  push(`/workspace/${workspace.uid}`)
+
+  toast(`Created new workspace '${workspaceName.value}'`)
+  workspaceName.value = ''
+  modal.hide()
+}
+</script>
+<template>
+  <div class="flex items-center text-sm w-[inherit]">
+    <ScalarDropdown>
+      <ScalarButton
+        class="font-normal h-full justify-start line-clamp-1 py-1.5 px-1.5 text-c-1 hover:bg-b-2 w-fit"
+        fullWidth
+        variant="ghost">
+        <div class="font-medium m-0 text-sm flex gap-1.5 items-center">
+          <h2 class="line-clamp-1 text-left w-[calc(100%-10px)]">
+            {{ activeWorkspace.name }}
+          </h2>
+          <ScalarIcon
+            class="size-3"
+            icon="ChevronDown"
+            thickness="3" />
+        </div>
+      </ScalarButton>
+
+      <!-- Workspace list -->
+      <template #items>
+        <ScalarDropdownItem
+          v-for="(workspace, uid) in workspaces"
+          :key="uid"
+          class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden w-full"
+          @click.stop="updateSelected(uid)">
+          <div
+            class="flex items-center justify-center rounded-full p-[3px] w-4 h-4 group-hover/item:shadow-border"
+            :class="
+              activeWorkspace.uid === uid
+                ? 'bg-blue text-b-1'
+                : 'text-transparent'
+            ">
+            <ScalarIcon
+              class="size-2.5"
+              icon="Checkmark"
+              thickness="3.5" />
+          </div>
+          <span class="text-ellipsis overflow-hidden">{{
+            workspace.name
+          }}</span>
+        </ScalarDropdownItem>
+        <ScalarDropdownDivider />
+
+        <!-- Add new workspace -->
+        <ScalarDropdownItem
+          class="flex items-center gap-1.5"
+          @click="modal.show()">
+          <div class="flex items-center justify-center h-4 w-4">
+            <ScalarIcon
+              class="h-2.5"
+              icon="Add"
+              thickness="3" />
+          </div>
+          <span>New Workspace</span>
+        </ScalarDropdownItem>
+      </template>
+    </ScalarDropdown>
+  </div>
+  <ScalarModal
+    bodyClass="!m-0 !p-1"
+    :size="'xxs'"
+    :state="modal"
+    variant="form">
+    <form
+      class="flex gap-1 rounded"
+      @submit.prevent="handleCreateWorkspace">
+      <input
+        v-model="workspaceName"
+        class="border-none outline-none flex-1 w-full text-sm min-h-8 p-1.5"
+        placeholder="New Workspace"
+        type="text" />
+      <ScalarButton
+        class="max-h-8 text-xs p-0 px-3"
+        :disabled="!workspaceName.trim()"
+        type="submit">
+        Continue
+      </ScalarButton>
+    </form>
+  </ScalarModal>
+</template>

--- a/packages/api-client/src/layouts/App/create-api-client-app.test.ts
+++ b/packages/api-client/src/layouts/App/create-api-client-app.test.ts
@@ -7,12 +7,12 @@ describe('createApiClientApp', () => {
     const element = document.createElement('div')
     expect(element).not.toBeNull()
 
-    expect(element.innerHTML).not.toContain('Search commands')
+    expect(element.innerHTML).not.toContain('request')
 
     createApiClientApp(element, {
       proxyUrl: 'https://proxy.scalar.com',
     })
 
-    expect(element.innerHTML).toContain('Search commands')
+    expect(element.innerHTML).toContain('request')
   })
 })

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.test.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.test.ts
@@ -7,7 +7,7 @@ describe('createApiClientModal', () => {
     const element = document.createElement('div')
     expect(element).not.toBeNull()
 
-    expect(element.innerHTML).not.toContain('Search commands')
+    expect(element.innerHTML).not.toContain('scalar-app')
 
     await createApiClientModal(element, {
       proxyUrl: 'https://proxy.scalar.com',

--- a/packages/api-client/src/layouts/Web/create-api-client-web.test.ts
+++ b/packages/api-client/src/layouts/Web/create-api-client-web.test.ts
@@ -7,12 +7,12 @@ describe('createApiClientWeb', () => {
     const element = document.createElement('div')
     expect(element).not.toBeNull()
 
-    expect(element.innerHTML).not.toContain('Search commands')
+    expect(element.innerHTML).not.toContain('scalar-app')
 
     createApiClientWeb(element, {
       proxyUrl: 'https://proxy.scalar.com',
     })
 
-    expect(element.innerHTML).toContain('Search commands')
+    expect(element.innerHTML).toContain('scalar-app')
   })
 })

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -23,6 +23,7 @@ withDefaults(
     variant?: ModalVariants['variant']
   }>(),
   {
+    alignment: 'top',
     size: 'md',
   },
 )
@@ -30,7 +31,7 @@ withDefaults(
 const modal = cva({
   base: [
     'scalar-modal',
-    'col relative mx-auto mb-0 mt-20 w-[calc(100vw-16px)] rounded-lg bg-b-2 p-0 text-left leading-snug text-c-1 opacity-0 lg:w-[calc(100vw-32px)]',
+    'col relative mx-auto mb-0 w-[calc(100vw-16px)] rounded-lg bg-b-2 p-0 text-left leading-snug text-c-1 opacity-0 lg:w-[calc(100vw-32px)]',
   ].join(' '),
   variants: {
     size: {
@@ -73,8 +74,9 @@ const body = cva({
 })
 </script>
 <script lang="ts">
-export const useModal = () =>
-  reactive({
+/** Hook for creating a reactive modal state */
+export function useModal() {
+  return reactive({
     open: false,
     show() {
       this.open = true
@@ -83,6 +85,7 @@ export const useModal = () =>
       this.open = false
     },
   })
+}
 </script>
 <template>
   <Dialog


### PR DESCRIPTION
Due to some how we have some of our accessibility stuff set up opening the command palette from inside another modal (e.g. the import modal) is difficult™. This creates a small dialog for creating a new workspace from inside the new import modal + some other modal related cleanup.

https://github.com/user-attachments/assets/0d6261a2-c5cc-47ba-80ef-21ddc46bf91f

Also on the todo is an overhaul of all the modals to bring them into alignment soon™ 

