### PR TITLE
fix(components): autoprefixer warning by using flex-start instead of start

### DIFF
--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -90,7 +90,7 @@ const isContentValid = computed(() => {
 /* Copy Button */
 .scalar-code-copy {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   justify-content: flex-end;
 
   position: sticky;


### PR DESCRIPTION
Fixes #3003

Replace `align-items: start` with `align-items: flex-start` in `packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/scalar/scalar/issues/3003?shareId=f0241905-a338-42c9-9d6e-76e5eda10a51).