### PR TITLE
fix(api-client): address bar hotkey submission

### DIFF
--- a/.changeset/thin-toys-draw.md
+++ b/.changeset/thin-toys-draw.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: removes stopped propagation on enter key in code input

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -222,7 +222,7 @@ export default {
         'flow-code-input--error': error,
       }"
       @keydown.down.stop="handleKeyDown('down', $event)"
-      @keydown.enter.stop="handleKeyDown('enter', $event)"
+      @keydown.enter="handleKeyDown('enter', $event)"
       @keydown.up.stop="handleKeyDown('up', $event)"></div>
   </template>
   <div


### PR DESCRIPTION
this pr removes the stopped propagation on key enter within code input, which is preventing the meta+enter action from submitting the request from the address bar focus.