### PR TITLE
feat(api-client): clear drafts

### DIFF
--- a/.changeset/nasty-rabbits-greet.md
+++ b/.changeset/nasty-rabbits-greet.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds clear drafts action to draft collection

--- a/packages/api-client/src/store/requests.ts
+++ b/packages/api-client/src/store/requests.ts
@@ -188,3 +188,16 @@ export function findRequestParentsFactory({
 
   return findRequestParentss
 }
+
+/** First draft request" */
+export function createInitialRequest() {
+  const request = requestSchema.parse({
+    method: 'get',
+    parameters: [],
+    path: '',
+    summary: 'My First Request',
+    examples: [],
+  })
+
+  return { request }
+}

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -2,7 +2,6 @@ import type { StoreContext } from '@/store/store-context'
 import {
   collectionSchema,
   requestExampleSchema,
-  requestSchema,
 } from '@scalar/oas-utils/entities/spec'
 import {
   type Workspace,
@@ -11,6 +10,8 @@ import {
 import { LS_KEYS } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { reactive } from 'vue'
+
+import { createInitialRequest } from './requests'
 
 /** Create storage for workspace entities */
 export function createStoreWorkspaces(useLocalStorage: boolean) {
@@ -38,13 +39,7 @@ export function extendedWorkspaceDataFactory({
 }: StoreContext) {
   const addWorkspace = (payload: Partial<Workspace> = {}) => {
     // Create some example data
-    const request = requestSchema.parse({
-      method: 'get',
-      parameters: [],
-      path: '',
-      summary: 'My First Request',
-      examples: [],
-    })
+    const { request } = createInitialRequest()
 
     const example = requestExampleSchema.parse({
       name: 'Example',

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -38,6 +38,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'update:showSidebar', v: boolean): void
   (e: 'newTab', { name, uid }: { name: string; uid: string }): void
+  (e: 'clearDrafts'): void
 }>()
 
 const workspaceContext = useWorkspace()
@@ -48,6 +49,8 @@ const {
   findRequestParents,
   isReadOnly,
   events,
+  requestMutators,
+  requests,
 } = workspaceContext
 
 const { handleDragEnd, isDroppable } = dragHandlerFactory(workspaceContext)
@@ -117,6 +120,17 @@ const selectedResultId = computed(() => {
     searchResultsWithPlaceholderResults.value[selectedSearchResult.value]
   return result?.item?.id ? `#search-input-${result.item.id}` : undefined
 })
+
+const handleClearDrafts = () => {
+  const draftCollection = activeWorkspaceCollections.value.find(
+    (collection) => collection.info?.title === 'Drafts',
+  )
+  if (draftCollection) {
+    draftCollection.requests.forEach((requestUid) => {
+      requestMutators.delete(requests[requestUid], draftCollection.uid)
+    })
+  }
+}
 </script>
 <template>
   <Sidebar
@@ -253,6 +267,7 @@ const selectedResultId = computed(() => {
   <RequestSidebarItemMenu
     v-if="!isReadOnly && menuItem"
     :menuItem="menuItem"
+    @clearDrafts="handleClearDrafts"
     @closeMenu="menuItem.open = false"
     @toggleWatchMode="handleToggleWatchMode" />
 </template>

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -9,6 +9,7 @@ import SidebarButton from '@/components/Sidebar/SidebarButton.vue'
 import { useSidebar } from '@/hooks'
 import type { HotKeyEvent } from '@/libs'
 import { useWorkspace } from '@/store'
+import { createInitialRequest } from '@/store/requests'
 import RequestSidebarItemMenu from '@/views/Request/RequestSidebarItemMenu.vue'
 import { dragHandlerFactory } from '@/views/Request/handle-drag'
 import type { SidebarItem, SidebarMenuItem } from '@/views/Request/types'
@@ -27,6 +28,7 @@ import {
   useId,
   watch,
 } from 'vue'
+import { useRouter } from 'vue-router'
 
 import RequestSidebarItem from './RequestSidebarItem.vue'
 
@@ -46,6 +48,7 @@ const {
   activeWorkspaceCollections,
   activeRequest,
   activeWorkspaceRequests,
+  activeWorkspace,
   findRequestParents,
   isReadOnly,
   events,
@@ -55,6 +58,7 @@ const {
 
 const { handleDragEnd, isDroppable } = dragHandlerFactory(workspaceContext)
 const { collapsedSidebarFolders, setCollapsedSidebarFolder } = useSidebar()
+const { replace } = useRouter()
 
 const searchResultsId = useId()
 
@@ -125,10 +129,29 @@ const handleClearDrafts = () => {
   const draftCollection = activeWorkspaceCollections.value.find(
     (collection) => collection.info?.title === 'Drafts',
   )
+
   if (draftCollection) {
     draftCollection.requests.forEach((requestUid) => {
       requestMutators.delete(requests[requestUid], draftCollection.uid)
     })
+  }
+
+  const hasRequests = activeWorkspaceRequests.value.length
+
+  if (!hasRequests) {
+    const { request } = createInitialRequest()
+
+    if (draftCollection) {
+      requestMutators.add(request, draftCollection.uid)
+      replace(`/workspace/${activeWorkspace.value.uid}/request/${request.uid}`)
+    }
+  } else {
+    const firstCollection = activeWorkspaceCollections.value[0]
+    const firstRequest = firstCollection?.requests[0]
+
+    if (firstRequest) {
+      replace(`/workspace/${activeWorkspace.value.uid}/request/${firstRequest}`)
+    }
   }
 }
 </script>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -245,6 +245,14 @@ const watchIconColor = computed(() => {
   if (watchModeStatus === 'ERROR') return 'text-red'
   return 'text-c-3'
 })
+
+const hasDraftRequests = computed(() => {
+  return (
+    item.value.title == 'Drafts' &&
+    !isReadOnly.value &&
+    item.value.children.length > 0
+  )
+})
 </script>
 
 <template>
@@ -366,6 +374,30 @@ const watchIconColor = computed(() => {
             <ScalarButton
               v-if="!isReadOnly && !isDraftCollection"
               class="px-0.5 py-0 hover:bg-b-3 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
+              :class="{
+                'flex':
+                  menuItem.item?.entity.uid === item.entity.uid &&
+                  menuItem.open,
+                'right-5': item.watchMode,
+              }"
+              size="sm"
+              variant="ghost"
+              @click.stop.prevent="
+                (ev) =>
+                  $emit('openMenu', {
+                    item,
+                    parentUids,
+                    targetRef: ev.currentTarget.parentNode,
+                    open: true,
+                  })
+              ">
+              <ScalarIcon
+                icon="Ellipses"
+                size="sm" />
+            </ScalarButton>
+            <ScalarButton
+              v-if="isDraftCollection && hasDraftRequests"
+              class="px-0.5 py-0 hover:bg-b-3 hidden group-hover:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
               :class="{
                 'flex':
                   menuItem.item?.entity.uid === item.entity.uid &&

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -12,7 +12,7 @@ import {
   ScalarModal,
   useModal,
 } from '@scalar/components'
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 const props = defineProps<{ menuItem: SidebarMenuItem }>()
@@ -20,6 +20,7 @@ const props = defineProps<{ menuItem: SidebarMenuItem }>()
 const emit = defineEmits<{
   (e: 'closeMenu'): []
   (e: 'toggleWatchMode', item: SidebarMenuItem['item']): void
+  (e: 'clearDrafts'): void
 }>()
 
 const { replace } = useRouter()
@@ -27,6 +28,7 @@ const { activeWorkspace, activeRouterParams, events } = useWorkspace()
 
 const editModal = useModal()
 const deleteModal = useModal()
+const clearDraftsModal = useModal()
 
 /** Add example */
 const handleAddExample = () =>
@@ -74,6 +76,15 @@ onBeforeUnmount(() => window.removeEventListener('click', globalClickListener))
 const toggleWatchMode = () => {
   emit('toggleWatchMode', props.menuItem.item)
 }
+
+const handleClearDrafts = () => {
+  emit('clearDrafts')
+  clearDraftsModal.hide()
+}
+
+const isDraftsMenuItem = computed(() => {
+  return props.menuItem.item?.title === 'Drafts'
+})
 </script>
 
 <template>
@@ -99,6 +110,7 @@ const toggleWatchMode = () => {
 
       <!-- Rename -->
       <ScalarDropdownItem
+        v-if="!isDraftsMenuItem"
         ref="menuRef"
         class="flex gap-2"
         @click="editModal.show()">
@@ -150,6 +162,7 @@ const toggleWatchMode = () => {
 
       <!-- Delete -->
       <ScalarDropdownItem
+        v-if="!isDraftsMenuItem"
         class="flex gap-2"
         @click="deleteModal.show()">
         <ScalarIcon
@@ -158,6 +171,19 @@ const toggleWatchMode = () => {
           size="md"
           thickness="1.5" />
         <span>Delete</span>
+      </ScalarDropdownItem>
+
+      <!-- Clear Drafts -->
+      <ScalarDropdownItem
+        v-if="isDraftsMenuItem"
+        class="flex gap-2"
+        @click="clearDraftsModal.show()">
+        <ScalarIcon
+          class="inline-flex"
+          icon="Delete"
+          size="md"
+          thickness="1.5" />
+        <span>Clear Drafts</span>
       </ScalarDropdownItem>
     </template>
   </ScalarDropdown>
@@ -188,6 +214,16 @@ const toggleWatchMode = () => {
       :name="menuItem.item?.title ?? ''"
       @close="editModal.hide()"
       @edit="handleEdit" />
+  </ScalarModal>
+  <ScalarModal
+    :size="'xxs'"
+    :state="clearDraftsModal"
+    :title="'Clear Drafts'">
+    <DeleteSidebarListElement
+      :variableName="'All Drafts'"
+      :warningMessage="'This action will clear all drafts. This cannot be undone.'"
+      @close="clearDraftsModal.hide()"
+      @delete="handleClearDrafts" />
   </ScalarModal>
 </template>
 <style scoped>


### PR DESCRIPTION
this pr adds the clear drafts capability from request sidebar draft collection, as seen below:

https://github.com/user-attachments/assets/d9b48bc6-2cfb-477b-95c6-c9ca17f2f9eb

we might want to set a more central empty state in the view afterward. 
