### PR TITLE
feat(api-reference): web component

### DIFF
--- a/examples/cdn-api-reference/src/index.ts
+++ b/examples/cdn-api-reference/src/index.ts
@@ -1,5 +1,6 @@
 import fastifyStatic from '@fastify/static'
 import apiReferenceBundle from '@scalar/api-reference/browser/standalone.js?raw'
+import apiReferenceComponentBundle from '@scalar/api-reference/component.js?raw'
 import playButtonBundle from '@scalar/play-button?raw'
 import fastify from 'fastify'
 import { readdirSync } from 'node:fs'
@@ -25,6 +26,13 @@ app.get('/api-reference/standalone.js', (_request, reply) => {
     .code(200)
     .header('Content-Type', 'text/javascript; charset=utf-8')
     .send(apiReferenceBundle)
+})
+
+app.get('/api-reference/component.js', (_request, reply) => {
+  reply
+    .code(200)
+    .header('Content-Type', 'text/javascript; charset=utf-8')
+    .send(apiReferenceComponentBundle)
 })
 
 // @scalar/play-button bundle

--- a/examples/cdn-api-reference/src/public/api-reference-leaky-component.html
+++ b/examples/cdn-api-reference/src/public/api-reference-leaky-component.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Scalar API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        --scalar-custom-header-height: 50px;
+        color-scheme: light dark;
+        font-family: sans-serif;
+      }
+      html {
+        max-height: 100dvh;
+      }
+      body {
+        margin: 0;
+      }
+      .custom-header {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        height: var(--scalar-custom-header-height);
+        padding: 0 18px;
+        position: sticky;
+        justify-content: space-between;
+        top: 0;
+        z-index: 100;
+
+        color: light-dark(#111, #eee);
+        background-color: light-dark(#eee, #111);
+        border-bottom: 0.5px solid light-dark(#111, #eee);
+      }
+      button {
+        background: red !important;
+        border-radius: 6px;
+        padding: 6px 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="custom-header">
+      <b>Leaky Styles with Custom Element</b>
+      <button><code>button { background: red !important; }</code></button>
+    </header>
+    <scalar-api-reference></scalar-api-reference>
+    <script src="/api-reference/component.js"></script>
+    <script>
+      document.querySelector('scalar-api-reference').configuration = {
+        spec: {
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+        },
+      }
+    </script>
+  </body>
+</html>

--- a/examples/cdn-api-reference/src/public/api-reference-leaky-standalone.html
+++ b/examples/cdn-api-reference/src/public/api-reference-leaky-standalone.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Scalar API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        --scalar-custom-header-height: 50px;
+        color-scheme: light dark;
+        font-family: sans-serif;
+      }
+      html {
+        max-height: 100dvh;
+      }
+      body {
+        margin: 0;
+      }
+      .custom-header {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        height: var(--scalar-custom-header-height);
+        padding: 0 18px;
+        position: sticky;
+        justify-content: space-between;
+        top: 0;
+        z-index: 100;
+
+        color: light-dark(#111, #eee);
+        background-color: light-dark(#eee, #111);
+        border-bottom: 0.5px solid light-dark(#111, #eee);
+      }
+      button {
+        background: red !important;
+        border-radius: 6px;
+        padding: 6px 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="custom-header">
+      <b>Leaky Styles with Vue App (Current Method)</b>
+      <button><code>button { background: red !important; }</code></button>
+    </header>
+    <script
+      id="api-reference"
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"></script>
+    <script src="/api-reference/standalone.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "dev:nuxt": "turbo dev --filter @scalar/nuxt",
     "dev:proxy-server": "pnpm --filter @scalar-examples/proxy-server dev",
     "dev:reference": "turbo dev --filter @scalar/api-reference",
+    "dev:reference:cdn": "turbo dev --filter @scalar-examples/cdn-api-reference",
     "dev:void-server": "pnpm --filter @scalar/void-server dev",
     "dev:web": "turbo dev --filter @scalar-examples/web",
     "@scalar/cli": "pnpm --filter @scalar/cli run @scalar/cli",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -27,9 +27,10 @@
   "scripts": {
     "analyze:default": "pnpm dlx vite-bundle-visualizer",
     "analyze:standalone": "pnpm dlx vite-bundle-visualizer -c vite.standalone.config.ts",
-    "build": "pnpm build:default && pnpm build:standalone && pnpm types:build && tsc-alias -p tsconfig.build.json",
+    "build": "pnpm build:default && pnpm build:standalone && pnpm build:component && pnpm types:build && tsc-alias -p tsconfig.build.json",
     "build:default": "vite build",
     "build:standalone": "vite build -c vite.standalone.config.ts",
+    "build:component": "vite build -c vite.component.config.ts",
     "dev": "vite",
     "dev:standalone": "vite -c vite.standalone.config.ts",
     "lint:check": "eslint .",
@@ -48,6 +49,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./style.css": "./dist/style.css",
+    "./component.js": "./dist/webComponent/component.js",
     "./browser/standalone.js": "./dist/browser/standalone.js"
   },
   "files": [

--- a/packages/api-reference/src/component.ts
+++ b/packages/api-reference/src/component.ts
@@ -1,0 +1,11 @@
+import { defineCustomElement } from 'vue'
+
+import ApiReference from './components/ApiReference.vue'
+
+/** Provide a web component interface for the ApiReference component */
+const CustomElement = defineCustomElement(ApiReference)
+
+// Register the custom element.
+// After registration, all `<scalar-api-reference>` tags
+// on the page will be upgraded.
+customElements.define('scalar-api-reference', CustomElement)

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -63,23 +63,27 @@ const favicon = computed(() => configuration.value.favicon)
 useFavicon(favicon)
 </script>
 <template>
-  <!-- Inject any custom CSS directly into a style tag -->
-  <component
-    :is="'style'"
-    v-if="configuration?.customCss">
-    {{ configuration.customCss }}
-  </component>
-  <Layouts
-    :configuration="configuration"
-    :isDark="darkLightMode === 'dark'"
-    :parsedSpec="parsedSpec"
-    :rawSpec="rawSpec"
-    @toggleDarkMode="() => toggleColorMode()"
-    @updateContent="$emit('updateContent', $event)">
-    <template #footer><slot name="footer" /></template>
-    <!-- Expose the content end slot as a slot for the footer -->
-    <template #content-end><slot name="footer" /></template>
-  </Layouts>
+  <div
+    class="contents"
+    :class="darkLightMode === 'dark' ? 'dark-mode' : 'light-mode'">
+    <!-- Inject any custom CSS directly into a style tag -->
+    <component
+      :is="'style'"
+      v-if="configuration?.customCss">
+      {{ configuration.customCss }}
+    </component>
+    <Layouts
+      :configuration="configuration"
+      :isDark="darkLightMode === 'dark'"
+      :parsedSpec="parsedSpec"
+      :rawSpec="rawSpec"
+      @toggleDarkMode="() => toggleColorMode()"
+      @updateContent="$emit('updateContent', $event)">
+      <template #footer><slot name="footer" /></template>
+      <!-- Expose the content end slot as a slot for the footer -->
+      <template #content-end><slot name="footer" /></template>
+    </Layouts>
+  </div>
 </template>
 <style>
 @layer scalar-base {

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -310,7 +310,7 @@ function updateHttpClient(value: string) {
   padding-left: 12px;
   padding-right: 9px;
 }
-.request-card-footer {
+.request-card-footer.request-card-footer {
   display: flex;
   justify-content: flex-end;
   padding: 6px;

--- a/packages/api-reference/src/helpers/scrollToId.ts
+++ b/packages/api-reference/src/helpers/scrollToId.ts
@@ -2,5 +2,7 @@
  * Tiny wrapper around the scrollIntoView API
  */
 export const scrollToId = async (id: string) => {
-  document.getElementById(id)?.scrollIntoView()
+  const root =
+    document.querySelector('scalar-api-reference')?.shadowRoot ?? document
+  root.getElementById(id)?.scrollIntoView()
 }

--- a/packages/api-reference/vite.component.config.ts
+++ b/packages/api-reference/vite.component.config.ts
@@ -1,0 +1,72 @@
+import vue from '@vitejs/plugin-vue'
+import { webpackStats } from 'rollup-plugin-webpack-stats'
+import banner from 'vite-plugin-banner'
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import { defineConfig } from 'vitest/config'
+
+import licenseBannerTemplate from './license-banner-template.txt'
+import { name, version } from './package.json'
+
+function replaceVariables(template: string, variables: Record<string, string>) {
+  return Object.entries(variables).reduce((content, [key, value]) => {
+    return content.replace(new RegExp(`\\{\\{ ${key} \\}\\}`, 'g'), value)
+  }, template)
+}
+
+export default defineConfig({
+  define: {
+    'process.env.NODE_ENV': '"production"',
+  },
+  plugins: [
+    // Important: Tells vite to treat all vue sub-components as custom elements
+    vue({ customElement: true }),
+    cssInjectedByJsPlugin(),
+    webpackStats(),
+    banner({
+      outDir: 'dist/webComponent',
+      content: replaceVariables(licenseBannerTemplate, {
+        packageName: name,
+        version: version,
+      }),
+    }),
+  ],
+  build: {
+    emptyOutDir: false,
+    outDir: 'dist/webComponent',
+    commonjsOptions: {
+      include: [/node_modules/],
+    },
+    cssCodeSplit: false,
+    minify: 'terser',
+    // With the default terserOptions, highlight.js breaks the build.
+    // * They’re using terser, too.
+    // * Copying their options fixes the build.
+    // * `max_line_len: 80` is the one setting that makes the difference.
+    //
+    // Source: https://github.com/highlightjs/highlight.js/blob/b9ae5fea90514b864f2c9b2889d7d3302d6156dc/tools/build_config.js#L58-L73
+    terserOptions: {
+      format: {
+        max_line_len: 80,
+      },
+    },
+    lib: {
+      entry: ['src/component.ts'],
+      name: '@scalar/api-reference',
+      formats: ['umd'],
+    },
+    rollupOptions: {
+      output: {
+        entryFileNames: '[name].js',
+      },
+    },
+  },
+  resolve: {
+    dedupe: ['vue'],
+  },
+  test: {
+    coverage: {
+      enabled: true,
+      reporter: 'text',
+    },
+  },
+})

--- a/packages/themes/src/variables.css
+++ b/packages/themes/src/variables.css
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
   --scalar-border-width: 0.5px;
   --scalar-radius: 3px;
   --scalar-radius-lg: 6px;
@@ -104,7 +105,8 @@
   color-scheme: dark !important;
 }
 @media (max-width: 460px) {
-  :root {
+  :root,
+  :host {
     --scalar-font-size-1: 22px;
     --scalar-font-size-2: 14px;
     --scalar-font-size-3: 12px;
@@ -112,7 +114,8 @@
 }
 
 @media (max-width: 720px) {
-  :root {
+  :root,
+  :host {
     --scalar-heading-1: 24px;
     --scalar-page-description: 20px;
   }


### PR DESCRIPTION
Adds a package export at `@scalar/api-reference/component.js` which registers the references as a web component 🚀 

Why would we want to do this? The only real way fully encapsulate our app (embedded in a webpage) from external styles is to either put it in an iFrame (which is likely to break scroll and all our modals) or to ship it as a web component. In theory web components and the shadow DOM promise to do exactly that. From MDN:

> An important aspect of custom elements is encapsulation, because a custom element, by definition, is a piece of reusable functionality: it might be dropped into any web page and be expected to work. So it's important that code running in the page should not be able to accidentally break a custom element by modifying its internal implementation. Shadow DOM enables you to attach a DOM tree to an element, and have the internals of this tree hidden from JavaScript and CSS running in the page.

I've added two demo pages with some CSS that selects `button` and overrides some of our styles. First start the server with `pnpm dev:reference:cdn`,  then

- http://127.0.0.1:3173/api-reference-local-leaky-no-component.html mounts the references using `standalone.js` (what we serve on the CDN). It should have lots of red buttons because of the global styles.
- http://127.0.0.1:3173/api-reference-leaky-component.html mounts the references using a web component (custom element) called `scalar-api-references` and should not have red buttons because the shadow root encapsulates our Vue app.

Everything should work in the web component version but you may find some little bugs (if so let me know and I can try to fix them). I fixed a few things already like an issue with scrollToId.

Cool benefits of this:

- It prevents all our code from leaking out of the references, we probably wouldn't need `scalar-app` wrapping our tailwind anymore if we don't want to
- It seems to load faster? Maybe it's just my computer but I don't see the UI flash the same when loading the web component
- It makes setting the configuration pretty simple

Problems / Questions:

- Headless UI attaches it's teleport to the `body` but that's outside our Shadow DOM so all our styles break.
- [Browser support is okay](https://caniuse.com/custom-elementsv1), we might need [a polyfill](https://github.com/ungap/custom-elements)
  - Update: I tested in lastest Chrome, Safari and Firefox and everything seems to be 🆗 
- Shipping an app that has to work as a custom element (e.g. in a shadow DOM) and as a normal element adds some complexity (but also we already ship the client in 3 different configurations so 🤷)