### PR TITLE
fix(api-client): import modal shows up for any URL

### DIFF
--- a/.changeset/sharp-clouds-sneeze.md
+++ b/.changeset/sharp-clouds-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: import modal shows for any URL

--- a/packages/api-client/src/components/ImportCollection/DropEventListener.vue
+++ b/packages/api-client/src/components/ImportCollection/DropEventListener.vue
@@ -3,7 +3,7 @@ import { ScalarIcon } from '@scalar/components'
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 
 const emit = defineEmits<{
-  (e: 'input', value: string): void
+  (e: 'input', value: string, integration: null, eventType: 'drop'): void
 }>()
 
 const isDragging = ref<boolean>(false)
@@ -46,7 +46,7 @@ async function handleDrop(event: DragEvent) {
     const droppedText = event.dataTransfer.getData('text').replace(/^blob:/, '')
 
     if (droppedText) {
-      emit('input', droppedText)
+      emit('input', droppedText, null, 'drop')
     }
     // Files
     else if (event.dataTransfer.files.length > 0) {
@@ -55,7 +55,7 @@ async function handleDrop(event: DragEvent) {
 
       reader.onload = async (e) => {
         if (e.target && typeof e.target.result === 'string') {
-          emit('input', e.target.result)
+          emit('input', e.target.result, null, 'drop')
         }
       }
       reader.readAsText(file)

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionListener.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionListener.vue
@@ -11,10 +11,13 @@ const source = ref<string | null>(null)
 
 const integration = ref<string | null>(null)
 
+const eventType = ref<'paste' | 'drop' | 'query' | null>(null)
+
 /** Reset the data when the modal was closed */
 async function resetData() {
   source.value = null
   integration.value = null
+  eventType.value = null
 
   await nextTick()
 }
@@ -23,18 +26,21 @@ async function resetData() {
 async function handleInput(
   newSource: string,
   newIntegration: string | null = null,
+  newEventType: 'paste' | 'drop' | 'query',
 ) {
   // Reset, to trigger the modal to reopen
   await resetData()
 
   source.value = newSource
   integration.value = newIntegration
+  eventType.value = newEventType
 }
 </script>
 
 <template>
   <!-- Modal -->
   <ImportCollectionModal
+    :eventType="eventType"
     :integration="integration"
     :source="source"
     @importFinished="resetData" />

--- a/packages/api-client/src/components/ImportCollection/PasteEventListener.vue
+++ b/packages/api-client/src/components/ImportCollection/PasteEventListener.vue
@@ -3,7 +3,7 @@
 import { onBeforeUnmount, onMounted } from 'vue'
 
 const emit = defineEmits<{
-  (e: 'input', value: string): void
+  (e: 'input', value: string, integration: null, eventType: 'paste'): void
 }>()
 
 // Register event listener
@@ -35,7 +35,7 @@ async function handlePaste(event: ClipboardEvent) {
     const pastedText = event.clipboardData.getData('text')
 
     if (pastedText) {
-      emit('input', pastedText)
+      emit('input', pastedText, null, 'paste')
     }
   }
 }

--- a/packages/api-client/src/components/ImportCollection/UrlQueryParameterChecker.vue
+++ b/packages/api-client/src/components/ImportCollection/UrlQueryParameterChecker.vue
@@ -3,7 +3,12 @@
 import { onMounted } from 'vue'
 
 const emit = defineEmits<{
-  (e: 'input', url: string, integration: string | null): void
+  (
+    e: 'input',
+    url: string,
+    integration: string | null,
+    eventType: 'query',
+  ): void
 }>()
 
 // Check URL query parameters for 'url' and 'integration' values
@@ -13,7 +18,12 @@ onMounted(() => {
   const urlQueryParameter = queryParameters.get('url')
 
   if (urlQueryParameter) {
-    emit('input', urlQueryParameter, queryParameters.get('integration'))
+    emit(
+      'input',
+      urlQueryParameter,
+      queryParameters.get('integration'),
+      'query',
+    )
   }
 })
 </script>

--- a/packages/api-client/src/components/ImportCollection/hooks/useUrlPrefetcher.ts
+++ b/packages/api-client/src/components/ImportCollection/hooks/useUrlPrefetcher.ts
@@ -26,6 +26,16 @@ export function useUrlPrefetcher() {
     error: null,
   })
 
+  async function resetPrefetchResult() {
+    Object.assign(prefetchResult, {
+      state: 'idle',
+      content: null,
+      url: null,
+      input: null,
+      error: null,
+    })
+  }
+
   async function prefetchUrl(input: string | null, proxy?: string) {
     if (!input) {
       return {
@@ -133,5 +143,6 @@ export function useUrlPrefetcher() {
   return {
     prefetchResult,
     prefetchUrl: prefetchUrlAndUpdateState,
+    resetPrefetchResult,
   }
 }


### PR DESCRIPTION
Currently, the import collection modal is shown when any URL is pasted or dropped into the UI.

With this PR we’re checking whether the pasted/dropped URL is pointing to an OpenAPI document first, and only then show the modal.

It still shows the import modal when an URL is provided through a query parameter (when following a link from the references).