### PR TITLE
style(api-reference): introduction card server description

### DIFF
--- a/.changeset/healthy-experts-sneeze.md
+++ b/.changeset/healthy-experts-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+style: updates introduction card server description

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -132,11 +132,12 @@ const introCardsSlot = computed(() =>
   flex-direction: column;
   justify-content: center;
 }
+.introduction-card-item:has(.description) :deep(.server-form-container) {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
 .introduction-card-item:last-of-type {
   border-bottom: none;
-}
-.introduction-card :deep(.description) {
-  padding: 0;
 }
 .introduction-card-title {
   font-weight: var(--scalar-semibold);

--- a/packages/api-reference/src/features/BaseUrl/ServerForm.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerForm.vue
@@ -97,7 +97,11 @@ function updateVariable(name: string, value: string) {
   border: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 .description {
-  padding: 6px 12px;
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-top: 0;
+  border-bottom-left-radius: var(--scalar-radius);
+  border-bottom-right-radius: var(--scalar-radius);
+  padding: 3px 9px;
   font-size: var(--scalar-small);
   font-weight: var(--scalar-semibold);
   color: var(--scalar-color-3);

--- a/packages/api-reference/src/features/BaseUrl/ServerVariablesForm.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerVariablesForm.vue
@@ -72,7 +72,7 @@ const getVariable = (name: string) => {
 .variable-label {
   padding: 9px 0 9px 9px;
   color: var(--scalar-color-2);
-  border-top: 1px solid var(--scalar-border-color);
+  border-top: 0.5px solid var(--scalar-border-color);
   font-size: var(--scalar-micro);
 }
 .variable-label:after {

--- a/packages/api-reference/src/features/BaseUrl/ServerVariablesSelect.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerVariablesSelect.vue
@@ -54,7 +54,7 @@ const selected = computed<ScalarListboxOption | undefined>({
   align-items: center;
   border-color: transparent;
   border-radius: 0;
-  border-top: 1px solid var(--scalar-border-color);
+  border-top: 0.5px solid var(--scalar-border-color);
   display: flex;
   font-size: var(--scalar-micro);
   font-weight: var(--scalar-regular);

--- a/packages/api-reference/src/features/BaseUrl/ServerVariablesTextbox.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerVariablesTextbox.vue
@@ -32,7 +32,8 @@ const model = computed<string>({
   align-items: center;
   border-color: transparent;
   border-radius: 0;
-  border-top: 1px solid var(--scalar-border-color);
+  border-left: 0;
+  border-top: 0.5px solid var(--scalar-border-color);
   display: flex;
   font-size: var(--scalar-micro);
   font-weight: var(--scalar-regular);


### PR DESCRIPTION
this pr updates the introduction card server description ui as seen below:
- fixes border consistency
- updates description ui

**before / after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/02436015-29a7-4d96-8837-b9a9caa05e3d">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0c2d0f67-30f7-4f7e-9cd1-3b42d1600c97">
</div>