### PR TITLE
fix(api-reference): section header long content + classic layout responsive

### DIFF
--- a/.changeset/neat-mayflies-learn.md
+++ b/.changeset/neat-mayflies-learn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+style: enhances section header long content

--- a/.changeset/tall-pots-rush.md
+++ b/.changeset/tall-pots-rush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: classic layout responsiveness

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -37,7 +37,6 @@ const getUrlWithId = (id: string) => {
 .label {
   position: relative;
   display: inline-block;
-  text-align: left;
   word-break: break-all;
 }
 .anchor {

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -37,6 +37,8 @@ const getUrlWithId = (id: string) => {
 .label {
   position: relative;
   display: inline-block;
+  text-align: left;
+  word-break: break-all;
 }
 .anchor {
   position: relative;

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -33,6 +33,7 @@ const { availableTargets, httpTargetTitle, httpClientTitle } =
   border-radius: 0 0 var(--scalar-radius) var(--scalar-radius);
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   border-top: none;
+  min-height: fit-content;
 }
 .client-libraries-heading {
   font-weight: var(--scalar-semibold);

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -135,10 +135,14 @@ const introCardsSlot = computed(() =>
 }
 .introduction-card-item {
   padding: 9px;
-  border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: start;
+}
+@container narrow-references-container (max-width: 900px) {
+  .introduction-card-item {
+    border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
+  }
 }
 .introduction-card-item:has(.description) :deep(.server-form-container) {
   border-bottom-left-radius: 0;
@@ -153,8 +157,12 @@ const introCardsSlot = computed(() =>
   color: var(--scalar-color-3);
 }
 .introduction-card-row {
-  flex-flow: row wrap;
   gap: 24px;
+}
+@media (min-width: 600px) {
+  .introduction-card-row {
+    flex-flow: row wrap;
+  }
 }
 .introduction-card-row > * {
   flex: 1;

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -37,21 +37,21 @@ const formattedSpecTitle = computed(() => {
   <SectionContainer>
     <Section class="introduction-section">
       <SectionContent :loading="!info.description && !info.title">
+        <div class="badges">
+          <Badge v-if="info.version">
+            {{ info.version }}
+          </Badge>
+          <Badge v-if="specVersion"> OAS {{ specVersion }}</Badge>
+        </div>
+        <SectionHeader
+          :level="1"
+          :loading="!info.title"
+          tight>
+          {{ info.title }}
+        </SectionHeader>
+        <DownloadLink :specTitle="formattedSpecTitle" />
         <SectionColumns>
           <SectionColumn>
-            <div class="badges">
-              <Badge v-if="info.version">
-                {{ info.version }}
-              </Badge>
-              <Badge v-if="specVersion"> OAS {{ specVersion }}</Badge>
-            </div>
-            <SectionHeader
-              :level="1"
-              :loading="!info.title"
-              tight>
-              {{ info.title }}
-            </SectionHeader>
-            <DownloadLink :specTitle="formattedSpecTitle" />
             <Description :value="info.description" />
           </SectionColumn>
           <SectionColumn v-if="$slots.aside">

--- a/packages/api-reference/src/components/Content/Tag/Endpoints.vue
+++ b/packages/api-reference/src/components/Content/Tag/Endpoints.vue
@@ -33,12 +33,12 @@ const scrollHandler = async (operation: TransformedOperation) => {
   <Section
     :id="id"
     :label="tag.name.toUpperCase()">
+    <SectionHeader :level="2">
+      <Anchor :id="getTagId(tag)">{{ tagName }}</Anchor>
+    </SectionHeader>
     <SectionContent>
       <SectionColumns>
         <SectionColumn>
-          <SectionHeader :level="2">
-            <Anchor :id="getTagId(tag)">{{ tagName }}</Anchor>
-          </SectionHeader>
           <ScalarMarkdown
             :clamp="isCollapsed ? '7' : false"
             :value="tag.description"

--- a/packages/api-reference/src/components/Content/Tag/TagAccordion.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagAccordion.vue
@@ -41,5 +41,6 @@ const { getTagId } = useNavState()
 }
 .tag-description {
   padding-bottom: 4px;
+  text-align: left;
 }
 </style>

--- a/packages/api-reference/src/components/Section/SectionColumn.vue
+++ b/packages/api-reference/src/components/Section/SectionColumn.vue
@@ -7,9 +7,6 @@
   flex: 1;
   min-width: 0;
 }
-.section-column:nth-of-type(2) {
-  padding-top: 48px;
-}
 @container narrow-references-container (max-width: 900px) {
   .section-column:nth-of-type(2) {
     padding-top: 0;

--- a/packages/api-reference/src/components/Section/SectionContainerAccordion.vue
+++ b/packages/api-reference/src/components/Section/SectionContainerAccordion.vue
@@ -69,6 +69,9 @@ import { ScalarIcon } from '@scalar/components'
   flex: 1;
   padding: 0 6px;
 }
+.section-accordion-title :deep(.section-header-wrapper) {
+  grid-template-columns: 1fr;
+}
 .section-accordion-title :deep(.section-header) {
   margin-bottom: 0;
 }

--- a/packages/api-reference/src/components/Section/SectionHeader.vue
+++ b/packages/api-reference/src/components/Section/SectionHeader.vue
@@ -12,17 +12,30 @@ withDefaults(
 </script>
 
 <template>
-  <LoadingSkeleton v-if="loading" />
-  <component
-    :is="`h${level}`"
-    v-else
-    class="section-header"
-    :class="{ tight }">
-    <slot />
-  </component>
+  <div class="section-header-wrapper">
+    <LoadingSkeleton v-if="loading" />
+    <component
+      :is="`h${level}`"
+      v-else
+      class="section-header"
+      :class="{ tight }">
+      <slot />
+    </component>
+  </div>
 </template>
 
 <style scoped>
+.section-header-wrapper {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+@screen xl {
+  .section-header-wrapper {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 .section-header {
   font-size: var(--font-size, var(--scalar-heading-2));
   font-weight: var(--font-weight, var(--scalar-bold));

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -202,9 +202,15 @@ const getHideTestRequestButton = inject(HIDE_TEST_REQUEST_BUTTON_SYMBOL)
 .endpoint-content {
   display: grid;
   grid-auto-columns: 1fr;
-  grid-auto-flow: column;
+  grid-auto-flow: row;
   gap: 9px;
   padding: 9px;
+}
+
+@screen lg {
+  .endpoint-content {
+    grid-auto-flow: column;
+  }
 }
 
 @container (max-width: 900px) {

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -28,16 +28,16 @@ defineProps<{
     :id="id"
     :label="operation.name">
     <SectionContent>
+      <Badge v-if="operation.information?.deprecated"> Deprecated </Badge>
+      <div :class="operation.information?.deprecated ? 'deprecated' : ''">
+        <SectionHeader :level="3">
+          <Anchor :id="id ?? ''">
+            {{ operation.name }}
+          </Anchor>
+        </SectionHeader>
+      </div>
       <SectionColumns>
         <SectionColumn>
-          <Badge v-if="operation.information?.deprecated"> Deprecated </Badge>
-          <div :class="operation.information?.deprecated ? 'deprecated' : ''">
-            <SectionHeader :level="3">
-              <Anchor :id="id ?? ''">
-                {{ operation.name }}
-              </Anchor>
-            </SectionHeader>
-          </div>
           <div class="operation-details">
             <ScalarMarkdown
               :value="operation.description"


### PR DESCRIPTION
this pr fixes #3956 by:
- enhancing section header display with long content
- fixing classic layout responsiveness

**⊢ header before / after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/fdd1cdb8-58ef-43ee-b4c2-60d0e1b4f69a">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/a3966982-2c0d-43b0-9306-57be384b99b4"> 
</div>

**⊢ classic alignment + border before / after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8f7648f7-44bf-4600-ab1c-dae9b736dd35">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/bd1d9ed4-bfdc-4d08-9265-10e3ca0d31da">
</div>

**⊢ classic mobile before / after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/88ff3664-d397-4833-a6f1-ed0b9a98772f">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7d0e4b14-8b01-49e5-b2d9-e62c39cc42c7">
</div>