### PR TITLE
feat(api-client): split workspace store into active-entities store

### DIFF
--- a/packages/api-client/src/hooks/use-active-entities.ts
+++ b/packages/api-client/src/hooks/use-active-entities.ts
@@ -1,0 +1,159 @@
+import { flattenEnvVars } from '@/libs/string-template'
+import { PathId } from '@/router'
+import { useWorkspace } from '@/store'
+import type { Request, RequestExample } from '@scalar/oas-utils/entities/spec'
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { getRouterParams } from '../store/router-params'
+
+/**
+ * Hook for the active entities store
+ *
+ * This store returns anything related to the currently active entities
+ */
+export const useActiveEntities = () => {
+  const {
+    workspaces,
+    collections,
+    environments,
+    requestExamples,
+    requests,
+    servers,
+  } = useWorkspace()
+  const router = useRouter()
+
+  /** Gives the required UID usually per route */
+  const activeRouterParams = computed(getRouterParams(router))
+
+  /** The currently selected workspace OR the first one */
+  const activeWorkspace = computed(() => {
+    const workspace =
+      workspaces[activeRouterParams.value[PathId.Workspace]] ??
+      workspaces[Object.keys(workspaces)[0]]
+
+    return workspace
+  })
+
+  /** Ordered list of the active workspace's collections with drafts last */
+  const activeWorkspaceCollections = computed(() =>
+    activeWorkspace.value?.collections
+      .map((uid) => collections[uid])
+      .sort((a, b) => {
+        if (a.info?.title === 'Drafts') return 1
+        if (b.info?.title === 'Drafts') return -1
+        return 0
+      }),
+  )
+
+  /** Simplified list of servers in the workspace for displaying */
+  const activeWorkspaceServers = computed(() =>
+    activeWorkspaceCollections.value?.flatMap((collection) =>
+      collection.servers.map((uid) => servers[uid]),
+    ),
+  )
+
+  /** Simplified list of requests in the workspace for displaying */
+  const activeWorkspaceRequests = computed(() =>
+    activeWorkspaceCollections.value?.flatMap(
+      (collection) => collection.requests,
+    ),
+  )
+
+  /** TODO: need to merge collection environments into the global space */
+  const activeEnvironment = computed(
+    () => environments[activeWorkspace.value?.activeEnvironmentId ?? 'default'],
+  )
+
+  /**
+   * Request associated with the current route
+   *
+   * undefined must be handled as we may have no requests
+   */
+  const activeRequest = computed<Request | undefined>(() => {
+    const key = activeRouterParams.value[PathId.Request]
+
+    // Can use this fallback to get an active request
+    // TODO: Do we really need this? We have to handle undefined anyways
+    const collection =
+      collections[activeRouterParams.value.collection] ||
+      collections[activeWorkspace.value.collections[0]]
+
+    return requests[key] || requests[collection?.requests[0]]
+  })
+
+  /** Grabs the currently active example using the path param */
+  const activeExample = computed<RequestExample | undefined>(() => {
+    const key =
+      activeRouterParams.value[PathId.Examples] === 'default'
+        ? activeRequest.value?.examples[0] || ''
+        : activeRouterParams.value[PathId.Examples]
+
+    return requestExamples[key]
+  })
+
+  /**
+   * First collection that the active request is in
+   *
+   * TODO we should add collection to the route and grab this from the params
+   */
+  const activeCollection = computed(() => {
+    const requestUid = activeRequest.value?.uid
+    if (requestUid)
+      return Object.values(collections).find((c) =>
+        c.requests?.includes(requestUid),
+      )
+
+    const fallbackUid =
+      activeWorkspace.value.collections[0] ?? collections[0]?.uid
+
+    return collections[fallbackUid]
+  })
+
+  /** The currently selected server in the addressBar */
+  const activeServer = computed(
+    () =>
+      servers[
+        activeRequest.value?.selectedServerUid ||
+          activeCollection.value?.selectedServerUid ||
+          ''
+      ],
+  )
+
+  /** Cookie associated with the current route */
+  const activeCookieId = computed<string | undefined>(
+    () => activeRouterParams.value[PathId.Cookies],
+  )
+
+  /**
+   * Active list all available substitution variables. Server variables
+   * will be populated into the environment on spec loading
+   */
+  const activeEnvVariables = computed(() => {
+    if (!activeEnvironment.value) return []
+    // TODO: Must merge global variables and collection level variables here
+    // Return a list of key value pairs that includes dot nested paths
+    return flattenEnvVars(JSON.parse(activeEnvironment.value.value)).map(
+      ([key, value]) => ({
+        key,
+        value,
+      }),
+    )
+  })
+
+  return {
+    activeCollection,
+    activeCookieId,
+    activeExample,
+    activeRequest,
+    activeRouterParams,
+    activeEnvironment,
+    activeServer,
+    activeWorkspace,
+    activeWorkspaceCollections,
+    activeWorkspaceServers,
+    activeEnvVariables,
+    activeWorkspaceRequests,
+    router,
+  }
+}

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -1,7 +1,14 @@
 import type { ClientLayout } from '@/hooks'
 import { loadAllResources } from '@/libs/local-storage'
-import { PathId } from '@/routes'
-import { type WorkspaceStore, createWorkspaceStore } from '@/store'
+import {
+  ACTIVE_ENTITIES_SYMBOL,
+  createActiveEntitiesStore,
+} from '@/store/active-entities'
+import {
+  WORKSPACE_SYMBOL,
+  type WorkspaceStore,
+  createWorkspaceStore,
+} from '@/store/store'
 import type { Collection, RequestMethod } from '@scalar/oas-utils/entities/spec'
 import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { LS_KEYS, objectMerge } from '@scalar/oas-utils/helpers'
@@ -109,10 +116,13 @@ export const createApiClient = ({
     _store ||
     createWorkspaceStore({
       isReadOnly,
-      useLocalStorage: persistData,
-      themeId: configuration.themeId,
       proxyUrl: configuration.proxyUrl,
+      themeId: configuration.themeId,
+      useLocalStorage: persistData,
     })
+
+  // Create the router based active entities store
+  const activeEntities = createActiveEntitiesStore({ ...store, router })
 
   // Load from localStorage if available
   // Check if we have localStorage data
@@ -141,7 +151,6 @@ export const createApiClient = ({
     store.workspaceMutators.add({
       uid: 'default',
       name: 'Workspace',
-      isReadOnly,
       proxyUrl: configuration.proxyUrl,
     })
 
@@ -161,12 +170,13 @@ export const createApiClient = ({
   const app = createApp(appComponent)
   app.use(router)
   // Provide the workspace store for the useWorkspace hook
-  app.provide('workspace', store)
+  app.provide(WORKSPACE_SYMBOL, store)
   // Provide the layout for the useLayout hook
   app.provide('layout', layout)
+  // Provide the active entities store
+  app.provide(ACTIVE_ENTITIES_SYMBOL, activeEntities)
 
   const {
-    collections,
     collectionMutators,
     importSpecFile,
     importSpecFromUrl,
@@ -174,9 +184,9 @@ export const createApiClient = ({
     requests,
     securitySchemes,
     servers,
-    workspaces,
     workspaceMutators,
   } = store
+  const { activeCollection, activeWorkspace } = activeEntities
 
   // Mount the vue app
   const mount = (mountingEl = el) => {
@@ -193,30 +203,20 @@ export const createApiClient = ({
   }
   if (mountOnInitialize) mount()
 
-  // Get active entities - pulled out since the others are moved to a new hook
-  const getActiveWorkspace = () =>
-    workspaces[router.currentRoute.value.params[PathId.Workspace] as string] ??
-    workspaces[Object.keys(workspaces)[0]]
-  const getActiveCollection = () =>
-    collections[
-      router.currentRoute.value.params[PathId.Collection] as string
-    ] ?? Object.values(collections)[0]
-
   /**
    * Update the spec
    *
    * @remarks Currently you should not use this directly, use updateConfig instead to get the side effects
    */
   const updateSpec = async (spec: SpecConfiguration) => {
-    const activeWorkspace = getActiveWorkspace()
     if (spec?.url) {
-      await importSpecFromUrl(spec.url, activeWorkspace.uid, {
+      await importSpecFromUrl(spec.url, activeWorkspace.value.uid, {
         proxy: configuration?.proxyUrl,
         setCollectionSecurity: true,
         ...configuration,
       })
     } else if (spec?.content) {
-      await importSpecFile(spec?.content, activeWorkspace.uid, {
+      await importSpecFile(spec?.content, activeWorkspace.value.uid, {
         setCollectionSecurity: true,
         ...configuration,
       })
@@ -253,8 +253,7 @@ export const createApiClient = ({
         store.serverMutators.reset()
         store.tagMutators.reset()
 
-        const activeWorkspace = getActiveWorkspace()
-        workspaceMutators.edit(activeWorkspace.uid, 'collections', [])
+        workspaceMutators.edit(activeWorkspace.value.uid, 'collections', [])
 
         updateSpec(newConfig.spec)
       }
@@ -262,11 +261,10 @@ export const createApiClient = ({
     /** Update the currently selected server via URL */
     updateServer: (serverUrl: string) => {
       const server = Object.values(servers).find((s) => s.url === serverUrl)
-      const activeCollection = getActiveCollection()
 
-      if (server && activeCollection)
+      if (server && activeCollection.value)
         collectionMutators.edit(
-          activeCollection.uid,
+          activeCollection.value?.uid,
           'selectedServerUid',
           server.uid,
         )
@@ -274,10 +272,7 @@ export const createApiClient = ({
     /** Update the currently selected server via URL */
     onUpdateServer: (callback: (url: string) => void) => {
       watch(
-        () => {
-          const activeCollection = getActiveCollection()
-          return activeCollection.selectedServerUid
-        },
+        () => activeCollection.value?.selectedServerUid,
         (uid) => {
           const server = Object.values(servers).find((s) => s.uid === uid)
           if (server?.url) callback(server.url)
@@ -298,11 +293,10 @@ export const createApiClient = ({
     }) => {
       const schemes = Object.values(securitySchemes)
       const scheme = schemes.find((s) => s.nameKey === nameKey)
-      const activeCollection = getActiveCollection()
 
-      if (scheme && activeCollection)
+      if (scheme && activeCollection.value)
         collectionMutators.edit(
-          activeCollection.uid,
+          activeCollection.value.uid,
           `auth.${scheme.uid}.${propertyKey}`,
           // @ts-expect-error why typescript why
           value,

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -1,5 +1,6 @@
 import type { ClientLayout } from '@/hooks'
 import { loadAllResources } from '@/libs/local-storage'
+import { PathId } from '@/routes'
 import { type WorkspaceStore, createWorkspaceStore } from '@/store'
 import type { Collection, RequestMethod } from '@scalar/oas-utils/entities/spec'
 import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
@@ -106,9 +107,11 @@ export const createApiClient = ({
   // Create the store if it wasn't passed in
   const store =
     _store ||
-    createWorkspaceStore(router, {
+    createWorkspaceStore({
+      isReadOnly,
       useLocalStorage: persistData,
-      defaultProxyUrl: configuration.proxyUrl,
+      themeId: configuration.themeId,
+      proxyUrl: configuration.proxyUrl,
     })
 
   // Load from localStorage if available
@@ -163,8 +166,7 @@ export const createApiClient = ({
   app.provide('layout', layout)
 
   const {
-    activeCollection,
-    activeWorkspace,
+    collections,
     collectionMutators,
     importSpecFile,
     importSpecFromUrl,
@@ -172,6 +174,7 @@ export const createApiClient = ({
     requests,
     securitySchemes,
     servers,
+    workspaces,
     workspaceMutators,
   } = store
 
@@ -188,27 +191,16 @@ export const createApiClient = ({
     }
     app.mount(mountingEl)
   }
+  if (mountOnInitialize) mount()
 
-  // Update some workspace params from the config
-  if (activeWorkspace.value) {
-    if (mountOnInitialize) mount()
-
-    if (configuration?.proxyUrl) {
-      workspaceMutators.edit(
-        activeWorkspace.value.uid,
-        'proxyUrl',
-        configuration?.proxyUrl,
-      )
-    }
-
-    if (configuration?.themeId) {
-      workspaceMutators.edit(
-        activeWorkspace.value.uid,
-        'themeId',
-        configuration?.themeId,
-      )
-    }
-  }
+  // Get active entities - pulled out since the others are moved to a new hook
+  const getActiveWorkspace = () =>
+    workspaces[router.currentRoute.value.params[PathId.Workspace] as string] ??
+    workspaces[Object.keys(workspaces)[0]]
+  const getActiveCollection = () =>
+    collections[
+      router.currentRoute.value.params[PathId.Collection] as string
+    ] ?? Object.values(collections)[0]
 
   /**
    * Update the spec
@@ -216,14 +208,15 @@ export const createApiClient = ({
    * @remarks Currently you should not use this directly, use updateConfig instead to get the side effects
    */
   const updateSpec = async (spec: SpecConfiguration) => {
+    const activeWorkspace = getActiveWorkspace()
     if (spec?.url) {
-      await importSpecFromUrl(spec.url, activeWorkspace.value.uid, {
+      await importSpecFromUrl(spec.url, activeWorkspace.uid, {
         proxy: configuration?.proxyUrl,
         setCollectionSecurity: true,
         ...configuration,
       })
     } else if (spec?.content) {
-      await importSpecFile(spec?.content, activeWorkspace.value.uid, {
+      await importSpecFile(spec?.content, activeWorkspace.uid, {
         setCollectionSecurity: true,
         ...configuration,
       })
@@ -260,7 +253,8 @@ export const createApiClient = ({
         store.serverMutators.reset()
         store.tagMutators.reset()
 
-        workspaceMutators.edit(activeWorkspace.value.uid, 'collections', [])
+        const activeWorkspace = getActiveWorkspace()
+        workspaceMutators.edit(activeWorkspace.uid, 'collections', [])
 
         updateSpec(newConfig.spec)
       }
@@ -268,10 +262,11 @@ export const createApiClient = ({
     /** Update the currently selected server via URL */
     updateServer: (serverUrl: string) => {
       const server = Object.values(servers).find((s) => s.url === serverUrl)
+      const activeCollection = getActiveCollection()
 
-      if (server && activeCollection.value)
+      if (server && activeCollection)
         collectionMutators.edit(
-          activeCollection.value?.uid,
+          activeCollection.uid,
           'selectedServerUid',
           server.uid,
         )
@@ -279,7 +274,10 @@ export const createApiClient = ({
     /** Update the currently selected server via URL */
     onUpdateServer: (callback: (url: string) => void) => {
       watch(
-        () => activeCollection.value?.selectedServerUid,
+        () => {
+          const activeCollection = getActiveCollection()
+          return activeCollection.selectedServerUid
+        },
         (uid) => {
           const server = Object.values(servers).find((s) => s.uid === uid)
           if (server?.url) callback(server.url)
@@ -300,10 +298,11 @@ export const createApiClient = ({
     }) => {
       const schemes = Object.values(securitySchemes)
       const scheme = schemes.find((s) => s.nameKey === nameKey)
+      const activeCollection = getActiveCollection()
 
-      if (scheme && activeCollection.value)
+      if (scheme && activeCollection)
         collectionMutators.edit(
-          activeCollection.value.uid,
+          activeCollection.uid,
           `auth.${scheme.uid}.${propertyKey}`,
           // @ts-expect-error why typescript why
           value,

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -1,28 +1,42 @@
 import { flattenEnvVars } from '@/libs/string-template'
 import { PathId } from '@/router'
-import { useWorkspace } from '@/store'
-import type { Request, RequestExample } from '@scalar/oas-utils/entities/spec'
-import { computed } from 'vue'
-import { useRouter } from 'vue-router'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
+import type {
+  Collection,
+  Request,
+  RequestExample,
+  Server,
+} from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
+import { type InjectionKey, computed, inject } from 'vue'
+import type { Router } from 'vue-router'
 
-import { getRouterParams } from '../store/router-params'
+import { getRouterParams } from './router-params'
+
+type CreateActiveEntitiesStoreParams = {
+  router: Router
+  collections: Record<string, Collection>
+  environments: Record<string, Environment>
+  requestExamples: Record<string, RequestExample>
+  requests: Record<string, Request>
+  servers: Record<string, Server>
+  workspaces: Record<string, Workspace>
+}
 
 /**
- * Hook for the active entities store
+ * Create the active entities store
  *
- * This store returns anything related to the currently active entities
+ * We need the factory function to pass the router instance
  */
-export const useActiveEntities = () => {
-  const {
-    workspaces,
-    collections,
-    environments,
-    requestExamples,
-    requests,
-    servers,
-  } = useWorkspace()
-  const router = useRouter()
-
+export const createActiveEntitiesStore = ({
+  collections,
+  environments,
+  requestExamples,
+  requests,
+  router,
+  servers,
+  workspaces,
+}: CreateActiveEntitiesStoreParams) => {
   /** Gives the required UID usually per route */
   const activeRouterParams = computed(getRouterParams(router))
 
@@ -157,3 +171,15 @@ export const useActiveEntities = () => {
     router,
   }
 }
+
+export type ActiveEntitiesStore = ReturnType<typeof createActiveEntitiesStore>
+export const ACTIVE_ENTITIES_SYMBOL =
+  Symbol() as InjectionKey<ActiveEntitiesStore>
+
+/**
+ * The active entities store
+ *
+ * This store returns anything related to the currently active entities
+ * The only reason this is a store and not a simple hook is due to storing the current router here
+ */
+export const useActiveEntities = () => inject(ACTIVE_ENTITIES_SYMBOL)

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -182,4 +182,8 @@ export const ACTIVE_ENTITIES_SYMBOL =
  * This store returns anything related to the currently active entities
  * The only reason this is a store and not a simple hook is due to storing the current router here
  */
-export const useActiveEntities = () => inject(ACTIVE_ENTITIES_SYMBOL)
+export const useActiveEntities = (): ActiveEntitiesStore => {
+  const store = inject(ACTIVE_ENTITIES_SYMBOL)
+  if (!store) throw new Error('Active entities store not provided')
+  return store
+}

--- a/packages/api-client/src/store/store-context.ts
+++ b/packages/api-client/src/store/store-context.ts
@@ -1,4 +1,3 @@
-import type { RouterPathParams } from '@/store/router-params'
 import type { Cookie } from '@scalar/oas-utils/entities/cookie'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type {
@@ -11,11 +10,8 @@ import type {
 } from '@scalar/oas-utils/entities/spec'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import type { Mutators } from '@scalar/object-utils/mutator-record'
-import type { ComputedRef } from 'vue'
 
 export type StoreContext = {
-  routerParams: ComputedRef<RouterPathParams>
-  //
   collections: Record<string, Collection>
   collectionMutators: Mutators<Collection>
   //

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -258,4 +258,8 @@ export const WORKSPACE_SYMBOL = Symbol() as InjectionKey<WorkspaceStore>
  * The rawAdd methods are the mutator.add methods. Some add methods have been replaced when we need some side effects
  * ex: add examples when adding a request
  */
-export const useWorkspace = () => inject(WORKSPACE_SYMBOL)
+export const useWorkspace = (): WorkspaceStore => {
+  const store = inject(WORKSPACE_SYMBOL)
+  if (!store) throw new Error('Workspace store not provided')
+  return store
+}

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -35,7 +35,7 @@ import type {
 } from '@scalar/oas-utils/entities/spec'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
-import { inject, reactive, ref, toRaw } from 'vue'
+import { type InjectionKey, inject, reactive, ref, toRaw } from 'vue'
 
 export type UpdateScheme = <P extends Path<SecurityScheme>>(
   path: P,
@@ -250,12 +250,12 @@ export const createWorkspaceStore = ({
 }
 
 export type WorkspaceStore = ReturnType<typeof createWorkspaceStore>
+export const WORKSPACE_SYMBOL = Symbol() as InjectionKey<WorkspaceStore>
 
 /**
  * Global hook which contains the store for the whole app
- * We may want to break this up at some point due to the massive file size
  *
  * The rawAdd methods are the mutator.add methods. Some add methods have been replaced when we need some side effects
  * ex: add examples when adding a request
  */
-export const useWorkspace = () => inject<WorkspaceStore>('workspace')!
+export const useWorkspace = () => inject(WORKSPACE_SYMBOL)

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -67,7 +67,7 @@ watch(isNarrow, (narrow) => (showSideBar.value = !narrow))
  */
 const selectedSecuritySchemeUids = computed(
   () =>
-    (isReadOnly.value
+    (isReadOnly
       ? activeCollection.value?.selectedSecuritySchemeUids
       : activeRequest.value?.selectedSecuritySchemeUids) ?? [],
 )

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -123,7 +123,7 @@ const schemeOptions = computed<SecuritySchemeOption[] | SecuritySchemeGroup[]>(
     ]
 
     // Read only mode we don't want to add new auth
-    if (isReadOnly.value)
+    if (isReadOnly)
       return requiredFormatted.length ? options : availableFormatted
 
     options.push({
@@ -160,7 +160,7 @@ const editSelectedSchemeUids = (uids: string[]) => {
   if (!activeCollection.value || !activeRequest.value) return
 
   // Set as selected on the collection for the modal
-  if (isReadOnly.value) {
+  if (isReadOnly) {
     collectionMutators.edit(
       activeCollection.value.uid,
       'selectedSecuritySchemeUids',

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -39,7 +39,7 @@ const sections = computed(() => {
 
 // If security = [] or [{}] just hide it on readOnly mode
 const isAuthHidden = computed(
-  () => isReadOnly.value && activeRequest.value?.security?.length === 0,
+  () => isReadOnly && activeRequest.value?.security?.length === 0,
 )
 
 type ActiveSections = (typeof sections.value)[number]

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { HttpMethod } from '@/components/HttpMethod'
 import { useSidebar } from '@/hooks'
-import { useActiveEntities } from '@/hooks/use-active-entities'
 import { getModifiers } from '@/libs'
 import { PathId } from '@/router'
 import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 import type { SidebarItem, SidebarMenuItem } from '@/views/Request/types'
 import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
 import {
@@ -51,7 +51,6 @@ defineSlots<{
   leftIcon(): void
 }>()
 
-console.log('asdhjaskd')
 const {
   activeCollection,
   router,

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { HttpMethod } from '@/components/HttpMethod'
 import { useSidebar } from '@/hooks'
+import { useActiveEntities } from '@/hooks/use-active-entities'
 import { getModifiers } from '@/libs'
 import { PathId } from '@/router'
 import { useWorkspace } from '@/store'
@@ -50,11 +51,15 @@ defineSlots<{
   leftIcon(): void
 }>()
 
+console.log('asdhjaskd')
 const {
   activeCollection,
+  router,
   activeRequest,
   activeRouterParams,
   activeWorkspace,
+} = useActiveEntities()
+const {
   collections,
   tags,
   isReadOnly,
@@ -64,7 +69,6 @@ const {
   tagMutators,
   requestMutators,
   requestExampleMutators,
-  router,
   events,
 } = useWorkspace()
 const { collapsedSidebarFolders, toggleSidebarFolder } = useSidebar()
@@ -160,12 +164,12 @@ const highlightClasses = 'hover:bg-sidebar-active-b indent-padding-left'
 /** Due to the nesting, we need a dynamic left offset for hover and active backgrounds */
 const leftOffset = computed(() => {
   if (!props.parentUids.length) return '12px'
-  else if (isReadOnly.value) return `${(props.parentUids.length - 1) * 12}px`
+  else if (isReadOnly) return `${(props.parentUids.length - 1) * 12}px`
   else return `${props.parentUids.length * 12}px`
 })
 const paddingOffset = computed(() => {
   if (!props.parentUids.length) return '0px'
-  else if (isReadOnly.value) return `${(props.parentUids.length - 1) * 12}px`
+  else if (isReadOnly) return `${(props.parentUids.length - 1) * 12}px`
   else return `${props.parentUids.length * 12}px`
 })
 
@@ -262,7 +266,7 @@ const watchIconColor = computed(() => {
 const hasDraftRequests = computed(() => {
   return (
     item.value.title == 'Drafts' &&
-    !isReadOnly.value &&
+    !isReadOnly &&
     item.value.children.length > 0
   )
 })

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -33,8 +33,6 @@ export const workspaceSchema = z.object({
   name: z.string().default('Default Workspace'),
   /** Workspace description */
   description: z.string().default('Basic Scalar Workspace'),
-  /** Controls read only mode for most entitites, but not things like params */
-  isReadOnly: z.boolean().default(false),
   /** List of all collection uids in a given workspace */
   collections: z.array(z.string()).default([]),
   /** List of all environment uids in a given workspace */


### PR DESCRIPTION
We need to remove anything router related from the workspace store so we can initialize it in the references.