### PR TITLE
fix(api-client): api client button is always visible

### DIFF
--- a/packages/api-client/src/components/OpenApiClientButton.vue
+++ b/packages/api-client/src/components/OpenApiClientButton.vue
@@ -11,18 +11,27 @@ const { integration, isDevelopment, url, buttonSource } = defineProps<{
 }>()
 
 /** Link to import an OpenAPI document */
-const href = computed(() => {
+const href = computed((): string | undefined => {
+  const absoluteUrl = makeUrlAbsolute(url)
+
+  if (!absoluteUrl?.length) {
+    return undefined
+  }
+
+  // Base URL
   const link = new URL(
     isDevelopment ? 'http://localhost:5065' : 'https://client.scalar.com',
   )
 
-  const absoluteUrl = makeUrlAbsolute(url)
-  if (absoluteUrl?.length) link.searchParams.set('url', absoluteUrl)
+  // URL that we’d like to import
+  link.searchParams.set('url', absoluteUrl)
 
-  // Default integration to vue if not explicitly null
-  if (integration !== null)
+  // Integration identifier
+  if (integration !== null) {
     link.searchParams.set('integration', integration ?? 'vue')
+  }
 
+  // UTM Source
   link.searchParams.set('utm_source', 'api-reference')
   link.searchParams.set('utm_medium', 'button')
   link.searchParams.set('utm_campaign', buttonSource)
@@ -33,7 +42,7 @@ const href = computed(() => {
 
 <template>
   <a
-    v-if="url"
+    v-if="href"
     class="open-api-client-button"
     :href="href"
     target="_blank">

--- a/packages/api-client/src/components/OpenApiClientButton.vue
+++ b/packages/api-client/src/components/OpenApiClientButton.vue
@@ -6,8 +6,8 @@ import { computed } from 'vue'
 const { integration, isDevelopment, url, buttonSource } = defineProps<{
   buttonSource: 'sidebar' | 'modal'
   isDevelopment?: boolean
-  integration?: string | null | undefined
-  url?: string | undefined
+  integration?: string | null
+  url?: string
 }>()
 
 /** Link to import an OpenAPI document */
@@ -33,7 +33,7 @@ const href = computed(() => {
 
 <template>
   <a
-    v-if="href"
+    v-if="url"
     class="open-api-client-button"
     :href="href"
     target="_blank">


### PR DESCRIPTION
Makes it so the button is only shown if the spec uses a URL.

We can't use `link` to check if the spec has a URL here because we construct it in a computed property and it's therefore always defined.