### PR TITLE
fix(api-client): environment content copy capability

### DIFF
--- a/.changeset/fresh-cats-clean.md
+++ b/.changeset/fresh-cats-clean.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds copy capability to environment code input

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -12,6 +12,9 @@ import DataTableInputSelect from '../DataTable/DataTableInputSelect.vue'
 import { pillPlugin, backspaceCommand } from './codeVariableWidget'
 import EnvironmentVariableDropdown from '@/views/Environment/EnvironmentVariableDropdown.vue'
 import { useWorkspace } from '@/store'
+import { useClipboard } from '@/hooks/useClipboard'
+import { ScalarIcon } from '@scalar/components'
+import { prettyPrintJson } from '@scalar/oas-utils/helpers'
 
 const props = withDefaults(
   defineProps<{
@@ -34,6 +37,7 @@ const props = withDefaults(
     nullable?: boolean
     withVariables?: boolean
     importCurl?: boolean
+    isCopyable?: boolean
   }>(),
   {
     disableCloseBrackets: false,
@@ -43,6 +47,7 @@ const props = withDefaults(
     colorPicker: false,
     nullable: false,
     withVariables: true,
+    isCopyable: false,
   },
 )
 const emit = defineEmits<{
@@ -66,6 +71,8 @@ const dropdownRef = ref<InstanceType<
 
 const { activeEnvVariables, isReadOnly, activeEnvironment, router } =
   useWorkspace()
+
+const { copyToClipboard } = useClipboard()
 
 // ---------------------------------------------------------------------------
 // Event mapping from codemirror to standard input interfaces
@@ -224,7 +231,21 @@ export default {
       }"
       @keydown.down.stop="handleKeyDown('down', $event)"
       @keydown.enter="handleKeyDown('enter', $event)"
-      @keydown.up.stop="handleKeyDown('up', $event)"></div>
+      @keydown.up.stop="handleKeyDown('up', $event)">
+      <div
+        v-if="isCopyable"
+        class="scalar-code-copy z-context">
+        <button
+          class="copy-button"
+          type="button"
+          @click="copyToClipboard(prettyPrintJson(props.modelValue))">
+          <span class="sr-only">Copy content</span>
+          <ScalarIcon
+            icon="Clipboard"
+            size="md" />
+        </button>
+      </div>
+    </div>
   </template>
   <div
     v-if="$slots.warning"
@@ -334,6 +355,48 @@ export default {
 }
 :deep(.cm-scroller) {
   overflow: auto;
+}
+/* Copy Button */
+.peer:hover .copy-button,
+.copy-button:focus-visible {
+  opacity: 100;
+}
+.scalar-code-copy {
+  align-items: flex-start;
+  display: flex;
+  inset: 0;
+  justify-content: flex-end;
+  position: sticky;
+}
+.copy-button {
+  align-items: center;
+  display: flex;
+  position: relative;
+  background-color: var(--scalar-background-2);
+  border: 1px solid var(--scalar-border-color);
+  border-radius: 3px;
+  color: var(--scalar-color-3);
+  cursor: pointer;
+  height: 30px;
+  margin-bottom: -30px;
+  opacity: 0;
+  padding: 6px;
+  transition:
+    opacity 0.15s ease-in-out,
+    color 0.15s ease-in-out;
+  top: 0px;
+  right: 0px;
+}
+.scalar-code-copy,
+.copy-button {
+  /* Pass down the background color */
+  background: inherit;
+}
+.copy-button:hover {
+  color: var(--scalar-color-1);
+}
+.copy-button svg {
+  stroke-width: 1.5;
 }
 </style>
 <style>

--- a/packages/api-client/src/components/Sidebar/SidebarList.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="flex flex-col p-2 pb-[75px]">
+  <ul class="flex flex-col px-3 pt-2.5 pb-[75px]">
     <slot />
   </ul>
 </template>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -132,6 +132,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
               v-for="environment in environments"
               :key="environment.uid"
               class="text-xs"
+              :isCopyable="false"
               :variable="{
                 name: environment.name,
                 uid: environment.uid,

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -178,7 +178,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
         </template>
         <CodeInput
           v-if="activeEnvironmentID"
-          class="pl-px pr-2 md:px-2 py-2.5"
+          class="pl-px pr-2 md:px-4 py-2"
           isCopyable
           language="json"
           lineNumbers

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -182,6 +182,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
           isCopyable
           language="json"
           lineNumbers
+          lint
           :modelValue="environments[activeEnvironmentID].value"
           @update:modelValue="handleEnvironmentUpdate" />
       </ViewLayoutSection>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -179,6 +179,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
         <CodeInput
           v-if="activeEnvironmentID"
           class="pl-px pr-2 md:px-2 py-2.5"
+          isCopyable
           language="json"
           lineNumbers
           :modelValue="environments[activeEnvironmentID].value"


### PR DESCRIPTION
this pr adds the following elements to the environment view:
- removes copy capability from sidebar item
- adds copy capability to code input
- updates style (sidebar / code input)
- adds lint to code input

**lint before / after**
<img width="800" alt="image" src="https://github.com/user-attachments/assets/a941fcc3-e8db-45cc-9928-b4e1c5e4d7c2">
<img width="800" alt="image" src="https://github.com/user-attachments/assets/82dde1bc-8853-43da-aa13-6f820add4161">

**style before / after**
![image](https://github.com/user-attachments/assets/4641cf23-3da9-4863-ac2f-1e22605e09a4)![image](https://github.com/user-attachments/assets/dc9fc9d2-e749-4d26-8713-60c18363a14d)

