### PR TITLE
feat(api-reference): add integration identifiers

### DIFF
--- a/.changeset/itchy-bobcats-look.md
+++ b/.changeset/itchy-bobcats-look.md
@@ -1,0 +1,16 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/nestjs-api-reference': patch
+'@scalar/nextjs-api-reference': patch
+'@scalar/api-reference-react': patch
+'@scalar/hono-api-reference': patch
+'@scalar/aspnetcore': patch
+'@scalar/api-reference': patch
+'@scalar/docusaurus': patch
+'@scalar/galaxy': patch
+'@scalar/types': patch
+'@scalar/nuxt': patch
+---
+
+feat: add framework identifier for debugging purposes

--- a/packages/api-reference-react/src/ApiReferenceReact.tsx
+++ b/packages/api-reference-react/src/ApiReferenceReact.tsx
@@ -13,7 +13,7 @@ globalThis.__VUE_PROD_HYDRATION_MISMATCH_DETAILS__ = true
 globalThis.__VUE_PROD_DEVTOOLS__ = false
 
 /**
- * React wrapper around Api Reference
+ * React wrapper around the Scalar API Reference
  */
 export const ApiReferenceReact = (props: ReferenceProps) => {
   const el = useRef<HTMLDivElement | null>(null)
@@ -25,10 +25,13 @@ export const ApiReferenceReact = (props: ReferenceProps) => {
   useEffect(() => {
     if (!el.current) return reference?.unmount
 
-    const instance = createScalarReferences(
-      el.current,
-      props.configuration ?? {},
-    )
+    const defaultConfig = {
+      _integration: 'react',
+    } as const
+
+    const mergedConfig = { ...defaultConfig, ...props.configuration }
+
+    const instance = createScalarReferences(el.current, mergedConfig)
     setReference(instance)
 
     // Unmount on cleanup
@@ -36,8 +39,11 @@ export const ApiReferenceReact = (props: ReferenceProps) => {
   }, [el])
 
   useEffect(() => {
+    const defaultConfig = { _integration: 'react' } as const
+    const mergedConfig = { ...defaultConfig, ...props.configuration }
+
     reference?.updateConfig(
-      props.configuration ?? {},
+      mergedConfig,
       /** For React we will just replace the config if it changes */
       false,
     )

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -27,6 +27,7 @@ import {
   GLOBAL_SECURITY_SYMBOL,
   HIDE_DOWNLOAD_BUTTON_SYMBOL,
   HIDE_TEST_REQUEST_BUTTON_SYMBOL,
+  INTEGRATION_SYMBOL,
   OPENAPI_DOCUMENT_URL_SYMBOL,
   downloadSpecBus,
   downloadSpecFile,
@@ -249,6 +250,11 @@ provide(
   () => props.configuration.hideTestRequestButton,
 )
 provide(OPENAPI_DOCUMENT_URL_SYMBOL, () => props.configuration.spec?.url)
+provide(INTEGRATION_SYMBOL, () =>
+  props.configuration._integration !== null
+    ? props.configuration._integration
+    : 'vue',
+)
 
 hideModels.value = props.configuration.hideModels ?? false
 defaultOpenAllTags.value = props.configuration.defaultOpenAllTags ?? false

--- a/packages/api-reference/src/helpers/provideSymbols.ts
+++ b/packages/api-reference/src/helpers/provideSymbols.ts
@@ -1,3 +1,4 @@
+import type { ReferenceConfiguration } from '@/types'
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { InjectionKey } from 'vue'
 
@@ -21,4 +22,8 @@ export const HIDE_TEST_REQUEST_BUTTON_SYMBOL = Symbol() as InjectionKey<
 
 export const OPENAPI_DOCUMENT_URL_SYMBOL = Symbol() as InjectionKey<
   () => string | undefined
+>
+
+export const INTEGRATION_SYMBOL = Symbol() as InjectionKey<
+  () => ReferenceConfiguration['_integration']
 >

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -23,11 +23,14 @@ const getConfiguration = (): ReferenceConfiguration => {
       configurationScriptElement.getAttribute('data-configuration')
 
     if (configurationFromElement) {
-      return JSON.parse(configurationFromElement.split('&quot;').join('"'))
+      return {
+        _integration: 'html',
+        ...JSON.parse(configurationFromElement.split('&quot;').join('"')),
+      }
     }
   }
 
-  return {}
+  return { _integration: 'html' }
 }
 
 const getSpecUrl = () => {
@@ -116,6 +119,7 @@ if (!specUrlElement && !specElement && !getSpecScriptTag()) {
 
   Object.assign(props, {
     configuration: {
+      _integration: 'html',
       ...getConfiguration(),
       spec: { ...specOrSpecUrl },
       proxy: getProxyUrl(),

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -14,6 +14,10 @@ export type ScalarOptions = {
  */
 const createDefaultScalarOptions = (options: ScalarOptions): ScalarOptions => ({
   showNavLink: true,
+  configuration: {
+    _integration: 'docusaurus',
+    ...(options.configuration ?? {}),
+  },
   ...options,
 })
 

--- a/packages/express-api-reference/src/expressApiReference.ts
+++ b/packages/express-api-reference/src/expressApiReference.ts
@@ -107,21 +107,28 @@ export const customThemeCSS = `
 /**
  * The HTML to load the @scalar/api-reference package.
  */
-export const ApiReference = (options: ApiReferenceOptions) => {
+export const ApiReference = (configuration: ApiReferenceOptions) => {
+  const defaultConfiguration: Partial<ReferenceConfiguration> = {
+    _integration: 'express',
+  }
+
   return `
     <script
       id="api-reference"
       type="application/json"
-      data-configuration="${JSON.stringify(options)
+      data-configuration="${JSON.stringify({
+        ...defaultConfiguration,
+        ...configuration,
+      })
         .split('"')
         .join('&quot;')}">${
-        options.spec?.content
-          ? typeof options.spec?.content === 'function'
-            ? JSON.stringify(options.spec?.content())
-            : JSON.stringify(options.spec?.content)
+        configuration.spec?.content
+          ? typeof configuration.spec?.content === 'function'
+            ? JSON.stringify(configuration.spec?.content())
+            : JSON.stringify(configuration.spec?.content)
           : ''
       }</script>
-      <script src="${options.cdn || 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'}"></script>
+      <script src="${configuration.cdn || 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'}"></script>
   `
 }
 

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -173,6 +173,12 @@ const fastifyApiReference = fp<
   async (fastify, options) => {
     let { configuration } = options
 
+    // Add _integration: 'fastify' to the configuration
+    configuration = {
+      _integration: 'fastify',
+      ...configuration,
+    }
+
     const specSource = (() => {
       const { content, url } = configuration?.spec ?? {}
       if (content)
@@ -319,6 +325,7 @@ const fastifyApiReference = fp<
          */
         if (specSource.type !== 'url') {
           configuration = {
+            _integration: 'fastify',
             ...configuration,
             spec: {
               // Use a relative URL in case we're proxied
@@ -330,6 +337,7 @@ const fastifyApiReference = fp<
         // Add the default CSS
         if (!configuration?.customCss && !configuration?.theme) {
           configuration = {
+            _integration: 'fastify',
             ...configuration,
             customCss: defaultCss,
           }

--- a/packages/hono-api-reference/src/honoApiReference.ts
+++ b/packages/hono-api-reference/src/honoApiReference.ts
@@ -116,11 +116,18 @@ export const customThemeCSS = `
  * The HTML to load the @scalar/api-reference JavaScript package.
  */
 export const javascript = (configuration: ApiReferenceOptions) => {
+  const defaultConfiguration: Partial<ReferenceConfiguration> = {
+    _integration: 'hono',
+  }
+
   return html`
     <script
       id="api-reference"
       type="application/json"
-      data-configuration="${JSON.stringify(configuration)
+      data-configuration="${JSON.stringify({
+        ...defaultConfiguration,
+        ...configuration,
+      })
         .split('"')
         .join('&quot;')}">
       ${raw(

--- a/packages/nestjs-api-reference/src/nestJSApiReference.ts
+++ b/packages/nestjs-api-reference/src/nestJSApiReference.ts
@@ -88,20 +88,25 @@ export const customThemeCSS = `
  * The HTML to load the @scalar/api-reference package.
  */
 export const ApiReference = (options: ApiReferenceOptions) => {
+  const configuration = {
+    _integration: 'nestjs',
+    ...options,
+  }
+
   return `
     <script
       id="api-reference"
       type="application/json"
-      data-configuration="${JSON.stringify(options)
+      data-configuration="${JSON.stringify(configuration)
         .split('"')
         .join('&quot;')}">${
-        options.spec?.content
-          ? typeof options.spec?.content === 'function'
-            ? JSON.stringify(options.spec?.content())
-            : JSON.stringify(options.spec?.content)
+        configuration.spec?.content
+          ? typeof configuration.spec?.content === 'function'
+            ? JSON.stringify(configuration.spec?.content())
+            : JSON.stringify(configuration.spec?.content)
           : ''
       }</script>
-    <script src="${options.cdn || 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'}"></script>
+    <script src="${configuration.cdn || 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'}"></script>
   `
 }
 

--- a/packages/nextjs-api-reference/src/ApiReference.ts
+++ b/packages/nextjs-api-reference/src/ApiReference.ts
@@ -1,4 +1,5 @@
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
+import type { defaultConfig } from 'next/dist/server/config-shared'
 
 import { nextjsThemeCss } from './theme'
 
@@ -49,8 +50,16 @@ export const ApiReference = (config: ApiReferenceOptions) => {
     ? config.cdn
     : 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest'
 
+  // Add _integration: 'nextjs' to the configuration, but allow user to overwrite.
+  const defaultConfiguration = {
+    _integration: 'nextjs',
+  }
+
   // Convert the configuration to a string
-  const configString = JSON.stringify(config ?? {})
+  const configString = JSON.stringify({
+    ...defaultConfiguration,
+    ...(config ?? {}),
+  })
     .split('"')
     .join('&quot;')
 

--- a/packages/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/packages/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -1,6 +1,10 @@
 <script lang="ts" setup>
 import { useHead, useRequestURL, useSeoMeta } from '#imports'
-import { ModernLayout, parse } from '@scalar/api-reference'
+import {
+  ModernLayout,
+  type ReferenceConfiguration,
+  parse,
+} from '@scalar/api-reference'
 import { reactive, ref, toRaw } from 'vue'
 import type { Configuration } from '~/src/types'
 
@@ -35,9 +39,14 @@ useHead({
 
 // Add baseServerURL and _integration
 const { origin } = useRequestURL()
-const config = {
+
+const config: Partial<
+  Omit<ReferenceConfiguration, 'theme'> & {
+    theme?: ReferenceConfiguration['theme'] | 'nuxt'
+  }
+> = {
   baseServerURL: origin,
-  _integration: 'nuxtjs',
+  _integration: 'nuxt',
   ...props.configuration,
 }
 </script>

--- a/packages/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/packages/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -33,10 +33,11 @@ useHead({
   },
 })
 
-// Add baseServerURL
+// Add baseServerURL and _integration
 const { origin } = useRequestURL()
 const config = {
   baseServerURL: origin,
+  _integration: 'nuxtjs',
   ...props.configuration,
 }
 </script>

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -50,7 +50,11 @@ public static class ScalarEndpointRouteBuilderExtensions
         var fileProvider = new EmbeddedFileProvider(typeof(ScalarEndpointRouteBuilderExtensions).Assembly, StaticAssets);
         var fileExtensionContentTypeProvider = new FileExtensionContentTypeProvider();
 
-        var configuration = JsonSerializer.Serialize(options.ToScalarConfiguration(), ScalaConfigurationSerializerContext.Default.ScalarConfiguration);
+        var scalarConfiguration = options.ToScalarConfiguration();
+
+        scalarConfiguration._integration = "dotnet";
+
+        var configuration = JsonSerializer.Serialize(scalarConfiguration, ScalaConfigurationSerializerContext.Default.ScalarConfiguration);
 
         return endpoints.MapGet(options.EndpointPathPrefix, (string documentName) =>
             {

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -50,11 +50,7 @@ public static class ScalarEndpointRouteBuilderExtensions
         var fileProvider = new EmbeddedFileProvider(typeof(ScalarEndpointRouteBuilderExtensions).Assembly, StaticAssets);
         var fileExtensionContentTypeProvider = new FileExtensionContentTypeProvider();
 
-        var scalarConfiguration = options.ToScalarConfiguration();
-
-        scalarConfiguration._integration = "dotnet";
-
-        var configuration = JsonSerializer.Serialize(scalarConfiguration, ScalaConfigurationSerializerContext.Default.ScalarConfiguration);
+        var configuration = JsonSerializer.Serialize(options.ToScalarConfiguration(), ScalaConfigurationSerializerContext.Default.ScalarConfiguration);
 
         return endpoints.MapGet(options.EndpointPathPrefix, (string documentName) =>
             {

--- a/packages/scalar_fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/packages/scalar_fastapi/scalar_fastapi/scalar_fastapi.py
@@ -272,6 +272,15 @@ def get_scalar_api_reference(
             """
         ),
     ] = False,
+    integration: Annotated[
+        str | None,
+        Doc(
+            """
+            The integration type. Default is 'fastapi'.
+            Set to None or a different value to override.
+            """
+        ),
+    ] = 'fastapi',
 ) -> HTMLResponse:
     html = f"""
     <!DOCTYPE html>
@@ -311,6 +320,7 @@ def get_scalar_api_reference(
         hiddenClients: {json.dumps(hidden_clients)},
         servers: {json.dumps(servers)},
         defaultOpenAllTags: {json.dumps(default_open_all_tags)},
+        _integration: {json.dumps(integration)},
       }}
 
       document.getElementById('api-reference').dataset.configuration =

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -215,12 +215,12 @@ export type ReferenceConfiguration = {
    *
    * Each supported integration has a unique identifier (e.g., 'express', 'nextjs', 'vue').
    *
-   * To explicitly disable this feature, you can pass `undefined`.
+   * To explicitly disable this feature, you can pass `null`.
    *
    * @private
-   * @type {string | undefined}
    */
   _integration?:
+    | null
     | 'adonisjs'
     | 'docusaurus'
     | 'dotnet'

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -226,7 +226,7 @@ export type ReferenceConfiguration = {
     | 'dotnet' // ✅
     | 'elysiajs'
     | 'express' // ✅
-    | 'fastapi'
+    | 'fastapi' // ✅
     | 'fastify' // ✅
     | 'go'
     | 'hono' // ✅

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -222,25 +222,25 @@ export type ReferenceConfiguration = {
   _integration?:
     | null
     | 'adonisjs'
-    | 'docusaurus'
-    | 'dotnet'
+    | 'docusaurus' // ✅
+    | 'dotnet' // ✅
     | 'elysiajs'
-    | 'express'
+    | 'express' // ✅
     | 'fastapi'
-    | 'fastify'
+    | 'fastify' // ✅
     | 'go'
-    | 'hono'
-    | 'html'
+    | 'hono' // ✅
+    | 'html' // ✅
     | 'laravel'
     | 'litestar'
-    | 'nestjs'
-    | 'nextjs'
+    | 'nestjs' // ✅
+    | 'nextjs' // ✅
     | 'nitro'
-    | 'nuxt'
+    | 'nuxt' // ✅
     | 'platformatic'
-    | 'react'
+    | 'react' // ✅
     | 'rust'
-    | 'vue'
+    | 'vue' // ✅
 }
 
 export type Server = OpenAPIV3.ServerObject | OpenAPIV3_1.ServerObject

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -223,7 +223,7 @@ export type ReferenceConfiguration = {
     | null
     | 'adonisjs'
     | 'docusaurus' // ✅
-    | 'dotnet' // ✅
+    | 'dotnet'
     | 'elysiajs'
     | 'express' // ✅
     | 'fastapi' // ✅

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -206,6 +206,41 @@ export type ReferenceConfiguration = {
     | 'alpha'
     | 'method'
     | ((a: TransformedOperation, b: TransformedOperation) => number)
+  /**
+   * Specifies the integration being used. This is primarily for internal purposes and should not be manually set.
+   *
+   * It’s used to:
+   * 1. Display debug information in the console.
+   * 2. Show a custom logo when importing OpenAPI documents in the Scalar App.
+   *
+   * Each supported integration has a unique identifier (e.g., 'express', 'nextjs', 'vue').
+   *
+   * To explicitly disable this feature, you can pass `undefined`.
+   *
+   * @private
+   * @type {string | undefined}
+   */
+  _integration?:
+    | 'adonisjs'
+    | 'docusaurus'
+    | 'dotnet'
+    | 'elysiajs'
+    | 'express'
+    | 'fastapi'
+    | 'fastify'
+    | 'go'
+    | 'hono'
+    | 'html'
+    | 'laravel'
+    | 'litestar'
+    | 'nestjs'
+    | 'nextjs'
+    | 'nitro'
+    | 'nuxt'
+    | 'platformatic'
+    | 'react'
+    | 'rust'
+    | 'vue'
 }
 
 export type Server = OpenAPIV3.ServerObject | OpenAPIV3_1.ServerObject


### PR DESCRIPTION
This PR adds an `_integration` identifier to the API reference configuration. All our official integration pass a string (for example `'nextjs'`) to `@scalar/api-reference` now.

This gives us the opportunity to make framework-specific optimisations or add some helpful debug information in the future.