### PR TITLE
style(api-client): response section childs space

### DIFF
--- a/.changeset/calm-files-float.md
+++ b/.changeset/calm-files-float.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: enhances response section childs spacing

--- a/.changeset/clean-paws-leave.md
+++ b/.changeset/clean-paws-leave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: adds scalar code block max height

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -17,7 +17,7 @@ withDefaults(
   <Disclosure
     v-slot="{ open }"
     as="div"
-    class="focus-within:bg-b-2 ui-not-open:hover:bg-b-2 focus-within:text-c-1 text-c-2 rounded request-item ui-not-open:bg-transparent ui-open:pb-1 ui-open:mb-3 ui-not-open:mb-0 ui-not-open:pb-0"
+    class="focus-within:bg-b-2 ui-not-open:hover:bg-b-2 focus-within:text-c-1 text-c-2 rounded request-item ui-not-open:bg-transparent ui-open:pb-1 ui-open:[&:not(:last-child)]:mb-1.5 ui-not-open:mb-0 ui-not-open:pb-0"
     :defaultOpen="defaultOpen">
     <div class="flex items-center">
       <DisclosureButton
@@ -48,7 +48,9 @@ withDefaults(
       </div>
     </div>
 
-    <DisclosurePanel class="rounded-b diclosure-panel">
+    <DisclosurePanel
+      v-bind="$attrs"
+      class="h-full max-h-fit rounded-b diclosure-panel">
       <slot :open="open" />
     </DisclosurePanel>
   </Disclosure>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -63,7 +63,7 @@ const dataUrl = computed<string>(() => {
 })
 </script>
 <template>
-  <ViewLayoutCollapse>
+  <ViewLayoutCollapse class="max-h-content overflow-x-auto">
     <template #title>{{ title }}</template>
     <template
       v-if="data && dataUrl"
@@ -75,7 +75,7 @@ const dataUrl = computed<string>(() => {
     </template>
     <div
       v-if="data"
-      class="mx-1 border-1/2 flex flex-col rounded bg-b-1">
+      class="max-h-[calc(100%-32px)] mx-1 border-1/2 flex flex-col rounded bg-b-1 overflow-hidden">
       <div class="flex justify-between items-center border-b-1/2 px-3 py-1.5">
         <span class="text-xxs leading-3 font-code">
           {{ mimeType.essence }}

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -12,16 +12,14 @@ const textContent = computed(() => formatJsonOrYamlString(props.content))
 </script>
 
 <template>
-  <ViewLayoutCollapse class="response-body-virtual">
+  <ViewLayoutCollapse class="!max-h-[calc(100%-32px)] response-body-virtual">
     <template #title>Body</template>
-
     <div
-      class="py-1.5 px-2.5 font-code text-xxs border-1/2 rounded-t border-b-0">
+      class="mx-1 py-1.5 px-2.5 font-code text-xxs border-1/2 rounded-t border-b-0">
       This response body is massive! Syntax highlighting won’t work here.
     </div>
-
     <ScalarVirtualText
-      containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1"
+      containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1 mx-1"
       contentClass="hljs language-plaintext"
       :lineHeight="20"
       :text="textContent" />

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -20,34 +20,39 @@ const findHeaderInfo = (name: string) => {
 </script>
 <template>
   <ViewLayoutCollapse
+    class="overflow-scroll"
     :defaultOpen="false"
     :itemCount="headers.length">
     <template #title>Headers</template>
-    <DataTable
+    <div
       v-if="headers.length"
-      :columns="['minmax(auto, min-content)', 'minmax(50%, 1fr)']"
-      scroll>
-      <DataTableRow
-        v-for="(item, idx) in headers"
-        :key="idx"
-        class="text-c-1">
-        <DataTableText class="sticky left-0 z-1 bg-b-1 max-w-48">
-          <template v-if="typeof findHeaderInfo(item.name)?.url === 'string'">
-            <HelpfulLink
-              class="decoration-c-3"
-              :href="findHeaderInfo(item.name)!.url">
+      class="border max-h-[calc(100%-32px)] overflow-y-auto rounded md:mx-1">
+      <DataTable
+        class="!border-0 !mx-0"
+        :columns="['minmax(auto, min-content)', 'minmax(50%, 1fr)']"
+        scroll>
+        <DataTableRow
+          v-for="(item, idx) in headers"
+          :key="idx"
+          class="text-c-1">
+          <DataTableText class="sticky left-0 z-1 bg-b-1 max-w-48">
+            <template v-if="typeof findHeaderInfo(item.name)?.url === 'string'">
+              <HelpfulLink
+                class="decoration-c-3"
+                :href="findHeaderInfo(item.name)!.url">
+                {{ item.name }}
+              </HelpfulLink>
+            </template>
+            <template v-else>
               {{ item.name }}
-            </HelpfulLink>
-          </template>
-          <template v-else>
-            {{ item.name }}
-          </template>
-        </DataTableText>
-        <DataTableText
-          class="z-0"
-          :text="item.value" />
-      </DataTableRow>
-    </DataTable>
+            </template>
+          </DataTableText>
+          <DataTableText
+            class="z-0"
+            :text="item.value" />
+        </DataTableRow>
+      </DataTable>
+    </div>
     <!-- Empty state -->
     <div
       v-else

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -86,7 +86,10 @@ const shouldVirtualize = computed(
       </div>
     </template>
     <div
-      class="custom-scroll relative flex flex-1 flex-col px-2 xl:px-4 py-2.5">
+      class="custom-scroll h-full relative grid gap-[.5px] px-2 xl:px-4 py-2.5"
+      :class="{
+        'content-start': response,
+      }">
       <template v-if="!response">
         <ResponseEmpty />
       </template>

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -47,7 +47,7 @@ const isContentValid = computed(() => {
 })
 </script>
 <template>
-  <div class="scalar-code-block custom-scroll">
+  <div class="scalar-code-block custom-scroll min-h-12">
     <div
       v-if="copy"
       class="scalar-code-copy">
@@ -73,7 +73,7 @@ const isContentValid = computed(() => {
   background: inherit;
   position: relative;
   overflow: auto;
-  padding: 0.5rem 0.5rem 0.5rem 0.75rem;
+  padding: 0.75rem;
 }
 .scalar-code-block:hover .copy-button,
 .copy-button:focus-visible {
@@ -86,6 +86,7 @@ const isContentValid = computed(() => {
   text-wrap: nowrap;
   white-space-collapse: preserve;
   border-radius: 0;
+  width: fit-content;
 }
 /* Copy Button */
 .scalar-code-copy {


### PR DESCRIPTION
this pr is a first raw approach regarding the response section items in order to have them fill up the given space vs overflowing no matter their height, along code block + response body virtual component fixtures:

**response body block before / after**

⊢ PR updates the overflow and style of the response section to maintain the visualization of section titles for any child's height:

<details>
<summary>before / after screenshots</summary>

https://github.com/user-attachments/assets/27550126-e492-4c90-baa1-a74a6ae0bd0a

https://github.com/user-attachments/assets/0196dd57-f840-417a-af8a-7bf742fb1ac0
</details>

**response cookie block before / after**

<details>
<summary>before / after screenshots</summary>
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/e2d311de-8f83-4abe-acf1-f9e7e970285b">
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/e96f4063-b361-4dcb-a0a1-2bf748430b2a">
</details>

**code block before / after**

⊢ PR adds a minimum height to maintain good visual balance on one line response body:

<details>
<summary>before / after screenshots</summary>

<img width="1129" alt="image" src="https://github.com/user-attachments/assets/e0d02aa1-19da-4f00-a16f-5ec5a9d1e98e">
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/c5d5c3c3-85b2-4d61-ad89-5ddfc24197d2">
</details>
