### PR TITLE
style(api-client): active element background

### DIFF
--- a/.changeset/sixty-suns-pay.md
+++ b/.changeset/sixty-suns-pay.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+fix: favors accent over blur color for active elment state

--- a/packages/api-client/src/components/AddressBar/AddressBarServerItem.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServerItem.vue
@@ -46,11 +46,11 @@ const isSelectedServer = (serverId: string) =>
     :value="serverOption.id"
     @click="updateSelectedServer(serverOption.id)">
     <div
-      class="flex size-4 items-center justify-center rounded-full p-[3px] group-hover:shadow-border"
+      class="flex size-4 items-center justify-center rounded-full p-[3px]"
       :class="
         isSelectedServer(serverOption.id)
-          ? 'bg-blue text-b-1'
-          : 'text-transparent'
+          ? 'bg-c-accent text-b-1'
+          : 'group-hover:shadow-border text-transparent'
       ">
       <ScalarIcon
         class="relative top-[0.5px] size-2.5"

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -98,9 +98,11 @@ watch(addingCustomValue, (newValue) => {
             :value="option"
             @click="updateSelected(option)">
             <div
-              class="flex items-center justify-center rounded-full p-[3px] w-4 h-4 group-hover/item:shadow-border"
+              class="flex items-center justify-center rounded-full p-[3px] w-4 h-4"
               :class="
-                isSelected(option) ? 'bg-blue text-b-1' : 'text-transparent'
+                isSelected(option)
+                  ? 'bg-c-accent text-b-1'
+                  : 'group-hover/item:shadow-border text-transparent'
               ">
               <ScalarIcon
                 class="size-2.5"

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -57,11 +57,11 @@ const envs = computed(() => [
           class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden"
           @click.stop="updateSelected(env.uid)">
           <div
-            class="flex items-center justify-center rounded-full p-[3px] w-4 h-4 group-hover/item:shadow-border"
+            class="flex items-center justify-center rounded-full p-[3px] w-4 h-4"
             :class="
               activeWorkspace.activeEnvironmentId === env.uid
-                ? 'bg-blue text-b-1'
-                : 'text-transparent'
+                ? 'bg-c-accent text-b-1'
+                : 'group-hover/item:shadow-border text-transparent'
             ">
             <ScalarIcon
               class="size-2.5"
@@ -74,11 +74,11 @@ const envs = computed(() => [
           class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden"
           @click.stop="updateSelected('')">
           <div
-            class="flex items-center justify-center rounded-full p-[3px] w-4 h-4 group-hover/item:shadow-border"
+            class="flex items-center justify-center rounded-full p-[3px] w-4 h-4"
             :class="
               activeWorkspace.activeEnvironmentId === ''
-                ? 'bg-blue text-b-1'
-                : 'text-transparent'
+                ? 'bg-c-accent text-b-1'
+                : 'group-hover/item:shadow-border text-transparent'
             ">
             <ScalarIcon
               class="size-2.5"

--- a/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
+++ b/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
@@ -67,11 +67,11 @@ const handleCreateWorkspace = () => {
           class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden w-full"
           @click.stop="updateSelected(uid)">
           <div
-            class="flex items-center justify-center rounded-full p-[3px] w-4 h-4 group-hover/item:shadow-border"
+            class="flex items-center justify-center rounded-full p-[3px] w-4 h-4"
             :class="
               activeWorkspace.uid === uid
-                ? 'bg-blue text-b-1'
-                : 'text-transparent'
+                ? 'bg-c-accent text-b-1'
+                : 'group-hover/item:shadow-border text-transparent'
             ">
             <ScalarIcon
               class="size-2.5"

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -100,11 +100,11 @@ const deleteWorkspace = async () => {
             class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden w-full"
             @click.stop="updateSelected(uid)">
             <div
-              class="flex items-center justify-center rounded-full p-[3px] w-4 h-4 group-hover/item:shadow-border"
+              class="flex items-center justify-center rounded-full p-[3px] w-4 h-4"
               :class="
                 activeWorkspace.uid === uid
-                  ? 'bg-blue text-b-1'
-                  : 'text-transparent'
+                  ? 'bg-c-accent text-b-1'
+                  : 'group-hover/item:shadow-border text-transparent'
               ">
               <ScalarIcon
                 class="size-2.5"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
@@ -28,9 +28,11 @@ const variants = cva({
 <template>
   <li :class="cx(variants({ active, selected }), 'group')">
     <div
-      class="flex size-4 items-center justify-center p-0.75 group-hover:shadow-border"
+      class="flex size-4 items-center justify-center p-0.75"
       :class="[
-        selected ? 'bg-blue text-b-1' : 'text-transparent',
+        selected
+          ? 'bg-c-accent text-b-1'
+          : 'text-transparent group-hover:shadow-border',
         style === 'checkbox' ? 'rounded' : 'rounded-full',
       ]">
       <!-- Icon needs help to be optically centered (╥﹏╥) -->

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -40,7 +40,7 @@ defineOptions({ inheritAttrs: false })
 const variants = cva({
   base: [
     // Layout
-    'group',
+    'group/listbox',
     'flex min-w-0 items-center gap-1.5 rounded px-2 py-1.5 text-left',
     'first-of-type:mt-0.75 last-of-type:mb-0.75',
     // Text / background style
@@ -96,8 +96,12 @@ const variants = cva({
                 cx(variants({ active, selected, disabled: option.disabled }))
               ">
               <div
-                class="flex size-4 items-center justify-center rounded-full p-[3px] group-hover:shadow-border"
-                :class="selected ? 'bg-blue text-b-1' : 'text-transparent'">
+                class="flex size-4 items-center justify-center rounded-full p-[3px]"
+                :class="
+                  selected
+                    ? 'bg-c-accent text-b-1'
+                    : 'text-transparent group-hover/listbox:shadow-border'
+                ">
                 <!-- Icon needs help to be optically centered (╥﹏╥) -->
                 <ScalarIcon
                   class="relative top-[0.5px] size-2.5"


### PR DESCRIPTION
this pr fixes the background inconsistencies when using themes in order to favor accent background:

**before**
<img width="627" alt="image" src="https://github.com/user-attachments/assets/74f40aeb-e192-41bc-8d06-1d9da6f62c14">

**after**
<img width="627" alt="image" src="https://github.com/user-attachments/assets/a32b2c32-ef98-4779-9313-6cff155511a6">