### PR TITLE
ci: continue when markdown links are dead

### DIFF
--- a/.github/workflows/lint-markdown-files.yml
+++ b/.github/workflows/lint-markdown-files.yml
@@ -24,4 +24,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Lint Markdown files
+        continue-on-error: true
         run: pnpm markdown:check


### PR DESCRIPTION
With this PR dead markdown links are a warning, not a blocker for the workflow. Sometimes external links are just dead and we can’t do anything about it, but it’s still great to be notified about it. We found a bunch of wrong links that way already.