### PR TITLE
style(api-client): request section ui

### DIFF
--- a/.changeset/fast-swans-teach.md
+++ b/.changeset/fast-swans-teach.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: updates request section ui

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -9,7 +9,7 @@ const id = nanoid()
     class="flex h-full xl:min-w-0 xl:flex-1 flex-col xl:custom-scroll bg-b-1">
     <div
       :id="id"
-      class="min-h-11 xl:min-h-header flex items-center border-b-1/2 px-3.5 py-1.5 md:px-4 md:py-1.5 xl:px-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 xl:rounded-none group">
+      class="min-h-11 xl:min-h-header flex items-center border-b-1/2 px-3.5 py-1.5 md:px-4 md:py-2.5 xl:px-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 xl:rounded-none">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -67,7 +67,7 @@ const updateRequestNameHandler = (event: Event) => {
   <ViewLayoutSection>
     <template #title>
       <div
-        class="flex-1 flex gap-1 items-center lg:pr-24 pointer-events-none h-full">
+        class="flex-1 flex gap-1 items-center lg:pr-24 pointer-events-none group">
         <label
           v-if="!isReadOnly"
           class="absolute w-full h-full top-0 left-0 pointer-events-auto opacity-0 cursor-text"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -5,7 +5,6 @@ import ResponseBody from '@/views/Request/ResponseSection/ResponseBody.vue'
 import ResponseEmpty from '@/views/Request/ResponseSection/ResponseEmpty.vue'
 import ResponseLoadingOverlay from '@/views/Request/ResponseSection/ResponseLoadingOverlay.vue'
 import ResponseMetaInformation from '@/views/Request/ResponseSection/ResponseMetaInformation.vue'
-import { ScalarIcon } from '@scalar/components'
 import type { ResponseInstance } from '@scalar/oas-utils/entities/spec'
 import { computed, ref } from 'vue'
 

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -68,7 +68,7 @@ const shouldVirtualize = computed(
   <ViewLayoutSection>
     <template #title>
       <div
-        class="flex items-center flex-1"
+        class="flex items-center flex-1 h-8"
         :class="{
           'animate-response-heading': response,
         }">


### PR DESCRIPTION
this pr fixes request section hover glitch and alignment as seen below:

**request section hover glitch before / after**

https://github.com/user-attachments/assets/076fd585-c791-42b5-ace2-e20ea3d187fc

https://github.com/user-attachments/assets/0fd4ef93-9b65-45ac-97fb-323af41dbd5b

**request section search <> input misalignment before / after**
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/87e496a5-e0b9-40ee-92b9-62ed0134d152">
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/7fd86827-23d1-4ac6-b3a0-261b7b0193ce">
