### PR TITLE
fix(components): resize and scroll scalar listbox and dropdown

### DIFF
--- a/.changeset/bright-comics-own.md
+++ b/.changeset/bright-comics-own.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+fix(components): resize and scroll scalar listbox and dropdown

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -71,6 +71,7 @@ const serverUrlWithoutTrailingSlash = computed(() => {
       (requestServerOptions && requestServerOptions?.length > 1) ||
       (collectionServerOptions && collectionServerOptions?.length > 1)
     "
+    class="w-max"
     teleport=".scalar-client">
     <button
       class="font-code lg:text-sm text-xs whitespace-nowrap border border-b-3 border-solid rounded px-1.5 py-0.5 text-c-2"

--- a/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
@@ -35,9 +35,11 @@ const selected = computed<ScalarListboxOption | undefined>({
 <template>
   <ScalarListbox
     v-model="selected"
+    class="text-sm"
     fullWidth
     :options="options"
-    resize>
+    resize
+    teleport>
     <ScalarButton
       :aria-describedby="describedBy"
       class="url-select"

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -29,15 +29,25 @@ defineOptions({ inheritAttrs: false })
         <slot />
       </MenuButton>
       <template #floating="{ width }">
-        <MenuItems
-          class="relative flex w-56 flex-col p-0.75"
+        <!-- Background container -->
+        <div
           v-bind="$attrs"
-          :static="static"
+          class="relative flex max-h-[inherit] w-56 rounded border"
           :style="{ width }">
-          <slot name="items" />
-          <div
-            class="absolute inset-0 -z-1 rounded bg-b-1 shadow-lg brightness-lifted" />
-        </MenuItems>
+          <!-- Scroll container -->
+          <div class="custom-scroll min-h-0 flex-1">
+            <!-- Menu items -->
+            <MenuItems
+              class="flex flex-col p-0.75"
+              v-bind="$attrs"
+              :static="static"
+              :style="{ width }">
+              <slot name="items" />
+            </MenuItems>
+            <div
+              class="absolute inset-0 -z-1 rounded bg-b-1 shadow-lg brightness-lifted" />
+          </div>
+        </div>
       </template>
     </ScalarFloating>
   </Menu>

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -6,6 +6,7 @@ import {
   flip,
   offset,
   shift,
+  size,
   useFloating,
 } from '@floating-ui/vue'
 import { type Ref, computed, ref } from 'vue'
@@ -64,6 +65,16 @@ const { floatingStyles, middlewareData } = useFloating(targetRef, floatingRef, {
     offset(5),
     flip(),
     shift(),
+    size({
+      apply({ availableWidth, availableHeight, elements }) {
+        // Assign the max width and height to the floating element
+        // @see https://floating-ui.com/docs/size
+        Object.assign(elements.floating.style, {
+          maxWidth: `${Math.max(0, availableWidth) - 25}px`,
+          maxHeight: `${Math.max(0, availableHeight) - 25}px`,
+        })
+      },
+    }),
     ...(props.middleware ?? []),
   ]),
 })

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -80,44 +80,53 @@ const variants = cva({
         <slot />
       </ListboxButton>
       <template #floating="{ width }">
-        <ListboxOptions
-          class="relative flex w-40 flex-col rounded border p-0.75"
-          :style="{ width }"
-          v-bind="$attrs">
-          <ListboxOption
-            v-for="option in options"
-            :key="option.id"
-            v-slot="{ active, selected }"
-            as="template"
-            :disabled="option.disabled"
-            :value="option">
-            <li
-              :class="
-                cx(variants({ active, selected, disabled: option.disabled }))
-              ">
-              <div
-                class="flex size-4 items-center justify-center rounded-full p-[3px]"
-                :class="
-                  selected
-                    ? 'bg-c-accent text-b-1'
-                    : 'text-transparent group-hover/listbox:shadow-border'
-                ">
-                <!-- Icon needs help to be optically centered (╥﹏╥) -->
-                <ScalarIcon
-                  class="relative top-[0.5px] size-2.5"
-                  icon="Checkmark"
-                  thickness="2.5" />
-              </div>
-              <span
-                class="inline-block min-w-0 flex-1 truncate"
-                :class="option.color ? option.color : 'text-c-1'">
-                {{ option.label }}
-              </span>
-            </li>
-          </ListboxOption>
+        <!-- Background container -->
+        <div
+          v-bind="$attrs"
+          class="relative flex max-h-[inherit] w-40 rounded border"
+          :style="{ width }">
+          <!-- Scroll container -->
+          <div class="custom-scroll min-h-0 flex-1">
+            <!-- Options list -->
+            <ListboxOptions class="flex flex-col p-0.75">
+              <ListboxOption
+                v-for="option in options"
+                :key="option.id"
+                v-slot="{ active, selected }"
+                as="template"
+                :disabled="option.disabled"
+                :value="option">
+                <li
+                  :class="
+                    cx(
+                      variants({ active, selected, disabled: option.disabled }),
+                    )
+                  ">
+                  <div
+                    class="flex size-4 items-center justify-center rounded-full p-[3px]"
+                    :class="
+                      selected
+                        ? 'bg-c-accent text-b-1'
+                        : 'text-transparent group-hover/listbox:shadow-border'
+                    ">
+                    <!-- Icon needs help to be optically centered (╥﹏╥) -->
+                    <ScalarIcon
+                      class="relative top-[0.5px] size-2.5"
+                      icon="Checkmark"
+                      thickness="2.5" />
+                  </div>
+                  <span
+                    class="inline-block min-w-0 flex-1 truncate"
+                    :class="option.color ? option.color : 'text-c-1'">
+                    {{ option.label }}
+                  </span>
+                </li>
+              </ListboxOption>
+            </ListboxOptions>
+          </div>
           <div
             class="absolute inset-0 -z-1 rounded bg-b-1 shadow-md brightness-lifted" />
-        </ListboxOptions>
+        </div>
       </template>
     </ScalarFloating>
   </Listbox>


### PR DESCRIPTION
Updates `ScalarListbox` and `ScalarDropdown` to not overflow their bounding boxes (e.g. their scroll boxes) and to scroll instead. I also updated the server selection dropdown in the API Client to use more horizontal space and show more of the server url.

## Before

https://github.com/user-attachments/assets/9bd0fb83-1c66-4490-a2eb-2062e87ab3e1

## After

https://github.com/user-attachments/assets/54e6c347-03f9-4c6d-921e-a86ab39241f4

