### PR TITLE
feat(oas-utils): add object-id value example

### DIFF
--- a/.changeset/dirty-laws-whisper.md
+++ b/.changeset/dirty-laws-whisper.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: support `format: object-id` in getExampleFromSchema

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -30,6 +30,7 @@ const genericExampleValues: Record<string, string> = {
   'uri-template': 'https://example.com/{id}',
   'uri': 'https://example.com',
   'uuid': '123e4567-e89b-12d3-a456-426614174000',
+  'object-id': '6592008029c8c3e4dc76256c',
 }
 
 /**


### PR DESCRIPTION
**Problem**
We use `format: object-id` to specify that the value should be a MongoDB Object ID. Currently, an example value isn't automatically generated for these fields.

**Solution**
With this PR, any field with `format: object-id` will now have a default example value, just like how it works for `format: uuid`.
