### PR TITLE
fix(oas-utils): relative URLs are wrong

### DIFF
--- a/.changeset/lazy-moose-talk.md
+++ b/.changeset/lazy-moose-talk.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: relative URLs are created wrong

--- a/packages/oas-utils/src/helpers/makeUrlAbsolute.test.ts
+++ b/packages/oas-utils/src/helpers/makeUrlAbsolute.test.ts
@@ -6,16 +6,16 @@ import { makeUrlAbsolute } from './makeUrlAbsolute'
  * @vitest-environment jsdom
  */
 describe('makeUrlAbsolute', () => {
-  it('should return undefined for undefined input', () => {
+  it('returns undefined for undefined input', () => {
     expect(makeUrlAbsolute(undefined)).toBeUndefined()
   })
 
-  it('should return the same URL for absolute URLs', () => {
+  it('returns the same URL for absolute URLs', () => {
     expect(makeUrlAbsolute('http://example.com')).toBe('http://example.com')
     expect(makeUrlAbsolute('https://example.com')).toBe('https://example.com')
   })
 
-  it('should convert relative URLs to absolute URLs', () => {
+  it('converts relative URLs to absolute URLs', () => {
     // Mock window.location.href
     const originalHref = window.location.href
     Object.defineProperty(window, 'location', {
@@ -35,7 +35,7 @@ describe('makeUrlAbsolute', () => {
     })
   })
 
-  it('should handle base URLs without trailing slash', () => {
+  it('handles base URLs without trailing slash', () => {
     // Mock window.location.href
     const originalHref = window.location.href
     Object.defineProperty(window, 'location', {
@@ -43,7 +43,7 @@ describe('makeUrlAbsolute', () => {
       writable: true,
     })
 
-    expect(makeUrlAbsolute('relative')).toBe('http://example.com/path/relative')
+    expect(makeUrlAbsolute('relative')).toBe('http://example.com/relative')
 
     // Restore original window.location.href
     Object.defineProperty(window, 'location', {
@@ -52,7 +52,7 @@ describe('makeUrlAbsolute', () => {
     })
   })
 
-  it('should ignore query parameters and hash in base URL', () => {
+  it('ignores query parameters and hash in base URL', () => {
     // Mock window.location.href
     const originalHref = window.location.href
     Object.defineProperty(window, 'location', {
@@ -60,7 +60,7 @@ describe('makeUrlAbsolute', () => {
       writable: true,
     })
 
-    expect(makeUrlAbsolute('relative')).toBe('http://example.com/path/relative')
+    expect(makeUrlAbsolute('relative')).toBe('http://example.com/relative')
 
     // Restore original window.location.href
     Object.defineProperty(window, 'location', {

--- a/packages/oas-utils/src/helpers/makeUrlAbsolute.ts
+++ b/packages/oas-utils/src/helpers/makeUrlAbsolute.ts
@@ -15,10 +15,11 @@ export const makeUrlAbsolute = (url?: string) => {
   // Remove any query parameters or hash from the base URL
   const cleanBaseUrl = baseUrl.split('?')[0].split('#')[0]
 
-  // Ensure the base URL ends with a slash if it doesn’t already
+  // For base URLs with a path component, we want to remove the last path segment
+  // if it doesn't end with a slash
   const normalizedBaseUrl = cleanBaseUrl.endsWith('/')
     ? cleanBaseUrl
-    : cleanBaseUrl + '/'
+    : cleanBaseUrl.substring(0, cleanBaseUrl.lastIndexOf('/') + 1)
 
   return new URL(url, normalizedBaseUrl).toString()
 }


### PR DESCRIPTION
When the OpenAPI document URL is relative and we try to make it an absolute URL this is happening currently:

❌ `https://example.com/swagger` + `swagger.json` = `https://example.com/swagger/swagger.json`

But we actually want this:

✅ `https://example.com/swagger` + `swagger.json` = `https://example.com/swagger.json`

Without touching this case (trailing slash):

✅ `https://example.com/swagger/` + `swagger.json` = `https://example.com/swagger/swagger.json`