### PR TITLE
fix(api-reference): strange jump on lazy loading

### DIFF
--- a/.changeset/shiny-tips-hang.md
+++ b/.changeset/shiny-tips-hang.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: api references jumping in next.js

--- a/examples/nextjs-api-reference/app/another-reference/page.tsx
+++ b/examples/nextjs-api-reference/app/another-reference/page.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { ApiReferenceReact } from '@scalar/api-reference-react'
+
+export default function ApiReferencePage() {
+  return (
+    <ApiReferenceReact
+      configuration={{
+        spec: {
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+        },
+        withDefaultFonts: false,
+        hideModels: true,
+        tagsSorter: 'alpha',
+        searchHotKey: 'k',
+        hideDarkModeToggle: true,
+        hideDownloadButton: true,
+        hiddenClients: true,
+        defaultHttpClient: {
+          targetKey: 'shell',
+          clientKey: 'curl',
+        },
+        operationsSorter: 'alpha',
+      }}
+    />
+  )
+}

--- a/examples/nextjs-api-reference/package.json
+++ b/examples/nextjs-api-reference/package.json
@@ -26,6 +26,7 @@
   "type": "module",
   "dependencies": {
     "@scalar/api-client-react": "workspace:*",
+    "@scalar/api-reference-react": "workspace:*",
     "@scalar/nextjs-api-reference": "workspace:*",
     "next": "^14.2.5",
     "react": "^18.3.1",

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -211,7 +211,7 @@ onMounted(() => {
     top: calc(var(--refs-header-height) - 1px);
   }
 }
-.references-loading-hidden-tag .section-container .section:first-child {
+.references-loading-hidden-tag .section-container > .section:first-child {
   display: none;
 }
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       '@scalar/api-client-react':
         specifier: workspace:*
         version: link:../../packages/api-client-react
+      '@scalar/api-reference-react':
+        specifier: workspace:*
+        version: link:../../packages/api-reference-react
       '@scalar/nextjs-api-reference':
         specifier: workspace:*
         version: link:../../packages/nextjs-api-reference
@@ -16571,8 +16574,8 @@ packages:
   vue-component-type-helpers@2.0.21:
     resolution: {integrity: sha512-3NaicyZ7N4B6cft4bfb7dOnPbE9CjLcx+6wZWAg5zwszfO4qXRh+U52dN5r5ZZfc6iMaxKCEcoH9CmxxoFZHLg==}
 
-  vue-component-type-helpers@2.1.8:
-    resolution: {integrity: sha512-ii36gDzrYAfOQIkOlo44yceDdT5269gKmNGxf07Qx6seH2U50+tQ2ol02XLhYPmxrh6YabAsOdte8WDrpaO6Tw==}
+  vue-component-type-helpers@2.1.10:
+    resolution: {integrity: sha512-lfgdSLQKrUmADiSV6PbBvYgQ33KF3Ztv6gP85MfGaGaSGMTXORVaHT1EHfsqCgzRNBstPKYDmvAV9Do5CmJ07A==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -24163,7 +24166,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.12(typescript@5.6.2)
-      vue-component-type-helpers: 2.1.8
+      vue-component-type-helpers: 2.1.10
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -37604,7 +37607,7 @@ snapshots:
 
   vue-component-type-helpers@2.0.21: {}
 
-  vue-component-type-helpers@2.1.8: {}
+  vue-component-type-helpers@2.1.10: {}
 
   vue-demi@0.14.10(vue@3.5.12(typescript@5.6.2)):
     dependencies:


### PR DESCRIPTION
closes #3447

not sure why this only happened on next.js 🤷🏾 Added ApiReferenceReact page to the next.js example as well


before:


https://github.com/user-attachments/assets/045c37a6-1bd7-4c89-b09c-ca2fe7c078c7


after:

https://github.com/user-attachments/assets/a9d744f9-049e-4665-99fa-5a53a9461eb9

