### PR TITLE
fix(api-client): environment default value

### DIFF
--- a/.changeset/nice-lies-agree.md
+++ b/.changeset/nice-lies-agree.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sets default environment variable value

--- a/packages/api-client/src/store/environment.ts
+++ b/packages/api-client/src/store/environment.ts
@@ -23,8 +23,7 @@ export function createStoreEnvironments(useLocalStorage: boolean) {
       uid: 'default',
       name: 'Global Environment',
       color: 'blue',
-      raw: JSON.stringify({ exampleKey: 'exampleValue' }, null, 2),
-      parsed: [],
+      value: JSON.stringify({ exampleKey: 'exampleValue' }, null, 2),
       isDefault: true,
     }),
   )

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -98,7 +98,7 @@ const handleHotKey = (event?: HotKeyEvent) => {
 }
 
 onMounted(() => {
-  setActiveEnvironment
+  setActiveEnvironment()
   events.hotKeys.on(handleHotKey)
 })
 onBeforeUnmount(() => events.hotKeys.off(handleHotKey))


### PR DESCRIPTION
this pr sets back the default environment variable value according to latest workspace refactoring:

<img width="982" alt="image" src="https://github.com/user-attachments/assets/ae0c20d3-ab50-420d-bc10-5ec603f3caeb">
