### PR TITLE
docs(mock-server): update the README

### DIFF
--- a/packages/mock-server/README.md
+++ b/packages/mock-server/README.md
@@ -5,21 +5,23 @@
 [![License](https://img.shields.io/npm/l/%40scalar%2Fmock-server)](https://www.npmjs.com/package/@scalar/mock-server)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-A powerful Node.js server that generates and returns realistic mock data based on OpenAPI specifications. Ideal for API development, testing, and prototyping.
+A powerful Node.js mock server that automatically generates realistic API responses from your OpenAPI/Swagger documents. It creates fully-functional endpoints with mock data, handles authentication, and respects content types - making it perfect for frontend development, API prototyping, and integration testing.
 
 ![](https://raw.githubusercontent.com/scalar/scalar/main/packages/cli/screenshots/mock.png)
 
 ## Features
 
-- Automatically creates endpoints from your OpenAPI/Swagger document
-- Generates realistic sample data matching your schema definitions
-- Supports Swagger 2.0, OpenAPI 3.0 and 3.1 specifications
-- Customizable response handling and data generation
-- Perfect for frontend development without an actual backend
+- Perfect for frontend development and testing
+- Creates endpoints automatically from OpenAPI documents
+- Generates realistic mock data based on your schemas
+- Handles authentication and responds with defined HTTP headers
+- Supports Swagger 2.0 and OpenAPI 3.x documents
+- Customizable response handling
 
 ## Quickstart
 
-It’s part of [our Scalar CLI](https://github.com/scalar/scalar/tree/main/packages/cli), you can boot it literllay in seconds:
+The easiest way to get started is through [our Scalar CLI](https://github.com/scalar/scalar/tree/main/packages/cli).
+You can have a mock server up and running in seconds:
 
 ```bash
 npx @scalar/cli mock openapi.json --watch
@@ -27,7 +29,7 @@ npx @scalar/cli mock openapi.json --watch
 
 ## Installation
 
-For more advanced use cases or finer control over the mock server, you can use the package directly in your Node.js application:
+For advanced use cases, you can integrate the mock server directly into your Node.js application for full control:
 
 ```bash
 npm install @scalar/mock-server
@@ -39,9 +41,9 @@ npm install @scalar/mock-server
 import { serve } from '@hono/node-server'
 import { createMockServer } from '@scalar/mock-server'
 
-// Your OpenAPI specification
+// Your OpenAPI document
 const specification = {
-  openapi: '3.1.0',
+  openapi: '3.1.1',
   info: {
     title: 'Hello World',
     version: '1.0.0',
@@ -69,6 +71,7 @@ const specification = {
 // Create the mocked routes
 const app = await createMockServer({
   specification,
+  // Custom logging
   onRequest({ context, operation }) {
     console.log(context.req.method, context.req.path)
   },
@@ -85,6 +88,100 @@ serve(
   },
 )
 ```
+
+### Authentication
+
+You can define security schemes in your OpenAPI document and the mock server will validate the authentication:
+
+```ts
+import { serve } from '@hono/node-server'
+import { createMockServer } from '@scalar/mock-server'
+
+// Your OpenAPI document
+const specification = {
+  openapi: '3.1.1',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  paths: {
+    '/secret': {
+      get: {
+        security: [
+          {
+            bearerAuth: [],
+          },
+          {
+            apiKey: [],
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                example: {
+                  foo: 'bar',
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Unauthorized',
+            content: {
+              'application/json': {
+                example: {
+                  error: 'Unauthorized',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+      apiKey: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-API-Key',
+      },
+    },
+  },
+}
+
+// Create the mocked routes
+const app = await createMockServer({
+  specification,
+  // Custom logging
+  onRequest({ context, operation }) {
+    console.log(context.req.method, context.req.path)
+  },
+})
+
+// Start the server
+serve(
+  {
+    fetch: app.fetch,
+    port: 3000,
+  },
+  (info) => {
+    console.log(`Listening on http://localhost:${info.port}`)
+  },
+)
+```
+
+### OpenAPI endpoints
+
+The given OpenAPI document is automatically exposed:
+
+- `/openapi.json` and `/openapi.yaml`
 
 ## Community
 

--- a/packages/mock-server/src/createMockServer.test.ts
+++ b/packages/mock-server/src/createMockServer.test.ts
@@ -568,4 +568,42 @@ describe('createMockServer', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get('X-Custom')).toBe('foobar')
   })
+
+  it('handles redirect headers', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/redirect': {
+          get: {
+            responses: {
+              '301': {
+                description: 'Moved Permanently',
+                headers: {
+                  Location: {
+                    schema: {
+                      type: 'string',
+                      example: '/new-location',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/redirect')
+
+    expect(response.status).toBe(301)
+    expect(response.headers.get('Location')).toBe('/new-location')
+  })
 })


### PR DESCRIPTION
With this PR:

* The README is updated.
* There’s an example for the recently added authentication mocking.
* It’s mentioned that OpenAPI documents are served automatically.
* A HTTP redirect test is added.