### PR TITLE
chore: weekly interval for automatically created PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,17 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     # This will disable updates, but still create PRs for security updates.
     open-pull-requests-limit: 0
   - package-ecosystem: 'nuget'
     directory: '/packages/scalar.aspnetcore'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     # This will disable updates, but still create PRs for security updates.
     open-pull-requests-limit: 0
   - package-ecosystem: npm

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -2,7 +2,8 @@ name: Update Contributors in README
 
 on:
   schedule:
-    - cron: '0 15 * * *'
+    # Run every Friday at 15:00 UTC
+    - cron: '0 15 * * 5'
 
 jobs:
   update-readme:


### PR DESCRIPTION
I think it’s fine to have the dependabot updates and the contributors update on a weekly basis.