### PR TITLE
ci: list appFiles before doing the todesktop build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,9 @@ jobs:
             api_client_app:
               - packages/api-client-app/package.json
       - if: steps.changed-files.outputs.api_client_app_any_changed == 'true'
+        name: Check whether appFiles are there
+        run: ls -R ./packages/api-client-app/out
+      - if: steps.changed-files.outputs.api_client_app_any_changed == 'true'
         name: Build in the toDesktop cloud
         run: pnpm --filter scalar-api-client todesktop:build:ci
         env:


### PR DESCRIPTION
This lists all files in  `./packages/api-client-app/out` before uploading it to toDesktop, just for the purpose of debugging the CI issues.

**Example Output**
```bash
main		preload		renderer

./packages/api-client-app/out/main:
chunks		index.js

./packages/api-client-app/out/main/chunks:
icon-BVRhZO9N.png

./packages/api-client-app/out/preload:
index.js

./packages/api-client-app/out/renderer:
assets		index.html

./packages/api-client-app/out/renderer/assets:
Cookies.vue-69pojGTh.js			Request.vue-Cpyzkg0L.js			Sidebar.vue-BnaErmk_.js			index-TLzcm0Kv.css
DataTableInput.vue-B5L2p30M.js		ScalarTextField.vue-BvLXS853.js		SidebarListElement.vue-CvSXMOHS.js	useSidebar-zyxptzzT.js
Environment.vue-CmxcreFu.js		Servers.vue-BHx4ZcC9.js			ViewLayoutContent.vue-WmK4pNwu.js
Form.vue-mi-V3wxO.js			Settings.vue-BejhuD5c.js		index-CXm_bC5d.js
```