### PR TITLE
docs(Scalar.AspNetCore): add .NET integration documentation

### DIFF
--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -1,6 +1,6 @@
 # Scalar.AspNetCore Integration
 
-The `Scalar.AspNetCore` package provides a simple way to integrate the Scalar API reference into your .NET 8+ application. This documentation covers configuration options for `Scalar.AspNetCore`, such as OAuth use cases, CDN configuration, and other settings available through the [`ScalarOptions`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs) class.
+The `Scalar.AspNetCore` package provides a simple way to integrate the Scalar API reference into your .NET 8+ application.
 
 ## Basic Setup
 
@@ -75,6 +75,32 @@ app.MapScalarApiReference(options =>
 });
 ```
 
+### OpenAPI document
+
+By default, Scalar uses the OpenAPI document located at `/openapi/{documentName}.json`, which aligns with the default route of Microsoft's built-in OpenAPI generator. If your OpenAPI document is located at a different path, such as with Swashbuckle or NSwag, you can specify the path using the `OpenApiRoutePattern` property:
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    options.WithOpenApiRoutePattern("/swagger/{documentName}.json");
+    // or
+    options.OpenApiRoutePattern = "/swagger/{documentName}.json";
+});
+```
+
+### API reference Route
+
+The Scalar API reference is initially accessible at `/scalar/{documentName}`, but you can customize this route using the `EndpointPathPrefix` property:
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    options.WithEndpointPrefix("/api-reference/{documentName}");
+    // or
+    options.EndpointPathPrefix = "/api-reference/{documentName}";
+});
+```
+
 ### Custom HTTP Client
 
 Scalar allows you to set a default HTTP client for code samples. The [`ScalarTarget`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTarget.cs) enum specifies the language, and the [`ScalarClient`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarClient.cs) enum specifies the client type.
@@ -82,11 +108,8 @@ Scalar allows you to set a default HTTP client for code samples. The [`ScalarTar
 ```csharp
 app.MapScalarApiReference(options =>
 {
-    // Fluent API
-    options
-        .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient);
-
-    // Object initializer
+    options.WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient);
+    // or
     options.DefaultHttpClient = new(ScalarTarget.CSharp, ScalarClient.HttpClient);
 });
 ```
@@ -98,6 +121,8 @@ By default, Scalar uses local assets to render the UI. If you prefer to load ass
 ```csharp
 app.MapScalarApiReference(options =>
 {
+    options.WithCdnUrl("https://cdn.jsdelivr.net/npm/@scalar/api-reference");
+    // or
     options.CdnUrl = "https://cdn.jsdelivr.net/npm/@scalar/api-reference";
 });
 ```
@@ -110,14 +135,22 @@ app.MapScalarApiReference(options =>
 Configuration options can also be set via dependency injection:
 
 ```csharp
-builder.Services.Configure<ScalarOptions>(options => options.Title = "My custom API");
-
+builder.Services.Configure<ScalarOptions>(options => options.Title = "My API");
 // or
-
 builder.Services.AddOptions<ScalarOptions>().BindConfiguration("Scalar");
 ```
 
 > [!NOTE]
-> Options set via the `MapScalarApiReference` method take precedence over options set via dependency injection.
+> Options set via the `MapScalarApiReference` method override those set through dependency injection.
+
+### Additional information
+
+The `MapScalarApiReference` method is implemented as a minimal API endpoint and returns an `IEndpointConventionBuilder`, allowing you to use minimal API features such as authorization:
+
+```csharp
+app
+    .MapScalarApiReference()
+    .RequireAuthorization();
+```
 
 For all available configuration properties and their default values, check out the [ScalarOptions](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs) and the [`ScalarOptionsExtensions`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs).

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -1,0 +1,123 @@
+# Scalar.AspNetCore Integration
+
+The `Scalar.AspNetCore` package provides a simple way to integrate the Scalar API reference into your .NET 8+ application. This documentation covers configuration options for `Scalar.AspNetCore`, such as OAuth use cases, CDN configuration, and other settings available through the [`ScalarOptions`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs) class.
+
+## Basic Setup
+
+To set up Scalar, use the `MapScalarApiReference` method in your `Program.cs`. See the [README](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/README.md) for general setup steps.
+
+## Configuration Options
+
+The `MapScalarApiReference` method accepts an optional `options` parameter, which you can use to customize Scalar using the fluent API or object initializer syntax:
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    // Fluent API
+    options
+        .WithTitle("Custom API")
+        .WithSidebar(false);
+
+    // Object initializer
+    options.Title = "Custom API";
+    options.ShowSidebar = false;
+});
+```
+
+### Authentication
+
+Scalar supports different authentication schemes, such as OAuth and API Key, by allowing you to provide authentication information.
+
+> [!NOTE]
+> Security schemes and flows are derived from the OpenAPI document, not defined by Scalar.
+
+#### API Key
+
+To simplify API key usage, you can provide a token:
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    // Fluent API
+    options
+        .WithPreferredScheme("ApiKey") // Name of the security scheme in the OpenAPI document
+        .WithApiKeyAuthentication(apiKey =>
+        {
+            apiKey.Token = "your-api-key";
+        });
+
+    // Object initializer
+    options.Authentication = new ScalarAuthenticationOptions
+    {
+        PreferredSecurityScheme = "ApiKey", // Name of the security scheme in the OpenAPI document
+        ApiKey = new ApiKeyOptions
+        {
+            Token = "your-api-key"
+        }
+    }
+});
+```
+
+#### OAuth
+
+Similarly, OAuth fields like the client ID and scopes can be pre-filled.
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    options
+        .WithPreferredScheme("OAuth2") // Name of the security scheme in the OpenAPI document
+        .WithOAuth2Authentication(oauth =>
+        {
+            oauth.ClientId = "your-client-id";
+            oauth.Scopes = ["profile"];
+        });
+});
+```
+
+### Custom HTTP Client
+
+Scalar allows you to set a default HTTP client for code samples. The [`ScalarTarget`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTarget.cs) enum specifies the language, and the [`ScalarClient`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarClient.cs) enum specifies the client type.
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    // Fluent API
+    options
+        .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient);
+
+    // Object initializer
+    options.DefaultHttpClient = new(ScalarTarget.CSharp, ScalarClient.HttpClient);
+});
+```
+
+### Assets
+
+By default, Scalar uses local assets to render the UI. If you prefer to load assets from a CDN, you can set the `CdnUrl` property to specify the CDN path.
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    options.CdnUrl = "https://cdn.jsdelivr.net/npm/@scalar/api-reference";
+});
+```
+
+> [!NOTE]
+> Fonts are loaded from a CDN by default. To disable this, set `DefaultFonts` to false.
+
+### Dependency Injection
+
+Configuration options can also be set via dependency injection:
+
+```csharp
+builder.Services.Configure<ScalarOptions>(options => options.Title = "My custom API");
+
+// or
+
+builder.Services.AddOptions<ScalarOptions>().BindConfiguration("Scalar");
+```
+
+> [!NOTE]
+> Options set via the `MapScalarApiReference` method take precedence over options set via dependency injection.
+
+For all available configuration properties and their default values, check out the [ScalarOptions](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs) and the [`ScalarOptionsExtensions`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs).

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -149,8 +149,8 @@ The `MapScalarApiReference` method is implemented as a minimal API endpoint and 
 
 ```csharp
 app
-    .MapScalarApiReference()
-    .RequireAuthorization();
+  .MapScalarApiReference()
+  .RequireAuthorization();
 ```
 
 For all available configuration properties and their default values, check out the [ScalarOptions](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs) and the [`ScalarOptionsExtensions`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs).

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -4,7 +4,7 @@ The `Scalar.AspNetCore` package provides a simple way to integrate the Scalar AP
 
 ## Basic Setup
 
-To set up Scalar, use the `MapScalarApiReference` method in your `Program.cs`. See the [README](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/README.md) for general setup steps.
+To set up Scalar, use the `MapScalarApiReference` method in your `Program.cs`. See the [README](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/README.md#usage) for general setup steps.
 
 ## Configuration Options
 
@@ -75,9 +75,9 @@ app.MapScalarApiReference(options =>
 });
 ```
 
-### OpenAPI document
+### OpenAPI Document
 
-By default, Scalar uses the OpenAPI document located at `/openapi/{documentName}.json`, which aligns with the default route of Microsoft's built-in OpenAPI generator. If your OpenAPI document is located at a different path, such as with Swashbuckle or NSwag, you can specify the path using the `OpenApiRoutePattern` property:
+Scalar expects the OpenAPI document to be located at `/openapi/{documentName}.json`, matching the route of the built-in .NET OpenAPI generator. If the document is located elsewhere (e.g., when using Swashbuckle or NSwag), specify the path using the `OpenApiRoutePattern` property:
 
 ```csharp
 app.MapScalarApiReference(options =>
@@ -88,9 +88,9 @@ app.MapScalarApiReference(options =>
 });
 ```
 
-### API reference Route
+### API Reference Route
 
-The Scalar API reference is initially accessible at `/scalar/{documentName}`, but you can customize this route using the `EndpointPathPrefix` property:
+The Scalar API reference is initially accessible at `/scalar/{documentName}`. Customize this route using the `EndpointPathPrefix` property:
 
 ```csharp
 app.MapScalarApiReference(options =>
@@ -116,7 +116,7 @@ app.MapScalarApiReference(options =>
 
 ### Assets
 
-By default, Scalar uses local assets to render the UI. If you prefer to load assets from a CDN, you can set the `CdnUrl` property to specify the CDN path.
+Scalar uses local assets by default to render the UI. To load assets from a CDN or a different location, specify the `CdnUrl` property:
 
 ```csharp
 app.MapScalarApiReference(options =>
@@ -128,7 +128,7 @@ app.MapScalarApiReference(options =>
 ```
 
 > [!NOTE]
-> Fonts are loaded from a CDN by default. To disable this, set `DefaultFonts` to false.
+> Fonts are loaded from a CDN by default. To disable this, set `DefaultFonts` to `false`.
 
 ### Dependency Injection
 

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -1,4 +1,4 @@
-# Scalar.AspNetCore Integration
+# .NET Integration
 
 The `Scalar.AspNetCore` package provides a simple way to integrate the Scalar API reference into your .NET 8+ application.
 

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -26,10 +26,10 @@ app.MapScalarApiReference(options =>
 
 ### Authentication
 
-Scalar supports different authentication schemes, such as OAuth and API Key, by allowing you to provide authentication information.
+Scalar supports various authentication schemes, including OAuth and API Key, by allowing you to pre-fill certain authentication details.
 
 > [!NOTE]
-> Security schemes and flows are derived from the OpenAPI document, not defined by Scalar.
+> The available security schemes and flows are defined in the OpenAPI document your app provides, not within Scalar itself.
 
 #### API Key
 
@@ -40,7 +40,7 @@ app.MapScalarApiReference(options =>
 {
     // Fluent API
     options
-        .WithPreferredScheme("ApiKey") // Name of the security scheme in the OpenAPI document
+        .WithPreferredScheme("ApiKey") // Security scheme name from the OpenAPI document
         .WithApiKeyAuthentication(apiKey =>
         {
             apiKey.Token = "your-api-key";
@@ -49,7 +49,7 @@ app.MapScalarApiReference(options =>
     // Object initializer
     options.Authentication = new ScalarAuthenticationOptions
     {
-        PreferredSecurityScheme = "ApiKey", // Name of the security scheme in the OpenAPI document
+        PreferredSecurityScheme = "ApiKey", // Security scheme name from the OpenAPI document
         ApiKey = new ApiKeyOptions
         {
             Token = "your-api-key"
@@ -60,13 +60,13 @@ app.MapScalarApiReference(options =>
 
 #### OAuth
 
-Similarly, OAuth fields like the client ID and scopes can be pre-filled.
+Similarly, you can pre-fill OAuth fields like the client ID and scopes:
 
 ```csharp
 app.MapScalarApiReference(options =>
 {
     options
-        .WithPreferredScheme("OAuth2") // Name of the security scheme in the OpenAPI document
+        .WithPreferredScheme("OAuth2") // Security scheme name from the OpenAPI document
         .WithOAuth2Authentication(oauth =>
         {
             oauth.ClientId = "your-client-id";

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -4,7 +4,70 @@ The `Scalar.AspNetCore` package provides a simple way to integrate the Scalar AP
 
 ## Basic Setup
 
-To set up Scalar, use the `MapScalarApiReference` method in your `Program.cs`. See the [README](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/README.md#usage) for general setup steps.
+1. **Install the package**
+
+```shell
+dotnet add package Scalar.AspNetCore --version 1.2.*
+```
+
+> [!NOTE]
+> We release new versions frequently to bring you the latest features and bug fixes. To reduce the noise in your project file, we recommend using a wildcard for the patch version, e.g., `1.2.*`.
+
+2. **Add the using directive**
+
+```csharp
+using Scalar.AspNetCore;
+```
+
+3. **Configure your application**
+
+Add the following to `Program.cs` based on your OpenAPI generator:
+
+For .NET 9 using `Microsoft.AspNetCore.OpenApi`:
+
+```csharp
+builder.Services.AddOpenApi();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+    app.MapScalarApiReference();
+}
+```
+
+For .NET 8 using `Swashbuckle`:
+
+```csharp
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger(options =>
+    {
+        options.RouteTemplate = "/openapi/{documentName}.json";
+    });
+    app.MapScalarApiReference();
+}
+```
+
+For .NET 8 using `NSwag`:
+
+```csharp
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddOpenApiDocument();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseOpenApi(options =>
+    {
+        options.Path = "/openapi/{documentName}.json";
+    });
+    app.MapScalarApiReference();
+}
+```
+
+That’s it! 🎉 With the default settings, you can now access the Scalar API reference at `/scalar/v1` in your browser, where `v1` is the default document name.
 
 ## Configuration Options
 
@@ -27,6 +90,9 @@ app.MapScalarApiReference(options =>
 ### Authentication
 
 Scalar supports various authentication schemes, including OAuth and API Key, by allowing you to pre-fill certain authentication details.
+
+> [!WARNING]
+> Sensitive Information: Pre-filled authentication details are exposed to the client/browser and may pose a security risk. Do not use this feature in production environments.
 
 > [!NOTE]
 > The available security schemes and flows are defined in the OpenAPI document your app provides, not within Scalar itself.
@@ -77,7 +143,7 @@ app.MapScalarApiReference(options =>
 
 ### OpenAPI Document
 
-Scalar expects the OpenAPI document to be located at `/openapi/{documentName}.json`, matching the route of the built-in .NET OpenAPI generator. If the document is located elsewhere (e.g., when using Swashbuckle or NSwag), specify the path using the `OpenApiRoutePattern` property:
+Scalar expects the OpenAPI document to be located at `/openapi/{documentName}.json`, matching the route of the built-in .NET OpenAPI generator in the `Microsoft.AspNetCore.OpenApi` package. If the document is located elsewhere (e.g., when using `Swashbuckle` or `NSwag`), specify the path using the `OpenApiRoutePattern` property:
 
 ```csharp
 app.MapScalarApiReference(options =>
@@ -143,7 +209,7 @@ builder.Services.AddOptions<ScalarOptions>().BindConfiguration("Scalar");
 > [!NOTE]
 > Options set via the `MapScalarApiReference` method override those set through dependency injection.
 
-### Additional information
+## Additional information
 
 The `MapScalarApiReference` method is implemented as a minimal API endpoint and returns an `IEndpointConventionBuilder`, allowing you to use minimal API features such as authorization:
 

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -153,4 +153,4 @@ app
   .RequireAuthorization();
 ```
 
-For all available configuration properties and their default values, check out the [ScalarOptions](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs) and the [`ScalarOptionsExtensions`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs).
+For all available configuration properties and their default values, check out the [`ScalarOptions`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs) and the [`ScalarOptionsExtensions`](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs).

--- a/packages/scalar.aspnetcore/README.md
+++ b/packages/scalar.aspnetcore/README.md
@@ -8,7 +8,7 @@ This .NET package `Scalar.AspNetCore` provides an easy way to render beautiful A
 
 Made possible by the wonderful work of [@captainsafia](https://github.com/captainsafia) on [building the integration and docs written](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/using-openapi-documents?view=aspnetcore-9.0#use-scalar-for-interactive-api-documentation) for the Scalar & .NET integration. Thanks to [@xC0dex](https://github.com/xC0dex) for making it awesome.
 
-![dotnet](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/dotnet.jpg)
+![dotnet](https://raw.githubusercontent.com/scalar/scalar/refs/heads/main/packages/scalar.aspnetcore/dotnet.jpg)
 
 ## Usage
 
@@ -29,7 +29,9 @@ using Scalar.AspNetCore;
 
 3. **Configure your application**
 
-Add the following lines to your `Program.cs` for .NET 9:
+Add the following to `Program.cs` based on your OpenAPI generator:
+
+For .NET 9 using `Microsoft.AspNetCore.OpenApi`:
 
 ```csharp
 builder.Services.AddOpenApi();
@@ -41,7 +43,7 @@ if (app.Environment.IsDevelopment())
 }
 ```
 
-or for .NET 8 with Swashbuckle:
+For .NET 8 using `Swashbuckle`:
 
 ```csharp
 builder.Services.AddEndpointsApiExplorer();
@@ -51,13 +53,29 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger(options =>
     {
-        options.RouteTemplate = "openapi/{documentName}.json";
+        options.RouteTemplate = "/openapi/{documentName}.json";
     });
     app.MapScalarApiReference();
 }
 ```
 
-That's it! 🎉 Now you will see the Scalar UI when using the defaults by navigating to `/scalar/v1` in your browser.
+For .NET 8 using `NSwag`:
+
+```csharp
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddOpenApiDocument();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseOpenApi(options =>
+    {
+        options.Path = "/openapi/{documentName}.json";
+    });
+    app.MapScalarApiReference();
+}
+```
+
+That’s it! 🎉 With the default settings, you can now access the Scalar API reference at `/scalar/v1` in your browser, where `v1` is the default document name.
 
 ## Configuration
 

--- a/packages/scalar.aspnetcore/README.md
+++ b/packages/scalar.aspnetcore/README.md
@@ -61,51 +61,7 @@ That's it! 🎉 Now you will see the Scalar UI when using the defaults by naviga
 
 ## Configuration
 
-The `MapScalarApiReference` method has an optional parameter that you can use to customize the behavior of the Scalar UI:
-
-```csharp
-// Fluent API
-app.MapScalarApiReference(options =>
-{
-    options
-        .WithTitle("My custom API")
-        .WithTheme(ScalarTheme.Mars)
-        .WithSidebar(false)
-        .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
-        .WithPreferredScheme("ApiKey")
-        .WithApiKeyAuthentication(x => x.Token = "my-api-key");
-});
-
-// Object initializer
-app.MapScalarApiReference(options =>
-{
-    options.Title = "My custom API";
-    options.Theme = ScalarTheme.Mars;
-    options.ShowSidebar = false;
-    options.DefaultHttpClient = new(ScalarTarget.CSharp, ScalarClient.HttpClient);
-    options.Authentication = new ScalarAuthenticationOptions
-    {
-        PreferredSecurityScheme = "ApiKey",
-        ApiKey = new ApiKeyOptions
-        {
-            Token = "my-api-key"
-        }
-    };
-});
-```
-
-For more possible options and their default values, check out the [ScalarOptions.cs](https://github.com/scalar/scalar/blob/main/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs) class.
-
-It is also possible to configure the options via dependency injection, using the options pattern:
-
-```csharp
-builder.Services.Configure<ScalarOptions>(options => options.Title = "My custom API");
-// or
-builder.Services.AddOptions<ScalarOptions>().BindConfiguration("Scalar");
-```
-
-> [!NOTE]
-> Options which are set via the `MapScalarApiReference` method will take precedence over options set via dependency injection.
+For a full configuration guide, including OAuth integration and custom settings, refer to the [dotnet integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md).
 
 ## Development
 


### PR DESCRIPTION
This PR addresses the missing .NET integration documentation in the `documentation/integrations` folder. I've added some useful examples and descriptions.

Closes #3617 

For easier reading: https://github.com/xC0dex/scalar/blob/docs/documentation/integrations/dotnet.md

**Note**: The `Lint Markdown files` flow is failing due to a dead reference. Once this is merged, the link is no longer dead 😆.