### PR TITLE
fix(api-reference): docker image can’t be scanned

### DIFF
--- a/.changeset/real-planets-rule.md
+++ b/.changeset/real-planets-rule.md
@@ -1,0 +1,5 @@
+---
+'@scalarapi/api-reference': patch
+---
+
+chore: execute command as a non-root user

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,23 @@ jobs:
           context: packages/api-reference/docker/src
           file: packages/api-reference/docker/src/Dockerfile
           push: false
-          platforms: linux/amd64,linux/arm64
+          load: true
+          # Linux-only at first
+          platforms: linux/amd64
           tags: |
             scalarapi/api-reference:latest
             scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
+
+      - name: Scan Docker image for vulnerabilities
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
+        with:
+          image-ref: scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
       - if: startsWith(github.event.head_commit.message, 'RELEASING:')
         name: Check whether there's a new version of the Docker image
         id: changed-files
@@ -78,17 +91,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
-        name: Scan Docker image for vulnerabilities
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
-        with:
-          image-ref: scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-
-      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Push Docker image
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
         with:
@@ -97,9 +99,12 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # With ARM
+          platforms: linux/amd64,linux/arm64
           tags: |
             scalarapi/api-reference:latest
             scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
+
   format:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          retry-count: 3
+          retry-delay: 30s
 
       - if: startsWith(github.event.head_commit.message, 'RELEASING:')
         name: Check whether there's a new version of the Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,24 @@ jobs:
             scalarapi/api-reference:latest
             scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
 
-      - name: Scan Dockerfile for vulnerabilities
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
+        with:
+          scan-type: 'config'
+          scan-ref: 'packages/api-reference/docker/src/Dockerfile'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          retry-count: 3
+          retry-delay: 30s
+
+      - name: Scan image contents for vulnerabilities
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
         with:
           scan-type: 'fs'
-          scan-ref: '.'
-          scan-path: 'packages/api-reference/docker/src'
+          scan-ref: 'packages/api-reference/docker/src'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
         with:
           scan-type: 'fs'
-          scan-ref: 'packages/api-reference/docker/src'
+          scan-ref: '.'
+          scan-path: 'packages/api-reference/docker/src'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,20 +89,6 @@ jobs:
           retry-count: 3
           retry-delay: 30s
 
-      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
-        name: Scan image contents for vulnerabilities
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
-        with:
-          scan-type: 'fs'
-          scan-ref: 'packages/api-reference/docker/src'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          retry-count: 3
-          retry-delay: 30s
-
       - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
         name: Log in to DockerHub
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,11 @@ jobs:
             scalarapi/api-reference:latest
             scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
 
-      - name: Scan Docker image for vulnerabilities
+      - name: Scan Dockerfile for vulnerabilities
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
         with:
-          image-ref: scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
+          scan-type: 'fs'
+          scan-ref: 'packages/api-reference/docker/src'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
               - packages/api-reference/docker/package.json
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
-        name: Set up Docker Buildx
+        name: Set up Docker
         uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
 
-      - name: Set up Docker Buildx
+      - name: Check whether the Dockerfile or any of its contents were modified
+        id: changed-files
+        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c
+        with:
+          files_yaml: |
+            api_reference_docker:
+              - packages/api-reference/docker/**
+            api_reference_docker_version:
+              - packages/api-reference/docker/package.json
+
+      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20
 
-      - name: Get version from package.json
+      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+        name: Get version from package.json
         id: package-version
         run: echo "VERSION=$(node -p "require('./packages/api-reference/docker/package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Build and tag Docker image
+      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+        name: Build and tag Docker image
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
         with:
           context: packages/api-reference/docker/src
@@ -62,7 +75,8 @@ jobs:
             scalarapi/api-reference:latest
             scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
 
-      - name: Scan for vulnerabilities
+      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+        name: Scan for vulnerabilities
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
         with:
           scan-type: 'config'
@@ -75,7 +89,8 @@ jobs:
           retry-count: 3
           retry-delay: 30s
 
-      - name: Scan image contents for vulnerabilities
+      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+        name: Scan image contents for vulnerabilities
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
         with:
           scan-type: 'fs'
@@ -88,16 +103,7 @@ jobs:
           retry-count: 3
           retry-delay: 30s
 
-      - if: startsWith(github.event.head_commit.message, 'RELEASING:')
-        name: Check whether there's a new version of the Docker image
-        id: changed-files
-        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c
-        with:
-          files_yaml: |
-            api_reference_docker:
-              - packages/api-reference/docker/package.json
-
-      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+      - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
         name: Log in to DockerHub
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
         with:
@@ -106,7 +112,7 @@ jobs:
           # https://app.docker.com/settings/personal-access-tokens
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+      - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
         name: Push Docker image
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
         with:

--- a/packages/api-reference/docker/src/Dockerfile
+++ b/packages/api-reference/docker/src/Dockerfile
@@ -14,7 +14,7 @@ COPY Caddyfile /etc/caddy/Caddyfile
 EXPOSE 80
 
 # Use an environment variable for the OpenAPI document URL, with a default value
-ENV OPENAPI_DOCUMENT_URL=https://example.com/openapi.json
+ENV OPENAPI_DOCUMENT_URL=https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json
 
 # Start Caddy
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/packages/api-reference/docker/src/Dockerfile
+++ b/packages/api-reference/docker/src/Dockerfile
@@ -1,6 +1,9 @@
 # Use the official Caddy image as a parent image
 FROM caddy:2-alpine
 
+# Create a non-root user
+RUN adduser -D -u 1000 caddy
+
 # Set the working directory in the container
 WORKDIR /usr/share/caddy
 
@@ -9,6 +12,12 @@ COPY index.html .
 
 # Copy the Caddyfile into the container
 COPY Caddyfile /etc/caddy/Caddyfile
+
+# Set proper ownership of files
+RUN chown -R caddy:caddy /usr/share/caddy /etc/caddy
+
+# Switch to non-root user
+USER caddy
 
 # Expose the port Caddy will run on
 EXPOSE 80


### PR DESCRIPTION
The release of the docker image failed because the security scanning failed. This PR fixes it.

* We’re now scanning specifically the Dockerfile.
* The suggestion to run caddy as a non-root user came up, so I’ve added this, too.
* All the Docker steps are only executed when something in the folder changed (to avoid blocking main with the security check at random times).