### PR TITLE
docs(api-reference): promote `url` instead of `content`

### DIFF
--- a/.changeset/big-carpets-agree.md
+++ b/.changeset/big-carpets-agree.md
@@ -1,0 +1,10 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/nestjs-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+chore: make OpenAPI document URLs the default, deprecated `content`

--- a/README.md
+++ b/README.md
@@ -97,10 +97,13 @@ You’re just one HTML file away from having an awesome API reference:
       content="width=device-width, initial-scale=1" />
   </head>
   <body>
-    <!-- Need a Custom Header? Check out this example https://codepen.io/scalarorg/pen/VwOXqam -->
+    <!-- Need a Custom Header? Check out this example: https://codepen.io/scalarorg/pen/VwOXqam -->
+    <!-- Note: We’re using our public proxy to avoid CORS issues. You can remove the `data-proxy-url` attribute if you don’t need it. -->
     <script
       id="api-reference"
-      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"></script>
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
+      data-proxy-url="https://proxy.scalar.com"></script>
+
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   </body>
 </html>

--- a/documentation/integrations/html.md
+++ b/documentation/integrations/html.md
@@ -58,6 +58,47 @@ If you want to fine-tune your API reference and pass a custom configuration, you
 </html>
 ```
 
+## JSON
+
+> Note: While this approach is convenient for quick setup, it may impact performance for large documents. For optimal performance with extensive OpenAPI specifications, consider using a URL to an external OpenAPI document instead.
+
+You can also just directly pass JSON content:
+
+```html
+<script
+  id="api-reference"
+  type="application/json">
+  {
+    "openapi": "3.1.0",
+    "info": {
+      "title": "Hello World",
+      "version": "1.0.0"
+    },
+    "paths": {}
+  }
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+```
+
+## YAML
+
+> Note: While this approach is convenient for quick setup, it may impact performance for large documents. For optimal performance with extensive OpenAPI specifications, consider using a URL to an external OpenAPI document instead.
+
+And if you prefer YAML, you just need to set the `type` attribute to `application/yaml`:
+
+```html
+<script
+  id="api-reference"
+  type="application/yaml">
+  openapi: 3.1.0
+  info:
+    title: Hello World
+    version: 1.0.0
+  paths: {}
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+```
+
 ## Version
 
 It’s recommended to use the latest version from jsdelivr. You’ll get continuous updates, fixes and other improvements and that’s also the one we’re testing and monitoring continuously:

--- a/documentation/integrations/html.md
+++ b/documentation/integrations/html.md
@@ -58,43 +58,6 @@ If you want to fine-tune your API reference and pass a custom configuration, you
 </html>
 ```
 
-## JSON
-
-You can also just directly pass JSON content:
-
-```html
-<script
-  id="api-reference"
-  type="application/json">
-  {
-    "openapi": "3.1.0",
-    "info": {
-      "title": "Hello World",
-      "version": "1.0.0"
-    },
-    "paths": {}
-  }
-</script>
-<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-```
-
-## YAML
-
-And if you prefer YAML, you just need to set the `type` attribute to `application/yaml`:
-
-```html
-<script
-  id="api-reference"
-  type="application/yaml">
-  openapi: 3.1.0
-  info:
-    title: Hello World
-    version: 1.0.0
-  paths: {}
-</script>
-<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-```
-
 ## Version
 
 It’s recommended to use the latest version from jsdelivr. You’ll get continuous updates, fixes and other improvements and that’s also the one we’re testing and monitoring continuously:

--- a/documentation/integrations/nextjs.md
+++ b/documentation/integrations/nextjs.md
@@ -50,7 +50,7 @@ import { ApiReference } from '@scalar/nextjs-api-reference'
 
 const config = {
   spec: {
-    content: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
   },
 }
 

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -42,8 +42,8 @@ import '@scalar/api-reference/style.css'
       content="width=device-width, initial-scale=1" />
   </head>
   <body>
-    <!-- Add your own OpenAPI/Swagger specification URL here: -->
-    <!-- Note: The example is our public proxy (to avoid CORS issues). You can remove the `data-proxy-url` attribute if you don’t need it. -->
+    <!-- Need a Custom Header? Check out this example: https://codepen.io/scalarorg/pen/VwOXqam -->
+    <!-- Note: We’re using our public proxy to avoid CORS issues. You can remove the `data-proxy-url` attribute if you don’t need it. -->
     <script
       id="api-reference"
       data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
@@ -58,6 +58,7 @@ import '@scalar/api-reference/style.css'
       document.getElementById('api-reference').dataset.configuration =
         JSON.stringify(configuration)
     </script>
+
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   </body>
 </html>

--- a/packages/express-api-reference/README.md
+++ b/packages/express-api-reference/README.md
@@ -15,27 +15,9 @@ npm install @scalar/express-api-reference
 
 ## Usage
 
-[Set up Express](https://expressjs.com/en/starter/hello-world.html) and pass an OpenAPI/Swagger spec to the `apiReference` middleware:
+[Set up Express](https://expressjs.com/en/starter/hello-world.html) and pass an URL to an OpenAPI/Swagger document to the `apiReference` middleware:
 
 > Wait, but how do we get the OpenApiSpecification? 🤔 There are multiple ways to generate an OpenAPI/Swagger file for Express. The most popular way is to use [`swagger-jsdoc`](https://github.com/Surnet/swagger-jsdoc).
-
-```ts
-import { apiReference } from '@scalar/express-api-reference'
-
-const OpenApiSpecification =
-  /* … */
-
-  app.use(
-    '/reference',
-    apiReference({
-      spec: {
-        content: OpenApiSpecification,
-      },
-    }),
-  )
-```
-
-If you’re serving an OpenAPI/Swagger file already, you can pass an URL, too:
 
 ```ts
 import { apiReference } from '@scalar/express-api-reference'
@@ -44,6 +26,7 @@ app.use(
   '/reference',
   apiReference({
     spec: {
+      // Put your OpenAPI url here:
       url: '/openapi.json',
     },
   }),
@@ -64,7 +47,7 @@ app.use(
   apiReference({
     theme: 'purple',
     spec: {
-      content: OpenApiSpecification,
+      url: '/openapi.json',
     },
   }),
 )
@@ -82,7 +65,7 @@ app.use(
   apiReference({
     cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
     spec: {
-      content: OpenApiSpecification,
+      url: '/openapi.json',
     },
   }),
 )

--- a/packages/fastify-api-reference/README.md
+++ b/packages/fastify-api-reference/README.md
@@ -40,37 +40,11 @@ fastify.register(require('@scalar/fastify-api-reference'), {
 })
 ```
 
-With [@fastify/swagger](https://github.com/fastify/fastify-swagger) you can even generate your OpenAPI documents from the registered routes and directly pass it to the plugin:
+With [@fastify/swagger], we’re picking it up automatically, so this would be enough:
 
 ```ts
 await fastify.register(require('@scalar/fastify-api-reference'), {
   routePrefix: '/reference',
-  configuration: {
-    spec: {
-      content: () => fastify.swagger(),
-    },
-  },
-})
-```
-
-Actually, we’re picking it up automatically, so this would be enough:
-
-```ts
-await fastify.register(require('@scalar/fastify-api-reference'), {
-  routePrefix: '/reference',
-})
-```
-
-Or, if you just have a static OpenAPI spec, you can directly pass it, too:
-
-```ts
-await fastify.register(require('@scalar/fastify-api-reference'), {
-  routePrefix: '/reference',
-  configuration: {
-    spec: {
-      content: { … }
-    },
-  },
 })
 ```
 

--- a/packages/hono-api-reference/README.md
+++ b/packages/hono-api-reference/README.md
@@ -86,7 +86,7 @@ app.use(
   apiReference({
     cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
     spec: {
-      content: OpenApiSpecification,
+      url: '/openapi.json',
     },
   }),
 )

--- a/packages/nestjs-api-reference/README.md
+++ b/packages/nestjs-api-reference/README.md
@@ -47,7 +47,7 @@ const OpenApiSpecification =
   )
 ```
 
-If you’re serving an OpenAPI/Swagger file already, you can pass an URL, too:
+Recommended: If you’re serving an OpenAPI/Swagger file already, you can pass an URL, too:
 
 ```ts
 import { apiReference } from '@scalar/nestjs-api-reference'
@@ -76,7 +76,7 @@ app.use(
   apiReference({
     theme: 'purple',
     spec: {
-      content: OpenApiSpecification,
+      url: '/openapi.json',
     },
   }),
 )

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -364,11 +364,17 @@ export type RequestBody = {
   content?: RequestBodyMimeTypes
 }
 
-/** For providing a OAS spec object or url to be fetched */
+/** The OpenAPI Document we’ll render */
 export type SpecConfiguration = {
-  /** URL to a Swagger/OpenAPI file */
+  /**
+   * URL to an OpenAPI/Swagger document
+   */
   url?: string
-  /** Swagger/Open API spec */
+  /**
+   * Directly embed the OpenAPI document in the HTML.
+   *
+   * @deprecated It’s recommended to pass an `url` instead of `content`.
+   */
   content?: string | Record<string, any> | (() => Record<string, any>)
 }
 

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -373,7 +373,7 @@ export type SpecConfiguration = {
   /**
    * Directly embed the OpenAPI document in the HTML.
    *
-   * @deprecated It’s recommended to pass an `url` instead of `content`.
+   * @remark It’s recommended to pass an `url` instead of `content`.
    */
   content?: string | Record<string, any> | (() => Record<string, any>)
 }


### PR DESCRIPTION
`url` has better performance for larger documents, can be cached by the browser, and it’s easier to import documents to let’s say <https://client.scalar.com>.

I’ve gone through all the READMEs and made sure we’re promoting `url` instead of `content` (embedded OpenAPI documents).

~~This also marks `content` as `@deprecated`. Let me know how you feel about this, but I think we should really go all-in on the URL.~~ Just adds a `@remark`.