### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/.changeset/loud-deers-double.md
+++ b/.changeset/loud-deers-double.md
@@ -1,0 +1,7 @@
+---
+'@scalar/hono-api-reference': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+chore: remove unused dependencies

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -180,7 +180,6 @@
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
-    "@types/content-type": "^1.1.8",
     "@types/js-cookie": "^3.0.6",
     "@types/shell-quote": "^1.7.5",
     "@types/whatwg-mimetype": "^3.0.2",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -75,15 +75,12 @@
     "@scalar/types": "workspace:*",
     "@scalar/use-toasts": "workspace:*",
     "@scalar/use-tooltip": "workspace:*",
-    "@unhead/schema": "^1.9.5",
     "@unhead/vue": "^1.9.13",
     "@vueuse/core": "^10.10.0",
     "fuse.js": "^7.0.0",
     "github-slugger": "^2.0.0",
     "httpsnippet-lite": "^3.0.5",
     "nanoid": "^5.0.7",
-    "unhead": "^1.8.3",
-    "unified": "^11.0.4",
     "vue": "^3.5.12"
   },
   "devDependencies": {

--- a/packages/api-reference/playground/examples/src/App.vue
+++ b/packages/api-reference/playground/examples/src/App.vue
@@ -38,7 +38,7 @@ onMounted(async () => {
 const configuration = reactive<ReferenceConfiguration>({
   proxy: 'https://proxy.scalar.com',
   spec: {
-    url: url.value,
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
   },
 })
 

--- a/packages/api-reference/playground/examples/src/App.vue
+++ b/packages/api-reference/playground/examples/src/App.vue
@@ -38,7 +38,7 @@ onMounted(async () => {
 const configuration = reactive<ReferenceConfiguration>({
   proxy: 'https://proxy.scalar.com',
   spec: {
-    url,
+    url: url.value,
   },
 })
 

--- a/packages/api-reference/playground/examples/src/App.vue
+++ b/packages/api-reference/playground/examples/src/App.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import '@scalar/api-reference/style.css'
 import { onMounted, reactive, ref } from 'vue'
 
 import { ApiReference, type ReferenceConfiguration } from '../../../src'

--- a/packages/hono-api-reference/package.json
+++ b/packages/hono-api-reference/package.json
@@ -47,7 +47,6 @@
     "@hono/zod-openapi": "^0.8.6",
     "@scalar/build-tooling": "workspace:*",
     "hono": "^4.6.5",
-    "tsup": "^7.2.0",
     "vite": "^5.2.10",
     "vitest": "^1.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,9 +851,6 @@ importers:
       '@scalar/use-tooltip':
         specifier: workspace:*
         version: link:../use-tooltip
-      '@unhead/schema':
-        specifier: ^1.9.5
-        version: 1.9.13
       '@unhead/vue':
         specifier: ^1.9.13
         version: 1.9.13(vue@3.5.12(typescript@5.6.2))
@@ -872,12 +869,6 @@ importers:
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7
-      unhead:
-        specifier: ^1.8.3
-        version: 1.9.13
-      unified:
-        specifier: ^11.0.4
-        version: 11.0.4
       vue:
         specifier: ^3.5.12
         version: 3.5.12(typescript@5.6.2)
@@ -1603,9 +1594,6 @@ importers:
       hono:
         specifier: ^4.6.5
         version: 4.6.5
-      tsup:
-        specifier: ^7.2.0
-        version: 7.3.0(@swc/core@1.5.29)(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2))(typescript@5.6.2)
       vite:
         specifier: ^5.2.10
         version: 5.3.3(@types/node@20.14.10)(terser@5.31.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -629,9 +629,6 @@ importers:
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
-      '@types/content-type':
-        specifier: ^1.1.8
-        version: 1.1.8
       '@types/js-cookie':
         specifier: ^3.0.6
         version: 3.0.6
@@ -6732,9 +6729,6 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
-
-  '@types/content-type@1.1.8':
-    resolution: {integrity: sha512-1tBhmVUeso3+ahfyaKluXe38p+94lovUZdoVfQ3OnJo9uJC42JT7CBoN3k9HYhAae+GwiBYmHu+N9FZhOG+2Pg==}
 
   '@types/cookie-parser@1.4.7':
     resolution: {integrity: sha512-Fvuyi354Z+uayxzIGCwYTayFKocfV7TuDYZClCdIP9ckhvAu/ixDtCB6qx2TT0FKjPLf1f3P/J1rgf6lPs64mw==}
@@ -24589,8 +24583,6 @@ snapshots:
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 20.14.10
-
-  '@types/content-type@1.1.8': {}
 
   '@types/cookie-parser@1.4.7':
     dependencies:


### PR DESCRIPTION
This PR removes some unused dependencies I’ve found in `@scalar/api-reference` and `@scalar/api-client`.