### PR TITLE
fix(import): resolve JSON/YAML URLs

### DIFF
--- a/.changeset/violet-bulldogs-nail.md
+++ b/.changeset/violet-bulldogs-nail.md
@@ -1,0 +1,5 @@
+---
+'@scalar/import': patch
+---
+
+fix: resolve JSON/YAML URLs

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -402,4 +402,22 @@ info:
 
     expect(result).toBe('https://example.com/docs/files/openapi.json')
   })
+
+  it('returns URL if it directly returns an OpenAPI document', async () => {
+    const openApiDoc = {
+      openapi: '3.0.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {},
+    }
+
+    // @ts-expect-error Mocking types are missing
+    fetch.mockResolvedValue(createFetchResponse(JSON.stringify(openApiDoc)))
+
+    const result = await resolve('https://example.com/swagger/json')
+
+    expect(result).toBe('https://example.com/swagger/json')
+  })
 })

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -61,6 +61,26 @@ export async function resolve(
 
       if (result.ok) {
         const content = await result.text()
+
+        // Check if content is directly JSON/YAML
+        try {
+          // Try parsing as JSON
+          const jsonContent = JSON.parse(content)
+          if (jsonContent.openapi || jsonContent.swagger) {
+            return value
+          }
+        } catch {
+          // Try parsing as YAML
+          try {
+            const yamlContent = parse(content)
+            if (yamlContent?.openapi || yamlContent?.swagger) {
+              return value
+            }
+          } catch {
+            // Not YAML
+          }
+        }
+
         const urlOrPathOrDocument = parseHtml(content)
 
         // Document (string)


### PR DESCRIPTION
Currently, `resolve()` returns `undefined` for URLs that respond with JSON/YAML (OpenAPI documents).

This PR fixes it and returns the URL if responded with an OpenAPI document.