### PR TITLE
perf(api-client): improve large response performance in Chromium

### DIFF
--- a/.changeset/new-apricots-exist.md
+++ b/.changeset/new-apricots-exist.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: large response performance problems due to chrome bug, increase virtualization threshold

--- a/packages/api-client/src/components/ViewLayout/ViewLayout.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayout.vue
@@ -1,22 +1,3 @@
-<style scoped>
-.view-layout > :not([hidden]):not(:first-child) {
-  border-top-width: calc(calc(var(--scalar-border-width) / 2));
-  border-left-width: 0px;
-}
-.view-layout > :not([hidden]):first-child {
-  border-bottom-width: 0px;
-}
-
-@screen xl {
-  .view-layout > :not([hidden]):first-child {
-    border-right-width: 0px;
-  }
-  .view-layout > :not([hidden]):not(:first-child) {
-    border-top-width: 0px;
-    border-left-width: calc(calc(var(--scalar-border-width) / 2));
-  }
-}
-</style>
 <template>
   <div
     class="flex flex-col min-h-0 flex-1 xl:overflow-hidden md:flex-row leading-3">

--- a/packages/api-client/src/components/ViewLayout/ViewLayout.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayout.vue
@@ -19,7 +19,7 @@
 </style>
 <template>
   <div
-    class="view-layout flex flex-col min-h-0 flex-1 xl:overflow-hidden md:flex-row leading-3">
+    class="flex flex-col min-h-0 flex-1 xl:overflow-hidden md:flex-row leading-3">
     <slot />
   </div>
 </template>

--- a/packages/api-client/src/components/ViewLayout/ViewLayout.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayout.vue
@@ -1,6 +1,25 @@
+<style scoped>
+.view-layout > :not([hidden]):not(:first-child) {
+  border-top-width: calc(calc(var(--scalar-border-width) / 2));
+  border-left-width: 0px;
+}
+.view-layout > :not([hidden]):first-child {
+  border-bottom-width: 0px;
+}
+
+@screen xl {
+  .view-layout > :not([hidden]):first-child {
+    border-right-width: 0px;
+  }
+  .view-layout > :not([hidden]):not(:first-child) {
+    border-top-width: 0px;
+    border-left-width: calc(calc(var(--scalar-border-width) / 2));
+  }
+}
+</style>
 <template>
   <div
-    class="divide-y md:divide-y-0 divide-1 flex flex-col min-h-0 flex-1 xl:overflow-hidden md:flex-row leading-3">
+    class="view-layout flex flex-col min-h-0 flex-1 xl:overflow-hidden md:flex-row leading-3">
     <slot />
   </div>
 </template>

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
@@ -1,6 +1,25 @@
+<style scoped>
+.view-layout-content > :not([hidden]):not(:first-child) {
+  border-top-width: calc(calc(var(--scalar-border-width) / 2));
+  border-left-width: 0px;
+}
+.view-layout-content > :not([hidden]):first-child {
+  border-bottom-width: 0px;
+}
+
+@screen xl {
+  .view-layout-content > :not([hidden]):first-child {
+    border-right-width: 0px;
+  }
+  .view-layout-content > :not([hidden]):not(:first-child) {
+    border-top-width: 0px;
+    border-left-width: calc(calc(var(--scalar-border-width) / 2));
+  }
+}
+</style>
 <template>
   <div
-    class="border-t-1/2 md:border-t-0 divide divide-y xl:divide-y-0 xl:divide-x-1/2 flex xl:flex-row flex-col custom-scroll pr-0">
+    class="view-layout-content border-t-1/2 md:border-t-0 flex xl:flex-row flex-col custom-scroll pr-0">
     <slot />
   </div>
 </template>

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
@@ -1,22 +1,3 @@
-<style scoped>
-.view-layout-content > :not([hidden]):not(:first-child) {
-  border-top-width: calc(calc(var(--scalar-border-width) / 2));
-  border-left-width: 0px;
-}
-.view-layout-content > :not([hidden]):first-child {
-  border-bottom-width: 0px;
-}
-
-@screen xl {
-  .view-layout-content > :not([hidden]):first-child {
-    border-right-width: 0px;
-  }
-  .view-layout-content > :not([hidden]):not(:first-child) {
-    border-top-width: 0px;
-    border-left-width: calc(calc(var(--scalar-border-width) / 2));
-  }
-}
-</style>
 <template>
   <div
     class="*:border-t-1/2 first:*:border-t-0 xl:*:border-t-0 xl:*:border-l-1/2 xl:first:*:border-l-0 flex xl:flex-row flex-col custom-scroll pr-0">

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- Using *:border-* to avoid chrome performance issue with adjacent sibling selector (~) -->
   <div
     class="*:border-t-1/2 first:*:border-t-0 xl:*:border-t-0 xl:*:border-l-1/2 xl:first:*:border-l-0 flex xl:flex-row flex-col custom-scroll pr-0">
     <slot />

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutContent.vue
@@ -19,7 +19,7 @@
 </style>
 <template>
   <div
-    class="view-layout-content border-t-1/2 md:border-t-0 flex xl:flex-row flex-col custom-scroll pr-0">
+    class="*:border-t-1/2 first:*:border-t-0 xl:*:border-t-0 xl:*:border-l-1/2 xl:first:*:border-l-0 flex xl:flex-row flex-col custom-scroll pr-0">
     <slot />
   </div>
 </template>

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -19,7 +19,7 @@ defineEmits<{
 </script>
 <template>
   <div
-    class="lg:min-h-header flex items-center w-full justify-center p-2 pt-1 lg:p-1 flex-wrap t-app__top-container md:border-b-1/2">
+    class="lg:min-h-header flex items-center w-full justify-center p-2 pt-1 lg:p-1 flex-wrap t-app__top-container border-b-1/2">
     <div
       class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-0.5 lg:flex-1 w-6/12">
       <SidebarToggle

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -59,7 +59,7 @@ type ActiveSections = (typeof sections)[number]
 const activeSection = ref<ActiveSections>('All')
 
 /** Threshold for virtualizing response bodies in bytes */
-const VIRTUALIZATION_THRESHOLD = 20_000
+const VIRTUALIZATION_THRESHOLD = 200_000
 const shouldVirtualize = computed(
   () => (props.response?.size ?? 0) > VIRTUALIZATION_THRESHOLD,
 )


### PR DESCRIPTION
**Problem**
Large responses are causing heavy input lag in Chromium browsers only, most recently with #3467. This is due to a performance bug in Chromium with the general sibling CSS selector that Tailwind uses for the `divide` classes. When this class is applied to an element with many, many descendants (as is the case with large parsed JSON responses) it causes the browser to halt as it re-renders the style. Firefox and Safari do not have this issue.

**Solution**
With this PR I've manually applied the same style to the two impacted components without using this selector, attempting to keep it as close as possible to the intended look. Also, through running some tests, I've found that Chrome can now render up to 200kb JSON responses, and have increased the threshold accordingly. For interest, Firefox is able to get around 400kb without major problems. 