### PR TITLE
feat(icons): add list of icons to the README

### DIFF
--- a/.changeset/cold-crabs-unite.md
+++ b/.changeset/cold-crabs-unite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/icons': patch
+---
+
+feat: add list of icons to the README

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -16,6 +16,107 @@ import { LibraryIcon } from '@scalar/icons'
 </script>
 
 <template>
-  <LibraryIcon src="brand-adobe" />
+  <LibraryIcon src="basic-shape-diamond" />
 </template>
 ```
+
+## Icons
+
+<!-- list-of-available-icons -->
+
+| Icon                                                                                                                                                                        | Name                                                |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/basic-shape-diamond.svg" style="display: block;"></span>                               | `basic-shape-diamond`                               |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/basic-shape-hexagon.svg" style="display: block;"></span>                               | `basic-shape-hexagon`                               |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/basic-shape-primary-circle-ellipse-round.svg" style="display: block;"></span>          | `basic-shape-primary-circle-ellipse-round`          |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/basic-shape-primary-square-rectangle.svg" style="display: block;"></span>              | `basic-shape-primary-square-rectangle`              |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/basic-shape-shield.svg" style="display: block;"></span>                                | `basic-shape-shield`                                |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-desktop-monitor.svg" style="display: block;"></span>                   | `computer-device-desktop-monitor`                   |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-desktop.svg" style="display: block;"></span>                           | `computer-device-desktop`                           |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-laptop.svg" style="display: block;"></span>                            | `computer-device-laptop`                            |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-mobile-phone-android-samsung-back.svg" style="display: block;"></span> | `computer-device-mobile-phone-android-samsung-back` |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-mobile-phone-android-samsung.svg" style="display: block;"></span>      | `computer-device-mobile-phone-android-samsung`      |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-mobile-phone-iphone-x-back.svg" style="display: block;"></span>        | `computer-device-mobile-phone-iphone-x-back`        |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-mobile-phone-iphone-x.svg" style="display: block;"></span>             | `computer-device-mobile-phone-iphone-x`             |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-mobile-tablet-touch.svg" style="display: block;"></span>               | `computer-device-mobile-tablet-touch`               |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-mobile-tablet.svg" style="display: block;"></span>                     | `computer-device-mobile-tablet`                     |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-network-ethernet-cat6.svg" style="display: block;"></span>             | `computer-device-network-ethernet-cat6`             |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-network-lan-www.svg" style="display: block;"></span>                   | `computer-device-network-lan-www`                   |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-network-wifi-connection.svg" style="display: block;"></span>           | `computer-device-network-wifi-connection`           |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/computer-device-network-wifi-router.svg" style="display: block;"></span>               | `computer-device-network-wifi-router`               |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/ecology-science-erlenmeyer-flask.svg" style="display: block;"></span>                  | `ecology-science-erlenmeyer-flask`                  |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/image-flash-lightning.svg" style="display: block;"></span>                             | `image-flash-lightning`                             |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/image-picture-flower.svg" style="display: block;"></span>                              | `image-picture-flower`                              |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-alert-exclamation-diamond.svg" style="display: block;"></span>               | `interface-alert-exclamation-diamond`               |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-alert-exclamation-triangle-warning.svg" style="display: block;"></span>      | `interface-alert-exclamation-triangle-warning`      |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-alert-information-circle.svg" style="display: block;"></span>                | `interface-alert-information-circle`                |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-award-crown.svg" style="display: block;"></span>                             | `interface-award-crown`                             |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-bookmark-tag.svg" style="display: block;"></span>                            | `interface-bookmark-tag`                            |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-bookmark.svg" style="display: block;"></span>                                | `interface-bookmark`                                |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-calendar-date-one.svg" style="display: block;"></span>                       | `interface-calendar-date-one`                       |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-content-book-open-pages.svg" style="display: block;"></span>                 | `interface-content-book-open-pages`                 |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-content-book-page.svg" style="display: block;"></span>                       | `interface-content-book-page`                       |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-content-file.svg" style="display: block;"></span>                            | `interface-content-file`                            |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-content-folder.svg" style="display: block;"></span>                          | `interface-content-folder`                          |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-copy-clipboard.svg" style="display: block;"></span>                          | `interface-copy-clipboard`                          |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-edit-attachment.svg" style="display: block;"></span>                         | `interface-edit-attachment`                         |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-edit-binocular.svg" style="display: block;"></span>                          | `interface-edit-binocular`                          |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-edit-magic-wand.svg" style="display: block;"></span>                         | `interface-edit-magic-wand`                         |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-edit-tool-paint-roller.svg" style="display: block;"></span>                  | `interface-edit-tool-paint-roller`                  |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-edit-tool-pencil.svg" style="display: block;"></span>                        | `interface-edit-tool-pencil`                        |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-favorite-award.svg" style="display: block;"></span>                          | `interface-favorite-award`                          |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-favorite-flag.svg" style="display: block;"></span>                           | `interface-favorite-flag`                           |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-favorite-heart.svg" style="display: block;"></span>                          | `interface-favorite-heart`                          |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-favorite-star.svg" style="display: block;"></span>                           | `interface-favorite-star`                           |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-favorite-stars-sparkles.svg" style="display: block;"></span>                 | `interface-favorite-stars-sparkles`                 |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-hierarchy-flowchart.svg" style="display: block;"></span>                     | `interface-hierarchy-flowchart`                     |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-home-house.svg" style="display: block;"></span>                              | `interface-home-house`                              |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-hyperlink.svg" style="display: block;"></span>                               | `interface-hyperlink`                               |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-lighting-brightness.svg" style="display: block;"></span>                     | `interface-lighting-brightness`                     |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-lock-closed.svg" style="display: block;"></span>                             | `interface-lock-closed`                             |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-lock-open-unlock.svg" style="display: block;"></span>                        | `interface-lock-open-unlock`                        |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-login-key.svg" style="display: block;"></span>                               | `interface-login-key`                               |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-search.svg" style="display: block;"></span>                                  | `interface-search`                                  |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-setting-cog.svg" style="display: block;"></span>                             | `interface-setting-cog`                             |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-share-megaphone-bullhorn.svg" style="display: block;"></span>                | `interface-share-megaphone-bullhorn`                |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-share-rocket.svg" style="display: block;"></span>                            | `interface-share-rocket`                            |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-share-satellite.svg" style="display: block;"></span>                         | `interface-share-satellite`                         |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-share-space-ship.svg" style="display: block;"></span>                        | `interface-share-space-ship`                        |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-share.svg" style="display: block;"></span>                                   | `interface-share`                                   |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-signal-square.svg" style="display: block;"></span>                           | `interface-signal-square`                           |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-time-clock-circle.svg" style="display: block;"></span>                       | `interface-time-clock-circle`                       |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-time-hour-glass.svg" style="display: block;"></span>                         | `interface-time-hour-glass`                         |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-users-multiple.svg" style="display: block;"></span>                          | `interface-users-multiple`                          |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/interface-weather-moon.svg" style="display: block;"></span>                            | `interface-weather-moon`                            |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/mail-chat-bubble-square.svg" style="display: block;"></span>                           | `mail-chat-bubble-square`                           |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/mail-send-email-paper-airplane.svg" style="display: block;"></span>                    | `mail-send-email-paper-airplane`                    |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/mail-send-envelope.svg" style="display: block;"></span>                                | `mail-send-envelope`                                |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/money-cashier-receipt.svg" style="display: block;"></span>                             | `money-cashier-receipt`                             |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/money-currency-dollar-pay.svg" style="display: block;"></span>                         | `money-currency-dollar-pay`                         |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/money-graph-arrow-increase.svg" style="display: block;"></span>                        | `money-graph-arrow-increase`                        |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/money-graph-bar-chart-increase.svg" style="display: block;"></span>                    | `money-graph-bar-chart-increase`                    |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/nature-ecology-leaf.svg" style="display: block;"></span>                               | `nature-ecology-leaf`                               |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/phone-telephone.svg" style="display: block;"></span>                                   | `phone-telephone`                                   |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/programming-bug.svg" style="display: block;"></span>                                   | `programming-bug`                                   |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/programming-cloud.svg" style="display: block;"></span>                                 | `programming-cloud`                                 |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/programming-computer-database-server.svg" style="display: block;"></span>              | `programming-computer-database-server`              |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/programming-computer-database.svg" style="display: block;"></span>                     | `programming-computer-database`                     |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/programming-module-four-layout.svg" style="display: block;"></span>                    | `programming-module-four-layout`                    |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/programming-module-three.svg" style="display: block;"></span>                          | `programming-module-three`                          |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/programming-module.svg" style="display: block;"></span>                                | `programming-module`                                |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/programming-script-code.svg" style="display: block;"></span>                           | `programming-script-code`                           |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/shopping-cart.svg" style="display: block;"></span>                                     | `shopping-cart`                                     |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/shopping-gift-present.svg" style="display: block;"></span>                             | `shopping-gift-present`                             |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/shopping-shipping-box-parcel-package.svg" style="display: block;"></span>              | `shopping-shipping-box-parcel-package`              |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/tag-new-circle.svg" style="display: block;"></span>                                    | `tag-new-circle`                                    |
+| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/travel-map-earth-globe.svg" style="display: block;"></span>                            | `travel-map-earth-globe`                            |
+
+<!-- /list-of-available-icons -->
+
+## Community
+
+We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/scalar>
+
+## License
+
+The source code in this repository is licensed under [MIT](https://github.com/scalar/scalar/blob/main/LICENSE).

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -15,7 +15,8 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "scalar-build-vite",
+    "build": "pnpm update:icons && pnpm prettier --write README.md && scalar-build-vite",
+    "update:icons": "vite-node ./scripts/update-list-of-icons.ts",
     "lint:check": "eslint . && pnpm lint:icons",
     "lint:fix": "eslint . --fix",
     "lint:icons": "svglint src/icons/*.svg --config .svglintrc.js",

--- a/packages/icons/scripts/update-list-of-icons.ts
+++ b/packages/icons/scripts/update-list-of-icons.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Get all SVG files from the icons directory
+const iconsDir = path.join(new URL(import.meta.url).pathname, '../../src/icons')
+
+const svgFiles = fs
+  .readdirSync(iconsDir)
+  .filter((file) => file.endsWith('.svg'))
+  .map((file) => path.basename(file, '.svg'))
+
+// Generate the Markdown table
+const tableHeader = `| Icon | Name |
+|------|------|`
+
+const tableRows = svgFiles
+  .map((iconName) => {
+    return `| <span style="background: white; display: block; padding: 2px;"><img src="./src/icons/${iconName}.svg" style="display: block;"></span> | \`${iconName}\` |`
+  })
+  .join('\n')
+
+const table = `${tableHeader}\n${tableRows}`
+
+// Output
+console.log(table)
+
+// Update the README.md
+const readmePath = path.join(
+  new URL(import.meta.url).pathname,
+  '../../README.md',
+)
+const readme = fs.readFileSync(readmePath, 'utf8')
+
+const startMarker = '<!-- list-of-available-icons -->'
+const endMarker = '<!-- /list-of-available-icons -->'
+
+const newReadme = readme.replace(
+  new RegExp(`${startMarker}[\\s\\S]*${endMarker}`),
+  `${startMarker}\n\n${table}\n\n${endMarker}`,
+)
+
+fs.writeFileSync(readmePath, newReadme)


### PR DESCRIPTION
This PR adds a list of all available icons to the README.

Great for a quick preview of what’s in the package.

<img width="918" alt="Screenshot 2024-11-18 at 12 02 38" src="https://github.com/user-attachments/assets/95fef322-5226-4e2f-862b-d3149c0e76dc">
