### PR TITLE
fix(api-reference): section borders missing

### DIFF
--- a/.changeset/tame-ads-type.md
+++ b/.changeset/tame-ads-type.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): missing section borders and card-form border

--- a/packages/api-reference/src/components/Section/Section.vue
+++ b/packages/api-reference/src/components/Section/Section.vue
@@ -58,6 +58,9 @@ function handleScroll() {
   /* Offset by header height to line up scroll position */
   scroll-margin-top: var(--refs-header-height);
 }
+.section:has(~ div.contents) {
+  border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
+}
 .references-classic .section {
   padding: 48px 0;
   gap: 24px;

--- a/packages/api-reference/src/components/Section/SectionContainer.vue
+++ b/packages/api-reference/src/components/Section/SectionContainer.vue
@@ -7,11 +7,11 @@
   position: relative;
   padding: 0 60px;
   width: 100%;
-}
-.section-container:last-of-type {
   border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
-
+.section-container:has(.introduction-section) {
+  border-top: none;
+}
 @container narrow-references-container (max-width: 900px) {
   .section-container {
     padding: 0;

--- a/packages/api-reference/src/legacy/components/CardFormGroup.vue
+++ b/packages/api-reference/src/legacy/components/CardFormGroup.vue
@@ -7,4 +7,7 @@
 .card-form-group {
   display: flex;
 }
+.card-form-group + .card-form-group {
+  border-top: var(--scalar-border-width) solid var(--scalar-border-color);
+}
 </style>


### PR DESCRIPTION
before:
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/a3ef4948-eeb4-4128-9041-cb902e197a03">
<img width="1347" alt="image" src="https://github.com/user-attachments/assets/bd3b9747-a21b-4fae-8e8c-f496cf10b1f1">
<img width="586" alt="image" src="https://github.com/user-attachments/assets/0d9a3fc2-f1cb-4275-aa97-37649cbe9847">


after:
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/a89e964e-fe5f-419c-b4d9-a3a3c6829e94">

<img width="1356" alt="image" src="https://github.com/user-attachments/assets/cc0c1d22-e6b1-43f5-8056-c760fbd7cc36">

<img width="579" alt="image" src="https://github.com/user-attachments/assets/04434124-9b9c-4e2b-9bc1-65d40c6f7f59">
