### PR TITLE
feat(use-hooks): add useBreakpoint hook

### DIFF
--- a/.changeset/fluffy-pigs-explain.md
+++ b/.changeset/fluffy-pigs-explain.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/use-hooks': patch
+---
+
+feat(use-hooks): add useBreakpoint hook

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useWorkspace } from '@/store'
-import { useMediaQuery } from '@vueuse/core'
+import { useBreakpoints } from '@scalar/use-hooks/useBreakpoints'
 import { ref } from 'vue'
 
 const props = withDefaults(
@@ -15,9 +15,8 @@ const props = withDefaults(
 const { isReadOnly, sidebarWidth, setSidebarWidth } = useWorkspace()
 const isDragging = ref(false)
 
-const isNarrow = useMediaQuery('(max-width: 780px)')
 const sidebarRef = ref<HTMLElement | null>(null)
-const isMobile = useMediaQuery('(max-width: 800px)')
+const { breakpoints } = useBreakpoints()
 
 const startDrag = (event: MouseEvent) => {
   event.preventDefault()
@@ -66,7 +65,7 @@ const startDrag = (event: MouseEvent) => {
     ref="sidebarRef"
     class="sidebar overflow-hidden relative flex flex-col flex-1 md:flex-none bg-b-1 md:border-b-0 md:border-r-1/2 min-w-full md:min-w-fit"
     :class="{ dragging: isDragging }"
-    :style="{ width: isNarrow ? '100%' : sidebarWidth }">
+    :style="{ width: breakpoints.md ? sidebarWidth : '100%' }">
     <slot name="header" />
     <div
       v-if="!isReadOnly && title"
@@ -75,7 +74,7 @@ const startDrag = (event: MouseEvent) => {
         {{ title }}
       </h2>
       <slot
-        v-if="isMobile"
+        v-if="!breakpoints.md"
         name="button" />
     </div>
     <div
@@ -85,15 +84,15 @@ const startDrag = (event: MouseEvent) => {
       }">
       <slot name="content" />
     </div>
-    <div
-      v-if="!isMobile"
-      class="relative z-10 pt-0 md:px-2.5 md:pb-2.5 sticky bottom-0 w-[inherit] has-[.empty-sidebar-item]:border-t-1/2">
-      <slot name="button" />
-    </div>
-    <div
-      v-if="!isNarrow"
-      class="resizer"
-      @mousedown="startDrag"></div>
+    <template v-if="breakpoints.md">
+      <div
+        class="relative z-10 pt-0 md:px-2.5 md:pb-2.5 sticky bottom-0 w-[inherit] has-[.empty-sidebar-item]:border-t-1/2">
+        <slot name="button" />
+      </div>
+      <div
+        class="resizer"
+        @mousedown="startDrag" />
+    </template>
   </aside>
 </template>
 <style scoped>

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -12,8 +12,8 @@ import ResponseSection from '@/views/Request/ResponseSection/ResponseSection.vue
 import { useOpenApiWatcher } from '@/views/Request/hooks/useOpenApiWatcher'
 import type { RequestPayload } from '@scalar/oas-utils/entities/spec'
 import { safeJSON } from '@scalar/object-utils/parse'
+import { useBreakpoints } from '@scalar/use-hooks/useBreakpoints'
 import { useToasts } from '@scalar/use-toasts'
-import { useMediaQuery } from '@vueuse/core'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -54,8 +54,8 @@ const activeHistoryEntry = computed(() =>
 )
 
 /** Show / hide the sidebar when we resize the screen */
-const isNarrow = useMediaQuery('(max-width: 800px)')
-watch(isNarrow, (narrow) => (showSideBar.value = !narrow))
+const { mediaQueries } = useBreakpoints()
+watch(mediaQueries.md, (isMedium) => (showSideBar.value = isMedium))
 
 /**
  * Selected scheme UIDs

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { OpenApiClientButton } from '@scalar/api-client/components'
-import { useMediaQuery } from '@vueuse/core'
+import { useBreakpoints } from '@scalar/use-hooks/useBreakpoints'
 import { watch } from 'vue'
 
 import { SearchButton } from '../../features/Search'
@@ -18,13 +18,13 @@ defineEmits<{
 
 const slots = defineSlots<ReferenceLayoutSlots>()
 
-const isMobile = useMediaQuery('(max-width: 1000px)')
+const { mediaQueries } = useBreakpoints()
 const { isSidebarOpen } = useSidebar()
 const isDevelopment = import.meta.env.MODE === 'development'
 
-watch(isMobile, (n, o) => {
+watch(mediaQueries.lg, (newValue, oldValue) => {
   // Close the drawer when we go from desktop to mobile
-  if (n && !o) isSidebarOpen.value = false
+  if (oldValue && !newValue) isSidebarOpen.value = false
 })
 
 const { hash } = useNavState()

--- a/packages/use-hooks/package.json
+++ b/packages/use-hooks/package.json
@@ -35,6 +35,11 @@
       "import": "./dist/useClipboard/index.js",
       "types": "./dist/useClipboard/index.d.ts",
       "default": "./dist/useClipboard/index.js"
+    },
+    "./useBreakpoints": {
+      "import": "./dist/useBreakpoints/index.js",
+      "types": "./dist/useBreakpoints/index.d.ts",
+      "default": "./dist/useBreakpoints/index.js"
     }
   },
   "files": [
@@ -42,7 +47,9 @@
   ],
   "module": "./dist/index.js",
   "dependencies": {
+    "@scalar/themes": "workspace:*",
     "@scalar/use-toasts": "workspace:*",
+    "@vueuse/core": "^10.10.0",
     "vue": "^3.5.12",
     "zod": "^3.23.8"
   },

--- a/packages/use-hooks/src/useBreakpoints/README.md
+++ b/packages/use-hooks/src/useBreakpoints/README.md
@@ -2,6 +2,11 @@
 
 Exposes [Tailwind CSS breakpoints](https://tailwindcss.com/docs/screens) as reactive min-width media queries for use in Vue templates.
 
+> [!WARNING]  
+> This hook is not a replacement for Tailwind CSS breakpoints. Using breakpoints in Javascript can cause issues with Server Side Rendering (SSR) and the Tailwind CSS breakpoints should be used when possible.
+>
+> These breakpoints are meant to be used as an alternative when the application isn't primarily Server Side Rendered and DOM manipulation is required, e.g. an element needs to be removed from the DOM rather than just hidden with CSS / Tailwind.
+
 Exposing the breakpoints in a hook allows us to remove the element from the DOM rather than just hiding it with CSS / Tailwind while mirroring how the tailwind breakpoints are used.
 
 For example,`<div v-if="breakpoints.md">` will remove the element from the DOM when the screen size is less than `md` whereas `<div class="hidden md:block">` will only hide the element.

--- a/packages/use-hooks/src/useBreakpoints/README.md
+++ b/packages/use-hooks/src/useBreakpoints/README.md
@@ -1,0 +1,21 @@
+# Scalar useBreakpoints Hook
+
+Exposes [Tailwind CSS breakpoints](https://tailwindcss.com/docs/screens) as reactive min-width media queries for use in Vue templates.
+
+Exposing the breakpoints in a hook allows us to remove the element from the DOM rather than just hiding it with CSS / Tailwind while mirroring how the tailwind breakpoints are used.
+
+For example,`<div v-if="breakpoints.md">` will remove the element from the DOM when the screen size is less than `md` whereas `<div class="hidden md:block">` will only hide the element.
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { useBreakpoints } from '@scalar/use-hooks/useBreakpoints'
+
+const { breakpoints } = useBreakpoints()
+</script>
+<template>
+  <!-- Render the component only on medium screens and larger -->
+  <div v-if="breakpoints.md">...</div>
+</template>
+```

--- a/packages/use-hooks/src/useBreakpoints/index.ts
+++ b/packages/use-hooks/src/useBreakpoints/index.ts
@@ -1,0 +1,1 @@
+export * from './useBreakpoints'

--- a/packages/use-hooks/src/useBreakpoints/useBreakpoints.test.ts
+++ b/packages/use-hooks/src/useBreakpoints/useBreakpoints.test.ts
@@ -1,0 +1,58 @@
+import preset from '@scalar/themes/tailwind'
+import { useMediaQuery } from '@vueuse/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { useBreakpoints } from './useBreakpoints'
+
+const screens = preset.theme.screens
+
+vi.mock('@vueuse/core', () => ({
+  useMediaQuery: vi.fn(),
+}))
+
+describe('useBreakpoints', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should expose the screen sizes', () => {
+    const { screens: exposedScreens } = useBreakpoints()
+    expect(exposedScreens).toEqual(screens)
+  })
+
+  it('should expose media queries for a given screen size', () => {
+    vi.mocked(useMediaQuery).mockImplementation((query) =>
+      ref(query === `(min-width: ${screens.md})`),
+    )
+
+    const { mediaQueries } = useBreakpoints()
+    expect(mediaQueries.sm.value).toEqual(false)
+    expect(mediaQueries.md.value).toEqual(true)
+  })
+
+  it('should expose breakpoints for a given screen size', () => {
+    vi.mocked(useMediaQuery).mockImplementation((query) =>
+      ref(query === `(min-width: ${screens.md})`),
+    )
+
+    const { breakpoints } = useBreakpoints()
+    expect(breakpoints.value.sm).toEqual(false)
+    expect(breakpoints.value.md).toEqual(true)
+  })
+
+  it('should update breakpoints when the media query changes', () => {
+    const mdQuery = ref(false)
+    vi.mocked(useMediaQuery).mockImplementation((query) =>
+      query === `(min-width: ${screens.md})` ? mdQuery : ref(false),
+    )
+
+    const { breakpoints } = useBreakpoints()
+
+    expect(breakpoints.value.md).toEqual(false)
+
+    mdQuery.value = true
+
+    expect(breakpoints.value.md).toEqual(true)
+  })
+})

--- a/packages/use-hooks/src/useBreakpoints/useBreakpoints.ts
+++ b/packages/use-hooks/src/useBreakpoints/useBreakpoints.ts
@@ -1,0 +1,39 @@
+import preset from '@scalar/themes/tailwind'
+import { useMediaQuery } from '@vueuse/core'
+import { type Ref, computed, unref } from 'vue'
+
+type Screen = keyof typeof preset.theme.screens
+
+/**
+ * Exposes Tailwind CSS breakpoints as reactive media queries
+ */
+export function useBreakpoints() {
+  const screens = preset.theme.screens
+
+  const mediaQueries = Object.fromEntries(
+    Object.entries(screens).map(([breakpoint, value]) => [
+      breakpoint,
+      useMediaQuery(`(min-width: ${value})`),
+    ]),
+  ) as Record<Screen, Ref<boolean>>
+
+  // We make the breakpoints a computed object so that we can use them in templates as `breakpoints.x` instead of `breakpoints.x.value`
+  const breakpoints = computed(
+    () =>
+      Object.fromEntries(
+        Object.entries(mediaQueries).map(([breakpoint, queryRef]) => [
+          breakpoint,
+          unref(queryRef),
+        ]),
+      ) as Record<Screen, boolean>,
+  )
+
+  return {
+    /** The screen sizes defined in the preset */
+    screens,
+    /** Min-width reactive media queries for each of the screen sizes */
+    mediaQueries,
+    /** The breakpoints as reactive min-width media queries */
+    breakpoints,
+  }
+}

--- a/packages/use-hooks/src/useBreakpoints/useBreakpoints.ts
+++ b/packages/use-hooks/src/useBreakpoints/useBreakpoints.ts
@@ -6,6 +6,8 @@ type Screen = keyof typeof preset.theme.screens
 
 /**
  * Exposes Tailwind CSS breakpoints as reactive media queries
+ *
+ * **Warning:** This hook is not a replacement for Tailwind CSS breakpoints. Using breakpoints in Javascript can cause issues with Server Side Rendering (SSR) and the Tailwind CSS breakpoints should be used when possible.
  */
 export function useBreakpoints() {
   const screens = preset.theme.screens

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2156,9 +2156,15 @@ importers:
 
   packages/use-hooks:
     dependencies:
+      '@scalar/themes':
+        specifier: workspace:*
+        version: link:../themes
       '@scalar/use-toasts':
         specifier: workspace:*
         version: link:../use-toasts
+      '@vueuse/core':
+        specifier: ^10.10.0
+        version: 10.11.0(vue@3.5.12(typescript@5.6.2))
       vue:
         specifier: ^3.5.12
         version: 3.5.12(typescript@5.6.2)


### PR DESCRIPTION
Adds a `useBreakpoint` hook so we can use our Tailwind breakpoints in a consistent way that matches how we use the in CSS. 

Fixes DOC-1338 😱 🧟 

Also fixed a bug with the API Client sidebar while I was in there (it used to be possible to do this if you opened the sidebar with a viewport between 780px and 800px)

![Google Chrome-2024-11-14-20-03-21@2x](https://github.com/user-attachments/assets/3bbf2f9f-995d-40a9-80e7-4c95f6457fbf)
