### PR TITLE
fix(api-client): request path variables url

### DIFF
--- a/.changeset/flat-phones-clean.md
+++ b/.changeset/flat-phones-clean.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sets path variables on full url

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -16,6 +16,7 @@ const {
   activeExample,
   requestMutators,
   requestExampleMutators,
+  activeServer,
 } = useWorkspace()
 
 const params = computed(() => {
@@ -96,14 +97,17 @@ const setPathVariable = (url: string) => {
   )
 }
 
-watch(
-  () => activeRequest.value?.path,
-  (newURL) => {
-    if (newURL) {
-      setPathVariable(newURL)
-    }
-  },
-)
+const fullURL = computed(() => {
+  const serverURL = activeServer.value?.url || ''
+  const requestPath = activeRequest.value?.path || ''
+  return serverURL + requestPath
+})
+
+watch(fullURL, (newURL) => {
+  if (newURL) {
+    setPathVariable(newURL)
+  }
+})
 </script>
 <template>
   <ViewLayoutCollapse :itemCount="params.length">


### PR DESCRIPTION
this pr is fast following on #3553 in order to display path variable items in tabs if available in the server.

**before**
<img width="594" alt="image" src="https://github.com/user-attachments/assets/d3436f65-724c-4201-9177-ad2601ba5a1e">

**after**
<img width="594" alt="image" src="https://github.com/user-attachments/assets/eb74baa9-75f0-44e7-af4a-3558fd51048d">
