### PR TITLE
fix(api-client): web layout hotkey display

### DIFF
--- a/.changeset/blue-eyes-walk.md
+++ b/.changeset/blue-eyes-walk.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: favors provide for web layout hotkey display

--- a/packages/api-client/src/components/Sidebar/SidebarButton.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarButton.vue
@@ -2,11 +2,16 @@
 import ScalarHotkey from '@/components/ScalarHotkey.vue'
 import { ScalarButton } from '@scalar/components'
 
-const props = defineProps<{
-  click: () => void
-  hotkey?: string
-  isApp?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    click: () => void
+    hotkey?: string
+    layout?: 'modal' | 'web' | 'desktop'
+  }>(),
+  {
+    layout: 'desktop',
+  },
+)
 
 const handleClick = () => {
   props.click()
@@ -20,7 +25,7 @@ const handleClick = () => {
     @click="handleClick">
     <slot name="title" />
     <ScalarHotkey
-      v-if="hotkey && !isApp"
+      v-if="hotkey && layout === 'desktop'"
       class="hidden md:block absolute right-2 group-hover:opacity-80 text-c-2 add-item-hotkey"
       :hotkey="hotkey" />
   </ScalarButton>

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -9,7 +9,14 @@ import { useWorkspace } from '@/store'
 import { addScalarClassesToHeadless } from '@scalar/components'
 import { getThemeStyles } from '@scalar/themes'
 import { ScalarToasts } from '@scalar/use-toasts'
-import { computed, onBeforeMount, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  computed,
+  onBeforeMount,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+  ref,
+} from 'vue'
 import { RouterView } from 'vue-router'
 
 import { APP_HOTKEYS } from './hotkeys'
@@ -31,6 +38,9 @@ useDarkModeState()
 
 const workspaceStore = useWorkspace()
 const { events } = workspaceStore
+
+// Provide the layout value
+provide('layout', 'desktop')
 
 // Ensure we add our scalar wrapper class to the headless ui root
 onBeforeMount(() => addScalarClassesToHeadless())

--- a/packages/api-client/src/layouts/Modal/ApiClientModal.vue
+++ b/packages/api-client/src/layouts/Modal/ApiClientModal.vue
@@ -2,10 +2,13 @@
 import { type HotKeyEvent, handleHotKeyDown } from '@/libs'
 import { useWorkspace } from '@/store'
 import { addScalarClassesToHeadless } from '@scalar/components'
-import { onBeforeMount, onBeforeUnmount, onMounted, watch } from 'vue'
+import { onBeforeMount, onBeforeUnmount, onMounted, provide, watch } from 'vue'
 import { RouterView } from 'vue-router'
 
 const { activeWorkspace, modalState, events } = useWorkspace()
+
+// Provide the layout value
+provide('layout', 'modal')
 
 /** Handles the hotkey events as well as custom config */
 const handleKeyDown = (ev: KeyboardEvent) =>

--- a/packages/api-client/src/layouts/Web/ApiClientWeb.vue
+++ b/packages/api-client/src/layouts/Web/ApiClientWeb.vue
@@ -7,7 +7,13 @@ import { useWorkspace } from '@/store'
 import { addScalarClassesToHeadless } from '@scalar/components'
 import { getThemeStyles } from '@scalar/themes'
 import { ScalarToasts } from '@scalar/use-toasts'
-import { computed, onBeforeMount, onBeforeUnmount, onMounted } from 'vue'
+import {
+  computed,
+  onBeforeMount,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+} from 'vue'
 import { RouterView } from 'vue-router'
 
 // Initialize dark mode state globally
@@ -15,6 +21,9 @@ useDarkModeState()
 
 const workspaceStore = useWorkspace()
 const { events } = workspaceStore
+
+// Provide the layout value
+provide('layout', 'web')
 
 // Ensure we add our scalar wrapper class to the headless ui root
 onBeforeMount(() => addScalarClassesToHeadless())

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -10,19 +10,17 @@ import type { HotKeyEvent } from '@/libs'
 import { useWorkspace } from '@/store'
 import { ScalarIcon } from '@scalar/components'
 import { type Cookie, cookieSchema } from '@scalar/oas-utils/entities/cookie'
-import { computed, onBeforeUnmount, onMounted } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import CookieForm from './CookieForm.vue'
 import CookieRaw from './CookieRaw.vue'
 
-defineProps<{
-  isApp: boolean
-}>()
 const { cookies, cookieMutators, events } = useWorkspace()
 const { collapsedSidebarFolders, toggleSidebarFolder } = useSidebar()
 const router = useRouter()
 const route = useRoute()
+const layout = inject<'modal' | 'web' | 'desktop'>('layout')
 
 const addCookieHandler = () => {
   const cookieIndex = Object.keys(cookies).length
@@ -164,7 +162,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
         <SidebarButton
           :click="addCookieHandler"
           hotkey="N"
-          :isApp="isApp">
+          :layout="layout">
           <template #title>Add Cookie</template>
         </SidebarButton>
       </template>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -12,15 +12,12 @@ import { useWorkspace } from '@/store'
 import { useModal } from '@scalar/components'
 import { environmentSchema } from '@scalar/oas-utils/entities/environment'
 import { nanoid } from 'nanoid'
-import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { inject, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import EnvironmentColorModal from './EnvironmentColorModal.vue'
 import EnvironmentModal from './EnvironmentModal.vue'
 
-defineProps<{
-  isApp: boolean
-}>()
 const router = useRouter()
 const route = useRoute()
 const { environments, environmentMutators, events } = useWorkspace()
@@ -32,6 +29,7 @@ const nameInputRef = ref<HTMLInputElement | null>(null)
 const isEditingName = ref(false)
 const colorModalEnvironment = ref<string | null>(null)
 const selectedColor = ref('')
+const layout = inject<'modal' | 'web' | 'desktop'>('layout')
 
 const parseEnvironmentValue = (value: string): Record<string, string> =>
   JSON.parse(value)
@@ -244,7 +242,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
         <SidebarButton
           :click="openEnvironmentModal"
           hotkey="N"
-          :isApp="isApp">
+          :layout="layout">
           <template #title>Add Environment</template>
         </SidebarButton>
       </template>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -4,11 +4,12 @@ import ScalarAsciiArt from '@/components/ScalarAsciiArt.vue'
 import ScalarHotkey from '@/components/ScalarHotkey.vue'
 import type { HotKeyEvent } from '@/libs'
 import { useWorkspace } from '@/store'
-import { onBeforeUnmount, onMounted } from 'vue'
+import { inject, onBeforeUnmount, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 
 const { isReadOnly, activeWorkspace, events } = useWorkspace()
 const route = useRoute()
+const layout = inject<'modal' | 'web' | 'desktop'>('layout')
 
 const openCommandPaletteRequest = () => {
   events.commandPalette.emit({ commandName: 'Create Request' })
@@ -55,7 +56,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
         <ScalarHotkey hotkey="↵" />
       </button>
       <button
-        v-if="!isReadOnly"
+        v-if="!isReadOnly && layout === 'desktop'"
         class="flex items-center gap-1.5"
         type="button"
         @click="openCommandPaletteRequest">


### PR DESCRIPTION
this pr favors provide / inject approach to condition scalar hotkey display in the web layout vs previous `isApp` prop set.

**on desktop**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/ee63ce25-3099-43c3-b304-ffc8d12b9e8b">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/5e598157-6dca-43ef-a107-a3d7c588cc65">

**on web**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/1c667966-2df5-4dc5-a7bb-7f983e86b3cc">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/94292ead-9421-4e1a-af09-84e96c045d4b">

