### PR TITLE
fix(api-reference): compact section

### DIFF
--- a/.changeset/young-cows-retire.md
+++ b/.changeset/young-cows-retire.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: fixtures schema properties margin

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -272,4 +272,7 @@ button.schema-card-title:hover {
 .children .schema-card-description:first-of-type {
   padding-top: 0;
 }
+.models-list-item .schema-properties {
+  margin-bottom: 10px;
+}
 </style>

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -55,7 +55,6 @@ watch(
 </template>
 <style scoped>
 .collapsible-section {
-  padding: 0 0 10px;
   border-top: var(--scalar-border-width) solid var(--scalar-border-color);
   position: relative;
 }
@@ -66,7 +65,7 @@ watch(
   display: flex;
   align-items: center;
   cursor: pointer;
-  padding-top: 10px;
+  padding: 10px 0;
   font-size: var(--scalar-font-size-3);
   z-index: 1;
   position: relative;
@@ -77,9 +76,6 @@ watch(
   width: 100%;
   position: absolute;
   bottom: 0;
-}
-.collapsible-section :deep(.schema-properties.schema-properties-open) {
-  margin-top: 10px;
 }
 .collapsible-section-trigger svg {
   color: var(--scalar-color-3);


### PR DESCRIPTION
this pr fixes the over margin on open schema properties + anchor clickable area:

**section before / after**

https://github.com/user-attachments/assets/3c2a8674-014d-447f-939c-356e292723d5

https://github.com/user-attachments/assets/b189e10d-44b1-46eb-85a7-c786c5a984ee


**anchor before / after**

https://github.com/user-attachments/assets/2d681850-a64a-4252-804c-3236e04b436d

https://github.com/user-attachments/assets/f4fdac41-4b1f-4a54-afc4-f1901d634d0e

