### PR TITLE
feat(galaxy): load the spec from a URL rather than as content

### DIFF
--- a/.changeset/itchy-cougars-relate.md
+++ b/.changeset/itchy-cougars-relate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat(galaxy): load the spec from a URL rather than as content

--- a/packages/galaxy/playground/index.ts
+++ b/packages/galaxy/playground/index.ts
@@ -29,7 +29,8 @@ app.get(
   '/',
   apiReference({
     spec: {
-      url: '/_fresh/openapi.yaml',
+      // Served by createMockServer
+      url: '/openapi.yaml',
     },
     pageTitle: 'Scalar Galaxy Spec',
   }),

--- a/packages/galaxy/playground/index.ts
+++ b/packages/galaxy/playground/index.ts
@@ -29,7 +29,7 @@ app.get(
   '/',
   apiReference({
     spec: {
-      content: specification,
+      url: '/_fresh/openapi.yaml',
     },
     pageTitle: 'Scalar Galaxy Spec',
   }),


### PR DESCRIPTION
Loads the Scalar Galaxy Spec by URL rather than via `content` so you can open it in the API client.

I'm assuming the playground is what we deploy to `galaxy.scalar.com`, let me know if it's something else...

## Before (galaxy.scalar.com)

![Google Chrome-2024-10-31-13-38-51@2x](https://github.com/user-attachments/assets/ef816366-1685-4422-9415-a8a4aaa74a68)

## After (this PR)

![Google Chrome-2024-10-31-13-38-28@2x](https://github.com/user-attachments/assets/15d11deb-4dbd-4c5b-a2e2-ccc9355409c9)
