### PR TITLE
fix: broken dependabot config, overlapping directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     # This will disable updates, but still create PRs for security updates.
     open-pull-requests-limit: 0
   - package-ecosystem: npm
-    directory: /
+    directory: /packages/api-client-app
     schedule:
       interval: weekly
     allow:


### PR DESCRIPTION
Dependabot was complaining because the npm configs had overlapping directories. Let’s see if this PR helps.