### PR TITLE
fix(api-client): prefill auth

### DIFF
--- a/.changeset/two-tables-invent.md
+++ b/.changeset/two-tables-invent.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: synced up client auth with references

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
@@ -36,12 +36,12 @@ export const createApiClientModal = async (
     await importSpecFromUrl(configuration.spec.url, 'default', {
       proxy: configuration.proxyUrl,
       overloadServers: configuration?.servers,
-      preferredSecurityScheme: configuration.preferredSecurityScheme,
+      authentication: configuration.authentication,
     })
   else if (configuration.spec?.content)
     await importSpecFile(configuration.spec?.content, 'default', {
       overloadServers: configuration?.servers,
-      preferredSecurityScheme: configuration.preferredSecurityScheme,
+      authentication: configuration.authentication,
     })
 
   return client

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
@@ -37,11 +37,13 @@ export const createApiClientModal = async (
       proxy: configuration.proxyUrl,
       overloadServers: configuration?.servers,
       authentication: configuration.authentication,
+      setCollectionSecurity: true,
     })
   else if (configuration.spec?.content)
     await importSpecFile(configuration.spec?.content, 'default', {
       overloadServers: configuration?.servers,
       authentication: configuration.authentication,
+      setCollectionSecurity: true,
     })
 
   return client

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -1,13 +1,11 @@
 import { loadAllResources } from '@/libs/local-storage'
 import { type WorkspaceStore, createWorkspaceStore } from '@/store'
-import type { StoreContext } from '@/store/store-context'
 import type { Collection, RequestMethod } from '@scalar/oas-utils/entities/spec'
 import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { LS_KEYS, objectMerge } from '@scalar/oas-utils/helpers'
 import { DATA_VERSION, DATA_VERSION_LS_LEY } from '@scalar/oas-utils/migrations'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import type {
-  AuthenticationState,
   ReferenceConfiguration,
   SpecConfiguration,
 } from '@scalar/types/legacy'
@@ -19,10 +17,9 @@ import type { Router } from 'vue-router'
 export type ClientConfiguration = {
   proxyUrl?: ReferenceConfiguration['proxy']
   themeId?: ReferenceConfiguration['theme']
-  preferredSecurityScheme?: AuthenticationState['preferredSecurityScheme']
 } & Pick<
   ReferenceConfiguration,
-  'spec' | 'showSidebar' | 'servers' | 'searchHotKey'
+  'spec' | 'showSidebar' | 'servers' | 'searchHotKey' | 'authentication'
 >
 
 export type OpenClientPayload = {

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -240,7 +240,7 @@ export const createRequestOperation = ({
   auth: Collection['auth']
   request: Request
   example: RequestExample
-  selectedSecuritySchemeUids: string[]
+  selectedSecuritySchemeUids?: string[]
   proxy?: string
   status?: EventBus<RequestStatus>
   environment: object | undefined
@@ -295,7 +295,7 @@ export const createRequestOperation = ({
     })
 
     // Populate all forms of auth to the request segments
-    selectedSecuritySchemeUids.forEach((uid) => {
+    selectedSecuritySchemeUids?.forEach((uid) => {
       const exampleAuth = auth[uid]
       const scheme = securitySchemes[uid]
       if (!exampleAuth || !scheme) return

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -231,6 +231,7 @@ export const createRequestOperation = ({
   example,
   server,
   securitySchemes,
+  selectedSecuritySchemeUids = [],
   proxy,
   status,
   environment,
@@ -239,6 +240,7 @@ export const createRequestOperation = ({
   auth: Collection['auth']
   request: Request
   example: RequestExample
+  selectedSecuritySchemeUids: string[]
   proxy?: string
   status?: EventBus<RequestStatus>
   environment: object | undefined
@@ -293,7 +295,7 @@ export const createRequestOperation = ({
     })
 
     // Populate all forms of auth to the request segments
-    request.selectedSecuritySchemeUids.forEach((uid) => {
+    selectedSecuritySchemeUids.forEach((uid) => {
       const exampleAuth = auth[uid]
       const scheme = securitySchemes[uid]
       if (!exampleAuth || !scheme) return

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -1,8 +1,4 @@
-import {
-  type ClientConfiguration,
-  type ErrorResponse,
-  normalizeError,
-} from '@/libs'
+import { type ErrorResponse, normalizeError } from '@/libs'
 import type { StoreContext } from '@/store/store-context'
 import { createHash, fetchSpecFromUrl } from '@scalar/oas-utils/helpers'
 import { importSpecToWorkspace } from '@scalar/oas-utils/transforms'

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -38,13 +38,7 @@ export function importSpecFileFactory({
   const importSpecFile = async (
     _spec: string | Record<string, any>,
     workspaceUid: string,
-    {
-      documentUrl,
-      watchForChanges = false,
-      overloadServers,
-      authentication,
-      setCollectionSecurity = false,
-    }: ImportSpecFileArgs = {},
+    { overloadServers, ...options }: ImportSpecFileArgs = {},
   ) => {
     const spec = toRaw(_spec)
 
@@ -52,12 +46,7 @@ export function importSpecFileFactory({
     if (overloadServers?.length && typeof spec === 'object')
       spec.servers = overloadServers
 
-    const workspaceEntities = await importSpecToWorkspace(spec, {
-      documentUrl,
-      authentication,
-      watchForChanges,
-      setCollectionSecurity,
-    })
+    const workspaceEntities = await importSpecToWorkspace(spec, options)
 
     if (workspaceEntities.error) {
       console.group('IMPORT ERRORS')
@@ -68,8 +57,8 @@ export function importSpecFileFactory({
     }
 
     // Store the schema for live updates
-    if (documentUrl && typeof spec === 'string') {
-      specDictionary[documentUrl] = {
+    if (options.documentUrl && typeof spec === 'string') {
+      specDictionary[options.documentUrl] = {
         hash: createHash(spec),
         schema: workspaceEntities.schema,
       }
@@ -105,10 +94,7 @@ export function importSpecFileFactory({
     workspaceUid: string,
     {
       proxy,
-      overloadServers,
-      watchForChanges = false,
-      authentication,
-      setCollectionSecurity = false,
+      ...options
     }: Omit<ImportSpecFileArgs, 'documentUrl'> &
       Pick<ReferenceConfiguration, 'proxy'> = {},
   ): Promise<ErrorResponse<Awaited<ReturnType<typeof importSpecFile>>>> {
@@ -119,10 +105,7 @@ export function importSpecFileFactory({
         null,
         await importSpecFile(spec, workspaceUid, {
           documentUrl: url,
-          overloadServers,
-          watchForChanges,
-          authentication,
-          setCollectionSecurity,
+          ...options,
         }),
       ]
     } catch (error) {

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -7,7 +7,7 @@ import type { StoreContext } from '@/store/store-context'
 import { createHash, fetchSpecFromUrl } from '@scalar/oas-utils/helpers'
 import { importSpecToWorkspace } from '@scalar/oas-utils/transforms'
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
-import type { Spec } from '@scalar/types/legacy'
+import type { ReferenceConfiguration, Spec } from '@scalar/types/legacy'
 import { toRaw } from 'vue'
 
 /** Maps the specs by URL */
@@ -34,7 +34,7 @@ export function importSpecFileFactory({
       documentUrl,
       watchForChanges = false,
       overloadServers,
-      preferredSecurityScheme,
+      authentication,
     }: {
       /** To store the documentUrl, used for watchForChanges */
       documentUrl?: string
@@ -45,7 +45,7 @@ export function importSpecFileFactory({
        * attach those as needed to entities below
        */
       overloadServers?: Spec['servers']
-      preferredSecurityScheme?: ClientConfiguration['preferredSecurityScheme']
+      authentication?: ReferenceConfiguration['authentication']
     } = {},
   ) => {
     const spec = toRaw(_spec)
@@ -56,7 +56,7 @@ export function importSpecFileFactory({
 
     const workspaceEntities = await importSpecToWorkspace(spec, {
       documentUrl,
-      preferredSecurityScheme,
+      authentication,
       watchForChanges,
     })
 
@@ -108,11 +108,11 @@ export function importSpecFileFactory({
       proxy,
       overloadServers,
       watchForChanges = false,
-      preferredSecurityScheme,
+      authentication,
     }: {
       watchForChanges?: boolean
       overloadServers?: Spec['servers']
-      preferredSecurityScheme?: ClientConfiguration['preferredSecurityScheme']
+      authentication?: ReferenceConfiguration['authentication']
       proxy?: string
     } = {},
   ): Promise<ErrorResponse<Awaited<ReturnType<typeof importSpecFile>>>> {
@@ -125,7 +125,7 @@ export function importSpecFileFactory({
           documentUrl: url,
           overloadServers,
           watchForChanges,
-          preferredSecurityScheme,
+          authentication,
         }),
       ]
     } catch (error) {

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -33,6 +33,7 @@ const {
   activeWorkspace,
   activeServer,
   cookies,
+  isReadOnly,
   modalState,
   requestHistory,
   securitySchemes,
@@ -57,6 +58,21 @@ const isNarrow = useMediaQuery('(max-width: 800px)')
 watch(isNarrow, (narrow) => (showSideBar.value = !narrow))
 
 /**
+ * Selected scheme UIDs
+ *
+ * In the modal we use collection.selectedSecuritySchemes and in the
+ * standalone client we use request.selectedSecuritySchemeUids
+ *
+ * These are centralized here so they can be drilled down AND used in send-request
+ */
+const selectedSecuritySchemeUids = computed(
+  () =>
+    (isReadOnly.value
+      ? activeCollection.value?.selectedSecuritySchemeUids
+      : activeRequest.value?.selectedSecuritySchemeUids) ?? [],
+)
+
+/**
  * Execute the request
  * called from the send button as well as keyboard shortcuts
  */
@@ -76,6 +92,7 @@ const executeRequest = async () => {
     auth: activeCollection.value.auth,
     request: activeRequest.value,
     example: activeExample.value,
+    selectedSecuritySchemeUids: selectedSecuritySchemeUids.value,
     proxy: activeWorkspace.value.proxyUrl ?? '',
     environment,
     globalCookies,
@@ -181,7 +198,8 @@ function handleCurlImport(curl: string) {
         v-if="activeExample"
         class="flex-1"
         :class="[showSideBar ? 'sidebar-active-hide-layout' : '']">
-        <RequestSection />
+        <RequestSection
+          :selectedSecuritySchemeUids="selectedSecuritySchemeUids" />
         <ResponseSection :response="activeHistoryEntry?.response" />
       </ViewLayoutContent>
     </ViewLayout>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -58,22 +58,23 @@ const teleportId = `combobox-${nanoid()}`
  * Currently we just filter out empty object for optional but when we add required security we shall handle it!
  */
 const availableSchemes = computed(() => {
+  // TODO: these are commented out for now until we decide how to handle request level requirements
   /** With optional ({}) filtered out */
-  const requestSecurity = activeRequest.value?.security?.filter(
-    (s) => Object.keys(s).length,
-  )
+  // const requestSecurity = activeRequest.value?.security?.filter(
+  //   (s) => Object.keys(s).length,
+  // )
+  // const base =
+  //   isReadOnly.value && requestSecurity?.length
+  //     ? requestSecurity.map((s) => {
+  //         const nameKey = Object.keys(s)[0]
+  //         return (
+  //           Object.values(securitySchemes).find((ss) => ss.nameKey === nameKey)
+  //             ?.uid ?? ''
+  //         )
+  //       })
+  //     : activeCollection.value?.securitySchemes
 
-  const base =
-    isReadOnly.value && requestSecurity?.length
-      ? requestSecurity.map((s) => {
-          const nameKey = Object.keys(s)[0]
-          return (
-            Object.values(securitySchemes).find((ss) => ss.nameKey === nameKey)
-              ?.uid ?? ''
-          )
-        })
-      : activeCollection.value?.securitySchemes
-
+  const base = activeCollection.value?.securitySchemes
   return (base ?? []).map((s) => securitySchemes[s]).filter((s) => s)
 })
 
@@ -97,17 +98,52 @@ const schemeOptions = computed<SecuritySchemeOption[] | SecuritySchemeGroup[]>(
   },
 )
 
-/** Currently selected auth schemes on the collection */
-const selectedAuth = computed(
+/**
+ * Selected scheme UIDs
+ *
+ * In the modal we use collection.selectedSecuritySchemes and in the
+ * standalone client we use request.selectedSecuritySchemeUids
+ */
+const selectedSecuritySchemeUids = computed(
   () =>
-    activeRequest.value?.selectedSecuritySchemeUids.map((uid) =>
-      displaySchemeFormatter(securitySchemes[uid]),
-    ) ?? [],
+    (isReadOnly.value
+      ? activeCollection.value?.selectedSecuritySchemeUids
+      : activeRequest.value?.selectedSecuritySchemeUids) ?? [],
+)
+
+/** Ensure to update the correct mutator with the selected scheme UIDs */
+const editSelectedSchemeUids = (uids: string[]) => {
+  if (!activeCollection.value || !activeRequest.value) return
+
+  // Set as selected on the collection for the modal
+  if (isReadOnly.value) {
+    collectionMutators.edit(
+      activeCollection.value.uid,
+      'selectedSecuritySchemeUids',
+      uids,
+    )
+  }
+  // Set as selected on request
+  else {
+    requestMutators.edit(
+      activeRequest.value.uid,
+      'selectedSecuritySchemeUids',
+      uids,
+    )
+  }
+}
+
+/** Currently selected auth schemes on the collection */
+const selectedAuth = computed(() =>
+  selectedSecuritySchemeUids.value.map((uid) =>
+    displaySchemeFormatter(securitySchemes[uid]),
+  ),
 )
 
 /** Update the selected auth types */
 function updateSelectedAuth(entries: SecuritySchemeOption[]) {
   if (!activeCollection.value?.uid || !activeRequest.value?.uid) return
+
   const addNewOption = entries.find((e) => e.payload)
   const _entries = entries.filter((e) => !e.payload).map(({ id }) => id)
 
@@ -135,23 +171,13 @@ function updateSelectedAuth(entries: SecuritySchemeOption[]) {
     }, activeCollection.value.auth),
   )
 
-  // Set as selected on request
-  requestMutators.edit(
-    activeRequest.value.uid,
-    'selectedSecuritySchemeUids',
-    _entries,
-  )
+  editSelectedSchemeUids(_entries)
 }
 
 /** Remove a single auth type from an example */
 const unselectAuth = (unSelectUid: string) =>
-  activeRequest.value &&
-  requestMutators.edit(
-    activeRequest.value.uid,
-    'selectedSecuritySchemeUids',
-    activeRequest.value.selectedSecuritySchemeUids.filter(
-      (uid) => uid !== unSelectUid,
-    ),
+  editSelectedSchemeUids(
+    selectedSecuritySchemeUids.value.filter((uid) => uid !== unSelectUid),
   )
 
 function handleDeleteScheme(option: { id: string; label: string }) {
@@ -179,7 +205,7 @@ function handleDeleteScheme(option: { id: string; label: string }) {
               ref="comboboxRef"
               class="text-xs w-full"
               fullWidth
-              isDeletable
+              :isDeletable="!isReadOnly"
               :modelValue="selectedAuth"
               multiple
               :options="schemeOptions"
@@ -227,7 +253,8 @@ function handleDeleteScheme(option: { id: string; label: string }) {
             </ScalarComboboxMultiselect>
           </DataTableHeader>
         </DataTableRow>
-        <RequestExampleAuth />
+        <RequestExampleAuth
+          :selectedSecuritySchemeUids="selectedSecuritySchemeUids" />
       </DataTable>
       <DeleteRequestAuthModal
         :scheme="selectedScheme"

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -27,7 +27,8 @@ import { computed, ref } from 'vue'
 import DeleteRequestAuthModal from './DeleteRequestAuthModal.vue'
 import RequestExampleAuth from './RequestExampleAuth.vue'
 
-defineProps<{
+const { selectedSecuritySchemeUids } = defineProps<{
+  selectedSecuritySchemeUids: string[]
   title: string
 }>()
 
@@ -98,19 +99,6 @@ const schemeOptions = computed<SecuritySchemeOption[] | SecuritySchemeGroup[]>(
   },
 )
 
-/**
- * Selected scheme UIDs
- *
- * In the modal we use collection.selectedSecuritySchemes and in the
- * standalone client we use request.selectedSecuritySchemeUids
- */
-const selectedSecuritySchemeUids = computed(
-  () =>
-    (isReadOnly.value
-      ? activeCollection.value?.selectedSecuritySchemeUids
-      : activeRequest.value?.selectedSecuritySchemeUids) ?? [],
-)
-
 /** Ensure to update the correct mutator with the selected scheme UIDs */
 const editSelectedSchemeUids = (uids: string[]) => {
   if (!activeCollection.value || !activeRequest.value) return
@@ -135,7 +123,7 @@ const editSelectedSchemeUids = (uids: string[]) => {
 
 /** Currently selected auth schemes on the collection */
 const selectedAuth = computed(() =>
-  selectedSecuritySchemeUids.value.map((uid) =>
+  selectedSecuritySchemeUids.map((uid) =>
     displaySchemeFormatter(securitySchemes[uid]),
   ),
 )
@@ -177,7 +165,7 @@ function updateSelectedAuth(entries: SecuritySchemeOption[]) {
 /** Remove a single auth type from an example */
 const unselectAuth = (unSelectUid: string) =>
   editSelectedSchemeUids(
-    selectedSecuritySchemeUids.value.filter((uid) => uid !== unSelectUid),
+    selectedSecuritySchemeUids.filter((uid) => uid !== unSelectUid),
   )
 
 function handleDeleteScheme(option: { id: string; label: string }) {

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestExampleAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestExampleAuth.vue
@@ -11,13 +11,17 @@ import { capitalize, computed } from 'vue'
 
 import OAuth2 from './OAuth2.vue'
 
+const { selectedSecuritySchemeUids } = defineProps<{
+  selectedSecuritySchemeUids: string[]
+}>()
+
 const { activeCollection, activeRequest, collectionMutators, securitySchemes } =
   useWorkspace()
 
 const security = computed(() => {
   if (!activeCollection.value || !activeRequest.value) return []
 
-  return activeRequest.value.selectedSecuritySchemeUids.map((uid) => ({
+  return selectedSecuritySchemeUids.map((uid) => ({
     example: activeCollection.value!.auth[uid],
     scheme: securitySchemes[uid],
   }))

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -5,11 +5,14 @@ import { useWorkspace } from '@/store'
 import RequestBody from '@/views/Request/RequestSection/RequestBody.vue'
 import RequestParams from '@/views/Request/RequestSection/RequestParams.vue'
 import RequestPathParams from '@/views/Request/RequestSection/RequestPathParams.vue'
-import { ScalarIcon } from '@scalar/components'
 import { canMethodHaveBody } from '@scalar/oas-utils/helpers'
 import { computed, ref, watch } from 'vue'
 
 import RequestAuth from './RequestAuth/RequestAuth.vue'
+
+defineProps<{
+  selectedSecuritySchemeUids: string[]
+}>()
 
 const { activeRequest, activeExample, isReadOnly, requestMutators } =
   useWorkspace()
@@ -92,6 +95,7 @@ const updateRequestNameHandler = (event: Event) => {
         v-show="
           !isAuthHidden && (activeSection === 'All' || activeSection === 'Auth')
         "
+        :selectedSecuritySchemeUids="selectedSecuritySchemeUids"
         title="Authentication" />
       <RequestPathParams
         v-show="

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -37,12 +37,9 @@
             token: 'api_key_12345abcde',
           },
           oAuth2: {
-            username: 'johndoe',
-            password: 'secretpass123',
             clientId: 'client_12345',
-            scopes: ['read', 'write', 'delete'],
+            scopes: ['write:planets', 'read:planets'],
             accessToken: 'access_token_67890fghij',
-            state: 'random_state_string',
           },
         },
       }

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -19,29 +19,10 @@
     <!-- Optional: You can set a full configuration object like this: -->
     <script>
       var configuration = {
-        authentication: {
-          // The OpenAPI file has keys for all security schemes:
-          // Which one should be used by default?
-          preferredSecurityScheme: 'apiKeyHeader',
-          // The `my_custom_security_scheme` security scheme is of type `apiKey`, so prefill the token:
-          http: {
-            basic: {
-              username: 'johndoe',
-              password: 'secretpass123',
-            },
-            bearer: {
-              token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
-            },
-          },
-          apiKey: {
-            token: 'api_key_12345abcde',
-          },
-          oAuth2: {
-            clientId: 'client_12345',
-            scopes: ['write:planets', 'read:planets'],
-            accessToken: 'access_token_67890fghij',
-          },
-        },
+        // defaultHttpClient: {
+        //   targetKey: 'node',
+        //   clientKey: 'undici',
+        // },
       }
 
       document.getElementById('api-reference').dataset.configuration =

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -19,10 +19,32 @@
     <!-- Optional: You can set a full configuration object like this: -->
     <script>
       var configuration = {
-        // defaultHttpClient: {
-        //   targetKey: 'node',
-        //   clientKey: 'undici',
-        // },
+        authentication: {
+          // The OpenAPI file has keys for all security schemes:
+          // Which one should be used by default?
+          preferredSecurityScheme: 'apiKeyHeader',
+          // The `my_custom_security_scheme` security scheme is of type `apiKey`, so prefill the token:
+          http: {
+            basic: {
+              username: 'johndoe',
+              password: 'secretpass123',
+            },
+            bearer: {
+              token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+            },
+          },
+          apiKey: {
+            token: 'api_key_12345abcde',
+          },
+          oAuth2: {
+            username: 'johndoe',
+            password: 'secretpass123',
+            clientId: 'client_12345',
+            scopes: ['read', 'write', 'delete'],
+            accessToken: 'access_token_67890fghij',
+            state: 'random_state_string',
+          },
+        },
       }
 
       document.getElementById('api-reference').dataset.configuration =

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -371,9 +371,7 @@ const themeStyleTag = computed(
     <!-- REST API Client Overlay -->
     <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withDefaultFonts: false` -->
     <ApiClientModal
-      :preferredSecurityScheme="
-        configuration.authentication?.preferredSecurityScheme
-      "
+      :authentication="configuration.authentication"
       :proxyUrl="configuration.proxy"
       :servers="configuration.servers"
       :spec="configuration.spec" />

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { getUrlFromServerState, useServerStore } from '#legacy'
 import type {
-  AuthenticationState,
+  ReferenceConfiguration,
   Spec,
   SpecConfiguration,
 } from '@scalar/types/legacy'
@@ -11,7 +11,7 @@ import { useApiClient } from './useApiClient'
 
 const props = defineProps<{
   proxyUrl?: string
-  authentication?: AuthenticationState
+  authentication?: ReferenceConfiguration['authentication']
   spec?: SpecConfiguration
   servers?: Spec['servers']
 }>()

--- a/packages/api-reference/src/features/ApiClientModal/useApiClient.ts
+++ b/packages/api-reference/src/features/ApiClientModal/useApiClient.ts
@@ -1,7 +1,7 @@
 import { createApiClientModal } from '@scalar/api-client/layouts/Modal'
 import type { ApiClient } from '@scalar/api-client/libs'
 import type {
-  AuthenticationState,
+  ReferenceConfiguration,
   Spec,
   SpecConfiguration,
 } from '@scalar/types/legacy'
@@ -10,7 +10,7 @@ import { ref } from 'vue'
 type InitArgs = {
   el: HTMLElement
   spec?: SpecConfiguration
-  authentication?: AuthenticationState
+  authentication?: ReferenceConfiguration['authentication']
   proxyUrl?: string
   servers?: Spec['servers']
 }
@@ -34,7 +34,7 @@ export const useApiClient = (): {
     servers,
   }: InitArgs): Promise<ApiClient> => {
     const _client = (await createApiClientModal(el, {
-      preferredSecurityScheme: authentication?.preferredSecurityScheme,
+      authentication,
       spec,
       proxyUrl,
       servers,

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -137,10 +137,10 @@ export type ImportSpecToWorkspaceArgs = Pick<
 export async function importSpecToWorkspace(
   spec: string | UnknownObject,
   {
-    documentUrl,
-    watchForChanges,
     authentication,
+    documentUrl,
     setCollectionSecurity = false,
+    watchForChanges = false,
   }: ImportSpecToWorkspaceArgs = {},
 ): Promise<
   | {

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -23,7 +23,7 @@ import { schemaModel } from '@/helpers/schema-model'
 import { keysOf } from '@scalar/object-utils/arrays'
 import { dereference, load, upgrade } from '@scalar/openapi-parser'
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
-import type { AuthenticationState } from '@scalar/types/legacy'
+import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import type { UnknownObject } from '@scalar/types/utils'
 import type { Entries } from 'type-fest'
 
@@ -79,9 +79,9 @@ export async function importSpecToWorkspace(
   {
     documentUrl,
     watchForChanges,
-    preferredSecurityScheme,
+    authentication,
   }: Pick<CollectionPayload, 'documentUrl' | 'watchForChanges'> &
-    Pick<Partial<AuthenticationState>, 'preferredSecurityScheme'> = {},
+    Pick<ReferenceConfiguration, 'authentication'> = {},
 ): Promise<
   | {
       error: false
@@ -205,9 +205,11 @@ export async function importSpecToWorkspace(
         // Set the initially selected security scheme
         if (securityRequirements.length) {
           const name =
-            preferredSecurityScheme &&
-            securityRequirements.includes(preferredSecurityScheme ?? '')
-              ? preferredSecurityScheme
+            authentication?.preferredSecurityScheme &&
+            securityRequirements.includes(
+              authentication?.preferredSecurityScheme ?? '',
+            )
+              ? authentication?.preferredSecurityScheme
               : securityRequirements[0]
           const uid = securitySchemeMap[name]
           selectedSecuritySchemeUids = [uid]


### PR DESCRIPTION
Closes #3377

1. Pre-fills client auth according to the authentication config object.
2. Syncs up the collection selected auth with the references one.
3. Update the selectedSecuritySchemeUids to come from the collection on the modal, and the request otherwise

This should hold us over until we get a collection page

