### PR TITLE
fix(api-client): overflow is added

### DIFF
--- a/.changeset/rude-books-smile.md
+++ b/.changeset/rude-books-smile.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: add an overflow to the dataTableInput to prevent it from overflowing

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -72,7 +72,7 @@ const handleDropdownMouseUp = () => {
       class="text-c-1 flex min-w-[94px] items-center pl-2 pr-0">
       <slot />
     </div>
-    <div class="row-1">
+    <div class="row-1 overflow-x-auto">
       <template v-if="props.enum && props.enum.length">
         <DataTableInputSelect
           :canAddCustomValue="canAddCustomEnumValue"


### PR DESCRIPTION
**Problem**
This PR solves the issue #3636, authentication entries do not overflow when they have many characters.

**Solution**

<img width="601" alt="image" src="https://github.com/user-attachments/assets/a34839d1-f1dc-42ca-9c63-1fe5a9157dae">

