### PR TITLE
fix(api-client): view layout z index

### DIFF
--- a/.changeset/smart-feet-roll.md
+++ b/.changeset/smart-feet-roll.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+style: sets z context to tooltip content

--- a/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
+++ b/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
@@ -50,7 +50,7 @@ defineEmits<{
         <TooltipContent
           v-if="!props.disabled"
           :align="props.align"
-          class="scalar-app"
+          class="scalar-app z-context"
           :class="props.class"
           :side="props.side"
           :sideOffset="props.sideOffset">


### PR DESCRIPTION
this pr fixes the variable value tooltip visibility when used within the address bar as seen below:

**⊢ before / after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/38b48be1-1ea8-46e2-9507-9bfa9bc19e0b">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/960a5073-b008-4978-a51d-f033316edd68">
</div>
