### PR TITLE
feat(api-client): code folding to the response preview

### DIFF
--- a/.changeset/six-seals-accept.md
+++ b/.changeset/six-seals-accept.md
@@ -1,0 +1,6 @@
+---
+'@scalar/use-codemirror': patch
+'@scalar/api-client': patch
+---
+
+fix: replace scalarcodeblock with codemirror for response preview

--- a/.changeset/weak-cameras-smash.md
+++ b/.changeset/weak-cameras-smash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-codemirror': patch
+---
+
+fix: replace scalarcodeblock with codemirror for response preview

--- a/.changeset/weak-cameras-smash.md
+++ b/.changeset/weak-cameras-smash.md
@@ -1,5 +1,0 @@
----
-'@scalar/use-codemirror': patch
----
-
-fix: replace scalarcodeblock with codemirror for response preview

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
-import { ScalarCodeBlock } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components'
 import { type CodeMirrorLanguage, useCodeMirror } from '@scalar/use-codemirror'
-import { ref } from 'vue'
+import { useClipboard } from '@scalar/use-hooks/useClipboard'
+import { ref, toRef } from 'vue'
 
 const props = defineProps<{
   content: any
@@ -9,19 +10,40 @@ const props = defineProps<{
 }>()
 
 const codeMirrorRef = ref<HTMLDivElement | null>(null)
+const { copyToClipboard } = useClipboard()
 
-useCodeMirror({
+const { codeMirror } = useCodeMirror({
   codeMirrorRef,
   readOnly: true,
   lineNumbers: true,
-  content: props.content,
-  language: props.language,
+  content: toRef(() => props.content),
+  language: toRef(() => props.language),
+  forceFoldGutter: true,
 })
+
+// Function to get current content
+const getCurrentContent = () => {
+  return codeMirror.value?.state.doc.toString() || ''
+}
 </script>
 <template>
-  <ScalarCodeBlock
-    :content="content"
-    :lang="language" />
+  <div class="relative">
+    <!-- Copy button -->
+    <div class="scalar-code-copy">
+      <button
+        class="copy-button"
+        type="button"
+        @click="copyToClipboard(getCurrentContent())">
+        <span class="sr-only">Copy content</span>
+        <ScalarIcon
+          icon="Clipboard"
+          size="md" />
+      </button>
+    </div>
+
+    <!-- CodeMirror container -->
+    <div ref="codeMirrorRef" />
+  </div>
 </template>
 <style scoped>
 :deep(.cm-editor) {
@@ -32,5 +54,49 @@ useCodeMirror({
 :deep(.cm-gutters) {
   background-color: var(--scalar-background-1);
   border-radius: var(--scalar-radius) 0 0 var(--scalar-radius);
+}
+
+/* Copy Button Styles */
+.scalar-code-copy {
+  align-items: flex-start;
+  display: flex;
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.copy-button {
+  align-items: center;
+  display: flex;
+  background-color: var(--scalar-background-2);
+  border: 1px solid var(--scalar-border-color);
+  border-radius: 3px;
+  color: var(--scalar-color-3);
+  cursor: pointer;
+  height: 30px;
+  opacity: 0;
+  padding: 6px;
+  pointer-events: auto;
+  transition:
+    opacity 0.15s ease-in-out,
+    color 0.15s ease-in-out;
+}
+
+/* Show button on container hover */
+.relative:hover .copy-button,
+.copy-button:focus-visible {
+  opacity: 1;
+}
+
+.copy-button:hover {
+  color: var(--scalar-color-1);
+}
+
+/* Ensure proper background inheritance */
+.scalar-code-copy,
+.copy-button {
+  background: inherit;
 }
 </style>

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -64,6 +64,7 @@ type BaseParameters = {
   /** Option to show line numbers in the editor */
   lineNumbers?: MaybeRefOrGetter<boolean | undefined>
   withVariables?: MaybeRefOrGetter<boolean | undefined>
+  forceFoldGutter?: MaybeRefOrGetter<boolean | undefined>
   disableEnter?: MaybeRefOrGetter<boolean | undefined>
   disableCloseBrackets?: MaybeRefOrGetter<boolean | undefined>
   /** Option to lint and show error in the editor */
@@ -159,6 +160,7 @@ export const useCodeMirror = (
     readOnly: toValue(params.readOnly),
     lineNumbers: toValue(params.lineNumbers),
     withVariables: toValue(params.withVariables),
+    forceFoldGutter: toValue(params.forceFoldGutter),
     disableEnter: toValue(params.disableEnter),
     disableCloseBrackets: toValue(params.disableCloseBrackets),
     withoutTheme: toValue(params.withoutTheme),
@@ -266,6 +268,7 @@ function getCodeMirrorExtensions({
   readOnly = false,
   lineNumbers = false,
   withVariables = false,
+  forceFoldGutter = false,
   disableEnter = false,
   disableCloseBrackets = false,
   disableTabIndent = false,
@@ -282,6 +285,7 @@ function getCodeMirrorExtensions({
   disableTabIndent?: boolean
   withVariables?: boolean
   disableEnter?: boolean
+  forceFoldGutter?: boolean
   onChange?: (val: string) => void
   onFocus?: (val: string) => void
   onBlur?: (val: string) => void
@@ -381,10 +385,8 @@ function getCodeMirrorExtensions({
   // Line numbers
   if (lineNumbers) extensions.push(lineNumbersExtension())
 
-  // Syntax highlighting
-  if (language && languageExtensions[language]) {
+  if (forceFoldGutter) {
     extensions.push(
-      languageExtensions[language](),
       foldGutter({
         markerDOM: (open) => {
           const icon = document.createElement('div')
@@ -398,6 +400,27 @@ function getCodeMirrorExtensions({
         },
       }),
     )
+  }
+
+  // Syntax highlighting
+  if (language && languageExtensions[language]) {
+    extensions.push(languageExtensions[language]())
+    if (!forceFoldGutter) {
+      extensions.push(
+        foldGutter({
+          markerDOM: (open) => {
+            const icon = document.createElement('div')
+            icon.classList.add('cm-foldMarker')
+            const vnode = h(ScalarIcon, {
+              icon: open ? 'ChevronDown' : 'ChevronRight',
+              size: 'xs',
+            })
+            render(vnode, icon)
+            return icon
+          },
+        }),
+      )
+    }
   }
 
   // JSON Linter

--- a/packages/use-codemirror/src/themes/index.ts
+++ b/packages/use-codemirror/src/themes/index.ts
@@ -50,7 +50,7 @@ export const customTheme = createTheme({
     },
     {
       tag: [t.number],
-      color: 'var(--scalar-color-blue)',
+      color: 'var(--scalar-color-orange)',
     },
     {
       tag: [t.name, t.quote],


### PR DESCRIPTION
Replaces `ScalarCodeBlock` with the `useCodeMirror` hook.

**Problem**
Currently we dont get:
- search
- folding
- any sort of advanced interactions with the text for the future of making variables from responses

**Solution**
Lets use our codemirror package since we handle large responses with virtualization

before:
<img width="612" alt="image" src="https://github.com/user-attachments/assets/dc76c67e-f1a3-473d-b9a4-2d3e5cb702a4">



after:
<img width="618" alt="image" src="https://github.com/user-attachments/assets/99232131-bc18-47d1-9220-88c9b9ea130a">
*edit*
i fixed the orange 
<img width="610" alt="image" src="https://github.com/user-attachments/assets/451aab68-9d79-47cb-b4bc-8cff57dd6f44">



