### PR TITLE
fix(api-client): proxy setting

### DIFF
--- a/.changeset/fuzzy-cameras-impress.md
+++ b/.changeset/fuzzy-cameras-impress.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates proxy default setting

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -290,8 +290,14 @@ export const createWorkspaceStore = (
   // PROXY URL STATE
   const PROXY_URL = 'proxyUrl' as const
 
-  // Initialize proxyUrl with the value from localStorage
-  const proxyUrl = ref(localStorage.getItem(PROXY_URL) || '')
+  // Initialize proxyUrl with the value from localStorage or default to the proxy URL according to env
+  const proxyUrl = ref(
+    localStorage.getItem(PROXY_URL) !== null
+      ? localStorage.getItem(PROXY_URL) || ''
+      : import.meta.env.PROD
+        ? 'https://proxy.scalar.com'
+        : '',
+  )
 
   const setProxyUrl = (url: string) => {
     proxyUrl.value = url


### PR DESCRIPTION
this pr updates the value of the api client's default proxy setting and adds :
- in development, proxy is disabled by default
- in production, proxy is enabled by default