### PR TITLE
fix(use-hooks): set default color mode to system instead of dark

### DIFF
--- a/.changeset/swift-games-drop.md
+++ b/.changeset/swift-games-drop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-hooks': patch
+---
+
+fix(use-hooks): set default color mode to system instead of dark

--- a/packages/use-hooks/src/useColorMode/useColorMode.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.ts
@@ -14,12 +14,14 @@ const colorModeSchema = z
  * A composable hook that provides color mode (dark/light) functionality.
  */
 export function useColorMode(opts: UseColorModeOptions = {}) {
-  const { initialColorMode = 'dark', overrideColorMode } = opts
+  const { initialColorMode = 'system', overrideColorMode } = opts
 
   /** Toggles the color mode between light and dark. */
   function toggleColorMode() {
+    const darkLightMode =
+      colorMode.value === 'system' ? getSystemModePreference() : colorMode.value
     // Update state
-    colorMode.value = colorMode.value === 'dark' ? 'light' : 'dark'
+    colorMode.value = darkLightMode === 'dark' ? 'light' : 'dark'
 
     // Store in local storage
     if (typeof window === 'undefined') return


### PR DESCRIPTION
Initial mode now defaults to `system` instead of `dark` 🤦 

Added some extra tests too.