### PR TITLE
fix: only virtualize text based contents

### DIFF
--- a/.changeset/lemon-hornets-tickle.md
+++ b/.changeset/lemon-hornets-tickle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: only virtualize text based contents

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -72,13 +72,38 @@ const shouldVirtualize = computed(() => {
     return false
   }
 
-  // Check if content type is text-based
-  const isTextBased =
-    contentType.includes('text/') ||
-    contentType.includes('application/json') ||
-    contentType.includes('application/xml') ||
-    contentType.includes('application/yaml') ||
-    contentType.includes('application/javascript')
+  // Common text-based content types
+  const textBasedTypes = [
+    // Text types
+    'text/',
+    // JSON types
+    'application/json',
+    'application/ld+json',
+    'application/problem+json',
+    'application/vnd.api+json',
+    // XML types
+    'application/xml',
+    'application/atom+xml',
+    'application/rss+xml',
+    'application/problem+xml',
+    // Other structured text
+    'application/javascript',
+    'application/ecmascript',
+    'application/x-yaml',
+    'application/yaml',
+    // Source code
+    'application/x-httpd-php',
+    'application/x-sh',
+    'application/x-perl',
+    'application/x-python',
+    'application/x-ruby',
+    'application/x-java-source',
+    // Form data
+    'application/x-www-form-urlencoded',
+  ]
+
+  // Check if content type matches any text-based type
+  const isTextBased = textBasedTypes.some((type) => contentType.includes(type))
 
   return isTextBased && (props.response.size ?? 0) > VIRTUALIZATION_THRESHOLD
 })

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -59,9 +59,29 @@ const activeSection = ref<ActiveSections>('All')
 
 /** Threshold for virtualizing response bodies in bytes */
 const VIRTUALIZATION_THRESHOLD = 200_000
-const shouldVirtualize = computed(
-  () => (props.response?.size ?? 0) > VIRTUALIZATION_THRESHOLD,
-)
+const shouldVirtualize = computed(() => {
+  if (!props.response) return false
+
+  // Get content type from headers
+  const contentType =
+    props.response.headers?.['content-type'] ||
+    props.response.headers?.['Content-Type']
+
+  // If no content type or response size is small, don't virtualize
+  if (!contentType || (props.response.size ?? 0) <= VIRTUALIZATION_THRESHOLD) {
+    return false
+  }
+
+  // Check if content type is text-based
+  const isTextBased =
+    contentType.includes('text/') ||
+    contentType.includes('application/json') ||
+    contentType.includes('application/xml') ||
+    contentType.includes('application/yaml') ||
+    contentType.includes('application/javascript')
+
+  return isTextBased && (props.response.size ?? 0) > VIRTUALIZATION_THRESHOLD
+})
 </script>
 <template>
   <ViewLayoutSection aria-label="Response">


### PR DESCRIPTION
**Problem**
Currently, we virtualize everything and dont check the content type

**Solution**
With this PR we virtualize only text based contents, so we can add a better more exhaustive check later but for now should handle most :) 
