### PR TITLE
feat(Scalar.AspNetCore): add missing options model definition for prefilling http basic/bearer tokens

### DIFF
--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -89,7 +89,7 @@ app.MapScalarApiReference(options =>
 
 ### Authentication
 
-Scalar supports various authentication schemes, including OAuth and API Key, by allowing you to pre-fill certain authentication details.
+Scalar supports various authentication schemes, including API Key, OAuth, HTTP Basic and Bearer, by allowing you to pre-fill certain authentication details.
 
 > [!WARNING]
 > Sensitive Information: Pre-filled authentication details are exposed to the client/browser and may pose a security risk. Do not use this feature in production environments.
@@ -137,6 +137,32 @@ app.MapScalarApiReference(options =>
         {
             oauth.ClientId = "your-client-id";
             oauth.Scopes = ["profile"];
+        });
+});
+```
+
+#### HTTP Basic/Bearer
+
+HTTP Basic or Bearer authentication fields can also be pre-filled easily:
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    // Basic
+    options
+        .WithPreferredScheme("Basic") // Security scheme name from the OpenAPI document
+        .WithHttpBasicAuthentication(basic =>
+        {
+            basic.Username = "your-username";
+            basic.Password = "your-password";
+        });
+
+    // Bearer
+    options
+        .WithPreferredScheme("Bearer") // Security scheme name from the OpenAPI document
+        .WithHttpBearerAuthentication(bearer =>
+        {
+            bearer.Token = "your-bearer-token";
         });
 });
 ```

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -302,6 +302,56 @@ public static class ScalarOptionsExtensions
     }
 
     /// <summary>
+    /// Sets the HTTP basic authentication options.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="httpBasicOptions">The HTTP basic options to set.</param>
+    public static ScalarOptions WithHttpBasicAuthentication(this ScalarOptions options, HttpBasicOptions httpBasicOptions)
+    {
+        options.Authentication ??= new ScalarAuthenticationOptions();
+        options.Authentication.Http ??= new HttpOptions();
+        options.Authentication.Http.Basic = httpBasicOptions;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the HTTP basic authentication options.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="configureHttpBasicOptions">The action to configure the HTTP basic options.</param>
+    public static ScalarOptions WithHttpBasicAuthentication(this ScalarOptions options, Action<HttpBasicOptions> configureHttpBasicOptions)
+    {
+        var httpBasicOptions = new HttpBasicOptions();
+        configureHttpBasicOptions(httpBasicOptions);
+        return options.WithHttpBasicAuthentication(httpBasicOptions);
+    }
+
+    /// <summary>
+    /// Sets the HTTP bearer authentication options.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="httpBearerOptions">The HTTP bearer options to set.</param>
+    public static ScalarOptions WithHttpBearerAuthentication(this ScalarOptions options, HttpBearerOptions httpBearerOptions)
+    {
+        options.Authentication ??= new ScalarAuthenticationOptions();
+        options.Authentication.Http ??= new HttpOptions();
+        options.Authentication.Http.Bearer = httpBearerOptions;
+        return options;
+    }
+
+    /// <summary>
+    /// Configures the HTTP bearer authentication options.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="configureHttpBearerOptions">The action to configure the HTTP bearer options.</param>
+    public static ScalarOptions WithHttpBearerAuthentication(this ScalarOptions options, Action<HttpBearerOptions> configureHttpBearerOptions)
+    {
+        var httpBearerOptions = new HttpBearerOptions();
+        configureHttpBearerOptions(httpBearerOptions);
+        return options.WithHttpBearerAuthentication(httpBearerOptions);
+    }
+
+    /// <summary>
     /// Sets the default HTTP client.
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpBasicOptions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpBasicOptions.cs
@@ -1,0 +1,19 @@
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents the options for HTTP basic authentication.
+/// </summary>
+public sealed class HttpBasicOptions
+{
+    /// <summary>
+    /// Gets or sets the username used for HTTP basic authentication.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public string? Username { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the password used for HTTP basic authentication.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public string? Password { get; set; }
+}

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpBearerOptions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpBearerOptions.cs
@@ -1,0 +1,13 @@
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents the options for HTTP bearer authentication.
+/// </summary>
+public sealed class HttpBearerOptions
+{
+    /// <summary>
+    /// Gets or sets the token used for HTTP bearer authentication.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public string? Token { get; set; }
+}

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpOptions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpOptions.cs
@@ -1,0 +1,21 @@
+﻿namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents the options for HTTP authentication.
+/// </summary>
+public sealed class HttpOptions
+{
+    /// <summary>
+    /// Gets or sets the HTTP basic options.
+    /// This can be used if the OpenApi document has a HTTP basic security scheme.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public HttpBasicOptions? Basic { get; set; }
+
+    /// <summary>
+    /// Gets or sets the HTTP bearer options.
+    /// This can be used if the OpenApi document has a HTTP bearer security scheme.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public HttpBearerOptions? Bearer { get; set; }
+}

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/Authentication/ScalarAuthenticationOptions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/Authentication/ScalarAuthenticationOptions.cs
@@ -24,4 +24,11 @@ public sealed class ScalarAuthenticationOptions
     /// </summary>
     /// <value>The default value is <c>null</c>.</value>
     public OAuth2Options? OAuth2 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the HTTP options.
+    /// This can be used if the OpenApi document has a HTTP security scheme.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public HttpOptions? Http { get; set; }
 }

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -22,12 +22,18 @@ public class ScalarOptionsExtensionsTests
             .WithProxyUrl("http://localhost:8080")
             .AddMetadata("key", "value")
             .WithPreferredScheme("my-scheme")
-            .WithApiKeyAuthentication(x => x.Token = "my-token")
+            .WithApiKeyAuthentication(x => x.Token = "my-api-token")
             .WithOAuth2Authentication(x =>
             {
                 x.ClientId = "my-client";
                 x.Scopes = ["scope"];
             })
+            .WithHttpBasicAuthentication(x =>
+            {
+                x.Username = "my-username";
+                x.Password = "my-password";
+            })
+            .WithHttpBearerAuthentication(x => x.Token = "my-bearer-token")
             .WithOpenApiRoutePattern("/swagger/{documentName}")
             .WithCdnUrl("http://localhost:8080")
             .WithDefaultFonts(false)
@@ -57,9 +63,12 @@ public class ScalarOptionsExtensionsTests
         options.ProxyUrl.Should().Be("http://localhost:8080");
         options.Metadata.Should().ContainKey("key").And.ContainValue("value");
         options.Authentication!.PreferredSecurityScheme.Should().Be("my-scheme");
-        options.Authentication!.ApiKey!.Token.Should().Be("my-token");
+        options.Authentication!.ApiKey!.Token.Should().Be("my-api-token");
         options.Authentication!.OAuth2!.ClientId.Should().Be("my-client");
         options.Authentication!.OAuth2!.Scopes.Should().Contain("scope");
+        options.Authentication!.Http!.Basic!.Username.Should().Contain("my-username");
+        options.Authentication!.Http!.Basic!.Password.Should().Contain("my-password");
+        options.Authentication!.Http!.Bearer!.Token.Should().Contain("my-bearer-token");
         options.OpenApiRoutePattern.Should().Be("/swagger/{documentName}");
         options.CdnUrl.Should().Be("http://localhost:8080");
         options.DefaultFonts.Should().BeFalse();


### PR DESCRIPTION
Add missing options model definition for prefilling http basic/bearer tokens.

**Problem**
Currently, there's no `Http` property in `ScalarAuthenticationOptions`, which makes users unable to set a prefilled token for http basic/bearer authentication according to https://github.com/scalar/scalar/issues/1356#issuecomment-2048333833.

**Solution**
This PR adds `Http.Bearer.*` `Http.Basic.*` properties to `ScalarAuthenticationOptions`, several `WithHttp*Authentication` extension methods, alongside with unit tests.
