### PR TITLE
chore: add @babel/core as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "pnpm": "^9.1.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.25.9",
     "@changesets/cli": "^2.27.8",
     "@playwright/test": "^1.47.2",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@babel/core':
+        specifier: ^7.25.9
+        version: 7.25.9
       '@changesets/cli':
         specifier: ^2.27.8
         version: 2.27.8
@@ -298,7 +301,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.4(@babel/core@7.24.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.8))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.3.3)))(typescript@5.3.3)
+        version: 29.1.4(@babel/core@7.25.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.9))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.3.3)))(typescript@5.3.3)
       ts-loader:
         specifier: ^9.4.3
         version: 9.5.1(typescript@5.3.3)(webpack@5.90.1(@swc/core@1.5.29(@swc/helpers@0.5.5)))
@@ -371,7 +374,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.4(@babel/core@7.24.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.8))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)))(typescript@5.6.2)
+        version: 29.1.4(@babel/core@7.25.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.9))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)))(typescript@5.6.2)
       ts-loader:
         specifier: ^9.4.3
         version: 9.5.1(typescript@5.6.2)(webpack@5.92.0(@swc/core@1.5.29(@swc/helpers@0.5.5)))
@@ -386,7 +389,7 @@ importers:
         version: link:../../packages/nextjs-api-reference
       next:
         specifier: ^14.2.5
-        version: 14.2.5(@babel/core@7.24.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.5(@babel/core@7.25.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -929,7 +932,7 @@ importers:
         version: 0.2.6(rollup@4.18.1)
       storybook:
         specifier: ^8.0.8
-        version: 8.1.9(@babel/preset-env@7.24.7(@babel/core@7.24.8))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.1.9(@babel/preset-env@7.24.7(@babel/core@7.25.9))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-dark-mode:
         specifier: ^4.0.1
         version: 4.0.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1340,7 +1343,7 @@ importers:
         version: 1.16.1(postcss@8.4.38)
       storybook:
         specifier: ^8.0.8
-        version: 8.1.9(@babel/preset-env@7.24.7)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.1.9(@babel/preset-env@7.24.7(@babel/core@7.25.9))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-dark-mode:
         specifier: ^4.0.1
         version: 4.0.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1715,7 +1718,7 @@ importers:
         version: 4.3.1(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))
       next:
         specifier: ^14.2.5
-        version: 14.2.5(@babel/core@7.24.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.5(@babel/core@7.25.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -1755,7 +1758,7 @@ importers:
         version: 18.3.0
       next:
         specifier: ^14.2.5
-        version: 14.2.5(@babel/core@7.24.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.5(@babel/core@7.25.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -2411,6 +2414,10 @@ packages:
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.25.9':
+    resolution: {integrity: sha512-z88xeGxnzehn2sqZ8UdGQEvYErF1odv2CftxInpSYJt6uHuPe9YjahKZITGs3l5LeI9d2ROG+obuDAoSlqbNfQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.24.7':
     resolution: {integrity: sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==}
     engines: {node: '>=6.9.0'}
@@ -2419,12 +2426,20 @@ packages:
     resolution: {integrity: sha512-c4IM7OTg6k1Q+AJ153e2mc2QVTezTwnb4VzquwcyiEzGnW0Kedv4do/TrkU98qPeC5LNiMt/QXwIjzYXLBpyZg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.25.9':
+    resolution: {integrity: sha512-yD+hEuJ/+wAJ4Ox2/rpNv5HIuPG82x3ZlQvYVn8iYCprdxzE7P1udpGF1jyjQVBU4dgznN+k2h103vxZ7NdPyw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/core@7.24.7':
     resolution: {integrity: sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.24.8':
     resolution: {integrity: sha512-6AWcmZC/MZCO0yKys4uhg5NlxL0ESF3K6IAaoQ+xSXvPyPyxNWRafP+GDbI88Oh68O7QkJgmEtedWPM9U0pZNg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.25.9':
+    resolution: {integrity: sha512-WYvQviPw+Qyib0v92AwNIrdLISTp7RfDkM7bPqBvpbnhY4wq8HvHBZREVdYDXk98C8BkOIVnHAY3yvj7AVISxQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.17.7':
@@ -2437,6 +2452,10 @@ packages:
 
   '@babel/generator@7.24.8':
     resolution: {integrity: sha512-47DG+6F5SzOi0uEvK4wMShmn5yY0mVjVJoWTphdY2B4Rx9wHgjK7Yhtr0ru6nE+sn0v38mzrWOlah0p/YlHHOQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.25.9':
+    resolution: {integrity: sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.24.7':
@@ -2453,6 +2472,10 @@ packages:
 
   '@babel/helper-compilation-targets@7.24.8':
     resolution: {integrity: sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.25.9':
+    resolution: {integrity: sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-create-class-features-plugin@7.24.7':
@@ -2506,6 +2529,10 @@ packages:
     resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.25.9':
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.24.7':
     resolution: {integrity: sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==}
     engines: {node: '>=6.9.0'}
@@ -2514,6 +2541,12 @@ packages:
 
   '@babel/helper-module-transforms@7.24.8':
     resolution: {integrity: sha512-m4vWKVqvkVAWLXfHCCfff2luJj86U+J0/x+0N3ArG/tP0Fq7zky2dYwMbtPmkc/oulkkbjdL3uWzuoBwQ8R00Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-module-transforms@7.25.9':
+    resolution: {integrity: sha512-TvLZY/F3+GvdRYFZFyxMvnsKi+4oJdgZzU3BoGN9Uc2d9C6zfNwJcKKhjqLAhK8i46mv93jsO74fDh3ih6rpHA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -2546,6 +2579,10 @@ packages:
     resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-simple-access@7.25.9':
+    resolution: {integrity: sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
     resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
     engines: {node: '>=6.9.0'}
@@ -2562,6 +2599,10 @@ packages:
     resolution: {integrity: sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
@@ -2570,12 +2611,20 @@ packages:
     resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.24.7':
     resolution: {integrity: sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.24.8':
     resolution: {integrity: sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.25.9':
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-wrap-function@7.24.7':
@@ -2590,8 +2639,16 @@ packages:
     resolution: {integrity: sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helpers@7.25.9':
+    resolution: {integrity: sha512-oKWp3+usOJSzDZOucZUAMayhPz/xVjzymyDzUN8dk0Wd3RWMlGLXi07UCQ/CgQVb8LvXx3XBajJH4XGgkt7H7g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/highlight@7.25.9':
+    resolution: {integrity: sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.24.7':
@@ -2606,6 +2663,11 @@ packages:
 
   '@babel/parser@7.25.8':
     resolution: {integrity: sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.25.9':
+    resolution: {integrity: sha512-aI3jjAAO1fh7vY/pBGsn1i9LDbRP43+asrRlkPuTXW5yHXtd1NgTEMudbBoDDxrf1daEEfPJqR+JBMakzrR4Dg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3178,6 +3240,10 @@ packages:
     resolution: {integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.25.9':
+    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.23.2':
     resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
     engines: {node: '>=6.9.0'}
@@ -3188,6 +3254,10 @@ packages:
 
   '@babel/traverse@7.24.8':
     resolution: {integrity: sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.25.9':
+    resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.17.0':
@@ -3204,6 +3274,10 @@ packages:
 
   '@babel/types@7.25.8':
     resolution: {integrity: sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.25.9':
+    resolution: {integrity: sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -8062,6 +8136,11 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  browserslist@4.24.2:
+    resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   bs-logger@0.2.6:
     resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
     engines: {node: '>= 6'}
@@ -8204,6 +8283,9 @@ packages:
 
   caniuse-lite@1.0.30001641:
     resolution: {integrity: sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==}
+
+  caniuse-lite@1.0.30001669:
+    resolution: {integrity: sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==}
 
   capnp-ts@0.7.0:
     resolution: {integrity: sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==}
@@ -9352,6 +9434,9 @@ packages:
   electron-to-chromium@1.4.827:
     resolution: {integrity: sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==}
 
+  electron-to-chromium@1.5.43:
+    resolution: {integrity: sha512-NxnmFBHDl5Sachd2P46O7UJiMaMHMLSofoIWVJq3mj8NJgG0umiSeljAVP9lGzjI0UDLJJ5jjoGjcrB8RSbjLQ==}
+
   electron-updater@4.6.5:
     resolution: {integrity: sha512-kdTly8O9mSZfm9fslc1mnCY+mYOeaYRy7ERa2Fed240u01BKll3aiupzkd07qKw69KvhBSzuHroIW3mF0D8DWA==}
 
@@ -9523,6 +9608,10 @@ packages:
 
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+    engines: {node: '>=6'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   escape-goat@4.0.0:
@@ -12748,6 +12837,9 @@ packages:
 
   node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+
+  node-releases@2.0.18:
+    resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
 
   nodemon@3.1.7:
     resolution: {integrity: sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==}
@@ -16205,6 +16297,12 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  update-browserslist-db@1.1.1:
+    resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   update-notifier@6.0.2:
     resolution: {integrity: sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==}
     engines: {node: '>=14.16'}
@@ -17251,9 +17349,16 @@ snapshots:
       '@babel/highlight': 7.24.7
       picocolors: 1.0.1
 
+  '@babel/code-frame@7.25.9':
+    dependencies:
+      '@babel/highlight': 7.25.9
+      picocolors: 1.1.0
+
   '@babel/compat-data@7.24.7': {}
 
   '@babel/compat-data@7.24.8': {}
+
+  '@babel/compat-data@7.25.9': {}
 
   '@babel/core@7.24.7':
     dependencies:
@@ -17295,6 +17400,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@7.25.9':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.25.9
+      '@babel/generator': 7.25.9
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-module-transforms': 7.25.9(@babel/core@7.25.9)
+      '@babel/helpers': 7.25.9
+      '@babel/parser': 7.25.9
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.25.9
+      convert-source-map: 2.0.0
+      debug: 4.3.7
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.17.7':
     dependencies:
       '@babel/types': 7.24.8
@@ -17310,19 +17435,26 @@ snapshots:
 
   '@babel/generator@7.24.8':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
+  '@babel/generator@7.25.9':
+    dependencies:
+      '@babel/types': 7.25.9
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.0.2
+
   '@babel/helper-annotate-as-pure@7.24.7':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
 
@@ -17342,6 +17474,14 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-compilation-targets@7.25.9':
+    dependencies:
+      '@babel/compat-data': 7.25.9
+      '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
   '@babel/helper-create-class-features-plugin@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -17357,30 +17497,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-class-features-plugin@7.24.7(@babel/core@7.24.8)':
+  '@babel/helper-create-class-features-plugin@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.24.7
       '@babel/helper-optimise-call-expression': 7.24.7
-      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-class-features-plugin@7.24.8(@babel/core@7.24.8)':
+  '@babel/helper-create-class-features-plugin@7.24.8(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.24.8
       '@babel/helper-optimise-call-expression': 7.24.7
-      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
       semver: 6.3.1
@@ -17394,9 +17534,9 @@ snapshots:
       regexpu-core: 5.3.2
       semver: 6.3.1
 
-  '@babel/helper-create-regexp-features-plugin@7.24.7(@babel/core@7.24.8)':
+  '@babel/helper-create-regexp-features-plugin@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-annotate-as-pure': 7.24.7
       regexpu-core: 5.3.2
       semver: 6.3.1
@@ -17412,9 +17552,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.24.8)':
+  '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-compilation-targets': 7.24.8
       '@babel/helper-plugin-utils': 7.24.8
       debug: 4.3.7
@@ -17425,56 +17565,52 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@babel/helper-function-name@7.24.7':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@babel/helper-hoist-variables@7.24.7':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@babel/helper-member-expression-to-functions@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-member-expression-to-functions@7.24.8':
     dependencies:
       '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.22.15':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@babel/helper-module-imports@7.24.7':
     dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.8
+      '@babel/traverse': 7.24.8
+      '@babel/types': 7.25.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.24.7(@babel/core@7.24.8)':
-    dependencies:
-      '@babel/core': 7.24.8
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-simple-access': 7.24.7
@@ -17490,7 +17626,7 @@ snapshots:
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-validator-identifier': 7.25.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17501,13 +17637,34 @@ snapshots:
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-validator-identifier': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.24.8(@babel/core@7.25.9)':
+    dependencies:
+      '@babel/core': 7.25.9
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-simple-access': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/helper-validator-identifier': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.25.9(@babel/core@7.25.9)':
+    dependencies:
+      '@babel/core': 7.25.9
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-simple-access': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.24.7':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@babel/helper-plugin-utils@7.24.7': {}
 
@@ -17522,9 +17679,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-remap-async-to-generator@7.24.7(@babel/core@7.24.8)':
+  '@babel/helper-remap-async-to-generator@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-wrap-function': 7.24.7
@@ -17540,9 +17697,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.24.7(@babel/core@7.24.8)':
+  '@babel/helper-replace-supers@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.24.7
       '@babel/helper-optimise-call-expression': 7.24.7
@@ -17552,55 +17709,80 @@ snapshots:
   '@babel/helper-simple-access@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-simple-access@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@babel/helper-string-parser@7.24.8': {}
 
   '@babel/helper-string-parser@7.25.7': {}
 
+  '@babel/helper-string-parser@7.25.9': {}
+
   '@babel/helper-validator-identifier@7.24.7': {}
 
   '@babel/helper-validator-identifier@7.25.7': {}
 
+  '@babel/helper-validator-identifier@7.25.9': {}
+
   '@babel/helper-validator-option@7.24.7': {}
 
   '@babel/helper-validator-option@7.24.8': {}
+
+  '@babel/helper-validator-option@7.25.9': {}
 
   '@babel/helper-wrap-function@7.24.7':
     dependencies:
       '@babel/helper-function-name': 7.24.7
       '@babel/template': 7.24.7
       '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.24.7':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@babel/helpers@7.24.8':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
+
+  '@babel/helpers@7.25.9':
+    dependencies:
+      '@babel/template': 7.25.9
+      '@babel/types': 7.25.9
 
   '@babel/highlight@7.24.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.24.7
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+      picocolors: 1.1.0
+
+  '@babel/highlight@7.25.9':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.0
@@ -17611,11 +17793,15 @@ snapshots:
 
   '@babel/parser@7.24.8':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@babel/parser@7.25.8':
     dependencies:
       '@babel/types': 7.25.8
+
+  '@babel/parser@7.25.9':
+    dependencies:
+      '@babel/types': 7.25.9
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -17623,9 +17809,9 @@ snapshots:
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -17634,19 +17820,10 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.7)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -17657,12 +17834,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -17672,18 +17849,18 @@ snapshots:
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-proposal-decorators@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-proposal-decorators@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-decorators': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-syntax-decorators': 7.24.7(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -17691,23 +17868,23 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.8)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.7)':
@@ -17715,9 +17892,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.7)':
@@ -17725,14 +17902,14 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-decorators@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-decorators@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.24.7)':
@@ -17740,9 +17917,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.7)':
@@ -17750,14 +17927,14 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-flow@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.24.7)':
@@ -17765,9 +17942,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.24.7)':
@@ -17775,9 +17952,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.7)':
@@ -17785,9 +17962,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.7)':
@@ -17795,9 +17972,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.7)':
@@ -17805,9 +17982,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.7)':
@@ -17815,9 +17992,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.7)':
@@ -17825,9 +18002,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.7)':
@@ -17835,9 +18012,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.7)':
@@ -17845,9 +18022,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.7)':
@@ -17855,9 +18032,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.7)':
@@ -17865,9 +18042,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.7)':
@@ -17875,9 +18052,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.7)':
@@ -17885,9 +18062,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.24.7)':
@@ -17895,9 +18072,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
 
-  '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.7)':
@@ -17906,10 +18083,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.8)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-arrow-functions@7.24.7(@babel/core@7.24.7)':
@@ -17922,6 +18099,11 @@ snapshots:
       '@babel/core': 7.24.8
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-arrow-functions@7.24.7(@babel/core@7.25.9)':
+    dependencies:
+      '@babel/core': 7.25.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-async-generator-functions@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -17932,13 +18114,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-generator-functions@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-async-generator-functions@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.8)
+      '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -17951,12 +18133,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-async-to-generator@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -17965,9 +18147,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-block-scoping@7.24.7(@babel/core@7.24.7)':
@@ -17975,18 +18157,10 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-block-scoping@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-block-scoping@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-class-properties@7.24.7':
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
-      '@babel/helper-plugin-utils': 7.24.8
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@babel/plugin-transform-class-properties@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -17996,22 +18170,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-properties@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-class-properties@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.24.7':
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.7)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@babel/plugin-transform-class-static-block@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -18022,12 +18187,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-class-static-block@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.8)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -18045,15 +18210,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-classes@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-compilation-targets': 7.24.8
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-split-export-declaration': 7.24.7
       globals: 11.12.0
     transitivePeerDependencies:
@@ -18065,9 +18230,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/template': 7.24.7
 
-  '@babel/plugin-transform-computed-properties@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-computed-properties@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/template': 7.24.7
 
@@ -18076,9 +18241,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-destructuring@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-destructuring@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.24.7)':
@@ -18087,10 +18252,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-duplicate-keys@7.24.7(@babel/core@7.24.7)':
@@ -18098,9 +18263,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-duplicate-keys@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-duplicate-keys@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-dynamic-import@7.24.7(@babel/core@7.24.7)':
@@ -18109,11 +18274,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
 
-  '@babel/plugin-transform-dynamic-import@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-dynamic-import@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.8)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.9)
 
   '@babel/plugin-transform-exponentiation-operator@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -18123,9 +18288,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-exponentiation-operator@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
@@ -18137,17 +18302,17 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.7)
 
-  '@babel/plugin-transform-export-namespace-from@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-export-namespace-from@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.8)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.9)
 
-  '@babel/plugin-transform-flow-strip-types@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-flow-strip-types@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.25.9)
 
   '@babel/plugin-transform-for-of@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -18157,9 +18322,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-for-of@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-for-of@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
@@ -18172,9 +18337,9 @@ snapshots:
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-function-name@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-function-name@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-compilation-targets': 7.24.8
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
@@ -18185,20 +18350,20 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.7)
 
-  '@babel/plugin-transform-json-strings@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-json-strings@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.8)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.9)
 
   '@babel/plugin-transform-literals@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-literals@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-literals@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.24.7)':
@@ -18207,20 +18372,20 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
 
-  '@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.8)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.9)
 
   '@babel/plugin-transform-member-expression-literals@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-member-expression-literals@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-member-expression-literals@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.24.7)':
@@ -18231,10 +18396,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-module-transforms': 7.24.8(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-module-transforms': 7.24.8(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -18242,16 +18407,16 @@ snapshots:
   '@babel/plugin-transform-modules-commonjs@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
-      '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-module-transforms': 7.24.8(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-simple-access': 7.24.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-modules-commonjs@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-module-transforms': 7.24.8(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-simple-access': 7.24.7
     transitivePeerDependencies:
@@ -18267,11 +18432,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-modules-systemjs@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-module-transforms': 7.24.8(@babel/core@7.24.8)
+      '@babel/helper-module-transforms': 7.24.8(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
     transitivePeerDependencies:
@@ -18285,10 +18450,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-modules-umd@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-module-transforms': 7.24.8(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-module-transforms': 7.24.8(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -18299,10 +18464,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-new-target@7.24.7(@babel/core@7.24.7)':
@@ -18310,9 +18475,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-new-target@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-new-target@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.24.7(@babel/core@7.24.7)':
@@ -18321,11 +18486,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.8)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.9)
 
   '@babel/plugin-transform-numeric-separator@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -18333,11 +18498,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
 
-  '@babel/plugin-transform-numeric-separator@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-numeric-separator@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.8)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.9)
 
   '@babel/plugin-transform-object-rest-spread@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -18347,13 +18512,13 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
       '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
 
-  '@babel/plugin-transform-object-rest-spread@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-object-rest-spread@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-compilation-targets': 7.24.8
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.25.9)
 
   '@babel/plugin-transform-object-super@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -18363,11 +18528,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-object-super@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -18377,11 +18542,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
 
-  '@babel/plugin-transform-optional-catch-binding@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-optional-catch-binding@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.8)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.9)
 
   '@babel/plugin-transform-optional-chaining@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -18392,12 +18557,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-chaining@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-optional-chaining@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.8)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -18406,18 +18571,10 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-parameters@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-parameters@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-private-methods@7.24.7':
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
-      '@babel/helper-plugin-utils': 7.24.8
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@babel/plugin-transform-private-methods@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -18427,23 +18584,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-methods@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-private-methods@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-transform-private-property-in-object@7.24.7':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.7)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@babel/plugin-transform-private-property-in-object@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -18455,13 +18602,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-private-property-in-object@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.8)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -18470,14 +18617,14 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-property-literals@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-property-literals@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-react-constant-elements@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-react-constant-elements@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-react-display-name@7.24.7(@babel/core@7.24.7)':
@@ -18485,9 +18632,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-react-display-name@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-react-display-name@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-react-jsx-development@7.24.7(@babel/core@7.24.7)':
@@ -18497,10 +18644,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-development@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-react-jsx-development@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -18521,18 +18668,18 @@ snapshots:
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.7)
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.8)
-      '@babel/types': 7.24.8
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.9)
+      '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
 
@@ -18542,9 +18689,9 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-react-pure-annotations@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-react-pure-annotations@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -18554,9 +18701,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       regenerator-transform: 0.15.2
 
-  '@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
       regenerator-transform: 0.15.2
 
@@ -18565,9 +18712,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-reserved-words@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-reserved-words@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-runtime@7.24.7(@babel/core@7.24.7)':
@@ -18582,14 +18729,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-runtime@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-runtime@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
-      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.8)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.8)
-      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.8)
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.25.9)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.25.9)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.25.9)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -18599,9 +18746,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-shorthand-properties@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-shorthand-properties@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-spread@7.24.7(@babel/core@7.24.7)':
@@ -18612,9 +18759,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-spread@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-spread@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
@@ -18625,9 +18772,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-sticky-regex@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-sticky-regex@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.24.7)':
@@ -18635,9 +18782,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-typeof-symbol@7.24.7(@babel/core@7.24.7)':
@@ -18645,9 +18792,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-typeof-symbol@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-typeof-symbol@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-typescript@7.24.7(@babel/core@7.24.7)':
@@ -18660,23 +18807,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-typescript@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.24.8(@babel/core@7.24.8)':
+  '@babel/plugin-transform-typescript@7.24.8(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.24.8)
+      '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -18685,9 +18832,9 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-unicode-escapes@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-unicode-escapes@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-unicode-property-regex@7.24.7(@babel/core@7.24.7)':
@@ -18696,10 +18843,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-unicode-property-regex@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-unicode-property-regex@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-unicode-regex@7.24.7(@babel/core@7.24.7)':
@@ -18708,10 +18855,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-unicode-regex@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-unicode-regex@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-unicode-sets-regex@7.24.7(@babel/core@7.24.7)':
@@ -18720,98 +18867,11 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-unicode-sets-regex@7.24.7(@babel/core@7.24.8)':
+  '@babel/plugin-transform-unicode-sets-regex@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.25.9)
       '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/preset-env@7.24.7':
-    dependencies:
-      '@babel/compat-data': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-validator-option': 7.24.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.7)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.7)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.7)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.7)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.7)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.7)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.7)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.7)
-      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-class-properties': 7.24.7
-      '@babel/plugin-transform-class-static-block': 7.24.7
-      '@babel/plugin-transform-classes': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-destructuring': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-modules-amd': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-modules-systemjs': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-modules-umd': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-private-methods': 7.24.7
-      '@babel/plugin-transform-private-property-in-object': 7.24.7
-      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-typeof-symbol': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.24.7)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.7)
-      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.7)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.7)
-      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.7)
-      core-js-compat: 3.37.1
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@babel/preset-env@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -18900,112 +18960,112 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-env@7.24.7(@babel/core@7.24.8)':
+  '@babel/preset-env@7.24.7(@babel/core@7.25.9)':
     dependencies:
       '@babel/compat-data': 7.24.7
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-validator-option': 7.24.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.8)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.8)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.8)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.8)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.8)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.8)
-      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-classes': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-destructuring': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-modules-amd': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-modules-systemjs': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-modules-umd': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-typeof-symbol': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.8)
-      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.8)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.8)
-      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.8)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.25.9)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.9)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.25.9)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.9)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.9)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.9)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.25.9)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.25.9)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-classes': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-destructuring': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-modules-amd': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-modules-systemjs': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-modules-umd': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-typeof-symbol': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.25.9)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.25.9)
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.25.9)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.25.9)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.25.9)
       core-js-compat: 3.37.1
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-flow@7.24.7(@babel/core@7.24.8)':
+  '@babel/preset-flow@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-validator-option': 7.24.8
-      '@babel/plugin-transform-flow-strip-types': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-flow-strip-types': 7.24.7(@babel/core@7.25.9)
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
       esutils: 2.0.3
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.8)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
       esutils: 2.0.3
 
   '@babel/preset-react@7.24.7(@babel/core@7.24.7)':
@@ -19020,15 +19080,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-react@7.24.7(@babel/core@7.24.8)':
+  '@babel/preset-react@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-validator-option': 7.24.7
-      '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-react-jsx-development': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-react-pure-annotations': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-react-jsx-development': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-react-pure-annotations': 7.24.7(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -19043,20 +19103,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.24.7(@babel/core@7.24.8)':
+  '@babel/preset-typescript@7.24.7(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-validator-option': 7.24.7
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-typescript': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-typescript': 7.24.7(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/register@7.24.6(@babel/core@7.24.8)':
+  '@babel/register@7.24.6(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -19079,8 +19139,14 @@ snapshots:
   '@babel/template@7.24.7':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/parser': 7.25.8
+      '@babel/types': 7.25.8
+
+  '@babel/template@7.25.9':
+    dependencies:
+      '@babel/code-frame': 7.25.9
+      '@babel/parser': 7.25.9
+      '@babel/types': 7.25.9
 
   '@babel/traverse@7.23.2':
     dependencies:
@@ -19120,8 +19186,20 @@ snapshots:
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/parser': 7.25.8
+      '@babel/types': 7.25.8
+      debug: 4.3.7
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.25.9':
+    dependencies:
+      '@babel/code-frame': 7.25.9
+      '@babel/generator': 7.25.9
+      '@babel/parser': 7.25.9
+      '@babel/template': 7.25.9
+      '@babel/types': 7.25.9
       debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
@@ -19140,8 +19218,8 @@ snapshots:
 
   '@babel/types@7.24.8':
     dependencies:
-      '@babel/helper-string-parser': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-string-parser': 7.25.7
+      '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
 
   '@babel/types@7.25.8':
@@ -19149,6 +19227,11 @@ snapshots:
       '@babel/helper-string-parser': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
+
+  '@babel/types@7.25.9':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -19554,13 +19637,13 @@ snapshots:
 
   '@docusaurus/core@3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.3)(react@18.3.1))(@swc/core@1.5.29)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/generator': 7.24.8
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-transform-runtime': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-env': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-react': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-transform-runtime': 7.24.7(@babel/core@7.25.9)
+      '@babel/preset-env': 7.24.7(@babel/core@7.25.9)
+      '@babel/preset-react': 7.24.7(@babel/core@7.25.9)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.25.9)
       '@babel/runtime': 7.24.7
       '@babel/runtime-corejs3': 7.24.7
       '@babel/traverse': 7.24.8
@@ -19572,7 +19655,7 @@ snapshots:
       '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(@swc/core@1.5.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.5.29)(typescript@5.6.2)
       '@mdx-js/react': 3.0.1(@types/react@18.3.3)(react@18.3.1)
       autoprefixer: 10.4.19(postcss@8.4.39)
-      babel-loader: 9.1.3(@babel/core@7.24.8)(webpack@5.92.0(@swc/core@1.5.29))
+      babel-loader: 9.1.3(@babel/core@7.25.9)(webpack@5.92.0(@swc/core@1.5.29))
       babel-plugin-dynamic-import-node: 2.3.3
       boxen: 6.2.1
       chalk: 4.1.2
@@ -21674,7 +21757,7 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
@@ -23337,7 +23420,7 @@ snapshots:
 
   '@storybook/addon-docs@8.1.9(@types/react-dom@18.3.0)(encoding@0.1.13)(prettier@3.3.3)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@mdx-js/react': 3.0.1(@types/react@18.3.3)(react@18.3.1)
       '@storybook/blocks': 8.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/client-logger': 8.1.9
@@ -23573,9 +23656,9 @@ snapshots:
       telejson: 7.2.0
       tiny-invariant: 1.3.3
 
-  '@storybook/cli@8.1.9(@babel/preset-env@7.24.7(@babel/core@7.24.8))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@storybook/cli@8.1.9(@babel/preset-env@7.24.7(@babel/core@7.25.9))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/types': 7.24.8
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 8.1.9
@@ -23600,54 +23683,7 @@ snapshots:
       get-npm-tarball-url: 2.1.0
       giget: 1.2.3
       globby: 14.0.2
-      jscodeshift: 0.15.2(@babel/preset-env@7.24.7(@babel/core@7.24.8))
-      leven: 3.1.0
-      ora: 5.4.1
-      prettier: 3.3.3
-      prompts: 2.4.2
-      read-pkg-up: 7.0.1
-      semver: 7.6.3
-      strip-json-comments: 3.1.1
-      tempy: 3.1.0
-      tiny-invariant: 1.3.3
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - bufferutil
-      - encoding
-      - react
-      - react-dom
-      - supports-color
-      - utf-8-validate
-
-  '@storybook/cli@8.1.9(@babel/preset-env@7.24.7)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/core': 7.24.8
-      '@babel/types': 7.24.8
-      '@ndelangen/get-tarball': 3.0.9
-      '@storybook/codemod': 8.1.9
-      '@storybook/core-common': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
-      '@storybook/core-events': 8.1.9
-      '@storybook/core-server': 8.1.9(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/csf-tools': 8.1.9
-      '@storybook/node-logger': 8.1.9
-      '@storybook/telemetry': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
-      '@storybook/types': 8.1.9
-      '@types/semver': 7.5.8
-      '@yarnpkg/fslib': 2.10.3
-      '@yarnpkg/libzip': 2.3.0
-      chalk: 4.1.2
-      commander: 6.2.1
-      cross-spawn: 7.0.3
-      detect-indent: 6.1.0
-      envinfo: 7.13.0
-      execa: 5.1.1
-      find-up: 5.0.0
-      fs-extra: 11.2.0
-      get-npm-tarball-url: 2.1.0
-      giget: 1.2.3
-      globby: 14.0.2
-      jscodeshift: 0.15.2(@babel/preset-env@7.24.7)
+      jscodeshift: 0.15.2(@babel/preset-env@7.24.7(@babel/core@7.25.9))
       leven: 3.1.0
       ora: 5.4.1
       prettier: 3.3.3
@@ -23681,9 +23717,9 @@ snapshots:
 
   '@storybook/codemod@8.1.9':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/preset-env': 7.24.7(@babel/core@7.24.8)
-      '@babel/types': 7.24.8
+      '@babel/core': 7.25.9
+      '@babel/preset-env': 7.24.7(@babel/core@7.25.9)
+      '@babel/types': 7.25.8
       '@storybook/csf': 0.1.8
       '@storybook/csf-tools': 8.1.9
       '@storybook/node-logger': 8.1.9
@@ -23691,7 +23727,7 @@ snapshots:
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.3
       globby: 14.0.2
-      jscodeshift: 0.15.2(@babel/preset-env@7.24.7(@babel/core@7.24.8))
+      jscodeshift: 0.15.2(@babel/preset-env@7.24.7(@babel/core@7.25.9))
       lodash: 4.17.21
       prettier: 3.3.3
       recast: 0.23.9
@@ -23788,7 +23824,7 @@ snapshots:
   '@storybook/core-server@8.1.9(encoding@0.1.13)(prettier@3.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/parser': 7.24.8
       '@discoveryjs/json-ext': 0.5.7
       '@storybook/builder-manager': 8.1.9(encoding@0.1.13)(prettier@3.3.3)
@@ -23851,9 +23887,9 @@ snapshots:
   '@storybook/csf-tools@8.1.9':
     dependencies:
       '@babel/generator': 7.24.8
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.25.8
       '@babel/traverse': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
       '@storybook/csf': 0.1.8
       '@storybook/types': 8.1.9
       fs-extra: 11.2.0
@@ -24197,54 +24233,54 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.24.8)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.24.8)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.24.8)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.24.8)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.24.8)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.24.8)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.24.8)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.24.8)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.24.8)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.25.9)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.24.8)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.24.8)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.24.8)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.24.8)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.24.8)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.24.8)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.24.8)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.25.9)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.25.9)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.25.9)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.25.9)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.25.9)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.25.9)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.25.9)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.25.9)
 
   '@svgr/core@8.1.0(typescript@5.6.2)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.25.9)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.6.2)
       snake-case: 3.0.4
@@ -24254,13 +24290,13 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
       entities: 4.5.0
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.6.2))':
     dependencies:
-      '@babel/core': 7.24.8
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.25.9)
       '@svgr/core': 8.1.0(typescript@5.6.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
@@ -24278,11 +24314,11 @@ snapshots:
 
   '@svgr/webpack@8.1.0(typescript@5.6.2)':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/plugin-transform-react-constant-elements': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-env': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-react': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/plugin-transform-react-constant-elements': 7.24.7(@babel/core@7.25.9)
+      '@babel/preset-env': 7.24.7(@babel/core@7.25.9)
+      '@babel/preset-react': 7.24.7(@babel/core@7.25.9)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.25.9)
       '@svgr/core': 8.1.0(typescript@5.6.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.6.2))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.6.2))(typescript@5.6.2)
@@ -24540,16 +24576,16 @@ snapshots:
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/parser': 7.25.8
+      '@babel/types': 7.25.8
 
   '@types/babel__traverse@7.20.6':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   '@types/body-parser@1.19.5':
     dependencies:
@@ -25217,9 +25253,9 @@ snapshots:
 
   '@vitejs/plugin-vue-jsx@4.0.0(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))(vue@3.5.12(typescript@5.6.2))':
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.8)
-      '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.25.9)
+      '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.25.9)
       vite: 5.3.3(@types/node@20.14.10)(terser@5.31.2)
       vue: 3.5.12(typescript@5.6.2)
     transitivePeerDependencies:
@@ -25355,7 +25391,7 @@ snapshots:
 
   '@vue-macros/common@1.10.4(rollup@4.18.1)(vue@3.5.12(typescript@5.6.2))':
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
       '@rollup/pluginutils': 5.1.0(rollup@4.18.1)
       '@vue/compiler-sfc': 3.4.31
       ast-kit: 0.12.2
@@ -25386,21 +25422,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/babel-plugin-jsx@1.2.2(@babel/core@7.24.8)':
+  '@vue/babel-plugin-jsx@1.2.2(@babel/core@7.25.9)':
     dependencies:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.9)
       '@babel/template': 7.24.7
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
       '@vue/babel-helper-vue-transform-on': 1.2.2
-      '@vue/babel-plugin-resolve-type': 1.2.2(@babel/core@7.24.8)
+      '@vue/babel-plugin-resolve-type': 1.2.2(@babel/core@7.25.9)
       camelcase: 6.3.0
       html-tags: 3.3.1
       svg-tags: 1.0.0
     optionalDependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -25410,16 +25446,16 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.25.8
       '@vue/compiler-sfc': 3.4.31
 
-  '@vue/babel-plugin-resolve-type@1.2.2(@babel/core@7.24.8)':
+  '@vue/babel-plugin-resolve-type@1.2.2(@babel/core@7.25.9)':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.25.8
       '@vue/compiler-sfc': 3.4.31
 
   '@vue/compiler-core@3.4.29':
@@ -25432,7 +25468,7 @@ snapshots:
 
   '@vue/compiler-core@3.4.31':
     dependencies:
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.25.8
       '@vue/shared': 3.4.31
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -25458,7 +25494,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.4.31':
     dependencies:
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.25.8
       '@vue/compiler-core': 3.4.31
       '@vue/compiler-dom': 3.4.31
       '@vue/compiler-ssr': 3.4.31
@@ -26092,7 +26128,7 @@ snapshots:
 
   ast-kit@0.12.2:
     dependencies:
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.25.8
       pathe: 1.1.2
 
   ast-types@0.16.1:
@@ -26101,7 +26137,7 @@ snapshots:
 
   ast-walker-scope@0.6.1:
     dependencies:
-      '@babel/parser': 7.24.8
+      '@babel/parser': 7.25.8
       ast-kit: 0.12.2
 
   astral-regex@2.0.0: {}
@@ -26180,17 +26216,17 @@ snapshots:
 
   b4a@1.6.6: {}
 
-  babel-core@7.0.0-bridge.0(@babel/core@7.24.8):
+  babel-core@7.0.0-bridge.0(@babel/core@7.25.9):
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
-  babel-jest@29.7.0(@babel/core@7.24.8):
+  babel-jest@29.7.0(@babel/core@7.25.9):
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.24.8)
+      babel-preset-jest: 29.6.3(@babel/core@7.25.9)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -26204,9 +26240,9 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.92.0(@swc/core@1.5.29)
 
-  babel-loader@9.1.3(@babel/core@7.24.8)(webpack@5.92.0(@swc/core@1.5.29)):
+  babel-loader@9.1.3(@babel/core@7.25.9)(webpack@5.92.0(@swc/core@1.5.29)):
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
       webpack: 5.92.0(@swc/core@1.5.29)
@@ -26228,7 +26264,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
@@ -26241,11 +26277,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs2@0.4.11(@babel/core@7.24.8):
+  babel-plugin-polyfill-corejs2@0.4.11(@babel/core@7.25.9):
     dependencies:
       '@babel/compat-data': 7.24.7
-      '@babel/core': 7.24.8
-      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.25.9)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -26258,10 +26294,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.24.8):
+  babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.25.9):
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.25.9)
       core-js-compat: 3.37.1
     transitivePeerDependencies:
       - supports-color
@@ -26273,38 +26309,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.2(@babel/core@7.24.8):
+  babel-plugin-polyfill-regenerator@0.6.2(@babel/core@7.25.9):
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
-  babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.8):
+  babel-preset-current-node-syntax@1.0.1(@babel/core@7.25.9):
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.8)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.9)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.25.9)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.9)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.9)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.25.9)
 
-  babel-preset-jest@29.6.3(@babel/core@7.24.8):
+  babel-preset-jest@29.6.3(@babel/core@7.25.9):
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.8)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.25.9)
 
   babel-walk@3.0.0-canary-5:
     dependencies:
-      '@babel/types': 7.24.8
+      '@babel/types': 7.25.8
 
   bail@2.0.2: {}
 
@@ -26477,6 +26513,13 @@ snapshots:
       node-releases: 2.0.14
       update-browserslist-db: 1.1.0(browserslist@4.23.2)
 
+  browserslist@4.24.2:
+    dependencies:
+      caniuse-lite: 1.0.30001669
+      electron-to-chromium: 1.5.43
+      node-releases: 2.0.18
+      update-browserslist-db: 1.1.1(browserslist@4.24.2)
+
   bs-logger@0.2.6:
     dependencies:
       fast-json-stable-stringify: 2.1.0
@@ -26642,6 +26685,8 @@ snapshots:
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001641: {}
+
+  caniuse-lite@1.0.30001669: {}
 
   capnp-ts@0.7.0:
     dependencies:
@@ -27064,8 +27109,8 @@ snapshots:
 
   constantinople@4.0.1:
     dependencies:
-      '@babel/parser': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/parser': 7.25.8
+      '@babel/types': 7.25.8
 
   content-disposition@0.5.2: {}
 
@@ -27860,6 +27905,8 @@ snapshots:
 
   electron-to-chromium@1.4.827: {}
 
+  electron-to-chromium@1.5.43: {}
+
   electron-updater@4.6.5:
     dependencies:
       '@types/semver': 7.5.8
@@ -28189,6 +28236,8 @@ snapshots:
       '@esbuild/win32-x64': 0.23.0
 
   escalade@3.1.2: {}
+
+  escalade@3.2.0: {}
 
   escape-goat@4.0.0: {}
 
@@ -30595,8 +30644,8 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/parser': 7.24.8
+      '@babel/core': 7.25.9
+      '@babel/parser': 7.25.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -30605,8 +30654,8 @@ snapshots:
 
   istanbul-lib-instrument@6.0.2:
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/parser': 7.24.8
+      '@babel/core': 7.25.9
+      '@babel/parser': 7.25.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.6.3
@@ -30761,10 +30810,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.3.3)):
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.8)
+      babel-jest: 29.7.0(@babel/core@7.25.9)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -30792,10 +30841,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)):
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.8)
+      babel-jest: 29.7.0(@babel/core@7.25.9)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -30816,17 +30865,17 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
   jest-config@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)):
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.8)
+      babel-jest: 29.7.0(@babel/core@7.25.9)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -31009,15 +31058,15 @@ snapshots:
 
   jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/generator': 7.24.7
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.8)
-      '@babel/types': 7.24.8
+      '@babel/core': 7.25.9
+      '@babel/generator': 7.24.8
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.25.9)
+      '@babel/types': 7.25.8
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.8)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.25.9)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -31160,19 +31209,19 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jscodeshift@0.15.2(@babel/preset-env@7.24.7(@babel/core@7.24.8)):
+  jscodeshift@0.15.2(@babel/preset-env@7.24.7(@babel/core@7.25.9)):
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/parser': 7.24.8
-      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-flow': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.8)
-      '@babel/register': 7.24.6(@babel/core@7.24.8)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/parser': 7.25.8
+      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.25.9)
+      '@babel/preset-flow': 7.24.7(@babel/core@7.25.9)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.25.9)
+      '@babel/register': 7.24.6(@babel/core@7.25.9)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.25.9)
       chalk: 4.1.2
       flow-parser: 0.238.0
       graceful-fs: 4.2.11
@@ -31183,34 +31232,7 @@ snapshots:
       temp: 0.8.4
       write-file-atomic: 2.4.3
     optionalDependencies:
-      '@babel/preset-env': 7.24.7(@babel/core@7.24.8)
-    transitivePeerDependencies:
-      - supports-color
-
-  jscodeshift@0.15.2(@babel/preset-env@7.24.7):
-    dependencies:
-      '@babel/core': 7.24.8
-      '@babel/parser': 7.24.8
-      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-flow': 7.24.7(@babel/core@7.24.8)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.8)
-      '@babel/register': 7.24.6(@babel/core@7.24.8)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.24.8)
-      chalk: 4.1.2
-      flow-parser: 0.238.0
-      graceful-fs: 4.2.11
-      micromatch: 4.0.7
-      neo-async: 2.6.2
-      node-dir: 0.1.17
-      recast: 0.23.9
-      temp: 0.8.4
-      write-file-atomic: 2.4.3
-    optionalDependencies:
-      '@babel/preset-env': 7.24.7
+      '@babel/preset-env': 7.24.7(@babel/core@7.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -32521,7 +32543,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@14.2.5(@babel/core@7.24.8)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.5(@babel/core@7.25.9)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.5
       '@swc/helpers': 0.5.5
@@ -32531,7 +32553,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.24.8)(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.25.9)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.5
       '@next/swc-darwin-x64': 14.2.5
@@ -32684,6 +32706,8 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.14: {}
+
+  node-releases@2.0.18: {}
 
   nodemon@3.1.7:
     dependencies:
@@ -35513,21 +35537,9 @@ snapshots:
       - react
       - react-dom
 
-  storybook@8.1.9(@babel/preset-env@7.24.7(@babel/core@7.24.8))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook@8.1.9(@babel/preset-env@7.24.7(@babel/core@7.25.9))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@storybook/cli': 8.1.9(@babel/preset-env@7.24.7(@babel/core@7.24.8))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - bufferutil
-      - encoding
-      - react
-      - react-dom
-      - supports-color
-      - utf-8-validate
-
-  storybook@8.1.9(@babel/preset-env@7.24.7)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@storybook/cli': 8.1.9(@babel/preset-env@7.24.7)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/cli': 8.1.9(@babel/preset-env@7.24.7(@babel/core@7.25.9))(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - bufferutil
@@ -35692,12 +35704,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.3
 
-  styled-jsx@5.1.1(@babel/core@7.24.8)(react@18.3.1):
+  styled-jsx@5.1.1(@babel/core@7.25.9)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
 
   stylehacks@6.1.1(postcss@8.4.39):
     dependencies:
@@ -36166,7 +36178,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.1.4(@babel/core@7.24.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.8))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.3.3)))(typescript@5.3.3):
+  ts-jest@29.1.4(@babel/core@7.25.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.9))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.3.3)))(typescript@5.3.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -36179,12 +36191,12 @@ snapshots:
       typescript: 5.3.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.8)
+      babel-jest: 29.7.0(@babel/core@7.25.9)
 
-  ts-jest@29.1.4(@babel/core@7.24.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.8))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)))(typescript@5.6.2):
+  ts-jest@29.1.4(@babel/core@7.25.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.9))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)))(typescript@5.6.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -36197,10 +36209,10 @@ snapshots:
       typescript: 5.6.2
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.8)
+      babel-jest: 29.7.0(@babel/core@7.25.9)
 
   ts-loader@9.5.1(typescript@5.3.3)(webpack@5.90.1(@swc/core@1.5.29(@swc/helpers@0.5.5))):
     dependencies:
@@ -36239,6 +36251,27 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.3.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.5.29(@swc/helpers@0.5.5)
+    optional: true
+
+  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.14.10
+      acorn: 8.12.1
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -36766,7 +36799,7 @@ snapshots:
 
   untyped@1.4.2:
     dependencies:
-      '@babel/core': 7.24.8
+      '@babel/core': 7.25.9
       '@babel/standalone': 7.24.8
       '@babel/types': 7.24.8
       defu: 6.1.4
@@ -36795,6 +36828,12 @@ snapshots:
     dependencies:
       browserslist: 4.23.2
       escalade: 3.1.2
+      picocolors: 1.1.0
+
+  update-browserslist-db@1.1.1(browserslist@4.24.2):
+    dependencies:
+      browserslist: 4.24.2
+      escalade: 3.2.0
       picocolors: 1.1.0
 
   update-notifier@6.0.2:
@@ -37083,12 +37122,12 @@ snapshots:
 
   vite-plugin-vue-inspector@5.1.2(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2)):
     dependencies:
-      '@babel/core': 7.24.8
-      '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.8)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.8)
-      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.8)
-      '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.24.8)
+      '@babel/core': 7.25.9
+      '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.25.9)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.9)
+      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.25.9)
+      '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.25.9)
       '@vue/compiler-dom': 3.4.31
       kolorist: 1.8.0
       magic-string: 0.30.10
@@ -37739,8 +37778,8 @@ snapshots:
 
   with@7.0.2:
     dependencies:
-      '@babel/parser': 7.24.8
-      '@babel/types': 7.24.8
+      '@babel/parser': 7.25.8
+      '@babel/types': 7.25.8
       assert-never: 1.2.1
       babel-walk: 3.0.0-canary-5
 


### PR DESCRIPTION
I love my terminal free of warnings. :)

<img width="687" alt="Screenshot 2024-10-23 at 11 33 53" src="https://github.com/user-attachments/assets/2b6372ff-d264-446a-81a3-27246e78c92e">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new development dependency, `@babel/core`, to enhance development capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->