### PR TITLE
chore(api-client): remove `defineExpose` import

### DIFF
--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -4,7 +4,7 @@ import type { WorkspaceStore } from '@/store'
 import { ScalarButton, ScalarDropdown, ScalarIcon } from '@scalar/components'
 import { onClickOutside } from '@vueuse/core'
 import Fuse from 'fuse.js'
-import { computed, defineExpose, onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import type { Router } from 'vue-router'
 
 const props = defineProps<{


### PR DESCRIPTION
`defineExpose` is available globally with the latest Vue version:

> [@vue/compiler-sfc] `defineExpose` is a compiler macro and no longer needs to be imported.