### PR TITLE
docs: add  `Scalar for Laravel` to the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ And there’s an ever-growing list of plugins and integrations:
 - [Fastify](packages/fastify-api-reference/README.md)
 - [Go](documentation/integrations/go.md)
 - [Hono](packages/hono-api-reference/README.md)
+- [Scalar for Laravel](https://github.com/scalar/laravel)
 - [Laravel Scribe](documentation/integrations/laravel-scribe.md)
 - [Litestar](https://docs.litestar.dev/latest/usage/openapi/ui_plugins.html)
 - [NestJS](packages/nestjs-api-reference/README.md)

--- a/documentation/integrations/laravel-scribe.md
+++ b/documentation/integrations/laravel-scribe.md
@@ -2,6 +2,8 @@
 
 Laravel Scribe is an amazing package to generate OpenAPI files from your existing code base. Clumsy annotations aren’t required, the package will just analyze your code.
 
+> Note: There’s also [Scalar for Laravel](https://github.com/scalar/laravel), which doesn’t come with OpenAPI generation, but renders existing OpenAPI documents.
+
 ## Create a new Laravel project (optional)
 
 If you’re starting fresh, download the Laravel installer with composer:


### PR DESCRIPTION
As composer (PHP package manager) doesn’t support monorepos, our Laravel package (secretly launched) has to live in its own repository. This PR makes sure it’s mentioned in the appropriate places.