### PR TITLE
fix: support server variables in request sending

### DIFF
--- a/.changeset/eight-bottles-rescue.md
+++ b/.changeset/eight-bottles-rescue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: support server variables in request sending

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -275,6 +275,12 @@ export const createRequestOperation = ({
     // Handle empty url
     if (!url) throw ERRORS.URL_EMPTY
 
+    // lets set the server variables
+    // for now we only support default values
+    Object.entries(server?.variables ?? {}).forEach(([k, v]) => {
+      url = replaceTemplateVariables(url, { [k]: v.default })
+    })
+
     const urlParams = createFetchQueryParams(example, env)
     const headers = createFetchHeaders(example, env)
     const { body } = createFetchBody(request.method, example, env)

--- a/packages/api-client/src/libs/string-template.ts
+++ b/packages/api-client/src/libs/string-template.ts
@@ -33,7 +33,9 @@ export function replaceTemplateVariables(
     const key = m.startsWith(':') ? m.slice(1) : m.replace(/[{}]/g, '').trim()
 
     const value = getDotPathValue(key, context)
-    if (value) substitutedString = substitutedString.replaceAll(m, value)
+    // value can be an empty string but not null or undefined
+    if (value !== null && value !== undefined)
+      substitutedString = substitutedString.replaceAll(m, value)
   })
 
   return substitutedString


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/52826c83-bc11-4665-9e38-47f68b4c28a8)

server variable requests would fail


now they use defaults :)
![image](https://github.com/user-attachments/assets/1c8db681-ed7a-4778-898e-86fe6a57ea05)
