### PR TITLE
style(api-client): address bar loading background

### DIFF
--- a/.changeset/eleven-frogs-smile.md
+++ b/.changeset/eleven-frogs-smile.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: increases address bar loading background index

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -154,7 +154,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
           <div
             class="pointer-events-none absolute left-0 top-0 block h-full w-full overflow-hidden">
             <div
-              class="bg-mix-transparent bg-mix-amount-90 absolute left-0 top-0 h-full w-full"
+              class="bg-mix-transparent bg-mix-amount-90 absolute left-0 top-0 h-full w-full z-context"
               :class="getBackgroundColor()"
               :style="{ transform: `translate3d(-${percentage}%,0,0)` }"></div>
           </div>


### PR DESCRIPTION
this pr increases z index on loading background in address bar component, in order to fix color inconsistencies when submitting request without focus as seen below:

**before**
<img width="815" alt="image" src="https://github.com/user-attachments/assets/673a8fae-7d11-4aa8-9596-5e8185cc21e2">

**after**
<img width="815" alt="image" src="https://github.com/user-attachments/assets/282dac85-8f2f-4a95-93f2-bc876ff12fe5">
