### PR TITLE
fix(mock-server): OpenAPI YAML endpoints don’t have a YAML content-type header

### DIFF
--- a/.changeset/large-zebras-sell.md
+++ b/.changeset/large-zebras-sell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+fix: openapi endpoints don’t have a YAML content type header

--- a/packages/mock-server/src/routes/respondWithOpenApiDocument.ts
+++ b/packages/mock-server/src/routes/respondWithOpenApiDocument.ts
@@ -18,7 +18,6 @@ export async function respondWithOpenApiDocument(
 
     // JSON
     if (format === 'json') {
-      c.header('Content-Type', 'application/json')
       return c.json(specification)
     }
 
@@ -26,7 +25,9 @@ export async function respondWithOpenApiDocument(
     try {
       const yamlSpecification = await openapi().load(input).toYaml()
       c.header('Content-Type', 'text/yaml')
-      return c.text(yamlSpecification)
+      return c.text(yamlSpecification, 200, {
+        'Content-Type': 'application/yaml; charset=UTF-8',
+      })
     } catch (error) {
       return c.json(
         {

--- a/packages/mock-server/tests/openapi.test.ts
+++ b/packages/mock-server/tests/openapi.test.ts
@@ -64,7 +64,7 @@ describe('openapi.{json|yaml}', () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toMatchObject(specification)
-    expect(response.headers.get('Content-Type')).toContain('application/yaml')
+    expect(response.headers.get('Content-Type')).toContain('application/json')
   })
 
   it('GET /openapi.yaml (object)', async () => {

--- a/packages/mock-server/tests/openapi.test.ts
+++ b/packages/mock-server/tests/openapi.test.ts
@@ -22,6 +22,7 @@ describe('openapi.{json|yaml}', () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toMatchObject(specification)
+    expect(response.headers.get('Content-Type')).toContain('application/json')
   })
 
   it('GET /openapi.json (from JSON string)', async () => {
@@ -42,6 +43,7 @@ describe('openapi.{json|yaml}', () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toMatchObject(specification)
+    expect(response.headers.get('Content-Type')).toContain('application/json')
   })
 
   it('GET /openapi.json (YAML string)', async () => {
@@ -62,6 +64,7 @@ describe('openapi.{json|yaml}', () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toMatchObject(specification)
+    expect(response.headers.get('Content-Type')).toContain('application/yaml')
   })
 
   it('GET /openapi.yaml (object)', async () => {
@@ -82,6 +85,7 @@ describe('openapi.{json|yaml}', () => {
 
     expect(response.status).toBe(200)
     expect(normalize(await response.text())).toMatchObject(specification)
+    expect(response.headers.get('Content-Type')).toContain('application/yaml')
   })
 
   it('GET /openapi.yaml (YAML string)', async () => {
@@ -102,6 +106,7 @@ describe('openapi.{json|yaml}', () => {
 
     expect(response.status).toBe(200)
     expect(normalize(await response.text())).toMatchObject(specification)
+    expect(response.headers.get('Content-Type')).toContain('application/yaml')
   })
 
   it('GET /openapi.yaml (JSON string)', async () => {
@@ -122,5 +127,6 @@ describe('openapi.{json|yaml}', () => {
 
     expect(response.status).toBe(200)
     expect(normalize(await response.text())).toMatchObject(specification)
+    expect(response.headers.get('Content-Type')).toContain('application/yaml')
   })
 })


### PR DESCRIPTION
Currently, `@scalar/mock-server` doesn’t add YAML http headers when serving the OpenAPI documents as YAML.

This PR adds them.