### PR TITLE
fix(proxy-server): redirects with relative URLs in the `Location` header, fix #3668

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
           packages-only: 'true'
       - name: Run tests
         run: pnpm test:ci
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Run tests for the proxy server (Go)
+        run: cd examples/proxy-server && pnpm test
 
   stats:
     needs: [build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Run tests
         run: pnpm test:ci
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
           go-version: '1.21'
       - name: Run tests for the proxy server (Go)

--- a/examples/proxy-server/go.mod
+++ b/examples/proxy-server/go.mod
@@ -1,0 +1,3 @@
+module github.com/scalar/examples/proxy-server
+
+go 1.21

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -90,6 +90,14 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		res.Header.Del("Access-Control-Allow-Methods")
 		res.Header.Del("Access-Control-Expose-Headers")
 
+		// Handle relative URLs in Location header
+		if location := res.Header.Get("Location"); location != "" {
+			if location[0] == '/' {
+				// If location starts with '/', it's a relative URL
+				res.Header.Set("Location", remote.Scheme+"://"+remote.Host+location)
+			}
+		}
+
 		return nil
 	}
 

--- a/examples/proxy-server/main_test.go
+++ b/examples/proxy-server/main_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPingEndpoint(t *testing.T) {
+	// Create a new request
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	w := httptest.NewRecorder()
+
+	// Call the handler directly
+	handleRequest(w, req)
+
+	// Check the response
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
+	}
+
+	if w.Body.String() != "pong" {
+		t.Errorf("Expected body 'pong', got '%s'", w.Body.String())
+	}
+}
+
+func TestMissingScalarURL(t *testing.T) {
+	// Create a new request without scalar_url parameter
+	req := httptest.NewRequest(http.MethodGet, "/some/path", nil)
+	w := httptest.NewRecorder()
+
+	// Call the handler directly
+	handleRequest(w, req)
+
+	// Check the response
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	expectedError := "The `scalar_url` query parameter is required. Try to add `?scalar_url=https%3A%2F%2Fgalaxy.scalar.com%2Fplanets` to the URL."
+	if w.Body.String() != expectedError+"\n" {
+		t.Errorf("Expected error message about missing scalar_url parameter")
+	}
+}
+
+func TestCORSMiddleware(t *testing.T) {
+	// Create a test handler
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("test response"))
+	})
+
+	// Wrap it with CORS middleware
+	handler := corsMiddleware(testHandler)
+
+	// Create a request with Origin header
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "http://example.com")
+	w := httptest.NewRecorder()
+
+	// Call the handler
+	handler.ServeHTTP(w, req)
+
+	// Check CORS headers
+	headers := w.Header()
+	if headers.Get("Access-Control-Allow-Origin") != "http://example.com" {
+		t.Errorf("Expected Allow-Origin header to be 'http://example.com'")
+	}
+	if headers.Get("Access-Control-Allow-Credentials") != "true" {
+		t.Errorf("Expected Allow-Credentials header to be 'true'")
+	}
+}
+
+func TestCORSPreflightRequest(t *testing.T) {
+	// Create a test handler
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("Handler should not be called for OPTIONS request")
+	})
+
+	// Wrap it with CORS middleware
+	handler := corsMiddleware(testHandler)
+
+	// Create an OPTIONS request
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	w := httptest.NewRecorder()
+
+	// Call the handler
+	handler.ServeHTTP(w, req)
+
+	// Check response
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code %d for OPTIONS request, got %d", http.StatusOK, w.Code)
+	}
+}

--- a/examples/proxy-server/package.json
+++ b/examples/proxy-server/package.json
@@ -24,7 +24,7 @@
     "lint:check": "go fmt ./main.go",
     "lint:fix": "go fmt ./main.go",
     "preview": "pnpm dev",
-    "test": "go test",
+    "test": "go test -v",
     "types:build": "pnpm build",
     "types:check": "pnpm build"
   },


### PR DESCRIPTION
When the proxy receives a response containing a `Location` header with a relative URL (e.g. `Location: /foobar`), it redirects to the proxy itself.

With this PR this is fixed and the relative URL is prefixed with the original URL, that we’d like to fetch.

This PR also adds some tests (finally) to the proxy server.