### PR TITLE
chore(Scalar.AspNetCore): bump dependencies to a stable version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,8 +427,6 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
-        with:
-          dotnet-version: 9.x
 
       - name: Build @scalar/api-reference
         uses: ./.github/actions/build
@@ -479,8 +477,6 @@ jobs:
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Setup .NET
         uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
-        with:
-          dotnet-version: 9.x
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Extract version from package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,8 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
+        with:
+          dotnet-version: 9.x
 
       - name: Build @scalar/api-reference
         uses: ./.github/actions/build
@@ -477,6 +479,8 @@ jobs:
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Setup .NET
         uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
+        with:
+          dotnet-version: 9.x
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Extract version from package.json

--- a/packages/scalar.aspnetcore/global.json
+++ b/packages/scalar.aspnetcore/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "9.0.0",
-    "rollForward": "latestMinor",
-    "allowPrerelease": true
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
   }
 }

--- a/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj
+++ b/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="APIWeaver.OpenApi" Version="2.5.0" />
+    <PackageReference Include="APIWeaver.OpenApi" Version="2.7.0" />
     <PackageReference Include="Bogus" Version="35.6.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.2.24474.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -15,8 +15,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rc.1.24452.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj
+++ b/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.1.24452.1"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
.NET 9 was released yesterday 🚀 and this PR updates all dependencies in the `Scalar.AspNetCore` package to use the latest stable versions.
