### PR TITLE
fix(api-client): request height section

### DIFF
--- a/.changeset/fifty-comics-speak.md
+++ b/.changeset/fifty-comics-speak.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: request / response section height

--- a/packages/api-client/src/assets/variables.css
+++ b/packages/api-client/src/assets/variables.css
@@ -1,5 +1,5 @@
 :root {
-  --scalar-client-header-height: 50px;
+  --scalar-client-header-height: 52px;
   --scalar-sidebar-width: 280px;
   --scalar-toc-width: 280px;
 }

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -70,7 +70,7 @@ const startDrag = (event: MouseEvent) => {
     <slot name="header" />
     <div
       v-if="!isReadOnly && title"
-      class="min-h-11 xl:min-h-header flex items-center justify-between border-b-1/2 px-3 py-1.5 md:px-4 md:py-2.5 text-sm">
+      class="min-h-12 xl:min-h-header flex items-center justify-between border-b-1/2 px-3 py-1.5 md:px-4 md:py-2.5 text-sm">
       <h2 class="font-medium m-0 text-sm whitespace-nowrap">
         {{ title }}
       </h2>

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -9,7 +9,7 @@ const id = nanoid()
     class="flex h-full xl:min-w-0 xl:flex-1 flex-col xl:custom-scroll bg-b-1">
     <div
       :id="id"
-      class="min-h-11 xl:min-h-header flex items-center border-b-1/2 px-3.5 py-1.5 md:px-4 md:py-2.5 xl:px-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 xl:rounded-none">
+      class="min-h-12 xl:min-h-header flex items-center border-b-1/2 px-3.5 py-1.5 md:px-4 md:py-2 xl:px-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 xl:rounded-none">
       <slot name="title" />
     </div>
     <slot />


### PR DESCRIPTION
this pr fixes the height issue on request section for non readonly spotted by @hanspagel : 

**before / after**
<img width="392" alt="image" src="https://github.com/user-attachments/assets/6f314992-a3d3-495f-be11-62c2a55bbd09">
<img width="392" alt="image" src="https://github.com/user-attachments/assets/7b658d0a-ef51-4ddd-b373-744ff31b17a7">