### PR TITLE
feat(openapi-types): add OpenAPI 3.0.4 and OpenAPI 3.1.1

### DIFF
--- a/.changeset/thick-readers-jog.md
+++ b/.changeset/thick-readers-jog.md
@@ -1,0 +1,7 @@
+---
+'@scalar/openapi-parser': patch
+'@scalar/openapi-types': patch
+'@scalar/galaxy': patch
+---
+
+feat: add openapi 3.0.4 and openapi 3.1.1

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.1.1
 info:
   title: Scalar Galaxy
   description: |

--- a/packages/galaxy/tests/yaml.test.ts
+++ b/packages/galaxy/tests/yaml.test.ts
@@ -4,6 +4,6 @@ import galaxy from '../src/specifications/3.1.yaml?raw'
 
 describe('yaml', () => {
   it('has OpenAPI version', () => {
-    expect(galaxy).toContain('openapi: 3.1.0')
+    expect(galaxy).toContain('openapi: 3.1.1')
   })
 })

--- a/packages/openapi-parser/src/utils/openapi/openapi.test.ts
+++ b/packages/openapi-parser/src/utils/openapi/openapi.test.ts
@@ -88,7 +88,7 @@ describe('pipeline', () => {
       .upgrade()
       .get()
 
-    expect(specification.openapi).toBe('3.1.0')
+    expect(specification.openapi).toBe('3.1.1')
   })
 
   it('details', async () => {
@@ -229,7 +229,7 @@ describe('pipeline', () => {
       .filter((schema) => !schema?.tags?.includes('Beta'))
       .get()
 
-    expect(specification.openapi).toBe('3.1.0')
+    expect(specification.openapi).toBe('3.1.1')
     expect(specification.paths['/'].get).toBeUndefined()
     expect(specification.paths['/foobar'].get).not.toBeUndefined()
   })

--- a/packages/openapi-parser/src/utils/openapi/utils/workThroughQueue.test.ts
+++ b/packages/openapi-parser/src/utils/openapi/utils/workThroughQueue.test.ts
@@ -14,7 +14,7 @@ describe('workThroughQueue', () => {
         paths: {},
       },
       specification: {
-        openapi: '3.1.0',
+        openapi: '3.1.1',
         info: {
           title: 'Hello World',
           version: '1.0.0',
@@ -68,7 +68,7 @@ describe('workThroughQueue', () => {
         paths: {},
       },
       specification: {
-        openapi: '3.1.0',
+        openapi: '3.1.1',
         info: {
           title: 'Hello World',
           version: '1.0.0',
@@ -106,7 +106,7 @@ describe('workThroughQueue', () => {
         },
       ],
       specification: {
-        openapi: '3.1.0',
+        openapi: '3.1.1',
         info: {
           title: 'Hello World',
           version: '1.0.0',
@@ -135,7 +135,7 @@ describe('workThroughQueue', () => {
         paths: {},
       },
       specification: {
-        openapi: '3.1.0',
+        openapi: '3.1.1',
         info: {
           title: 'Hello World',
           version: '1.0.0',
@@ -174,7 +174,7 @@ describe('workThroughQueue', () => {
         },
       ],
       specification: {
-        openapi: '3.1.0',
+        openapi: '3.1.1',
         info: {
           title: 'Hello World',
           version: '1.0.0',
@@ -224,7 +224,7 @@ describe('workThroughQueue', () => {
       errors: [],
       version: '3.1',
       specification: {
-        openapi: '3.1.0',
+        openapi: '3.1.1',
         info: {
           title: 'Hello World',
           version: '1.0.0',

--- a/packages/openapi-parser/src/utils/openapi/utils/workThroughQueue.test.ts
+++ b/packages/openapi-parser/src/utils/openapi/utils/workThroughQueue.test.ts
@@ -68,7 +68,7 @@ describe('workThroughQueue', () => {
         paths: {},
       },
       specification: {
-        openapi: '3.1.1',
+        openapi: '3.1.0',
         info: {
           title: 'Hello World',
           version: '1.0.0',
@@ -106,7 +106,7 @@ describe('workThroughQueue', () => {
         },
       ],
       specification: {
-        openapi: '3.1.1',
+        openapi: '3.1.0',
         info: {
           title: 'Hello World',
           version: '1.0.0',
@@ -135,7 +135,7 @@ describe('workThroughQueue', () => {
         paths: {},
       },
       specification: {
-        openapi: '3.1.1',
+        openapi: '3.1.0',
         info: {
           title: 'Hello World',
           version: '1.0.0',
@@ -174,7 +174,7 @@ describe('workThroughQueue', () => {
         },
       ],
       specification: {
-        openapi: '3.1.1',
+        openapi: '3.1.0',
         info: {
           title: 'Hello World',
           version: '1.0.0',
@@ -242,7 +242,7 @@ describe('workThroughQueue', () => {
               title: 'Hello World',
               version: '1.0.0',
             },
-            openapi: '3.1.0',
+            openapi: '3.1.1',
             paths: {},
           },
         },

--- a/packages/openapi-parser/src/utils/upgrade.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade.test.ts
@@ -16,7 +16,7 @@ describe('upgrade', () => {
     })
 
     expect(specification.swagger).toBeUndefined()
-    expect(specification.openapi).toBe('3.1.0')
+    expect(specification.openapi).toBe('3.1.1')
   })
 
   it('changes the version to from 3.0.0 to 3.1.0', async () => {
@@ -29,7 +29,7 @@ describe('upgrade', () => {
       paths: {},
     })
 
-    expect(specification.openapi).toBe('3.1.0')
+    expect(specification.openapi).toBe('3.1.1')
   })
 
   it('changes the version to 3.0.3 to 3.1.0', async () => {
@@ -42,7 +42,7 @@ describe('upgrade', () => {
       paths: {},
     })
 
-    expect(specification.openapi).toBe('3.1.0')
+    expect(specification.openapi).toBe('3.1.1')
   })
 
   it('works with a filesystem', async () => {
@@ -57,6 +57,6 @@ describe('upgrade', () => {
       }),
     )
 
-    expect(specification.openapi).toBe('3.1.0')
+    expect(specification.openapi).toBe('3.1.1')
   })
 })

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
@@ -64,7 +64,7 @@ describe('upgradeFromThreeToThreeOne', () => {
       expect(result.swagger).toBe('2.0')
     })
 
-    it('changes the version to from 3.0.0 to 3.1.0', async () => {
+    it('changes the version to from 3.0.0 to 3.1.1', async () => {
       const result = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -74,10 +74,10 @@ describe('upgradeFromThreeToThreeOne', () => {
         paths: {},
       })
 
-      expect(result.openapi).toBe('3.1.0')
+      expect(result.openapi).toBe('3.1.1')
     })
 
-    it('changes the version to 3.0.3 to 3.1.0', async () => {
+    it('changes the version to 3.0.3 to 3.1.1', async () => {
       const result = upgradeFromThreeToThreeOne({
         openapi: '3.0.3',
         info: {
@@ -87,7 +87,7 @@ describe('upgradeFromThreeToThreeOne', () => {
         paths: {},
       })
 
-      expect(result.openapi).toBe('3.1.0')
+      expect(result.openapi).toBe('3.1.1')
     })
   })
 

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -11,7 +11,7 @@ export function upgradeFromThreeToThreeOne(originalSpecification: AnyObject) {
 
   // Version
   if (specification.openapi?.startsWith('3.0')) {
-    specification.openapi = '3.1.0'
+    specification.openapi = '3.1.1'
   } else {
     // Skip if it’s something else than 3.0.x
     return specification

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -13,7 +13,7 @@ describe('upgradeFromTwoToThree', () => {
       paths: {},
     })
 
-    expect(result.openapi).toBe('3.0.3')
+    expect(result.openapi).toBe('3.0.4')
     expect(result.swagger).toBeUndefined()
   })
 

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -11,7 +11,7 @@ import { traverse } from './traverse'
 export function upgradeFromTwoToThree(specification: AnyObject) {
   // Version
   if (specification.swagger?.startsWith('2.0')) {
-    specification.openapi = '3.0.3'
+    specification.openapi = '3.0.4'
     delete specification.swagger
   } else {
     // Skip if it’s something else than 3.0.x

--- a/packages/openapi-types/src/openapi-types.test-d.ts
+++ b/packages/openapi-types/src/openapi-types.test-d.ts
@@ -19,7 +19,7 @@ describe('OpenAPI', () => {
     expectTypeOf(specification).toMatchTypeOf<OpenAPIV2.Document>()
   })
 
-  it('narrows it down to OpenAPI 3.0', () => {
+  it('narrows it down to OpenAPI 3.0.0', () => {
     const specification: OpenAPI.Document = {
       openapi: '3.0.0',
     }
@@ -27,9 +27,25 @@ describe('OpenAPI', () => {
     expectTypeOf(specification).toMatchTypeOf<OpenAPIV3.Document>()
   })
 
-  it('narrows it down to OpenAPI 3.1', () => {
+  it('narrows it down to OpenAPI 3.0.4', () => {
+    const specification: OpenAPI.Document = {
+      openapi: '3.0.4',
+    }
+
+    expectTypeOf(specification).toMatchTypeOf<OpenAPIV3.Document>()
+  })
+
+  it('narrows it down to OpenAPI 3.1.0', () => {
     const specification: OpenAPI.Document = {
       openapi: '3.1.0',
+    }
+
+    expectTypeOf(specification).toMatchTypeOf<OpenAPIV3_1.Document>()
+  })
+
+  it('narrows it down to OpenAPI 3.1.1', () => {
+    const specification: OpenAPI.Document = {
+      openapi: '3.1.1',
     }
 
     expectTypeOf(specification).toMatchTypeOf<OpenAPIV3_1.Document>()

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -90,7 +90,7 @@ export namespace OpenAPIV3_1 {
        * Version of the OpenAPI specification
        * @see https://github.com/OAI/OpenAPI-Specification/tree/main/versions
        */
-      openapi?: '3.1.0'
+      openapi?: '3.1.0' | '3.1.1'
       swagger?: undefined
       info?: InfoObject
       jsonSchemaDialect?: string
@@ -322,7 +322,7 @@ export namespace OpenAPIV3 {
      * Version of the OpenAPI specification
      * @see https://github.com/OAI/OpenAPI-Specification/tree/main/versions
      */
-    openapi?: '3.0.0' | '3.0.1' | '3.0.2' | '3.0.3'
+    openapi?: '3.0.0' | '3.0.1' | '3.0.2' | '3.0.3' | '3.0.4'
     swagger?: undefined
     info?: InfoObject
     servers?: ServerObject[]


### PR DESCRIPTION
Adds [OpenAPI 3.0.4](https://github.com/OAI/OpenAPI-Specification/releases/tag/3.0.4) and [OpenAPI 3.1.1](https://github.com/OAI/OpenAPI-Specification/releases/tag/3.1.1) to:

* `@scalar/openapi-types`
* `@scalar/openapi-parser`
* `@scalar/galaxy`

There’s no new features, just additional explanations in the specification it seems.

Fixes #3652.