### PR TITLE
fix(api-client): favors input on data table password type when masked

### DIFF
--- a/.changeset/healthy-brooms-film.md
+++ b/.changeset/healthy-brooms-film.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: favors input on data table password type when masked

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -81,7 +81,25 @@ const handleDropdownMouseUp = () => {
           @update:modelValue="emit('update:modelValue', $event)" />
       </template>
       <template v-else>
+        <input
+          v-if="mask && type === 'password'"
+          v-bind="$attrs"
+          :id="id"
+          autocomplete="off"
+          class="border-none text-c-1 disabled:text-c-2 min-w-0 w-full peer px-2 py-1.25 outline-none"
+          data-1p-ignore
+          :readOnly="readOnly"
+          spellcheck="false"
+          :type="inputType"
+          :value="modelValue"
+          @input="
+            emit(
+              'update:modelValue',
+              ($event.target as HTMLInputElement).value ?? '',
+            )
+          " />
         <CodeInput
+          v-else
           v-bind="$attrs"
           :id="id"
           class="border-none text-c-1 disabled:text-c-2 min-w-0 w-full peer outline-none"


### PR DESCRIPTION
this pr fixes #3630 by setting an input for masked password state:

before:

![2024-10-25_17-13-19](https://github.com/user-attachments/assets/21744ae9-940b-4e92-8685-e4bc2c117547)

