### PR TITLE
feat(components): cleanup and extend floating components

### DIFF
--- a/.changeset/purple-otters-suffer.md
+++ b/.changeset/purple-otters-suffer.md
@@ -1,0 +1,6 @@
+---
+'@scalar/components': minor
+'@scalar/api-client': patch
+---
+
+feat(components): cleanup and extend floating components

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
@@ -133,7 +133,7 @@ const handleSubmit = () => {
       placeholder="Request Name"
       @onDelete="emits('back', $event)" />
     <template #options>
-      <div class="flex gap-2">
+      <div class="flex">
         <HttpMethod
           :isEditable="true"
           isSquare
@@ -143,7 +143,7 @@ const handleSubmit = () => {
           v-model="selectedCollection"
           :options="collections">
           <ScalarButton
-            class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+            class="justify-between p-2 ml-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
             variant="outlined">
             <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
               selectedCollection
@@ -161,7 +161,7 @@ const handleSubmit = () => {
           v-model="selectedTag"
           :options="tags">
           <ScalarButton
-            class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+            class="justify-between p-2 ml-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
             variant="outlined">
             <span :class="selectedTag ? 'text-c-1' : 'text-c-3'">
               {{ selectedTag ? selectedTag.label : 'Select Tag' }}

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -37,7 +37,7 @@ const envs = computed(() => [
 </script>
 <template>
   <div>
-    <ScalarDropdown>
+    <ScalarDropdown placement="bottom-end">
       <ScalarButton
         class="font-normal h-auto justify-start py-1.5 px-1.5 pl-2 text-c-1 hover:bg-b-2 text-c-1 w-fit"
         fullWidth

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -7,6 +7,7 @@ import {
   ScalarDropdownDivider,
   ScalarDropdownItem,
   ScalarIcon,
+  ScalarListboxCheckbox,
 } from '@scalar/components'
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
@@ -56,18 +57,8 @@ const envs = computed(() => [
           :key="env.uid"
           class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden"
           @click.stop="updateSelected(env.uid)">
-          <div
-            class="flex items-center justify-center rounded-full p-[3px] w-4 h-4"
-            :class="
-              activeWorkspace.activeEnvironmentId === env.uid
-                ? 'bg-c-accent text-b-1'
-                : 'group-hover/item:shadow-border text-transparent'
-            ">
-            <ScalarIcon
-              class="size-2.5"
-              icon="Checkmark"
-              thickness="3.5" />
-          </div>
+          <ScalarListboxCheckbox
+            :selected="activeWorkspace.activeEnvironmentId === env.uid" />
           {{ env.name }}
         </ScalarDropdownItem>
         <ScalarDropdownItem

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -7,8 +7,9 @@ import { useActiveEntities } from '@/store/active-entities'
 import {
   type Icon,
   ScalarContextMenu,
-  ScalarDropdown,
-  ScalarDropdownItem,
+  ScalarDropdownButton,
+  ScalarDropdownMenu,
+  ScalarFloating,
   ScalarIcon,
 } from '@scalar/components'
 import { capitalize } from '@scalar/oas-utils/helpers'
@@ -165,33 +166,33 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
               <span>{{ topNavItems[0].label }}</span>
             </template>
             <template #content>
-              <ScalarDropdown
-                class="scalar-client"
-                static>
-                <template #items>
-                  <ScalarDropdownItem
-                    class="flex items-center gap-1.5"
-                    @click="addNavItem">
-                    <ScalarIcon
-                      icon="AddTab"
-                      size="sm"
-                      thickness="1.5" />
-                    New Tab
-                    <ScalarHotkey
-                      class="bg-b-2 ml-auto"
-                      hotkey="T" />
-                  </ScalarDropdownItem>
-                  <ScalarDropdownItem
-                    class="flex items-center gap-1.5"
-                    @click="copyUrl(activeNavItemIdxValue)">
-                    <ScalarIcon
-                      icon="Link"
-                      size="sm"
-                      thickness="1.5" />
-                    Copy URL
-                  </ScalarDropdownItem>
+              <ScalarFloating placement="right-start">
+                <template #floating>
+                  <ScalarDropdownMenu class="scalar-app scalar-client">
+                    <ScalarDropdownButton
+                      class="flex items-center gap-1.5"
+                      @click="addNavItem">
+                      <ScalarIcon
+                        icon="AddTab"
+                        size="sm"
+                        thickness="1.5" />
+                      New Tab
+                      <ScalarHotkey
+                        class="bg-b-2 ml-auto"
+                        hotkey="T" />
+                    </ScalarDropdownButton>
+                    <ScalarDropdownButton
+                      class="flex items-center gap-1.5"
+                      @click="copyUrl(activeNavItemIdxValue)">
+                      <ScalarIcon
+                        icon="Link"
+                        size="sm"
+                        thickness="1.5" />
+                      Copy URL
+                    </ScalarDropdownButton>
+                  </ScalarDropdownMenu>
                 </template>
-              </ScalarDropdown>
+              </ScalarFloating>
             </template>
           </ScalarContextMenu>
         </div>

--- a/packages/api-client/src/components/TopNav/TopNavItem.vue
+++ b/packages/api-client/src/components/TopNav/TopNavItem.vue
@@ -3,9 +3,10 @@ import ScalarHotkey from '@/components/ScalarHotkey.vue'
 import {
   type Icon,
   ScalarContextMenu,
-  ScalarDropdown,
+  ScalarDropdownButton,
   ScalarDropdownDivider,
-  ScalarDropdownItem,
+  ScalarDropdownMenu,
+  ScalarFloating,
   ScalarIcon,
   ScalarTooltip,
 } from '@scalar/components'
@@ -68,55 +69,55 @@ defineEmits<{
       </ScalarTooltip>
     </template>
     <template #content>
-      <ScalarDropdown
-        class="scalar-client"
-        static>
-        <template #items>
-          <ScalarDropdownItem
-            class="flex items-center gap-1.5"
-            @click="$emit('newTab')">
-            <ScalarIcon
-              icon="AddTab"
-              size="sm"
-              thickness="1.5" />
-            New Tab
-            <ScalarHotkey
-              class="bg-b-2 ml-auto"
-              hotkey="T" />
-          </ScalarDropdownItem>
-          <ScalarDropdownItem
-            class="flex items-center gap-1.5"
-            @click="$emit('copyUrl')">
-            <ScalarIcon
-              icon="Link"
-              size="sm"
-              thickness="1.5" />
-            Copy URL
-          </ScalarDropdownItem>
-          <ScalarDropdownDivider />
-          <ScalarDropdownItem
-            class="flex items-center gap-1.5"
-            @click="$emit('close')">
-            <ScalarIcon
-              icon="CloseTab"
-              size="sm"
-              thickness="1.5" />
-            Close Tab
-            <ScalarHotkey
-              class="bg-b-2 ml-auto"
-              hotkey="W" />
-          </ScalarDropdownItem>
-          <ScalarDropdownItem
-            class="flex items-center gap-1.5"
-            @click="$emit('closeOtherTabs')">
-            <ScalarIcon
-              icon="CloseTabs"
-              size="sm"
-              thickness="1.5" />
-            Close Other Tabs
-          </ScalarDropdownItem>
+      <ScalarFloating placement="right-start">
+        <template #floating>
+          <ScalarDropdownMenu class="scalar-app scalar-client">
+            <ScalarDropdownButton
+              class="flex items-center gap-1.5"
+              @click="$emit('newTab')">
+              <ScalarIcon
+                icon="AddTab"
+                size="sm"
+                thickness="1.5" />
+              New Tab
+              <ScalarHotkey
+                class="bg-b-2 ml-auto"
+                hotkey="T" />
+            </ScalarDropdownButton>
+            <ScalarDropdownButton
+              class="flex items-center gap-1.5"
+              @click="$emit('copyUrl')">
+              <ScalarIcon
+                icon="Link"
+                size="sm"
+                thickness="1.5" />
+              Copy URL
+            </ScalarDropdownButton>
+            <ScalarDropdownDivider />
+            <ScalarDropdownButton
+              class="flex items-center gap-1.5"
+              @click="$emit('close')">
+              <ScalarIcon
+                icon="CloseTab"
+                size="sm"
+                thickness="1.5" />
+              Close Tab
+              <ScalarHotkey
+                class="bg-b-2 ml-auto"
+                hotkey="W" />
+            </ScalarDropdownButton>
+            <ScalarDropdownButton
+              class="flex items-center gap-1.5"
+              @click="$emit('closeOtherTabs')">
+              <ScalarIcon
+                icon="CloseTabs"
+                size="sm"
+                thickness="1.5" />
+              Close Other Tabs
+            </ScalarDropdownButton>
+          </ScalarDropdownMenu>
         </template>
-      </ScalarDropdown>
+      </ScalarFloating>
     </template>
   </ScalarContextMenu>
 </template>

--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -165,6 +165,7 @@ onClickOutside(
           icon="Add" />
         Add Variable
       </ScalarButton>
+      <!-- Backdrop for the dropdown -->
       <div
         class="absolute inset-0 -z-1 rounded bg-b-1 shadow-lg brightness-lifted" />
     </div>

--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { parseEnvVariables } from '@/libs'
 import type { ActiveEntitiesStore } from '@/store/active-entities'
-import { ScalarButton, ScalarDropdown, ScalarIcon } from '@scalar/components'
+import { ScalarButton, ScalarIcon } from '@scalar/components'
 import { onClickOutside } from '@vueuse/core'
 import Fuse from 'fuse.js'
-import { computed, onMounted, ref } from 'vue'
+import { type CSSProperties, computed, onMounted, ref } from 'vue'
 import type { Router } from 'vue-router'
 
 const props = defineProps<{
@@ -54,7 +54,7 @@ const filteredVariables = computed(() => {
   }
 
   /** filter environment variables by name */
-  const result = fuse.search(searchQuery)
+  const result = fuse.search(searchQuery, { limit: 10 })
   if (result.length > 0) {
     return result
       .map((res) => res.item)
@@ -108,6 +108,14 @@ onMounted(() => {
   selectedVariableIndex.value = 0
 })
 
+const dropdownStyle = computed<CSSProperties>(() => {
+  return {
+    left: (props.dropdownPosition?.left ?? 0) + 'px',
+    // Add a 5px offset from the editor
+    top: (props.dropdownPosition?.top ?? 0) + 5 + 'px',
+  }
+})
+
 onClickOutside(
   dropdownRef,
   () => {
@@ -117,16 +125,13 @@ onClickOutside(
 )
 </script>
 <template>
-  <ScalarDropdown
-    ref="dropdownRef"
-    static
-    :staticOpen="isOpen"
-    :style="{
-      left: dropdownPosition?.left + 'px',
-      top: dropdownPosition?.top + 'px',
-    }"
-    teleport=".scalar-client">
-    <template #items>
+  <Teleport
+    v-if="isOpen"
+    :to="'.scalar-client'">
+    <div
+      ref="dropdownRef"
+      class="fixed left-0 top-0 flex flex-col p-0.75 max-h-[60svh] w-56 rounded border custom-scroll"
+      :style="dropdownStyle">
       <ul v-if="filteredVariables.length">
         <template
           v-for="(item, index) in filteredVariables"
@@ -135,7 +140,6 @@ onClickOutside(
             class="h-8 font-code text-xxs hover:bg-b-2 flex cursor-pointer items-center justify-between gap-1.5 rounded p-1.5 transition-colors duration-150"
             :class="{ 'bg-b-2': index === selectedVariableIndex }"
             @click="selectVariable(item.key)">
-            <!-- @click.stop="selectVariable(variable)" -->
             <div class="flex items-center gap-1.5 whitespace-nowrap">
               <span
                 class="h-2.5 w-2.5 min-w-2.5 rounded-full"
@@ -161,6 +165,8 @@ onClickOutside(
           icon="Add" />
         Add Variable
       </ScalarButton>
-    </template>
-  </ScalarDropdown>
+      <div
+        class="absolute inset-0 -z-1 rounded bg-b-1 shadow-lg brightness-lifted" />
+    </div>
+  </Teleport>
 </template>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -321,9 +321,10 @@ const hasDraftRequests = computed(() => {
                 v-if="!isReadOnly"
                 class="px-0.5 py-0 hover:bg-b-3 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
                 :class="{
-                  flex:
+                  'flex':
                     menuItem?.item?.entity.uid === item.entity.uid &&
                     menuItem.open,
+                  'opacity-100': menuItem.open,
                 }"
                 size="sm"
                 type="button"
@@ -333,8 +334,8 @@ const hasDraftRequests = computed(() => {
                     $emit('openMenu', {
                       item,
                       parentUids,
-                      targetRef: ev.currentTarget.parentNode,
-                      open: true,
+                      targetRef: ev.currentTarget,
+                      open: !menuItem.open,
                     })
                 ">
                 <ScalarIcon

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -321,10 +321,9 @@ const hasDraftRequests = computed(() => {
                 v-if="!isReadOnly"
                 class="px-0.5 py-0 hover:bg-b-3 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
                 :class="{
-                  'flex':
+                  flex:
                     menuItem?.item?.entity.uid === item.entity.uid &&
                     menuItem.open,
-                  'opacity-100': menuItem.open,
                 }"
                 size="sm"
                 type="button"

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -116,7 +116,7 @@ const isDraftsMenuItem = computed(() => {
   <ScalarDropdown
     v-if="menuItem.targetRef && menuItem.open"
     static
-    :targetRef="menuItem.targetRef"
+    :target="menuItem.targetRef"
     teleport
     @keydown.escape="$emit('closeMenu')">
     <template #items>

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -8,8 +8,10 @@ import { useActiveEntities } from '@/store/active-entities'
 import { createInitialRequest } from '@/store/requests'
 import type { SidebarMenuItem } from '@/views/Request/types'
 import {
-  ScalarDropdown,
-  ScalarDropdownItem,
+  type ScalarDropdown,
+  ScalarDropdownButton,
+  ScalarDropdownMenu,
+  ScalarFloating,
   ScalarIcon,
   ScalarModal,
   useModal,
@@ -113,47 +115,47 @@ const isDraftsMenuItem = computed(() => {
 </script>
 
 <template>
-  <ScalarDropdown
+  <ScalarFloating
     v-if="menuItem.targetRef && menuItem.open"
-    static
+    placement="right-start"
     :target="menuItem.targetRef"
-    teleport
-    @keydown.escape="$emit('closeMenu')">
-    <template #items>
-      <!-- Add example -->
-      <ScalarDropdownItem
-        v-if="menuItem.item?.entity.type === 'request'"
-        class="flex gap-2"
-        @click="handleAddExample">
-        <ScalarIcon
-          class="inline-flex"
-          icon="Example"
-          size="md"
-          thickness="1.5" />
-        <span>Add Example</span>
-      </ScalarDropdownItem>
+    teleport>
+    <template #floating>
+      <ScalarDropdownMenu @keydown.escape="$emit('closeMenu')">
+        <!-- Add example -->
+        <ScalarDropdownButton
+          v-if="menuItem.item?.entity.type === 'request'"
+          class="flex gap-2"
+          @click="handleAddExample">
+          <ScalarIcon
+            class="inline-flex"
+            icon="Example"
+            size="md"
+            thickness="1.5" />
+          <span>Add Example</span>
+        </ScalarDropdownButton>
 
-      <!-- Rename -->
-      <ScalarDropdownItem
-        v-if="!isDraftsMenuItem"
-        ref="menuRef"
-        class="flex gap-2"
-        @click="editModal.show()">
-        <ScalarIcon
-          class="inline-flex"
-          icon="Edit"
-          size="md"
-          thickness="1.5" />
-        <span>
-          <template v-if="menuItem.item?.entity.type === 'collection'">
-            Edit
-          </template>
-          <template v-else> Rename </template>
-        </span>
-      </ScalarDropdownItem>
+        <!-- Rename -->
+        <ScalarDropdownButton
+          v-if="!isDraftsMenuItem"
+          ref="menuRef"
+          class="flex gap-2"
+          @click="editModal.show()">
+          <ScalarIcon
+            class="inline-flex"
+            icon="Edit"
+            size="md"
+            thickness="1.5" />
+          <span>
+            <template v-if="menuItem.item?.entity.type === 'collection'">
+              Edit
+            </template>
+            <template v-else> Rename </template>
+          </span>
+        </ScalarDropdownButton>
 
-      <!-- Duplicate -->
-      <!-- <ScalarDropdownItem
+        <!-- Duplicate -->
+        <!-- <ScalarDropdownButton
         class="flex !gap-2"
         @click="handleItemDuplicate">
         <ScalarIcon
@@ -162,56 +164,57 @@ const isDraftsMenuItem = computed(() => {
           icon="Duplicate"
           size="sm" />
         <span>Duplicate</span>
-      </ScalarDropdownItem>
+      </ScalarDropdownButton>
       <ScalarDropdownDivider /> -->
 
-      <!-- Watch -->
-      <ScalarDropdownItem
-        v-if="menuItem.item?.documentUrl"
-        ref="menuRef"
-        class="flex gap-2"
-        @click="toggleWatchMode">
-        <ScalarIcon
-          class="inline-flex"
-          :icon="menuItem.item?.watchMode ? 'Unwatch' : 'Watch'"
-          size="md"
-          thickness="1.5" />
-        <span>
-          {{
-            menuItem.item?.watchMode
-              ? 'Disable Watch Mode'
-              : 'Enable Watch Mode'
-          }}
-        </span>
-      </ScalarDropdownItem>
+        <!-- Watch -->
+        <ScalarDropdownButton
+          v-if="menuItem.item?.documentUrl"
+          ref="menuRef"
+          class="flex gap-2"
+          @click="toggleWatchMode">
+          <ScalarIcon
+            class="inline-flex"
+            :icon="menuItem.item?.watchMode ? 'Unwatch' : 'Watch'"
+            size="md"
+            thickness="1.5" />
+          <span>
+            {{
+              menuItem.item?.watchMode
+                ? 'Disable Watch Mode'
+                : 'Enable Watch Mode'
+            }}
+          </span>
+        </ScalarDropdownButton>
 
-      <!-- Delete -->
-      <ScalarDropdownItem
-        v-if="!isDraftsMenuItem"
-        class="flex gap-2"
-        @click="deleteModal.show()">
-        <ScalarIcon
-          class="inline-flex"
-          icon="Delete"
-          size="md"
-          thickness="1.5" />
-        <span>Delete</span>
-      </ScalarDropdownItem>
+        <!-- Delete -->
+        <ScalarDropdownButton
+          v-if="!isDraftsMenuItem"
+          class="flex gap-2"
+          @click="deleteModal.show()">
+          <ScalarIcon
+            class="inline-flex"
+            icon="Delete"
+            size="md"
+            thickness="1.5" />
+          <span>Delete</span>
+        </ScalarDropdownButton>
 
-      <!-- Clear Drafts -->
-      <ScalarDropdownItem
-        v-if="isDraftsMenuItem"
-        class="flex gap-2"
-        @click="clearDraftsModal.show()">
-        <ScalarIcon
-          class="inline-flex"
-          icon="Delete"
-          size="md"
-          thickness="1.5" />
-        <span>Clear Drafts</span>
-      </ScalarDropdownItem>
+        <!-- Clear Drafts -->
+        <ScalarDropdownButton
+          v-if="isDraftsMenuItem"
+          class="flex gap-2"
+          @click="clearDraftsModal.show()">
+          <ScalarIcon
+            class="inline-flex"
+            icon="Delete"
+            size="md"
+            thickness="1.5" />
+          <span>Clear Drafts</span>
+        </ScalarDropdownButton>
+      </ScalarDropdownMenu>
     </template>
-  </ScalarDropdown>
+  </ScalarFloating>
 
   <!-- Modals -->
   <ScalarModal

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -9,6 +9,7 @@ import {
   ScalarDropdownDivider,
   ScalarDropdownItem,
   ScalarIcon,
+  ScalarListboxCheckbox,
   ScalarModal,
   ScalarTooltip,
   useModal,
@@ -113,18 +114,7 @@ const deleteWorkspace = async () => {
             :key="uid"
             class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden w-full"
             @click.stop="updateSelected(uid)">
-            <div
-              class="flex items-center justify-center rounded-full p-[3px] w-4 h-4"
-              :class="
-                activeWorkspace.uid === uid
-                  ? 'bg-c-accent text-b-1'
-                  : 'group-hover/item:shadow-border text-transparent'
-              ">
-              <ScalarIcon
-                class="size-2.5"
-                icon="Checkmark"
-                thickness="3.5" />
-            </div>
+            <ScalarListboxCheckbox :selected="activeWorkspace.uid === uid" />
             <span class="text-ellipsis overflow-hidden">{{
               workspace.name
             }}</span>

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -118,7 +118,9 @@ const deleteWorkspace = async () => {
             <span class="text-ellipsis overflow-hidden">{{
               workspace.name
             }}</span>
-            <ScalarDropdown teleport=".scalar-client">
+            <ScalarDropdown
+              placement="right-start"
+              teleport=".scalar-client">
               <ScalarButton
                 class="px-0.5 py-0 hover:bg-b-3 group-hover/item:flex aspect-square ml-auto -mr-1 h-fit"
                 size="sm"

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.spec.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.spec.ts
@@ -15,6 +15,8 @@ describe('ScalarCombobox', () => {
       },
       slots: {
         default: `<button>Button</button>`,
+        before: `<div>Before</div>`,
+        after: `<div>After</div>`,
       },
     })
 

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
@@ -72,7 +72,7 @@ export const Base: Story = {
       return { args, selected }
     },
     template: `
-<div class="flex justify-center w-full h-72">
+<div class="flex justify-center w-full min-h-96">
   <ScalarCombobox v-model="selected" placeholder="Change fruit..." v-bind="args">
     <ScalarButton class="w-48 px-3" variant="outlined">
       <div class="flex flex-1 items-center min-w-0">
@@ -100,7 +100,7 @@ export const Groups: Story = {
       return { args, selected }
     },
     template: `
-<div class="flex justify-center w-full h-72">
+<div class="flex justify-center w-full min-h-96">
   <ScalarCombobox v-model="selected" placeholder="Change city..." v-bind="args">
     <ScalarButton class="w-48 px-3" variant="outlined">
       <div class="flex flex-1 items-center min-w-0">
@@ -128,7 +128,7 @@ export const Multiselect: Story = {
       return { args, selected }
     },
     template: `
-<div class="flex justify-center w-full h-72">
+<div class="flex justify-center w-full min-h-96">
   <ScalarComboboxMultiselect v-model="selected" placeholder="Select fruits..." v-bind="args">
     <ScalarButton class="w-48 px-3" variant="outlined">
       <div class="flex flex-1 items-center min-w-0">
@@ -156,7 +156,7 @@ export const MultiselectGroups: Story = {
       return { args, selected }
     },
     template: `
-<div class="flex justify-center w-full h-72">
+<div class="flex justify-center w-full min-h-96">
   <ScalarComboboxMultiselect v-model="selected" placeholder="Select cities..." v-bind="args">
     <ScalarButton class="w-48 px-3" variant="outlined">
       <div class="flex flex-1 items-center min-w-0">

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
@@ -21,7 +21,7 @@ defineEmits<{
     :isOpen="isOpen"
     :placement="placement ?? 'bottom-start'"
     :resize="resize"
-    :targetRef="targetRef"
+    :target="target"
     :teleport="teleport">
     <slot />
     <template #popover="{ open, close }">

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
@@ -9,7 +9,7 @@ defineProps<
     options: Option[] | OptionGroup[]
     modelValue?: Option
     placeholder?: string
-  } & Omit<FloatingOptions, 'middleware'>
+  } & FloatingOptions
 >()
 
 defineEmits<{
@@ -19,6 +19,7 @@ defineEmits<{
 <template>
   <ComboboxPopover
     :isOpen="isOpen"
+    :middleware="middleware"
     :placement="placement ?? 'bottom-start'"
     :resize="resize"
     :target="target"

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
@@ -1,30 +1,47 @@
 <script setup lang="ts">
-import type { FloatingOptions } from '../ScalarFloating'
+import type { Slot } from 'vue'
+
+import type { ScalarFloatingOptions } from '../ScalarFloating'
 import ComboboxOptions from './ScalarComboboxOptions.vue'
 import ComboboxPopover from './ScalarComboboxPopover.vue'
 import type { Option, OptionGroup } from './types'
 
-defineProps<
-  {
-    options: Option[] | OptionGroup[]
-    modelValue?: Option
-    placeholder?: string
-  } & FloatingOptions
->()
+type Props = {
+  options: Option[] | OptionGroup[]
+  modelValue?: Option
+  placeholder?: string
+} & ScalarFloatingOptions
+
+type SlotProps = {
+  /** Whether or not the combobox is open */
+  open: boolean
+}
+
+defineProps<Props>()
 
 defineEmits<{
   (e: 'update:modelValue', v: Option): void
 }>()
+
+defineSlots<{
+  /** The reference element for the combobox */
+  default(props: SlotProps): Slot
+  /** A slot for contents before the combobox options */
+  before(props: SlotProps): Slot
+  /** A slot for contents after the combobox options */
+  after(props: SlotProps): Slot
+}>()
 </script>
 <template>
   <ComboboxPopover
-    :isOpen="isOpen"
     :middleware="middleware"
     :placement="placement ?? 'bottom-start'"
     :resize="resize"
     :target="target"
     :teleport="teleport">
-    <slot />
+    <template #default="{ open }">
+      <slot :open="open" />
+    </template>
     <template #popover="{ open, close }">
       <ComboboxOptions
         :modelValue="modelValue ? [modelValue] : []"
@@ -35,12 +52,16 @@ defineEmits<{
         <template
           v-if="$slots.before"
           #before>
-          <slot name="before" />
+          <slot
+            name="before"
+            :open="open" />
         </template>
         <template
           v-if="$slots.after"
           #after>
-          <slot name="after" />
+          <slot
+            name="after"
+            :open="open" />
         </template>
       </ComboboxOptions>
     </template>

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
@@ -21,6 +21,7 @@ defineEmits<{
     :isOpen="isOpen"
     :placement="placement ?? 'bottom-start'"
     :resize="resize"
+    :targetRef="targetRef"
     :teleport="teleport">
     <slot />
     <template #popover="{ open, close }">
@@ -29,9 +30,18 @@ defineEmits<{
         :open="open"
         :options="options"
         :placeholder="placeholder"
-        @update:modelValue="
-          (v) => (close(), $emit('update:modelValue', v[0]))
-        " />
+        @update:modelValue="(v) => (close(), $emit('update:modelValue', v[0]))">
+        <template
+          v-if="$slots.before"
+          #before>
+          <slot name="before" />
+        </template>
+        <template
+          v-if="$slots.after"
+          #after>
+          <slot name="after" />
+        </template>
+      </ComboboxOptions>
     </template>
   </ComboboxPopover>
 </template>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
-import type { FloatingOptions } from '../ScalarFloating'
+import type { ScalarFloatingOptions } from '../ScalarFloating'
 import ComboboxOptions from './ScalarComboboxOptions.vue'
 import ComboboxPopover from './ScalarComboboxPopover.vue'
 import type { Option, OptionGroup } from './types'
@@ -12,7 +12,7 @@ defineProps<
     modelValue?: Option[]
     placeholder?: string
     isDeletable?: boolean
-  } & Omit<FloatingOptions, 'middleware'>
+  } & ScalarFloatingOptions
 >()
 
 defineEmits<{
@@ -28,9 +28,10 @@ defineExpose({ comboboxPopoverRef })
 <template>
   <ComboboxPopover
     ref="comboboxPopoverRef"
-    :isOpen="isOpen"
+    :middleware="middleware"
     :placement="placement ?? 'bottom-start'"
     :resize="resize"
+    :target="target"
     :teleport="teleport">
     <slot />
     <template #popover="{ open }">

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { cva, cx } from '../../cva'
 import { ScalarIcon } from '../ScalarIcon'
+import { ScalarListboxCheckbox } from '../ScalarListbox'
 
 defineProps<{
   active?: boolean
@@ -15,8 +16,9 @@ defineEmits<{
 
 const variants = cva({
   base: [
+    // Group
+    'group/item',
     // Layout
-    'group',
     'flex min-w-0 items-center gap-1.5 rounded px-2 py-1.5 text-left',
     // Text / background style
     'truncate bg-transparent text-c-1',
@@ -30,25 +32,14 @@ const variants = cva({
 })
 </script>
 <template>
-  <li :class="cx(variants({ active, selected }), 'group')">
-    <div
-      class="flex size-4 items-center justify-center p-0.75"
-      :class="[
-        selected
-          ? 'bg-c-accent text-b-1'
-          : 'text-transparent group-hover:shadow-border',
-        style === 'checkbox' ? 'rounded' : 'rounded-full',
-      ]">
-      <!-- Icon needs help to be optically centered (╥﹏╥) -->
-      <ScalarIcon
-        class="relative top-[0.5px] size-2.5"
-        icon="Checkmark"
-        thickness="2.5" />
-    </div>
+  <li :class="cx(variants({ active, selected }))">
+    <ScalarListboxCheckbox
+      :selected="selected"
+      :style="style" />
     <span class="inline-block min-w-0 flex-1 truncate text-c-1"><slot /></span>
     <ScalarIcon
       v-if="isDeletable"
-      class="text-c-2 opacity-0 group-hover:opacity-100"
+      class="text-c-2 opacity-0 group-hover/item:opacity-100"
       icon="Delete"
       size="md"
       thickness="1.5"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { cva, cx } from '../../cva'
 import { ScalarIcon } from '../ScalarIcon'
-import { ScalarListboxCheckbox } from '../ScalarListbox'
+import {
+  ScalarListboxCheckbox,
+  type ScalarListboxOptionStyle,
+} from '../ScalarListbox'
 
 defineProps<{
   active?: boolean
   selected?: boolean
-  style?: 'radio' | 'checkbox' | 'button'
+  style?: ScalarListboxOptionStyle
   isDeletable?: boolean
 }>()
 

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
@@ -5,8 +5,12 @@ import { ScalarIcon } from '../ScalarIcon'
 defineProps<{
   active?: boolean
   selected?: boolean
-  style?: 'radio' | 'checkbox'
+  style?: 'radio' | 'checkbox' | 'button'
   isDeletable?: boolean
+}>()
+
+defineEmits<{
+  (e: 'delete'): void
 }>()
 
 const variants = cva({

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -113,9 +113,10 @@ function moveActive(dir: 1 | -1) {
       @keydown.up.prevent="moveActive(-1)" />
   </div>
   <ul
-    v-show="filtered.length"
+    v-show="filtered.length || $slots.before || $slots.after"
     :id="id"
     class="border-t p-0.75">
+    <slot name="before" />
     <template
       v-for="(group, i) in groups"
       :key="i">
@@ -145,5 +146,6 @@ function moveActive(dir: 1 | -1) {
         </ComboboxOption>
       </template>
     </template>
+    <slot name="after" />
   </ul>
 </template>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { nanoid } from 'nanoid'
-import { computed, ref, watch } from 'vue'
+import { type Slot, computed, ref, watch } from 'vue'
 
 import { ScalarIcon } from '../ScalarIcon'
 import ComboboxOption from './ScalarComboboxOption.vue'
@@ -18,6 +18,13 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'update:modelValue', v: Option[]): void
   (e: 'delete', option: Option): void
+}>()
+
+defineSlots<{
+  /** A slot for contents before the combobox options */
+  before(): Slot
+  /** A slot for contents after the combobox options */
+  after(): Slot
 }>()
 
 defineOptions({ inheritAttrs: false })

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
@@ -2,9 +2,12 @@
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
 import { ref } from 'vue'
 
-import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
+import { ScalarFloating, type ScalarFloatingOptions } from '../ScalarFloating'
+import type { ScalarPopoverSlots } from '../ScalarPopover'
 
-defineProps<Omit<FloatingOptions, 'middleware'>>()
+defineProps<ScalarFloatingOptions>()
+
+defineSlots<ScalarPopoverSlots>()
 
 defineOptions({ inheritAttrs: false })
 
@@ -24,17 +27,12 @@ defineExpose({ popoverButtonRef })
   <Popover
     v-slot="{ open }"
     as="template">
-    <ScalarFloating
-      :isOpen="open ?? isOpen"
-      :placement="placement ?? 'bottom-start'"
-      :resize="resize"
-      :target="target"
-      :teleport="teleport">
+    <ScalarFloating v-bind="$props">
       <PopoverButton
         ref="popoverButtonRef"
         as="template"
         @keydown="handleKeydown">
-        <slot />
+        <slot :open="open" />
       </PopoverButton>
       <template #floating="{ width }">
         <PopoverPanel

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
@@ -34,7 +34,9 @@ defineExpose({ popoverButtonRef })
         @keydown="handleKeydown">
         <slot :open="open" />
       </PopoverButton>
-      <template #floating="{ width }">
+      <template
+        v-if="open"
+        #floating="{ width }">
         <PopoverPanel
           v-slot="{ close }"
           class="relative flex w-40 flex-col rounded border text-sm"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
@@ -28,6 +28,7 @@ defineExpose({ popoverButtonRef })
       :isOpen="open ?? isOpen"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
+      :targetRef="targetRef"
       :teleport="teleport">
       <PopoverButton
         ref="popoverButtonRef"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
@@ -28,7 +28,7 @@ defineExpose({ popoverButtonRef })
       :isOpen="open ?? isOpen"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
-      :targetRef="targetRef"
+      :target="target"
       :teleport="teleport">
       <PopoverButton
         ref="popoverButtonRef"

--- a/packages/components/src/components/ScalarCombobox/types.ts
+++ b/packages/components/src/components/ScalarCombobox/types.ts
@@ -10,14 +10,14 @@ export type OptionGroup = {
   options: Option[]
 }
 
-export const isGroup = (
-  option: Option | OptionGroup,
-): option is OptionGroup => {
+/** Type guard to check if an option is a group */
+export function isGroup(option: Option | OptionGroup): option is OptionGroup {
   return (option as OptionGroup).options !== undefined
 }
 
-export const isGroups = (
+/** Type guard to check if an array of options is an array of groups */
+export function isGroups(
   options: Option[] | OptionGroup[],
-): options is OptionGroup[] => {
+): options is OptionGroup[] {
   return isGroup(options[0])
 }

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.spec.ts
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.spec.ts
@@ -9,6 +9,7 @@ describe('ScalarIconButton', () => {
       props: {},
       slots: {
         default: `<button>Button</button>`,
+        items: `<div>Items</div>`,
       },
     })
 

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.stories.ts
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.stories.ts
@@ -29,7 +29,7 @@ const meta = {
       return { args }
     },
     template: `
-<div class="flex items-center justify-center w-full h-screen">
+<div class="flex justify-center w-full min-h-96">
   <ScalarDropdown v-bind="args">
     <ScalarButton>Click Me</ScalarButton>
     <template #items>

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -1,8 +1,27 @@
+<script lang="ts">
+/**
+ * Scalar dropdown component
+ *
+ * Uses the headlessui Menu component under the hood
+ * @see https://headlessui.com/v1/vue/menu
+ *
+ * @example
+ * <ScalarDropdown>
+ *   <ScalarButton>Click Me</ScalarButton>
+ *   <template #items>
+ *     <ScalarDropdownItem>Item 1</ScalarDropdownItem>
+ *     <ScalarDropdownItem>Item 2</ScalarDropdownItem>
+ *   </template>
+ * </ScalarDropdown>
+ */
+export default {}
+</script>
 <script setup lang="ts">
 import { Menu, MenuButton, MenuItems } from '@headlessui/vue'
 import type { Slot } from 'vue'
 
 import { ScalarFloating, type ScalarFloatingOptions } from '../ScalarFloating'
+import ScalarDropdownMenu from './ScalarDropdownMenu.vue'
 
 defineProps<ScalarFloatingOptions>()
 
@@ -34,24 +53,15 @@ defineOptions({ inheritAttrs: false })
       </MenuButton>
       <template #floating="{ width }">
         <!-- Background container -->
-        <MenuItems
+        <ScalarDropdownMenu
+          :is="MenuItems"
           v-bind="$attrs"
-          class="relative flex max-h-[inherit] w-56 rounded border"
+          class="max-h-[inherit]"
           :style="{ width }">
-          <!-- Scroll container -->
-          <div class="custom-scroll min-h-0 flex-1">
-            <!-- Menu items -->
-            <div
-              class="flex flex-col p-0.75"
-              :style="{ width }">
-              <slot
-                name="items"
-                :open="open" />
-            </div>
-            <div
-              class="absolute inset-0 -z-1 rounded bg-b-1 shadow-lg brightness-lifted" />
-          </div>
-        </MenuItems>
+          <slot
+            name="items"
+            :open="open" />
+        </ScalarDropdownMenu>
       </template>
     </ScalarFloating>
   </Menu>

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -21,7 +21,7 @@ defineOptions({ inheritAttrs: false })
       :isOpen="static ? staticOpen : (open ?? isOpen)"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
-      :targetRef="targetRef"
+      :target="target"
       :teleport="teleport">
       <MenuButton
         v-if="!static"

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -5,7 +5,7 @@ import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
 
 withDefaults(
   defineProps<
-    Omit<FloatingOptions, 'middleware'> & {
+    FloatingOptions & {
       static?: boolean
       staticOpen?: boolean
     }
@@ -19,6 +19,7 @@ defineOptions({ inheritAttrs: false })
   <Menu v-slot="{ open }">
     <ScalarFloating
       :isOpen="static ? staticOpen : (open ?? isOpen)"
+      :middleware="middleware"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
       :target="target"

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -1,32 +1,35 @@
 <script setup lang="ts">
 import { Menu, MenuButton, MenuItems } from '@headlessui/vue'
+import type { Slot } from 'vue'
 
-import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
+import { ScalarFloating, type ScalarFloatingOptions } from '../ScalarFloating'
 
-withDefaults(
-  defineProps<
-    FloatingOptions & {
-      static?: boolean
-      staticOpen?: boolean
-    }
-  >(),
-  { static: false, staticOpen: true },
-)
+defineProps<ScalarFloatingOptions>()
+
+defineSlots<{
+  /** The reference element for the element in the #floating slot */
+  default(props: {
+    /** Whether or not the dropdown is open */
+    open: boolean
+  }): Slot
+  /** The list of dropdown items */
+  items(props: {
+    /** Whether or not the dropdown is open */
+    open: boolean
+  }): Slot
+}>()
 
 defineOptions({ inheritAttrs: false })
 </script>
 <template>
   <Menu v-slot="{ open }">
     <ScalarFloating
-      :isOpen="static ? staticOpen : (open ?? isOpen)"
       :middleware="middleware"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
       :target="target"
       :teleport="teleport">
-      <MenuButton
-        v-if="!static"
-        as="template">
+      <MenuButton as="template">
         <slot :open="open" />
       </MenuButton>
       <template #floating="{ width }">
@@ -34,7 +37,6 @@ defineOptions({ inheritAttrs: false })
         <MenuItems
           v-bind="$attrs"
           class="relative flex max-h-[inherit] w-56 rounded border"
-          :static="static"
           :style="{ width }">
           <!-- Scroll container -->
           <div class="custom-scroll min-h-0 flex-1">
@@ -42,7 +44,9 @@ defineOptions({ inheritAttrs: false })
             <div
               class="flex flex-col p-0.75"
               :style="{ width }">
-              <slot name="items" />
+              <slot
+                name="items"
+                :open="open" />
             </div>
             <div
               class="absolute inset-0 -z-1 rounded bg-b-1 shadow-lg brightness-lifted" />

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdownButton.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdownButton.vue
@@ -1,0 +1,59 @@
+<script lang="ts">
+/**
+ * Scalar dropdown button base component
+ *
+ * Provide a styled button for the ScalarDropdown or similar
+ *
+ * This is used internally by the ScalarDropdownItem component
+ *
+ * If you're looking to add items to a dropdown menu you
+ * probably want the ScalarDropdownItem component
+ *
+ * @example
+ * <ScalarDropdownButton ＠click="handleClick">
+ *   Label
+ * </ScalarDropdownButton>
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import { cva, cx } from '../../cva'
+
+defineProps<{
+  active?: boolean
+  disabled?: boolean
+}>()
+
+defineEmits<{
+  (e: 'click', event: MouseEvent): void
+}>()
+
+const variants = cva({
+  base: [
+    // Layout
+    'h-8 min-w-0 items-center gap-1.5 rounded px-2.5 py-1.5 text-left',
+    // Text / background style
+    'truncate text-sm text-c-1',
+    // Interaction
+    'cursor-pointer hover:bg-b-2 hover:text-c-1',
+  ],
+  variants: {
+    disabled: { true: 'pointer-events-none text-c-3' },
+    active: { true: 'bg-b-2 text-c-1' },
+  },
+})
+</script>
+<template>
+  <button
+    class="item"
+    :class="cx('scalar-dropdown-item', variants({ active, disabled }))"
+    type="button"
+    @click="($event) => $emit('click', $event)">
+    <slot />
+  </button>
+</template>
+<style scoped>
+.dark-mode .scalar-dropdown-item:hover {
+  filter: brightness(1.1);
+}
+</style>

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdownDivider.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdownDivider.vue
@@ -1,3 +1,22 @@
+<script lang="ts">
+/**
+ * Scalar dropdown divider component
+ *
+ * Used to create a divider between items in the ScalarDropdown component
+ *
+ * @example
+ * <ScalarDropdown>
+ *   ...
+ *   <template #items>
+ *     <ScalarDropdownItem>Item 1</ScalarDropdownItem>
+ *     <ScalarDropdownItem>Item 2</ScalarDropdownItem>
+ *     <ScalarDropdownDivider />
+ *     <ScalarDropdownItem>Item 3</ScalarDropdownItem>
+ *   </template>
+ * </ScalarDropdown>
+ */
+export default {}
+</script>
 <template>
   <div class="-mx-0.75 my-0.75 h-px bg-border" />
 </template>

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdownItem.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdownItem.vue
@@ -1,7 +1,20 @@
+<script lang="ts">
+/**
+ * Scalar dropdown item component
+ *
+ * Used to create items for the ScalarDropdown component
+ *
+ * @example
+ * <ScalarDropdownItem ＠click="handleClick">
+ *   Label
+ * </ScalarDropdownItem>
+ */
+export default {}
+</script>
 <script setup lang="ts">
 import { MenuItem } from '@headlessui/vue'
 
-import { cva, cx } from '../../cva'
+import ScalarDropdownButton from './ScalarDropdownButton.vue'
 
 defineProps<{
   disabled?: boolean
@@ -10,33 +23,17 @@ defineProps<{
 defineEmits<{
   (e: 'click', event: MouseEvent): void
 }>()
-
-const variants = cva({
-  base: [
-    // Layout
-    'h-8 min-w-0 items-center gap-1.5 rounded px-2.5 py-1.5 text-left',
-    // Text / background style
-    'truncate text-sm text-c-1',
-    // Interaction
-    'cursor-pointer hover:bg-b-2 hover:text-c-1',
-  ],
-  variants: {
-    disabled: { true: 'pointer-events-none text-c-3' },
-    active: { true: 'bg-b-2 text-c-1' },
-  },
-})
 </script>
 <template>
   <MenuItem
     v-slot="{ active }"
     :disabled="disabled">
-    <button
-      class="item"
-      :class="cx('scalar-dropdown-item', variants({ active, disabled }))"
-      type="button"
+    <ScalarDropdownButton
+      :active="active"
+      :disabled="disabled"
       @click="($event) => $emit('click', $event)">
       <slot />
-    </button>
+    </ScalarDropdownButton>
   </MenuItem>
 </template>
 <style scoped>

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdownMenu.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdownMenu.vue
@@ -1,0 +1,44 @@
+<script lang="ts">
+/**
+ * Scalar dropdown menu component
+ *
+ * Provides a scrollable container for dropdown items
+ * This is used internally by the ScalarDropdown component
+ *
+ * If you're looking to create a dropdown menu with a trigger
+ * button you probably want the ScalarDropdown component
+ *
+ * @example
+ * <ScalarDropdownMenu>
+ *   <ScalarDropdownItem>Item 1</ScalarDropdownItem>
+ *   <ScalarDropdownItem>Item 2</ScalarDropdownItem>
+ * </ScalarDropdownMenu>
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import type { Component } from 'vue'
+
+defineProps<{
+  /** The component to render */
+  is?: string | Component
+}>()
+</script>
+<template>
+  <!-- Background container -->
+  <component
+    :is="is ?? 'div'"
+    class="relative flex w-56 rounded border"
+    role="menu"
+    tabindex="0">
+    <!-- Scroll container -->
+    <div class="custom-scroll min-h-0 flex-1">
+      <!-- Menu items -->
+      <div class="flex flex-col p-0.75">
+        <slot />
+      </div>
+      <div
+        class="absolute inset-0 -z-1 rounded bg-b-1 shadow-lg brightness-lifted" />
+    </div>
+  </component>
+</template>

--- a/packages/components/src/components/ScalarDropdown/index.ts
+++ b/packages/components/src/components/ScalarDropdown/index.ts
@@ -1,3 +1,5 @@
 export { default as ScalarDropdown } from './ScalarDropdown.vue'
 export { default as ScalarDropdownDivider } from './ScalarDropdownDivider.vue'
+export { default as ScalarDropdownButton } from './ScalarDropdownButton.vue'
 export { default as ScalarDropdownItem } from './ScalarDropdownItem.vue'
+export { default as ScalarDropdownMenu } from './ScalarDropdownMenu.vue'

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.spec.ts
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.spec.ts
@@ -1,14 +1,102 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import ScalarFloating from './ScalarFloating.vue'
 
-describe('ScalarIconButton', () => {
-  it('renders properly', async () => {
-    const wrapper = mount(ScalarFloating, {
-      props: {},
+describe('ScalarFloating', () => {
+  let wrapper: any
+  let targetDiv: HTMLElement
+
+  beforeEach(() => {
+    // Create a target div for ID-based tests
+    targetDiv = document.createElement('div')
+    targetDiv.id = 'test-target'
+    document.body.appendChild(targetDiv)
+  })
+
+  // Cleanup after each test
+  afterEach(() => {
+    wrapper?.unmount()
+    targetDiv.remove()
+  })
+
+  describe('floating target', () => {
+    it('should find target by ID string', async () => {
+      wrapper = mount(ScalarFloating, {
+        props: {
+          target: 'test-target',
+          isOpen: true,
+        },
+      })
+
+      await nextTick()
+
+      expect(wrapper.vm.targetRef).toBe(targetDiv)
     })
 
-    expect(wrapper.exists()).toBeTruthy()
+    it('should fallback to the wrapper if target ID is not found', async () => {
+      const consoleSpy = vi.spyOn(console, 'warn')
+
+      wrapper = mount(ScalarFloating, {
+        props: {
+          target: 'non-existent-id',
+          isOpen: true,
+        },
+      })
+
+      await nextTick()
+
+      expect(wrapper.vm.targetRef).toBe(wrapper.vm.wrapperRef)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('non-existent-id'),
+      )
+
+      consoleSpy.mockRestore()
+    })
+
+    it('should use direct HTMLElement target', async () => {
+      const directTarget = document.createElement('div')
+
+      wrapper = mount(ScalarFloating, {
+        props: {
+          target: directTarget,
+          isOpen: true,
+        },
+      })
+
+      await nextTick()
+
+      expect(wrapper.vm.targetRef).toBe(directTarget)
+    })
+
+    it('should fallback to first child of wrapper when no target specified', async () => {
+      wrapper = mount(ScalarFloating, {
+        props: {
+          isOpen: true,
+        },
+        slots: {
+          default: '<div class="child">Target Content</div>',
+          floating: '<div class="floating">Floating Content</div>',
+        },
+      })
+
+      await nextTick()
+      const childElement = wrapper.find('.child').element
+
+      expect(wrapper.vm.targetRef).toBe(childElement)
+    })
+
+    it('should fallback to wrapper itself when no children present', async () => {
+      wrapper = mount(ScalarFloating, {
+        props: {
+          isOpen: true,
+        },
+      })
+
+      await nextTick()
+
+      expect(wrapper.vm.targetRef).toBe(wrapper.vm.wrapperRef)
+    })
   })
 })

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.spec.ts
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.spec.ts
@@ -23,12 +23,7 @@ describe('ScalarFloating', () => {
 
   describe('floating target', () => {
     it('should find target by ID string', async () => {
-      wrapper = mount(ScalarFloating, {
-        props: {
-          target: 'test-target',
-          isOpen: true,
-        },
-      })
+      wrapper = mount(ScalarFloating, { props: { target: 'test-target' } })
 
       await nextTick()
 
@@ -38,12 +33,7 @@ describe('ScalarFloating', () => {
     it('should fallback to the wrapper if target ID is not found', async () => {
       const consoleSpy = vi.spyOn(console, 'warn')
 
-      wrapper = mount(ScalarFloating, {
-        props: {
-          target: 'non-existent-id',
-          isOpen: true,
-        },
-      })
+      wrapper = mount(ScalarFloating, { props: { target: 'non-existent-id' } })
 
       await nextTick()
 
@@ -58,23 +48,18 @@ describe('ScalarFloating', () => {
     it('should use direct HTMLElement target', async () => {
       const directTarget = document.createElement('div')
 
-      wrapper = mount(ScalarFloating, {
-        props: {
-          target: directTarget,
-          isOpen: true,
-        },
-      })
+      wrapper = mount(ScalarFloating, { props: { target: directTarget } })
 
       await nextTick()
 
       expect(wrapper.vm.targetRef).toBe(directTarget)
+
+      directTarget.remove()
     })
 
     it('should fallback to first child of wrapper when no target specified', async () => {
       wrapper = mount(ScalarFloating, {
-        props: {
-          isOpen: true,
-        },
+        props: {},
         slots: {
           default: '<div class="child">Target Content</div>',
           floating: '<div class="floating">Floating Content</div>',
@@ -88,11 +73,7 @@ describe('ScalarFloating', () => {
     })
 
     it('should fallback to wrapper itself when no children present', async () => {
-      wrapper = mount(ScalarFloating, {
-        props: {
-          isOpen: true,
-        },
-      })
+      wrapper = mount(ScalarFloating, { props: {} })
 
       await nextTick()
 

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.stories.ts
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.stories.ts
@@ -1,4 +1,5 @@
 import { placements } from '@floating-ui/utils'
+import { offset } from '@floating-ui/vue'
 import type { Meta, StoryObj } from '@storybook/vue3'
 
 import ScalarFloating from './ScalarFloating.vue'
@@ -38,3 +39,30 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Base: Story = {}
+
+/**
+ * You can override the offset (or other middleware) by passing a custom middleware array
+ */
+export const CustomOffset: Story = {
+  render: () => ({
+    components: { ScalarFloating },
+    setup() {
+      const middleware = [offset(15)]
+      return { middleware }
+    },
+    template: `
+<div class="flex items-center justify-center w-full h-screen">
+  <ScalarFloating :middleware="middleware" isOpen>
+    <div class="rounded border bg-b-2 p-2">Target for #floating</div>
+    <template #floating="{ width, height }">
+      <div 
+        class="flex items-center justify-center rounded border shadow bg-b-2 p-1" 
+        :style="{ width, height }">
+        Floating
+      </div>
+    </template>
+  </ScalarDropdown>
+</div>
+`,
+  }),
+}

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.stories.ts
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.stories.ts
@@ -52,7 +52,7 @@ export const CustomOffset: Story = {
     },
     template: `
 <div class="flex items-center justify-center w-full h-screen">
-  <ScalarFloating :middleware="middleware" isOpen>
+  <ScalarFloating :middleware="middleware">
     <div class="rounded border bg-b-2 p-2">Target for #floating</div>
     <template #floating="{ width, height }">
       <div 

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -9,7 +9,7 @@ import {
   size,
   useFloating,
 } from '@floating-ui/vue'
-import { type Ref, computed, ref } from 'vue'
+import { type Ref, type Slot, computed, ref } from 'vue'
 
 import type { FloatingOptions } from './types'
 import { useResizeWithTarget } from './useResizeWithTarget'
@@ -18,7 +18,7 @@ const props = defineProps<FloatingOptions>()
 
 defineSlots<{
   /** The reference element for the element in the #floating slot */
-  default(): any
+  default(): Slot
   /** The floating element */
   floating(props: {
     /** The width of the reference element if `resize` is true and placement is on the y axis */
@@ -27,7 +27,7 @@ defineSlots<{
     height?: string
     /** The middleware data return by Floating UI */
     data?: MiddlewareData
-  }): any
+  }): Slot
 }>()
 
 defineOptions({ inheritAttrs: false })
@@ -96,7 +96,6 @@ const { floatingStyles, middlewareData } = useFloating(targetRef, floatingRef, {
     <slot />
   </div>
   <Teleport
-    v-if="isOpen"
     :disabled="!teleport"
     :to="typeof teleport === 'string' ? teleport : 'body'">
     <div class="scalar-app">

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -35,12 +35,22 @@ defineOptions({ inheritAttrs: false })
 const floatingRef: Ref<HTMLElement | null> = ref(null)
 const wrapperRef: Ref<HTMLElement | null> = ref(null)
 
-/** Fallback to div wrapper if a button element is not provided */
-const targetRef = computed(
-  () =>
-    (props.targetRef || wrapperRef.value?.children?.[0] || wrapperRef.value) ??
-    undefined,
-)
+const targetRef = computed(() => {
+  // If target is a string (id), try to find it in the document
+  if (typeof props.target === 'string') {
+    const target = document.getElementById(props.target)
+    if (target) return target
+    else
+      console.warn(`ScalarFloating: Target with id="${props.target}" not found`)
+  }
+  // If target is an HTMLElement, return it
+  else if (props.target instanceof HTMLElement) return props.target
+  // Fallback to div wrapper if no child element is provided
+  if (wrapperRef.value)
+    return wrapperRef.value.children?.[0] || wrapperRef.value
+  // Return undefined if nothing is found
+  return undefined
+})
 
 const targetSize = useResizeWithTarget(targetRef, {
   enabled: computed(() => props.resize),

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -96,6 +96,7 @@ const { floatingStyles, middlewareData } = useFloating(targetRef, floatingRef, {
     <slot />
   </div>
   <Teleport
+    v-if="$slots.floating"
     :disabled="!teleport"
     :to="typeof teleport === 'string' ? teleport : 'body'">
     <div class="scalar-app">

--- a/packages/components/src/components/ScalarFloating/index.ts
+++ b/packages/components/src/components/ScalarFloating/index.ts
@@ -1,3 +1,3 @@
 export { default as ScalarFloating } from './ScalarFloating.vue'
 
-export type { FloatingOptions } from './types'
+export type { FloatingOptions as ScalarFloatingOptions } from './types'

--- a/packages/components/src/components/ScalarFloating/types.ts
+++ b/packages/components/src/components/ScalarFloating/types.ts
@@ -1,5 +1,6 @@
 import type { Middleware, Placement } from '@floating-ui/vue'
 
+/** The props for the ScalarFloating component */
 export type FloatingOptions = {
   /**
    * Where to place the floating element relative to its reference element.
@@ -33,11 +34,6 @@ export type FloatingOptions = {
    * @see https://floating-ui.com/docs/computePosition#middleware
    */
   middleware?: Middleware[]
-  /**
-   * Whether the floating element is open or not.
-   * @default false
-   */
-  isOpen?: boolean
   /**
    * Whether to teleport the floating element.
    * Can be an `id` to teleport to or `true` to teleport to the `<body>`.

--- a/packages/components/src/components/ScalarFloating/types.ts
+++ b/packages/components/src/components/ScalarFloating/types.ts
@@ -4,6 +4,8 @@ export type FloatingOptions = {
   /**
    * Where to place the floating element relative to its reference element.
    * @default 'bottom'
+   *
+   * @see https://floating-ui.com/docs/computePosition#placement
    */
   placement?: Placement
   /**

--- a/packages/components/src/components/ScalarFloating/types.ts
+++ b/packages/components/src/components/ScalarFloating/types.ts
@@ -12,10 +12,12 @@ export type FloatingOptions = {
    */
   resize?: boolean
   /**
-   * Override the targetRef, useful if we are not passing a button
+   * Override the target, useful if we are not passing a button
    * into the slot but is controlled from an external button
+   *
+   * Can be a string id or a reference to an element
    */
-  targetRef?: HTMLElement
+  target?: string | HTMLElement
   /**
    * Floating UI Middleware to be passed to Floating UI
    *

--- a/packages/components/src/components/ScalarFloating/types.ts
+++ b/packages/components/src/components/ScalarFloating/types.ts
@@ -1,5 +1,4 @@
 import type { Middleware, Placement } from '@floating-ui/vue'
-import type { Ref } from 'vue'
 
 export type FloatingOptions = {
   /**
@@ -19,6 +18,14 @@ export type FloatingOptions = {
   targetRef?: HTMLElement
   /**
    * Floating UI Middleware to be passed to Floating UI
+   *
+   * Overrides the default middleware
+   *
+   * @example
+   * ```ts
+   * // change the offset to 10px
+   * middleware: [offset(10)]
+   * ```
    * @see https://floating-ui.com/docs/computePosition#middleware
    */
   middleware?: Middleware[]

--- a/packages/components/src/components/ScalarFloating/useResizeWithTarget.ts
+++ b/packages/components/src/components/ScalarFloating/useResizeWithTarget.ts
@@ -4,6 +4,9 @@ type ResizeOptions = {
   enabled?: MaybeRefOrGetter<boolean>
 }
 
+/**
+ * Resize a floating element to match a target element
+ */
 export function useResizeWithTarget(
   target: MaybeRefOrGetter<Element | undefined>,
   opts: ResizeOptions = { enabled: ref(true) },

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.stories.ts
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.stories.ts
@@ -38,12 +38,48 @@ export const Base: Story = {
       return { args, selected }
     },
     template: `
-<div class="flex items-center justify-center w-full h-screen">
+<div class="flex justify-center w-full min-h-96">
   <ScalarListbox v-model="selected" v-bind="args">
     <ScalarButton class="w-48 px-3" variant="outlined">
       <div class="flex flex-1 items-center min-w-0">
         <span class="inline-block truncate flex-1 min-w-0 text-left">
         {{ selected?.label ?? 'Select an option' }}
+        </span>
+        <ScalarIcon icon="ChevronDown" size="sm" class="ml-1 ui-open:rotate-180" />
+      </div>
+    </ScalarButton>
+  </ScalarListbox>
+</div>
+`,
+  }),
+}
+
+export const Multiselect: Story = {
+  args: {
+    multiple: true,
+    options: [
+      { id: '1', label: 'Option 1' },
+      { id: '2', label: 'Option 2' },
+      { id: '3', label: 'Option 3' },
+    ],
+  },
+  render: (args) => ({
+    components: {
+      ScalarListbox,
+      ScalarButton,
+      ScalarIcon,
+    },
+    setup() {
+      const selected = ref<Option[]>([])
+      return { args, selected }
+    },
+    template: `
+<div class="flex justify-center w-full min-h-96">
+  <ScalarListbox v-model="selected" v-bind="args">
+    <ScalarButton class="w-48 min-w-max px-3" variant="outlined">
+      <div class="flex flex-1 items-center min-w-0">
+        <span class="inline-block truncate flex-1 min-w-0 text-left">
+        {{ selected?.length ? selected.map(o => o.label).join(', ') : 'Select an option' }}
         </span>
         <ScalarIcon icon="ChevronDown" size="sm" class="ml-1 ui-open:rotate-180" />
       </div>

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -5,8 +5,9 @@ import {
   ListboxLabel,
   ListboxOptions,
 } from '@headlessui/vue'
+import type { Slot } from 'vue'
 
-import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
+import { ScalarFloating, type ScalarFloatingOptions } from '../ScalarFloating'
 import ScalarListboxOption from './ScalarListboxItem.vue'
 import type { Option } from './types'
 
@@ -26,11 +27,19 @@ defineProps<
     id?: string
     label?: string
   } & (SingleSelectListboxProps | MultipleSelectListboxProps) &
-    FloatingOptions
+    ScalarFloatingOptions
 >()
 
 defineEmits<{
   (e: 'update:modelValue', v: Option): void
+}>()
+
+defineSlots<{
+  /** The reference element for the listbox */
+  default(props: {
+    /** Whether or not the listbox is open */
+    open: boolean
+  }): Slot
 }>()
 
 defineOptions({ inheritAttrs: false })
@@ -47,7 +56,6 @@ defineOptions({ inheritAttrs: false })
       {{ label }}
     </ListboxLabel>
     <ScalarFloating
-      :isOpen="open ?? isOpen"
       :middleware="middleware"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
@@ -62,6 +70,7 @@ defineOptions({ inheritAttrs: false })
       <template #floating="{ width }">
         <!-- Background container -->
         <div
+          v-if="open"
           v-bind="$attrs"
           class="relative flex max-h-[inherit] w-40 rounded border text-sm"
           :style="{ width }">

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -3,56 +3,29 @@ import {
   Listbox,
   ListboxButton,
   ListboxLabel,
-  ListboxOption,
   ListboxOptions,
 } from '@headlessui/vue'
 
-import { cva, cx } from '../../cva'
 import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
-import { ScalarIcon } from '../ScalarIcon'
+import ScalarListboxOption from './ScalarListboxOption.vue'
 import type { Option } from './types'
 
-withDefaults(
-  defineProps<
-    {
-      /**
-       * Allow selecting multiple values
-       *
-       * @default false
-       */
-      multiple?: boolean
-      options: Option[]
-      modelValue?: Option | Option[]
-      id?: string
-      label?: string
-    } & Omit<FloatingOptions, 'middleware' | 'offset' | 'targetRef'>
-  >(),
-  { multiple: false },
-)
+defineProps<
+  {
+    /** Allow selecting multiple values */
+    multiple?: boolean
+    options: Option[]
+    modelValue?: Option | Option[]
+    id?: string
+    label?: string
+  } & Omit<FloatingOptions, 'middleware' | 'targetRef'>
+>()
 
 defineEmits<{
   (e: 'update:modelValue', v: Option): void
 }>()
 
 defineOptions({ inheritAttrs: false })
-
-const variants = cva({
-  base: [
-    // Layout
-    'group/listbox',
-    'flex min-w-0 items-center gap-1.5 rounded px-2 py-1.5 text-left',
-    'first-of-type:mt-0.75 last-of-type:mb-0.75',
-    // Text / background style
-    'truncate bg-transparent text-c-1',
-    // Interaction
-    'cursor-pointer hover:bg-b-2',
-  ],
-  variants: {
-    selected: { true: 'text-c-1' },
-    active: { true: 'bg-b-2' },
-    disabled: { true: 'pointer-events-none opacity-50' },
-  },
-})
 </script>
 <template>
   <Listbox
@@ -86,39 +59,10 @@ const variants = cva({
           <div class="custom-scroll min-h-0 flex-1">
             <!-- Options list -->
             <ListboxOptions class="flex flex-col p-0.75">
-              <ListboxOption
+              <ScalarListboxOption
                 v-for="option in options"
                 :key="option.id"
-                v-slot="{ active, selected }"
-                as="template"
-                :disabled="option.disabled"
-                :value="option">
-                <li
-                  :class="
-                    cx(
-                      variants({ active, selected, disabled: option.disabled }),
-                    )
-                  ">
-                  <div
-                    class="flex size-4 items-center justify-center rounded-full p-[3px]"
-                    :class="
-                      selected
-                        ? 'bg-c-accent text-b-1'
-                        : 'text-transparent group-hover/listbox:shadow-border'
-                    ">
-                    <!-- Icon needs help to be optically centered (╥﹏╥) -->
-                    <ScalarIcon
-                      class="relative top-[0.5px] size-2.5"
-                      icon="Checkmark"
-                      thickness="2.5" />
-                  </div>
-                  <span
-                    class="inline-block min-w-0 flex-1 truncate"
-                    :class="option.color ? option.color : 'text-c-1'">
-                    {{ option.label }}
-                  </span>
-                </li>
-              </ListboxOption>
+                :option="option" />
             </ListboxOptions>
           </div>
           <div

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -7,18 +7,26 @@ import {
 } from '@headlessui/vue'
 
 import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
-import ScalarListboxOption from './ScalarListboxOption.vue'
+import ScalarListboxOption from './ScalarListboxItem.vue'
 import type { Option } from './types'
+
+type SingleSelectListboxProps = {
+  multiple?: false
+  modelValue?: Option
+}
+
+type MultipleSelectListboxProps = {
+  multiple: true
+  modelValue?: Option[]
+}
 
 defineProps<
   {
-    /** Allow selecting multiple values */
-    multiple?: boolean
     options: Option[]
-    modelValue?: Option | Option[]
     id?: string
     label?: string
-  } & Omit<FloatingOptions, 'middleware' | 'targetRef'>
+  } & (SingleSelectListboxProps | MultipleSelectListboxProps) &
+    Omit<FloatingOptions, 'middleware' | 'targetRef'>
 >()
 
 defineEmits<{
@@ -62,7 +70,8 @@ defineOptions({ inheritAttrs: false })
               <ScalarListboxOption
                 v-for="option in options"
                 :key="option.id"
-                :option="option" />
+                :option="option"
+                :style="multiple ? 'checkbox' : 'radio'" />
             </ListboxOptions>
           </div>
           <div

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -26,7 +26,7 @@ defineProps<
     id?: string
     label?: string
   } & (SingleSelectListboxProps | MultipleSelectListboxProps) &
-    Omit<FloatingOptions, 'middleware'>
+    FloatingOptions
 >()
 
 defineEmits<{
@@ -48,6 +48,7 @@ defineOptions({ inheritAttrs: false })
     </ListboxLabel>
     <ScalarFloating
       :isOpen="open ?? isOpen"
+      :middleware="middleware"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
       :target="target"

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -26,7 +26,7 @@ defineProps<
     id?: string
     label?: string
   } & (SingleSelectListboxProps | MultipleSelectListboxProps) &
-    Omit<FloatingOptions, 'middleware' | 'targetRef'>
+    Omit<FloatingOptions, 'middleware'>
 >()
 
 defineEmits<{
@@ -50,6 +50,7 @@ defineOptions({ inheritAttrs: false })
       :isOpen="open ?? isOpen"
       :placement="placement ?? 'bottom-start'"
       :resize="resize"
+      :target="target"
       :teleport="teleport">
       <ListboxButton
         :id="id"

--- a/packages/components/src/components/ScalarListbox/ScalarListboxCheckbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListboxCheckbox.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { ScalarIcon } from '../ScalarIcon'
+import type { OptionStyle } from './types'
+
+defineProps<{
+  selected?: boolean
+  style?: OptionStyle
+}>()
+</script>
+<template>
+  <div
+    class="flex size-4 items-center justify-center p-0.75"
+    :class="[
+      selected
+        ? 'bg-c-accent text-b-1'
+        : 'text-transparent group-hover/item:shadow-border',
+      style === 'checkbox' ? 'rounded' : 'rounded-full',
+    ]">
+    <!-- Icon needs help to be optically centered (╥﹏╥) -->
+    <ScalarIcon
+      class="relative top-[0.5px] size-2.5"
+      icon="Checkmark"
+      thickness="2.5" />
+  </div>
+</template>

--- a/packages/components/src/components/ScalarListbox/ScalarListboxItem.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListboxItem.vue
@@ -2,17 +2,18 @@
 import { ListboxOption } from '@headlessui/vue'
 
 import { cva, cx } from '../../cva'
-import { ScalarIcon } from '../ScalarIcon'
-import type { Option } from './types'
+import ScalarListboxCheckbox from './ScalarListboxCheckbox.vue'
+import type { Option, OptionStyle } from './types'
 
 defineProps<{
   option: Option
+  style?: OptionStyle
 }>()
 
 const variants = cva({
   base: [
     // Layout
-    'group/listbox',
+    'group/item',
     'flex min-w-0 items-center gap-1.5 rounded px-2 py-1.5 text-left',
     'first-of-type:mt-0.75 last-of-type:mb-0.75',
     // Text / background style
@@ -34,19 +35,9 @@ const variants = cva({
     :disabled="option.disabled"
     :value="option">
     <li :class="cx(variants({ active, selected, disabled: option.disabled }))">
-      <div
-        class="flex size-4 items-center justify-center rounded-full p-[3px]"
-        :class="
-          selected
-            ? 'bg-c-accent text-b-1'
-            : 'text-transparent group-hover/listbox:shadow-border'
-        ">
-        <!-- Icon needs help to be optically centered (╥﹏╥) -->
-        <ScalarIcon
-          class="relative top-[0.5px] size-2.5"
-          icon="Checkmark"
-          thickness="2.5" />
-      </div>
+      <ScalarListboxCheckbox
+        :selected="selected"
+        :style="style" />
       <span
         class="inline-block min-w-0 flex-1 truncate"
         :class="option.color ? option.color : 'text-c-1'">

--- a/packages/components/src/components/ScalarListbox/ScalarListboxOption.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListboxOption.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { ListboxOption } from '@headlessui/vue'
+
+import { cva, cx } from '../../cva'
+import { ScalarIcon } from '../ScalarIcon'
+import type { Option } from './types'
+
+defineProps<{
+  option: Option
+}>()
+
+const variants = cva({
+  base: [
+    // Layout
+    'group/listbox',
+    'flex min-w-0 items-center gap-1.5 rounded px-2 py-1.5 text-left',
+    'first-of-type:mt-0.75 last-of-type:mb-0.75',
+    // Text / background style
+    'truncate bg-transparent text-c-1',
+    // Interaction
+    'cursor-pointer hover:bg-b-2',
+  ],
+  variants: {
+    selected: { true: 'text-c-1' },
+    active: { true: 'bg-b-2' },
+    disabled: { true: 'pointer-events-none opacity-50' },
+  },
+})
+</script>
+<template>
+  <ListboxOption
+    v-slot="{ active, selected }"
+    as="template"
+    :disabled="option.disabled"
+    :value="option">
+    <li :class="cx(variants({ active, selected, disabled: option.disabled }))">
+      <div
+        class="flex size-4 items-center justify-center rounded-full p-[3px]"
+        :class="
+          selected
+            ? 'bg-c-accent text-b-1'
+            : 'text-transparent group-hover/listbox:shadow-border'
+        ">
+        <!-- Icon needs help to be optically centered (╥﹏╥) -->
+        <ScalarIcon
+          class="relative top-[0.5px] size-2.5"
+          icon="Checkmark"
+          thickness="2.5" />
+      </div>
+      <span
+        class="inline-block min-w-0 flex-1 truncate"
+        :class="option.color ? option.color : 'text-c-1'">
+        {{ option.label }}
+      </span>
+    </li>
+  </ListboxOption>
+</template>

--- a/packages/components/src/components/ScalarListbox/index.ts
+++ b/packages/components/src/components/ScalarListbox/index.ts
@@ -1,3 +1,5 @@
 export { default as ScalarListbox } from './ScalarListbox.vue'
+export { default as ScalarListboxItem } from './ScalarListboxItem.vue'
+export { default as ScalarListboxCheckbox } from './ScalarListboxCheckbox.vue'
 
 export type { Option as ScalarListboxOption } from './types'

--- a/packages/components/src/components/ScalarListbox/index.ts
+++ b/packages/components/src/components/ScalarListbox/index.ts
@@ -2,4 +2,7 @@ export { default as ScalarListbox } from './ScalarListbox.vue'
 export { default as ScalarListboxItem } from './ScalarListboxItem.vue'
 export { default as ScalarListboxCheckbox } from './ScalarListboxCheckbox.vue'
 
-export type { Option as ScalarListboxOption } from './types'
+export type {
+  Option as ScalarListboxOption,
+  OptionStyle as ScalarListboxOptionStyle,
+} from './types'

--- a/packages/components/src/components/ScalarListbox/types.ts
+++ b/packages/components/src/components/ScalarListbox/types.ts
@@ -5,4 +5,4 @@ export type Option = {
   [x: string]: any
 }
 
-export type OptionStyle = 'radio' | 'checkbox' | 'button'
+export type OptionStyle = 'radio' | 'checkbox'

--- a/packages/components/src/components/ScalarListbox/types.ts
+++ b/packages/components/src/components/ScalarListbox/types.ts
@@ -4,3 +4,5 @@ export type Option = {
   disabled?: boolean
   [x: string]: any
 }
+
+export type OptionStyle = 'radio' | 'checkbox' | 'button'

--- a/packages/components/src/components/ScalarMenu/ScalarMenu.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenu.vue
@@ -1,16 +1,11 @@
 <script setup lang="ts">
-import { type FloatingOptions, ScalarPopover } from '../../'
+import { ScalarPopover } from '../ScalarPopover'
 import ScalarMenuButton from './ScalarMenuButton.vue'
 import ScalarMenuProducts from './ScalarMenuProducts.vue'
 import ScalarMenuResources from './ScalarMenuResources.vue'
-
-defineProps<Pick<FloatingOptions, 'placement' | 'teleport'>>()
 </script>
 <template>
-  <ScalarPopover
-    class="max-h-[inherit] w-[280px] max-w-[inherit]"
-    :placement="placement ?? 'bottom-start'"
-    :teleport="teleport">
+  <ScalarPopover class="max-h-[inherit] w-[280px] max-w-[inherit]">
     <!-- Logo Button to open the popover -->
     <template #default="{ open }">
       <slot

--- a/packages/components/src/components/ScalarMenu/ScalarMenu.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenu.vue
@@ -1,11 +1,34 @@
 <script setup lang="ts">
+import type { ScalarFloatingOptions } from '../ScalarFloating'
 import { ScalarPopover } from '../ScalarPopover'
 import ScalarMenuButton from './ScalarMenuButton.vue'
 import ScalarMenuProducts from './ScalarMenuProducts.vue'
 import ScalarMenuResources from './ScalarMenuResources.vue'
+
+defineProps<ScalarFloatingOptions>()
+
+type ButtonSlotProps = { open: boolean }
+type MenuSlotProps = { close: () => void }
+
+defineSlots<{
+  /** Overrides the menu button */
+  button?: (p: ButtonSlotProps) => any
+  /** Overrides the logo in the menu button */
+  logo?: () => any
+  /** Overrides the label in the menu button */
+  label?: () => any
+  /** Overrides the products list */
+  products?: (p: MenuSlotProps) => any
+  /** Adds items the profile section (e.g. a team picker) */
+  profile?: (p: MenuSlotProps) => any
+  /** Overrides the resources section */
+  sections?: (p: MenuSlotProps) => any
+}>()
 </script>
 <template>
-  <ScalarPopover class="max-h-[inherit] w-[280px] max-w-[inherit]">
+  <ScalarPopover
+    v-bind="$props"
+    class="max-h-[inherit] w-[280px] max-w-[inherit]">
     <!-- Logo Button to open the popover -->
     <template #default="{ open }">
       <slot

--- a/packages/components/src/components/ScalarMenu/ScalarMenu.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenu.vue
@@ -28,7 +28,8 @@ defineSlots<{
 <template>
   <ScalarPopover
     v-bind="$props"
-    class="max-h-[inherit] w-[280px] max-w-[inherit]">
+    class="max-h-[inherit] w-[280px] max-w-[inherit]"
+    :placement="placement ?? 'bottom-start'">
     <!-- Logo Button to open the popover -->
     <template #default="{ open }">
       <slot
@@ -48,7 +49,7 @@ defineSlots<{
     </template>
     <!-- Popover content -->
     <template #popover="{ close }">
-      <div class="custom-scroll flex flex-col gap-3 p-2.25 sm:gap-3">
+      <div class="custom-scroll flex flex-col gap-3 p-2.25">
         <!-- Base Product List (can be overridden by slot) -->
         <slot
           :close="close"

--- a/packages/components/src/components/ScalarMenu/ScalarMenuButton.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuButton.vue
@@ -7,7 +7,7 @@ defineProps<{
 </script>
 <template>
   <button
-    class="group/button -m-1 flex items-center gap-1 rounded bg-transparent px-2.5 py-2 hover:bg-b-2"
+    class="group/button flex items-center gap-1 rounded bg-transparent px-2.5 py-2 hover:bg-b-2"
     type="button">
     <div class="size-5">
       <slot><ScalarIcon icon="Logo" /></slot>

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.spec.ts
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.spec.ts
@@ -9,6 +9,7 @@ describe('ScalarPopover', () => {
       props: {},
       slots: {
         default: `<button>Button</button>`,
+        popover: `<div>Popover</div>`,
       },
     })
 

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.stories.ts
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.stories.ts
@@ -25,7 +25,7 @@ const meta = {
       return { args }
     },
     template: `
-<div class="flex items-center justify-center w-full h-screen">
+<div class="flex justify-center w-full min-h-96">
   <ScalarPopover v-bind="args">
     <ScalarButton>Click Me</ScalarButton>
     <template #popover>

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.vue
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.vue
@@ -3,7 +3,6 @@ import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
 
 import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
 
-// eslint-disable-next-line vue/no-unused-properties
 defineProps<Omit<FloatingOptions, 'middleware'>>()
 
 defineOptions({ inheritAttrs: false })
@@ -15,6 +14,7 @@ defineOptions({ inheritAttrs: false })
     <ScalarFloating
       v-bind="$props"
       :isOpen="open ?? isOpen"
+      :target="target"
       :teleport="teleport">
       <PopoverButton as="template">
         <slot :open="open" />

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.vue
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
 
-import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
+import { ScalarFloating, type ScalarFloatingOptions } from '../ScalarFloating'
+import type { Slots } from './types'
 
-defineProps<FloatingOptions>()
+defineProps<ScalarFloatingOptions>()
+
+defineSlots<Slots>()
 
 defineOptions({ inheritAttrs: false })
 </script>
@@ -11,12 +14,7 @@ defineOptions({ inheritAttrs: false })
   <Popover
     v-slot="{ open }"
     as="template">
-    <ScalarFloating
-      v-bind="$props"
-      :isOpen="open ?? isOpen"
-      :middleware="middleware"
-      :target="target"
-      :teleport="teleport">
+    <ScalarFloating v-bind="$props">
       <PopoverButton as="template">
         <slot :open="open" />
       </PopoverButton>
@@ -28,7 +26,8 @@ defineOptions({ inheritAttrs: false })
           v-bind="$attrs">
           <slot
             :close="() => close()"
-            name="popover" />
+            name="popover"
+            :open="open" />
           <div
             class="absolute inset-0 -z-1 rounded bg-b-1 shadow-lg brightness-lifted" />
         </PopoverPanel>

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.vue
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.vue
@@ -3,7 +3,7 @@ import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
 
 import { type FloatingOptions, ScalarFloating } from '../ScalarFloating'
 
-defineProps<Omit<FloatingOptions, 'middleware'>>()
+defineProps<FloatingOptions>()
 
 defineOptions({ inheritAttrs: false })
 </script>
@@ -14,6 +14,7 @@ defineOptions({ inheritAttrs: false })
     <ScalarFloating
       v-bind="$props"
       :isOpen="open ?? isOpen"
+      :middleware="middleware"
       :target="target"
       :teleport="teleport">
       <PopoverButton as="template">

--- a/packages/components/src/components/ScalarPopover/index.ts
+++ b/packages/components/src/components/ScalarPopover/index.ts
@@ -1,1 +1,3 @@
 export { default as ScalarPopover } from './ScalarPopover.vue'
+
+export type { Slots as ScalarPopoverSlots } from './types'

--- a/packages/components/src/components/ScalarPopover/types.ts
+++ b/packages/components/src/components/ScalarPopover/types.ts
@@ -1,0 +1,15 @@
+import type { Slot } from 'vue'
+
+export type Slots = {
+  default(props: {
+    /** Whether or not the popover is open */
+    open: boolean
+  }): Slot
+  /** The popover contents */
+  popover(props: {
+    /** Whether or not the popover is open */
+    open: boolean
+    /** A callback to close the popover */
+    close: () => void
+  }): Slot
+}


### PR DESCRIPTION
Updates and cleans up a bunch of the floating components (ScalarFloating, ScalarDropdown etc.). Theres a few small breaking changes in here but since we're the only ones that use `@scalar/components` (and it's semver < 1.0.0) I don't think we should have any problems. That being said a quick test of the client and references never hurt.

## Overview of changes

### In `@scalar/components`

* All components
  * Cleaned up the stories and docs
  * Updated them to provide all their `FloatingOptions` to their `ScalarFloating` component (e.g. middleware)
  * Updated their slots to include the menu open state where available (so you can make a chevron flip over in the trigger button or whatever).
  * Defined all slots

* `ScalarFloating`
  * Added an example and a story of how to use the middleware prop to adjust the offset.
  * Updated the type export to be `ScalarFloatingOptions` to be consistent with the rest of the library.
  * Refactored the `targetRef` prop to be `target` and to take either an `HTMLElement` or a `string` for an ID and added tests to that effect. 
  * Remove the `isOpen` prop which wasn't being used except for in the `EnvironmentVariableDropdown.vue` (see below). As a primitive `ScalarFloating` shouldn't really control it's open state and rather should just handle the position of the elements. If we want to hide the floating element we can just put a `v-if` on the `#floating` slot (but all the elements using it right now handle their own open and closed state).
* `ScalarListbox`
  * Extracted the listbox checkbox to be it's own component since we use it in a bunch of places
  * Updated the the listbox to use square checkboxes if it's in multiselect mode
  * Added a story showing how multiselect works
  * Improved the types for multiselect so you can't give it the wrong `v-model` type
  * Extracted the listbox item component so it can be reused
* `ScalarCombobox`
  * Added `#before` and `after#` slots so we can add buttons before and after the combobox list (note: this only works a11y because the combobox is actually a popover and you can tab through it unlike the listbox or dropdown).
* `ScalarDropdown`
  * Remove the `isOpen` and `static` props which weren't being used except for in the `EnvironmentVariableDropdown.vue, see below.
* `ScalarPopover`
  * Just cleaned it up and typed the slots
* `ScalarMenu`
  * Cleaned the floating props
  * Removed a negative margin from the button

### Outside of `@scalar/components`

* Updated `EnvironmentSelector.vue` and `WorkspaceDropdown.vue` to use the standardized `<ScalarListboxCheckbox>`.
* Refactored `EnvironmentVariableDropdown.vue` to not use `ScalarDropdown` anymore. It wasn't using very much from `<ScalarDropdown>` and was basically just rendering an absolutely positioned box in the dropdown (while running floating UI with no reference element). At some point might be worth refactoring the EnvironmentVariableDropdown to actually use FloatingUI to target the code mirror editor column or something.
* Updated the prop name from `targetRef` to `target` in `RequestSidebarItemMenu.vue`

