### PR TITLE
fix(openapi-parser): update `uri` types to be `uri-reference` in schema v3.1

### DIFF
--- a/.changeset/early-cobras-fail.md
+++ b/.changeset/early-cobras-fail.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+Allow relative URLs in v3.1 documents

--- a/packages/openapi-parser/src/schemas/v3.1/schema.json
+++ b/packages/openapi-parser/src/schemas/v3.1/schema.json
@@ -13,7 +13,7 @@
     },
     "jsonSchemaDialect": {
       "type": "string",
-      "format": "uri",
+      "format": "uri-reference",
       "default": "https://spec.openapis.org/oas/3.1/dialect/base"
     },
     "servers": {
@@ -85,7 +85,7 @@
         },
         "termsOfService": {
           "type": "string",
-          "format": "uri"
+          "format": "uri-reference"
         },
         "contact": {
           "$ref": "#/$defs/contact"
@@ -110,7 +110,7 @@
         },
         "url": {
           "type": "string",
-          "format": "uri"
+          "format": "uri-reference"
         },
         "email": {
           "type": "string",
@@ -132,7 +132,7 @@
         },
         "url": {
           "type": "string",
-          "format": "uri"
+          "format": "uri-reference"
         }
       },
       "required": ["name"],
@@ -407,7 +407,7 @@
         },
         "url": {
           "type": "string",
-          "format": "uri"
+          "format": "uri-reference"
         }
       },
       "required": ["url"],
@@ -846,7 +846,7 @@
         "value": true,
         "externalValue": {
           "type": "string",
-          "format": "uri"
+          "format": "uri-reference"
         }
       },
       "not": {
@@ -1139,7 +1139,7 @@
             "properties": {
               "openIdConnectUrl": {
                 "type": "string",
-                "format": "uri"
+                "format": "uri-reference"
               }
             },
             "required": ["openIdConnectUrl"]
@@ -1183,11 +1183,11 @@
           "properties": {
             "authorizationUrl": {
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "refreshUrl": {
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "scopes": {
               "$ref": "#/$defs/map-of-strings"
@@ -1202,11 +1202,11 @@
           "properties": {
             "tokenUrl": {
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "refreshUrl": {
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "scopes": {
               "$ref": "#/$defs/map-of-strings"
@@ -1221,11 +1221,11 @@
           "properties": {
             "tokenUrl": {
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "refreshUrl": {
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "scopes": {
               "$ref": "#/$defs/map-of-strings"
@@ -1240,15 +1240,15 @@
           "properties": {
             "authorizationUrl": {
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "tokenUrl": {
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "refreshUrl": {
               "type": "string",
-              "format": "uri"
+              "format": "uri-reference"
             },
             "scopes": {
               "$ref": "#/$defs/map-of-strings"


### PR DESCRIPTION
According to the OpenAPI 3.1 spec ([link](https://swagger.io/specification/#:~:text=to%20RFC3986.-,Relative%20References%20in%20URLs,-Unless%20specified%20otherwise)),

> Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2). Unless specified otherwise, relative references are resolved using the URLs defined in the [Server Object](https://swagger.io/specification/#server-object) as a Base URL. Note that these themselves MAY be relative to the referring document.

It seems the v3.0 spec already uses `uri-reference`. This PR updates v3.1 to use the same
