### PR TITLE
fix(api-client): falsy value display in RequestTableTooltip

### DIFF
--- a/.changeset/blue-rats-wait.md
+++ b/.changeset/blue-rats-wait.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: falsy value display in RequestTableTooltip

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -5,13 +5,15 @@ import { computed } from 'vue'
 
 const props = defineProps<{ item: RequestExampleParameter }>()
 
+const isDefined = (value: unknown): boolean => value !== undefined
+
 const hasItemProperties = computed(
   () =>
     props.item.type ||
     props.item.format ||
-    props.item.minimum ||
-    props.item.maximum ||
-    props.item.default,
+    isDefined(props.item.minimum) ||
+    isDefined(props.item.maximum) ||
+    isDefined(props.item.default),
 )
 </script>
 <template>
@@ -43,17 +45,17 @@ const hasItemProperties = computed(
             >{{ props.item.format }}</span
           >
           <span
-            v-if="props.item.minimum"
+            v-if="isDefined(props.item.minimum)"
             class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-nowrap"
             >min: {{ props.item.minimum }}</span
           >
           <span
-            v-if="props.item.maximum"
+            v-if="isDefined(props.item.maximum)"
             class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-nowrap"
             >max: {{ props.item.maximum }}</span
           >
           <span
-            v-if="props.item.default"
+            v-if="isDefined(props.item.default)"
             class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-nowrap"
             >default: {{ props.item.default }}</span
           >


### PR DESCRIPTION
This PR enhanced template logic to conditionally display `minimum`, `maximum`, and `default` properties even if their values are falsy (0, false) but defined.

before:
<img width="618" alt="Screenshot 2567-11-18 at 15 40 05" src="https://github.com/user-attachments/assets/78f0b451-ebca-4260-8377-72c0c381e384">
after:
<img width="618" alt="Screenshot 2567-11-18 at 15 40 21" src="https://github.com/user-attachments/assets/b2e684cc-3dd3-4ca6-bab6-148137817a5f">
