### PR TITLE
fix: remove URL validation from collection info

### DIFF
--- a/.changeset/odd-pans-grow.md
+++ b/.changeset/odd-pans-grow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: remove url validation from collection info

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -15,7 +15,7 @@ export const oasLicenseSchema = z.object({
    * A URL to the license used for the API. This MUST be in the form of a URL. The url field
    * is mutually exclusive of the identifier field.
    */
-  url: z.string().url().optional(),
+  url: z.string().optional(),
 })
 
 /**
@@ -28,7 +28,7 @@ export const oasContactSchema = z.object({
   /** The identifying name of the contact person/organization. */
   name: z.string().optional(),
   /** The URL pointing to the contact information. This MUST be in the form of a URL. */
-  url: z.string().url().optional(),
+  url: z.string().optional(),
   /** The email address of the contact person/organization. This MUST be in the form of an email address. */
   email: z.string().email().optional(),
 })


### PR DESCRIPTION
I think this is the last of it, I would add safe parsing to collection but if there's no collection, we can't show anything anyway