### PR TITLE
fix(api-reference-react): reactive auth

### DIFF
--- a/.changeset/warm-apes-build.md
+++ b/.changeset/warm-apes-build.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-reference-react': patch
+'@scalar/api-reference': patch
+'@scalar/object-utils': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: fix reactivitiy of references + client

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -196,7 +196,10 @@ export const createApiClient = ({
     }
   }
 
-  /** Uses a diff to update the spec */
+  /**
+   * This currently just duplicates all data
+   * TODO: Uses a diff to update the spec
+   */
   const updateSpec = async (spec: SpecConfiguration) => {
     if (spec?.url) {
       await importSpecFromUrl(spec.url, activeWorkspace.value.uid, {

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -240,7 +240,13 @@ export const createApiClient = ({
       }
       // Update the spec, reset the store first
       if (newConfig.spec) {
-        store.resetStore()
+        store.collectionMutators.reset()
+        store.requestMutators.reset()
+        store.requestExampleMutators.reset()
+        store.securitySchemeMutators.reset()
+        store.serverMutators.reset()
+        store.tagMutators.reset()
+
         updateSpec(newConfig.spec)
       }
     },

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -196,9 +196,27 @@ export const createApiClient = ({
     }
   }
 
+  /** Uses a diff to update the spec */
+  const updateSpec = async (spec: SpecConfiguration) => {
+    if (spec?.url) {
+      await importSpecFromUrl(spec.url, activeWorkspace.value.uid, {
+        proxy: configuration?.proxyUrl,
+      })
+    } else if (spec?.content) {
+      await importSpecFile(spec?.content, activeWorkspace.value.uid)
+    } else {
+      console.error(
+        `[@scalar/api-client-modal] Could not create the API client.`,
+        `Please provide an OpenAPI document: { spec: { url: '…' } }`,
+        `Read more: https://github.com/scalar/scalar/tree/main/packages/api-client`,
+      )
+    }
+  }
+
   return {
     /** The vue app instance for the modal, be careful with this */
     app,
+    updateSpec,
     /** Update the API client config */
     updateConfig(newConfig: ClientConfiguration, mergeConfigs = true) {
       if (mergeConfigs) {
@@ -206,9 +224,8 @@ export const createApiClient = ({
       } else {
         objectMerge(configuration ?? {}, newConfig)
       }
-      if (newConfig.spec) {
-        importSpecFile(newConfig.spec, activeWorkspace.value.uid)
-      }
+      // Update the spec
+      if (newConfig.spec) updateSpec(newConfig.spec)
     },
     /** Update the currently selected server via URL */
     updateServer: (serverUrl: string) => {
@@ -253,22 +270,6 @@ export const createApiClient = ({
           // @ts-expect-error why typescript why
           value,
         )
-    },
-    /** Update the spec file, this will re-parse it and clear your store */
-    updateSpec: async (spec: SpecConfiguration) => {
-      if (spec?.url) {
-        await importSpecFromUrl(spec.url, activeWorkspace.value.uid, {
-          proxy: configuration?.proxyUrl,
-        })
-      } else if (spec?.content) {
-        await importSpecFile(spec?.content, activeWorkspace.value.uid)
-      } else {
-        console.error(
-          `[@scalar/api-client-modal] Could not create the API client.`,
-          `Please provide an OpenAPI document: { spec: { url: '…' } }`,
-          `Read more: https://github.com/scalar/scalar/tree/main/packages/api-client`,
-        )
-      }
     },
     /** Route to a method + path */
     route: (

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -200,21 +200,18 @@ export const createApiClient = ({
    *
    * @remarks Currently you should not use this directly, use updateConfig instead to get the side effects
    */
-  const updateSpec = async (
-    spec: SpecConfiguration,
-    config: ClientConfiguration = configuration,
-  ) => {
+  const updateSpec = async (spec: SpecConfiguration) => {
     if (spec?.url) {
       await importSpecFromUrl(spec.url, activeWorkspace.value.uid, {
-        proxy: config?.proxyUrl,
-        overloadServers: config?.servers,
-        authentication: config.authentication,
+        proxy: configuration?.proxyUrl,
+        overloadServers: configuration?.servers,
+        authentication: configuration.authentication,
         setCollectionSecurity: true,
       })
     } else if (spec?.content) {
       await importSpecFile(spec?.content, activeWorkspace.value.uid, {
-        overloadServers: config?.servers,
-        authentication: config.authentication,
+        overloadServers: configuration?.servers,
+        authentication: configuration.authentication,
         setCollectionSecurity: true,
       })
     } else {
@@ -244,7 +241,7 @@ export const createApiClient = ({
       // Update the spec, reset the store first
       if (newConfig.spec) {
         store.resetStore()
-        updateSpec(newConfig.spec, newConfig)
+        updateSpec(newConfig.spec)
       }
     },
     /** Update the currently selected server via URL */

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -200,18 +200,21 @@ export const createApiClient = ({
    *
    * @remarks Currently you should not use this directly, use updateConfig instead to get the side effects
    */
-  const updateSpec = async (spec: SpecConfiguration) => {
+  const updateSpec = async (
+    spec: SpecConfiguration,
+    config: ClientConfiguration = configuration,
+  ) => {
     if (spec?.url) {
       await importSpecFromUrl(spec.url, activeWorkspace.value.uid, {
-        proxy: configuration?.proxyUrl,
-        overloadServers: configuration?.servers,
-        authentication: configuration.authentication,
+        proxy: config?.proxyUrl,
+        overloadServers: config?.servers,
+        authentication: config.authentication,
         setCollectionSecurity: true,
       })
     } else if (spec?.content) {
       await importSpecFile(spec?.content, activeWorkspace.value.uid, {
-        overloadServers: configuration?.servers,
-        authentication: configuration.authentication,
+        overloadServers: config?.servers,
+        authentication: config.authentication,
         setCollectionSecurity: true,
       })
     } else {
@@ -241,7 +244,7 @@ export const createApiClient = ({
       // Update the spec, reset the store first
       if (newConfig.spec) {
         store.resetStore()
-        updateSpec(newConfig.spec)
+        updateSpec(newConfig.spec, newConfig)
       }
     },
     /** Update the currently selected server via URL */

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -247,6 +247,8 @@ export const createApiClient = ({
         store.serverMutators.reset()
         store.tagMutators.reset()
 
+        workspaceMutators.edit(activeWorkspace.value.uid, 'collections', [])
+
         updateSpec(newConfig.spec)
       }
     },

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -265,19 +265,6 @@ export const createWorkspaceStore = (
 
   // ---------------------------------------------------------------------------
   // OTHER HELPER DATA
-
-  /** Reset the store */
-  const resetStore = () => {
-    collectionMutators.clear()
-    requestMutators.clear()
-    requestExampleMutators.clear()
-    securitySchemeMutators.clear()
-    serverMutators.clear()
-    tagMutators.clear()
-
-    workspaceMutators.edit(activeWorkspace.value.uid, 'collections', [])
-  }
-
   /** Running request history list */
   const requestHistory = reactive<RequestEvent[]>([])
 
@@ -423,7 +410,6 @@ export const createWorkspaceStore = (
       add: addWorkspace,
       delete: deleteWorkspace,
     },
-    resetStore,
   }
 }
 

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -265,6 +265,19 @@ export const createWorkspaceStore = (
 
   // ---------------------------------------------------------------------------
   // OTHER HELPER DATA
+
+  /** Reset the store */
+  const resetStore = () => {
+    collectionMutators.clear()
+    requestMutators.clear()
+    requestExampleMutators.clear()
+    securitySchemeMutators.clear()
+    serverMutators.clear()
+    tagMutators.clear()
+
+    workspaceMutators.edit(activeWorkspace.value.uid, 'collections', [])
+  }
+
   /** Running request history list */
   const requestHistory = reactive<RequestEvent[]>([])
 
@@ -410,6 +423,7 @@ export const createWorkspaceStore = (
       add: addWorkspace,
       delete: deleteWorkspace,
     },
+    resetStore,
   }
 }
 

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -27,6 +27,7 @@
     "build-only": "vite build",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
+    "playground": "vite ./playground -c ./vite.config.ts",
     "types:check": "tsc --noEmit --skipLibCheck"
   },
   "type": "module",
@@ -45,12 +46,15 @@
     "@scalar/api-reference": "workspace:*"
   },
   "devDependencies": {
+    "@scalar/galaxy": "workspace:*",
     "@types/react": "^18.2.60",
     "@types/react-dom": "^18.2.19",
     "@vitejs/plugin-react": "^4.2.1",
     "character-entities": "^2.0.2",
     "decode-named-character-reference": "^1.0.2",
     "path": "^0.12.7",
+    "random-words": "^2.0.1",
+    "react-dom": "^18.3.1",
     "vite": "^5.4.9",
     "vite-plugin-dts": "^3.6.3",
     "vue": "^3.5.12"

--- a/packages/api-reference-react/playground/App.tsx
+++ b/packages/api-reference-react/playground/App.tsx
@@ -5,25 +5,9 @@ import { useEffect, useState } from 'react'
 import { ApiReferenceReact, ReferenceProps } from '../src'
 
 function App() {
-  const [spec, setSpec] = useState({ ...galaxySpec })
   const [auth, setAuth] = useState<
     Required<ReferenceProps>['configuration']['authentication']
   >({})
-
-  useEffect(() => {
-    // Update the spec periodically to test reactivity
-    const changeInt = setInterval(() => {
-      setSpec({
-        ...galaxySpec,
-        info: {
-          ...galaxySpec.info,
-          title: (generate(2) as string[]).join(' '),
-        },
-      })
-    }, 2000)
-
-    return () => clearInterval(changeInt)
-  }, []) // Empty dependency array ensures the effect runs only once
 
   const apiKeys = [
     'apiKeyHeader',
@@ -61,7 +45,7 @@ function App() {
     <ApiReferenceReact
       configuration={{
         spec: {
-          content: spec,
+          content: galaxySpec,
         },
         authentication: auth,
       }}

--- a/packages/api-reference-react/playground/App.tsx
+++ b/packages/api-reference-react/playground/App.tsx
@@ -10,20 +10,20 @@ function App() {
     Required<ReferenceProps>['configuration']['authentication']
   >({})
 
-  // useEffect(() => {
-  //   // Update the spec periodically to test reactivity
-  //   const changeInt = setInterval(() => {
-  //     setSpec({
-  //       ...galaxySpec,
-  //       info: {
-  //         ...galaxySpec.info,
-  //         title: (generate(2) as string[]).join(' '),
-  //       },
-  //     })
-  //   }, 2000)
+  useEffect(() => {
+    // Update the spec periodically to test reactivity
+    const changeInt = setInterval(() => {
+      setSpec({
+        ...galaxySpec,
+        info: {
+          ...galaxySpec.info,
+          title: (generate(2) as string[]).join(' '),
+        },
+      })
+    }, 2000)
 
-  //   return () => clearInterval(changeInt)
-  // }, []) // Empty dependency array ensures the effect runs only once
+    return () => clearInterval(changeInt)
+  }, []) // Empty dependency array ensures the effect runs only once
 
   const apiKeys = [
     'apiKeyHeader',

--- a/packages/api-reference-react/playground/App.tsx
+++ b/packages/api-reference-react/playground/App.tsx
@@ -1,0 +1,57 @@
+import { galaxySpec } from '@scalar/galaxy'
+import { generate } from 'random-words'
+import { useEffect, useState } from 'react'
+
+import { ApiReferenceReact, ReferenceProps } from '../src'
+
+function App() {
+  const [spec, setSpec] = useState({ ...galaxySpec })
+  const [auth, setAuth] = useState<
+    Required<ReferenceProps>['configuration']['authentication']
+  >({})
+
+  // useEffect(() => {
+  //   // Update the spec periodically to test reactivity
+  //   const changeInt = setInterval(() => {
+  //     setSpec({
+  //       ...galaxySpec,
+  //       info: {
+  //         ...galaxySpec.info,
+  //         title: (generate(2) as string[]).join(' '),
+  //       },
+  //     })
+  //   }, 2000)
+
+  //   return () => clearInterval(changeInt)
+  // }, []) // Empty dependency array ensures the effect runs only once
+
+  const apiKeys = ['apiKeyHeader', 'apiKeyQuery', 'apiKeyCookie']
+
+  useEffect(() => {
+    // Update the spec periodically to test reactivity
+    const changeInt = setInterval(() => {
+      setAuth({
+        preferredSecurityScheme:
+          apiKeys[Math.floor(Math.random() * apiKeys.length)],
+        apiKey: {
+          token: 'api_key_12345abcde',
+        },
+      })
+    }, 2000)
+
+    return () => clearInterval(changeInt)
+  }, [])
+
+  return (
+    <ApiReferenceReact
+      configuration={{
+        spec: {
+          content: spec,
+        },
+        authentication: auth,
+      }}
+    />
+  )
+}
+
+export default App

--- a/packages/api-reference-react/playground/App.tsx
+++ b/packages/api-reference-react/playground/App.tsx
@@ -37,7 +37,7 @@ function App() {
           token: 'api_key_12345abcde',
         },
       })
-    }, 2000)
+    }, 10000)
 
     return () => clearInterval(changeInt)
   }, [])

--- a/packages/api-reference-react/playground/App.tsx
+++ b/packages/api-reference-react/playground/App.tsx
@@ -25,7 +25,13 @@ function App() {
   //   return () => clearInterval(changeInt)
   // }, []) // Empty dependency array ensures the effect runs only once
 
-  const apiKeys = ['apiKeyHeader', 'apiKeyQuery', 'apiKeyCookie']
+  const apiKeys = [
+    'apiKeyHeader',
+    'apiKeyQuery',
+    'apiKeyCookie',
+    'basicAuth',
+    'bearerAuth',
+  ]
 
   useEffect(() => {
     // Update the spec periodically to test reactivity
@@ -33,8 +39,17 @@ function App() {
       setAuth({
         preferredSecurityScheme:
           apiKeys[Math.floor(Math.random() * apiKeys.length)],
+        http: {
+          basic: {
+            username: (generate(2) as string[]).join('_'),
+            password: (generate(2) as string[]).join('_'),
+          },
+          bearer: {
+            token: (generate(2) as string[]).join('_'),
+          },
+        },
         apiKey: {
-          token: 'api_key_12345abcde',
+          token: (generate(2) as string[]).join('_'),
         },
       })
     }, 10000)

--- a/packages/api-reference-react/playground/index.html
+++ b/packages/api-reference-react/playground/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/vite.svg" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script
+      type="module"
+      src="/main.tsx"></script>
+  </body>
+</html>

--- a/packages/api-reference-react/playground/main.tsx
+++ b/packages/api-reference-react/playground/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/packages/api-reference-react/tsconfig.json
+++ b/packages/api-reference-react/tsconfig.json
@@ -5,7 +5,7 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "isolatedModules": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "lib": ["esnext", "dom", "dom.iterable"],
     "module": "ESNext",
     "moduleDetection": "force",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -68,6 +68,7 @@
     "@scalar/code-highlight": "workspace:*",
     "@scalar/components": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
+    "@scalar/object-utils": "workspace:*",
     "@scalar/openapi-parser": "workspace:*",
     "@scalar/openapi-types": "workspace:*",
     "@scalar/snippetz": "workspace:*",

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -369,11 +369,7 @@ const themeStyleTag = computed(
     </template>
     <!-- REST API Client Overlay -->
     <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withDefaultFonts: false` -->
-    <ApiClientModal
-      :authentication="configuration.authentication"
-      :proxyUrl="configuration.proxy"
-      :servers="configuration.servers"
-      :spec="configuration.spec" />
+    <ApiClientModal :configuration="configuration" />
   </div>
   <ScalarToasts />
 </template>

--- a/packages/api-reference/src/embeds/OpenApiDocument/OpenApiDocument.vue
+++ b/packages/api-reference/src/embeds/OpenApiDocument/OpenApiDocument.vue
@@ -117,7 +117,6 @@ loadDocument()
     }"></slot>
 
   <ApiClientModal
-    :proxyUrl="configuration?.proxy"
-    :servers="configuration?.servers"
-    :spec="spec" />
+    v-if="configuration"
+    :configuration="configuration" />
 </template>

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -54,38 +54,33 @@ watch(
   (newAuth) => {
     if (!newAuth?.preferredSecurityScheme || !client.value) return
 
-    console.log(newAuth.preferredSecurityScheme)
-
-    const firstCollection = Object.values(client.value.store.collections)[0]
-    if (!firstCollection) return
-
-    console.log(firstCollection)
+    const collection =
+      client.value.store.activeCollection ??
+      Object.values(client.value.store.collections)[0]
+    if (!collection) return
 
     // Select auth
-    const schemeUid = firstCollection.securitySchemes.find((uid) => {
-      client.value!.store.securitySchemes[uid].nameKey ===
-        newAuth.preferredSecurityScheme
-    })
+    const schemeUid = collection.securitySchemes.find(
+      (uid) =>
+        client.value!.store.securitySchemes[uid].nameKey ===
+        newAuth.preferredSecurityScheme,
+    )
     if (!schemeUid) return
 
-    console.log(schemeUid)
-
     client.value.store.collectionMutators.edit(
-      firstCollection.uid,
+      collection.uid,
       'selectedSecuritySchemeUids',
       [schemeUid],
     )
 
-    const scheme = Object.values(client.value.store.securitySchemes).find(
-      ({ nameKey }) => nameKey === newAuth.preferredSecurityScheme,
+    // Lets update the currently selected auth for now
+    // TODO: we can diff this later to update everything that changes
+    const baseValues = getBaseAuthValues(
+      client.value.store.securitySchemes[schemeUid],
+      newAuth,
     )
-    if (!scheme) return
-
-    console.log(scheme)
-
-    const baseValues = getBaseAuthValues(scheme, newAuth)
     console.log(baseValues)
-    // // Update auth properties
+    // Update auth properties
     // client.value.updateAuth({
     //   nameKey: newAuth.preferredSecurityScheme,
     //   propertyKey: 'username',

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { getUrlFromServerState, useServerStore } from '#legacy'
 import { getBaseAuthValues } from '@scalar/oas-utils/transforms'
+import type { Path } from '@scalar/object-utils/nested'
 import type {
   ReferenceConfiguration,
   Spec,
@@ -79,13 +80,15 @@ watch(
       client.value.store.securitySchemes[schemeUid],
       newAuth,
     )
-    console.log(baseValues)
+
     // Update auth properties
-    // client.value.updateAuth({
-    //   nameKey: newAuth.preferredSecurityScheme,
-    //   propertyKey: 'username',
-    //   value: newAuth.username,
-    // })
+    Object.entries(baseValues).forEach(([propertyKey, value]) =>
+      client.value?.updateAuth({
+        nameKey: newAuth.preferredSecurityScheme!,
+        propertyKey: propertyKey as Path<typeof baseValues>,
+        value,
+      }),
+    )
   },
 )
 

--- a/packages/api-reference/src/legacy/components/SecuritySchemeSelector.vue
+++ b/packages/api-reference/src/legacy/components/SecuritySchemeSelector.vue
@@ -50,10 +50,14 @@ const setSecuritySchemeKey = (key: string) => {
 
   // Set it in the client as well
   if (client.value?.store) {
-    const { collections, collectionMutators, securitySchemes } =
-      client.value.store
+    const {
+      activeCollection,
+      collections,
+      collectionMutators,
+      securitySchemes,
+    } = client.value.store
 
-    const collectionUid = Object.keys(collections)[0]
+    const collectionUid = activeCollection?.uid ?? Object.keys(collections)[0]
     const securityScheme = Object.values(securitySchemes).find(
       ({ nameKey }) => nameKey === key,
     )

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -71,7 +71,7 @@ const convertOauth2Flows = (
 }
 
 /** Pre-fill baseValues if we have authentication config */
-const getBaseValues = (
+export const getBaseAuthValues = (
   scheme: SecurityScheme,
   auth?: ReferenceConfiguration['authentication'],
 ): Record<string, never> | Partial<SecuritySchemeExampleValue> => {
@@ -378,7 +378,7 @@ export async function importSpecToWorkspace(
   // Generate Collection
   // Create the auth examples
   const auth = securitySchemes?.reduce<Collection['auth']>((prev, s) => {
-    const baseValues = getBaseValues(s, authentication)
+    const baseValues = getBaseAuthValues(s, authentication)
     const example = authExampleFromSchema(s, baseValues)
 
     if (example) prev[s.uid] = example

--- a/packages/object-utils/src/mutator-record/handlers.ts
+++ b/packages/object-utils/src/mutator-record/handlers.ts
@@ -51,14 +51,6 @@ export function mutationFactory<
       delete mutationMap[uid]
       onChange()
     },
-    /** Destructive, clears the record */
-    clear: () => {
-      Object.keys(entityMap).forEach((uid) => {
-        delete entityMap[uid]
-        delete mutationMap[uid]
-      })
-      onChange()
-    },
     /** Destructive, overwrites a record to a new item and creates a new mutation tracking instance */
     set: (item: T) => {
       entityMap[item.uid] = item
@@ -91,6 +83,14 @@ export function mutationFactory<
     redo: (uid: string) => {
       const mutator = getMutator(uid)
       mutator?.redo()
+      onChange()
+    },
+    /** Destructive, clears the record */
+    reset: () => {
+      Object.keys(entityMap).forEach((uid) => {
+        delete entityMap[uid]
+        delete mutationMap[uid]
+      })
       onChange()
     },
   }

--- a/packages/object-utils/src/mutator-record/handlers.ts
+++ b/packages/object-utils/src/mutator-record/handlers.ts
@@ -51,6 +51,14 @@ export function mutationFactory<
       delete mutationMap[uid]
       onChange()
     },
+    /** Destructive, clears the record */
+    clear: () => {
+      Object.keys(entityMap).forEach((uid) => {
+        delete entityMap[uid]
+        delete mutationMap[uid]
+      })
+      onChange()
+    },
     /** Destructive, overwrites a record to a new item and creates a new mutation tracking instance */
     set: (item: T) => {
       entityMap[item.uid] = item

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,6 +836,9 @@ importers:
       '@scalar/oas-utils':
         specifier: workspace:*
         version: link:../oas-utils
+      '@scalar/object-utils':
+        specifier: workspace:*
+        version: link:../object-utils
       '@scalar/openapi-parser':
         specifier: workspace:*
         version: link:../openapi-parser

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1001,6 +1001,9 @@ importers:
         specifier: ^18.0.0
         version: 18.3.1
     devDependencies:
+      '@scalar/galaxy':
+        specifier: workspace:*
+        version: link:../galaxy
       '@types/react':
         specifier: ^18.2.60
         version: 18.3.3
@@ -1019,6 +1022,12 @@ importers:
       path:
         specifier: ^0.12.7
         version: 0.12.7
+      random-words:
+        specifier: ^2.0.1
+        version: 2.0.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       vite:
         specifier: ^5.4.9
         version: 5.4.10(@types/node@20.14.10)(terser@5.31.2)

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,11 @@
       "persistent": true,
       "dependsOn": ["^build"]
     },
+    "playground": {
+      "cache": false,
+      "persistent": true,
+      "dependsOn": ["^build"]
+    },
     "playground:modal": {
       "cache": false,
       "persistent": true,


### PR DESCRIPTION
Alright in this pr we fixed the react and regular api-reference reactivity by destroying the store and re-creating it on update.

Also added a api-reference-react playground for testing reactive auth changes

Also added a reset command to the mutators.

I booted using diffing into another ticket https://github.com/scalar/scalar/issues/3676

To test: 
`pnpx turbo run playground --filter @scalar/api-reference-react` It will update every 10 seconds