### PR TITLE
style(api-reference): authentication form

### DIFF
--- a/.changeset/two-rivers-destroy.md
+++ b/.changeset/two-rivers-destroy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+style: updates authentication form radiuses

--- a/packages/api-reference/src/legacy/components/CardFormTextInput.vue
+++ b/packages/api-reference/src/legacy/components/CardFormTextInput.vue
@@ -103,8 +103,12 @@ defineOptions({
   /* Remove default outline */
   box-shadow: none;
 }
+.card-form-input:not(:only-child) {
+  border-radius: var(--scalar-radius) 0 0 var(--scalar-radius);
+}
 .card-form-input + .card-form-input {
   border-left: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-radius: 0 var(--scalar-radius) var(--scalar-radius) 0;
 }
 .card-form-input-text:not(:placeholder-shown) + label {
   color: var(--scalar-color-2);


### PR DESCRIPTION
this pr updates the border style of the basic authentication form with double input:

**before**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/58355f68-3d40-4207-bbd0-155467bd1b7e">

**after** 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/40159dfc-eafc-4f78-b4ea-24228b3267b0">