### PR TITLE
fix(api-client): response preview pretty print

### DIFF
--- a/.changeset/funny-pets-play.md
+++ b/.changeset/funny-pets-play.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: updates response headers and copy button ui"

--- a/.changeset/nine-dryers-brush.md
+++ b/.changeset/nine-dryers-brush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: pretty print response body content

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { ScalarIcon } from '@scalar/components'
+import { prettyPrintJson } from '@scalar/oas-utils/helpers'
 import { type CodeMirrorLanguage, useCodeMirror } from '@scalar/use-codemirror'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { ref, toRef } from 'vue'
@@ -16,7 +17,7 @@ const { codeMirror } = useCodeMirror({
   codeMirrorRef,
   readOnly: true,
   lineNumbers: true,
-  content: toRef(() => props.content),
+  content: toRef(() => prettyPrintJson(props.content)),
   language: toRef(() => props.language),
   forceFoldGutter: true,
 })

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
@@ -27,9 +27,11 @@ const getCurrentContent = () => {
 }
 </script>
 <template>
-  <div class="relative">
+  <div class="body-raw relative overflow-auto">
     <!-- Copy button -->
-    <div class="scalar-code-copy">
+    <div
+      v-if="getCurrentContent()"
+      class="scalar-code-copy">
       <button
         class="copy-button"
         type="button"
@@ -65,12 +67,14 @@ const getCurrentContent = () => {
   right: 6px;
   z-index: 10;
   pointer-events: none;
+  position: sticky;
+  transform: translateX(-6px);
 }
 
 .copy-button {
   align-items: center;
   display: flex;
-  background-color: var(--scalar-background-2);
+  background-color: var(--scalar-background-1);
   border: 1px solid var(--scalar-border-color);
   border-radius: 3px;
   color: var(--scalar-color-3);
@@ -85,18 +89,12 @@ const getCurrentContent = () => {
 }
 
 /* Show button on container hover */
-.relative:hover .copy-button,
+.body-raw:hover .copy-button,
 .copy-button:focus-visible {
   opacity: 1;
 }
 
 .copy-button:hover {
   color: var(--scalar-color-1);
-}
-
-/* Ensure proper background inheritance */
-.scalar-code-copy,
-.copy-button {
-  background: inherit;
 }
 </style>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -20,7 +20,7 @@ const findHeaderInfo = (name: string) => {
 </script>
 <template>
   <ViewLayoutCollapse
-    class="overflow-scroll"
+    class="overflow-auto"
     :defaultOpen="false"
     :itemCount="headers.length">
     <template #title>Headers</template>
@@ -56,7 +56,7 @@ const findHeaderInfo = (name: string) => {
     <!-- Empty state -->
     <div
       v-else
-      class="text-c-3 px-4 text-sm border rounded min-h-12 justify-center flex items-center bg-b-1 mx-1">
+      class="text-c-3 px-4 text-sm border rounded min-h-12 justify-center flex items-center bg-b-1">
       No Headers
     </div>
   </ViewLayoutCollapse>


### PR DESCRIPTION
this pr fixes #3955 and #3962 along:
- response body content display pretty printed
- response body content scrollability back
- copy button style to only display it on content hover
- response headers style

**⊢ header before after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/634d75dd-1225-451c-a19b-d42dfbdd4e2a">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f51e0c45-e2bd-420e-a532-ea52129855c6">
</div>

**⊢ response before after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/6d0809f6-7974-48f3-9725-f42af67a5ddc">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/3eb9096c-b041-4dad-9801-b1d3cc6d1e2f">
</div>