### PR TITLE
fix(api-client): empty state new request button

### DIFF
--- a/.changeset/stale-drinks-shave.md
+++ b/.changeset/stale-drinks-shave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: displays empty state new request button in desktop only

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -95,7 +95,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
         <ScalarHotkey hotkey="↵" />
       </button>
       <button
-        v-if="layout !== 'modal'"
+        v-if="layout === 'desktop'"
         class="flex items-center gap-1.5"
         type="button"
         @click="openCommandPaletteRequest">


### PR DESCRIPTION
this pr sets the empty state new request button to be displayed in desktop only as we do not overload the meta+n event on web:

**⊢ web layout before / after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/23e593a9-45b5-4abf-ac58-2adae44592b9">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/3276c873-68f5-4646-9359-e01786c5a088">
</div>