### PR TITLE
feat(proxy-server): follow redirects DOC-2535

### DIFF
--- a/.changeset/green-nails-sparkle.md
+++ b/.changeset/green-nails-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/import': minor
+---
+
+feat: use X-Forwarded-Host header (if available)

--- a/.changeset/lemon-tomatoes-wash.md
+++ b/.changeset/lemon-tomatoes-wash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: allow to pass a base URL to makeUrlAbsolute

--- a/examples/proxy-server/README.md
+++ b/examples/proxy-server/README.md
@@ -2,19 +2,25 @@
 
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-The Scalar Proxy redirects requests to another server to avoid CORS issues. It’s made to work well with the Scalar API Client.
+When making requests from a web browser to different domains, browsers enforce the Same-Origin Policy by default. These
+cross-origin requests are blocked unless the target server implements proper [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+(Cross-Origin Resource Sharing) headers.
+
+The Scalar Proxy Server acts as an intermediary, forwarding requests to external servers while automatically adding the
+necessary CORS headers to the responses. This enables seamless cross-origin requests when using the Scalar API Client
+in browser environments.
 
 ## Features
 
-- Full CORS support with customizable origins
+- Full CORS support
 - Handles HTTP redirects while preserving headers
-- Supports HTTPS with TLS
+- Supports HTTPS (and even self-signed certificates)
 - Request logging with method and target URL
 - Health check endpoint at `/ping`
-- Configurable port via environment variable
-- Preserves original request headers and body
+- Configurable port via environment variable (`PORT`)
+- Preserves original request headers and body (except `Origin` header)
 - Forwards all HTTP methods (GET, POST, PUT, DELETE, PATCH)
-- Zero external dependencies - uses only Go standard library
+- Zero external dependencies (only using Go standard libraries)
 
 ## Usage
 
@@ -24,6 +30,8 @@ The Scalar Proxy redirects requests to another server to avoid CORS issues. It�
 
 ### Run
 
+You can start the proxy server in two ways. The default port is 1337:
+
 ```bash
 go run main.go
 ```
@@ -32,11 +40,13 @@ go run main.go
 2024/05/08 10:49:59 🥤 Proxy Server listening on http://localhost:1337
 ```
 
+But you can customize it using the `PORT` environment variable:
+
 ```bash
 PORT=8080 go run main.go
 ```
 
-### Example
+### Example request
 
 ```bash
 curl --request GET \

--- a/examples/proxy-server/README.md
+++ b/examples/proxy-server/README.md
@@ -4,6 +4,18 @@
 
 The Scalar Proxy redirects requests to another server to avoid CORS issues. It’s made to work well with the Scalar API Client.
 
+## Features
+
+- Full CORS support with customizable origins
+- Handles HTTP redirects while preserving headers
+- Supports HTTPS with TLS
+- Request logging with method and target URL
+- Health check endpoint at `/ping`
+- Configurable port via environment variable
+- Preserves original request headers and body
+- Forwards all HTTP methods (GET, POST, PUT, DELETE, PATCH)
+- Zero external dependencies - uses only Go standard library
+
 ## Usage
 
 ### Requirements
@@ -55,9 +67,9 @@ curl --request GET \
 }
 ```
 
-> Yo, there’s no mod file.
+## Community
 
-You’re so right! We’re using the standard libraries. Isn’t that why we all love Go? Anyway, we just don’t need a mod file. :)
+We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/scalar>
 
 ## License
 

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -120,8 +120,12 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 		return err
 	}
 
-	// Copy the headers
-	outreq.Header = r.Header
+	// Copy the headers but exclude Origin
+	for key, values := range r.Header {
+		if !strings.EqualFold(key, "Origin") {
+			outreq.Header[key] = values
+		}
+	}
 
 	// Make the request
 	resp, err := client.Do(outreq)

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -53,6 +53,30 @@ func (ps *ProxyServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Serve HTML page for root path
+	if r.URL.Path == "/" && r.URL.RawQuery == "" {
+		w.Header().Set("Content-Type", "text/html")
+		content, err := os.ReadFile("public/index.html")
+		if err != nil {
+			http.Error(w, "Error reading index.html", http.StatusInternalServerError)
+			return
+		}
+		w.Write(content)
+		return
+	}
+
+	// Serve OpenAPI spec for /openapi.yaml path
+	if r.URL.Path == "/openapi.yaml" {
+		w.Header().Set("Content-Type", "text/yaml")
+		content, err := os.ReadFile("public/openapi.yaml")
+		if err != nil {
+			http.Error(w, "Error reading openapi.yaml", http.StatusInternalServerError)
+			return
+		}
+		w.Write(content)
+		return
+	}
+
 	// Get and validate target URL
 	target := r.URL.Query().Get("scalar_url")
 	if target == "" {

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -146,6 +146,9 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Add the final URL as a header
+	w.Header().Set("X-Forwarded-Host", resp.Request.URL.String())
+
 	// Copy the status code
 	w.WriteHeader(resp.StatusCode)
 

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -10,28 +10,39 @@ import (
 	"strings"
 )
 
+// Set up and start the proxy server. The server is designed to bypass CORS and make cross-origin requests in browsers
+// behave like server-side requests (or let’s say like `curl`).
 func main() {
-	// Default port
+	// The default port
 	port := ":1337"
 
+	// Allow to overwrite the port with an environment variable
 	if p := os.Getenv("PORT"); p != "" {
 		port = ":" + p
 	}
 
+	// Create a new proxy server instance
 	proxyServer := NewProxyServer()
+
+	// Set up routing using the default HTTP multiplexer
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", proxyServer.handleRequest)
 
+	// Add our custom CORS middleware to handle cross-origin requests
 	handler := corsMiddleware(mux)
 
 	log.Println("🥤 Proxy Server listening on http://localhost" + port)
 
+	// Start the server and log any errors that occur
 	if err := http.ListenAndServe(port, handler); err != nil {
 		log.Fatal("⚠️ Error starting the Proxy Server: ", err)
 	}
 }
 
-// ProxyServer encapsulates the proxy server configuration and handlers
+// ProxyServer encapsulates the proxy server configuration and handlers.
+//
+// It uses a custom transport to handle HTTPS connections, including those
+// with self-signed certificates for development environments.
 type ProxyServer struct {
 	transport *http.Transport
 }
@@ -40,20 +51,28 @@ type ProxyServer struct {
 func NewProxyServer() *ProxyServer {
 	return &ProxyServer{
 		transport: &http.Transport{
+			// Skip TLS verification. This is useful for development environments
+			// where the target API might use self-signed certificates.
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
 }
 
-// Handle all incoming requests
+// Processes all incoming HTTP requests.
+//
+// It serves both as a proxy for API requests, but also provides some utility endpoints.
+//
+// - /openapi.yaml: OpenAPI specification
+// For all other paths, it forwards the request to the URL specified in scalar_url
 func (ps *ProxyServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 	// Health check
 	if r.URL.Path == "/ping" {
 		w.Write([]byte("pong"))
+
 		return
 	}
 
-	// Serve HTML page for root path
+	// Serve an API reference on root
 	if r.URL.Path == "/" && r.URL.RawQuery == "" {
 		w.Header().Set("Content-Type", "text/html")
 		content, err := os.ReadFile("public/index.html")
@@ -65,7 +84,7 @@ func (ps *ProxyServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Serve OpenAPI spec for /openapi.yaml path
+	// Serve the OpenAPI document
 	if r.URL.Path == "/openapi.yaml" {
 		w.Header().Set("Content-Type", "text/yaml")
 		content, err := os.ReadFile("public/openapi.yaml")
@@ -77,37 +96,48 @@ func (ps *ProxyServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get and validate target URL
+	// Get and validate the target URL from the `scalar_url` query parameter
 	target := r.URL.Query().Get("scalar_url")
+
+	// Show an error if the scalar_url is missing
 	if target == "" {
 		http.Error(w, "The `scalar_url` query parameter is required. Try to add `?scalar_url=https%3A%2F%2Fgalaxy.scalar.com%2Fplanets` to the URL.", http.StatusBadRequest)
 		return
 	}
 
+	// Validate the URL
 	remote, err := url.Parse(target)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
 
+	// Log the request
 	log.Println(r.Method, target)
 
 	// Create and execute the proxy request
 	if err := ps.executeProxyRequest(w, r, remote, target); err != nil {
-		// Only log the error, don't override the response
-		// The status code should already be set by executeProxyRequest
+		// Log any errors
 		log.Printf("[ERROR] %v\n", err)
 	}
 }
 
-// The actual proxying logic
+// executeProxyRequest handles the proxying logic
+//
+// 1. Preserves all original headers (except CORS headers)
+// 2. Maintains session state through redirects
+// 3. Adds consistent CORS headers to allow browser access
+// 4. Tracks the final URL after any redirects
 func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Request, remote *url.URL, target string) error {
 	client := &http.Client{
 		Transport: ps.transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Copy headers from the original request to maintain authentication
+			// and other important headers through redirect chains.
 			for key, values := range via[0].Header {
 				req.Header[key] = values
 			}
+
 			return nil
 		},
 	}
@@ -115,12 +145,14 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 	// Create the outbound request
 	outreq, err := http.NewRequest(r.Method, target, r.Body)
 
+	// Return error if request creation fails
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+
 		return err
 	}
 
-	// Copy the headers but exclude Origin
+	// Copy the headers but exclude Origin. It’s not required and might confuse some target servers.
 	for key, values := range r.Header {
 		if !strings.EqualFold(strings.ToLower(key), "origin") {
 			outreq.Header[key] = values
@@ -135,16 +167,18 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 		return err
 	}
 
+	// Close response body when done to prevent resource leaks
 	defer resp.Body.Close()
 
 	// Copy headers from final response, but skip CORS headers
 	for key, values := range resp.Header {
-		// Check if header is a CORS header
-		isCORSHeader := func(header string) bool {
+
+		// Check if header is a CORS headers
+		isCorsHeader := func(header string) bool {
 			return strings.HasPrefix(strings.ToLower(header), "access-control-")
 		}
 
-		if !isCORSHeader(key) {
+		if !isCorsHeader(key) {
 			for _, value := range values {
 				w.Header().Add(key, value)
 			}
@@ -178,17 +212,19 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 	return nil
 }
 
-// Adds CORS headers to the response and handle pre-flight requests
+// Handle preflight requests and ensures browsers can access the proxy regardless of where the request originates from.
+// This is essential to make cross-origin requests work in browser environments.
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Headers", "*")
 
 		allowOrigin := "*"
+
 		if r.Header.Get("Origin") != "" {
 			allowOrigin = r.Header.Get("Origin")
 		}
-		w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
 
+		w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH")
 		w.Header().Set("Access-Control-Expose-Headers", "*")
@@ -196,10 +232,11 @@ func corsMiddleware(next http.Handler) http.Handler {
 		// Handle pre-flight requests
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(http.StatusOK)
+
 			return
 		}
 
-		// Pass down the request to the next middleware (or final handler)
+		// Pass down the request to the next middleware or handler
 		next.ServeHTTP(w, r)
 	})
 }

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -90,12 +90,15 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		res.Header.Del("Access-Control-Allow-Methods")
 		res.Header.Del("Access-Control-Expose-Headers")
 
-		// Handle relative URLs in Location header
+		// Handle Location header to ensure redirects go through the proxy
 		if location := res.Header.Get("Location"); location != "" {
+			// If location starts with '/', make it absolute using the remote host
 			if location[0] == '/' {
-				// If location starts with '/', it's a relative URL
-				res.Header.Set("Location", remote.Scheme+"://"+remote.Host+location)
+				location = remote.Scheme + "://" + remote.Host + location
 			}
+			// URL encode the location and prefix with scalar_url parameter
+			encodedLocation := url.QueryEscape(location)
+			res.Header.Set("Location", "/?scalar_url=" + encodedLocation)
 		}
 
 		return nil

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -122,7 +122,7 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 
 	// Copy the headers but exclude Origin
 	for key, values := range r.Header {
-		if !strings.EqualFold(key, "Origin") {
+		if !strings.EqualFold(strings.ToLower(key), "origin") {
 			outreq.Header[key] = values
 		}
 	}

--- a/examples/proxy-server/main_test.go
+++ b/examples/proxy-server/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -110,9 +111,10 @@ func TestLocationHeaderRewrite(t *testing.T) {
 	// Call the main handler
 	handleRequest(w, req)
 
-	// Check that Location header was rewritten to include full URL
+	// Check that Location header was rewritten correctly
 	location := w.Header().Get("Location")
-	if location != ts.URL+"/foobar" {
-		t.Errorf("Expected Location header to be '%s/foobar', got '%s'", ts.URL, location)
+	expectedLocation := "/?scalar_url=" + url.QueryEscape(ts.URL+"/foobar")
+	if location != expectedLocation {
+		t.Errorf("Expected Location header to be '%s', got '%s'", expectedLocation, location)
 	}
 }

--- a/examples/proxy-server/main_test.go
+++ b/examples/proxy-server/main_test.go
@@ -254,7 +254,7 @@ func TestProxyBehavior(t *testing.T) {
 		defer server.server.Close()
 
 		// Create a request with scalar_url pointing to our test server's initial path
-		// Ensure the URL ends with exactly /initial (no trailing slash)
+		// Ensure the URL ends with exactly /initial
 		targetURL := server.url + "/initial"
 		req := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetURL, nil)
 		w := httptest.NewRecorder()

--- a/examples/proxy-server/main_test.go
+++ b/examples/proxy-server/main_test.go
@@ -22,13 +22,15 @@ func setupTestServer(handler http.HandlerFunc) *proxyTestServer {
 }
 
 func TestBasicEndpoints(t *testing.T) {
+	proxyServer := NewProxyServer()
+
 	t.Run("Ping returns pong", func(t *testing.T) {
 		// Create a new request
 		req := httptest.NewRequest(http.MethodGet, "/ping", nil)
 		w := httptest.NewRecorder()
 
 		// Call the handler directly
-		handleRequest(w, req)
+		proxyServer.handleRequest(w, req)
 
 		// Check the response
 		if w.Code != http.StatusOK {
@@ -46,7 +48,7 @@ func TestBasicEndpoints(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		// Call the handler directly
-		handleRequest(w, req)
+		proxyServer.handleRequest(w, req)
 
 		// Check the response
 		if w.Code != http.StatusBadRequest {
@@ -61,6 +63,8 @@ func TestBasicEndpoints(t *testing.T) {
 }
 
 func TestCORSHandling(t *testing.T) {
+	proxyServer := NewProxyServer()
+
 	t.Run("Adds CORS headers to normal requests", func(t *testing.T) {
 		// Create a test handler
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -126,7 +130,7 @@ func TestCORSHandling(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		// Call the handler
-		handleRequest(w, req)
+		proxyServer.handleRequest(w, req)
 
 		// Check response
 		if w.Code != http.StatusOK {
@@ -164,6 +168,8 @@ func TestCORSHandling(t *testing.T) {
 }
 
 func TestProxyBehavior(t *testing.T) {
+	proxyServer := NewProxyServer()
+
 	t.Run("Forwards X-Forwarded-Host header", func(t *testing.T) {
 		// Create a test handler that checks the X-Forwarded-Host header
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -260,7 +266,7 @@ func TestProxyBehavior(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		// Call the handler
-		handleRequest(w, req)
+		proxyServer.handleRequest(w, req)
 
 		// Check response
 		if w.Code != http.StatusOK {
@@ -293,7 +299,7 @@ func TestProxyBehavior(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/?scalar_url=http://invalid.localhost:99999", nil)
 		w := httptest.NewRecorder()
 
-		handleRequest(w, req)
+		proxyServer.handleRequest(w, req)
 
 		if w.Code != http.StatusServiceUnavailable {
 			t.Errorf("Expected status code %d, got %d", http.StatusServiceUnavailable, w.Code)
@@ -311,7 +317,7 @@ func TestProxyBehavior(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/?scalar_url="+server.url, nil)
 		w := httptest.NewRecorder()
 
-		handleRequest(w, req)
+		proxyServer.handleRequest(w, req)
 
 		if w.Header().Get("X-Custom-Header") != "custom-value" {
 			t.Errorf("Expected X-Custom-Header to be 'custom-value', got '%s'",
@@ -327,7 +333,7 @@ func TestProxyBehavior(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/?scalar_url=:", nil)
 		w := httptest.NewRecorder()
 
-		handleRequest(w, req)
+		proxyServer.handleRequest(w, req)
 
 		if w.Code != http.StatusServiceUnavailable {
 			t.Errorf("Expected status code %d, got %d", http.StatusServiceUnavailable, w.Code)

--- a/examples/proxy-server/package.json
+++ b/examples/proxy-server/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "go build main.go",
-    "dev": "PORT=5051 go run main.go",
+    "dev": "PORT=5051 nodemon --quiet --exec go run main.go --signal SIGTERM",
     "lint:check": "go fmt ./main.go",
     "lint:fix": "go fmt ./main.go",
     "preview": "pnpm dev",

--- a/examples/proxy-server/public/index.html
+++ b/examples/proxy-server/public/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Scalar Proxy Server</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+
+  <body>
+    <script
+      id="api-reference"
+      data-url="/openapi.yaml"></script>
+
+    <script>
+      var configuration = {
+        servers: [
+          {
+            url: '/',
+          },
+          {
+            url: 'https://proxy.scalar.com',
+          },
+        ],
+      }
+
+      document.getElementById('api-reference').dataset.configuration =
+        JSON.stringify(configuration)
+    </script>
+
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -90,23 +90,7 @@ $ pnpm dev:void-server
   }
 })
 
-describe('createRequestOperation', () => {
-  it('shows a warning when scalar_url is missing', async () => {
-    const [error, requestOperation] = createRequestOperation(
-      createRequestPayload({
-        serverPayload: { url: PROXY_URL },
-      }),
-    )
-    if (error) throw error
-
-    const [requestError, result] = await requestOperation.sendRequest()
-
-    expect(requestError).toBe(null)
-    expect(result?.response.data).toContain(
-      'The `scalar_url` query parameter is required.',
-    )
-  })
-
+describe('create-request-operation', () => {
   it('builds a request with a relative server url', async () => {
     const [error, requestOperation] = createRequestOperation(
       createRequestPayload({

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -44,6 +44,7 @@
   ],
   "module": "dist/index.js",
   "dependencies": {
+    "@scalar/oas-utils": "workspace:*",
     "@scalar/openapi-parser": "workspace:*",
     "yaml": "^2.4.5"
   },

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -4,10 +4,14 @@ import { resolve } from './resolve'
 
 global.fetch = vi.fn()
 
-function createFetchResponse(data: string) {
+function createFetchResponse(
+  data: string,
+  headers: Record<string, string> = {},
+) {
   return {
     ok: true,
     text: () => new Promise((r) => r(data)),
+    headers: new Headers(headers),
   }
 }
 
@@ -138,6 +142,37 @@ describe('resolve', () => {
     const result = await resolve('https://example.com/reference')
 
     expect(result).toBe('https://example.com/openapi.yaml')
+  })
+
+  it('returns absolute URLs based on the X-Forwarded-Host header', async () => {
+    const html = `<!doctype html>
+<html>
+  <head>
+    <title>Scalar API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div data-url="/not-what-we-are-looking-for" id="foobar" />
+    <script
+      id="api-reference"
+      data-url="../openapi.yaml"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>`
+
+    // @ts-expect-error Mocking types are missing
+    fetch.mockResolvedValue(
+      createFetchResponse(html, {
+        'X-Forwarded-Host': 'https://example.com/somewhere/else/',
+      }),
+    )
+
+    const result = await resolve('https://example.com/reference')
+
+    expect(result).toBe('https://example.com/somewhere/openapi.yaml')
   })
 
   it('finds URLs in some wrangled configuration object', async () => {

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -64,8 +64,6 @@ export async function resolve(
         const content = await result.text()
         const forwardedHost = result.headers.get('X-Forwarded-Host')
 
-        console.log('ASAS', forwardedHost)
-
         // Check if content is directly JSON/YAML
         try {
           // Try parsing as JSON

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -112,7 +112,6 @@ export async function resolve(
 
         // Relative or absolute URL
         if (urlOrPathOrDocument) {
-          console.log('make absolute', forwardedHost, urlOrPathOrDocument)
           return makeUrlAbsolute(urlOrPathOrDocument, forwardedHost || value)
         }
 

--- a/packages/oas-utils/src/helpers/makeUrlAbsolute.test.ts
+++ b/packages/oas-utils/src/helpers/makeUrlAbsolute.test.ts
@@ -68,4 +68,23 @@ describe('makeUrlAbsolute', () => {
       writable: true,
     })
   })
+
+  it('handles parent directory paths', () => {
+    // Mock window.location.href
+    const originalHref = window.location.href
+    Object.defineProperty(window, 'location', {
+      value: { href: 'http://example.com/path/to/current/' },
+      writable: true,
+    })
+
+    expect(makeUrlAbsolute('../openapi.json')).toBe(
+      'http://example.com/path/to/openapi.json',
+    )
+
+    // Restore original window.location.href
+    Object.defineProperty(window, 'location', {
+      value: { href: originalHref },
+      writable: true,
+    })
+  })
 })

--- a/packages/oas-utils/src/helpers/makeUrlAbsolute.ts
+++ b/packages/oas-utils/src/helpers/makeUrlAbsolute.ts
@@ -1,19 +1,20 @@
 /**
  * Pass an URL or a relative URL and get an absolute URL
  */
-export const makeUrlAbsolute = (url?: string) => {
+export const makeUrlAbsolute = (url?: string, baseUrl?: string) => {
   if (
     !url ||
     url.startsWith('http://') ||
     url.startsWith('https://') ||
-    typeof window === 'undefined'
-  )
+    (typeof window === 'undefined' && !baseUrl)
+  ) {
     return url
+  }
 
-  const baseUrl = window.location.href
+  const base = baseUrl || window.location.href
 
   // Remove any query parameters or hash from the base URL
-  const cleanBaseUrl = baseUrl.split('?')[0]?.split('#')[0]
+  const cleanBaseUrl = base.split('?')[0]?.split('#')[0]
 
   // For base URLs with a path component, we want to remove the last path segment
   // if it doesn't end with a slash

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1536,6 +1536,9 @@ importers:
 
   packages/import:
     dependencies:
+      '@scalar/oas-utils':
+        specifier: workspace:*
+        version: link:../oas-utils
       '@scalar/openapi-parser':
         specifier: workspace:*
         version: link:../openapi-parser


### PR DESCRIPTION
A previous version of this PR has been merged and rolled back. This PR has more changes than the initial PR:

* Even more tests
* Refactor of the proxy, hopefully easier to follow the code
* It doesn't merge CORS headers anymore, but overwrites them (the idea of the proxy is to be easy with cross-origin requests)
* Manually tested with a bunch of URLs, too (directly, in the reference and in the API client)

Here’s the original description:

Currently, when the proxy gets a `Location` header (redirect), it just proxies it:

`https://proxy.scalar.com/?scalar_url=https://example.com/foo` responds with `Location: /bar`

And the browser will follow the redirect, requesting an URL that doesn’t exist:

`https://proxy.scalar.com/bar`

With this PR, the proxy just follows the redirect:

`https://proxy.scalar.com/?scalar_url=https://example.com/foo` responds with the _content_ of `https://example.com/bar`

But in `@scalar/import` we try to transform relative URLs to absolute URLs, so we need to know the resulting URL. To achieve this, the proxy now adds a [`X-Forwarded-Host` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host) and `@scalar/import` uses this to prefix relative URLs (if it’s available).

This PR also adds a test for parent paths (`https://example.com/foo/bar/` + `../openapi.json` = `https://example.com/foo/openapi.json`) and merges the `makeRelativeUrlsAbsolute` and the `makeUrlAbsolute()` helper.

The proxy renders an API reference on the root path now. This is great to quickly test this PR for example:

1. `cd examples/proxy-server`
2. `pnpm run dev`
3. `open http://localhost:5051`

<img width="1185" alt="Screenshot 2024-11-20 at 11 35 49" src="https://github.com/user-attachments/assets/11837d1d-a1bc-474d-adc9-4ac7f8041a6f">
