### PR TITLE
chore(api-reference): skip the docker build if docker isn’t available

### DIFF
--- a/packages/api-reference/docker/package.json
+++ b/packages/api-reference/docker/package.json
@@ -4,7 +4,7 @@
   "description": "Official Docker image for @scalar/api-reference",
   "private": true,
   "scripts": {
-    "build": "docker build -t scalarapi/api-reference:latest ./src",
+    "build": "command -v docker >/dev/null 2>&1 && docker build -t scalarapi/api-reference:latest ./src || echo '⚠️ Docker is not available, skipping the build.'",
     "dev": "docker-compose up"
   },
   "keywords": [],


### PR DESCRIPTION
I’ve added the docker build as a `build` npm script, which is executed on `pnpm turbo build`, but fails in environments without Docker.

Let’s only build the Docker image, when Docker is actually available.