### PR TITLE
chore(galaxy): align galaxy package.json with prettier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-${{ github.sha }}
 
   format:
-    needs: [build]
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -45,10 +44,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Build
-        uses: ./.github/actions/build
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dev dependencies
+        run: pnpm install --dev
       - name: Check code style
         run: pnpm format:check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-${{ github.sha }}
 
   format:
+    needs: [build]
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -44,14 +45,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+      - name: Build
+        uses: ./.github/actions/build
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dev dependencies
-        run: pnpm install --dev
       - name: Check code style
         run: pnpm format:check
 

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -29,7 +29,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "dependencies": {

--- a/packages/galaxy/scripts/publish.ts
+++ b/packages/galaxy/scripts/publish.ts
@@ -22,4 +22,4 @@ packageFile.exports = {
   './latest.json': './dist/latest.json',
 }
 
-fs.writeFileSync('./package.json', JSON.stringify(packageFile, null, 2))
+fs.writeFileSync('./package.json', JSON.stringify(packageFile, null, 2) + '\n')


### PR DESCRIPTION
No more removed new line at the end of the `galaxy/package.json`!

Also updates the fetch `package.json`.

Also runs the `ci` → `format` action _after_ the build so that our build tooling can't create prettier errors (and pass build) like was happening with the galaxy package json.

It would be nice to confirm that the `build` command doesn't leave any uncommited files, but I looked it up and it seemed complicated with GH actions (if someone wants to add that though that would be cool).