### PR TITLE
fix(api-reference): sidebar a11y improvements

### DIFF
--- a/.changeset/tidy-pandas-tease.md
+++ b/.changeset/tidy-pandas-tease.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): sidebar a11y improvements

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -294,9 +294,8 @@ const themeStyleTag = computed(
         name="header" />
     </div>
     <!-- Navigation (sidebar) wrapper -->
-    <nav
+    <aside
       v-if="configuration.showSidebar"
-      :aria-label="`Contents of ${parsedSpec.info?.title}`"
       class="references-navigation t-doc__sidebar">
       <!-- Navigation tree / Table of Contents -->
       <div class="references-navigation-list">
@@ -316,7 +315,7 @@ const themeStyleTag = computed(
           </template>
         </Sidebar>
       </div>
-    </nav>
+    </aside>
     <!-- Swagger file editing -->
     <div
       v-show="configuration.isEditable"

--- a/packages/api-reference/src/components/DarkModeToggle/DarkModeToggle.vue
+++ b/packages/api-reference/src/components/DarkModeToggle/DarkModeToggle.vue
@@ -18,6 +18,7 @@ defineEmits<{
       <ScalarIcon
         icon="LightDarkModeToggle"
         size="md" />
+      <div class="sr-only">Set to</div>
       <template v-if="isDarkMode">
         <span>Light Mode</span>
       </template>

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -71,8 +71,9 @@ onMounted(() => {
 <template>
   <div class="sidebar">
     <slot name="sidebar-start" />
-    <div
+    <nav
       ref="scrollerEl"
+      :aria-label="`Contents of ${parsedSpec.info?.title}`"
       class="sidebar-pages custom-scroll custom-scroll-self-contain-overflow">
       <SidebarGroup :level="0">
         <template
@@ -174,7 +175,7 @@ onMounted(() => {
           </template>
         </template>
       </SidebarGroup>
-    </div>
+    </nav>
     <slot name="sidebar-end" />
   </div>
 </template>

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -100,9 +100,10 @@ const onAnchorClick = async (ev: Event) => {
         v-if="hasChildren"
         class="sidebar-heading-chevron">
         <ScalarIconButton
+          :aria-expanded="open"
           class="toggle-nested-icon"
           :icon="open ? 'ChevronDown' : 'ChevronRight'"
-          label="Toggle group"
+          :label="`${open ? 'Collapse' : 'Expand'} ${item.title}`"
           size="xs"
           @click.stop="handleClick" />
         &hairsp;
@@ -122,6 +123,7 @@ const onAnchorClick = async (ev: Event) => {
           v-if="item.httpVerb && !hasChildren"
           class="sidebar-heading-link-method">
           &hairsp;
+          <span class="sr-only">HTTP Method:&nbsp;</span>
           <SidebarHttpBadge
             :active="isActive"
             :method="item.httpVerb" />

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -173,6 +173,15 @@ const onAnchorClick = async (ev: Event) => {
   color: var(--scalar-sidebar-item-hover-color);
 }
 
+.sidebar-heading-link:focus-visible {
+  outline: none;
+}
+
+.sidebar-heading:has(> .sidebar-heading-link:focus-visible) {
+  z-index: 1;
+  outline: 1px solid var(--scalar-color-accent);
+}
+
 .active_page.sidebar-heading:hover,
 .active_page.sidebar-heading {
   color: var(--scalar-sidebar-color-active, var(--scalar-color-accent));

--- a/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
@@ -44,8 +44,10 @@ const selected = computed<ScalarListboxOption | undefined>({
       :class="{ 'pointer-events-none': options.length <= 1 }"
       fullWidth
       variant="ghost">
-      <span class="custom-scroll">
-        <slot></slot>
+      <span
+        class="custom-scroll"
+        tabindex="-1">
+        <slot />
       </span>
       <ScalarIcon
         v-if="options.length > 1"


### PR DESCRIPTION
Various improvements to the references sidebar.

## Keyboard Focus Outlines Before & After

https://github.com/user-attachments/assets/06bcf541-fe9b-4825-8060-7f23113395d9

## Screen Reader

Keep in mind that this is voiceover in Chrome and all screen readers work a little bit differently.

### Before

https://github.com/user-attachments/assets/ff082dbf-f242-4591-b497-d510478979f1

### After

https://github.com/user-attachments/assets/d18da811-919e-4259-9ba2-7f3641ea2fcc

