### PR TITLE
fix: add mapping of header to headers

### DIFF
--- a/.changeset/lovely-peas-jog.md
+++ b/.changeset/lovely-peas-jog.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: add mapping of header to headers for api client ingress

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -141,19 +141,27 @@ export function createExampleFromRequest(
   // ---------------------------------------------------------------------------
   // Populate all parameters with an example value
   const parameters: Record<
-    'path' | 'cookie' | 'header' | 'query',
+    'path' | 'cookie' | 'header' | 'query' | 'headers',
     RequestExampleParameter[]
   > = {
     path: [],
     query: [],
     cookie: [],
+    // deprecated TODO: add zod transform to remove
     header: [],
+    headers: [],
   }
 
   // Populated the separated params
   request.parameters?.forEach((p) =>
     parameters[p.in].push(createParamInstance(p)),
   )
+
+  // TODO: add zod transform to remove header and only support headers
+  if (parameters.header.length > 0) {
+    parameters.headers = parameters.header
+    parameters.header = []
+  }
 
   // ---------------------------------------------------------------------------
   // Handle request body defaulting for various content type encodings


### PR DESCRIPTION
**Problem**
Currently we set the parameters to `header` and not `headers`

**Solution**
we map it to headers so we can render it in the client

we can add a proper migration later, but for now this doesnt impact any data just ingress

<img width="634" alt="image" src="https://github.com/user-attachments/assets/f2e34136-4795-435d-ac59-7e90eb652cb2">
before:
![image](https://github.com/user-attachments/assets/8e5ecff4-94b0-48aa-976f-cf81d68ae2b1)

after:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/03fde31e-f11d-418e-865c-42bd024e2e0d">

🥳 
