### PR TITLE
feat(mock-server): OpenID Connect (OIDC) endpoint

### DIFF
--- a/.changeset/little-dragons-care.md
+++ b/.changeset/little-dragons-care.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+feat: add openIdConnect support

--- a/.changeset/silver-mice-sleep.md
+++ b/.changeset/silver-mice-sleep.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat: add an openIdConnect security scheme

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -423,6 +423,10 @@ components:
             read:account: read your account information
             write:planets: modify planets in your account
             read:planets: read your planets
+    openIdConnect:
+      type: openIdConnect
+      openIdConnectUrl: https://galaxy.scalar.com/.well-known/openid-configuration
+      description: OpenID Connect Authentication
   parameters:
     planetId:
       name: planetId

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -372,23 +372,29 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
+      description: JWT Bearer token authentication
     basicAuth:
       type: http
       scheme: basic
+      description: Basic HTTP authentication
     apiKeyHeader:
       type: apiKey
       in: header
       name: X-API-Key
+      description: API key request header
     apiKeyQuery:
       type: apiKey
       in: query
       name: api_key
+      description: API key query parameter
     apiKeyCookie:
       type: apiKey
       in: cookie
       name: api_key
+      description: API key browser cookie
     oAuth2:
       type: oauth2
+      description: OAuth 2.0 authentication
       flows:
         authorizationCode:
           authorizationUrl: https://galaxy.scalar.com/oauth/authorize

--- a/packages/mock-server/src/utils/handleAuthentication.ts
+++ b/packages/mock-server/src/utils/handleAuthentication.ts
@@ -69,7 +69,13 @@ export function handleAuthentication(
                 if (c.req.header('Authorization')?.startsWith('Bearer ')) {
                   isAuthenticated = true
                 }
-
+                break
+              case 'openIdConnect':
+                authScheme = 'Bearer'
+                // Handle OpenID Connect similar to OAuth2
+                if (c.req.header('Authorization')?.startsWith('Bearer ')) {
+                  isAuthenticated = true
+                }
                 break
             }
           }

--- a/packages/mock-server/src/utils/logAuthenticationInstructions.ts
+++ b/packages/mock-server/src/utils/logAuthenticationInstructions.ts
@@ -15,8 +15,6 @@ export function logAuthenticationInstructions(
   console.log('Authentication:')
   console.log()
 
-  console.log(securitySchemes)
-
   Object.entries(securitySchemes).forEach(([_, scheme]) => {
     switch (scheme.type) {
       case 'apiKey':

--- a/packages/mock-server/src/utils/logAuthenticationInstructions.ts
+++ b/packages/mock-server/src/utils/logAuthenticationInstructions.ts
@@ -15,6 +15,8 @@ export function logAuthenticationInstructions(
   console.log('Authentication:')
   console.log()
 
+  console.log(securitySchemes)
+
   Object.entries(securitySchemes).forEach(([_, scheme]) => {
     switch (scheme.type) {
       case 'apiKey':
@@ -132,7 +134,13 @@ export function logAuthenticationInstructions(
         }
         break
       case 'openIdConnect':
-        console.log('⚠️ OpenID Connect Authentication')
+        console.log('✅ OpenID Connect Authentication')
+        console.log('   Use the following OpenID Connect discovery URL:')
+        console.log()
+        console.log(
+          `   ${getPathFromUrl(scheme.openIdConnectUrl || '/.well-known/openid-configuration')}`,
+        )
+        console.log()
         break
       default:
         console.warn(`Unsupported security scheme type: ${scheme.type}`)

--- a/packages/mock-server/src/utils/setupAuthenticationRoutes.ts
+++ b/packages/mock-server/src/utils/setupAuthenticationRoutes.ts
@@ -76,7 +76,9 @@ export function setupAuthenticationRoutes(
     } else if (scheme.type === 'openIdConnect') {
       // Handle OpenID Connect configuration
       if (scheme.openIdConnectUrl) {
-        const configPath = getPathFromUrl(scheme.openIdConnectUrl)
+        const configPath = getPathFromUrl(
+          scheme.openIdConnectUrl ?? '/.well-known/openid-configuration',
+        )
 
         // Add route for OpenID Connect configuration
         app.get(configPath, (c) => {

--- a/packages/mock-server/src/utils/setupAuthenticationRoutes.ts
+++ b/packages/mock-server/src/utils/setupAuthenticationRoutes.ts
@@ -73,6 +73,30 @@ export function setupAuthenticationRoutes(
           scheme.flows.clientCredentials.tokenUrl ?? '/oauth/token'
         tokenUrls.add(tokenRoute)
       }
+    } else if (scheme.type === 'openIdConnect') {
+      // Handle OpenID Connect configuration
+      if (scheme.openIdConnectUrl) {
+        const configPath = getPathFromUrl(scheme.openIdConnectUrl)
+
+        // Add route for OpenID Connect configuration
+        app.get(configPath, (c) => {
+          return c.json({
+            issuer: 'https://example.com',
+            authorization_endpoint: '/oauth/authorize',
+            token_endpoint: '/oauth/token',
+            response_types_supported: ['code', 'token', 'id_token'],
+            subject_types_supported: ['public'],
+            id_token_signing_alg_values_supported: ['RS256'],
+          })
+        })
+
+        // Add standard endpoints
+        const authorizeRoute = '/oauth/authorize'
+        const tokenRoute = '/oauth/token'
+
+        authorizeUrls.add(getPathFromUrl(authorizeRoute))
+        tokenUrls.add(tokenRoute)
+      }
     }
   })
 

--- a/packages/mock-server/tests/authentication/openIdConnect.test.ts
+++ b/packages/mock-server/tests/authentication/openIdConnect.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMockServer } from '../../src/createMockServer'
+import { createOpenAPIDocument } from '../../src/utils/createOpenAPIDocument'
+
+describe('OpenID Connect', () => {
+  const specification = createOpenAPIDocument({
+    openIdConnect: {
+      type: 'openIdConnect',
+      openIdConnectUrl: 'https://example.com/.well-known/openid-configuration',
+    },
+  })
+
+  specification.paths = {
+    '/oauth-test': {
+      get: {
+        security: [{ openIdConnect: [] }],
+        responses: { '200': { description: 'OK' } },
+      },
+    },
+    '/protected': {
+      get: {
+        security: [{ openIdConnect: ['profile', 'email'] }],
+        responses: { '200': { description: 'OK' } },
+      },
+    },
+  }
+
+  it('returns OpenID configuration', async () => {
+    const server = await createMockServer({ specification })
+    const response = await server.request('/.well-known/openid-configuration')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      issuer: 'https://example.com',
+      authorization_endpoint: '/oauth/authorize',
+      token_endpoint: '/oauth/token',
+      response_types_supported: ['code', 'token', 'id_token'],
+      subject_types_supported: ['public'],
+      id_token_signing_alg_values_supported: ['RS256'],
+    })
+  })
+
+  it('succeeds with valid OAuth token', async () => {
+    const server = await createMockServer({ specification })
+
+    const response = await server.request('/oauth-test', {
+      headers: { Authorization: 'Bearer valid-token' },
+    })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('succeeds with valid OAuth token for scoped endpoint', async () => {
+    const server = await createMockServer({ specification })
+
+    const response = await server.request('/protected', {
+      headers: { Authorization: 'Bearer valid-token' },
+    })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('fails without OAuth token', async () => {
+    const server = await createMockServer({ specification })
+    const response = await server.request('/oauth-test')
+
+    expect(response.status).toBe(401)
+  })
+})


### PR DESCRIPTION
This PR adds everything that’s necessary to use OpenID Connect authentication with the Mock Server. :)