### PR TITLE
feat(use-hooks): add computed dark light mode

### DIFF
--- a/.changeset/stupid-games-burn.md
+++ b/.changeset/stupid-games-burn.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/use-hooks': patch
+---
+
+feat(use-hooks): add computed dark light mode

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -19,7 +19,7 @@ defineEmits<{
   (e: 'updateContent', value: string): void
 }>()
 
-const { setColorMode, toggleColorMode, colorMode } = useColorMode({
+const { setColorMode, toggleColorMode, darkLightMode } = useColorMode({
   initialColorMode: props.configuration?.darkMode ? 'dark' : undefined,
   overrideColorMode: props.configuration?.forceDarkModeState,
 })
@@ -99,7 +99,7 @@ useFavicon(favicon)
   </component>
   <Layouts
     :configuration="configuration"
-    :isDark="colorMode === 'dark'"
+    :isDark="darkLightMode === 'dark'"
     :parsedSpec="parsedSpec"
     :rawSpec="rawSpec"
     @toggleDarkMode="() => toggleColorMode()"

--- a/packages/use-hooks/src/useColorMode/types.ts
+++ b/packages/use-hooks/src/useColorMode/types.ts
@@ -1,6 +1,9 @@
 /** Possible color modes */
 export type ColorMode = 'light' | 'dark' | 'system'
 
+/** Specific dark/light mode */
+export type DarkLightMode = 'light' | 'dark'
+
 /** Options for the useColorMode hook */
 export type UseColorModeOptions = {
   /** The initial color mode to use */

--- a/packages/use-hooks/src/useColorMode/useColorMode.test.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.test.ts
@@ -57,29 +57,34 @@ describe('useColorMode', () => {
         removeEventListener: vi.fn(),
       }))
 
-      const { colorMode, toggleColorMode } = useColorMode()
+      const { colorMode, darkLightMode, toggleColorMode } = useColorMode()
       expect(colorMode.value).toBe('system')
+      expect(darkLightMode.value).toBe(mode)
 
       toggleColorMode()
       const inverted = mode === 'light' ? 'dark' : 'light'
       expect(colorMode.value).toBe(inverted)
+      expect(darkLightMode.value).toBe(inverted)
       expect(localStorage.getItem('colorMode')).toBe(inverted)
 
       toggleColorMode()
       expect(colorMode.value).toBe(mode)
+      expect(darkLightMode.value).toBe(mode)
       expect(localStorage.getItem('colorMode')).toBe(mode)
     },
   )
 
   it('sets specific color mode', () => {
-    const { colorMode, setColorMode } = useColorMode()
+    const { colorMode, darkLightMode, setColorMode } = useColorMode()
 
     setColorMode('light')
     expect(colorMode.value).toBe('light')
+    expect(darkLightMode.value).toBe('light')
     expect(localStorage.getItem('colorMode')).toBe('light')
 
     setColorMode('dark')
     expect(colorMode.value).toBe('dark')
+    expect(darkLightMode.value).toBe('dark')
     expect(localStorage.getItem('colorMode')).toBe('dark')
   })
 
@@ -92,8 +97,9 @@ describe('useColorMode', () => {
         removeEventListener: vi.fn(),
       }))
 
-      const { getSystemModePreference } = useColorMode()
+      const { getSystemModePreference, darkLightMode } = useColorMode()
       expect(getSystemModePreference()).toBe(mode)
+      expect(darkLightMode.value).toBe(mode)
     },
   )
 

--- a/packages/use-hooks/src/useColorMode/useColorMode.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.ts
@@ -1,7 +1,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { z } from 'zod'
 
-import type { ColorMode, UseColorModeOptions } from './types'
+import type { ColorMode, DarkLightMode, UseColorModeOptions } from './types'
 
 const colorMode = ref<ColorMode>('dark')
 
@@ -18,10 +18,8 @@ export function useColorMode(opts: UseColorModeOptions = {}) {
 
   /** Toggles the color mode between light and dark. */
   function toggleColorMode() {
-    const darkLightMode =
-      colorMode.value === 'system' ? getSystemModePreference() : colorMode.value
     // Update state
-    colorMode.value = darkLightMode === 'dark' ? 'light' : 'dark'
+    colorMode.value = darkLightMode.value === 'dark' ? 'light' : 'dark'
 
     // Store in local storage
     if (typeof window === 'undefined') return
@@ -36,13 +34,20 @@ export function useColorMode(opts: UseColorModeOptions = {}) {
   }
 
   /** Gets the system mode preference. */
-  function getSystemModePreference(): ColorMode {
+  function getSystemModePreference(): DarkLightMode {
     if (typeof window?.matchMedia !== 'function') return 'dark'
 
     return window?.matchMedia('(prefers-color-scheme: dark)')?.matches
       ? 'dark'
       : 'light'
   }
+
+  /** The computed dark/light mode with system preference applied */
+  const darkLightMode = computed<DarkLightMode>(() => {
+    return colorMode.value === 'system'
+      ? getSystemModePreference()
+      : colorMode.value
+  })
 
   /** Applies the appropriate color mode class to the body. */
   function applyColorMode(mode: ColorMode): void {
@@ -87,6 +92,7 @@ export function useColorMode(opts: UseColorModeOptions = {}) {
 
   return {
     colorMode: computed(() => colorMode.value),
+    darkLightMode,
     toggleColorMode,
     setColorMode,
     getSystemModePreference,


### PR DESCRIPTION
Small fix to add a computed dark / light mode so that the toggle can show the correct value initially.

## Before

![Google Chrome-2024-11-17-21-48-43@2x](https://github.com/user-attachments/assets/bd9b5f10-4614-489a-872a-5b4f0fae6282)

## After

![Google Chrome-2024-11-17-21-49-15@2x](https://github.com/user-attachments/assets/38d54d27-4054-4c54-8442-62957ab22552)
