### PR TITLE
fix(oas-utils): added safe parsing to oauth example generation

### DIFF
--- a/.changeset/modern-drinks-peel.md
+++ b/.changeset/modern-drinks-peel.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+fix: added safe parsing for oauth examples

--- a/packages/api-client/src/store/security-schemes.ts
+++ b/packages/api-client/src/store/security-schemes.ts
@@ -52,6 +52,7 @@ export function extendedSecurityDataFactory({
     // Add to the collection as auth
     // This is NOT written to spec and just allows collections to use securitySchemes ad-hoc
     const defaultValue = authExampleFromSchema(scheme)
+    if (!defaultValue) return null
 
     collectionMutators.edit(collectionUid, 'auth', {
       ...collections[collectionUid].auth,

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -143,7 +143,7 @@ function updateSelectedAuth(entries: SecuritySchemeOption[]) {
       activeCollection.value.uid,
     )
 
-    _entries.push(scheme.uid)
+    if (scheme) _entries.push(scheme.uid)
   }
 
   // Here we grab the keys for auth that doesn't yet exist

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -14,7 +14,7 @@
     <script
       id="api-reference"
       data-proxy-url="https://proxy.scalar.com"
-      data-url="https://gist.githubusercontent.com/amritk/c329b63ccb8e28fafc77b9b33f11fb42/raw/c5ce9fa156bec4d804445a37861f92a91e795443/test.json"></script>
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json"></script>
 
     <!-- Optional: You can set a full configuration object like this: -->
     <script>

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -14,7 +14,7 @@
     <script
       id="api-reference"
       data-proxy-url="https://proxy.scalar.com"
-      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json"></script>
+      data-url="https://gist.githubusercontent.com/amritk/c329b63ccb8e28fafc77b9b33f11fb42/raw/c5ce9fa156bec4d804445a37861f92a91e795443/test.json"></script>
 
     <!-- Optional: You can set a full configuration object like this: -->
     <script>

--- a/packages/oas-utils/src/entities/spec/security.ts
+++ b/packages/oas-utils/src/entities/spec/security.ts
@@ -1,3 +1,4 @@
+import { schemaModel } from '@/helpers/schema-model'
 import { z } from 'zod'
 
 import { nanoidSchema } from '../shared'
@@ -74,22 +75,45 @@ export type SecuritySchemeOauth2ExampleValue = Extract<
 export function authExampleFromSchema(
   scheme: SecurityScheme,
   baseValues: any = {},
-) {
-  if (scheme.type === 'apiKey')
-    return apiKeyExampleSchema.parse({ name: scheme.name, ...baseValues })
-  if (scheme.type === 'http') return httpExampleSchema.parse(baseValues)
-  if (scheme.type === 'oauth2') {
-    if (scheme.flow.type === 'authorizationCode')
-      return oauthAuthorizationCodeExampleSchema.parse(baseValues)
-    if (scheme.flow.type === 'clientCredentials')
-      return oauthClientCredentialsExampleSchema.parse(baseValues)
-    if (scheme.flow.type === 'implicit')
-      return oauthImplicitExampleSchema.parse(baseValues)
-    if (scheme.flow.type === 'password')
-      return oauthPasswordExampleSchema.parse(baseValues)
+): SecuritySchemeExampleValue | null {
+  try {
+    if (scheme.type === 'apiKey') {
+      return schemaModel(
+        { name: scheme.name, ...baseValues },
+        apiKeyExampleSchema,
+        false,
+      )
+    }
+    if (scheme.type === 'http') {
+      return schemaModel(baseValues, httpExampleSchema, false)
+    }
+    if (scheme.type === 'oauth2') {
+      if (scheme.flow.type === 'authorizationCode')
+        return schemaModel(
+          baseValues,
+          oauthAuthorizationCodeExampleSchema,
+          false,
+        )
+      if (scheme.flow.type === 'clientCredentials')
+        return schemaModel(
+          baseValues,
+          oauthClientCredentialsExampleSchema,
+          false,
+        )
+      if (scheme.flow.type === 'implicit')
+        return schemaModel(baseValues, oauthImplicitExampleSchema, false)
+      if (scheme.flow.type === 'password')
+        return schemaModel(baseValues, oauthPasswordExampleSchema, false)
+    }
+  } catch (e) {
+    console.error(e)
   }
+  console.warn(
+    '[@scalar/oas-utils:security] Invalid schema for oauth example',
+    baseValues,
+  )
 
-  throw Error('INVALID SCHEMA FOR OAUTH EXAMPLE')
+  return null
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This is a quick to the problem, long term solutions have been added to the canvas such as:
- proper error handling
- removing these oauthexamples

closes #3624