### PR TITLE
style(api-reference): font size fixtures

### DIFF
--- a/.changeset/thin-drinks-sparkle.md
+++ b/.changeset/thin-drinks-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@scalar/code-highlight': patch
+'@scalar/api-reference': patch
+---
+
+style: font size fixtures

--- a/packages/api-reference/src/components/Content/Operation/RequestBody.vue
+++ b/packages/api-reference/src/components/Content/Operation/RequestBody.vue
@@ -100,11 +100,11 @@ if (prop.requestBody?.content) {
 }
 .request-body-title-select:after {
   content: '';
-  width: 7px;
-  height: 7px;
-  transform: rotate(45deg) translate3d(-2px, -4px, 0);
+  width: 6px;
+  height: 6px;
+  transform: rotate(45deg) translate3d(0, -3px, 0);
   display: block;
-  margin-left: 5px;
+  margin-left: 6px;
   box-shadow: 1px 1px 0 currentColor;
   margin-right: 5px;
 }

--- a/packages/api-reference/src/features/BaseUrl/ServerVariablesForm.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerVariablesForm.vue
@@ -70,10 +70,10 @@ const getVariable = (name: string) => {
 }
 
 .variable-label {
-  padding: 9px 0 9px 9px;
-  color: var(--scalar-color-2);
   border-top: 0.5px solid var(--scalar-border-color);
-  font-size: var(--scalar-micro);
+  color: var(--scalar-color-2);
+  font-size: var(--scalar-mini);
+  padding: 9px 0 9px 9px;
 }
 .variable-label:after {
   content: ':';

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -184,6 +184,10 @@
     padding: 0 3px;
   }
 
+  .markdown .hljs {
+    font-size: var(--scalar-small);
+  }
+
   .markdown pre code {
     display: block;
     white-space: pre;


### PR DESCRIPTION
this pr fixes font / icon size glitch in api reference as seen below:

**⊢ base url before / after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/2c4cb9e2-b952-4245-9c83-8b00dee11b07">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/6640e946-efb0-4a45-8b63-dc019c349d25">
</div>


**⊢ markdown code before / after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ec4c81b2-31fe-49ad-87f9-b0cd70debbff">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9c27adcd-cb8f-42d3-bb70-d76fcacf4cf3">
</div>


**⊢ request body select before / after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/530b1ec4-da67-4991-b565-6bbd891c5bda">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/a00f6d0b-f06a-4b2d-ae79-fe89abf0cded">
</div>