### PR TITLE
refactor(components): scalar menu apply same styles as sidebar

### DIFF
--- a/.changeset/late-bikes-provide.md
+++ b/.changeset/late-bikes-provide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+style(components): scalar menu flex col for products

--- a/packages/components/src/components/ScalarMenu/ScalarMenu.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenu.vue
@@ -8,7 +8,7 @@ defineProps<Pick<FloatingOptions, 'placement' | 'teleport'>>()
 </script>
 <template>
   <ScalarPopover
-    class="max-h-[inherit] w-[420px] max-w-[inherit]"
+    class="max-h-[inherit] w-[280px] max-w-[inherit]"
     :placement="placement ?? 'bottom-start'"
     :teleport="teleport">
     <!-- Logo Button to open the popover -->
@@ -30,7 +30,7 @@ defineProps<Pick<FloatingOptions, 'placement' | 'teleport'>>()
     </template>
     <!-- Popover content -->
     <template #popover="{ close }">
-      <div class="custom-scroll flex flex-col gap-3 p-3 sm:gap-5 sm:p-4">
+      <div class="custom-scroll flex flex-col gap-3 p-2.25 sm:gap-3">
         <!-- Base Product List (can be overridden by slot) -->
         <slot
           :close="close"

--- a/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
@@ -8,7 +8,7 @@ defineProps<{
 <template>
   <component
     :is="is ?? 'a'"
-    class="relative flex cursor-pointer rounded px-2.5 py-1 font-medium leading text-c-2 no-underline hover:bg-b-2 hover:text-c-1"
+    class="relative flex cursor-pointer rounded px-2.5 py-1 font-medium leading text-c-2 no-underline hover:bg-b-2 focus:text-c-1"
     :type="is === 'button' ? 'button' : undefined">
     <slot />
   </component>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuProduct.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuProduct.vue
@@ -8,10 +8,10 @@ defineProps<{
 </script>
 <template>
   <a
-    class="relative flex min-w-0 flex-1 flex-col items-center justify-center gap-1 overflow-hidden rounded border p-3 leading no-underline xs:flex-row"
+    class="relative flex min-w-0 flex-1 flex-col items-center gap-2 overflow-hidden rounded px-2 py-1.5 leading no-underline xs:flex-row"
     :class="
       selected
-        ? 'pointer-events-none border-c-1 bg-b-2'
+        ? 'pointer-events-none bg-b-2'
         : 'cursor-pointer bg-b-1 hover:bg-b-2'
     "
     target="_blank">
@@ -19,6 +19,6 @@ defineProps<{
       :icon="icon"
       size="xs"
       thickness="2.5" />
-    <span class="font-bold"><slot /></span>
+    <span class="font-medium"><slot /></span>
   </a>
 </template>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuProducts.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuProducts.vue
@@ -13,7 +13,7 @@ defineEmits<{
 }>()
 </script>
 <template>
-  <div class="flex gap-2 sm:gap-3">
+  <div class="flex flex-col">
     <ScalarMenuProduct
       :href="hrefs?.dashboard ?? 'https://dashboard.scalar.com'"
       icon="House"

--- a/packages/components/src/components/ScalarMenu/ScalarMenuSection.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts"></script>
 <template>
   <div class="flex flex-col gap-1.5">
-    <div class="px-2.5 leading text-c-1">
+    <div class="px-2.5 font-medium leading text-c-3">
       <slot name="title" />
     </div>
     <div class="flex flex-col">


### PR DESCRIPTION
Ended up going with 1 column here to make it closer to our sidebar

<img width="586" alt="image" src="https://github.com/user-attachments/assets/2dac8cab-4d06-48f7-adb3-bd7006658bbb">