### PR TITLE
feat(Scalar.AspNetCore): add StringSyntax attribute to urls

### DIFF
--- a/.changeset/sour-lamps-warn.md
+++ b/.changeset/sour-lamps-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feat: Add StringSyntax attribute to urls

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -201,7 +201,7 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="url">The URL of the server to add.</param>
-    public static ScalarOptions AddServer(this ScalarOptions options, string url)
+    public static ScalarOptions AddServer(this ScalarOptions options, [StringSyntax(StringSyntaxAttribute.Uri)] string url)
     {
         return options.AddServer(new ScalarServer(url));
     }
@@ -329,7 +329,7 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="url">The CDN URL to set.</param>
-    public static ScalarOptions WithCdnUrl(this ScalarOptions options, string url)
+    public static ScalarOptions WithCdnUrl(this ScalarOptions options, [StringSyntax(StringSyntaxAttribute.Uri)] string url)
     {
         options.CdnUrl = url;
         return options;


### PR DESCRIPTION
This PR adds 2 little annotations to URL parameters to tell the IDE that a URI is expected here. IDE's like Rider or Visual Studio understand this attribute and will provide better syntax highlighting.