### PR TITLE
fix(api-reference): pre-select first auth in the modal when no auth selected

### DIFF
--- a/.changeset/silly-planes-yawn.md
+++ b/.changeset/silly-planes-yawn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: preselect auth in the modal

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -385,11 +385,12 @@ export async function importSpecToWorkspace(
     return prev
   }, {})
 
-  /** Selected security scheme UIDs for the collection, defaults to the first key */
+  const securityKeys = Object.keys(security)
   let selectedSecuritySchemeUids: string[] = []
-  if (setCollectionSecurity) {
-    const preferred =
-      authentication?.preferredSecurityScheme || Object.keys(security)[0]
+
+  /** Selected security scheme UIDs for the collection, defaults to the first key */
+  if (setCollectionSecurity && securityKeys.length) {
+    const preferred = authentication?.preferredSecurityScheme || securityKeys[0]
     const uid = securitySchemeMap[preferred]
 
     selectedSecuritySchemeUids = [uid]

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -385,10 +385,13 @@ export async function importSpecToWorkspace(
     return prev
   }, {})
 
-  /** Selected security scheme UIDs for the collection */
+  /** Selected security scheme UIDs for the collection, defaults to the first key */
   let selectedSecuritySchemeUids: string[] = []
-  if (setCollectionSecurity && authentication?.preferredSecurityScheme) {
-    const uid = securitySchemeMap[authentication.preferredSecurityScheme]
+  if (setCollectionSecurity) {
+    const preferred =
+      authentication?.preferredSecurityScheme || Object.keys(security)[0]
+    const uid = securitySchemeMap[preferred]
+
     selectedSecuritySchemeUids = [uid]
   }
 


### PR DESCRIPTION
fixes #1939

This just pre-selects the first auth in modal mode if there's no preferredSecurityScheme passed in to match the reference auth. 