### PR TITLE
feat(components): simplify index exports

### DIFF
--- a/.changeset/lemon-pens-protect.md
+++ b/.changeset/lemon-pens-protect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat(components): simplify index exports

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,88 +1,24 @@
-import { ScalarButton } from './components/ScalarButton'
-import { ScalarCodeBlock } from './components/ScalarCodeBlock'
-import {
-  ScalarCombobox,
-  ScalarComboboxMultiselect,
-  type ScalarComboboxOption,
-} from './components/ScalarCombobox'
-import { ScalarContextMenu } from './components/ScalarContextMenu'
-import {
-  ScalarDropdown,
-  ScalarDropdownDivider,
-  ScalarDropdownItem,
-} from './components/ScalarDropdown'
-import { ScalarFloating } from './components/ScalarFloating'
-import { type Icon, ScalarIcon } from './components/ScalarIcon'
-import { ScalarIconButton } from './components/ScalarIconButton'
-import {
-  ScalarListbox,
-  type ScalarListboxOption,
-} from './components/ScalarListbox'
-import { ScalarLoading, useLoadingState } from './components/ScalarLoading'
-import { ScalarMarkdown } from './components/ScalarMarkdown'
-import {
-  ScalarMenu,
-  ScalarMenuLink,
-  ScalarMenuProduct,
-  ScalarMenuProducts,
-  ScalarMenuProfile,
-  ScalarMenuResources,
-  ScalarMenuSection,
-} from './components/ScalarMenu'
-import {
-  type ModalState,
-  ScalarModal,
-  useModal,
-} from './components/ScalarModal'
-import { ScalarPopover } from './components/ScalarPopover'
-import { ScalarSearchInput } from './components/ScalarSearchInput'
-import {
-  ScalarSearchResultItem,
-  ScalarSearchResultList,
-} from './components/ScalarSearchResults'
-import { ScalarTextField } from './components/ScalarTextField'
-import { ScalarToggle } from './components/ScalarToggle'
-import { ScalarTooltip } from './components/ScalarTooltip'
-import { ScalarVirtualText } from './components/ScalarVirtualText'
 import './tailwind/tailwind.css'
 
-export * from './helpers'
+export * from './components/ScalarButton'
+export * from './components/ScalarCodeBlock'
+export * from './components/ScalarCombobox'
+export * from './components/ScalarContextMenu'
+export * from './components/ScalarDropdown'
+export * from './components/ScalarFloating'
+export * from './components/ScalarIcon'
+export * from './components/ScalarIconButton'
+export * from './components/ScalarListbox'
+export * from './components/ScalarLoading'
+export * from './components/ScalarMarkdown'
+export * from './components/ScalarModal'
+export * from './components/ScalarMenu'
+export * from './components/ScalarPopover'
+export * from './components/ScalarSearchInput'
+export * from './components/ScalarSearchResults'
+export * from './components/ScalarTextField'
+export * from './components/ScalarToggle'
+export * from './components/ScalarTooltip'
+export * from './components/ScalarVirtualText'
 
-export {
-  ScalarButton,
-  ScalarCodeBlock,
-  ScalarCombobox,
-  ScalarComboboxMultiselect,
-  ScalarMarkdown,
-  ScalarDropdown,
-  ScalarDropdownDivider,
-  ScalarDropdownItem,
-  ScalarFloating,
-  ScalarIcon,
-  ScalarIconButton,
-  ScalarListbox,
-  ScalarLoading,
-  ScalarContextMenu,
-  ScalarMenu,
-  ScalarMenuLink,
-  ScalarMenuProduct,
-  ScalarMenuProducts,
-  ScalarMenuProfile,
-  ScalarMenuResources,
-  ScalarMenuSection,
-  ScalarModal,
-  ScalarPopover,
-  ScalarSearchInput,
-  ScalarSearchResultItem,
-  ScalarSearchResultList,
-  ScalarTextField,
-  ScalarToggle,
-  ScalarTooltip,
-  ScalarVirtualText,
-  type Icon,
-  type ScalarListboxOption,
-  type ScalarComboboxOption,
-  type ModalState,
-  useLoadingState,
-  useModal,
-}
+export * from './helpers'


### PR DESCRIPTION
Not the final solution but simplifies the index file and makes it easier to export new components.

I don't think this should change the consumed API anywhere but someone who knows about packages can weigh in?