### PR TITLE
feat(api-reference): disclosure button for enum values

### DIFF
--- a/.changeset/cold-planes-compete.md
+++ b/.changeset/cold-planes-compete.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: adds disclosure button on enum values

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { ScalarMarkdown } from '@scalar/components'
+import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
+import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
 
 import Schema from './Schema.vue'
 import SchemaPropertyHeading from './SchemaPropertyHeading.vue'
@@ -156,11 +157,31 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
       <template v-else>
         <ul class="property-enum-values">
           <li
-            v-for="enumValue in getEnumFromValue(value)"
+            v-for="enumValue in getEnumFromValue(value).slice(0, 4)"
             :key="enumValue"
             class="property-enum-value">
             {{ enumValue }}
           </li>
+          <Disclosure
+            v-if="getEnumFromValue(value).length > 4"
+            v-slot="{ open }">
+            <DisclosurePanel>
+              <li
+                v-for="enumValue in getEnumFromValue(value).slice(4)"
+                :key="enumValue"
+                class="property-enum-value">
+                {{ enumValue }}
+              </li>
+            </DisclosurePanel>
+            <DisclosureButton class="enum-toggle-button">
+              <ScalarIcon
+                class="enum-toggle-button-icon h-2.5"
+                :class="{ 'enum-toggle-button-icon--open': open }"
+                icon="Add"
+                thickness="3" />
+              {{ open ? 'Hide values' : 'Show all values' }}
+            </DisclosureButton>
+          </Disclosure>
         </ul>
       </template>
     </div>
@@ -336,5 +357,25 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 .property-name {
   font-family: var(--scalar-font-code);
   font-weight: var(--scalar-semibold);
+}
+.enum-toggle-button {
+  align-items: center;
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-radius: 13.5px;
+  cursor: pointer;
+  color: var(--scalar-color-2);
+  display: flex;
+  font-weight: var(--scalar-semibold);
+  gap: 4px;
+  margin-top: 8px;
+  padding: 6px 10px;
+  user-select: none;
+  white-space: nowrap;
+}
+.enum-toggle-button:hover {
+  color: var(--scalar-color-1);
+}
+.enum-toggle-button-icon--open {
+  transform: rotate(45deg);
 }
 </style>


### PR DESCRIPTION
this pr adds a disclosure button over 4 enum values as proposed in #3320 in order to avoid too long list displayed at all time:

![image](https://github.com/user-attachments/assets/e5c3980f-6e28-4e7b-94da-d361e80248cd)
