### PR TITLE
fix: handle no prefix

### DIFF
--- a/packages/api-client/src/libs/send-request.test.ts
+++ b/packages/api-client/src/libs/send-request.test.ts
@@ -554,4 +554,23 @@ describe('sendRequest', () => {
       },
     })
   })
+
+  it('adds http://', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        requestPayload: {
+          path: 'void.scalar.com/me',
+        },
+      }),
+    )
+    if (error) throw error
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(JSON.parse(result?.response.data as string)).toMatchObject({
+      method: 'GET',
+      path: '/me',
+      body: '',
+    })
+  })
 })

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -221,10 +221,16 @@ type SendRequestResponse = Promise<
   }>
 >
 
-/**
- * Execute the request
- * called from the send button as well as keyboard shortcuts
- */
+/** Ensure URL has a protocol prefix */
+function ensureProtocol(url: string): string {
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url
+  }
+  // Default to http if no protocol is specified
+  return `http://${url}`
+}
+
+/** Execute the request */
 export const createRequestOperation = ({
   request,
   auth,
@@ -352,7 +358,10 @@ export const createRequestOperation = ({
         // Extract and merge all query params
         if (url && (!isRelativePath(url) || typeof window !== 'undefined')) {
           /** Prefix the url with the origin if it is relative */
-          const base = isRelativePath(url) ? window.location.origin + url : url
+          const base = isRelativePath(url)
+            ? window.location.origin + url
+            : ensureProtocol(url)
+
           /** We create a separate server URL to snag any search params from the server */
           const serverURL = new URL(base)
           /** We create a separate path URL to grab the path params */

--- a/packages/api-client/src/libs/send-request.ts
+++ b/packages/api-client/src/libs/send-request.ts
@@ -15,6 +15,7 @@ import type {
 } from '@scalar/oas-utils/entities/spec'
 import {
   canMethodHaveBody,
+  concatenateUrlAndPath,
   isRelativePath,
   shouldUseProxy,
 } from '@scalar/oas-utils/helpers'
@@ -359,8 +360,10 @@ export const createRequestOperation = ({
         if (url && (!isRelativePath(url) || typeof window !== 'undefined')) {
           /** Prefix the url with the origin if it is relative */
           const base = isRelativePath(url)
-            ? window.location.origin + url
+            ? concatenateUrlAndPath(window.location.origin, url)
             : ensureProtocol(url)
+
+          console.log('base', base)
 
           /** We create a separate server URL to snag any search params from the server */
           const serverURL = new URL(base)

--- a/packages/oas-utils/src/helpers/redirectToProxy.ts
+++ b/packages/oas-utils/src/helpers/redirectToProxy.ts
@@ -18,8 +18,21 @@ export function redirectToProxy(proxy?: string, url?: string): string {
   return newUrl.toString()
 }
 
-/** Check if the URL is relative, aka doesn't start with http[s] */
-export const isRelativePath = (url: string) => !/^https?:\/\//.test(url)
+/** Check if the URL is relative or if it's a domain without protocol */
+export const isRelativePath = (url: string) => {
+  // Absolute URLs start with http:// or https://
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return false
+  }
+
+  // Check if it looks like a domain (contains dots and no spaces)
+  // This catches cases like "galaxy.scalar.com/planets"
+  if (/^[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+(\/|$)/.test(url)) {
+    return false
+  }
+
+  return true
+}
 
 /** Returns false for requests to localhost, relative URLs, if no proxy is defined … */
 export function shouldUseProxy(proxy?: string, url?: string): boolean {


### PR DESCRIPTION
**Problem**
Currently, we would not handle requests without a protocol (google.com) now we do :) 
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/4ae3e88c-6ad7-421c-a5b3-1d4e45a230a0">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/06dc8ada-3149-4660-b93d-79365f4d3b74">


also, we werent properly joining origin with the url 🥶 

now we are 😎 
