### PR TITLE
feat: added another option for rust integration

### DIFF
--- a/documentation/integrations/rust.md
+++ b/documentation/integrations/rust.md
@@ -31,13 +31,14 @@ let router: ApiRouter = ApiRouter::new()
 ```
 
 If you want to use Scalar with Actix or any other web framework, you can do that too with the crate [scalar-doc](https://crates.io/crates/scalar-doc).
-To get started with Actix, first install the crate and activate `actix` feature : 
-  
+To get started with Actix, first install the crate and activate `actix` feature :
+
 ```bash
 cargo add scalar-doc -F actix
 ```
 
 You can use the following code
+
 ```rust
 use actix_web::{get, App, HttpResponse, HttpServer, Responder};
 use scalar_doc::scalar_actix::ActixDocumentation;

--- a/documentation/integrations/rust.md
+++ b/documentation/integrations/rust.md
@@ -29,3 +29,37 @@ let router: ApiRouter = ApiRouter::new()
 
 // …
 ```
+
+If you want to use Scalar with Actix or any other web framework, you can do that too with the crate [scalar-doc](https://crates.io/crates/scalar-doc).
+To get started with Actix, first install the crate and activate `actix` feature : 
+  
+```bash
+cargo add scalar-doc -F actix
+```
+
+You can use the following code
+```rust
+use actix_web::{get, App, HttpResponse, HttpServer, Responder};
+use scalar_doc::scalar_actix::ActixDocumentation;
+
+#[get("/")]
+async fn doc() -> impl Responder {
+    ActixDocumentation::new("Api Documentation title", "/openapi")
+        .theme(scalar_doc::Theme::Kepler)
+        .service()
+}
+
+#[get("/openapi")]
+async fn openapi() -> impl Responder {
+    let open = include_str!("openapi.json");
+    HttpResponse::Ok().body(open)
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| App::new().service(doc).service(openapi))
+        .bind(("127.0.0.1", 8080))?
+        .run()
+        .await
+}
+```


### PR DESCRIPTION
**Problem**
Currently, I struggled a bit with the current rust integration of scalar since it was to much oriented towards axum and I couldn't make it work with actix.

**Solution**
With this PR I propose another integration of scalar in rust that focuses on integrating scalar in any rust web framework. Don't get me wrong, tamasfe's crate is really good, but its DX is too much scoped towards axum.

Here is the crate I propose : [scalar-doc.rs](https://crates.io/crates/scalar-doc)