### PR TITLE
feat(Scalar.AspNetCore): support multiple scalar endpoints

### DIFF
--- a/.changeset/healthy-pens-juggle.md
+++ b/.changeset/healthy-pens-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feat: Support multiple scalar endpoints

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -36,7 +36,8 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// <param name="configureOptions">An action to configure the Scalar options.</param>
     public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, Action<ScalarOptions> configureOptions)
     {
-        var options = endpoints.ServiceProvider.GetService<IOptions<ScalarOptions>>()?.Value ?? new ScalarOptions();
+        // Clone existing ScalarOptions or create a new instance
+        var options = endpoints.ServiceProvider.GetService<IOptions<ScalarOptions>>()?.Value is { } existingOptions ? existingOptions with { } : new ScalarOptions();
         configureOptions(options);
 
         if (!options.EndpointPathPrefix.Contains(DocumentName))

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -4,7 +4,7 @@ namespace Scalar.AspNetCore;
 /// Represents all available options for the Scalar API reference.
 /// Based on <a href="https://github.com/scalar/scalar/blob/main/documentation/configuration.md">Configuration</a>.
 /// </summary>
-public sealed class ScalarOptions
+public sealed record ScalarOptions
 {
     /// <summary>
     /// Metadata title.

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -139,4 +139,23 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         act.Should().Throw<ArgumentException>().WithMessage("'EndpointPathPrefix' must define '{documentName}'.");
     }
+
+    [Fact]
+    public async Task MapScalarApiReference_ShouldHandleMultipleReferenceEndpoints_WhenAdded()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+
+        // Act
+        var fooResponse = await client.GetAsync("/foo-docs/v1");
+        var barResponse = await client.GetAsync("/bar-docs/v1");
+
+        // Assert
+        fooResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var fooContent = await fooResponse.Content.ReadAsStringAsync();
+        fooContent.Should().Contain("/foo/v1.json");
+        barResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var barContent = await barResponse.Content.ReadAsStringAsync();
+        barContent.Should().Contain("/bar/v1.json");
+    }
 }

--- a/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Program.cs
+++ b/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Program.cs
@@ -10,6 +10,18 @@ if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
     app.MapScalarApiReference();
+    app.MapScalarApiReference(options =>
+    {
+        options
+            .WithEndpointPrefix("/foo-docs/{documentName}")
+            .WithOpenApiRoutePattern("/foo/{documentName}.json");
+    });
+    app.MapScalarApiReference(options =>
+    {
+        options
+            .WithEndpointPrefix("/bar-docs/{documentName}")
+            .WithOpenApiRoutePattern("/bar/{documentName}.json");
+    });
 }
 
 app.Run();


### PR DESCRIPTION
This PR introduces support for registering multiple `MapScalarApiReference` endpoints. To achieve this, I decided to clone the options before invoking them in the action. This approach ensures that the options can be invoked multiple times without side effects.

Closes #3901