### PR TITLE
fix(oas-utils): path regex

### DIFF
--- a/.changeset/many-eagles-judge.md
+++ b/.changeset/many-eagles-judge.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: updates path regex

--- a/packages/oas-utils/src/helpers/regexHelpers.ts
+++ b/packages/oas-utils/src/helpers/regexHelpers.ts
@@ -1,2 +1,2 @@
 export const variableRegex = /{{((?:[^{}]|{[^{}]*})*)}}/g
-export const pathRegex = /(?<!{){([^{}]+)}(?!})/g
+export const pathRegex = /(?:{)([^{}]+)}(?!})/g


### PR DESCRIPTION
this pr fixes the path regex that is [not supported by safari](https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group) and breaks the client rendering.

```
SyntaxError: Invalid regular expression: invalid group specifier name
```