### PR TITLE
ci: in the reusable build action, only restore from the cache

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -26,7 +26,10 @@ runs:
       uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
       with:
         path: .turbo
-        key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}
+        key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}-${{ github.sha }}
+        restore-keys:
+          - turbo-${{ runner.os }}-node-${{ inputs.node-version }}-
+          - turbo-${{ runner.os }}-node-
     - if: ${{ inputs.packages-only == 'false' }}
       name: Build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,8 +22,8 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm install
-    - name: Turborepo cache
-      uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8
+    - name: Restore Turborepo cache
+      uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
       with:
         path: .turbo
         key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -27,9 +27,9 @@ runs:
       with:
         path: .turbo
         key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}-${{ github.sha }}
-        restore-keys:
-          - turbo-${{ runner.os }}-node-${{ inputs.node-version }}-
-          - turbo-${{ runner.os }}-node-
+        restore-keys: |
+          turbo-${{ runner.os }}-node-${{ inputs.node-version }}-
+          turbo-${{ runner.os }}-node-
     - if: ${{ inputs.packages-only == 'false' }}
       name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache/save@3624ceb22c1c5a301c8db4169662070a689d9ea8
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-${{ github.sha }}
 
   format:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Update Turborepo cache
+      - name: Save Turborepo cache
         uses: actions/cache/save@3624ceb22c1c5a301c8db4169662070a689d9ea8
         with:
           path: .turbo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   harden_security:
-    name: Harden Security
+    name: Check used GitHub Actions
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
-      - name: Ensure SHA pinned actions
+      - name: Ensure all Actions are pinned to a Commit SHA
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ed00f72a3ca5b6eff8ad4d3ffdcacedb67a21db1
 
   build:
@@ -56,8 +56,8 @@ jobs:
         run: pnpm format:check
 
   types:
-    runs-on: ubuntu-20.04
     needs: [build]
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [20]
@@ -73,8 +73,8 @@ jobs:
         run: pnpm turbo types:check
 
   test:
-    runs-on: ubuntu-20.04
     needs: [build]
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [18, 20]
@@ -91,8 +91,8 @@ jobs:
         run: pnpm test:ci
 
   stats:
+    needs: [build]
     runs-on: ubuntu-20.04
-    needs: build
     strategy:
       matrix:
         node-version: [20]
@@ -257,8 +257,8 @@ jobs:
   deploy-api-client:
     # Only run this job for PRs from the same repository
     if: github.ref == 'refs/heads/main' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-20.04
     needs: [build]
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [20]
@@ -345,6 +345,7 @@ jobs:
 
   aspnetcore-build-test:
     runs-on: ubuntu-latest
+    needs: [build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -29,7 +29,7 @@ jobs:
         run: echo "DEPLOY_ID=$(uuidgen)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Install dependencies
         run: pnpm --filter web install
-      - name: Turborepo cache
+      - name: Restore Turborepo cache
         uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
         with:
           path: .turbo

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Turborepo cache
+      - name: Restore Turborepo cache
         uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
         with:
           path: .turbo

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Turborepo cache
+      - name: Restore Turborepo cache
         uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
         with:
           path: .turbo

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Turborepo cache
+      - name: Restore Turborepo cache
         uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
         with:
           path: .turbo

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Turborepo cache
+      - name: Restore Turborepo cache
         uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
         with:
           path: .turbo

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,6 +1,6 @@
 # Scalar Icons
 
-All the icons we’re using
+The icon library that we use to provide user selectable icons.
 
 ## Installation
 

--- a/packages/mock-server/README.md
+++ b/packages/mock-server/README.md
@@ -19,7 +19,7 @@ A powerful Node.js server that generates and returns realistic mock data based o
 
 ## Quickstart
 
-It’s part of [our Scalar CLI](https://github.com/scalar/scalar/tree/main/packages/cli), sou can boot it literllay in seconds:
+It’s part of [our Scalar CLI](https://github.com/scalar/scalar/tree/main/packages/cli), you can boot it literllay in seconds:
 
 ```bash
 npx @scalar/cli mock openapi.json --watch


### PR DESCRIPTION
Currently, the build action that we use everywhere restores *and* writes to the cache. This produces conflicts.

<img width="249" alt="Screenshot 2024-10-22 at 13 09 15" src="https://github.com/user-attachments/assets/cab5747c-2693-40fa-a3fe-bcfd6975e0f6">

With this PR we’re making sure, we’re only restoring from the cache. There’s only one place where we write to the Turborepo cache, and this is in the build job of the ci workflow. So after the build was done the first time.

**Results**

1st run: 9m 17s
2nd run: 3m 45s