### PR TITLE
fix(api-client): workspace default request

### DIFF
--- a/.changeset/ninety-yaks-tie.md
+++ b/.changeset/ninety-yaks-tie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sets default request uid to request example

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -38,14 +38,21 @@ export function extendedWorkspaceDataFactory({
 }: StoreContext) {
   const addWorkspace = (payload: Partial<Workspace> = {}) => {
     // Create some example data
-    const example = requestExampleSchema.parse({ name: 'Example' })
     const request = requestSchema.parse({
       method: 'get',
       parameters: [],
       path: '',
       summary: 'My First Request',
-      examples: [example.uid],
+      examples: [],
     })
+
+    const example = requestExampleSchema.parse({
+      name: 'Example',
+      requestUid: request.uid,
+    })
+
+    request.examples.push(example.uid)
+
     const collection = collectionSchema.parse({
       info: {
         title: 'Drafts',


### PR DESCRIPTION
this pr fixes the default workspace request by setting the request uid to its request example in order to have the request history display.

**before**
<img width="791" alt="image" src="https://github.com/user-attachments/assets/264d00fb-064a-4ed4-aa22-fb46e6ba740b">

**after**
<img width="791" alt="image" src="https://github.com/user-attachments/assets/87f620c0-290d-44e4-9211-8a0b26b575b3">
