### PR TITLE
fix(openapi-types): include '3.0.3' in allowed OpenAPIV3 versions

### DIFF
--- a/.changeset/lazy-buttons-remember.md
+++ b/.changeset/lazy-buttons-remember.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-types': minor
+---
+
+Include `3.0.3` in allowed OpenApiV3 versions

--- a/.changeset/lazy-buttons-remember.md
+++ b/.changeset/lazy-buttons-remember.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/openapi-types': minor
+'@scalar/openapi-types': patch
 ---
 
 Include `3.0.3` in allowed OpenApiV3 versions

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -322,7 +322,7 @@ export namespace OpenAPIV3 {
      * Version of the OpenAPI specification
      * @see https://github.com/OAI/OpenAPI-Specification/tree/main/versions
      */
-    openapi?: '3.0.0' | '3.0.1' | '3.0.2' | '3.0.2'
+    openapi?: '3.0.0' | '3.0.1' | '3.0.2' | '3.0.3'
     swagger?: undefined
     info?: InfoObject
     servers?: ServerObject[]


### PR DESCRIPTION
**Problem**
Currently, the `openapi` field of the OpenAPIV3 Document mistakenly duplicates `3.0.2` and does not include `3.0.3`
```ts
openapi?: '3.0.0' | '3.0.1' | '3.0.2' | '3.0.2';
```

**Solution**
This pr adds `3.0.3` to the allowed values of `openapi` in the OpenAPIV3 Document.
