### PR TITLE
feat(import): find OpenAPI document URLs in escaped JS objects

### DIFF
--- a/.changeset/dry-foxes-do.md
+++ b/.changeset/dry-foxes-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/import': patch
+---
+
+feat: import from escaped JS object

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -420,4 +420,19 @@ info:
 
     expect(result).toBe('https://example.com/swagger/json')
   })
+
+  it('finds the URL in an escaped JS object', async () => {
+    // @ts-expect-error Mocking types are missing
+    fetch.mockResolvedValue(
+      createFetchResponse(
+        `<html>\\"$L8e\\",null,{\\"configuration\\":{\\"spec\\":{\\"url\\":\\"https://raw.githubusercontent.com/Foo/Bar/main/api/foobar.json\\"}},\\"initialRequest`,
+      ),
+    )
+
+    const result = await resolve('https://example.com/foo')
+
+    expect(result).toBe(
+      'https://raw.githubusercontent.com/Foo/Bar/main/api/foobar.json',
+    )
+  })
 })

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -195,8 +195,18 @@ function parseHtml(html?: string) {
   const linkMatch = html.match(
     /<a[^>]*href=["']([^"']+\.(?:yaml|yml|json))["'][^>]*>/i,
   )
+
   if (linkMatch?.[1]) {
     return linkMatch[1]
+  }
+
+  // Check for URLs in escaped JS objects
+  const escapedJsonMatch = html.match(
+    /\\"spec\\":\{.*?\\"url\\":\\"([^"\\]+)\\"/,
+  )
+
+  if (escapedJsonMatch?.[1]) {
+    return escapedJsonMatch[1]
   }
 
   return undefined


### PR DESCRIPTION
This should help to resolve a few more URLs from our friends at GitBook. :)