### PR TITLE
feat(api-client-react): add caching strategy to allow for multiple clients

### DIFF
--- a/.changeset/dirty-eels-know.md
+++ b/.changeset/dirty-eels-know.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client-react': patch
+---
+
+feat: allow for multiple api-client caching

--- a/packages/api-client-react/playground/App.tsx
+++ b/packages/api-client-react/playground/App.tsx
@@ -1,13 +1,20 @@
+import type {
+  ClientConfiguration,
+  OpenClientPayload,
+} from '@scalar/api-client/libs'
 import React from 'react'
 
 import { useApiClientModal } from '../src/ApiClientModalProvider'
 
-export const App = () => {
+export const App = ({
+  initialRequest,
+}: {
+  initialRequest?: OpenClientPayload
+}) => {
   const client = useApiClientModal()
 
   return (
-    <button
-      onClick={() => client?.open({ path: '/auth/token', method: 'get' })}>
+    <button onClick={() => client?.open(initialRequest)}>
       Click me to open the Api Client
     </button>
   )

--- a/packages/api-client-react/playground/main.tsx
+++ b/packages/api-client-react/playground/main.tsx
@@ -7,10 +7,22 @@ import App from './App'
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ApiClientModalProvider
-      initialRequest={{
-        method: 'DELETE',
-        path: '/planets/{planetId}',
-      }}
+      configuration={{
+        spec: {
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+        },
+      }}>
+      <App />
+    </ApiClientModalProvider>
+    <ApiClientModalProvider
+      configuration={{
+        spec: {
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+        },
+      }}>
+      <App />
+    </ApiClientModalProvider>
+    <ApiClientModalProvider
       configuration={{
         spec: {
           url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',

--- a/packages/api-client-react/playground/main.tsx
+++ b/packages/api-client-react/playground/main.tsx
@@ -20,7 +20,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         },
       }}>
-      <App />
+      <App initialRequest={{ path: '/auth/token', method: 'post' }} />
     </ApiClientModalProvider>
     <ApiClientModalProvider
       configuration={{
@@ -28,7 +28,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         },
       }}>
-      <App />
+      <App initialRequest={{ path: '/planets', method: 'get' }} />
     </ApiClientModalProvider>
   </React.StrictMode>,
 )

--- a/packages/api-client-react/src/ApiClientModalProvider.tsx
+++ b/packages/api-client-react/src/ApiClientModalProvider.tsx
@@ -97,7 +97,7 @@ export const ApiClientModalProvider = ({
   return (
     <ApiClientModalContext.Provider value={state.clientDict[key]}>
       <div
-        class="scalar-app"
+        className="scalar-app"
         ref={el}
       />
       {children}

--- a/packages/api-client-react/src/ApiClientModalProvider.tsx
+++ b/packages/api-client-react/src/ApiClientModalProvider.tsx
@@ -96,7 +96,10 @@ export const ApiClientModalProvider = ({
 
   return (
     <ApiClientModalContext.Provider value={state.clientDict[key]}>
-      <div ref={el} />
+      <div
+        class="scalar-app"
+        ref={el}
+      />
       {children}
     </ApiClientModalContext.Provider>
   )

--- a/packages/api-client-react/src/ApiClientModalProvider.tsx
+++ b/packages/api-client-react/src/ApiClientModalProvider.tsx
@@ -11,9 +11,10 @@ import React, {
   useContext,
   useEffect,
   useRef,
-  useState,
+  useSyncExternalStore,
 } from 'react'
 
+import { clientStore } from './client-store'
 import './style.css'
 
 const ApiClientModalContext = createContext<ReturnType<
@@ -27,67 +28,74 @@ type Props = PropsWithChildren<{
   configuration?: ClientConfiguration
 }>
 
-// These are required for the vue bundler version
-globalThis.__VUE_OPTIONS_API__ = true
-globalThis.__VUE_PROD_HYDRATION_MISMATCH_DETAILS__ = true
-globalThis.__VUE_PROD_DEVTOOLS__ = false
+/** Ensures we only load createClient once */
+let isLoading = false
+
+/** Hack: this is strictly to prevent creation of extra clients as the store lags a bit */
+const clientDict: Record<
+  string,
+  ReturnType<typeof CreateApiClientModalSync>
+> = {}
 
 /**
  * Api Client Modal React
  *
- * Provider which mounts the Scalar Api Client Modal vue app
+ * Provider which mounts the Scalar Api Client Modal vue app.
+ * Rebuilt to support multiple instances when using a unique spec.url
  */
 export const ApiClientModalProvider = ({
   children,
   initialRequest,
   configuration = {},
 }: Props) => {
+  const key = configuration.spec?.url || 'default'
   const el = useRef<HTMLDivElement | null>(null)
 
-  const [createClient, setCreateClient] = useState<
-    typeof CreateApiClientModalSync | null
-  >(null)
-  const [client, setClient] = useState<ReturnType<
-    typeof CreateApiClientModalSync
-  > | null>(null)
+  const state = useSyncExternalStore(
+    clientStore.subscribe,
+    clientStore.getSnapshot,
+  )
 
-  // Lazyload the js to create the client
+  // Lazyload the js to create the client, but we only wanna call this once
   useEffect(() => {
     const loadApiClientJs = async () => {
+      isLoading = true
       const { createApiClientModalSync } = await import(
         '@scalar/api-client/layouts/Modal'
       )
-      setCreateClient(() => createApiClientModalSync)
+      clientStore.setCreateClient(createApiClientModalSync)
     }
-    loadApiClientJs()
+    if (!isLoading) loadApiClientJs()
   }, [])
 
   useEffect(() => {
-    if (!el?.current || !createClient) return
+    if (!el.current || !state.createClient || clientDict[key]) return () => null
 
-    // Create vue app
-    const _client = createClient(el.current, configuration)
-    setClient(_client)
+    // Check for cached client first
+    const _client = state.createClient(el.current, configuration)
 
     const updateSpec = async () => {
       await _client.updateSpec(configuration.spec!)
       if (initialRequest) _client.route(initialRequest)
     }
 
+    // Add the client to the store and dict
+    clientStore.addClient(key, _client)
+    clientDict[key] = _client
+
     // We update the config as we are using the sync version
     if (configuration.spec) updateSpec()
     else if (initialRequest) _client.route(initialRequest)
 
     // Ensure we unmount the vue app on unmount
-    // eslint-disable-next-line consistent-return
     return () => {
       _client.app.unmount()
-      setClient(null)
+      clientStore.removeClient(key)
     }
-  }, [el, createClient])
+  }, [el.current, state.createClient])
 
   return (
-    <ApiClientModalContext.Provider value={client}>
+    <ApiClientModalContext.Provider value={state.clientDict[key]}>
       <div ref={el} />
       {children}
     </ApiClientModalContext.Provider>

--- a/packages/api-client-react/src/ApiClientModalProvider.tsx
+++ b/packages/api-client-react/src/ApiClientModalProvider.tsx
@@ -54,6 +54,7 @@ export const ApiClientModalProvider = ({
   const state = useSyncExternalStore(
     clientStore.subscribe,
     clientStore.getSnapshot,
+    clientStore.getSnapshot,
   )
 
   // Lazyload the js to create the client, but we only wanna call this once

--- a/packages/api-client-react/src/client-store.ts
+++ b/packages/api-client-react/src/client-store.ts
@@ -1,0 +1,57 @@
+import type { createApiClientModalSync as CreateApiClientModalSync } from '@scalar/api-client/layouts/Modal'
+
+// These are required for the vue bundler version
+globalThis.__VUE_OPTIONS_API__ = true
+globalThis.__VUE_PROD_HYDRATION_MISMATCH_DETAILS__ = true
+globalThis.__VUE_PROD_DEVTOOLS__ = false
+
+/** Client state */
+let state = {
+  createClient: null as typeof CreateApiClientModalSync | null,
+  clientDict: {} as Record<string, ReturnType<typeof CreateApiClientModalSync>>,
+}
+
+/** Set of listener functions to be called when state changes */
+const listeners = new Set<() => void>()
+
+/** Subscribe to state changes */
+const subscribe = (listener: () => void) => {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/** Get the current state at this moment in time */
+const getSnapshot = () => state
+
+/** Trigger all listeners */
+const emit = () => listeners.forEach((listener) => listener())
+
+/** Set the create client state */
+const setCreateClient = (client: typeof CreateApiClientModalSync) => {
+  state = { ...state, createClient: client }
+  emit()
+}
+
+/** Add a client to the client dict */
+const addClient = (
+  url: string,
+  client: ReturnType<typeof CreateApiClientModalSync>,
+) => {
+  state = { ...state, clientDict: { ...state.clientDict, [url]: client } }
+  emit()
+}
+
+/** Remove a client from the client dict */
+const removeClient = (url: string) => {
+  const { [url]: _, ...clientDict } = state.clientDict
+  state = { ...state, clientDict }
+  emit()
+}
+
+export const clientStore = {
+  getSnapshot,
+  subscribe,
+  setCreateClient,
+  addClient,
+  removeClient,
+}


### PR DESCRIPTION
Added caching strategy so if you try to load mulitple clients with the same spec.url, it will open the cached one! Had to get a bit hacky to make it work but it works!

To test:
- `cd packages/api-client-react`
- `pnpm dev`

the bottome two buttons should open different routes, the top button should re-open the last route