### PR TITLE
fix(components): scalar menu flex not on just small screen

### DIFF
--- a/.changeset/stupid-dryers-warn.md
+++ b/.changeset/stupid-dryers-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): remove col on larger screens only use row

--- a/packages/components/src/components/ScalarMenu/ScalarMenuProduct.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuProduct.vue
@@ -8,7 +8,7 @@ defineProps<{
 </script>
 <template>
   <a
-    class="relative flex min-w-0 flex-1 flex-col items-center gap-2 overflow-hidden rounded px-2 py-1.5 leading no-underline xs:flex-row"
+    class="relative flex min-w-0 flex-1 items-center gap-2 overflow-hidden rounded px-2 py-1.5 leading no-underline flex-row"
     :class="
       selected
         ? 'pointer-events-none bg-b-2'


### PR DESCRIPTION
This menu has flex-col on larger, screens

<img width="308" alt="image" src="https://github.com/user-attachments/assets/09f70d2b-3511-4759-82d6-bde3522b107f">

this pr fixes that