### PR TITLE
fix(api-reference): arrays with `allOf` items render invalid examples

### DIFF
--- a/.changeset/silver-papayas-retire.md
+++ b/.changeset/silver-papayas-retire.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/oas-utils': patch
+---
+
+fix: arrays with allOf items render invalid examples

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -373,7 +373,6 @@ describe('getExampleFromSchema', () => {
   it('uses all examples in object allOf', () => {
     expect(
       getExampleFromSchema({
-        type: 'object',
         allOf: [
           {
             type: 'object',
@@ -390,6 +389,31 @@ describe('getExampleFromSchema', () => {
         ],
       }),
     ).toMatchObject({ foo: 1, bar: '' })
+  })
+
+  it('uses first example in oneOf array items', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'array',
+        items: {
+          allOf: [
+            {
+              type: 'object',
+              properties: {
+                foobar: { type: 'string' },
+                foo: { type: 'number' },
+              },
+            },
+            {
+              type: 'object',
+              properties: {
+                bar: { type: 'string' },
+              },
+            },
+          ],
+        },
+      }),
+    ).toMatchObject([{ foobar: '', foo: 1, bar: '' }])
   })
 
   it('uses the first example in array anyOf', () => {

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -391,7 +391,7 @@ describe('getExampleFromSchema', () => {
     ).toMatchObject({ foo: 1, bar: '' })
   })
 
-  it('uses first example in oneOf array items', () => {
+  it('merges allOf items in arrays', () => {
     expect(
       getExampleFromSchema({
         type: 'array',
@@ -414,6 +414,35 @@ describe('getExampleFromSchema', () => {
         },
       }),
     ).toMatchObject([{ foobar: '', foo: 1, bar: '' }])
+  })
+
+  it('handles array items with allOf containing objects', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'array',
+        items: {
+          allOf: [
+            {
+              type: 'object',
+              properties: {
+                id: { type: 'number', example: 1 },
+              },
+            },
+            {
+              type: 'object',
+              properties: {
+                name: { type: 'string', example: 'test' },
+              },
+            },
+          ],
+        },
+      }),
+    ).toMatchObject([
+      {
+        id: 1,
+        name: 'test',
+      },
+    ])
   })
 
   it('uses the first example in array anyOf', () => {


### PR DESCRIPTION
We recently improved how examples are generated for the anyOf, oneOf, allOf … rules, but there were still issues with them when they are in an array.

More context in: #3510

**Before**

```json
{
  "cats": [
    {
      "$type": "",
      "name": ""
    },
    {
      "breed": "Unknown"
    }
  ],
  "dogs": [
    {
      "$type": "…",
      "name": "…"
    },
    {
      "breed": "Unknown"
    }
  ]
}
```

**After**

```json
{
  "cats": [
    {
      "$type": "",
      "name": "",
      "breed": "Unknown"
    }
  ],
  "dogs": [
    {
      "$type": "…",
      "name": "…",
      "breed": "Unknown"
    }
  ]
}
```