### PR TITLE
feat(api-client): environment collection variables

### DIFF
--- a/.changeset/fifty-eggs-warn.md
+++ b/.changeset/fifty-eggs-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+updates environment sidebar to welcome collection environment

--- a/.changeset/little-pugs-heal.md
+++ b/.changeset/little-pugs-heal.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-codemirror': patch
+---
+
+fix: editor view rendering

--- a/.changeset/sharp-shoes-poke.md
+++ b/.changeset/sharp-shoes-poke.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds collection environments logic

--- a/.changeset/soft-kings-dream.md
+++ b/.changeset/soft-kings-dream.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: adds globe icon

--- a/.changeset/thirty-falcons-serve.md
+++ b/.changeset/thirty-falcons-serve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: adds v-2.3.0 migration for workspace type

--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -4,6 +4,40 @@ We’re expecting the passed specification to adhere to [the Swagger 2.0, OpenAP
 
 On top of that, we’ve added a few things for your convenience:
 
+## x-scalar-environments
+
+you can specify predefined environment variables for the API Client/References to consume and use :)
+
+```
+x-scalar-environments:
+  production:
+    description: "Production environment"
+    color: "#0082D0"
+    # Variables are saved directly to the specification
+    variables:
+      userId:
+        description: "User ID"
+        default: "1234567890"
+      apiUrl:
+        description: "API URL"
+        default: "https://api.production.example.com"
+  staging:
+    description: "Staging environment"
+    variables:
+      userId: "1234567890"
+      apiUrl:
+        description: "API URL"
+        default: "https://api.staging.example.com"
+```
+
+## x-scalar-active-environment
+
+You can also specify the default active environment a user will have :) if theres none set here we pick the first from the `x-scalar-environments` to be the default
+
+```
+x-scalar-active-environment: staging
+```
+
 ## x-codeSamples
 
 We provide examples for a lot of popular HTTP clients and frameworks. For something completly custom, for example to show the use of your own SDK, you can use `x-codeSamples`:

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -71,7 +71,8 @@ const dropdownRef = ref<InstanceType<
   typeof EnvironmentVariableDropdown
 > | null>(null)
 
-const { activeEnvVariables, activeEnvironment, router } = useActiveEntities()
+const { activeEnvVariables, activeEnvironment, activeWorkspace, router } =
+  useActiveEntities()
 const { isReadOnly } = useWorkspace()
 
 const { copyToClipboard } = useClipboard()
@@ -126,6 +127,7 @@ extensions.push(
   pillPlugin({
     activeEnvironment,
     activeEnvVariables,
+    activeWorkspace,
     isReadOnly,
   }),
   backspaceCommand,

--- a/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
+++ b/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
@@ -20,11 +20,13 @@ type ActiveParsedEnvironments = ActiveEntitiesStore['activeEnvVariables']
 type IsReadOnly = WorkspaceStore['isReadOnly']
 
 const getEnvColor = (activeEnvironment: ActiveEnvironment) => {
-  if (activeEnvironment.value) {
-    return activeEnvironment.value.color
-  }
+  if (!activeEnvironment.value) return '#8E8E8E'
 
-  return '#8E8E8E'
+  if (activeEnvironment.value.color) {
+    return activeEnvironment.value.color
+  } else {
+    return '#8E8E8E'
+  }
 }
 
 /**
@@ -67,7 +69,7 @@ class PillWidget extends WidgetType {
             ? getEnvColor(this.activeEnvironment)
             : '#8E8E8E'
 
-        span.style.setProperty('--tw-bg-base', pillColor)
+        span.style.setProperty('--tw-bg-base', pillColor || '#8E8E8E')
 
         // Set opacity based on the existence of a value
         span.style.opacity = val?.value ? '1' : '0.5'
@@ -88,14 +90,16 @@ class PillWidget extends WidgetType {
                         window.location.href = '/environment'
                       },
                     },
-                    [
-                      h(ScalarIcon, {
-                        class: 'w-2',
-                        icon: 'Add',
-                        size: 'xs',
-                      }),
-                      'Add variable',
-                    ],
+                    {
+                      default: () => [
+                        h(ScalarIcon, {
+                          class: 'w-2',
+                          icon: 'Add',
+                          size: 'xs',
+                        }),
+                        'Add variable',
+                      ],
+                    },
                   ),
                 ]),
             ])
@@ -168,7 +172,10 @@ export const pillPlugin = (props: {
 
       update(update: ViewUpdate) {
         if (update.docChanged || update.viewportChanged) {
-          this.decorations = this.buildDecorations(update.view)
+          requestAnimationFrame(() => {
+            this.decorations = this.buildDecorations(update.view)
+            update.view.update([])
+          })
         }
       }
 

--- a/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
+++ b/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
@@ -16,6 +16,7 @@ import {
 import { createApp, defineComponent, h } from 'vue'
 
 type ActiveEnvironment = ActiveEntitiesStore['activeEnvironment']
+type ActiveWorkspace = ActiveEntitiesStore['activeWorkspace']
 type ActiveParsedEnvironments = ActiveEntitiesStore['activeEnvVariables']
 type IsReadOnly = WorkspaceStore['isReadOnly']
 
@@ -36,17 +37,20 @@ class PillWidget extends WidgetType {
   private app: any
   activeEnvironment: ActiveEnvironment
   activeEnvVariables: ActiveParsedEnvironments
+  activeWorkspace: ActiveWorkspace
   isReadOnly: IsReadOnly
 
   constructor(
     private variableName: string,
     activeEnvironment: ActiveEnvironment,
     activeEnvVariables: ActiveParsedEnvironments,
+    activeWorkspace: ActiveWorkspace,
     isReadOnly: IsReadOnly,
   ) {
     super()
     this.variableName = variableName
     this.activeEnvironment = activeEnvironment
+    this.activeWorkspace = activeWorkspace
     this.activeEnvVariables = activeEnvVariables
     this.isReadOnly = isReadOnly
   }
@@ -87,7 +91,7 @@ class PillWidget extends WidgetType {
                         'gap-1.5 justify-start font-normal px-1 py-1.5 h-auto transition-colors rounded no-underline text-xxs w-full hover:bg-b-2',
                       variant: 'ghost',
                       onClick: () => {
-                        window.location.href = '/environment'
+                        window.location.href = `/workspace/${this.activeWorkspace.value.uid}/environment`
                       },
                     },
                     {
@@ -160,6 +164,7 @@ class PillWidget extends WidgetType {
 export const pillPlugin = (props: {
   activeEnvironment: ActiveEntitiesStore['activeEnvironment']
   activeEnvVariables: ActiveParsedEnvironments
+  activeWorkspace: ActiveEntitiesStore['activeWorkspace']
   isReadOnly: IsReadOnly
 }) =>
   ViewPlugin.fromClass(
@@ -198,6 +203,7 @@ export const pillPlugin = (props: {
                   variableName,
                   props.activeEnvironment,
                   props.activeEnvVariables,
+                  props.activeWorkspace,
                   props.isReadOnly,
                 ),
                 side: 1,

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -58,8 +58,8 @@ const availableEnvironments = computed(() => {
 })
 
 const setInitialEnvironment = (collection: Collection) => {
-  if (collection['x-scalar-environment']) {
-    setActiveEnvironment(collection['x-scalar-environment'])
+  if (collection['x-scalar-active-environment']) {
+    setActiveEnvironment(collection['x-scalar-active-environment'])
   } else if (
     collection['x-scalar-environments'] &&
     Object.keys(collection['x-scalar-environments']).length > 0

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -9,18 +9,23 @@ import {
   ScalarIcon,
   ScalarListboxCheckbox,
 } from '@scalar/components'
-import { computed } from 'vue'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+import { computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
-const { activeWorkspace, activeEnvironment } = useActiveEntities()
-const { environments, workspaceMutators, isReadOnly } = useWorkspace()
+const {
+  activeCollection,
+  activeWorkspace,
+  activeEnvironment,
+  setActiveEnvironment,
+} = useActiveEntities()
+const { isReadOnly } = useWorkspace()
 
 const router = useRouter()
 
 const updateSelected = (uid: string) => {
-  workspaceMutators.edit(activeWorkspace.value.uid, 'activeEnvironmentId', uid)
+  setActiveEnvironment(uid)
 }
-
 const createNewEnvironment = () =>
   router.push({
     name: 'environment',
@@ -29,11 +34,50 @@ const createNewEnvironment = () =>
     },
   })
 
-const envs = computed(() => [
-  // Always add the default environment
-  environments['default'],
-  ...Object.values(environments).filter((env) => env.uid !== 'default'),
-])
+const selectedEnvironment = computed(() => {
+  if (!activeEnvironment.value) {
+    return 'No Environment'
+  }
+
+  return activeEnvironment?.value?.uid === ''
+    ? 'No Environment'
+    : activeEnvironment?.value?.uid
+})
+
+const availableEnvironments = computed(() => {
+  if (
+    activeCollection.value?.['x-scalar-environments'] &&
+    Object.keys(activeCollection.value['x-scalar-environments']).length > 0
+  ) {
+    return Object.entries(activeCollection.value['x-scalar-environments']).map(
+      ([key, env]) => ({ ...env, uid: key, name: key }),
+    )
+  } else {
+    return []
+  }
+})
+
+const setInitialEnvironment = (collection: Collection) => {
+  if (collection['x-scalar-environment']) {
+    setActiveEnvironment(collection['x-scalar-environment'])
+  } else if (
+    collection['x-scalar-environments'] &&
+    Object.keys(collection['x-scalar-environments']).length > 0
+  ) {
+    const firstEnvironment = Object.keys(collection['x-scalar-environments'])[0]
+    setActiveEnvironment(firstEnvironment)
+  } else {
+    setActiveEnvironment('')
+  }
+}
+
+watch(activeCollection, (newCollection) => {
+  setInitialEnvironment(newCollection as Collection)
+})
+
+onMounted(() => {
+  setInitialEnvironment(activeCollection.value as Collection)
+})
 </script>
 <template>
   <div>
@@ -43,7 +87,7 @@ const envs = computed(() => [
         fullWidth
         variant="ghost">
         <h2 class="font-medium m-0 flex gap-1.5 items-center whitespace-nowrap">
-          {{ activeEnvironment?.name ?? 'No Environment' }}
+          {{ selectedEnvironment }}
           <ScalarIcon
             icon="ChevronDown"
             size="md" />
@@ -52,13 +96,15 @@ const envs = computed(() => [
       <!-- Workspace list -->
       <template #items>
         <ScalarDropdownItem
-          v-for="env in envs"
-          :key="env.uid"
+          v-for="environment in availableEnvironments"
+          :key="environment.uid"
           class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden"
-          @click.stop="updateSelected(env.uid)">
+          @click.stop="updateSelected(environment.uid)">
           <ScalarListboxCheckbox
-            :selected="activeWorkspace.activeEnvironmentId === env.uid" />
-          {{ env.name }}
+            :selected="
+              activeWorkspace.activeEnvironmentId === environment.uid
+            " />
+          {{ environment.name }}
         </ScalarDropdownItem>
         <ScalarDropdownItem
           class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden"
@@ -66,7 +112,7 @@ const envs = computed(() => [
           <div
             class="flex items-center justify-center rounded-full p-[3px] w-4 h-4"
             :class="
-              activeWorkspace.activeEnvironmentId === ''
+              activeEnvironment.uid === ''
                 ? 'bg-c-accent text-b-1'
                 : 'group-hover/item:shadow-border text-transparent'
             ">

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -26,6 +26,7 @@ const updateSelected = (uid: string) => {
       'x-scalar-active-environment',
       uid,
     )
+    activeWorkspace.value.activeEnvironmentId = uid
   }
 }
 const createNewEnvironment = () =>
@@ -62,6 +63,7 @@ const setInitialEnvironment = (collection: Collection) => {
   const activeEnv = collection['x-scalar-active-environment']
   if (activeEnv && activeCollection.value) {
     activeCollection.value['x-scalar-active-environment'] = activeEnv
+    activeWorkspace.value.activeEnvironmentId = activeEnv
   } else {
     activeWorkspace.value.activeEnvironmentId = ''
   }

--- a/packages/api-client/src/components/Sidebar/SidebarList.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="flex flex-col px-3 pt-2.5 pb-[75px]">
+  <ul class="flex flex-col gap-px px-3 pt-2.5 pb-[75px]">
     <slot />
   </ul>
 </template>

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import SidebarListElementActions from '@/components/Sidebar/SidebarListElementActions.vue'
+import { type Icon, ScalarIcon } from '@scalar/components'
 import { useRouter } from 'vue-router'
 
 withDefaults(
@@ -8,6 +9,7 @@ withDefaults(
       uid: string
       name: string
       color?: string
+      icon?: Icon
       isDefault?: boolean
     }
     warningMessage?: string
@@ -46,7 +48,7 @@ const handleColorClick = (uid: string) => {
 <template>
   <li>
     <router-link
-      class="h-8 text-c-2 hover:bg-b-2 group relative block flex items-center gap-1 rounded py-1 pr-2 font-medium no-underline"
+      class="h-8 text-c-2 hover:bg-b-2 group relative block flex items-center gap-1.5 rounded py-1 pr-2 font-medium no-underline"
       :class="[variable.color ? 'pl-1' : 'pl-2']"
       exactActiveClass="active-link"
       :to="`${variable.uid}`"
@@ -60,7 +62,11 @@ const handleColorClick = (uid: string) => {
           class="h-2.5 w-2.5 rounded-xl"
           :style="{ backgroundColor: variable.color }"></div>
       </button>
-      <span class="empty-variable-name">{{ variable.name }}</span>
+      <ScalarIcon
+        v-if="variable.icon"
+        class="text-sidebar-c-2 size-3.5 stroke-[2.25]"
+        :icon="variable.icon" />
+      <span class="empty-variable-name text-sm">{{ variable.name }}</span>
       <SidebarListElementActions
         :isCopyable="isCopyable"
         :isDeletable="isDeletable"

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -16,12 +16,14 @@ const props = defineProps<{
   warningMessage?: string
   isDeletable?: boolean
   isCopyable?: boolean
+  isRenameable?: boolean
   type: 'environment' | 'cookies' | 'server'
 }>()
 
 const emit = defineEmits<{
   (e: 'delete', id: string): void
   (e: 'colorModal', id: string): void
+  (e: 'rename', id: string): void
 }>()
 
 const router = useRouter()
@@ -54,6 +56,10 @@ const handleDelete = (id: string) => {
 const handleColorClick = (uid: string) => {
   emit('colorModal', uid)
 }
+
+const handleRename = (id: string) => {
+  emit('rename', id)
+}
 </script>
 <template>
   <li>
@@ -84,9 +90,11 @@ const handleColorClick = (uid: string) => {
       <SidebarListElementActions
         :isCopyable="isCopyable"
         :isDeletable="isDeletable"
+        :isRenameable="isRenameable"
         :variable="{ ...variable, isDefault: variable.isDefault ?? false }"
         :warningMessage="warningMessage"
-        @delete="handleDelete" />
+        @delete="handleDelete"
+        @rename="handleRename" />
     </router-link>
   </li>
 </template>

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -12,6 +12,7 @@ withDefaults(
       icon?: Icon
       isDefault?: boolean
     }
+    collectionId?: string
     warningMessage?: string
     isDeletable?: boolean
     isCopyable?: boolean
@@ -29,11 +30,18 @@ const emit = defineEmits<{
 
 const router = useRouter()
 
-const handleNavigation = (event: MouseEvent, uid: string) => {
+const handleNavigation = (
+  event: MouseEvent,
+  uid: string,
+  collectionId?: string,
+) => {
+  const path = collectionId
+    ? `/workspace/default/environment/${collectionId}/${uid}`
+    : `/workspace/default/environment/${uid}`
   if (event.metaKey) {
-    window.open(uid, '_blank')
+    window.open(path, '_blank')
   } else {
-    router.push(uid)
+    router.push({ path })
   }
 }
 
@@ -52,7 +60,7 @@ const handleColorClick = (uid: string) => {
       :class="[variable.color ? 'pl-1' : 'pl-2']"
       exactActiveClass="active-link"
       :to="`${variable.uid}`"
-      @click.prevent="handleNavigation($event, variable.uid)">
+      @click.prevent="handleNavigation($event, variable.uid, collectionId)">
       <button
         v-if="variable.color"
         class="hover:bg-b-3 rounded p-1.5"

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -1,27 +1,23 @@
 <script setup lang="ts">
 import SidebarListElementActions from '@/components/Sidebar/SidebarListElementActions.vue'
+import { useActiveEntities } from '@/store/active-entities'
 import { type Icon, ScalarIcon } from '@scalar/components'
 import { useRouter } from 'vue-router'
 
-withDefaults(
-  defineProps<{
-    variable: {
-      uid: string
-      name: string
-      color?: string
-      icon?: Icon
-      isDefault?: boolean
-    }
-    collectionId?: string
-    warningMessage?: string
-    isDeletable?: boolean
-    isCopyable?: boolean
-  }>(),
-  {
-    isCopyable: true,
-    isDeletable: true,
-  },
-)
+const props = defineProps<{
+  variable: {
+    uid: string
+    name: string
+    color?: string
+    icon?: Icon
+    isDefault?: boolean
+  }
+  collectionId?: string
+  warningMessage?: string
+  isDeletable?: boolean
+  isCopyable?: boolean
+  type: 'environment' | 'cookies' | 'server'
+}>()
 
 const emit = defineEmits<{
   (e: 'delete', id: string): void
@@ -29,15 +25,22 @@ const emit = defineEmits<{
 }>()
 
 const router = useRouter()
-
+const { activeWorkspace } = useActiveEntities()
+console.log(activeWorkspace.value)
 const handleNavigation = (
   event: MouseEvent,
   uid: string,
   collectionId?: string,
 ) => {
+  const params = {
+    workspaceId: activeWorkspace.value.uid,
+    type: props.type,
+    collectionId: collectionId || undefined,
+    uid: uid,
+  }
   const path = collectionId
-    ? `/workspace/default/environment/${collectionId}/${uid}`
-    : `/workspace/default/environment/${uid}`
+    ? `/workspace/${params.workspaceId}/${params.type}/${params.collectionId}/${params.uid}`
+    : `/workspace/${params.workspaceId}/${params.type}/${params.uid}`
   if (event.metaKey) {
     window.open(path, '_blank')
   } else {
@@ -59,7 +62,11 @@ const handleColorClick = (uid: string) => {
       class="h-8 text-c-2 hover:bg-b-2 group relative block flex items-center gap-1.5 rounded py-1 pr-2 font-medium no-underline"
       :class="[variable.color ? 'pl-1' : 'pl-2']"
       exactActiveClass="active-link"
-      :to="`${variable.uid}`"
+      :to="
+        collectionId
+          ? `/workspace/${activeWorkspace.uid}/${type}/${collectionId}/${variable.uid}`
+          : `/workspace/${activeWorkspace.uid}/${type}/${variable.uid}`
+      "
       @click.prevent="handleNavigation($event, variable.uid, collectionId)">
       <button
         v-if="variable.color"

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -26,7 +26,6 @@ const emit = defineEmits<{
 
 const router = useRouter()
 const { activeWorkspace } = useActiveEntities()
-console.log(activeWorkspace.value)
 const handleNavigation = (
   event: MouseEvent,
   uid: string,

--- a/packages/api-client/src/components/Sidebar/SidebarListElementActions.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElementActions.vue
@@ -13,10 +13,12 @@ const { variable } = defineProps<{
   warningMessage?: string
   isCopyable?: boolean
   isDeletable?: boolean
+  isRenameable?: boolean
 }>()
 
 const emit = defineEmits<{
   (e: 'delete', id: string): void
+  (e: 'rename', id: string): void
 }>()
 
 enum ModalAction {
@@ -54,6 +56,15 @@ function handleDelete(id: string) {
       <ScalarIcon
         class="h-3 w-3"
         icon="Clipboard" />
+    </button>
+    <button
+      v-if="isRenameable"
+      class="text-c-3 hover:bg-b-3 hover:text-c-1 rounded p-[5px]"
+      type="button"
+      @click="emit('rename', variable.uid)">
+      <ScalarIcon
+        class="h-3 w-3"
+        icon="Edit" />
     </button>
     <button
       v-if="!variable.isDefault && isDeletable"

--- a/packages/api-client/src/libs/environment-parser.ts
+++ b/packages/api-client/src/libs/environment-parser.ts
@@ -1,6 +1,6 @@
 /** Parses the active environment variables and extracts key-value pairs. */
 export function parseEnvVariables(
-  activeEnvVariables: { key: string; value: string }[],
+  activeEnvVariables: { key: string; value: string; source: string }[],
 ) {
   return activeEnvVariables.flatMap((variable) => {
     if (variable.key === 'value') {
@@ -9,6 +9,7 @@ export function parseEnvVariables(
         return Object.keys(parsedValue).map((key) => ({
           key,
           value: parsedValue[key],
+          source: variable.source,
         }))
       } catch (e) {
         // Skip invalid environment editor JSON entries

--- a/packages/api-client/src/routes.ts
+++ b/packages/api-client/src/routes.ts
@@ -169,6 +169,12 @@ export const routes = [
         component: () => import('@/views/Environment/Environment.vue'),
       },
       {
+        name: 'environment.collection',
+        path: 'environment/:collectionId/:environmentId',
+        component: () => import('@/views/Environment/Environment.vue'),
+        props: true,
+      },
+      {
         name: 'cookies.default',
         path: 'cookies',
         redirect: (to) => ({

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -121,24 +121,6 @@ export const createActiveEntitiesStore = ({
   })
 
   /**
-   * Sets the active environment
-   */
-  const setActiveEnvironment = (uid?: string) => {
-    if (!uid) {
-      activeWorkspace.value.activeEnvironmentId = ''
-      return
-    }
-
-    if (uid === 'default') {
-      // Global environment
-      activeWorkspace.value.activeEnvironmentId = 'default'
-    } else {
-      // Collection environment
-      activeWorkspace.value.activeEnvironmentId = uid
-    }
-  }
-
-  /**
    * Request associated with the current route
    *
    * undefined must be handled as we may have no requests
@@ -252,7 +234,6 @@ export const createActiveEntitiesStore = ({
     activeWorkspaceServers,
     activeEnvVariables,
     activeWorkspaceRequests,
-    setActiveEnvironment,
     router,
   }
 }

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -195,14 +195,13 @@ export const createActiveEntitiesStore = ({
    */
   const activeEnvVariables = computed(() => {
     if (!activeEnvironment.value) return []
-    // TODO: Must merge global variables and collection level variables here
-    // Return a list of key value pairs that includes dot nested paths
-    return flattenEnvVars(JSON.parse(activeEnvironment.value.value)).map(
-      ([key, value]) => ({
-        key,
-        value,
-      }),
-    )
+    const globalEnvironment = activeWorkspace.value.environments
+    const collectionEnvironment = JSON.parse(activeEnvironment.value.value)
+    const mergedEnvironment = { ...globalEnvironment, ...collectionEnvironment }
+    return flattenEnvVars(mergedEnvironment).map(([key, value]) => ({
+      key,
+      value,
+    }))
   })
 
   return {

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -74,10 +74,60 @@ export const createActiveEntitiesStore = ({
     ),
   )
 
-  /** The currently active environment */
-  const activeEnvironment = computed(
-    () => environments[activeWorkspace.value?.activeEnvironmentId ?? 'default'],
-  )
+  /** The currently selected environment */
+  const activeEnvironment = computed(() => {
+    if (!activeWorkspace.value.activeEnvironmentId) {
+      return ''
+    }
+
+    const activeEnvironmentCollection = activeWorkspaceCollections.value.find(
+      (c) =>
+        c['x-scalar-environments']?.[activeWorkspace.value.activeEnvironmentId],
+    )
+
+    if (activeEnvironmentCollection) {
+      return {
+        uid: activeWorkspace.value.activeEnvironmentId,
+        name: activeWorkspace.value.activeEnvironmentId,
+        value: JSON.stringify(
+          activeEnvironmentCollection['x-scalar-environments']?.[
+            activeWorkspace.value.activeEnvironmentId
+          ].variables,
+          null,
+          2,
+        ),
+        color:
+          activeEnvironmentCollection['x-scalar-environments']?.[
+            activeWorkspace.value.activeEnvironmentId
+          ].color,
+        isDefault: false,
+      }
+    }
+
+    return {
+      uid: 'default',
+      name: 'Global Environment',
+      value: JSON.stringify(activeWorkspace.value.environments, null, 2),
+    }
+  })
+
+  /**
+   * Sets the active environment
+   */
+  const setActiveEnvironment = (uid?: string) => {
+    if (!uid) {
+      activeWorkspace.value.activeEnvironmentId = ''
+      return
+    }
+
+    if (uid === 'default') {
+      // Global environment
+      activeWorkspace.value.activeEnvironmentId = 'default'
+    } else {
+      // Collection environment
+      activeWorkspace.value.activeEnvironmentId = uid
+    }
+  }
 
   /**
    * Request associated with the current route
@@ -168,6 +218,7 @@ export const createActiveEntitiesStore = ({
     activeWorkspaceServers,
     activeEnvVariables,
     activeWorkspaceRequests,
+    setActiveEnvironment,
     router,
   }
 }

--- a/packages/api-client/src/store/collections.ts
+++ b/packages/api-client/src/store/collections.ts
@@ -2,6 +2,7 @@ import type { StoreContext } from '@/store/store-context'
 import {
   type Collection,
   type CollectionPayload,
+  type XScalarEnvironment,
   collectionSchema,
 } from '@scalar/oas-utils/entities/spec'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
@@ -87,8 +88,43 @@ export function extendedCollectionDataFactory({
     collectionMutators.delete(collection.uid)
   }
 
+  const addCollectionEnvironment = (
+    environmentName: string,
+    environment: XScalarEnvironment,
+    collectionUid: string,
+  ) => {
+    const collection = collections[collectionUid]
+    if (collection) {
+      const currentEnvironments = collection['x-scalar-environments'] || {}
+      collectionMutators.edit(collectionUid, 'x-scalar-environments', {
+        ...currentEnvironments,
+        [environmentName]: environment,
+      })
+    }
+  }
+
+  const removeCollectionEnvironment = (
+    environmentName: string,
+    collectionUid: string,
+  ) => {
+    const collection = collections[collectionUid]
+    if (collection) {
+      const currentEnvironments = collection['x-scalar-environments'] || {}
+      if (environmentName in currentEnvironments) {
+        delete currentEnvironments[environmentName]
+        collectionMutators.edit(
+          collectionUid,
+          'x-scalar-environments',
+          currentEnvironments,
+        )
+      }
+    }
+  }
+
   return {
     addCollection,
     deleteCollection,
+    addCollectionEnvironment,
+    removeCollectionEnvironment,
   }
 }

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -130,6 +130,8 @@ export const createWorkspaceStore = ({
     extendedWorkspaceDataFactory(storeContext)
   const { addSecurityScheme, deleteSecurityScheme } =
     extendedSecurityDataFactory(storeContext)
+  const { addCollectionEnvironment, removeCollectionEnvironment } =
+    extendedCollectionDataFactory(storeContext)
 
   // ---------------------------------------------------------------------------
   // OTHER HELPER DATA
@@ -204,6 +206,8 @@ export const createWorkspaceStore = ({
       rawAdd: collectionMutators.add,
       add: addCollection,
       delete: deleteCollection,
+      addEnvironment: addCollectionEnvironment,
+      removeEnvironment: removeCollectionEnvironment,
     },
     environmentMutators: {
       ...environmentMutators,
@@ -247,6 +251,8 @@ export const createWorkspaceStore = ({
       add: addWorkspace,
       delete: deleteWorkspace,
     },
+    addCollectionEnvironment,
+    removeCollectionEnvironment,
   }
 }
 

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -80,6 +80,15 @@ const handleHotKey = (event?: HotKeyEvent) => {
   }
 }
 
+const handleNavigation = (event: MouseEvent, uid: string) => {
+  const path = `/workspace/default/cookies/${uid}`
+  if (event.metaKey) {
+    window.open(path, '_blank')
+  } else {
+    router.push({ path })
+  }
+}
+
 /** Initialize collapsedSidebarFolders to be open by default */
 onMounted(() => {
   const domains = Object.keys(groupedCookies.value)
@@ -145,8 +154,10 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                       v-for="cookie in cookieList"
                       :key="cookie.uid"
                       class="cookie text-xs"
+                      type="cookies"
                       :variable="{ name: cookie.name, uid: cookie.uid }"
                       :warningMessage="`Are you sure you want to delete this cookie?`"
+                      @click.prevent="handleNavigation($event, cookie.uid)"
                       @delete="removeCookie(cookie.uid)" />
                   </div>
                 </div>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -7,9 +7,11 @@ import SidebarListElement from '@/components/Sidebar/SidebarListElement.vue'
 import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
 import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import { useSidebar } from '@/hooks'
 import type { HotKeyEvent } from '@/libs'
 import { useWorkspace } from '@/store'
-import { useModal } from '@scalar/components'
+import { ScalarButton, ScalarIcon, useModal } from '@scalar/components'
+import { LibraryIcon } from '@scalar/icons'
 import { environmentSchema } from '@scalar/oas-utils/entities/environment'
 import { nanoid } from 'nanoid'
 import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
@@ -20,7 +22,13 @@ import EnvironmentModal from './EnvironmentModal.vue'
 
 const router = useRouter()
 const route = useRoute()
-const { environments, environmentMutators, events } = useWorkspace()
+const {
+  environments,
+  environmentMutators,
+  events,
+  activeWorkspaceCollections,
+} = useWorkspace()
+const { collapsedSidebarFolders, toggleSidebarFolder } = useSidebar()
 const colorModal = useModal()
 const environmentModal = useModal()
 
@@ -190,6 +198,10 @@ const updateEnvironmentName = (event: Event) => {
   }
 }
 
+const showChildren = (key: string) => {
+  return collapsedSidebarFolders[key]
+}
+
 const handleHotKey = (event?: HotKeyEvent) => {
   if (event?.createNew && route.name === 'environment') {
     addEnvironment({ name: '', color: '' })
@@ -210,30 +222,94 @@ watch(
 onMounted(() => {
   setActiveEnvironment()
   events.hotKeys.on(handleHotKey)
+  // TODO: open folder according to the environment
+  collapsedSidebarFolders.global = true
 })
 onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
 </script>
 <template>
   <ViewLayout>
-    <Sidebar title="Environment">
+    <Sidebar title="Collections">
       <template #content>
         <div class="flex-1">
           <SidebarList>
-            <SidebarListElement
-              v-for="environment in environments"
-              :key="environment.uid"
-              class="text-xs"
-              :isCopyable="false"
-              :variable="{
-                name: environment.name,
-                uid: environment.uid,
-                color: environment.color,
-                isDefault: environment.isDefault,
-              }"
-              :warningMessage="`Are you sure you want to delete this environment?`"
-              @click="activeEnvironmentID = environment.uid"
-              @colorModal="handleOpenColorModal"
-              @delete="removeEnvironment(environment.uid)" />
+            <div class="flex flex-col gap-0.25">
+              <button
+                class="flex font-medium gap-1.5 group items-center px-2 py-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
+                type="button"
+                @click="toggleSidebarFolder('global')">
+                <ScalarIcon
+                  class="text-sidebar-c-2 size-3.5 stroke-[2.25] group-hover:hidden"
+                  icon="Globe" />
+                <ScalarIcon
+                  class="text-c-3 hidden group-hover:block"
+                  :class="{
+                    'rotate-90': collapsedSidebarFolders['global'],
+                  }"
+                  icon="ChevronRight"
+                  size="sm"
+                  thickness="2.5" />
+                Global
+              </button>
+              <div
+                v-show="showChildren('global')"
+                class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                <SidebarListElement
+                  v-for="environment in environments"
+                  :key="environment.uid"
+                  class="text-xs [&>a]:pl-5"
+                  :isCopyable="false"
+                  :variable="{
+                    name: environment.name,
+                    uid: environment.uid,
+                    color: environment.color,
+                    isDefault: environment.isDefault,
+                  }"
+                  :warningMessage="`Are you sure you want to delete this environment?`"
+                  @colorModal="handleOpenColorModal"
+                  @delete="removeEnvironment(environment.uid)" />
+              </div>
+            </div>
+            <div
+              v-for="collection in activeWorkspaceCollections"
+              :key="collection.uid">
+              <button
+                v-if="collection.info?.title !== 'Drafts'"
+                class="flex font-medium gap-1.5 group items-center px-2 py-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
+                type="button"
+                @click="toggleSidebarFolder(collection.uid)">
+                <LibraryIcon
+                  class="text-sidebar-c-2 size-3.5 stroke-[2.25] group-hover:hidden"
+                  :src="
+                    collection['x-scalar-icon'] || 'interface-content-folder'
+                  " />
+                <ScalarIcon
+                  class="text-c-3 hidden text-sm group-hover:block"
+                  :class="{
+                    'rotate-90': collapsedSidebarFolders[collection.uid],
+                  }"
+                  icon="ChevronRight"
+                  size="sm"
+                  thickness="2.5" />
+                {{ collection.info?.title ?? '' }}
+              </button>
+              <div
+                v-if="collection.info?.title !== 'Drafts'"
+                v-show="showChildren(collection.uid)"
+                class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                <!-- TODO: add collection environment list -->
+                <ScalarButton
+                  class="mb-[.5px] flex gap-1.5 h-8 text-c-1 justify-start text-xs w-full hover:bg-b-2"
+                  variant="ghost"
+                  @click="openEnvironmentModal">
+                  <ScalarIcon
+                    class="ml-0.5 h-2.5 w-2.5"
+                    icon="Add"
+                    thickness="3" />
+                  <span>Add Environment</span>
+                </ScalarButton>
+              </div>
+            </div>
           </SidebarList>
         </div>
       </template>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -267,6 +267,21 @@ onMounted(() => {
   }
 })
 onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
+
+const handleNavigation = (
+  event: MouseEvent,
+  uid: string,
+  collectionId?: string,
+) => {
+  const path = collectionId
+    ? `/workspace/default/environment/${collectionId}/${uid}`
+    : `/workspace/default/environment/${uid}`
+  if (event.metaKey) {
+    window.open(path, '_blank')
+  } else {
+    router.push({ path })
+  }
+}
 </script>
 <template>
   <ViewLayout>
@@ -278,6 +293,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
               :key="'default'"
               class="text-xs"
               :isCopyable="false"
+              type="environment"
               :variable="{
                 name: 'Global Environment',
                 uid: 'default',
@@ -322,6 +338,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                   class="text-xs [&>a]:pl-5"
                   :collectionId="collection.uid"
                   :isCopyable="false"
+                  type="environment"
                   :variable="{
                     name: environmentName,
                     uid: environmentName,
@@ -329,6 +346,9 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                     isDefault: false,
                   }"
                   :warningMessage="`Are you sure you want to delete this environment?`"
+                  @click.prevent="
+                    handleNavigation($event, environmentName, collection.uid)
+                  "
                   @colorModal="handleOpenColorModal(environmentName)"
                   @delete="removeCollectionEnvironment(environmentName)" />
                 <ScalarButton

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -81,6 +81,7 @@ function addEnvironment(environment: {
 
     environmentMutators.add(newEnvironment)
     activeEnvironmentID.value = newEnvironment.uid
+    toggleSidebarFolder('global')
     router.push(activeEnvironmentID.value)
   } else if (environment.type === 'collection' && environment.collectionId) {
     const collection = activeWorkspaceCollections.value.find(
@@ -94,6 +95,12 @@ function addEnvironment(environment: {
           variables: { '': '' },
           color: environment.color,
         },
+      })
+      activeEnvironmentID.value = environment.name
+      toggleSidebarFolder(collection.uid)
+      router.push({
+        name: 'environment',
+        params: { environment: environment.name },
       })
     }
   }
@@ -260,6 +267,37 @@ const removeCollectionEnvironment = (envName: string) => {
       )
     }
   })
+
+  if (activeEnvironmentID.value === envName) {
+    const remainingEnvironments = Object.values(environments)
+    const remainingCollectionEnvironments =
+      activeWorkspaceCollections.value.flatMap((collection) =>
+        Object.keys(collection['x-scalar-environments'] || {}),
+      )
+
+    if (remainingCollectionEnvironments.length > 0) {
+      const lastCollectionEnvironment =
+        remainingCollectionEnvironments[
+          remainingCollectionEnvironments.length - 1
+        ]
+      activeEnvironmentID.value = lastCollectionEnvironment
+      router.push({
+        name: 'environment',
+        params: { environment: lastCollectionEnvironment },
+      })
+    } else if (remainingEnvironments.length > 0) {
+      const lastEnvironment =
+        remainingEnvironments[remainingEnvironments.length - 1]
+      activeEnvironmentID.value = lastEnvironment.uid
+      router.push({
+        name: 'environment',
+        params: { environment: lastEnvironment.uid },
+      })
+    } else {
+      activeEnvironmentID.value = environments.default.uid
+      router.push({ name: 'environment', params: { environment: 'default' } })
+    }
+  }
 }
 
 function setActiveEnvironment() {

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -271,7 +271,7 @@ function handleCancelRename() {
 }
 
 function handleRename(newName: string) {
-  if (selectedEnvironmentId.value !== 'default') {
+  if (newName && selectedEnvironmentId.value !== 'default') {
     activeWorkspaceCollections.value.forEach((collection) => {
       if (
         collection['x-scalar-environments']?.[selectedEnvironmentId.value ?? '']
@@ -291,7 +291,7 @@ function handleRename(newName: string) {
     })
   }
 
-  if (currentEnvironmentId.value === selectedEnvironmentId.value) {
+  if (newName && currentEnvironmentId.value === selectedEnvironmentId.value) {
     currentEnvironmentId.value = newName
   }
 
@@ -435,7 +435,6 @@ function handleRename(newName: string) {
       :size="'xxs'"
       :state="editModal"
       :title="`Edit ${selectedEnvironmentId}`">
-      <input v-model="tempEnvironmentName" />
       <EditSidebarListElement
         :name="tempEnvironmentName ?? ''"
         @close="handleCancelRename"

--- a/packages/api-client/src/views/Environment/EnvironmentColorModal.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentColorModal.vue
@@ -20,6 +20,11 @@ const newColor = ref('')
 const handleColorSelect = (color: string) => {
   newColor.value = color
 }
+
+const handleSubmit = () => {
+  emit('submit', newColor.value)
+  newColor.value = ''
+}
 </script>
 <template>
   <ScalarModal
@@ -33,7 +38,7 @@ const handleColorSelect = (color: string) => {
         @select="handleColorSelect" />
       <SidebarListElementForm
         @cancel="emit('cancel')"
-        @submit="emit('submit', newColor)">
+        @submit="handleSubmit">
       </SidebarListElementForm>
     </div>
   </ScalarModal>

--- a/packages/api-client/src/views/Environment/EnvironmentModal.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentModal.vue
@@ -1,25 +1,59 @@
 <script setup lang="ts">
-import SidebarListElementForm from '@/components/Sidebar/Actions/SidebarListElementForm.vue'
+import CommandActionForm from '@/components/CommandPalette/CommandActionForm.vue'
+import CommandActionInput from '@/components/CommandPalette/CommandActionInput.vue'
 import {
   type ModalState,
+  ScalarButton,
+  type ScalarComboboxOption,
+  ScalarIcon,
+  ScalarListbox,
   ScalarModal,
-  ScalarTextField,
 } from '@scalar/components'
-import { ref, watch } from 'vue'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+import { useToasts } from '@scalar/use-toasts'
+import { computed, ref, watch } from 'vue'
 
 import EnvironmentColors from './EnvironmentColors.vue'
 
 const props = defineProps<{
   state: ModalState
+  activeWorkspaceCollections: Collection[]
 }>()
 
 const emit = defineEmits<{
   (event: 'cancel'): void
-  (event: 'submit', environment: { name: string; color: string }): void
+  (
+    event: 'submit',
+    environment: {
+      name: string
+      color: string
+      type: string
+      collectionId?: string
+    },
+  ): void
 }>()
 
 const environmentName = ref('')
 const selectedColor = ref('#8E8E8E')
+const environmentType = ref<ScalarComboboxOption | undefined>()
+
+const collections = computed(() => [
+  { id: 'global', label: 'Global' },
+  ...props.activeWorkspaceCollections
+    .filter((collection) => collection.info?.title !== 'Drafts')
+    .map((collection) => ({
+      id: collection.uid,
+      label: collection.info?.title ?? 'Untitled Collection',
+    })),
+])
+
+const selectedEnvironment = ref<ScalarComboboxOption | undefined>(
+  collections.value.find(
+    (collection) => collection.id === environmentType.value?.id,
+  ),
+)
+
+const { toast } = useToasts()
 
 const handleColorSelect = (color: string) => {
   selectedColor.value = color
@@ -32,32 +66,69 @@ watch(
     if (isOpen) {
       environmentName.value = ''
       selectedColor.value = '#8E8E8E'
+      environmentType.value = undefined
+      selectedEnvironment.value = undefined
     }
   },
 )
+
+const handleSubmit = () => {
+  if (!selectedEnvironment.value?.id) {
+    toast('Please select a collection before adding an environment.', 'error')
+    return
+  }
+  emit('submit', {
+    name: environmentName.value,
+    color: selectedColor.value,
+    type: selectedEnvironment.value?.id === 'global' ? 'global' : 'collection',
+    collectionId:
+      selectedEnvironment.value?.id !== 'global'
+        ? selectedEnvironment.value?.id
+        : undefined,
+  })
+}
 </script>
+
 <template>
   <ScalarModal
-    size="xxs"
-    :state="state"
-    title="Add Environment">
-    <div class="flex flex-col gap-3">
-      <ScalarTextField
-        v-model="environmentName"
-        placeholder="Environment name" />
-      <EnvironmentColors
-        :activeColor="selectedColor"
-        class="p-3 w-full"
-        @select="handleColorSelect" />
-      <SidebarListElementForm
-        @cancel="emit('cancel')"
-        @submit="
-          emit('submit', {
-            name: environmentName,
-            color: selectedColor,
-          })
-        ">
-      </SidebarListElementForm>
-    </div>
+    bodyClass="!border-t-0 !rounded-t-lg"
+    size="xs"
+    :state="state">
+    <CommandActionForm
+      :disabled="!selectedEnvironment"
+      @cancel="emit('cancel')"
+      @submit="handleSubmit">
+      <div class="flex gap-2 items-start">
+        <EnvironmentColors
+          :activeColor="selectedColor"
+          class="peer"
+          selector
+          @select="handleColorSelect" />
+        <CommandActionInput
+          v-model="environmentName"
+          class="!p-0 peer-has-[.color-selector]:hidden -mt-[.5px]"
+          placeholder="Environment name" />
+      </div>
+      <template #options>
+        <ScalarListbox
+          v-model="selectedEnvironment"
+          :options="collections"
+          placeholder="Select Type">
+          <ScalarButton
+            v-if="collections.length > 0"
+            class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2 w-fit"
+            variant="outlined">
+            <span :class="selectedEnvironment ? 'text-c-1' : 'text-c-3'">{{
+              selectedEnvironment ? selectedEnvironment.label : 'Select Scope'
+            }}</span>
+            <ScalarIcon
+              class="text-c-3"
+              icon="ChevronDown"
+              size="xs" />
+          </ScalarButton>
+        </ScalarListbox>
+      </template>
+      <template #submit>Add Environment</template>
+    </CommandActionForm>
   </ScalarModal>
 </template>

--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -71,11 +71,13 @@ const selectVariable = (variableKey: string) => {
 const getEnvColor = (
   activeEnvironment: ActiveEntitiesStore['activeEnvironment'],
 ) => {
-  if (activeEnvironment.value) {
-    return activeEnvironment.value.color
-  }
+  if (!activeEnvironment.value) return '#8E8E8E'
 
-  return '#8E8E8E'
+  if (activeEnvironment.value.color) {
+    return activeEnvironment.value.color
+  } else {
+    return '#8E8E8E'
+  }
 }
 
 const handleArrowKey = (direction: 'up' | 'down') => {

--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -134,7 +134,9 @@ onClickOutside(
       ref="dropdownRef"
       class="fixed left-0 top-0 flex flex-col p-0.75 max-h-[60svh] w-56 rounded border custom-scroll"
       :style="dropdownStyle">
-      <ul v-if="filteredVariables.length">
+      <ul
+        v-if="filteredVariables.length"
+        class="flex flex-col gap-px">
         <template
           v-for="(item, index) in filteredVariables"
           :key="item.key">
@@ -144,10 +146,15 @@ onClickOutside(
             @click="selectVariable(item.key)">
             <div class="flex items-center gap-1.5 whitespace-nowrap">
               <span
+                v-if="item.source === 'collection'"
                 class="h-2.5 w-2.5 min-w-2.5 rounded-full"
                 :style="{
                   backgroundColor: getEnvColor(activeEnvironment),
                 }"></span>
+              <ScalarIcon
+                v-else
+                class="w-2.5"
+                icon="Globe" />
               {{ item.key }}
             </div>
             <span

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -84,7 +84,11 @@ const executeRequest = async () => {
     return
 
   // Parse the environment string
-  const e = safeJSON.parse(activeEnvironment.value?.value || '{}')
+  const environmentValue =
+    typeof activeEnvironment.value === 'object'
+      ? activeEnvironment.value.value
+      : '{}'
+  const e = safeJSON.parse(environmentValue)
   if (e.error) console.error('INVALID ENVIRONMENT!')
   const environment =
     e.error || typeof e.data !== 'object' ? {} : (e.data ?? {})

--- a/packages/api-client/src/views/Servers/Servers.vue
+++ b/packages/api-client/src/views/Servers/Servers.vue
@@ -40,6 +40,7 @@ const addServerHandler = () => {
               v-for="serverUid in activeCollection?.servers"
               :key="serverUid"
               class="text-xs"
+              type="server"
               :variable="{
                 name: servers[serverUid].url ?? '',
                 uid: serverUid,

--- a/packages/components/src/components/ScalarIcon/icons/Globe.svg
+++ b/packages/components/src/components/ScalarIcon/icons/Globe.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M22 12c0 5.523-4.477 10-10 10m10-10c0-5.523-4.477-10-10-10m10 10H2m10 10C6.477 22 2 17.523 2 12m10 10a14.5 14.5 0 0 1 0-20m0 20a14.5 14.5 0 0 0 0-20M2 12C2 6.477 6.477 2 12 2" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/components/src/components/ScalarIcon/icons/index.ts
+++ b/packages/components/src/components/ScalarIcon/icons/index.ts
@@ -37,6 +37,7 @@ export const ICONS = [
   'Folder',
   'GitHub',
   'GitHubLine',
+  'Globe',
   'Google',
   'Help',
   'Hide',

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -50,6 +50,11 @@
       "types": "./dist/migrations/index.d.ts",
       "default": "./dist/migrations/index.js"
     },
+    "./migrations/v-2.3.0": {
+      "import": "./dist/migrations/v-2.3.0/index.js",
+      "types": "./dist/migrations/v-2.3.0/index.d.ts",
+      "default": "./dist/migrations/v-2.3.0/index.js"
+    },
     "./migrations/v-2.2.0": {
       "import": "./dist/migrations/v-2.2.0/index.js",
       "types": "./dist/migrations/v-2.2.0/index.d.ts",

--- a/packages/oas-utils/src/entities/spec/collection.ts
+++ b/packages/oas-utils/src/entities/spec/collection.ts
@@ -39,7 +39,7 @@ export const oasCollectionSchema = z.object({
   'webhooks': z.record(z.string(), z.unknown()).optional(),
   /** A custom icon representing the collection */
   'x-scalar-icon': z.string().optional().default('interface-content-folder'),
-  'x-scalar-environment': z.string().optional(),
+  'x-scalar-active-environment': z.string().optional(),
   'x-scalar-environments': xScalarEnvironmentsSchema.optional(),
   'x-scalar-secrets': xScalarSecretsSchema.optional(),
   // These properties will be stripped out and mapped back as id lists

--- a/packages/oas-utils/src/entities/spec/index.ts
+++ b/packages/oas-utils/src/entities/spec/index.ts
@@ -5,6 +5,7 @@ export * from './request-examples'
 export * from './spec-objects'
 export * from './parameters'
 export * from './security'
+export * from './x-scalar-environments'
 
 type FetchRequest = Request
 export type { FetchRequest }

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -36,7 +36,7 @@ export const workspaceSchema = z.object({
   /** List of all collection uids in a given workspace */
   collections: z.array(z.string()).default([]),
   /** List of all environment uids in a given workspace */
-  environments: z.record(z.string()).default({ '': '' }),
+  environments: z.record(z.string()).default({}),
   /** Customize hotkeys */
   hotKeyConfig: hotKeyConfigSchema,
   /** Active Environment ID to use for requests  */

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -36,7 +36,7 @@ export const workspaceSchema = z.object({
   /** List of all collection uids in a given workspace */
   collections: z.array(z.string()).default([]),
   /** List of all environment uids in a given workspace */
-  environments: z.array(z.string()).default([]),
+  environments: z.record(z.string()).default({ '': '' }),
   /** Customize hotkeys */
   hotKeyConfig: hotKeyConfigSchema,
   /** Active Environment ID to use for requests  */

--- a/packages/oas-utils/src/migrations/data-version.ts
+++ b/packages/oas-utils/src/migrations/data-version.ts
@@ -7,7 +7,7 @@
  * - 2.1.0 - refactor
  * - 2.2.0 - auth compliancy
  */
-export const DATA_VERSION = '2.2.0'
+export const DATA_VERSION = '2.3.0'
 
 /** The localStorage key under which the data version is stored */
 export const DATA_VERSION_LS_LEY = 'scalar_api_client_data_version'

--- a/packages/oas-utils/src/migrations/migrator.ts
+++ b/packages/oas-utils/src/migrations/migrator.ts
@@ -4,10 +4,11 @@ import {
 } from '@/migrations/local-storage'
 import { semverLessThan } from '@/migrations/semver'
 import { migrate_v_2_1_0 } from '@/migrations/v-2.1.0'
-import { migrate_v_2_2_0, type v_2_2_0 } from '@/migrations/v-2.2.0'
+import { migrate_v_2_2_0 } from '@/migrations/v-2.2.0'
+import { migrate_v_2_3_0, type v_2_3_0 } from '@/migrations/v-2.3.0'
 
 /** Handles all data migrations per entity */
-export const migrator = (): v_2_2_0.DataArray => {
+export const migrator = (): v_2_3_0.DataArray => {
   const dataVersion = getLocalStorageVersion()
   console.info('Data version: ' + dataVersion)
 
@@ -28,6 +29,8 @@ export const migrator = (): v_2_2_0.DataArray => {
   if (semverLessThan(dataVersion, '2.1.0')) data = migrate_v_2_1_0(data)
   // 2.1.0 -> 2.2.0 migration
   if (semverLessThan(dataVersion, '2.2.0')) data = migrate_v_2_2_0(data)
+  // 2.2.0 -> 2.3.0 migration
+  if (semverLessThan(dataVersion, '2.3.0')) data = migrate_v_2_3_0(data)
 
   // Convert to data array
   data = {
@@ -40,7 +43,7 @@ export const migrator = (): v_2_2_0.DataArray => {
     servers: Object.values(data.servers),
     tags: Object.values(data.tags),
     workspaces: Object.values(data.workspaces),
-  } satisfies v_2_2_0.DataArray
+  } satisfies v_2_3_0.DataArray
 
   return data
 }

--- a/packages/oas-utils/src/migrations/v-2.2.0/types.generated.ts
+++ b/packages/oas-utils/src/migrations/v-2.2.0/types.generated.ts
@@ -8,7 +8,6 @@ import type {
   SecurityScheme as SS,
   Tag as T,
 } from '@/entities/spec'
-import type { Workspace as W } from '@/entities/workspace'
 
 /**
  * The most current types are not generated
@@ -22,7 +21,60 @@ export namespace v_2_2_0 {
   export type SecurityScheme = SS
   export type Server = S
   export type Tag = T
-  export type Workspace = W
+
+  export type Workspace = {
+    uid: string
+    name: string
+    description: string
+    isReadOnly: boolean
+    collections: string[]
+    environments: string[]
+    hotKeyConfig?:
+      | {
+          modifiers: ('Meta' | 'Control' | 'Shift' | 'Alt' | 'default')[]
+          hotKeys?:
+            | {
+                [x: string]: {
+                  modifiers?:
+                    | ('Meta' | 'Control' | 'Shift' | 'Alt' | 'default')[]
+                    | undefined
+                  event:
+                    | 'closeModal'
+                    | 'navigateSearchResultsDown'
+                    | 'selectSearchResult'
+                    | 'navigateSearchResultsUp'
+                    | 'openCommandPalette'
+                    | 'createNew'
+                    | 'toggleSidebar'
+                    | 'addTopNav'
+                    | 'closeTopNav'
+                    | 'navigateTopNavLeft'
+                    | 'navigateTopNavRight'
+                    | 'focusAddressBar'
+                    | 'jumpToTab'
+                    | 'jumpToLastTab'
+                    | 'focusRequestSearch'
+                }
+              }
+            | undefined
+        }
+      | undefined
+    activeEnvironmentId: string
+    cookies: string[]
+    proxyUrl?: string | undefined
+    themeId:
+      | 'alternate'
+      | 'default'
+      | 'moon'
+      | 'purple'
+      | 'solarized'
+      | 'bluePlanet'
+      | 'deepSpace'
+      | 'saturn'
+      | 'kepler'
+      | 'mars'
+      | 'none'
+  }
 
   export type DataRecord = {
     collections: Record<string, Collection>

--- a/packages/oas-utils/src/migrations/v-2.3.0/index.ts
+++ b/packages/oas-utils/src/migrations/v-2.3.0/index.ts
@@ -1,0 +1,2 @@
+export * from './migration'
+export * from './types.generated'

--- a/packages/oas-utils/src/migrations/v-2.3.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.3.0/migration.ts
@@ -1,0 +1,72 @@
+import type { v_2_2_0 } from '@/migrations/v-2.2.0/types.generated'
+
+import type { v_2_3_0 } from './types.generated'
+
+/** V-2.2.0 to V-2.3.0 migration */
+export const migrate_v_2_3_0 = (
+  data: v_2_2_0.DataRecord,
+): v_2_3_0.DataRecord => {
+  console.info('Performing data migration v-2.2.0 to v-2.3.0')
+
+  const environments = data.environments
+
+  const workspaces = Object.values(data.workspaces).reduce<
+    v_2_3_0.DataRecord['workspaces']
+  >((prev, w) => {
+    const workspaceEnvironments: Record<string, any> = {}
+
+    Object.entries(environments).forEach(([envId, envData]) => {
+      const parsedData =
+        typeof envData.value === 'string'
+          ? JSON.parse(envData.value)
+          : envData.value
+      if (envId === 'default') {
+        Object.assign(workspaceEnvironments, parsedData)
+      }
+    })
+
+    prev[w.uid] = {
+      ...w,
+      environments: workspaceEnvironments,
+    }
+    return prev
+  }, {})
+
+  const collections = Object.values(data.collections).reduce<
+    v_2_3_0.DataRecord['collections']
+  >((prev, c) => {
+    prev[c.uid] = {
+      ...c,
+      'x-scalar-environments': c['x-scalar-environments'] || {},
+    }
+    return prev
+  }, {})
+
+  Object.values(workspaces).forEach((workspace) => {
+    Object.entries(environments).forEach(([envKey, envData]) => {
+      if (envKey !== 'default') {
+        const parsedData =
+          typeof envData.value === 'string'
+            ? JSON.parse(envData.value)
+            : envData.value
+        const envName = envData.name
+        Object.values(collections).forEach((collection) => {
+          collection['x-scalar-environments'] =
+            collection['x-scalar-environments'] || {}
+          collection['x-scalar-environments'][envName] = {
+            variables: parsedData,
+          }
+          if (workspace.activeEnvironmentId === envKey) {
+            collection['x-scalar-active-environment'] = envName ?? ''
+          }
+        })
+      }
+    })
+  })
+
+  return {
+    ...data,
+    collections,
+    workspaces,
+  } satisfies v_2_3_0.DataRecord
+}

--- a/packages/oas-utils/src/migrations/v-2.3.0/types.generated.ts
+++ b/packages/oas-utils/src/migrations/v-2.3.0/types.generated.ts
@@ -1,0 +1,47 @@
+import type { Cookie as Ck } from '@/entities/cookie'
+import type { Environment as E } from '@/entities/environment'
+import type {
+  Collection as Co,
+  Request as R,
+  RequestExample as RE,
+  Server as S,
+  SecurityScheme as SS,
+  Tag as T,
+} from '@/entities/spec'
+import type { Workspace as W } from '@/entities/workspace'
+
+export namespace v_2_3_0 {
+  export type Cookie = Ck
+  export type Environment = E
+  export type Collection = Co
+  export type Request = R
+  export type RequestExample = RE
+  export type SecurityScheme = SS
+  export type Server = S
+  export type Tag = T
+  export type Workspace = W
+
+  export type DataRecord = {
+    collections: Record<string, Collection>
+    cookies: Record<string, Cookie>
+    environments: Record<string, Environment>
+    requestExamples: Record<string, RequestExample>
+    requests: Record<string, Request>
+    securitySchemes: Record<string, SecurityScheme>
+    servers: Record<string, Server>
+    tags: Record<string, Tag>
+    workspaces: Record<string, Workspace>
+  }
+
+  export type DataArray = {
+    collections: Collection[]
+    cookies: Cookie[]
+    environments: Environment[]
+    requestExamples: RequestExample[]
+    requests: Request[]
+    securitySchemes: SecurityScheme[]
+    servers: Server[]
+    tags: Tag[]
+    workspaces: Workspace[]
+  }
+}

--- a/packages/oas-utils/src/spec-extentions/x-scalar-environments.yaml
+++ b/packages/oas-utils/src/spec-extentions/x-scalar-environments.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Environments
   version: 1.0.0
-x-scalar-environment: staging
+x-scalar-active-environment: staging
 # Secrets will be defined separately from variables
 # All environments will inherit the same secrets
 # We will provide an interface for fetching secrets from a secret manager (Scalar hosted for now)

--- a/packages/use-codemirror/src/hooks/useDropdown.ts
+++ b/packages/use-codemirror/src/hooks/useDropdown.ts
@@ -22,13 +22,15 @@ export function useDropdown(params: {
   /** Updates position of the dropdown based on the current cursor position */
   function updateDropdownPosition() {
     const cursorPos = getCursorPos()
-    const coords = getCoordsAtPos(cursorPos - query.value.length - 2)
-    if (coords) {
-      dropdownPosition.value = {
-        left: coords.left,
-        top: Math.max(coords.bottom),
+    requestAnimationFrame(() => {
+      const coords = getCoordsAtPos(cursorPos - query.value.length - 2)
+      if (coords) {
+        dropdownPosition.value = {
+          left: coords.left,
+          top: Math.max(coords.bottom),
+        }
       }
-    }
+    })
   }
 
   // Watch for changes in the query and update the dropdown position


### PR DESCRIPTION
this pr re-organize the environment sidebar to include collections along collection environment.

<img width="1466" alt="image" src="https://github.com/user-attachments/assets/9886728e-bf85-44ac-b146-421c876dd4c0">

⊢ course of action:
- [x] Adds collection environment editor
- [x] Setup collection environment routes
- [x] Redirection on environment removal
- [x] Sets global environment from workspace
- [x] Substitutes environment variable value