### PR TITLE
fix(openapi-parser): better handle invalid API definitions

### DIFF
--- a/.changeset/shiny-geckos-fix.md
+++ b/.changeset/shiny-geckos-fix.md
@@ -1,0 +1,8 @@
+---
+'@scalar/openapi-parser': patch
+'@scalar/oas-utils': patch
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+---
+
+Add error handling for invalid partial specs

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import type { SecuritySchemeOauth2 } from '@/entities/spec/security'
-import { importSpecToWorkspace } from '@/transforms/import-spec'
+import { importSpecToWorkspace, parseSchema } from '@/transforms/import-spec'
 import circular from '@test/fixtures/basic-circular-spec.json'
 import modifiedPetStoreExample from '@test/fixtures/petstore-tls.json'
 import { describe, expect, it } from 'vitest'
@@ -463,5 +463,22 @@ describe('importSpecToWorkspace', () => {
       // Test URLS only
       expect(res.servers.map(({ url }) => url)).toEqual(['https://scalar.com'])
     })
+  })
+})
+
+describe('Handles invalid input', () => {
+  it('Handles invalid JSON', async () => {
+    const res = await parseSchema('"invalid')
+    expect(res.errors).toHaveLength(1)
+  })
+
+  it('Handles invalid YAML', async () => {
+    const res = await parseSchema(`
+
+      openapi: 3.1.0
+      asd
+      `)
+
+    expect(res.errors).toHaveLength(1)
   })
 })

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -32,11 +32,15 @@ import type { Entries } from 'type-fest'
 export const parseSchema = async (spec: string | UnknownObject) => {
   // TODO: Plugins for URLs and files with the proxy is missing here.
   // @see packages/api-reference/src/helpers/parse.ts
-  const { filesystem } = await load(spec)
-  const { specification } = upgrade(filesystem)
-  const { schema, errors = [] } = await dereference(specification)
 
-  return { schema: schema as OpenAPIV3.Document | OpenAPIV3_1.Document, errors }
+  const { filesystem, errors: loadErrors = [] } = await load(spec)
+  const { specification } = upgrade(filesystem)
+  const { schema, errors: derefErrors = [] } = await dereference(specification)
+
+  return {
+    schema: schema as OpenAPIV3.Document | OpenAPIV3_1.Document,
+    errors: [...loadErrors, ...derefErrors],
+  }
 }
 
 export type ImportSpecToWorkspaceArgs = Pick<

--- a/packages/openapi-parser/src/configuration/index.ts
+++ b/packages/openapi-parser/src/configuration/index.ts
@@ -29,6 +29,7 @@ export const ERRORS = {
   EXTERNAL_REFERENCE_NOT_FOUND: 'Can’t resolve external reference: %s',
   FILE_DOES_NOT_EXIST: 'File does not exist: %s',
   NO_CONTENT: 'No content found',
+  INVALID_CONTENT: 'Unable to parse valid JSON or YAML.',
 } as const
 
 export type ValidationError = keyof typeof ERRORS

--- a/packages/openapi-parser/src/utils/normalize.ts
+++ b/packages/openapi-parser/src/utils/normalize.ts
@@ -27,3 +27,48 @@ export function normalize(
 
   return specification
 }
+
+/**
+ * Normalize the OpenAPI document (YAML, JSON, object) to a JavaScript object.
+ *
+ * Catch any parsing errors and return messages
+ */
+export function normalizeSafe(specification: string | AnyObject | Filesystem): {
+  error: boolean
+  content: AnyObject | Filesystem | null
+} {
+  if (isFilesystem(specification)) {
+    return {
+      content: specification as Filesystem,
+      error: false,
+    }
+  }
+
+  if (typeof specification === 'string') {
+    try {
+      return {
+        error: false,
+        content: JSON.parse(specification),
+      }
+    } catch (error) {
+      try {
+        return {
+          error: false,
+          content: parse(specification, {
+            maxAliasCount: 10000,
+          }),
+        }
+      } catch {
+        return {
+          error: true,
+          content: null,
+        }
+      }
+    }
+  }
+
+  return {
+    error: false,
+    content: specification,
+  }
+}


### PR DESCRIPTION
Invalid string errors were not being caught properly and causing failures on spec changes. This captures them and assigns an appropriate error message. 