### PR TITLE
test(api-reference): make the standalone test stable

### DIFF
--- a/packages/api-reference/src/helpers/waitFor.ts
+++ b/packages/api-reference/src/helpers/waitFor.ts
@@ -1,0 +1,24 @@
+/**
+ * Wait for a condition to be met
+ */
+export const waitFor = async (
+  checkFn: () => boolean,
+  timeout = 4000,
+  interval = 50,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now()
+
+    const check = () => {
+      if (checkFn()) {
+        resolve()
+      } else if (Date.now() - startTime >= timeout) {
+        reject(new Error('Condition not met within timeout period'))
+      } else {
+        setTimeout(check, interval)
+      }
+    }
+
+    check()
+  })
+}

--- a/packages/api-reference/src/standalone.spec.ts
+++ b/packages/api-reference/src/standalone.spec.ts
@@ -4,9 +4,9 @@ import { describe, expect, it } from 'vitest'
 import { waitFor } from './helpers/waitFor'
 import type { ReferenceProps } from './types'
 
-describe('standalone', { retry: 3 }, () => {
-  // The HTML API requires a script tag with type="application/json" and an ID of "api-reference":
-
+describe.sequential('standalone', { retry: 3, timeout: 10000 }, () => {
+  // Generates the required script tag on the fly:
+  //
   // <script id="api-reference" type="application/json">
   //   { "openapi": "3.1.0", "info": { "title": "Example" }, "paths": {} }
   // </script>

--- a/packages/api-reference/src/standalone.spec.ts
+++ b/packages/api-reference/src/standalone.spec.ts
@@ -8,17 +8,18 @@ import type { ReferenceProps } from './types'
 
 /**
  * Tests for standalone
- * A bit hacky as we are working with the dom without jsdom, but works for these tests
- * as each test builds off the last
  */
-describe('Standalone API References', () => {
+describe('Standalone API References', { retry: 3 }, () => {
   const matchMediaMock = new MatchMediaMock()
 
   afterAll(() => {
     matchMediaMock.clear()
   })
 
-  it('renders very basic references with standalone', async () => {
+  it('Renders and updates the standalone reference', async () => {
+    /*
+     * renders very basic references with standalone
+     */
     const script = document.createElement('script')
     script.id = 'api-reference'
     script.type = 'application/json'
@@ -32,35 +33,38 @@ describe('Standalone API References', () => {
     await import('./standalone')
     await sleep(50)
 
-    const rootElement = document.querySelector('[data-v-app]')
-    const reference = rootElement?.querySelector('.scalar-api-reference')
-    const h1 = reference?.querySelector('h1')
+    const rootElement1 = document.querySelector('[data-v-app]')
+    const reference1 = rootElement1?.querySelector('.scalar-api-reference')
+    const header1 = reference1?.querySelector('h1')
 
-    expect(rootElement?.contains(reference!)).toBeTruthy()
-    expect(h1?.innerHTML).toEqual('Example')
-  })
+    expect(rootElement1?.contains(reference1!)).toBeTruthy()
+    expect(header1?.innerHTML).toEqual('Example')
 
-  it('removes the app element and reloads', async () => {
+    /*
+     * removes the app element and reloads
+     */
+
     // Remove the main element
-    let rootElement = document.querySelector('[data-v-app]')
-    rootElement?.parentNode?.removeChild(rootElement)
+    let rootElement2 = document.querySelector('[data-v-app]')
+    rootElement2?.parentNode?.removeChild(rootElement2)
 
-    expect(document.body.contains(rootElement)).toBeFalsy()
+    expect(document.body.contains(rootElement2!)).toBeFalsy()
     expect(document.querySelector('[data-v-app]')).toBeNull()
 
     // Now we use the event to re-load the app
     document.dispatchEvent(new Event('scalar:reload-references'))
     await sleep(50)
 
-    rootElement = document.querySelector('[data-v-app]')
-    const reference = rootElement?.querySelector('.scalar-api-reference')
-    const h1 = reference?.querySelector('h1')
+    rootElement2 = document.querySelector('[data-v-app]')
+    const reference2 = rootElement2?.querySelector('.scalar-api-reference')
+    const header2 = reference2?.querySelector('h1')
 
-    expect(rootElement?.contains(reference!)).toBeTruthy()
-    expect(h1?.innerHTML).toEqual('Example')
-  })
+    expect(rootElement2?.contains(reference2!)).toBeTruthy()
+    expect(header2?.innerHTML).toEqual('Example')
 
-  it('updates the spec url, detect for changes', async () => {
+    /*
+     * updates the spec url, detect for changes
+     */
     // Update the config with the galaxy spec
     const ev = new CustomEvent('scalar:update-references-config', {
       detail: {
@@ -74,9 +78,9 @@ describe('Standalone API References', () => {
     document.dispatchEvent(ev)
     await sleep(50)
 
-    const rootElement = document.querySelector('[data-v-app]')
-    const h1 = rootElement?.querySelector('h1')
+    const rootElement3 = document.querySelector('[data-v-app]')
+    const header3 = rootElement3?.querySelector('h1')
 
-    expect(h1?.innerHTML).toEqual('Scalar Galaxy')
+    expect(header3?.innerHTML).toEqual('Scalar Galaxy')
   })
 })

--- a/packages/api-reference/src/standalone.spec.ts
+++ b/packages/api-reference/src/standalone.spec.ts
@@ -1,9 +1,8 @@
-// @vitest-environment jsdom
 import galaxyContent from '@scalar/galaxy/latest.yaml?raw'
 import { afterAll, describe, expect, it } from 'vitest'
 import MatchMediaMock from 'vitest-matchmedia-mock'
 
-import { sleep } from './helpers'
+import { waitFor } from './helpers/waitFor'
 import type { ReferenceProps } from './types'
 
 /**
@@ -31,7 +30,12 @@ describe('Standalone API References', { retry: 3 }, () => {
     document.body.appendChild(script)
 
     await import('./standalone')
-    await sleep(50)
+
+    await waitFor(() => {
+      const reference = document.querySelector('.scalar-api-reference')
+      const header = reference?.querySelector('h1')
+      return header?.innerHTML === 'Example'
+    })
 
     const rootElement1 = document.querySelector('[data-v-app]')
     const reference1 = rootElement1?.querySelector('.scalar-api-reference')
@@ -43,17 +47,19 @@ describe('Standalone API References', { retry: 3 }, () => {
     /*
      * removes the app element and reloads
      */
-
-    // Remove the main element
     let rootElement2 = document.querySelector('[data-v-app]')
     rootElement2?.parentNode?.removeChild(rootElement2)
 
     expect(document.body.contains(rootElement2!)).toBeFalsy()
     expect(document.querySelector('[data-v-app]')).toBeNull()
 
-    // Now we use the event to re-load the app
     document.dispatchEvent(new Event('scalar:reload-references'))
-    await sleep(50)
+
+    await waitFor(() => {
+      const reference = document.querySelector('.scalar-api-reference')
+      const header = reference?.querySelector('h1')
+      return header?.innerHTML === 'Example'
+    })
 
     rootElement2 = document.querySelector('[data-v-app]')
     const reference2 = rootElement2?.querySelector('.scalar-api-reference')
@@ -65,7 +71,6 @@ describe('Standalone API References', { retry: 3 }, () => {
     /*
      * updates the spec url, detect for changes
      */
-    // Update the config with the galaxy spec
     const ev = new CustomEvent('scalar:update-references-config', {
       detail: {
         configuration: {
@@ -76,11 +81,14 @@ describe('Standalone API References', { retry: 3 }, () => {
       } satisfies ReferenceProps,
     })
     document.dispatchEvent(ev)
-    await sleep(50)
+
+    await waitFor(() => {
+      const header = document.querySelector('[data-v-app] h1')
+      return header?.innerHTML === 'Scalar Galaxy'
+    })
 
     const rootElement3 = document.querySelector('[data-v-app]')
     const header3 = rootElement3?.querySelector('h1')
-
     expect(header3?.innerHTML).toEqual('Scalar Galaxy')
   })
 })

--- a/packages/api-reference/src/standalone.spec.ts
+++ b/packages/api-reference/src/standalone.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import galaxyContent from '@scalar/galaxy/latest.yaml?raw'
 import { afterAll, describe, expect, it } from 'vitest'
 import MatchMediaMock from 'vitest-matchmedia-mock'

--- a/packages/api-reference/src/standalone.spec.ts
+++ b/packages/api-reference/src/standalone.spec.ts
@@ -1,24 +1,16 @@
 import galaxyContent from '@scalar/galaxy/latest.yaml?raw'
-import { afterAll, describe, expect, it } from 'vitest'
-import MatchMediaMock from 'vitest-matchmedia-mock'
+import { describe, expect, it } from 'vitest'
 
 import { waitFor } from './helpers/waitFor'
 import type { ReferenceProps } from './types'
 
-/**
- * Tests for standalone
- */
-describe('Standalone API References', { retry: 3 }, () => {
-  const matchMediaMock = new MatchMediaMock()
+describe('standalone', { retry: 3 }, () => {
+  // The HTML API requires a script tag with type="application/json" and an ID of "api-reference":
 
-  afterAll(() => {
-    matchMediaMock.clear()
-  })
-
-  it('Renders and updates the standalone reference', async () => {
-    /*
-     * renders very basic references with standalone
-     */
+  // <script id="api-reference" type="application/json">
+  //   { "openapi": "3.1.0", "info": { "title": "Example" }, "paths": {} }
+  // </script>
+  it('renders a basic reference with the HTML API', async () => {
     const script = document.createElement('script')
     script.id = 'api-reference'
     script.type = 'application/json'
@@ -36,21 +28,13 @@ describe('Standalone API References', { retry: 3 }, () => {
       const header = reference?.querySelector('h1')
       return header?.innerHTML === 'Example'
     })
+  })
 
-    const rootElement1 = document.querySelector('[data-v-app]')
-    const reference1 = rootElement1?.querySelector('.scalar-api-reference')
-    const header1 = reference1?.querySelector('h1')
+  it('reloads the reference after removing the app element', async () => {
+    const rootElement = document.querySelector('[data-v-app]')
+    rootElement?.parentNode?.removeChild(rootElement)
 
-    expect(rootElement1?.contains(reference1!)).toBeTruthy()
-    expect(header1?.innerHTML).toEqual('Example')
-
-    /*
-     * removes the app element and reloads
-     */
-    let rootElement2 = document.querySelector('[data-v-app]')
-    rootElement2?.parentNode?.removeChild(rootElement2)
-
-    expect(document.body.contains(rootElement2!)).toBeFalsy()
+    expect(document.body.contains(rootElement!)).toBeFalsy()
     expect(document.querySelector('[data-v-app]')).toBeNull()
 
     document.dispatchEvent(new Event('scalar:reload-references'))
@@ -60,18 +44,10 @@ describe('Standalone API References', { retry: 3 }, () => {
       const header = reference?.querySelector('h1')
       return header?.innerHTML === 'Example'
     })
+  })
 
-    rootElement2 = document.querySelector('[data-v-app]')
-    const reference2 = rootElement2?.querySelector('.scalar-api-reference')
-    const header2 = reference2?.querySelector('h1')
-
-    expect(rootElement2?.contains(reference2!)).toBeTruthy()
-    expect(header2?.innerHTML).toEqual('Example')
-
-    /*
-     * updates the spec url, detect for changes
-     */
-    const ev = new CustomEvent('scalar:update-references-config', {
+  it('updates when the configuration changes', async () => {
+    const event = new CustomEvent('scalar:update-references-config', {
       detail: {
         configuration: {
           spec: {
@@ -80,15 +56,12 @@ describe('Standalone API References', { retry: 3 }, () => {
         },
       } satisfies ReferenceProps,
     })
-    document.dispatchEvent(ev)
+
+    document.dispatchEvent(event)
 
     await waitFor(() => {
       const header = document.querySelector('[data-v-app] h1')
       return header?.innerHTML === 'Scalar Galaxy'
     })
-
-    const rootElement3 = document.querySelector('[data-v-app]')
-    const header3 = rootElement3?.querySelector('h1')
-    expect(header3?.innerHTML).toEqual('Scalar Galaxy')
   })
 })

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -23,9 +23,9 @@
   "scripts": {
     "build": "scalar-build-rollup && vite-node scripts/publish.ts",
     "dev": "vite-node playground/index.ts",
-    "test": "vitest",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
+    "test": "vitest",
     "test:unit": "vitest",
     "types:build": "tsc -p tsconfig.build.json",
     "types:check": "tsc --noEmit --skipLibCheck"

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "scripts": {
     "test:e2e": "playwright test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 12.3.2(typescript@5.6.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
+        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -16455,8 +16455,8 @@ packages:
   vue-component-type-helpers@2.0.21:
     resolution: {integrity: sha512-3NaicyZ7N4B6cft4bfb7dOnPbE9CjLcx+6wZWAg5zwszfO4qXRh+U52dN5r5ZZfc6iMaxKCEcoH9CmxxoFZHLg==}
 
-  vue-component-type-helpers@2.1.6:
-    resolution: {integrity: sha512-ng11B8B/ZADUMMOsRbqv0arc442q7lifSubD0v8oDXIFoMg/mXwAPUunrroIDkY+mcD0dHKccdaznSVp8EoX3w==}
+  vue-component-type-helpers@2.1.8:
+    resolution: {integrity: sha512-ii36gDzrYAfOQIkOlo44yceDdT5269gKmNGxf07Qx6seH2U50+tQ2ol02XLhYPmxrh6YabAsOdte8WDrpaO6Tw==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -21613,7 +21613,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -21632,7 +21632,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -23986,7 +23986,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.12(typescript@5.6.2)
-      vue-component-type-helpers: 2.1.6
+      vue-component-type-helpers: 2.1.8
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -30718,7 +30718,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -30749,7 +30749,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -33463,7 +33463,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
 
   postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)):
     dependencies:
@@ -33471,7 +33471,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
 
   postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.39)(tsx@4.19.1):
     dependencies:
@@ -36294,7 +36294,7 @@ snapshots:
       '@swc/core': 1.5.29(@swc/helpers@0.5.5)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2):
+  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -37381,7 +37381,7 @@ snapshots:
 
   vue-component-type-helpers@2.0.21: {}
 
-  vue-component-type-helpers@2.1.6: {}
+  vue-component-type-helpers@2.1.8: {}
 
   vue-demi@0.14.10(vue@3.5.12(typescript@5.6.2)):
     dependencies:


### PR DESCRIPTION
**Problem**
Currently, the standalone test is flaky in CI on Node 18

**Solution**
This PR:
- adds retries 
- explicitly adds the jsdom file directive for the runtime environment
- combines the tests because they build off each other to guarantee execution order


