### PR TITLE
feat(api-client): display which auth is required on a request

### DIFF
--- a/.changeset/metal-ants-travel.md
+++ b/.changeset/metal-ants-travel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: indicate which auth is required


### PR DESCRIPTION
closes #3613

Based on feedback from [prev PR](https://github.com/scalar/scalar/pull/3826), added all options like this instead. Copy is up for debate as usual

Preview:
![image](https://github.com/user-attachments/assets/5e2e31fe-9646-40a0-9ddd-809a038f5396)
