### PR TITLE
refactor(api-client-app): simpler npm scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
               - packages/api-client-app/package.json
       - if: steps.changed-files.outputs.api_client_app_any_changed == 'true'
         name: Build in the toDesktop cloud
-        run: pnpm --filter scalar-api-client todesktop:build:ci
+        run: pnpm --filter scalar-api-client todesktop:build
         env:
           TODESKTOP_EMAIL: ${{ secrets.TODESKTOP_EMAIL }}
           TODESKTOP_ACCESS_TOKEN: ${{ secrets.TODESKTOP_ACCESS_TOKEN }}

--- a/packages/api-client-app/package.json
+++ b/packages/api-client-app/package.json
@@ -16,18 +16,17 @@
     "node": ">=20"
   },
   "scripts": {
-    "build": "npm run types:check && electron-vite build",
+    "build": "electron-vite build",
     "dev": "electron-vite dev",
     "dev:update": "electron-vite dev -- --runtime-simulate-updates=update-available",
     "preview": "electron-vite preview",
     "test": "vitest",
-    "todesktop:build": "npm run build && todesktop build",
-    "todesktop:build:ci": "todesktop build",
+    "todesktop:build": "todesktop build",
     "todesktop:release": "todesktop release",
     "todesktop:release:ci": "todesktop release --latest --force",
     "todesktop:test": "todesktop smoke-test",
     "todesktop:test:ci": "todesktop smoke-test",
-    "types:check": "npm run types:check:node && npm run types:check:web",
+    "types:check": "pnpm types:check:node && pnpm types:check:web",
     "types:check:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "types:check:web": "vue-tsc --noEmit -p tsconfig.web.json --composite false"
   },


### PR DESCRIPTION
This PR refactors the npm scripts for the Electron app, to make it a little simpler (or a little bit more like the other packages).

@coderabbitai summary