### PR TITLE
ci: skip `deploy-examples` job for forks and bot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,8 +305,8 @@ jobs:
           comment_tag: 'cloudflare-preview'
 
   deploy-examples:
-    # Only run this job for PRs from the same repository, not for pushes to main
-    if: github.ref != 'refs/heads/main' && github.event.pull_request.head.repo.full_name == github.repository
+    # Skip for forks and bot PRs
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]')
     needs: [build]
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
A new attempt to skip the `deploy-examples` in environments where the repository secrets aren’t available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow to refine deployment conditions for pull requests, enhancing control over deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->