### PR TITLE
test(oas-utils): more tests for `importSpecToWorkspace`

### DIFF
--- a/.changeset/clever-phones-stare.md
+++ b/.changeset/clever-phones-stare.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+chore: add time logging for the workspace store

--- a/.changeset/three-llamas-watch.md
+++ b/.changeset/three-llamas-watch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: remove time logging for the search index

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -6,7 +6,7 @@ import {
   importSpecToWorkspace,
 } from '@scalar/oas-utils/transforms'
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
-import type { ReferenceConfiguration, Spec } from '@scalar/types/legacy'
+import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import { toRaw } from 'vue'
 
 /** Maps the specs by URL */

--- a/packages/api-reference/src/features/Search/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.ts
@@ -80,8 +80,6 @@ export function useSearchIndex({
   watch(
     specification.value,
     async () => {
-      const start = performance.now()
-
       fuseDataArray.value = []
 
       // Likely an incomplete/invalid spec
@@ -204,9 +202,6 @@ export function useSearchIndex({
       }
 
       fuse.setCollection(fuseDataArray.value)
-
-      const end = performance.now()
-      console.log(`create-search-index: ${Math.round(end - start)} ms`)
     },
     { immediate: true },
   )

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -1,16 +1,14 @@
-/**
- * @vitest-environment jsdom
- */
+/** @vitest-environment jsdom */
 import type { SecuritySchemeOauth2 } from '@/entities/spec/security'
 import { importSpecToWorkspace } from '@/transforms/import-spec'
 import circular from '@test/fixtures/basic-circular-spec.json'
-import petstoreMod from '@test/fixtures/petstore-tls.json'
-import { describe, expect, it, test } from 'vitest'
+import modifiedPetStoreExample from '@test/fixtures/petstore-tls.json'
+import { describe, expect, it } from 'vitest'
 
 import galaxy from '../../../galaxy/dist/latest.json'
 
-describe('Import OAS Specs', () => {
-  test('Handles circular', async () => {
+describe('import-spec', () => {
+  it('handles circular references', async () => {
     const res = await importSpecToWorkspace(circular)
 
     // console.log(JSON.stringify(res, null, 2))
@@ -23,20 +21,18 @@ describe('Import OAS Specs', () => {
     ).toEqual(true)
   })
 
-  test('Handles weird petstore', async () => {
-    const res = await importSpecToWorkspace(petstoreMod)
+  it('handles a weird Petstore example', async () => {
+    const res = await importSpecToWorkspace(modifiedPetStoreExample)
 
     expect(res.error).toBe(false)
   })
 
-  // Causes cyclic dependency
-  test('Loads galaxy spec', async () => {
+  it('loads the Scalar Galaxy example (with cyclic dependencies)', async () => {
     const res = await importSpecToWorkspace(galaxy)
 
     expect(res.error).toEqual(false)
   })
 
-  // Security
   describe('security', () => {
     it('handles vanilla security schemes', async () => {
       const res = await importSpecToWorkspace(galaxy)
@@ -151,7 +147,7 @@ describe('Import OAS Specs', () => {
       const res = await importSpecToWorkspace(relativeGalaxy)
       if (res.error) throw res.error
 
-      // Test URLS only
+      // Test URLs only
       expect(res.servers.map(({ url }) => url)).toEqual([
         'https://galaxy.scalar.com',
         '{protocol}://void.scalar.com/{path}',

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -1,36 +1,82 @@
 /** @vitest-environment jsdom */
 import type { SecuritySchemeOauth2 } from '@/entities/spec/security'
-import { importSpecToWorkspace } from '@/transforms/import-spec'
+import {
+  getBaseAuthValues,
+  importSpecToWorkspace,
+} from '@/transforms/import-spec'
 import circular from '@test/fixtures/basic-circular-spec.json'
 import modifiedPetStoreExample from '@test/fixtures/petstore-tls.json'
 import { describe, expect, it } from 'vitest'
 
 import galaxy from '../../../galaxy/dist/latest.json'
 
-describe('import-spec', () => {
-  it('handles circular references', async () => {
-    const res = await importSpecToWorkspace(circular)
+describe('importSpecToWorkspace', () => {
+  describe('basics', () => {
+    it('handles circular references', async () => {
+      const res = await importSpecToWorkspace(circular)
 
-    // console.log(JSON.stringify(res, null, 2))
-    if (res.error) return
+      // console.log(JSON.stringify(res, null, 2))
+      if (res.error) return
 
-    expect(res.requests[0].path).toEqual('/api/v1/updateEmployee')
-    expect(res.tags[0].children.includes(res.tags[1].uid)).toEqual(true)
-    expect(
-      res.tags[0].children.includes(Object.values(res.requests)[0].uid),
-    ).toEqual(true)
+      expect(res.requests[0].path).toEqual('/api/v1/updateEmployee')
+      expect(res.tags[0].children.includes(res.tags[1].uid)).toEqual(true)
+      expect(
+        res.tags[0].children.includes(Object.values(res.requests)[0].uid),
+      ).toEqual(true)
+    })
+
+    it('handles a weird Petstore example', async () => {
+      const res = await importSpecToWorkspace(modifiedPetStoreExample)
+
+      expect(res.error).toBe(false)
+    })
+
+    it('loads the Scalar Galaxy example (with cyclic dependencies)', async () => {
+      const res = await importSpecToWorkspace(galaxy)
+
+      expect(res.error).toEqual(false)
+    })
   })
 
-  it('handles a weird Petstore example', async () => {
-    const res = await importSpecToWorkspace(modifiedPetStoreExample)
+  describe('tags', () => {
+    it('creates missing tag definitions', async () => {
+      const specWithUndefinedTags = {
+        ...galaxy,
+        tags: [],
+        paths: {
+          '/test': {
+            get: {
+              tags: ['undefined-tag'],
+            },
+          },
+        },
+      }
 
-    expect(res.error).toBe(false)
-  })
+      const res = await importSpecToWorkspace(specWithUndefinedTags)
+      if (res.error) throw res.error
 
-  it('loads the Scalar Galaxy example (with cyclic dependencies)', async () => {
-    const res = await importSpecToWorkspace(galaxy)
+      expect(res.tags.some((t) => t.name === 'undefined-tag')).toBe(true)
+    })
 
-    expect(res.error).toEqual(false)
+    it('handles requests without tags', async () => {
+      const specWithUntaggedRequest = {
+        ...galaxy,
+        paths: {
+          '/test': {
+            get: {
+              // No tags specified
+              operationId: 'untaggedRequest',
+            },
+          },
+        },
+      }
+
+      const res = await importSpecToWorkspace(specWithUntaggedRequest)
+      if (res.error) throw res.error
+
+      // The untagged request should be in the collection's root children
+      expect(res.collection.children).toContain(res.requests[0].uid)
+    })
   })
 
   describe('security', () => {
@@ -117,9 +163,111 @@ describe('import-spec', () => {
       const authScheme = res.securitySchemes[5] as SecuritySchemeOauth2
       expect(authScheme['x-scalar-client-id']).toEqual(testId)
     })
+
+    it('handles empty security requirements', async () => {
+      const specWithEmptySecurity = {
+        ...galaxy,
+        security: [{}],
+        paths: {
+          '/test': {
+            get: {
+              security: [{}],
+            },
+          },
+        },
+      }
+
+      const res = await importSpecToWorkspace(specWithEmptySecurity)
+      if (res.error) throw res.error
+
+      expect(res.requests[0].security).toEqual([{}])
+    })
+
+    it('prefers operation level security over global security', async () => {
+      const specWithGlobalAndOperationSecurity = {
+        ...galaxy,
+        security: [{ bearerAuth: [] }],
+        paths: {
+          '/test': {
+            get: {
+              security: [{ basicAuth: [] }],
+            },
+          },
+        },
+      }
+
+      const res = await importSpecToWorkspace(
+        specWithGlobalAndOperationSecurity,
+      )
+      if (res.error) throw res.error
+
+      // Operation level security should override global security
+      expect(res.requests[0].security).toEqual([{ basicAuth: [] }])
+    })
+
+    it('sets collection level security when specified', async () => {
+      const res = await importSpecToWorkspace(galaxy, {
+        setCollectionSecurity: true,
+        authentication: {
+          preferredSecurityScheme: 'basicAuth',
+        },
+      })
+      if (res.error) throw res.error
+
+      expect(res.collection.selectedSecuritySchemeUids).toHaveLength(1)
+      const scheme = res.securitySchemes.find(
+        (s) => s.uid === res.collection.selectedSecuritySchemeUids[0],
+      )
+      expect(scheme?.nameKey).toBe('basicAuth')
+    })
+
+    it('handles array scopes conversion', async () => {
+      const specWithArrayScopes = {
+        ...galaxy,
+        components: {
+          securitySchemes: {
+            oAuth2: {
+              type: 'oauth2',
+              flows: {
+                authorizationCode: {
+                  authorizationUrl: 'https://example.com/auth',
+                  tokenUrl: 'https://example.com/token',
+                  scopes: ['read:test', 'write:test'],
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const res = await importSpecToWorkspace(specWithArrayScopes)
+      if (res.error) throw res.error
+
+      const oauth2Scheme = res.securitySchemes.find((s) => s.type === 'oauth2')
+      expect(oauth2Scheme?.flow?.scopes).toEqual({
+        'read:test': '',
+        'write:test': '',
+      })
+    })
+
+    it('handles oauth2 authentication configuration', async () => {
+      const res = await importSpecToWorkspace(galaxy, {
+        authentication: {
+          // @ts-expect-error
+          oAuth2: {
+            clientId: 'test-client',
+            scopes: ['read:account'],
+          },
+        },
+      })
+      if (res.error) throw res.error
+
+      const oauth2Scheme = res.securitySchemes.find((s) => s.type === 'oauth2')
+      expect(oauth2Scheme?.['x-scalar-client-id']).toBe('test-client')
+      expect(oauth2Scheme?.flow?.selectedScopes).toEqual(['read:account'])
+    })
   })
 
-  // Servers
   describe('servers', () => {
     it('vanilla servers are returned', async () => {
       const res = await importSpecToWorkspace(galaxy)
@@ -179,6 +327,103 @@ describe('import-spec', () => {
 
       // Test URLS only
       expect(res.servers.map(({ url }) => url)).toEqual(['https://scalar.com'])
+    })
+  })
+})
+
+describe('getBaseAuthValues', () => {
+  it('handles implicit oauth2 flow', async () => {
+    const res = await importSpecToWorkspace(galaxy, {
+      authentication: {
+        // @ts-expect-error
+        oAuth2: {
+          accessToken: 'test-token',
+        },
+      },
+    })
+    if (res.error) throw res.error
+
+    // Modify one scheme to be implicit flow
+    const implicitScheme = {
+      ...res.securitySchemes[5],
+      flow: {
+        // @ts-expect-error
+        ...res.securitySchemes[5].flow,
+        type: 'implicit',
+      },
+    }
+
+    const baseValues = getBaseAuthValues(implicitScheme, {
+      // @ts-expect-error
+      oAuth2: { accessToken: 'test-token' },
+    })
+
+    expect(baseValues).toEqual({
+      type: 'oauth-implicit',
+      token: 'test-token',
+    })
+  })
+
+  it('handles password oauth2 flow', async () => {
+    const res = await importSpecToWorkspace(galaxy, {
+      authentication: {
+        // @ts-expect-error
+        oAuth2: {
+          accessToken: 'test-token',
+          username: 'test-user',
+          password: 'test-pass',
+        },
+      },
+    })
+    if (res.error) throw res.error
+
+    // Modify one scheme to be password flow
+    const passwordScheme = {
+      ...res.securitySchemes[5],
+      flow: {
+        ...res.securitySchemes[5].flow,
+        type: 'password',
+      },
+    }
+
+    const baseValues = getBaseAuthValues(passwordScheme, {
+      // @ts-expect-error
+      oAuth2: {
+        accessToken: 'test-token',
+        username: 'test-user',
+        password: 'test-pass',
+      },
+    })
+
+    expect(baseValues).toEqual({
+      type: 'oauth-password',
+      token: 'test-token',
+      username: 'test-user',
+      password: 'test-pass',
+    })
+  })
+
+  it('handles basic http auth', async () => {
+    const baseValues = getBaseAuthValues(
+      // @ts-expect-error
+      {
+        type: 'http',
+        scheme: 'basic',
+        nameKey: 'basicAuth',
+      },
+      {
+        http: {
+          basic: {
+            username: 'test-user',
+            password: 'test-pass',
+          },
+        },
+      },
+    )
+
+    expect(baseValues).toEqual({
+      username: 'test-user',
+      password: 'test-pass',
     })
   })
 })

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -403,6 +403,7 @@ describe('getBaseAuthValues', () => {
     const passwordScheme = {
       ...res.securitySchemes[5],
       flow: {
+        // @ts-expect-error
         ...res.securitySchemes[5].flow,
         type: 'password',
       },

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -36,6 +36,28 @@ describe('importSpecToWorkspace', () => {
 
       expect(res.error).toEqual(false)
     })
+
+    it('merges path and operation parameters', async () => {
+      const specWithParams = {
+        ...galaxy,
+        paths: {
+          '/test/{id}': {
+            parameters: [{ name: 'id', in: 'path', required: true }],
+            get: {
+              parameters: [{ name: 'filter', in: 'query' }],
+            },
+          },
+        },
+      }
+
+      const res = await importSpecToWorkspace(specWithParams)
+      if (res.error) throw res.error
+
+      const request = res.requests[0]
+      expect(request.parameters).toHaveLength(2)
+      expect(request.parameters?.map((p) => p.name)).toContain('id')
+      expect(request.parameters?.map((p) => p.name)).toContain('filter')
+    })
   })
 
   describe('tags', () => {

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -122,6 +122,8 @@ export const getBaseAuthValues = (
 
 /** Takes a string or object and parses it into an openapi spec compliant schema */
 export const parseSchema = async (spec: string | UnknownObject) => {
+  // TODO: Plugins for URLs and files with the proxy is missing here.
+  // @see packages/api-reference/src/helpers/parse.ts
   const { filesystem } = await load(spec)
   const { specification } = upgrade(filesystem)
   const { schema, errors = [] } = await dereference(specification)

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -144,12 +144,17 @@ export type ImportSpecToWorkspaceArgs = Pick<
   }
 
 /**
- * Import an OpenAPI spec file and convert it to workspace entities
+ * Imports an OpenAPI document and converts it to workspace entities (Collection, Request, Server, etc.)
  *
- * We will aim to keep the entities as close to the specification as possible
- * to leverage bi-directional translation. Where entities are able to be
- * created and used at various levels we will index via the uids to create
- * the relationships
+ * The imported entities maintain a close mapping to the original OpenAPI specification to enable:
+ * - Bi-directional translation between spec and workspace entities
+ * - Preservation of specification details and structure
+ * - Accurate representation of relationships between components
+ *
+ * Relationships between entities are maintained through unique identifiers (UIDs) which allow:
+ * - Flexible organization at different levels (workspace, collection, request)
+ * - Proper linking between related components
+ * - Easy lookup and reference of dependent entities
  */
 export async function importSpecToWorkspace(
   spec: string | UnknownObject,

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -185,6 +185,7 @@ export async function importSpecToWorkspace(
   if (!schema) return { importWarnings, error: true }
   // ---------------------------------------------------------------------------
   // Some entities will be broken out as individual lists for modification in the workspace
+  const start = performance.now()
   const requests: Request[] = []
 
   // Grab the base server URL for relative servers
@@ -453,6 +454,9 @@ export async function importSpecToWorkspace(
     },
     securitySchemes: securitySchemes.map((s) => s.uid),
   })
+
+  const end = performance.now()
+  console.log(`workspace: ${Math.round(end - start)} ms`)
 
   /**
    * Servers and requests will be saved in top level maps and indexed via UID to

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,73 +677,6 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.14.10)(jsdom@22.1.0)(terser@5.31.2)
 
-  packages/scalar-app:
-    dependencies:
-      '@electron-toolkit/preload':
-        specifier: ^3.0.0
-        version: 3.0.1(electron@33.0.0)
-      '@electron-toolkit/utils':
-        specifier: ^3.0.0
-        version: 3.0.0(electron@33.0.0)
-      '@scalar/api-client':
-        specifier: workspace:*
-        version: link:../api-client
-      '@scalar/components':
-        specifier: workspace:*
-        version: link:../components
-      '@scalar/import':
-        specifier: workspace:*
-        version: link:../import
-      '@scalar/themes':
-        specifier: workspace:*
-        version: link:../themes
-      '@todesktop/runtime':
-        specifier: ^2.0.0
-        version: 2.0.0
-      electron-window-state:
-        specifier: ^5.0.3
-        version: 5.0.3
-      fathom-client:
-        specifier: ^3.7.2
-        version: 3.7.2
-    devDependencies:
-      '@electron-toolkit/tsconfig':
-        specifier: ^1.0.1
-        version: 1.0.1(@types/node@20.14.10)
-      '@rushstack/eslint-patch':
-        specifier: ^1.10.3
-        version: 1.10.3
-      '@todesktop/cli':
-        specifier: ^1.10.2
-        version: 1.10.2(@types/react@18.3.3)
-      '@types/node':
-        specifier: ^20.14.10
-        version: 20.14.10
-      '@vitejs/plugin-vue':
-        specifier: ^5.0.4
-        version: 5.0.5(vite@5.4.10(@types/node@20.14.10)(terser@5.31.2))(vue@3.5.12(typescript@5.6.2))
-      '@vue/eslint-config-prettier':
-        specifier: ^9.0.0
-        version: 9.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.3.3)
-      '@vue/eslint-config-typescript':
-        specifier: ^12.0.0
-        version: 12.0.0(eslint-plugin-vue@9.27.0(eslint@8.57.0))(eslint@8.57.0)(typescript@5.6.2)
-      electron:
-        specifier: ^33.0.0
-        version: 33.0.0
-      electron-vite:
-        specifier: ^2.3.0
-        version: 2.3.0(@swc/core@1.5.29)(vite@5.4.10(@types/node@20.14.10)(terser@5.31.2))
-      vite:
-        specifier: ^5.4.9
-        version: 5.4.10(@types/node@20.14.10)(terser@5.31.2)
-      vue:
-        specifier: ^3.5.12
-        version: 3.5.12(typescript@5.6.2)
-      vue-tsc:
-        specifier: ^2.1.10
-        version: 2.1.10(typescript@5.6.2)
-
   packages/api-client-proxy:
     dependencies:
       cors:
@@ -1955,6 +1888,73 @@ importers:
       vite-svg-loader:
         specifier: ^5.1.0
         version: 5.1.0(vue@3.5.12(typescript@5.6.2))
+
+  packages/scalar-app:
+    dependencies:
+      '@electron-toolkit/preload':
+        specifier: ^3.0.0
+        version: 3.0.1(electron@33.0.0)
+      '@electron-toolkit/utils':
+        specifier: ^3.0.0
+        version: 3.0.0(electron@33.0.0)
+      '@scalar/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@scalar/components':
+        specifier: workspace:*
+        version: link:../components
+      '@scalar/import':
+        specifier: workspace:*
+        version: link:../import
+      '@scalar/themes':
+        specifier: workspace:*
+        version: link:../themes
+      '@todesktop/runtime':
+        specifier: ^2.0.0
+        version: 2.0.0
+      electron-window-state:
+        specifier: ^5.0.3
+        version: 5.0.3
+      fathom-client:
+        specifier: ^3.7.2
+        version: 3.7.2
+    devDependencies:
+      '@electron-toolkit/tsconfig':
+        specifier: ^1.0.1
+        version: 1.0.1(@types/node@20.14.10)
+      '@rushstack/eslint-patch':
+        specifier: ^1.10.3
+        version: 1.10.3
+      '@todesktop/cli':
+        specifier: ^1.10.2
+        version: 1.10.2(@types/react@18.3.3)
+      '@types/node':
+        specifier: ^20.14.10
+        version: 20.14.10
+      '@vitejs/plugin-vue':
+        specifier: ^5.0.4
+        version: 5.0.5(vite@5.4.10(@types/node@20.14.10)(terser@5.31.2))(vue@3.5.12(typescript@5.6.2))
+      '@vue/eslint-config-prettier':
+        specifier: ^9.0.0
+        version: 9.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.3.3)
+      '@vue/eslint-config-typescript':
+        specifier: ^12.0.0
+        version: 12.0.0(eslint-plugin-vue@9.27.0(eslint@8.57.0))(eslint@8.57.0)(typescript@5.6.2)
+      electron:
+        specifier: ^33.0.0
+        version: 33.0.0
+      electron-vite:
+        specifier: ^2.3.0
+        version: 2.3.0(@swc/core@1.5.29)(vite@5.4.10(@types/node@20.14.10)(terser@5.31.2))
+      vite:
+        specifier: ^5.4.9
+        version: 5.4.10(@types/node@20.14.10)(terser@5.31.2)
+      vue:
+        specifier: ^3.5.12
+        version: 3.5.12(typescript@5.6.2)
+      vue-tsc:
+        specifier: ^2.1.10
+        version: 2.1.10(typescript@5.6.2)
 
   packages/scalar.aspnetcore:
     dependencies:


### PR DESCRIPTION
This PR improve a few code comments and adds a bunch of tests for `importSpecToWorkspace`.

It’s also adding a console.log for the time it takes to create the workspace, and removes the console.log for the time it takes to create the search index. The search index was never really blocking anything, and it was rather quick, even for big files. The workspace becomes more relevant for the time to interaction, so I’d like to keep an eye on it for real-world examples. 

The diff is hard to follow, but no actual code is touched (except the mentioned logging).