### PR TITLE
fix(oas-utils): parameter example value

### DIFF
--- a/.changeset/fresh-chairs-learn.md
+++ b/.changeset/fresh-chairs-learn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: adds example and examples to parameter schema

--- a/packages/oas-utils/src/entities/spec/parameters.test.ts
+++ b/packages/oas-utils/src/entities/spec/parameters.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { oasParameterSchema } from '../../../src/entities/spec/parameters'
+
+describe('oasParameterSchema', () => {
+  it('should validate a parameter with a correct example', () => {
+    const validParameterWithExample = {
+      in: 'query',
+      name: 'limit',
+      example: 10,
+    }
+
+    expect(() =>
+      oasParameterSchema.parse(validParameterWithExample),
+    ).not.toThrow()
+  })
+
+  it('should validate examples as a record with correct structure', () => {
+    const validExamples = {
+      milkyWay: {
+        value: 'Milky Way',
+        summary: 'Our galaxy',
+      },
+      andromeda: {
+        value: 'Andromeda',
+        summary: 'Nearest major galaxy',
+      },
+    }
+
+    const validParameter = {
+      in: 'query',
+      name: 'galaxy',
+      examples: validExamples,
+    }
+
+    expect(() => oasParameterSchema.parse(validParameter)).not.toThrow()
+  })
+
+  it('should fail validation if examples have incorrect structure', () => {
+    const invalidExamples = {
+      milkyWay: {
+        value: 'Milky Way',
+        // Summary is optional, so this should not cause a failure
+      },
+      andromeda: 'This should be an object, not a string',
+    }
+
+    const invalidParameter = {
+      in: 'query',
+      name: 'galaxy',
+      examples: invalidExamples,
+    }
+
+    expect(() => oasParameterSchema.parse(invalidParameter)).toThrow(z.ZodError)
+  })
+})

--- a/packages/oas-utils/src/entities/spec/parameters.ts
+++ b/packages/oas-utils/src/entities/spec/parameters.ts
@@ -30,6 +30,16 @@ export const oasParameterSchema = z.object({
   content: z.unknown().optional(),
   /** Defaulted according to @url https://spec.openapis.org/oas/v3.1.0#parameter-object */
   style: parameterStyleSchema.optional(),
+  example: z.unknown().optional(),
+  examples: z
+    .record(
+      z.string(),
+      z.object({
+        value: z.unknown(),
+        summary: z.string().optional(),
+      }),
+    )
+    .optional(),
 }) satisfies ZodSchema<OpenAPI.Parameter>
 
 export type RequestParameter = z.infer<typeof oasParameterSchema>

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -106,7 +106,9 @@ export function createParamInstance(param: RequestParameter) {
    * - Need to handle non-string parameters much better
    * - Need to handle unions/array values for schema
    */
-  const value = String(schema?.default ?? schema?.examples?.[0] ?? '')
+  const value = String(
+    schema?.default ?? schema?.examples?.[0] ?? schema?.example ?? '',
+  )
 
   // safe parse the example
   const example = schemaModel(

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -107,7 +107,12 @@ export function createParamInstance(param: RequestParameter) {
    * - Need to handle unions/array values for schema
    */
   const value = String(
-    schema?.default ?? schema?.examples?.[0] ?? schema?.example ?? '',
+    schema?.default ??
+      schema?.examples?.[0] ??
+      schema?.example ??
+      param.examples?.[Object.keys(param.examples)[0]]?.value ??
+      param.example ??
+      '',
   )
 
   // safe parse the example


### PR DESCRIPTION
this pr fixes #3456 by adding to parameter schema example and examples along setting theme aside schema examples as request example value.

this should now enable to retrieve value on the following usage:
```yaml
name: limit
in: query
description: The number of items to return
example: 123
```