### PR TITLE
fix(themes): remove vendor prefixes for input placeholder

### DIFF
--- a/.changeset/short-cats-camp.md
+++ b/.changeset/short-cats-camp.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix(themes): remove vendor prefixes for input placeholder

--- a/packages/themes/src/reset.css
+++ b/packages/themes/src/reset.css
@@ -75,12 +75,12 @@
     border-width: 1px;
   }
 
-  input::placeholder,
-  input:-ms-input-placeholder,
-  input::-webkit-input-placeholder {
+  /** Style placeholder text */
+  input::placeholder {
     color: var(--scalar-color-3);
     font-family: var(--scalar-font);
   }
+
   /** Remove yellow/blue autofill indicator */
   input:-webkit-autofill {
     background-clip: text !important;


### PR DESCRIPTION
I'm not sure why but having the vendor prefixes here was breaking the placeholder selector. This seems to fix it in chrome and has [good compatibility](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder#browser_compatibility).

## Before

<img width="1321" alt="Google Chrome-2024-10-17-14-05-19@2x" src="https://github.com/user-attachments/assets/9246dfdd-b3e9-47ba-9789-17958b094fee">

## After

![Google Chrome-2024-10-17-14-06-30@2x](https://github.com/user-attachments/assets/69a73731-dc89-4b8b-b569-5a7534358410)
