### PR TITLE
fix(api-client): data cell dropdown overflow issue

### DIFF
--- a/.changeset/green-eyes-act.md
+++ b/.changeset/green-eyes-act.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: data table cell overflow issue

--- a/packages/api-client/src/components/DataTable/DataTableCell.vue
+++ b/packages/api-client/src/components/DataTable/DataTableCell.vue
@@ -11,7 +11,7 @@ withDefaults(
 <template>
   <component
     :is="is"
-    class="min-h-8 min-w-8 border-l-0 border-t-0 border-b-1/2 border-r-1/2 flex text-sm last:border-r-0 group-last:border-b-transparent p-0 m-0 relative overflow-hidden"
+    class="min-h-8 min-w-8 border-l-0 border-t-0 border-b-1/2 border-r-1/2 flex text-sm last:border-r-0 group-last:border-b-transparent p-0 m-0 relative"
     role="cell">
     <slot />
   </component>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -20,7 +20,7 @@ const hasItemProperties = computed(
     class="w-full"
     :delay="0"
     side="left"
-    triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 before:min-h-full before:right-[23px] before:w-3 absolute h-8 right-0">
+    triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 before:min-h-full before:right-[23px] before:w-3 absolute h-full right-0">
     <template #trigger>
       <div class="pl-1 pr-1.5 py-[9px]">
         <ScalarIcon


### PR DESCRIPTION
this pr fixes #3543 and the dropdown overflow issue within api client data table cell - mistakenly added to fix tooltip gradient visibility, now fixed using full height:

**before**
<img width="791" alt="image" src="https://github.com/user-attachments/assets/0fa16515-b8cc-41dd-a13d-96da74be4ab5">

**after
<img width="791" alt="image" src="https://github.com/user-attachments/assets/41a2113c-ace6-4f2e-b033-7a66729f36de">

