### PR TITLE
fix(api-client-app): check for updates doesn’t do anything

### DIFF
--- a/.changeset/short-experts-breathe.md
+++ b/.changeset/short-experts-breathe.md
@@ -1,0 +1,5 @@
+---
+'scalar-api-client': patch
+---
+
+fix: check for updates doesn’t do anything

--- a/packages/api-client-app/src/main/index.ts
+++ b/packages/api-client-app/src/main/index.ts
@@ -153,10 +153,17 @@ function createWindow(): void {
                 click: async () => {
                   console.log('Checking for updates…')
 
-                  const updateCheck =
-                    await todesktop.autoUpdater?.checkForUpdates()
+                  try {
+                    const result =
+                      await todesktop.autoUpdater?.checkForUpdates()
 
-                  console.log('Update:', updateCheck?.updateInfo)
+                    if (result?.updateInfo) {
+                      console.log('Update:', result.updateInfo.version)
+                      todesktop.autoUpdater?.restartAndInstall()
+                    }
+                  } catch (e) {
+                    console.log('Update check failed:', e)
+                  }
                 },
               },
               { type: 'separator' },


### PR DESCRIPTION
This PR exists and restarts the app when an update is found after manually clicking “Check for updates”.

Requires #3542 to run the Electron app locally. Simulate an update with `pnpm dev:update`, ignore the first popup, select Check for updates in the menu.

Next week: proper UX