### PR TITLE
fix: ui tweaks and fixes

### DIFF
--- a/.changeset/brown-birds-join.md
+++ b/.changeset/brown-birds-join.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: ui tweaks and fixes

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -233,6 +233,9 @@ export default {
   padding: 0;
   background: transparent;
 }
+:deep(.cm-placeholder) {
+  color: var(--scalar-color-3);
+}
 :deep(.cm-content) {
   font-family: var(--scalar-font-code);
   font-size: var(--scalar-small);

--- a/packages/api-client/src/components/ContextBar.vue
+++ b/packages/api-client/src/components/ContextBar.vue
@@ -28,7 +28,7 @@ defineEmits<{
       </button>
       <div
         class="flex items-center group-hover:text-c-1 absolute -right-6 top-1/2 -translate-y-1/2">
-        <span class="mr-4 group-hover:hidden">{{ activeSection }}</span>
+        <span class="mr-1.5 group-hover:hidden">{{ activeSection }}</span>
         <ScalarIcon
           icon="FilterList"
           size="md"

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -37,11 +37,11 @@ const envs = computed(() => [
   <div>
     <ScalarDropdown>
       <ScalarButton
-        class="font-normal h-auto justify-start py-1.5 px-1.5 text-c-1 hover:bg-b-2 text-c-2 w-fit"
+        class="font-normal h-auto justify-start py-1.5 px-1.5 pl-2 text-c-1 hover:bg-b-2 text-c-3 w-fit"
         fullWidth
         variant="ghost">
         <h2
-          class="font-medium m-0 text-sm flex gap-1.5 items-center whitespace-nowrap">
+          class="font-medium m-0 text-xs flex gap-1.5 items-center whitespace-nowrap">
           {{ activeEnvironment?.name ?? 'No Environment' }}
           <ScalarIcon
             class="size-3"

--- a/packages/api-client/src/components/SideNav/SideHelp.vue
+++ b/packages/api-client/src/components/SideNav/SideHelp.vue
@@ -10,7 +10,7 @@ import {
     class="max-w-[150px]"
     :placement="'top-end'">
     <button
-      class="min-w-[37px] max-w-[37px] hover:bg-b-2 flex items-center justify-center rounded-lg p-[7px] text-c-3 focus:text-c-1 scalar-app-nav-padding"
+      class="min-w-[37px] max-w-[37px] hover:bg-b-2 flex items-center justify-center rounded-lg p-[8px] text-c-3 focus:text-c-1 scalar-app-nav-padding"
       type="button">
       <ScalarIcon
         icon="Help"

--- a/packages/api-client/src/components/SideNav/SideNavLink.vue
+++ b/packages/api-client/src/components/SideNav/SideNavLink.vue
@@ -19,7 +19,7 @@ const { activeWorkspace } = useWorkspace()
     class="flex flex-col items-center gap-1 group no-underline"
     :to="`/workspace/${activeWorkspace.uid}/${name}`">
     <div
-      class="min-w-[37px] max-w-[37px] group-hover:bg-b-2 active:text-c-1 flex items-center justify-center rounded-lg p-[7px] scalar-app-nav-padding text-c-3"
+      class="min-w-[37px] max-w-[37px] group-hover:bg-b-2 active:text-c-1 flex items-center justify-center rounded-lg p-[8px] scalar-app-nav-padding text-c-3"
       :class="{
         'bg-b-2 transition-none group-hover:cursor-auto !text-c-1': active,
       }">

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -87,7 +87,7 @@ const startDrag = (event: MouseEvent) => {
     </div>
     <div
       v-if="!isMobile"
-      class="relative z-10 pt-0 md:px-2.5 md:pb-2.5 -translate-y-full w-[inherit] has-[.empty-sidebar-item]:border-t-1/2">
+      class="relative z-10 pt-0 md:px-2.5 md:pb-2.5 sticky bottom-0 w-[inherit] has-[.empty-sidebar-item]:border-t-1/2">
       <slot name="button" />
     </div>
     <div
@@ -98,15 +98,15 @@ const startDrag = (event: MouseEvent) => {
 </template>
 <style scoped>
 .sidebar-height {
-  min-height: calc(100% - 50px);
+  min-height: 100%;
 }
 @screen md {
   .sidebar-mask {
     mask-image: linear-gradient(
       0,
       transparent 0,
-      transparent 40px,
-      var(--scalar-background-2) 60px
+      transparent 0,
+      var(--scalar-background-2) 30px
     );
   }
 }

--- a/packages/api-client/src/components/Sidebar/SidebarList.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="flex flex-col p-2">
+  <ul class="flex flex-col p-2 pb-[75px]">
     <slot />
   </ul>
 </template>

--- a/packages/api-client/src/components/Sidebar/SidebarToggle.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarToggle.vue
@@ -9,7 +9,7 @@ defineEmits<{
 </script>
 <template>
   <button
-    class="text-c-3 hover:bg-b-2 active:text-c-1 p-2 rounded"
+    class="text-c-1 hover:bg-b-2 active:text-c-1 p-2 rounded"
     type="button"
     @click="$emit('update:modelValue', !modelValue)">
     <svg

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -221,11 +221,6 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
 </template>
 <style scoped>
 .t-app__top-nav {
-  background-color: color-mix(
-    in sRGB,
-    var(--scalar-background-1) 50%,
-    transparent
-  );
   padding-left: 52px;
   padding-right: 4px;
   position: relative;

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -95,6 +95,6 @@ const themeStyleTag = computed(
   background-color: var(--scalar-background-2);
 }
 .dark-mode #scalar-client {
-  background-color: color-mix(in srgb, var(--scalar-background-1) 30%, black);
+  background-color: color-mix(in srgb, var(--scalar-background-1) 60%, black);
 }
 </style>

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -52,7 +52,7 @@ const activeHistoryEntry = computed(() =>
 )
 
 /** Show / hide the sidebar when we resize the screen */
-const isNarrow = useMediaQuery('(max-width: 780px)')
+const isNarrow = useMediaQuery('(max-width: 800px)')
 watch(isNarrow, (narrow) => (showSideBar.value = !narrow))
 
 /**
@@ -199,7 +199,7 @@ function handleCurlImport(curl: string) {
   );
   box-shadow: 0 0 0 1px var(--scalar-border-color);
 }
-@media screen and (max-width: 780px) {
+@media screen and (max-width: 800px) {
   .sidebar-active-hide-layout {
     display: none;
   }

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -63,13 +63,7 @@ const updateRequestNameHandler = (event: Event) => {
 <template>
   <ViewLayoutSection>
     <template #title>
-      <ScalarIcon
-        class="text-c-3 mr-2 pointer-events-none"
-        icon="ExternalLink"
-        size="sm"
-        thickness="2.5" />
       <div class="flex-1 flex gap-1 items-center lg:pr-24 pointer-events-none">
-        Request
         <label
           v-if="!isReadOnly"
           class="absolute w-full h-full top-0 left-0 pointer-events-auto opacity-0 cursor-text"
@@ -77,13 +71,13 @@ const updateRequestNameHandler = (event: Event) => {
         <input
           v-if="!isReadOnly"
           id="requestname"
-          class="outline-none border-0 text-c-2 rounded pointer-events-auto relative w-full"
+          class="outline-none border-0 text-c-1 rounded pointer-events-auto relative w-full"
           placeholder="Request Name"
           :value="activeRequest?.summary"
           @input="updateRequestNameHandler" />
         <span
           v-else
-          class="text-c-2">
+          class="text-c-1">
           {{ activeRequest?.summary }}
         </span>
       </div>

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -113,8 +113,6 @@ onBeforeUnmount(() => {
     <template
       v-if="!isReadonly"
       #header>
-      <WorkspaceDropdown
-        class="min-h-11 xl:min-h-header xl:py-2.5 py-1 px-2.5 border-b-1/2" />
     </template>
     <template #content>
       <div class="search-button-fade sticky px-3 py-2.5 top-0 z-10">

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -4,6 +4,8 @@ import EnvironmentSelector from '@/components/EnvironmentSelector/EnvironmentSel
 import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
 import { ScalarIcon } from '@scalar/components'
 
+import { WorkspaceDropdown } from './components'
+
 defineProps<{
   modelValue: boolean
   isReadonly: boolean
@@ -24,6 +26,7 @@ defineEmits<{
         class="gitbook-hidden"
         :modelValue="modelValue"
         @update:modelValue="$emit('update:modelValue', $event)" />
+      <WorkspaceDropdown v-if="!isReadonly" />
       <a
         class="text-c-2 text-sm font-medium gitbook-show ml-.5 hover:text-c-1 border p-1 rounded hover:bg-b-3"
         href="https://scalar.com/"
@@ -38,12 +41,12 @@ defineEmits<{
       <!-- TODO: There should be an `ìsModal` flag instead -->
       <button
         v-if="isReadonly"
-        class="text-c-3 hover:bg-b-2 active:text-c-1 p-2 rounded"
+        class="text-c-1 hover:bg-b-2 active:text-c-1 p-2 rounded -mr-1.5"
         type="button"
         @click="$emit('hideModal')">
         <ScalarIcon
           icon="Close"
-          size="lg"
+          size="md"
           thickness="1.75" />
       </button>
     </div>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -67,11 +67,6 @@ const shouldVirtualize = computed(
 <template>
   <ViewLayoutSection>
     <template #title>
-      <ScalarIcon
-        class="text-c-3 mr-2 rotate-180"
-        icon="ExternalLink"
-        size="sm"
-        thickness="2.5" />
       <div class="flex items-center flex-1">
         Response
         <ResponseMetaInformation

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -78,10 +78,10 @@ const deleteWorkspace = async () => {
     <div class="flex items-center text-sm w-[inherit]">
       <ScalarDropdown>
         <ScalarButton
-          class="font-normal h-full justify-start line-clamp-1 py-1.5 px-1.5 text-c-1 hover:bg-b-2 w-fit"
+          class="font-normal h-full justify-start line-clamp-1 py-1.5 px-1.5 text-c-3 hover:bg-b-2 w-fit"
           fullWidth
           variant="ghost">
-          <div class="font-medium m-0 text-sm flex gap-1.5 items-center">
+          <div class="font-medium m-0 text-xs flex gap-1.5 items-center">
             <h2 class="line-clamp-1 text-left w-[calc(100%-10px)]">
               {{ activeWorkspace.name }}
             </h2>


### PR DESCRIPTION
fix sidebar between 780 - 800px 🙃 
<img width="791" alt="image" src="https://github.com/user-attachments/assets/d30896e2-6c3d-422a-a8cd-6907ebcc1e34">

- fix codemirror placeholder colors
- reduce details in request / response
- better aligned 'all / active filter' with global enviornment
- move workspace selector to top bar
- aligned modal x (close) button with filter 
- made modal x and sidebar toggle have more contrast
- improved background colours for tabs across all themes