### PR TITLE
fix(import): sandbox links with uppercase letters can’t be resolved

### DIFF
--- a/.changeset/big-cooks-look.md
+++ b/.changeset/big-cooks-look.md
@@ -1,0 +1,5 @@
+---
+'@scalar/import': patch
+---
+
+fix: sandbox links with uppercase letters can not be resolved

--- a/packages/import/README.md
+++ b/packages/import/README.md
@@ -20,10 +20,12 @@ Find any OpenAPI/Swagger document URL in any content:
 ```ts
 import { resolve } from '@scalar/import'
 
-// Get the Swagger 2.0 URL from Swagger UI
-const result = await resolve('https://petstore.swagger.io/')
+// Get the raw file URL from a GitHub link
+const result = await resolve(
+  'https://github.com/outline/openapi/blob/main/spec3.yml',
+)
 
-// https://petstore.swagger.io/v2/swagger.json
+// https://raw.githubusercontent.com/outline/openapi/refs/heads/main/spec3.yml
 ```
 
 ## Features

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -46,14 +46,14 @@ describe('resolve', () => {
   })
 
   it('finds URLs from sandbox URL', async () => {
-    const result = await resolve('https://sandbox.scalar.com/p/dlw8v')
+    const result = await resolve('https://sandbox.scalar.com/p/GcxDQ')
 
-    expect(result).toBe('https://sandbox.scalar.com/files/dlw8v/openapi.yaml')
+    expect(result).toBe('https://sandbox.scalar.com/files/GcxDQ/openapi.yaml')
 
-    const otherResult = await resolve('https://sandbox.scalar.com/e/dlw8v')
+    const otherResult = await resolve('https://sandbox.scalar.com/e/GcxDQ')
 
     expect(otherResult).toBe(
-      'https://sandbox.scalar.com/files/dlw8v/openapi.yaml',
+      'https://sandbox.scalar.com/files/GcxDQ/openapi.yaml',
     )
   })
 

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -29,7 +29,7 @@ export async function resolve(
 
     // https://sandbox.scalar.com
     const sandboxUrl = value.match(
-      /https:\/\/sandbox\.scalar\.com\/(p|e)\/([a-z0-9]+)/,
+      /https:\/\/sandbox\.scalar\.com\/(p|e)\/([a-zA-Z0-9]+)/,
     )
 
     if (sandboxUrl?.[2]) {

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -3,7 +3,7 @@
  * This is useful to open the OpenAPI document from basically any source.
  */
 export async function resolve(
-  value?: string,
+  value?: string | null,
 ): Promise<string | Record<string, any> | undefined> {
   // URLs
   if (value?.startsWith('http://') || value?.startsWith('https://')) {


### PR DESCRIPTION
Oops, sandbox links that contain uppercase letters aren’t resolved by `@scalar/import`. This PR fixes it.

And let’s allow `null` as a value, too. Let’s just try to be as flexible as possible with what we take as an input.