### PR TITLE
fix(api-client): not respecting server overload

### DIFF
--- a/.changeset/nine-peaches-search.md
+++ b/.changeset/nine-peaches-search.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: make the api-client respect the server overload

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
@@ -35,13 +35,11 @@ export const createApiClientModal = async (
   if (configuration.spec?.url)
     await importSpecFromUrl(configuration.spec.url, 'default', {
       proxy: configuration.proxyUrl,
-      overloadServers: configuration?.servers,
       setCollectionSecurity: true,
       ...configuration,
     })
   else if (configuration.spec?.content)
     await importSpecFile(configuration.spec?.content, 'default', {
-      overloadServers: configuration?.servers,
       setCollectionSecurity: true,
       ...configuration,
     })

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -209,17 +209,13 @@ export const createApiClient = ({
     if (spec?.url) {
       await importSpecFromUrl(spec.url, activeWorkspace.value.uid, {
         proxy: configuration?.proxyUrl,
-        overloadServers: configuration?.servers,
-        baseServerURL: configuration?.baseServerURL,
-        authentication: configuration.authentication,
         setCollectionSecurity: true,
+        ...configuration,
       })
     } else if (spec?.content) {
       await importSpecFile(spec?.content, activeWorkspace.value.uid, {
-        overloadServers: configuration?.servers,
-        baseServerURL: configuration?.baseServerURL,
-        authentication: configuration.authentication,
         setCollectionSecurity: true,
+        ...configuration,
       })
     } else {
       console.error(

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -15,14 +15,8 @@ export const specDictionary: Record<
   { hash: number; schema: OpenAPIV3.Document | OpenAPIV3_1.Document }
 > = {}
 
-type ImportSpecFileArgs = ImportSpecToWorkspaceArgs & {
-  /**
-   * TODO: What do these look like?
-   * Ideally we reference some existing UIDs in the store and
-   * attach those as needed to entities below
-   */
-  overloadServers?: Spec['servers']
-}
+type ImportSpecFileArgs = ImportSpecToWorkspaceArgs &
+  Pick<ReferenceConfiguration, 'servers'>
 
 /** Generate the import functions from a store context */
 export function importSpecFileFactory({
@@ -38,14 +32,9 @@ export function importSpecFileFactory({
   const importSpecFile = async (
     _spec: string | Record<string, any>,
     workspaceUid: string,
-    { overloadServers, ...options }: ImportSpecFileArgs = {},
+    options: ImportSpecFileArgs = {},
   ) => {
     const spec = toRaw(_spec)
-
-    // Overload the servers
-    if (overloadServers?.length && typeof spec === 'object')
-      spec.servers = overloadServers
-
     const workspaceEntities = await importSpecToWorkspace(spec, options)
 
     if (workspaceEntities.error) {

--- a/packages/oas-utils/src/entities/spec/security.ts
+++ b/packages/oas-utils/src/entities/spec/security.ts
@@ -110,6 +110,7 @@ export function authExampleFromSchema(
   }
   console.warn(
     '[@scalar/oas-utils:security] Invalid schema for oauth example',
+    scheme,
     baseValues,
   )
 

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -86,5 +86,15 @@ describe('Import OAS Specs', () => {
         'https://scalar.com',
       ])
     })
+
+    it('handles overloading servers with the servers property', async () => {
+      const res = await importSpecToWorkspace(relativeGalaxy, {
+        servers: [{ url: 'https://scalar.com' }],
+      })
+      if (res.error) throw res.error
+
+      // Test URLS only
+      expect(res.servers.map(({ url }) => url)).toEqual(['https://scalar.com'])
+    })
   })
 })

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -186,7 +186,10 @@ export async function importSpecToWorkspace(
         return {
           ...s,
           // Ensure we only have one slash between
-          url: (_baseServerUrl + s.url).replace(/\/+/g, '/'),
+          url: [
+            _baseServerUrl.replace(/\/$/, ''),
+            s.url.replace(/^\//, ''),
+          ].join('/'),
         }
 
       // Just return a regular server

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -182,10 +182,7 @@ export async function importSpecToWorkspace(
         return {
           ...s,
           // Ensure we only have one slash between
-          url: [
-            _baseServerUrl.replace(/\/$/, ''),
-            s.url.replace(/^\//, ''),
-          ].join('/'),
+          url: (_baseServerUrl + s.url).replace(/\/+/g, '/'),
         }
 
       // Just return a regular server

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -126,7 +126,10 @@ export type ImportSpecToWorkspaceArgs = Pick<
   CollectionPayload,
   'documentUrl' | 'watchMode'
 > &
-  Pick<ReferenceConfiguration, 'authentication' | 'baseServerURL'> & {
+  Pick<
+    ReferenceConfiguration,
+    'authentication' | 'baseServerURL' | 'servers'
+  > & {
     /** Sets the preferred security scheme on the collection instead of the requests */
     setCollectionSecurity?: boolean
   }
@@ -145,6 +148,7 @@ export async function importSpecToWorkspace(
     authentication,
     baseServerURL,
     documentUrl,
+    servers: overloadServers,
     setCollectionSecurity = false,
     watchMode = false,
   }: ImportSpecToWorkspaceArgs = {},
@@ -176,7 +180,7 @@ export async function importSpecToWorkspace(
 
   // Add the base server url to any relative servers
   const servers: Server[] = serverSchema.array().parse(
-    schema.servers?.map((s) => {
+    (overloadServers ?? schema.servers)?.map((s) => {
       // Prepend base server url if relative
       if (s?.url?.startsWith('/'))
         return {


### PR DESCRIPTION
closes #3295
closes #3476
references #3475

Overload servers wasn't doing much before, I renamed it to servers so it matches the references + shares types + simplifies the config. Now we just pass the reference config straight into the client. (only proxy remains with a different name)

I based this off my other PR because I wanted those config changes.  So merge #3606 first, then rebase, then this one