### PR TITLE
Fix/client always uses proxy

### DIFF
--- a/.changeset/tasty-donkeys-behave.md
+++ b/.changeset/tasty-donkeys-behave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: API client always uses proxy.scalar.com

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -68,6 +68,7 @@ export const createApiClient = ({
 }: CreateApiClientParams) => {
   const store = createWorkspaceStore(router, {
     useLocalStorage: persistData,
+    defaultProxyUrl: configuration.proxyUrl,
   })
 
   // Load from localStorage if available

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -66,7 +66,9 @@ export const createApiClient = ({
   mountOnInitialize = true,
   router,
 }: CreateApiClientParams) => {
-  const store = createWorkspaceStore(router, persistData)
+  const store = createWorkspaceStore(router, {
+    useLocalStorage: persistData,
+  })
 
   // Load from localStorage if available
   // Check if we have localStorage data

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -55,15 +55,36 @@ declare global {
   }
 }
 
+type CreateWorkspaceStoreOptions = {
+  /**
+   * When true, changes made to the store will be saved in the browser’s localStorage.
+   *
+   * @default true
+   */
+  useLocalStorage: boolean
+}
+
 /**
- * Factory for creating the entire store for the api-client
- * This should be injected once per app instance
+ /**
+ * Factory function for creating the centralized store for the API client.
+ *
+ * This store manages all data and state for the application.
+ * It should be instantiated once and injected into the app’s root component.
  */
 export const createWorkspaceStore = (
   router: Router,
   /** If true data will be persisted to localstorage when changes are made */
-  useLocalStorage = true,
+  options: Partial<CreateWorkspaceStoreOptions> = {},
 ) => {
+  const defaultOptions: CreateWorkspaceStoreOptions = {
+    useLocalStorage: true,
+  }
+
+  const { useLocalStorage } = {
+    ...defaultOptions,
+    ...options,
+  }
+
   /** Gives the required UID usually per route */
   const activeRouterParams = computed(getRouterParams(router))
 
@@ -298,6 +319,8 @@ export const createWorkspaceStore = (
         ? 'https://proxy.scalar.com'
         : '',
   )
+
+  console.log('FOO', proxyUrl)
 
   const setProxyUrl = (url: string) => {
     proxyUrl.value = url

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -62,6 +62,7 @@ type CreateWorkspaceStoreOptions = {
    * @default true
    */
   useLocalStorage: boolean
+  defaultProxyUrl: string | undefined
 }
 
 /**
@@ -73,7 +74,10 @@ type CreateWorkspaceStoreOptions = {
  */
 export const createWorkspaceStore = (
   router: Router,
-  { useLocalStorage = true }: CreateWorkspaceStoreOptions,
+  {
+    useLocalStorage = true,
+    defaultProxyUrl = undefined,
+  }: CreateWorkspaceStoreOptions,
 ) => {
   /** Gives the required UID usually per route */
   const activeRouterParams = computed(getRouterParams(router))
@@ -299,22 +303,21 @@ export const createWorkspaceStore = (
 
   // ---------------------------------------------------------------------------
   // PROXY URL STATE
-  const PROXY_URL = 'proxyUrl' as const
+  const PROXY_URL = 'globalProxyUrl' as const
 
-  // Initialize proxyUrl with the value from localStorage or default to the proxy URL according to env
+  // Initialize proxyUrl with the value from localStorage, defaultProxyUrl, or https://proxy.scalar.com
   const proxyUrl = ref(
-    localStorage.getItem(PROXY_URL) !== null
-      ? localStorage.getItem(PROXY_URL) || ''
-      : import.meta.env.PROD
-        ? 'https://proxy.scalar.com'
-        : '',
+    // Something custom
+    localStorage.getItem(PROXY_URL) ||
+      // The configured default
+      defaultProxyUrl,
   )
-
-  console.log('FOO', proxyUrl)
 
   const setProxyUrl = (url: string) => {
     proxyUrl.value = url
+
     localStorage.setItem(PROXY_URL, url)
+
     workspaceMutators.edit(activeWorkspace.value.uid, 'proxyUrl', url)
   }
 
@@ -354,6 +357,7 @@ export const createWorkspaceStore = (
     setSidebarWidth,
     proxyUrl,
     setProxyUrl,
+    defaultProxyUrl,
     // ---------------------------------------------------------------------------
     // METHODS
     importSpecFile,

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -73,18 +73,8 @@ type CreateWorkspaceStoreOptions = {
  */
 export const createWorkspaceStore = (
   router: Router,
-  /** If true data will be persisted to localstorage when changes are made */
-  options: Partial<CreateWorkspaceStoreOptions> = {},
+  { useLocalStorage = true }: CreateWorkspaceStoreOptions,
 ) => {
-  const defaultOptions: CreateWorkspaceStoreOptions = {
-    useLocalStorage: true,
-  }
-
-  const { useLocalStorage } = {
-    ...defaultOptions,
-    ...options,
-  }
-
   /** Gives the required UID usually per route */
   const activeRouterParams = computed(getRouterParams(router))
 

--- a/packages/api-client/src/views/Settings/SettingsGeneral.vue
+++ b/packages/api-client/src/views/Settings/SettingsGeneral.vue
@@ -8,14 +8,6 @@ import SettingsGeneralMode from './SettingsGeneralMode.vue'
 const { activeWorkspace, workspaceMutators, proxyUrl, setProxyUrl } =
   useWorkspace()
 
-const toggleScalarProxy = () => {
-  if (proxyUrl.value) {
-    setProxyUrl('')
-  } else {
-    setProxyUrl('https://proxy.scalar.com')
-  }
-}
-
 const themeIds: ThemeId[] = [
   'default',
   'alternate',

--- a/packages/api-client/src/views/Settings/SettingsGeneral.vue
+++ b/packages/api-client/src/views/Settings/SettingsGeneral.vue
@@ -5,8 +5,13 @@ import { type ThemeId, themeLabels } from '@scalar/themes'
 
 import SettingsGeneralMode from './SettingsGeneralMode.vue'
 
-const { activeWorkspace, workspaceMutators, proxyUrl, setProxyUrl } =
-  useWorkspace()
+const {
+  activeWorkspace,
+  workspaceMutators,
+  proxyUrl,
+  setProxyUrl,
+  defaultProxyUrl,
+} = useWorkspace()
 
 const themeIds: ThemeId[] = [
   'default',
@@ -79,6 +84,7 @@ const changeTheme = (themeId: ThemeId) => {
             >.
           </p>
           <div class="gap-2 mt-4 mb-8 flex flex-col">
+            <!-- Default proxy -->
             <ScalarButton
               class="w-full shadow-none text-c-1 justify-start pl-2 gap-2 bg-b-2 border-1/2"
               :class="{ 'bg-b-1 text-c-1': proxyUrl }"
@@ -87,13 +93,35 @@ const changeTheme = (themeId: ThemeId) => {
               <div
                 class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1">
                 <ScalarIcon
-                  v-if="proxyUrl"
+                  v-if="proxyUrl === 'https://proxy.scalar.com'"
                   icon="Checkmark"
                   size="xs"
                   thickness="3.5" />
               </div>
               Use proxy.scalar.com (default)
             </ScalarButton>
+
+            <!-- Custom proxy (only if configured) -->
+            <ScalarButton
+              v-if="
+                defaultProxyUrl &&
+                defaultProxyUrl !== 'https://proxy.scalar.com'
+              "
+              class="w-full shadow-none text-c-1 justify-start pl-2 gap-2 bg-b-1 border-1/2"
+              variant="primary"
+              @click="setProxyUrl(defaultProxyUrl)">
+              <div
+                class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1">
+                <ScalarIcon
+                  v-if="proxyUrl === defaultProxyUrl"
+                  icon="Checkmark"
+                  size="xs"
+                  thickness="3.5" />
+              </div>
+              Use custom proxy ({{ defaultProxyUrl }})
+            </ScalarButton>
+
+            <!-- No proxy -->
             <ScalarButton
               class="w-full shadow-none text-c-1 justify-start pl-2 gap-2 bg-b-2 border-1/2"
               :class="{ 'bg-b-1 text-c-1': !proxyUrl }"


### PR DESCRIPTION
Currently, the API client is just always using our public proxy.

We just recently merged the following code:

```ts
  const proxyUrl = ref(
    localStorage.getItem(PROXY_URL) !== null
      ? localStorage.getItem(PROXY_URL) || ''
      : import.meta.env.PROD
        ? 'https://proxy.scalar.com'
        : '',
```

This basically say, use what’s in localStorage, and if nothing is localStorage, just use proxy.scalar.com. It doesn’t take the configuration into account.

With this PR the configured proxy is passed to `createWorkspaceStore` and the decision is made like this:

1. Use what’s in localStorage
2. If nothing is set in localStorage, use the proxy from the configuration

If there’s a custom proxy configured, a third setting for the custom proxy shows up on the settings page:

<img width="733" alt="Screenshot 2024-10-22 at 11 55 03" src="https://github.com/user-attachments/assets/267492ff-ad18-4f4a-963f-42f86276603c">

Note: I’ve modified the localStorage key. Otherwise users that already had the proxyUrl in the localStorage, wouldn’t notice any changes.