### PR TITLE
fix(api-reference): base url variables DOC-2476

### DIFF
--- a/.changeset/breezy-baboons-admire.md
+++ b/.changeset/breezy-baboons-admire.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+refactor: updates regexHelpers

--- a/.changeset/poor-days-rhyme.md
+++ b/.changeset/poor-days-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: base url server variables

--- a/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
+++ b/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
@@ -2,7 +2,7 @@
 import { parseEnvVariables } from '@/libs'
 import type { WorkspaceStore } from '@/store'
 import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
-import { variableRegex } from '@scalar/oas-utils/helpers'
+import { REGEX } from '@scalar/oas-utils/helpers'
 import {
   Decoration,
   type DecorationSet,
@@ -178,7 +178,7 @@ export const pillPlugin = (props: {
           const text = view.state.doc.sliceString(from, to)
           let match
 
-          while ((match = variableRegex.exec(text)) !== null) {
+          while ((match = REGEX.VARIABLES.exec(text)) !== null) {
             const start = from + match.index
             const end = start + match[0].length
             const variableName = match[1]

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -3,7 +3,7 @@ import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useWorkspace } from '@/store'
 import RequestTable from '@/views/Request/RequestSection/RequestTable.vue'
 import type { RequestExample } from '@scalar/oas-utils/entities/spec'
-import { pathRegex } from '@scalar/oas-utils/helpers'
+import { REGEX } from '@scalar/oas-utils/helpers'
 import { computed, watch } from 'vue'
 
 const props = defineProps<{
@@ -72,7 +72,7 @@ const setPathVariable = (url: string) => {
   if (!activeExample.value) return
 
   /** matching regex for nested curly braces {value} */
-  const pathVariables = url.match(pathRegex)?.map((v) => v.slice(1, -1)) || []
+  const pathVariables = url.match(REGEX.PATH)?.map((v) => v.slice(1, -1)) || []
   const parameters = activeExample.value.parameters[props.paramKey]
 
   const paramMap = new Map(parameters.map((param) => [param.key, param]))

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -33,8 +33,8 @@ onMounted(async () => {
 
 // Update the server on select
 watch(server, (newServer) => {
-  const serverUrl = getUrlFromServerState(newServer)
-  if (serverUrl && client.value) client.value.updateServer(serverUrl)
+  const { originalUrl } = getUrlFromServerState(newServer)
+  if (originalUrl && client.value) client.value.updateServer(originalUrl)
 })
 
 // Update the config on change

--- a/packages/api-reference/src/features/BaseUrl/ServerVariablesSelect.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerVariablesSelect.vue
@@ -36,9 +36,13 @@ const selected = computed<ScalarListboxOption | undefined>({
       class="variable-select"
       fullWidth
       variant="ghost">
-      <span>
-        <span class="sr-only">Selected:</span>
-        {{ value }}
+      <span :class="{ 'text-c-1': value }">
+        <span
+          v-if="value"
+          class="sr-only"
+          >Selected:</span
+        >
+        {{ value || 'Select value' }}
       </span>
       <ScalarIcon
         icon="ChevronDown"

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -132,7 +132,7 @@ async function generateSnippet() {
   // Generate a request object
   const harRequest = getHarRequest(
     {
-      url: getUrlFromServerState(serverState),
+      url: getUrlFromServerState(serverState).modifiedUrl,
     },
     getRequestFromOperation(
       props.operation,

--- a/packages/api-reference/src/helpers/getApiClientRequest.ts
+++ b/packages/api-reference/src/helpers/getApiClientRequest.ts
@@ -32,7 +32,7 @@ export function getApiClientRequest({
 }): ClientRequestConfig {
   const request = getHarRequest(
     {
-      url: getUrlFromServerState(serverState),
+      url: getUrlFromServerState(serverState).modifiedUrl,
     },
     getRequestFromOperation(operation, { requiredOnly: false }),
     // Only generate authentication parameters if an authentication state is passed.
@@ -61,7 +61,7 @@ export function getApiClientRequest({
       return { ...queryString, enabled: query.required ?? true }
     }),
     headers: enable(request.headers),
-    url: getUrlFromServerState(serverState) ?? '',
+    url: getUrlFromServerState(serverState).modifiedUrl ?? '',
     body: request.postData?.text,
   }
 }

--- a/packages/api-reference/src/helpers/getExampleCode.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.ts
@@ -32,6 +32,11 @@ export async function getExampleCode(
     )
   }
 
+  // Prevent snippet generation if starting by a variable
+  if (request.url.startsWith('__')) {
+    return request.url
+  }
+
   // httpsnippet-lite
   try {
     const httpSnippetLiteTargetKey = target?.replace(

--- a/packages/api-reference/src/legacy/components/SecurityScheme.vue
+++ b/packages/api-reference/src/legacy/components/SecurityScheme.vue
@@ -427,7 +427,7 @@ const startAuthentication = (url: string) => {
                         | OpenAPIV3_1.OAuth2SecurityScheme
                     ).flows?.password?.tokenUrl,
                     {
-                      baseUrl: getUrlFromServerState(server),
+                      baseUrl: getUrlFromServerState(server).modifiedUrl,
                       proxy,
                     },
                   )

--- a/packages/api-reference/src/legacy/helpers/getUrlFromServerState.test.ts
+++ b/packages/api-reference/src/legacy/helpers/getUrlFromServerState.test.ts
@@ -4,8 +4,8 @@ import { createEmptyServerState } from '../stores'
 import { getUrlFromServerState } from './getUrlFromServerState'
 
 describe('getUrlFromServerState', () => {
-  it('gets an URL', () => {
-    const request = getUrlFromServerState({
+  it('returns both original and modified URLs without variables', () => {
+    const { originalUrl, modifiedUrl } = getUrlFromServerState({
       ...createEmptyServerState(),
       servers: [
         {
@@ -15,11 +15,12 @@ describe('getUrlFromServerState', () => {
       selectedServer: 0,
     })
 
-    expect(request).toMatchObject('https://example.com')
+    expect(originalUrl).toBe('https://example.com')
+    expect(modifiedUrl).toBe('https://example.com')
   })
 
-  it('replaces variables', () => {
-    const request = getUrlFromServerState({
+  it('replaces variables in the modified URL', () => {
+    const { originalUrl, modifiedUrl } = getUrlFromServerState({
       ...createEmptyServerState(),
       selectedServer: 0,
       servers: [
@@ -32,11 +33,12 @@ describe('getUrlFromServerState', () => {
       },
     })
 
-    expect(request).toMatchObject('https://unicorn.fantasy')
+    expect(originalUrl).toBe('https://{example_variable}.fantasy')
+    expect(modifiedUrl).toBe('https://unicorn.fantasy')
   })
 
-  it('replaces variables first, and then checks whether a prefix is necessary', () => {
-    const request = getUrlFromServerState({
+  it('replaces variables and maintains original URL', () => {
+    const { originalUrl, modifiedUrl } = getUrlFromServerState({
       ...createEmptyServerState(),
       variables: {
         protocol: 'https',
@@ -64,6 +66,7 @@ describe('getUrlFromServerState', () => {
       ],
     })
 
-    expect(request).toMatchObject('https://localhost:8083/management/v2')
+    expect(originalUrl).toBe('{protocol}://{managementAPIHost}/management/v2')
+    expect(modifiedUrl).toBe('https://localhost:8083/management/v2')
   })
 })

--- a/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
@@ -18,5 +18,13 @@ export function getUrlFromServerState(state: ServerState) {
       ? replaceVariables(server?.url, state.variables)
       : server?.url
 
-  return url
+  // {id} -> __ID__
+  const urlVariables = url?.match(/{(.*?)}/g)
+
+  const modifiedUrl = urlVariables?.reduce((acc, variable) => {
+    const variableName = variable.replace(/{|}/g, '')
+    return acc?.replace(variable, `__${variableName.toUpperCase()}__`)
+  }, url)
+
+  return modifiedUrl
 }

--- a/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
@@ -19,12 +19,17 @@ export function getUrlFromServerState(state: ServerState) {
       : server?.url
 
   // {id} -> __ID__
-  const urlVariables = url?.match(/{(.*?)}/g)
+  const urlVariables = url?.match(/{[^{}]*}/g)
 
-  const modifiedUrl = urlVariables?.reduce((acc, variable) => {
-    const variableName = variable.replace(/{|}/g, '')
-    return acc?.replace(variable, `__${variableName.toUpperCase()}__`)
-  }, url)
+  const modifiedUrl =
+    urlVariables?.reduce((acc, variable) => {
+      const variableName = variable.replace(/{|}/g, '')
+      const variableValue = state.variables?.[variableName]
+      return acc?.replace(
+        variable,
+        variableValue ? variableValue : `__${variableName.toUpperCase()}__`,
+      )
+    }, url) ?? url
 
   return modifiedUrl
 }

--- a/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
@@ -12,6 +12,9 @@ export function getUrlFromServerState(state: ServerState) {
     server.url = server.url.slice(0, -1)
   }
 
+  // Store the original URL before any modifications
+  const originalUrl = server?.url
+
   // Replace variables: {protocol}://{host}:{port}/{basePath}
   const url =
     typeof server?.url === 'string'
@@ -31,5 +34,6 @@ export function getUrlFromServerState(state: ServerState) {
       )
     }, url) ?? url
 
-  return modifiedUrl
+  // Return original and modified URLs to handle reference and client updates
+  return { originalUrl, modifiedUrl }
 }

--- a/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
@@ -1,5 +1,5 @@
 import type { ServerState } from '#legacy'
-import { replaceVariables } from '@scalar/oas-utils/helpers'
+import { REGEX, replaceVariables } from '@scalar/oas-utils/helpers'
 
 /**
  * Get the URL from the server state.
@@ -19,7 +19,7 @@ export function getUrlFromServerState(state: ServerState) {
       : server?.url
 
   // {id} -> __ID__
-  const urlVariables = url?.match(/{[^{}]*}/g)
+  const urlVariables = url?.match(REGEX.PATH)
 
   const modifiedUrl =
     urlVariables?.reduce((acc, variable) => {

--- a/packages/api-reference/src/legacy/stores/useServerStore.ts
+++ b/packages/api-reference/src/legacy/stores/useServerStore.ts
@@ -21,9 +21,26 @@ export const createEmptyServerState = (): ServerState => ({
 const serverStore = reactive<ServerState>(createEmptyServerState())
 
 const setServer = (newState: Partial<ServerState>) => {
+  const currentServer =
+    serverStore.servers?.[
+      newState.selectedServer ?? serverStore.selectedServer ?? 0
+    ]
+  const defaultVariables = currentServer?.variables
+    ? Object.fromEntries(
+        Object.entries(currentServer.variables).map(([key, variable]) => [
+          key,
+          variable.default ?? '',
+        ]),
+      )
+    : {}
+
   Object.assign(serverStore, {
     ...serverStore,
     ...newState,
+    variables: {
+      ...defaultVariables,
+      ...newState.variables,
+    },
   })
 }
 

--- a/packages/oas-utils/src/helpers/findVariables.ts
+++ b/packages/oas-utils/src/helpers/findVariables.ts
@@ -1,11 +1,12 @@
+import { REGEX } from '../helpers'
+
 /**
  * Find all strings wrapped in {} or {{}} in value.
  */
 export const findVariables = (value: string) => {
-  // Wrapped in single or double curly braces.
-  // Ignores whitespace
-  // Works with lowercase, uppercase, numbers, dashes, underscores
-  const regex = /(?:\{+)\s*(\w+)\s*(?:\}+)/g
-
-  return [...value.matchAll(regex)].map((match) => match[1]?.trim()) || []
+  return (
+    [...value.matchAll(REGEX.PATH), ...value.matchAll(REGEX.VARIABLES)].map(
+      (match) => match[1]?.trim(),
+    ) || []
+  )
 }

--- a/packages/oas-utils/src/helpers/regexHelpers.test.ts
+++ b/packages/oas-utils/src/helpers/regexHelpers.test.ts
@@ -1,58 +1,58 @@
 import { describe, expect, it } from 'vitest'
 
-import { pathRegex, variableRegex } from './regexHelpers'
+import { REGEX } from './regexHelpers'
 
 describe('variableRegex', () => {
   it('matches variables with double curly braces', () => {
     const text = '{{example.com}}'
-    const matches = [...text.matchAll(variableRegex)]
+    const matches = [...text.matchAll(REGEX.VARIABLES)]
     expect(matches.length).toBe(1)
     expect(matches[0][1]).toBe('example.com')
   })
 
   it('matches variables with nested curly braces', () => {
     const text = '{{example.com:{port}}}'
-    const matches = [...text.matchAll(variableRegex)]
+    const matches = [...text.matchAll(REGEX.VARIABLES)]
     expect(matches.length).toBe(1)
     expect(matches[0][1]).toBe('example.com:{port}')
   })
 
   it('matches multiple variables', () => {
     const text = '{{{host}.example.com:{port}}}'
-    const matches = [...text.matchAll(variableRegex)]
+    const matches = [...text.matchAll(REGEX.VARIABLES)]
     expect(matches.length).toBe(1)
     expect(matches[0][1]).toBe('{host}.example.com:{port}')
   })
 
   it('does not match single curly braces', () => {
     const text = '{example.com}'
-    const matches = [...text.matchAll(variableRegex)]
+    const matches = [...text.matchAll(REGEX.VARIABLES)]
     expect(matches.length).toBe(0)
   })
 
   it('does not match unbalanced curly braces', () => {
     const text = '{{example.com}'
-    const matches = [...text.matchAll(variableRegex)]
+    const matches = [...text.matchAll(REGEX.VARIABLES)]
     expect(matches.length).toBe(0)
   })
 
   it('matches variables with whitespace', () => {
     const text = '{{ example.com }}'
-    const matches = [...text.matchAll(variableRegex)]
+    const matches = [...text.matchAll(REGEX.VARIABLES)]
     expect(matches.length).toBe(1)
     expect(matches[0][1]).toBe(' example.com ')
   })
 
   it('matches variables in longer text', () => {
     const text = 'prefix {{variable}} suffix'
-    const matches = [...text.matchAll(variableRegex)]
+    const matches = [...text.matchAll(REGEX.VARIABLES)]
     expect(matches.length).toBe(1)
     expect(matches[0][1]).toBe('variable')
   })
 
   it('matches multiple separate variables', () => {
     const text = '{{first}} middle {{second}}'
-    const matches = [...text.matchAll(variableRegex)]
+    const matches = [...text.matchAll(REGEX.VARIABLES)]
     expect(matches.length).toBe(2)
     expect(matches[0][1]).toBe('first')
     expect(matches[1][1]).toBe('second')
@@ -62,14 +62,14 @@ describe('variableRegex', () => {
 describe('pathRegex', () => {
   it('matches path parameters', () => {
     const text = '/users/{id}'
-    const matches = [...text.matchAll(pathRegex)]
+    const matches = [...text.matchAll(REGEX.PATH)]
     expect(matches.length).toBe(1)
     expect(matches[0][1]).toBe('id')
   })
 
   it('matches multiple path parameters', () => {
     const text = '/users/{userId}/posts/{postId}'
-    const matches = [...text.matchAll(pathRegex)]
+    const matches = [...text.matchAll(REGEX.PATH)]
     expect(matches.length).toBe(2)
     expect(matches[0][1]).toBe('userId')
     expect(matches[1][1]).toBe('postId')
@@ -77,20 +77,20 @@ describe('pathRegex', () => {
 
   it('does not match double curly braces', () => {
     const text = '/users/{{id}}'
-    const matches = [...text.matchAll(pathRegex)]
+    const matches = [...text.matchAll(REGEX.PATH)]
     expect(matches.length).toBe(0)
   })
 
   it('matches path parameters with dots', () => {
     const text = '/api/{version}/users'
-    const matches = [...text.matchAll(pathRegex)]
+    const matches = [...text.matchAll(REGEX.PATH)]
     expect(matches.length).toBe(1)
     expect(matches[0][1]).toBe('version')
   })
 
   it('matches path parameters with hyphens and underscores', () => {
     const text = '/users/{user-id}/posts/{post_id}'
-    const matches = [...text.matchAll(pathRegex)]
+    const matches = [...text.matchAll(REGEX.PATH)]
     expect(matches.length).toBe(2)
     expect(matches[0][1]).toBe('user-id')
     expect(matches[1][1]).toBe('post_id')
@@ -98,20 +98,20 @@ describe('pathRegex', () => {
 
   it('does not match nested curly braces', () => {
     const text = '/users/{outer{inner}}'
-    const matches = [...text.matchAll(pathRegex)]
+    const matches = [...text.matchAll(REGEX.PATH)]
     expect(matches.length).toBe(0)
   })
 
   it('matches path parameters at start of string', () => {
     const text = '{version}/api'
-    const matches = [...text.matchAll(pathRegex)]
+    const matches = [...text.matchAll(REGEX.PATH)]
     expect(matches.length).toBe(1)
     expect(matches[0][1]).toBe('version')
   })
 
   it('matches path parameters at end of string', () => {
     const text = '/api/{version}'
-    const matches = [...text.matchAll(pathRegex)]
+    const matches = [...text.matchAll(REGEX.PATH)]
     expect(matches.length).toBe(1)
     expect(matches[0][1]).toBe('version')
   })

--- a/packages/oas-utils/src/helpers/regexHelpers.ts
+++ b/packages/oas-utils/src/helpers/regexHelpers.ts
@@ -1,2 +1,4 @@
-export const variableRegex = /{{((?:[^{}]|{[^{}]*})*)}}/g
-export const pathRegex = /(?:{)([^{}]+)}(?!})/g
+export const REGEX = {
+  VARIABLES: /{{((?:[^{}]|{[^{}]*})*)}}/g,
+  PATH: /(?:{)([^{}]+)}(?!})/g,
+} as const

--- a/packages/oas-utils/src/spec-getters/getRequestFromOperation.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestFromOperation.ts
@@ -6,6 +6,7 @@ import type {
   TransformedOperation,
 } from '@scalar/types/legacy'
 
+import { REGEX } from '../helpers'
 import { getParametersFromOperation } from './getParametersFromOperation'
 import { getRequestBodyFromOperation } from './getRequestBodyFromOperation'
 
@@ -28,7 +29,7 @@ export const getRequestFromOperation = (
   const pathParameters = getParametersFromOperation(operation, 'path', false)
 
   if (pathParameters.length) {
-    const pathVariables = path.match(/{(.*?)}/g)
+    const pathVariables = path.match(REGEX.PATH)
 
     if (pathVariables) {
       pathVariables.forEach((variable) => {
@@ -49,7 +50,7 @@ export const getRequestFromOperation = (
 
   // {id} -> __ID__
   if (options?.replaceVariables === true) {
-    const pathVariables = path.match(/{(.*?)}/g)
+    const pathVariables = path.match(REGEX.PATH)
 
     if (pathVariables) {
       pathVariables.forEach((variable) => {


### PR DESCRIPTION
this pr fixes #3697 by setting default server variable and enhancing empty variable value as seen below:

**⊢ base url before / after**
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/a0e2acab-965e-44f1-9c43-cc7cf277ea6a">
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/24eb4344-f0b3-4887-bbb2-c3eb701171b1">

**⊢ request example before / after**
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/f3c26868-e38c-42d7-aa4f-80e4f120bd83">
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/2da49c62-d4b8-487f-a66c-f612959f7562">