### PR TITLE
style(api-client): mobile layout fixtures

### DIFF
--- a/.changeset/big-rats-own.md
+++ b/.changeset/big-rats-own.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: enhances responsive alignment layout

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -21,7 +21,7 @@ withDefaults(
     :defaultOpen="defaultOpen">
     <div class="flex items-center">
       <DisclosureButton
-        class="group hover:text-c-1 flex flex-1 items-center gap-2.5 overflow-hidden py-1.5 text-sm font-medium px-2.5 outline-none">
+        class="group hover:text-c-1 flex flex-1 items-center gap-2.5 overflow-hidden py-1.5 text-sm font-medium px-1 md:px-1.5 xl:px-2 outline-none">
         <ScalarIcon
           class="text-c-3 group-hover:text-c-1 group-focus-visible:outline ui-open:rotate-90 ui-not-open:rotate-0 rounded-[1px] outline-offset-2"
           icon="ChevronRight"

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -1,6 +1,6 @@
 <template>
   <section
-    class="flex xl:h-full xl:min-w-0 xl:flex-1 flex-col xl:custom-scroll bg-b-1">
+    class="flex xl:h-full xl:min-w-0 flex-1 flex-col xl:custom-scroll bg-b-1">
     <div
       class="min-h-12 xl:min-h-header flex items-center border-b-1/2 px-3.5 py-1.5 md:px-4 md:py-2 xl:px-6 xl:pr-5 text-sm font-medium sticky top-0 bg-b-1 xl:rounded-none z-1">
       <slot name="title" />

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -76,7 +76,7 @@ const updateRequestNameHandler = (event: Event) => {
         <input
           v-if="!isReadOnly"
           id="requestname"
-          class="text-c-1 rounded pointer-events-auto relative w-full pl-3 -ml-3 has-[:focus-visible]:outline h-8 group-hover-input has-[:focus-visible]:outline z-10"
+          class="text-c-1 rounded pointer-events-auto relative w-full pl-2 -ml-0.5 md:-ml-1 xl:-ml-2 has-[:focus-visible]:outline h-8 group-hover-input has-[:focus-visible]:outline z-10"
           placeholder="Request Name"
           :value="activeRequest?.summary"
           @input="updateRequestNameHandler" />


### PR DESCRIPTION
this pr fixes few responsive glitches as listed below:
- request section input alignment
- environment editor height
- view layout caret alignment

**⊢ request section before after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/859699fe-9c8e-4d58-acf0-dd5a51a1ba19">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1e026ff7-a673-4ed7-8ae6-a590dc78291a">
</div>
<br>

**⊢ environment editor before after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/95270b72-00da-48f2-9cb6-b72b1ab13398">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/30e3fcf1-29c6-46ee-84f8-988b32a8f224">
</div>