### PR TITLE
docs(config): add .NET integration documentation to scalar config

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -34,6 +34,11 @@
           "type": "folder",
           "children": [
             {
+              "name": ".NET integration",
+              "path": "documentation/integrations/dotnet.md",
+              "type": "page"
+            },
+            {
               "name": "AdonisJS",
               "path": "documentation/integrations/adonisjs.md",
               "type": "page"


### PR DESCRIPTION
This PR adds the .NET integration docs to the navigation tree!

Closes #3903