### PR TITLE
style(api-client): tooltip fixtures

### DIFF
--- a/.changeset/few-shrimps-buy.md
+++ b/.changeset/few-shrimps-buy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: environment variable tooltip fixtures

--- a/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
+++ b/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
@@ -84,8 +84,8 @@ class PillWidget extends WidgetType {
         return h(
           ScalarTooltip,
           {
-            align: 'start',
-            class: 'bg-b-1 w-full',
+            align: 'center',
+            class: 'bg-b-2 w-full',
             delay: 0,
             side: 'bottom',
             sideOffset: 6,
@@ -97,7 +97,7 @@ class PillWidget extends WidgetType {
                 'div',
                 {
                   class:
-                    'w-content shadow-lg rounded bg-b-1 text-xxs leading-5 text-c-1',
+                    'w-content shadow-lg rounded bg-b-1 brightness-lifted text-xxs leading-5 text-c-1',
                 },
                 tooltipContent,
               ),

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -505,3 +505,8 @@ watch(
     </DataTable>
   </ViewLayoutCollapse>
 </template>
+<style scoped>
+:deep(.cm-content) {
+  font-size: var(--scalar-mini);
+}
+</style>


### PR DESCRIPTION
this pr styles tooltip position/brightness and decreases back the request body content size:

**before**
<img width="594" alt="image" src="https://github.com/user-attachments/assets/1cff7fd4-07b1-4436-a9eb-c4da27101c1a">

**after**
<img width="594" alt="image" src="https://github.com/user-attachments/assets/96d196e6-d1f0-4a22-9aaf-25101ec91429">
