### PR TITLE
fix(fastify-api-reference): JSON endpoint does not have CORS headers

### DIFF
--- a/.changeset/cold-phones-bake.md
+++ b/.changeset/cold-phones-bake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: JSON endpoint does not have CORS headers

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -256,6 +256,8 @@ const fastifyApiReference = fp<
         return reply
           .header('Content-Type', `application/json`)
           .header('Content-Disposition', `filename=${filename}.json`)
+          .header('Access-Control-Allow-Origin', '*')
+          .header('Access-Control-Allow-Methods', '*')
           .send(json)
       },
     })


### PR DESCRIPTION
This PR adds CORS headers to the JSON endpoint again, we must have lost them in some merge conflicts.