### PR TITLE
style(api-client): top navigation

### DIFF
--- a/.changeset/heavy-hotels-grin.md
+++ b/.changeset/heavy-hotels-grin.md
@@ -1,0 +1,5 @@
+---
+'scalar-api-client': patch
+---
+
+style: updates sidenav icon size

--- a/.changeset/serious-plums-begin.md
+++ b/.changeset/serious-plums-begin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: removes top border and sets overscroll property

--- a/packages/api-client-app/src/renderer/index.html
+++ b/packages/api-client-app/src/renderer/index.html
@@ -27,7 +27,4 @@
   .scalar-client .scalar-app-show {
     display: block;
   }
-  .scalar-client .scalar-app-nav-padding {
-    padding: 10px;
-  }
 </style>

--- a/packages/api-client/src/components/SideNav/SideNav.vue
+++ b/packages/api-client/src/components/SideNav/SideNav.vue
@@ -10,7 +10,7 @@ const { currentRoute } = useRouter()
 <template>
   <nav
     aria-label="App Navigation"
-    class="text-c-2 sm:w-13 flex sm:flex-col justify-center items-center px-2 py-2 scalar-sidenav relative drag-region bg-b-1 border-t-1/2"
+    class="text-c-2 sm:w-13 flex sm:flex-col justify-center items-center px-2 py-2 scalar-sidenav relative drag-region bg-b-1"
     role="navigation">
     <ul class="flex sm:flex-col gap-1.5">
       <li

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -146,7 +146,7 @@ onMounted(() => events.hotKeys.on(handleHotKey))
 onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
 </script>
 <template>
-  <nav class="flex h-10 t-app__top-nav">
+  <nav class="border-b-1/2 flex h-10 t-app__top-nav">
     <div class="t-app__top-nav-draggable"></div>
     <div
       class="flex h-10 flex-1 items-center gap-1.5 text-sm font-medium pr-1 relative overflow-hidden">

--- a/packages/api-client/src/layouts/App/MainLayout.vue
+++ b/packages/api-client/src/layouts/App/MainLayout.vue
@@ -10,7 +10,7 @@ import SideNav from '@/components/SideNav/SideNav.vue'
     <!-- Popup command palette to add resources from anywhere -->
     <TheCommandPalette />
 
-    <div class="flex flex-1 flex-col min-w-0 min-h-0 border-l-1/2 border-t-1/2">
+    <div class="flex flex-1 flex-col min-w-0 min-h-0 border-l-1/2">
       <slot />
     </div>
   </main>

--- a/packages/api-client/src/layouts/Web/ApiClientWeb.vue
+++ b/packages/api-client/src/layouts/Web/ApiClientWeb.vue
@@ -61,6 +61,7 @@ const themeStyleTag = computed(
 html,
 body {
   background-color: var(--scalar-background-1);
+  overscroll-behavior: none;
 }
 
 #scalar-client {


### PR DESCRIPTION
this pr moves the app top border to the topnav component in order to fix the glitch from the preview modal in #3236, and also sets [overscroll behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior) and fix icon size consistencies between web / desktop:

**before**
import modal
<img width="600" alt="image" src="https://github.com/user-attachments/assets/958ffe21-595b-4c1e-ba3e-5e485216df87">

sidenav icon
<img width="600" alt="image" src="https://github.com/user-attachments/assets/b27783cb-7a3f-4e34-a5be-4afe9db80c8f">

**after**

import modal
<img width="600" alt="image" src="https://github.com/user-attachments/assets/0de80919-49fe-4919-8254-76af08728697">

sidenav icon
<img width="600" alt="image" src="https://github.com/user-attachments/assets/b9445b30-b1b0-470c-a607-71a405fa5e3d">
