### PR TITLE
chore(api-client): update import collection wording

### DIFF
--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
@@ -102,7 +102,7 @@ async function importCollection() {
     <template v-if="!documentDetails || isUrl(inputContent)">
       <CommandActionInput
         v-model="inputContent"
-        placeholder="Paste Swagger/OpenAPI File URL or content"
+        placeholder="OpenAPI/Swagger URL or document"
         @onDelete="emits('back', $event)" />
     </template>
     <template v-else>

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -19,7 +19,7 @@ export default {
 }
 
 export const PaletteComponents = {
-  'Import Collection': CommandPaletteImport,
+  'Import from OpenAPI/Swagger': CommandPaletteImport,
   'Create Request': CommandPaletteRequest,
   'Create Workspace': CommandPaletteWorkspace,
   'Add Tag': CommandPaletteTag,
@@ -57,7 +57,7 @@ const availableCommands = [
         icon: 'ExternalLink',
       },
       {
-        name: 'Import Collection',
+        name: 'Import from OpenAPI/Swagger',
         icon: 'Import',
       },
       {


### PR DESCRIPTION
Currently, we say “Import Collection”, but we’re actually importing OpenAPI documents. That’s why I propose a new label.

<img width="599" alt="Screenshot 2024-10-18 at 15 52 56" src="https://github.com/user-attachments/assets/971a646e-eee6-420a-92db-1245eeea4878">

<img width="614" alt="Screenshot 2024-10-18 at 15 52 50" src="https://github.com/user-attachments/assets/6599d3cf-d020-4639-99ba-e0306a402fb8">
