### PR TITLE
feat(api-client): improve oauth2 error handling + add PKCE capabilities with tests

### DIFF
--- a/.changeset/fluffy-comics-deny.md
+++ b/.changeset/fluffy-comics-deny.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: add support for PKCE auth code flow

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -111,18 +111,20 @@ watch(addingCustomValue, (newValue) => {
             </div>
             {{ option }}
           </ScalarDropdownItem>
-          <ScalarDropdownDivider />
-          <ScalarDropdownItem
-            v-if="canAddCustomValue"
-            class="flex items-center gap-1.5"
-            @click="addingCustomValue = true">
-            <div class="flex items-center justify-center h-4 w-4">
-              <ScalarIcon
-                class="h-2.5"
-                icon="Add" />
-            </div>
-            <span>Add value</span>
-          </ScalarDropdownItem>
+
+          <template v-if="canAddCustomValue">
+            <ScalarDropdownDivider />
+            <ScalarDropdownItem
+              class="flex items-center gap-1.5"
+              @click="addingCustomValue = true">
+              <div class="flex items-center justify-center h-4 w-4">
+                <ScalarIcon
+                  class="h-2.5"
+                  icon="Add" />
+              </div>
+              <span>Add value</span>
+            </ScalarDropdownItem>
+          </template>
         </template>
       </ScalarDropdown>
     </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
@@ -176,6 +176,18 @@ const handleAuthorize = async () => {
       </RequestAuthDataTableInput>
     </DataTableRow>
 
+    <!-- PKCE -->
+    <DataTableRow v-if="'x-usePkce' in scheme.flow">
+      <RequestAuthDataTableInput
+        :id="`oauth2-use-pkce-${scheme.uid}`"
+        :enum="['yes', 'no']"
+        :modelValue="scheme.flow['x-usePkce'] ? 'yes' : 'no'"
+        readOnly
+        @update:modelValue="(v) => updateScheme('flow.x-usePkce', v === 'yes')">
+        Use PKCE
+      </RequestAuthDataTableInput>
+    </DataTableRow>
+
     <!-- Scopes -->
     <DataTableRow v-if="scheme.flow.scopes">
       <OAuthScopesInput

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
@@ -4,9 +4,10 @@ import { type UpdateScheme, useWorkspace } from '@/store'
 import RequestAuthDataTableInput from '@/views/Request/RequestSection/RequestAuthDataTableInput.vue'
 import { authorizeOauth2 } from '@/views/Request/libs'
 import { ScalarButton, useLoadingState } from '@scalar/components'
-import type {
-  SecuritySchemeOauth2,
-  SecuritySchemeOauth2ExampleValue,
+import {
+  type SecuritySchemeOauth2,
+  type SecuritySchemeOauth2ExampleValue,
+  pkceOptions,
 } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
 
@@ -180,10 +181,10 @@ const handleAuthorize = async () => {
     <DataTableRow v-if="'x-usePkce' in scheme.flow">
       <RequestAuthDataTableInput
         :id="`oauth2-use-pkce-${scheme.uid}`"
-        :enum="['yes', 'no']"
-        :modelValue="scheme.flow['x-usePkce'] ? 'yes' : 'no'"
+        :enum="pkceOptions"
+        :modelValue="scheme.flow['x-usePkce']"
         readOnly
-        @update:modelValue="(v) => updateScheme('flow.x-usePkce', v === 'yes')">
+        @update:modelValue="(v) => updateScheme('flow.x-usePkce', v)">
         Use PKCE
       </RequestAuthDataTableInput>
     </DataTableRow>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
@@ -8,6 +8,7 @@ import type {
   SecuritySchemeOauth2,
   SecuritySchemeOauth2ExampleValue,
 } from '@scalar/oas-utils/entities/spec'
+import { useToasts } from '@scalar/use-toasts'
 
 import OAuthScopesInput from './OAuthScopesInput.vue'
 
@@ -17,6 +18,8 @@ const props = defineProps<{
 }>()
 
 const loadingState = useLoadingState()
+const { toast } = useToasts()
+
 const {
   activeCollection,
   activeServer,
@@ -41,13 +44,17 @@ const handleAuthorize = async () => {
   if (loadingState.isLoading || !activeCollection.value?.uid) return
   loadingState.startLoading()
 
-  const accessToken = await authorizeOauth2(
+  const [error, accessToken] = await authorizeOauth2(
     props.scheme,
     props.example,
     activeServer.value,
   ).finally(() => loadingState.stopLoading())
 
   if (accessToken) updateAuth(`auth.${props.scheme.uid}.token`, accessToken)
+  else {
+    console.error(error)
+    toast(error?.message ?? 'Failed to authorize', 'error')
+  }
 }
 </script>
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
@@ -184,7 +184,10 @@ const handleAuthorize = async () => {
         :enum="pkceOptions"
         :modelValue="scheme.flow['x-usePkce']"
         readOnly
-        @update:modelValue="(v) => updateScheme('flow.x-usePkce', v)">
+        @update:modelValue="
+          (v) =>
+            updateScheme('flow.x-usePkce', v as (typeof pkceOptions)[number])
+        ">
         Use PKCE
       </RequestAuthDataTableInput>
     </DataTableRow>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuthDataTableInput.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuthDataTableInput.vue
@@ -23,6 +23,7 @@ const emit = defineEmits<{
 <template>
   <DataTableInput
     :id="props.id"
+    :canAddCustomEnumValue="!props.readOnly"
     :containerClass="props.containerClass"
     :modelValue="props.modelValue"
     :readOnly="props.readOnly"

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import type {
   SecuritySchemeOauth2,
   SecuritySchemeOauth2ExampleValue,

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -226,8 +226,7 @@ describe('oauth2', () => {
           redirect_uri: scheme.flow['x-scalar-redirect-uri'],
           code,
           grant_type: 'authorization_code',
-          code_verifier:
-            'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-.',
+          code_verifier: 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8',
         }),
       })
     })

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -1,5 +1,5 @@
 /**
- * @vitest-environment jsdom
+ * @vitest-environment node
  */
 import type {
   SecuritySchemeOauth2,

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -81,7 +81,7 @@ describe('oauth2', () => {
       type: 'oauth2',
       flow: {
         ...baseFlow,
-        'x-usePkce': false,
+        'x-usePkce': 'no',
         'type': 'authorizationCode',
         authorizationUrl,
         tokenUrl,
@@ -151,14 +151,15 @@ describe('oauth2', () => {
     })
 
     // PKCE
-    it('should generate valid PKCE code verifier and challenge', async () => {
+    it('should generate valid PKCE code verifier and challenge using SHA-256 encryption', async () => {
       const _scheme = {
         ...scheme,
         flow: {
           ...scheme.flow,
-          'x-usePkce': true,
+          'x-usePkce': 'SHA-256',
         },
-      }
+      } as const
+
       const accessToken = 'pkce_access_token_123'
       const codeChallenge = 'AQIDBAUGCAkK'
       const code = 'pkce_auth_code_123'

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -9,7 +9,7 @@ import type {
 import { flushPromises } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { authorizeOauth2, authorizeServers } from './oauth2'
+import { authorizeOauth2 } from './oauth2'
 
 const baseScheme: Pick<
   SecuritySchemeOauth2,

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -147,6 +147,48 @@ describe('oauth2', () => {
       })
     })
 
+    // PKCE
+    // it('should generate valid PKCE code verifier and challenge', async () => {
+    //   const _scheme = {
+    //     ...scheme,
+    //     flow: {
+    //       ...scheme.flow,
+    //       'x-usePkce': true,
+    //     },
+    //   }
+
+    //   const mockCodeVerifier = 'mock_code_verifier_random_string'
+    //   const mockCodeChallenge = 'mock_code_challenge_base64url'
+
+    //   vi.spyOn(crypto, 'getRandomValues').mockImplementation(
+    //     () => new Uint8Array([1, 2, 3]),
+    //   )
+    //   vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(
+    //     new Uint8Array([4, 5, 6]).buffer,
+    //   )
+
+    //   mockWindow.location.href = `https://callback.example.com?code=pkce_auth_code_123&state=mock_state`
+
+    //   global.fetch = vi.fn().mockResolvedValueOnce({
+    //     json: () => Promise.resolve({ access_token: 'pkce_access_token_123' }),
+    //   })
+
+    //   const result = await authorizeOauth2(_scheme, example, mockServer)
+
+    //   expect(result).toBe('pkce_access_token_123')
+    //   expect(window.open).toHaveBeenCalledWith(
+    //     expect.stringContaining('code_challenge_method=S256'),
+    //     'openAuth2Window',
+    //     expect.any(String),
+    //   )
+    //   expect(global.fetch).toHaveBeenCalledWith(
+    //     'https://auth.example.com/token',
+    //     expect.objectContaining({
+    //       body: expect.stringContaining('code_verifier='),
+    //     }),
+    //   )
+    // })
+
     // Test user closing the window
     it('should handle window closure before authorization', async () => {
       const promise = authorizeOauth2(scheme, example, mockServer)
@@ -365,42 +407,6 @@ describe('oauth2', () => {
   //     type: 'oauth-pkce',
   //     clientId: 'client123',
   //   }
-
-  //   it('should generate valid PKCE code verifier and challenge', async () => {
-  //     const mockCodeVerifier = 'mock_code_verifier_random_string'
-  //     const mockCodeChallenge = 'mock_code_challenge_base64url'
-
-  //     vi.spyOn(crypto, 'getRandomValues').mockImplementation(
-  //       () => new Uint8Array([1, 2, 3]),
-  //     )
-  //     vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(
-  //       new Uint8Array([4, 5, 6]).buffer,
-  //     )
-
-  //     setTimeout(() => {
-  //       mockWindow.location.href = `https://callback.example.com?code=pkce_auth_code_123&state=mock_state`
-  //     }, 100)
-
-  //     global.fetch = vi.fn().mockResolvedValueOnce({
-  //       json: () => Promise.resolve({ access_token: 'pkce_access_token_123' }),
-  //     })
-
-  //     const result = await authorizeOauth2(scheme, example, mockServer)
-
-  //     expect(result).toBe('pkce_access_token_123')
-  //     expect(window.open).toHaveBeenCalledWith(
-  //       expect.stringContaining('code_challenge_method=S256'),
-  //       'openAuth2Window',
-  //       expect.any(String),
-  //     )
-  //     expect(global.fetch).toHaveBeenCalledWith(
-  //       'https://auth.example.com/token',
-  //       expect.objectContaining({
-  //         body: expect.stringContaining('code_verifier='),
-  //       }),
-  //     )
-  //   })
-  // })
 
   // Device code is coming in openapi spec 3.2.0
   // If anyone needs it before we can add it

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -1,5 +1,5 @@
 /**
- * @vitest-environment node
+ * @vitest-environment jsdom
  */
 import type {
   SecuritySchemeOauth2,
@@ -178,6 +178,8 @@ describe('oauth2', () => {
       })
 
       // Mock crypto.subtle.digest
+      // @ts-expect-error we mock in subtle
+      vi.spyOn(crypto, 'subtle').mockImplementation(() => ({}))
       vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(
         new Uint8Array([1, 2, 3, 4, 5, 6, 8, 9, 10]).buffer,
       )

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -151,7 +151,7 @@ describe('oauth2', () => {
     })
 
     // PKCE
-    it.only('should generate valid PKCE code verifier and challenge', async () => {
+    it('should generate valid PKCE code verifier and challenge', async () => {
       const _scheme = {
         ...scheme,
         flow: {

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -49,12 +49,16 @@ const generateCodeChallenge = async (
 ): Promise<string> => {
   if (encoding === 'plain') return verifier
 
+  // ASCII encoding is just taking the lower 8 bits of each character
   const encoder = new TextEncoder()
   const data = encoder.encode(verifier)
   const digest = await crypto.subtle.digest('SHA-256', data)
-  const str = String.fromCharCode(...new Uint8Array(digest))
 
-  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  // Base64URL encode the bytes
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
 }
 
 /**

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -24,21 +24,19 @@ type PKCEState = {
 }
 
 /**
- * Generates a random string of specified length using crypto API
- * Length must be between 43 and 128 characters as per RFC 7636
+ * Generates a random string for PKCE code verifier
+ * Compliant with RFC 7636 section 4.1
  */
-const generateCodeVerifier = (length = 64): string => {
-  const array = new Uint8Array(length)
-  crypto.getRandomValues(array)
+const generateCodeVerifier = (): string => {
+  // Generate 32 random bytes
+  const buffer = new Uint8Array(32)
+  crypto.getRandomValues(buffer)
 
-  return Array.from(array)
-    .map(
-      (x) =>
-        'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~'[
-          x % 66
-        ],
-    )
-    .join('')
+  // Base64URL encode the bytes
+  return btoa(String.fromCharCode(...buffer))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
 }
 
 /**
@@ -116,6 +114,8 @@ export const authorizeOauth2 = async (
             codeChallengeMethod:
               scheme.flow['x-usePkce'] === 'SHA-256' ? 'S256' : 'plain',
           }
+
+          console.log('pkce', pkce)
 
           // Set the code challenge and method on the url
           url.searchParams.set('code_challenge', codeChallenge)

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -25,7 +25,8 @@ type PKCEState = {
 
 /**
  * Generates a random string for PKCE code verifier
- * Compliant with RFC 7636 section 4.1
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc7636#page-8
  */
 const generateCodeVerifier = (): string => {
   // Generate 32 random bytes

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -120,8 +120,6 @@ export const authorizeOauth2 = async (
               scheme.flow['x-usePkce'] === 'SHA-256' ? 'S256' : 'plain',
           }
 
-          console.log('pkce', pkce)
-
           // Set the code challenge and method on the url
           url.searchParams.set('code_challenge', codeChallenge)
           url.searchParams.set(

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -43,7 +43,7 @@ const generateCodeVerifier = (): string => {
 /**
  * Creates a code challenge from the code verifier
  */
-const generateCodeChallenge = async (
+export const generateCodeChallenge = async (
   verifier: string,
   encoding: 'SHA-256' | 'plain',
 ): Promise<string> => {

--- a/packages/oas-utils/src/entities/spec/security.ts
+++ b/packages/oas-utils/src/entities/spec/security.ts
@@ -238,6 +238,9 @@ const defaultRedirectUri =
     ? window.location.origin + window.location.pathname
     : ''
 
+/** Options for the x-usePkce extension */
+export const pkceOptions = ['SHA-256', 'plain', 'no'] as const
+
 export const oasOauthFlowSchema = z
   .discriminatedUnion('type', [
     /** Configuration for the OAuth Implicit flow */
@@ -268,7 +271,7 @@ export const oasOauthFlowSchema = z
        *
        * TODO: add docs
        */
-      'x-usePkce': z.boolean().optional().default(false),
+      'x-usePkce': z.enum(pkceOptions).optional().default('no'),
       'x-scalar-redirect-uri': z
         .string()
         .optional()

--- a/packages/oas-utils/src/entities/spec/security.ts
+++ b/packages/oas-utils/src/entities/spec/security.ts
@@ -263,6 +263,12 @@ export const oasOauthFlowSchema = z
     oauthCommon.extend({
       'type': z.literal('authorizationCode'),
       authorizationUrl,
+      /**
+       * Whether to use PKCE for the authorization code flow.
+       *
+       * TODO: add docs
+       */
+      'x-usePkce': z.boolean().optional().default(false),
       'x-scalar-redirect-uri': z
         .string()
         .optional()

--- a/packages/oas-utils/src/migrations/v-2.1.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.1.0/migration.ts
@@ -243,7 +243,7 @@ export const migrate_v_2_1_0 = (data: Omit<v_0_0_0.Data, 'folders'>) => {
     return {
       ...flow,
       ...base,
-      'x-usePkce': false,
+      'x-usePkce': 'no',
       'x-scalar-redirect-uri':
         ('redirectUri' in flow ? flow.redirectUri : '') || '',
       'authorizationUrl': flow.authorizationUrl || '',

--- a/packages/oas-utils/src/migrations/v-2.1.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.1.0/migration.ts
@@ -239,9 +239,11 @@ export const migrate_v_2_1_0 = (data: Omit<v_0_0_0.Data, 'folders'>) => {
         ...base,
         tokenUrl: flow.tokenUrl || '',
       }
+
     return {
       ...flow,
       ...base,
+      'x-usePkce': false,
       'x-scalar-redirect-uri':
         ('redirectUri' in flow ? flow.redirectUri : '') || '',
       'authorizationUrl': flow.authorizationUrl || '',


### PR DESCRIPTION
closes #604
closes #3705

Added a super basic front-end
![image](https://github.com/user-attachments/assets/99c272c6-b546-4a1d-8e7f-c17a11d7ef1c)

and tested it using spotify (they support pkce)
![image](https://github.com/user-attachments/assets/316aeb2c-c101-4a9c-a04e-6e1c2c26f160)
