### PR TITLE
fix(openapi-parser): when migrating plain `example` to example objects there’s no `value` attribute

### DIFF
--- a/.changeset/ten-cobras-run.md
+++ b/.changeset/ten-cobras-run.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: when migrating example to example objects, the example should be inside the value attribute

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
@@ -172,8 +172,8 @@ describe('upgradeFromThreeToThreeOne', () => {
     })
   })
 
-  describe('use examples not example in schemas', () => {
-    it('migrates example to examples', async () => {
+  describe('migrates example to examples', () => {
+    it('uses arrays in schemas', async () => {
       const result = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -207,6 +207,49 @@ describe('upgradeFromThreeToThreeOne', () => {
       ).toEqual({
         type: 'integer',
         examples: [1],
+      })
+    })
+
+    it('uses example objects everywhere else', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/test': {
+            get: {
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  schema: {
+                    type: 'integer',
+                    example: 10,
+                  },
+                  example: 10,
+                },
+              ],
+            },
+          },
+        },
+      })
+
+      expect(result.paths['/test'].get.parameters[0]).toEqual({
+        name: 'limit',
+        in: 'query',
+        schema: {
+          type: 'integer',
+          // array, because it’s in a schema
+          examples: [10],
+        },
+        // object, because it’s not in a schema
+        examples: {
+          default: {
+            value: 10,
+          },
+        },
       })
     })
   })

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -56,7 +56,9 @@ export function upgradeFromThreeToThreeOne(originalSpecification: AnyObject) {
       // Objects everywhere else
       else {
         schema.examples = {
-          default: schema.example,
+          default: {
+            value: schema.example,
+          },
         }
       }
       delete schema.example


### PR DESCRIPTION
When upgrading an (old) example structure to the (new) example objects, for some reason I didn’t put the example in the `value` attribute. I just reread the specification and fixed this.

@amritk Does this break the API client schema? Would you mind to look into this? 

**Before**
```js
{
  examples: {
    default: 'foobar'
  }
}
```

**After**
```js
{
  examples: {
    default: {
      value: 'foobar'
    }
  }
}
```

OpenAPI 3.1 Example Object: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#example-object

Fixes #3760.