### PR TITLE
refactor(api-reference): properly show hidden http clients and custom examples

### DIFF
--- a/.changeset/tame-starfishes-bow.md
+++ b/.changeset/tame-starfishes-bow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): reflect hidden http clients and custom examples

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -70,19 +70,12 @@ const { authentication: authenticationState } = useAuthenticationStore()
 const id = useId()
 
 const customRequestExamples = computed(() => {
-  const keys = ['x-custom-examples', 'x-codeSamples', 'x-code-samples']
+  const keys = ['x-custom-examples', 'x-codeSamples', 'x-code-samples'] as const
 
   for (const key of keys) {
-    if (
-      props.operation.information?.[
-        key as 'x-custom-examples' | 'x-codeSamples' | 'x-code-samples'
-      ]
-    ) {
-      return (
-        props.operation.information[
-          key as 'x-custom-examples' | 'x-codeSamples' | 'x-code-samples'
-        ] ?? []
-      )
+    if (props.operation.information?.[key]) {
+      const examples = [...props.operation.information[key]]
+      return examples
     }
   }
 
@@ -194,14 +187,12 @@ const language = computed(() => {
   return key
 })
 
+type TextSelectOptions = InstanceType<typeof TextSelect>['$props']['options']
+
 /** All options for the dropdown */
-const options = computed(() => {
+const options = computed<TextSelectOptions>(() => {
   // Add available the client libraries
-  const entries: {
-    value: string
-    label: string
-    options: { value: string; label: string }[]
-  }[] = availableTargets.value.map((target) => {
+  const entries: TextSelectOptions = availableTargets.value.map((target) => {
     return {
       value: target.key,
       label: target.title,
@@ -217,22 +208,19 @@ const options = computed(() => {
     }
   })
 
-  // Add entries for all available custom examples
-  if (customRequestExamples.value.length) {
+  // Add entries for custom examples if any are available
+  if (customRequestExamples.value.length)
     entries.unshift({
       value: 'customExamples',
       label: 'Examples',
-      options: customRequestExamples.value.map((example, index) => {
-        return {
-          value: JSON.stringify({
-            targetKey: 'customExamples',
-            clientKey: index,
-          }),
-          label: example.label ?? example.lang ?? `Example #${index + 1}`,
-        }
-      }),
+      options: customRequestExamples.value.map((example, index) => ({
+        value: JSON.stringify({
+          targetKey: 'customExamples',
+          clientKey: index,
+        }),
+        label: example.label ?? example.lang ?? `Example #${index + 1}`,
+      })),
     })
-  }
 
   return entries
 })

--- a/packages/api-reference/src/features/ExampleRequest/TextSelect.vue
+++ b/packages/api-reference/src/features/ExampleRequest/TextSelect.vue
@@ -1,5 +1,7 @@
 <script lang="ts" setup>
-defineProps<{
+import { computed } from 'vue'
+
+const props = defineProps<{
   modelValue: any
   options: {
     value: string
@@ -15,12 +17,15 @@ defineProps<{
 defineEmits<{
   (event: 'update:modelValue', value: any): void
 }>()
-</script>
 
+const count = computed(
+  () => props.options.flatMap((o) => o.options ?? o).length,
+)
+</script>
 <template>
   <label
     class="text-select"
-    :class="options.length === 1 ? 'text-select--single-option' : ''">
+    :class="count === 1 ? 'text-select--single-option' : ''">
     <span class="text-select-label">
       <slot />
     </span>

--- a/packages/api-reference/src/stores/useHttpClientStore.test.ts
+++ b/packages/api-reference/src/stores/useHttpClientStore.test.ts
@@ -205,8 +205,33 @@ describe('useHttpClientStore', () => {
             clients: [],
           },
         ],
-        // No Node.js
-        ref({}),
+        ref([]),
+      ),
+    ).toMatchObject([])
+  })
+
+  it('filters targets that have all clients hidden', () => {
+    expect(
+      filterHiddenClients(
+        [
+          {
+            title: 'Node.js',
+            key: 'node',
+            extname: '.js',
+            default: 'foobar',
+            clients: [
+              {
+                title: 'Fetch',
+                key: 'fetch',
+                description:
+                  'The Fetch API provides an interface for fetching resources',
+                link: 'https://example.com',
+              },
+            ],
+          },
+        ],
+        // No fetch
+        ref(['fetch']),
       ),
     ).toMatchObject([])
   })

--- a/packages/api-reference/src/stores/useHttpClientStore.ts
+++ b/packages/api-reference/src/stores/useHttpClientStore.ts
@@ -71,8 +71,9 @@ export function filterHiddenClients(
         // @ts-expect-error Typescript, chill. It’s all good. It has to be an array.
         (client) => !exclude.value.includes(client.key),
       )
-
-      return [target]
+      // Remove targets that don’t have any clients left
+      if (!target.clients.length) return []
+      else return [target]
     }
 
     // Determine if the whole target (language) is to be excluded


### PR DESCRIPTION
This fixes a few things:

* Removes available target sections if they don't have any available clients and an array of hidden client is passed in
* Still shows custom examples if `hiddenClients` is `true`
* Cleans up some of the types in `ExampleRequest.vue`

Fixes #3688
Fixes #3689

![Google Chrome-2024-10-30-19-58-06@2x](https://github.com/user-attachments/assets/a6709b6c-49c4-4502-8f23-b850cd52ff4e)
![Google Chrome-2024-10-30-20-00-59@2x](https://github.com/user-attachments/assets/9ea45455-aa9d-466d-9b71-398a38ee5f1f)
