### PR TITLE
chore(api-reference): remove unnecessary SVG attribute

### DIFF
--- a/.changeset/silly-beers-unite.md
+++ b/.changeset/silly-beers-unite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: remove unnecessary svg attribute

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
@@ -112,8 +112,7 @@ const showSchema = ref(false)
           @click="() => copyToClipboard(currentJsonResponse?.example)">
           <ScalarIcon
             icon="Clipboard"
-            width="12px"
-            x="asd" />
+            width="12px" />
         </button>
         <label
           v-if="currentJsonResponse?.schema"


### PR DESCRIPTION
I think this attribute is just a leftover. Let’s try to remove it. :)

Fixes #3725