### PR TITLE
feat(scalar.aspnetcore): add integration configuration property

### DIFF
--- a/.changeset/moody-points-juggle.md
+++ b/.changeset/moody-points-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feat: Add DotNetFlag configuration property

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -229,7 +229,7 @@ public static class ScalarOptionsExtensions
         options.TagSorter = tagSorter;
         return options;
     }
-    
+
     /// <summary>
     /// Sets the operation sorter for the <see cref="ScalarOptions" />.
     /// </summary>
@@ -332,6 +332,18 @@ public static class ScalarOptionsExtensions
     public static ScalarOptions WithCdnUrl(this ScalarOptions options, string url)
     {
         options.CdnUrl = url;
+        return options;
+    }
+
+
+    /// <summary>
+    /// Sets whether to expose 'dotnet' to the configuration
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="expose">Whether to expose 'dotnet'.</param>
+    public static ScalarOptions WithExposeFramework(this ScalarOptions options, bool expose)
+    {
+        options.ExposeFramework = expose;
         return options;
     }
 }

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -337,13 +337,13 @@ public static class ScalarOptionsExtensions
 
 
     /// <summary>
-    /// Sets whether to expose 'dotnet' to the configuration
+    /// Sets whether to expose 'dotnet' to the configuration.
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="expose">Whether to expose 'dotnet'.</param>
-    public static ScalarOptions WithExposeFramework(this ScalarOptions options, bool expose)
+    public static ScalarOptions WithDotNetFlag(this ScalarOptions options, bool expose)
     {
-        options.ExposeFramework = expose;
+        options.DotNetFlag = expose;
         return options;
     }
 }

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -53,7 +53,7 @@ internal static class ScalarOptionsMapper
                 ClientKey = options.DefaultHttpClient.Value.ToStringFast(),
                 TargetKey = options.DefaultHttpClient.Key.ToStringFast()
             },
-            Integration = options.ExposeFramework ? "dotnet" : null
+            Integration = options.DotNetFlag ? "dotnet" : null
         };
     }
 

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -52,7 +52,8 @@ internal static class ScalarOptionsMapper
             {
                 ClientKey = options.DefaultHttpClient.Value.ToStringFast(),
                 TargetKey = options.DefaultHttpClient.Key.ToStringFast()
-            }
+            },
+            Integration = options.ExposeFramework ? "dotnet" : null
         };
     }
 

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -181,6 +181,6 @@ public sealed class ScalarOptions
     /// <summary>
     /// Gets or sets whether to expose 'dotnet' to the configuration.
     /// </summary>
-    /// <value>A boolean that indicates if 'dotnet' should be exposed. The default value is <c>false</c>.</value>
-    public bool ExposeFramework { get; set; } = true;
+    /// <value>A boolean that indicates if 'dotnet' should be exposed to the configuration. The default value is <c>true</c>.</value>
+    public bool DotNetFlag { get; set; } = true;
 }

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -177,4 +177,10 @@ public sealed class ScalarOptions
     /// <value>A list of <see cref="ScalarServer" /> representing the servers. The default value is <c>null</c>.</value>
     /// <remarks>This list will override the servers defined in the OpenAPI document.</remarks>
     public IList<ScalarServer>? Servers { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to expose 'dotnet' to the configuration.
+    /// </summary>
+    /// <value>A boolean that indicates if 'dotnet' should be exposed. The default value is <c>false</c>.</value>
+    public bool ExposeFramework { get; set; } = true;
 }

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
@@ -49,6 +49,10 @@ internal sealed class ScalarConfiguration
     public required string? Theme { get; init; }
 
     public required string? Favicon { get; init; }
+    
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    [JsonPropertyName("_integration")]
+    public required string? Integration { get; init; }
 }
 
 [JsonSerializable(typeof(ScalarConfiguration))]

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -42,7 +42,7 @@ public class ScalarOptionsExtensionsTests
             .AddServer(new ScalarServer("https://example.org", "My other server"))
             .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
             .WithFavicon("/favicon.png")
-            .WithExposeFramework(false);
+            .WithDotNetFlag(false);
 
         // Assert
         options.Title.Should().Be("My title");
@@ -76,6 +76,6 @@ public class ScalarOptionsExtensionsTests
         options.OperationSorter.Should().Be(OperationSorter.Alpha);
         options.DefaultHttpClient.Should().Be(new KeyValuePair<ScalarTarget, ScalarClient>(ScalarTarget.CSharp, ScalarClient.HttpClient));
         options.Favicon.Should().Be("/favicon.png");
-        options.ExposeFramework.Should().BeFalse();
+        options.DotNetFlag.Should().BeFalse();
     }
 }

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -41,7 +41,8 @@ public class ScalarOptionsExtensionsTests
             .AddServer("https://example.com")
             .AddServer(new ScalarServer("https://example.org", "My other server"))
             .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
-            .WithFavicon("/favicon.png");
+            .WithFavicon("/favicon.png")
+            .WithExposeFramework(false);
 
         // Assert
         options.Title.Should().Be("My title");
@@ -75,5 +76,6 @@ public class ScalarOptionsExtensionsTests
         options.OperationSorter.Should().Be(OperationSorter.Alpha);
         options.DefaultHttpClient.Should().Be(new KeyValuePair<ScalarTarget, ScalarClient>(ScalarTarget.CSharp, ScalarClient.HttpClient));
         options.Favicon.Should().Be("/favicon.png");
+        options.ExposeFramework.Should().BeFalse();
     }
 }

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -33,6 +33,7 @@ public class ScalarOptionsMapperTests
         configuration.TagSorter.Should().BeNull();
         configuration.OperationsSorter.Should().BeNull();
         configuration.Theme.Should().Be(ScalarTheme.Purple.ToStringFast());
+        configuration.Integration.Should().Be("dotnet");
     }
 
     [Fact]
@@ -67,7 +68,8 @@ public class ScalarOptionsMapperTests
             DefaultFonts = false,
             DefaultOpenAllTags = true,
             TagSorter = TagSorter.Alpha,
-            OperationSorter = OperationSorter.Method
+            OperationSorter = OperationSorter.Method,
+            ExposeFramework = false
         };
 
         // Act
@@ -98,6 +100,7 @@ public class ScalarOptionsMapperTests
         configuration.TagSorter.Should().Be(TagSorter.Alpha.ToStringFast());
         configuration.OperationsSorter.Should().Be(OperationSorter.Method.ToStringFast());
         configuration.Theme.Should().Be(ScalarTheme.Saturn.ToStringFast());
+        configuration.Integration.Should().BeNull();
     }
 
     [Fact]

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -69,7 +69,7 @@ public class ScalarOptionsMapperTests
             DefaultOpenAllTags = true,
             TagSorter = TagSorter.Alpha,
             OperationSorter = OperationSorter.Method,
-            ExposeFramework = false
+            DotNetFlag = false
         };
 
         // Act


### PR DESCRIPTION
## Description

This PR adds the `_integration` property to the configuration. The .NET integration provides a new `DotNetFlag` property, which is set to `true` by default.