### PR TITLE
feat(proxy-server): follow redirects

### DIFF
--- a/.changeset/green-nails-sparkle.md
+++ b/.changeset/green-nails-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/import': minor
+---
+
+feat: use X-Forwarded-Host header (if available)

--- a/.changeset/lemon-tomatoes-wash.md
+++ b/.changeset/lemon-tomatoes-wash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: allow to pass a base URL to makeUrlAbsolute

--- a/examples/proxy-server/README.md
+++ b/examples/proxy-server/README.md
@@ -4,6 +4,18 @@
 
 The Scalar Proxy redirects requests to another server to avoid CORS issues. It’s made to work well with the Scalar API Client.
 
+## Features
+
+- Full CORS support with customizable origins
+- Handles HTTP redirects while preserving headers
+- Supports HTTPS with TLS
+- Request logging with method and target URL
+- Health check endpoint at `/ping`
+- Configurable port via environment variable
+- Preserves original request headers and body
+- Forwards all HTTP methods (GET, POST, PUT, DELETE, PATCH)
+- Zero external dependencies - uses only Go standard library
+
 ## Usage
 
 ### Requirements
@@ -55,9 +67,9 @@ curl --request GET \
 }
 ```
 
-> Yo, there’s no mod file.
+## Community
 
-You’re so right! We’re using the standard libraries. Isn’t that why we all love Go? Anyway, we just don’t need a mod file. :)
+We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/scalar>
 
 ## License
 

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -146,6 +146,9 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Add the final URL as a header
+	w.Header().Set("X-Forwarded-Host", resp.Request.URL.String())
+
 	// Copy the status code
 	w.WriteHeader(resp.StatusCode)
 

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -90,12 +90,15 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		res.Header.Del("Access-Control-Allow-Methods")
 		res.Header.Del("Access-Control-Expose-Headers")
 
-		// Handle relative URLs in Location header
+		// Handle Location header to ensure redirects go through the proxy
 		if location := res.Header.Get("Location"); location != "" {
+			// If location starts with '/', make it absolute using the remote host
 			if location[0] == '/' {
-				// If location starts with '/', it's a relative URL
-				res.Header.Set("Location", remote.Scheme+"://"+remote.Host+location)
+				location = remote.Scheme + "://" + remote.Host + location
 			}
+			// URL encode the location and prefix with scalar_url parameter
+			encodedLocation := url.QueryEscape(location)
+			res.Header.Set("Location", "/?scalar_url=" + encodedLocation)
 		}
 
 		return nil

--- a/examples/proxy-server/main_test.go
+++ b/examples/proxy-server/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -110,9 +111,10 @@ func TestLocationHeaderRewrite(t *testing.T) {
 	// Call the main handler
 	handleRequest(w, req)
 
-	// Check that Location header was rewritten to include full URL
+	// Check that Location header was rewritten correctly
 	location := w.Header().Get("Location")
-	if location != ts.URL+"/foobar" {
-		t.Errorf("Expected Location header to be '%s/foobar', got '%s'", ts.URL, location)
+	expectedLocation := "/?scalar_url=" + url.QueryEscape(ts.URL+"/foobar")
+	if location != expectedLocation {
+		t.Errorf("Expected Location header to be '%s', got '%s'", expectedLocation, location)
 	}
 }

--- a/examples/proxy-server/package.json
+++ b/examples/proxy-server/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "go build main.go",
-    "dev": "PORT=5051 go run main.go",
+    "dev": "PORT=5051 nodemon --quiet --exec go run main.go --signal SIGTERM",
     "lint:check": "go fmt ./main.go",
     "lint:fix": "go fmt ./main.go",
     "preview": "pnpm dev",

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -44,6 +44,7 @@
   ],
   "module": "dist/index.js",
   "dependencies": {
+    "@scalar/oas-utils": "workspace:*",
     "@scalar/openapi-parser": "workspace:*",
     "yaml": "^2.4.5"
   },

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -4,10 +4,14 @@ import { resolve } from './resolve'
 
 global.fetch = vi.fn()
 
-function createFetchResponse(data: string) {
+function createFetchResponse(
+  data: string,
+  headers: Record<string, string> = {},
+) {
   return {
     ok: true,
     text: () => new Promise((r) => r(data)),
+    headers: new Headers(headers),
   }
 }
 
@@ -138,6 +142,37 @@ describe('resolve', () => {
     const result = await resolve('https://example.com/reference')
 
     expect(result).toBe('https://example.com/openapi.yaml')
+  })
+
+  it('returns absolute URLs based on the X-Forwarded-Host header', async () => {
+    const html = `<!doctype html>
+<html>
+  <head>
+    <title>Scalar API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div data-url="/not-what-we-are-looking-for" id="foobar" />
+    <script
+      id="api-reference"
+      data-url="../openapi.yaml"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>`
+
+    // @ts-expect-error Mocking types are missing
+    fetch.mockResolvedValue(
+      createFetchResponse(html, {
+        'X-Forwarded-Host': 'https://example.com/somewhere/else/',
+      }),
+    )
+
+    const result = await resolve('https://example.com/reference')
+
+    expect(result).toBe('https://example.com/somewhere/openapi.yaml')
   })
 
   it('finds URLs in some wrangled configuration object', async () => {

--- a/packages/oas-utils/src/helpers/makeUrlAbsolute.test.ts
+++ b/packages/oas-utils/src/helpers/makeUrlAbsolute.test.ts
@@ -68,4 +68,23 @@ describe('makeUrlAbsolute', () => {
       writable: true,
     })
   })
+
+  it('handles parent directory paths', () => {
+    // Mock window.location.href
+    const originalHref = window.location.href
+    Object.defineProperty(window, 'location', {
+      value: { href: 'http://example.com/path/to/current/' },
+      writable: true,
+    })
+
+    expect(makeUrlAbsolute('../openapi.json')).toBe(
+      'http://example.com/path/to/openapi.json',
+    )
+
+    // Restore original window.location.href
+    Object.defineProperty(window, 'location', {
+      value: { href: originalHref },
+      writable: true,
+    })
+  })
 })

--- a/packages/oas-utils/src/helpers/makeUrlAbsolute.ts
+++ b/packages/oas-utils/src/helpers/makeUrlAbsolute.ts
@@ -1,19 +1,20 @@
 /**
  * Pass an URL or a relative URL and get an absolute URL
  */
-export const makeUrlAbsolute = (url?: string) => {
+export const makeUrlAbsolute = (url?: string, baseUrl?: string) => {
   if (
     !url ||
     url.startsWith('http://') ||
     url.startsWith('https://') ||
-    typeof window === 'undefined'
-  )
+    (typeof window === 'undefined' && !baseUrl)
+  ) {
     return url
+  }
 
-  const baseUrl = window.location.href
+  const base = baseUrl || window.location.href
 
   // Remove any query parameters or hash from the base URL
-  const cleanBaseUrl = baseUrl.split('?')[0]?.split('#')[0]
+  const cleanBaseUrl = base.split('?')[0]?.split('#')[0]
 
   // For base URLs with a path component, we want to remove the last path segment
   // if it doesn't end with a slash

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1591,6 +1591,9 @@ importers:
 
   packages/import:
     dependencies:
+      '@scalar/oas-utils':
+        specifier: workspace:*
+        version: link:../oas-utils
       '@scalar/openapi-parser':
         specifier: workspace:*
         version: link:../openapi-parser


### PR DESCRIPTION
Currently, when the proxy gets a `Location` header (redirect), it just proxies it:

`https://proxy.scalar.com/?scalar_url=https://example.com/foo` responds with `Location: /bar`

And the browser will follow the redirect, requesting an URL that doesn’t exist:

`https://proxy.scalar.com/bar`

With this PR, the proxy just follows the redirect:

`https://proxy.scalar.com/?scalar_url=https://example.com/foo` responds with the _content_ of `https://example.com/bar`

But in `@scalar/import` we try to transform relative URLs to absolute URLs, so we need to know the resulting URL. To achieve this, the proxy now adds a [`X-Forwarded-Host` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host) and `@scalar/import` uses this to prefix relative URLs (if it’s available).

This PR also adds a test for parent paths (`https://example.com/foo/bar/` + `../openapi.json` = `https://example.com/foo/openapi.json`) and merges the `makeRelativeUrlsAbsolute` and the `makeUrlAbsolute()` helper.