### PR TITLE
refactor(themes): apply variables to :root instead of the body class

### DIFF
--- a/.changeset/quiet-feet-melt.md
+++ b/.changeset/quiet-feet-melt.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/themes': patch
+---
+
+refactor(themes): apply variables to :root instead of the body class

--- a/packages/api-client/src/assets/variables.css
+++ b/packages/api-client/src/assets/variables.css
@@ -3,6 +3,3 @@
   --scalar-sidebar-width: 280px;
   --scalar-toc-width: 280px;
 }
-html:has(.dark-mode) {
-  --scalar-background-1: #0f0f0f;
-}

--- a/packages/themes/src/presets/alternate.css
+++ b/packages/themes/src/presets/alternate.css
@@ -1,10 +1,12 @@
-/* basic theme */
+/* Global Theme Settings */
 :root {
+  /* text decoration */
   --scalar-text-decoration: underline;
   --scalar-text-decoration-hover: underline;
 }
-.light-mode,
+:root:has(body.light-mode),
 .light-mode .dark-mode {
+  /* basic theme */
   --scalar-background-1: #f9f9f9;
   --scalar-background-2: #f1f1f1;
   --scalar-background-3: #e7e7e7;
@@ -18,8 +20,21 @@
   --scalar-background-accent: var(--scalar-background-3);
 
   --scalar-border-color: rgba(0, 0, 0, 0.1);
+
+  /* advanced theme */
+  --scalar-color-green: #069061;
+  --scalar-color-red: #ef0006;
+  --scalar-color-yellow: #edbe20;
+  --scalar-color-blue: #0082d0;
+  --scalar-color-orange: #fb892c;
+  --scalar-color-purple: #5203d1;
+
+  --scalar-button-1: rgba(0, 0, 0, 1);
+  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
+  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
 }
-.dark-mode {
+:root:has(body.dark-mode) {
+  /* basic theme */
   --scalar-background-1: #131313;
   --scalar-background-2: #1d1d1d;
   --scalar-background-3: #272727;
@@ -33,7 +48,20 @@
   --scalar-background-accent: var(--scalar-background-3);
 
   --scalar-border-color: #2a2b2a;
+
+  /* advanced theme */
+  --scalar-color-green: #00b648;
+  --scalar-color-red: #dd2f2c;
+  --scalar-color-yellow: #ffc90d;
+  --scalar-color-blue: #4eb3ec;
+  --scalar-color-orange: #ff8d4d;
+  --scalar-color-purple: #b191f9;
+
+  --scalar-button-1: rgba(255, 255, 255, 1);
+  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: black;
 }
+
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
 .dark-mode .t-doc__sidebar {
@@ -55,34 +83,16 @@
   --scalar-sidebar-indent-border: var(--scalar-sidebar-border-color);
   --scalar-sidebar-indent-border-hover: var(--scalar-sidebar-border-color);
   --scalar-sidebar-indent-border-active: var(--scalar-sidebar-border-color);
-}
-/* advanced */
-.light-mode .dark-mode,
-.light-mode {
-  --scalar-color-green: #069061;
-  --scalar-color-red: #ef0006;
-  --scalar-color-yellow: #edbe20;
-  --scalar-color-blue: #0082d0;
-  --scalar-color-orange: #fb892c;
-  --scalar-color-purple: #5203d1;
 
-  --scalar-button-1: rgba(0, 0, 0, 1);
-  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
-}
-.dark-mode {
-  --scalar-color-green: #00b648;
-  --scalar-color-red: #dd2f2c;
-  --scalar-color-yellow: #ffc90d;
-  --scalar-color-blue: #4eb3ec;
-  --scalar-color-orange: #ff8d4d;
-  --scalar-color-purple: #b191f9;
-
-  --scalar-button-1: rgba(255, 255, 255, 1);
-  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
-  --scalar-button-1-color: black;
+  --scalar-color-green: var(--scalar-color-1);
+  --scalar-color-red: var(--scalar-color-1);
+  --scalar-color-yellow: var(--scalar-color-1);
+  --scalar-color-blue: var(--scalar-color-1);
+  --scalar-color-orange: var(--scalar-color-1);
+  --scalar-color-purple: var(--scalar-color-1);
 }
 
+/* Inverted Card Colors */
 .scalar-api-client__item,
 .scalar-card,
 .dark-mode .dark-mode.scalar-card {
@@ -92,12 +102,4 @@
 }
 .dark-mode .dark-mode.scalar-card {
   --scalar-background-3: var(--scalar-background-3);
-}
-.t-doc__sidebar {
-  --scalar-color-green: var(--scalar-color-1);
-  --scalar-color-red: var(--scalar-color-1);
-  --scalar-color-yellow: var(--scalar-color-1);
-  --scalar-color-blue: var(--scalar-color-1);
-  --scalar-color-orange: var(--scalar-color-1);
-  --scalar-color-purple: var(--scalar-color-1);
 }

--- a/packages/themes/src/presets/bluePlanet.css
+++ b/packages/themes/src/presets/bluePlanet.css
@@ -1,9 +1,11 @@
-/* basic theme */
+/* Global Theme Settings */
 :root {
+  /* text decoration */
   --scalar-text-decoration: underline;
   --scalar-text-decoration-hover: underline;
 }
-.light-mode {
+:root:has(body.light-mode) {
+  /* basic theme */
   --scalar-background-1: #f0f2f5;
   --scalar-background-2: #eaecf0;
   --scalar-background-3: #e0e2e6;
@@ -15,9 +17,22 @@
 
   --scalar-color-accent: var(--scalar-color-1);
   --scalar-background-accent: #8ab4f81f;
+
+  /* advanced theme */
+  --scalar-color-green: #069061;
+  --scalar-color-red: #ef0006;
+  --scalar-color-yellow: #edbe20;
+  --scalar-color-blue: #0082d0;
+  --scalar-color-orange: #fb892c;
+  --scalar-color-purple: #5203d1;
+
+  --scalar-button-1: rgba(0, 0, 0, 1);
+  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
+  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
 }
-.light-mode .scalar-card.dark-mode,
-.dark-mode {
+:root:has(body.dark-mode),
+.light-mode .scalar-card.dark-mode {
+  /* basic theme */
   --scalar-background-1: #000e23;
   --scalar-background-2: #01132e;
   --scalar-background-3: #03193b;
@@ -31,6 +46,18 @@
   --scalar-background-accent: #8ab4f81f;
 
   --scalar-code-language-color-supersede: var(--scalar-color-1);
+
+  /* advanced theme */
+  --scalar-color-green: rgba(69, 255, 165, 0.823);
+  --scalar-color-red: #ff8589;
+  --scalar-color-yellow: #ffcc4d;
+  --scalar-color-blue: #6bc1fe;
+  --scalar-color-orange: #f98943;
+  --scalar-color-purple: #b191f9;
+
+  --scalar-button-1: rgba(255, 255, 255, 1);
+  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: black;
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
@@ -53,31 +80,6 @@
 }
 .light-mode .t-doc__sidebar {
   --scalar-sidebar-search-background: white;
-}
-/* advanced */
-.light-mode {
-  --scalar-color-green: #069061;
-  --scalar-color-red: #ef0006;
-  --scalar-color-yellow: #edbe20;
-  --scalar-color-blue: #0082d0;
-  --scalar-color-orange: #fb892c;
-  --scalar-color-purple: #5203d1;
-
-  --scalar-button-1: rgba(0, 0, 0, 1);
-  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
-}
-.dark-mode {
-  --scalar-color-green: rgba(69, 255, 165, 0.823);
-  --scalar-color-red: #ff8589;
-  --scalar-color-yellow: #ffcc4d;
-  --scalar-color-blue: #6bc1fe;
-  --scalar-color-orange: #f98943;
-  --scalar-color-purple: #b191f9;
-
-  --scalar-button-1: rgba(255, 255, 255, 1);
-  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
-  --scalar-button-1-color: black;
 }
 /* Custom theme */
 /* Document header */

--- a/packages/themes/src/presets/deepSpace.css
+++ b/packages/themes/src/presets/deepSpace.css
@@ -1,9 +1,12 @@
-/* basic theme */
+/* Global Theme Settings */
 :root {
+  /* text decoration */
   --scalar-text-decoration: underline;
   --scalar-text-decoration-hover: underline;
 }
-.light-mode {
+:root:has(body.light-mode),
+.dark-mode .light-mode {
+  /* basic theme */
   --scalar-color-1: rgb(9, 9, 11);
   --scalar-color-2: rgb(113, 113, 122);
   --scalar-color-3: rgba(25, 25, 28, 0.5);
@@ -16,8 +19,22 @@
 
   --scalar-border-color: rgb(228, 228, 231);
   --scalar-code-language-color-supersede: var(--scalar-color-1);
+
+  /* advanced theme */
+  --scalar-color-green: #069061;
+  --scalar-color-red: #ef0006;
+  --scalar-color-yellow: #edbe20;
+  --scalar-color-blue: #0082d0;
+  --scalar-color-orange: #fb892c;
+  --scalar-color-purple: #5203d1;
+
+  --scalar-button-1: rgba(0, 0, 0, 1);
+  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
+  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
 }
-.dark-mode {
+:root:has(body.dark-mode),
+.light-mode .dark-mode {
+  /* basic theme */
   --scalar-color-1: #fafafa;
   --scalar-color-2: rgb(161, 161, 170);
   --scalar-color-3: rgba(255, 255, 255, 0.533);
@@ -30,6 +47,18 @@
 
   --scalar-border-color: rgba(255, 255, 255, 0.16);
   --scalar-code-language-color-supersede: var(--scalar-color-1);
+
+  /* advanced theme */
+  --scalar-color-green: rgba(69, 255, 165, 0.823);
+  --scalar-color-red: #ff8589;
+  --scalar-color-yellow: #ffcc4d;
+  --scalar-color-blue: #6bc1fe;
+  --scalar-color-orange: #f98943;
+  --scalar-color-purple: #b191f9;
+
+  --scalar-button-1: rgba(255, 255, 255, 1);
+  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: black;
 }
 
 /* Document Sidebar */
@@ -52,31 +81,6 @@
 }
 .light-mode .t-doc__sidebar {
   --scalar-sidebar-item-active-background: var(--scalar-background-2);
-}
-/* advanced */
-.light-mode {
-  --scalar-color-green: #069061;
-  --scalar-color-red: #ef0006;
-  --scalar-color-yellow: #edbe20;
-  --scalar-color-blue: #0082d0;
-  --scalar-color-orange: #fb892c;
-  --scalar-color-purple: #5203d1;
-
-  --scalar-button-1: rgba(0, 0, 0, 1);
-  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
-}
-.dark-mode {
-  --scalar-color-green: rgba(69, 255, 165, 0.823);
-  --scalar-color-red: #ff8589;
-  --scalar-color-yellow: #ffcc4d;
-  --scalar-color-blue: #6bc1fe;
-  --scalar-color-orange: #f98943;
-  --scalar-color-purple: #b191f9;
-
-  --scalar-button-1: rgba(255, 255, 255, 1);
-  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
-  --scalar-button-1-color: black;
 }
 /* Custom theme */
 .dark-mode h2.t-editor__heading,

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -1,5 +1,20 @@
-/* basic theme */
-.light-mode {
+/* Global Theme Settings */
+:root {
+  /* text decoration */
+  --scalar-text-decoration: none;
+  --scalar-text-decoration-hover: underline;
+
+  /* selection colors */
+  --scalar-selection-background: color-mix(
+    in sRGB,
+    var(--scalar-color-1) 80%,
+    transparent
+  );
+  --scalar-selection-color: var(--scalar-background-1);
+}
+:root:has(body.light-mode),
+.dark-mode .light-mode {
+  /* basic theme */
   --scalar-background-1: #fff;
   --scalar-background-2: #f6f6f6;
   --scalar-background-3: #e7e7e7;
@@ -11,8 +26,22 @@
 
   --scalar-color-accent: #0099ff;
   --scalar-border-color: #dfdfdf;
+
+  /* advanced theme */
+  --scalar-color-green: #069061;
+  --scalar-color-red: #ef0006;
+  --scalar-color-yellow: #edbe20;
+  --scalar-color-blue: #0082d0;
+  --scalar-color-orange: #fb892c;
+  --scalar-color-purple: #5203d1;
+
+  --scalar-button-1: rgba(0, 0, 0, 1);
+  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
+  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
 }
-.dark-mode {
+:root:has(body.dark-mode),
+.light-mode .dark-mode {
+  /* basic theme */
   --scalar-background-1: #0f0f0f;
   --scalar-background-2: #1a1a1a;
   --scalar-background-3: #272727;
@@ -25,6 +54,18 @@
   --scalar-background-accent: #3ea6ff1f;
 
   --scalar-border-color: #2d2d2d;
+
+  /* advanced theme */
+  --scalar-color-green: #00b648;
+  --scalar-color-red: #dc1b19;
+  --scalar-color-yellow: #ffc90d;
+  --scalar-color-blue: #4eb3ec;
+  --scalar-color-orange: #ff8d4d;
+  --scalar-color-purple: #b191f9;
+
+  --scalar-button-1: rgba(255, 255, 255, 1);
+  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: black;
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
@@ -43,39 +84,4 @@
   --scalar-sidebar-search-background: transparent;
   --scalar-sidebar-search-color: var(--scalar-color-3);
   --scalar-sidebar-search-border-color: var(--scalar-border-color);
-}
-/* selection colors */
-.light-mode,
-.dark-mode {
-  --scalar-selection-background: color-mix(
-    in sRGB,
-    var(--scalar-color-1) 80%,
-    transparent
-  );
-  --scalar-selection-color: var(--scalar-background-1);
-}
-/* advanced */
-.light-mode {
-  --scalar-color-green: #069061;
-  --scalar-color-red: #ef0006;
-  --scalar-color-yellow: #edbe20;
-  --scalar-color-blue: #0082d0;
-  --scalar-color-orange: #fb892c;
-  --scalar-color-purple: #5203d1;
-
-  --scalar-button-1: rgba(0, 0, 0, 1);
-  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
-}
-.dark-mode {
-  --scalar-color-green: #00b648;
-  --scalar-color-red: #dc1b19;
-  --scalar-color-yellow: #ffc90d;
-  --scalar-color-blue: #4eb3ec;
-  --scalar-color-orange: #ff8d4d;
-  --scalar-color-purple: #b191f9;
-
-  --scalar-button-1: rgba(255, 255, 255, 1);
-  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
-  --scalar-button-1-color: black;
 }

--- a/packages/themes/src/presets/kepler.css
+++ b/packages/themes/src/presets/kepler.css
@@ -1,5 +1,6 @@
-/* basic theme */
-.light-mode {
+/* Global Theme Settings */
+:root:has(body.light-mode) {
+  /* basic theme */
   --scalar-color-1: #2a2f45;
   --scalar-color-2: #757575;
   --scalar-color-3: #8e8e8e;
@@ -13,8 +14,21 @@
   --scalar-border-color: rgba(0, 0, 0, 0.1);
 
   --scalar-code-language-color-supersede: var(--scalar-color-3);
+
+  /* advanced theme */
+  --scalar-color-green: #069061;
+  --scalar-color-red: #ef0006;
+  --scalar-color-yellow: #edbe20;
+  --scalar-color-blue: #0082d0;
+  --scalar-color-orange: #fb892c;
+  --scalar-color-purple: #5203d1;
+
+  --scalar-button-1: rgba(0, 0, 0, 1);
+  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
+  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
 }
-.dark-mode {
+:root:has(body.dark-mode) {
+  /* basic theme */
   --scalar-color-1: #f7f8f8;
   --scalar-color-2: rgb(180, 188, 208);
   --scalar-color-3: #b4bcd099;
@@ -27,6 +41,18 @@
 
   --scalar-border-color: #313245;
   --scalar-code-language-color-supersede: var(--scalar-color-3);
+
+  /* advanced theme */
+  --scalar-color-green: #00b648;
+  --scalar-color-red: #dc1b19;
+  --scalar-color-yellow: #ffc90d;
+  --scalar-color-blue: #4eb3ec;
+  --scalar-color-orange: #ff8d4d;
+  --scalar-color-purple: #b191f9;
+
+  --scalar-button-1: rgba(255, 255, 255, 1);
+  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: black;
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar {
@@ -55,31 +81,6 @@
   --scalar-sidebar-search-background: rgba(255, 255, 255, 0.1);
   --scalar-sidebar-search-border-color: 1px solid rgba(255, 255, 255, 0.05);
   --scalar-sidebar-search-color: var(--scalar-color-3);
-}
-/* advanced */
-.light-mode {
-  --scalar-color-green: #069061;
-  --scalar-color-red: #ef0006;
-  --scalar-color-yellow: #edbe20;
-  --scalar-color-blue: #0082d0;
-  --scalar-color-orange: #fb892c;
-  --scalar-color-purple: #5203d1;
-
-  --scalar-button-1: rgba(0, 0, 0, 1);
-  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
-}
-.dark-mode {
-  --scalar-color-green: #00b648;
-  --scalar-color-red: #dc1b19;
-  --scalar-color-yellow: #ffc90d;
-  --scalar-color-blue: #4eb3ec;
-  --scalar-color-orange: #ff8d4d;
-  --scalar-color-purple: #b191f9;
-
-  --scalar-button-1: rgba(255, 255, 255, 1);
-  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
-  --scalar-button-1-color: black;
 }
 /* Custom Theme */
 .dark-mode h2.t-editor__heading,

--- a/packages/themes/src/presets/mars.css
+++ b/packages/themes/src/presets/mars.css
@@ -1,9 +1,12 @@
-/* basic theme */
+/* Global Theme Settings */
 :root {
+  /* text decoration */
   --scalar-text-decoration: underline;
   --scalar-text-decoration-hover: underline;
 }
-.light-mode {
+:root:has(body.light-mode),
+.dark-mode .light-mode {
+  /* basic theme */
   --scalar-background-1: #f9f6f0;
   --scalar-background-2: #f2efe8;
   --scalar-background-3: #e9e7e2;
@@ -18,14 +21,29 @@
 
   --scalar-code-language-color-supersede: var(--scalar-color-1);
 
+  /* selection colors */
   --scalar-selection-background: color-mix(
     in sRGB,
     var(--scalar-color-1) 90%,
     transparent
   );
   --scalar-selection-color: var(--scalar-background-1);
+
+  /* advanced theme */
+  --scalar-color-green: #09533a;
+  --scalar-color-red: #aa181d;
+  --scalar-color-yellow: #ab8d2b;
+  --scalar-color-blue: #19689a;
+  --scalar-color-orange: #b26c34;
+  --scalar-color-purple: #4c2191;
+
+  --scalar-button-1: rgba(0, 0, 0, 1);
+  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
+  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
 }
-.dark-mode {
+:root:has(body.dark-mode),
+.light-mode .dark-mode {
+  /* basic theme */
   --scalar-background-1: #140507;
   --scalar-background-2: #20090c;
   --scalar-background-3: #321116;
@@ -40,12 +58,25 @@
 
   --scalar-code-language-color-supersede: var(--scalar-color-1);
 
+  /* selection colors */
   --scalar-selection-background: color-mix(
     in sRGB,
     var(--scalar-color-1) 50%,
     transparent
   );
   --scalar-selection-color: var(--scalar-background-1);
+
+  /* advanced theme */
+  --scalar-color-green: rgba(69, 255, 165, 0.823);
+  --scalar-color-red: #ff8589;
+  --scalar-color-yellow: #ffcc4d;
+  --scalar-color-blue: #6bc1fe;
+  --scalar-color-orange: #f98943;
+  --scalar-color-purple: #b191f9;
+
+  --scalar-button-1: rgba(255, 255, 255, 1);
+  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: black;
 }
 
 /* Document Sidebar */
@@ -66,31 +97,6 @@
   --scalar-sidebar-search-color: var(--scalar-color-3);
   --scalar-sidebar-search-border-color: var(--scalar-border-color);
   z-index: 1;
-}
-/* advanced */
-.light-mode {
-  --scalar-color-green: #09533a;
-  --scalar-color-red: #aa181d;
-  --scalar-color-yellow: #ab8d2b;
-  --scalar-color-blue: #19689a;
-  --scalar-color-orange: #b26c34;
-  --scalar-color-purple: #4c2191;
-
-  --scalar-button-1: rgba(0, 0, 0, 1);
-  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
-}
-.dark-mode {
-  --scalar-color-green: rgba(69, 255, 165, 0.823);
-  --scalar-color-red: #ff8589;
-  --scalar-color-yellow: #ffcc4d;
-  --scalar-color-blue: #6bc1fe;
-  --scalar-color-orange: #f98943;
-  --scalar-color-purple: #b191f9;
-
-  --scalar-button-1: rgba(255, 255, 255, 1);
-  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
-  --scalar-button-1-color: black;
 }
 /* Custom Theme */
 .dark-mode h2.t-editor__heading,

--- a/packages/themes/src/presets/moon.css
+++ b/packages/themes/src/presets/moon.css
@@ -1,5 +1,7 @@
-.light-mode {
+:root:has(body.light-mode),
+.dark-mode .light-mode {
   color-scheme: light;
+  /* basic theme */
   --scalar-color-1: #000000;
   --scalar-color-2: #000000;
   --scalar-color-3: #000000;
@@ -19,6 +21,7 @@
   --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
     rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, var(--scalar-border-color) 0px 0 0 1px;
 
+  /* advanced theme */
   --scalar-button-1: rgb(49 53 56);
   --scalar-button-1-color: #fff;
   --scalar-button-1-hover: rgb(28 31 33);
@@ -31,8 +34,10 @@
   --scalar-color-purple: #6d28d9;
 }
 
-.dark-mode {
+:root:has(body.dark-mode),
+.light-mode .dark-mode {
   color-scheme: dark;
+  /* basic theme */
   --scalar-color-1: #fffef3;
   --scalar-color-2: #fffef3;
   --scalar-color-3: #fffef3;
@@ -52,6 +57,7 @@
   --scalar-shadow-2: rgba(15, 15, 15, 0.2) 0px 3px 6px,
     rgba(15, 15, 15, 0.4) 0px 9px 24px, 0 0 0 1px rgba(255, 255, 255, 0.1);
 
+  /* advanced theme */
   --scalar-button-1: #f6f6f6;
   --scalar-button-1-color: #000;
   --scalar-button-1-hover: #e7e7e7;
@@ -79,7 +85,7 @@
   --scalar-sidebar-search--color: var(--scalar-color-3);
 }
 
-.dark-mode .sidebar {
+.dark-mode .t-doc__sidebar {
   --scalar-sidebar-background-1: var(--scalar-background-1);
   --scalar-sidebar-item-hover-color: currentColor;
   --scalar-sidebar-item-hover-background: var(--scalar-background-2);

--- a/packages/themes/src/presets/purple.css
+++ b/packages/themes/src/presets/purple.css
@@ -1,5 +1,7 @@
-/* basic theme */
-.light-mode {
+/* Global Theme Settings */
+:root:has(body.light-mode),
+.dark-mode .light-mode {
+  /* basic theme */
   --scalar-background-1: #fff;
   --scalar-background-2: #f5f6f8;
   --scalar-background-3: #eceef1;
@@ -12,8 +14,22 @@
   --scalar-background-accent: #5469d41f;
 
   --scalar-border-color: rgba(215, 215, 206, 0.68);
+
+  /* advanced theme */
+  --scalar-color-green: #17803d;
+  --scalar-color-red: #e10909;
+  --scalar-color-yellow: #edbe20;
+  --scalar-color-blue: #1763a6;
+  --scalar-color-orange: #e25b09;
+  --scalar-color-purple: #5c3993;
+
+  --scalar-button-1: rgba(0, 0, 0, 1);
+  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
+  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
 }
-.dark-mode {
+:root:has(body.dark-mode),
+.light-mode .dark-mode {
+  /* basic theme */
   --scalar-background-1: #15171c;
   --scalar-background-2: #1c1e24;
   --scalar-background-3: #22252b;
@@ -26,6 +42,18 @@
   --scalar-background-accent: #5469d41f;
 
   --scalar-border-color: #3f4145;
+
+  /* advanced theme */
+  --scalar-color-green: #30a159;
+  --scalar-color-red: #dc1b19;
+  --scalar-color-yellow: #eec644;
+  --scalar-color-blue: #2b7abf;
+  --scalar-color-orange: #f07528;
+  --scalar-color-purple: #7a59b1;
+
+  --scalar-button-1: rgba(255, 255, 255, 1);
+  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: black;
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
@@ -44,30 +72,4 @@
   --scalar-sidebar-search-background: var(--scalar-background-1);
   --scalar-sidebar-search-color: var(--scalar-color-3);
   --scalar-sidebar-search-border-color: var(--scalar-border-color);
-}
-
-/* advanced */
-.light-mode {
-  --scalar-color-green: #17803d;
-  --scalar-color-red: #e10909;
-  --scalar-color-yellow: #edbe20;
-  --scalar-color-blue: #1763a6;
-  --scalar-color-orange: #e25b09;
-  --scalar-color-purple: #5c3993;
-
-  --scalar-button-1: rgba(0, 0, 0, 1);
-  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
-}
-.dark-mode {
-  --scalar-color-green: #30a159;
-  --scalar-color-red: #dc1b19;
-  --scalar-color-yellow: #eec644;
-  --scalar-color-blue: #2b7abf;
-  --scalar-color-orange: #f07528;
-  --scalar-color-purple: #7a59b1;
-
-  --scalar-button-1: rgba(255, 255, 255, 1);
-  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
-  --scalar-button-1-color: black;
 }

--- a/packages/themes/src/presets/saturn.css
+++ b/packages/themes/src/presets/saturn.css
@@ -1,5 +1,7 @@
-/* basic theme */
-.light-mode {
+/* Global Theme Settings */
+:root:has(body.light-mode),
+.dark-mode .light-mode {
+  /* basic theme */
   --scalar-background-1: #f3f3ee;
   --scalar-background-2: #e8e8e3;
   --scalar-background-3: #e4e4df;
@@ -11,8 +13,22 @@
 
   --scalar-color-accent: #1763a6;
   --scalar-background-accent: #1f648e1f;
+
+  /* advanced theme */
+  --scalar-color-green: #17803d;
+  --scalar-color-red: #e10909;
+  --scalar-color-yellow: #edbe20;
+  --scalar-color-blue: #1763a6;
+  --scalar-color-orange: #e25b09;
+  --scalar-color-purple: #5c3993;
+
+  --scalar-button-1: rgba(0, 0, 0, 1);
+  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
+  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
 }
-.dark-mode {
+:root:has(body.dark-mode),
+.light-mode .dark-mode {
+  /* basic theme */
   --scalar-background-1: #09090b;
   --scalar-background-2: #18181b;
   --scalar-background-3: #2c2c30;
@@ -24,6 +40,18 @@
 
   --scalar-color-accent: #4eb3ec;
   --scalar-background-accent: #8ab4f81f;
+
+  /* advanced theme */
+  --scalar-color-green: #30a159;
+  --scalar-color-red: #dc1b19;
+  --scalar-color-yellow: #eec644;
+  --scalar-color-blue: #2b7abf;
+  --scalar-color-orange: #f07528;
+  --scalar-color-purple: #7a59b1;
+
+  --scalar-button-1: rgba(255, 255, 255, 1);
+  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: black;
 }
 /* Document Sidebar */
 .light-mode .t-doc__sidebar,
@@ -44,31 +72,7 @@
   --scalar-sidebar-search-color: var(--scalar-color-3);
 }
 
-/* advanced */
-.light-mode {
-  --scalar-color-green: #17803d;
-  --scalar-color-red: #e10909;
-  --scalar-color-yellow: #edbe20;
-  --scalar-color-blue: #1763a6;
-  --scalar-color-orange: #e25b09;
-  --scalar-color-purple: #5c3993;
-
-  --scalar-button-1: rgba(0, 0, 0, 1);
-  --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
-}
-.dark-mode {
-  --scalar-color-green: #30a159;
-  --scalar-color-red: #dc1b19;
-  --scalar-color-yellow: #eec644;
-  --scalar-color-blue: #2b7abf;
-  --scalar-color-orange: #f07528;
-  --scalar-color-purple: #7a59b1;
-
-  --scalar-button-1: rgba(255, 255, 255, 1);
-  --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
-  --scalar-button-1-color: black;
-}
+/* Custom Theme */
 .dark-mode h2.t-editor__heading,
 .dark-mode .t-editor__page-title h1,
 .dark-mode h1.section-header:not(::selection),

--- a/packages/themes/src/presets/solarized.css
+++ b/packages/themes/src/presets/solarized.css
@@ -1,5 +1,9 @@
-.light-mode {
+/* Global Theme Settings */
+:root:has(body.light-mode),
+.dark-mode .light-mode {
   color-scheme: light;
+
+  /* basic theme */
   --scalar-color-1: #584c27;
   --scalar-color-2: #616161;
   --scalar-color-3: #a89f84;
@@ -19,6 +23,7 @@
   --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
     rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 1px;
 
+  /* advanced theme */
   --scalar-button-1: rgb(49 53 56);
   --scalar-button-1-color: #fff;
   --scalar-button-1-hover: rgb(28 31 33);
@@ -30,9 +35,11 @@
   --scalar-color-orange: #c2410c;
   --scalar-color-purple: #6d28d9;
 }
-
-.dark-mode {
+:root:has(body.dark-mode),
+.light-mode .dark-mode {
   color-scheme: dark;
+
+  /* basic theme */
   --scalar-color-1: #fff;
   --scalar-color-2: #cccccc;
   --scalar-color-3: #6d8890;
@@ -52,6 +59,7 @@
   --scalar-shadow-2: rgba(15, 15, 15, 0.2) 0px 3px 6px,
     rgba(15, 15, 15, 0.4) 0px 9px 24px, 0 0 0 1px rgba(255, 255, 255, 0.1);
 
+  /* advanced theme */
   --scalar-button-1: #f6f6f6;
   --scalar-button-1-color: #000;
   --scalar-button-1-hover: #e7e7e7;
@@ -64,8 +72,8 @@
   --scalar-color-purple: #b191f9;
 }
 
-/* Sidebar */
-.light-mode .t-doc__sidebar {
+/* Document Sidebar */
+.light-mode .t-doc__sidebar .dark-mode .t-doc__sidebar {
   --scalar-sidebar-background-1: var(--scalar-background-1);
   --scalar-sidebar-item-hover-color: currentColor;
   --scalar-sidebar-item-hover-background: var(--scalar-background-2);
@@ -73,22 +81,13 @@
   --scalar-sidebar-border-color: var(--scalar-border-color);
   --scalar-sidebar-color-1: var(--scalar-color-1);
   --scalar-sidebar-color-2: var(--scalar-color-2);
-  --scalar-sidebar-color-active: var(--scalar-color-accent);
   --scalar-sidebar-search-background: var(--scalar-background-2);
   --scalar-sidebar-search-border-color: var(--scalar-sidebar-search-background);
   --scalar-sidebar-search--color: var(--scalar-color-3);
 }
-
-.dark-mode .sidebar {
-  --scalar-sidebar-background-1: var(--scalar-background-1);
-  --scalar-sidebar-item-hover-color: currentColor;
-  --scalar-sidebar-item-hover-background: var(--scalar-background-2);
-  --scalar-sidebar-item-active-background: var(--scalar-background-accent);
-  --scalar-sidebar-border-color: var(--scalar-border-color);
-  --scalar-sidebar-color-1: var(--scalar-color-1);
-  --scalar-sidebar-color-2: var(--scalar-color-2);
+.light-mode .t-doc__sidebar {
+  --scalar-sidebar-color-active: var(--scalar-color-accent);
+}
+.dark-mode .t-doc__sidebar {
   --scalar-sidebar-color-active: var(--scalar-sidebar-color-1);
-  --scalar-sidebar-search-background: var(--scalar-background-2);
-  --scalar-sidebar-search-border-color: var(--scalar-sidebar-search-background);
-  --scalar-sidebar-search--color: var(--scalar-color-3);
 }

--- a/packages/themes/src/variables.css
+++ b/packages/themes/src/variables.css
@@ -46,9 +46,6 @@
 
   --scalar-font-medium: 500;
   --scalar-font-bold: 700;
-
-  --scalar-text-decoration: none;
-  --scalar-text-decoration-hover: underline;
 }
 .dark-mode {
   color-scheme: dark;


### PR DESCRIPTION
@antlio pointed out that we could use :has to apply our color variables to the :root instead of body.light-mode which I think is a good idea. It seems like :has has good support and this allows CSS variables to be used anywhere including on the html.