### PR TITLE
fix(api-reference): property detail long content

### DIFF
--- a/.changeset/eighty-buses-reply.md
+++ b/.changeset/eighty-buses-reply.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: wrap property heading and detail

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -332,6 +332,8 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
 .property-enum-value {
   padding: 3px 0;
   color: var(--scalar-color-2);
+  line-height: 1.5;
+  word-break: break-word;
 }
 .property-enum-value::before {
   content: '⊢';

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.spec.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.spec.ts
@@ -14,7 +14,7 @@ describe('SchemaPropertyHeading', () => {
       },
     })
 
-    const defaultValueElement = wrapper.find('.property-details')
+    const defaultValueElement = wrapper.find('.property-heading')
     expect(defaultValueElement.text()).toContain('default:')
     expect(defaultValueElement.text()).toContain('false')
   })
@@ -41,7 +41,7 @@ describe('SchemaPropertyHeading', () => {
       },
     })
 
-    const detailsElement = wrapper.find('.property-details')
+    const detailsElement = wrapper.find('.property-heading')
     expect(detailsElement.text()).toContain('string')
     expect(detailsElement.text()).toContain('date-time')
   })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -51,9 +51,7 @@ const flattenDefaultValue = (value: Record<string, any>) => {
         {{ value.const ?? value.enum[0] }}
       </SchemaPropertyDetail>
     </div>
-    <div
-      v-else-if="value?.type"
-      class="property-details">
+    <template v-else-if="value?.type">
       <SchemaPropertyDetail>
         <!-- prettier-ignore -->
         <template v-if="value?.items?.type">
@@ -115,7 +113,7 @@ const flattenDefaultValue = (value: Record<string, any>) => {
         <template #prefix>default:</template>
         {{ flattenDefaultValue(value) }}
       </SchemaPropertyDetail>
-    </div>
+    </template>
     <div
       v-if="value?.writeOnly"
       class="property-write-only">
@@ -141,9 +139,22 @@ const flattenDefaultValue = (value: Record<string, any>) => {
 <style scoped>
 .property-heading {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
-  gap: 9px;
+  row-gap: 9px;
   white-space: nowrap;
+}
+
+.property-heading > * {
+  margin-right: 9px;
+}
+
+.property-heading:last-child {
+  margin-right: 0;
+}
+
+.property-heading > .property-detail:not(:last-of-type) {
+  margin-right: 0;
 }
 
 .property-name {
@@ -175,7 +186,7 @@ const flattenDefaultValue = (value: Record<string, any>) => {
   font-size: var(--scalar-micro);
   color: var(--scalar-color-green);
 }
-.property-details {
+.property-detail {
   font-size: var(--scalar-micro);
   color: var(--scalar-color-2);
   display: flex;


### PR DESCRIPTION
this pr fixes small glitches on long content usage in api reference:

**⊢ schema property before / after**
<img width="531" alt="image" src="https://github.com/user-attachments/assets/a4360aff-f4de-448c-99d6-94fca640dbc7">
<img width="531" alt="image" src="https://github.com/user-attachments/assets/2c345a93-4bf0-4b91-9f22-488ffeab31ac">

**⊢ property enum before / after**
<img width="591" alt="image" src="https://github.com/user-attachments/assets/10306106-d4f1-4b49-9814-51faec52889b">
<img width="531" alt="image" src="https://github.com/user-attachments/assets/98f5895b-61a8-4b0b-a924-9d50f8d0f971">

