### PR TITLE
fix(api-client): css conflict with grid

### DIFF
--- a/.changeset/brown-tips-sort.md
+++ b/.changeset/brown-tips-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): fix css conflict with grid

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -131,7 +131,7 @@ const shouldVirtualize = computed(() => {
       </div>
     </template>
     <div
-      class="custom-scroll h-full relative grid gap-[.5px] px-2 xl:px-3 py-2.5"
+      class="custom-scroll h-full relative grid gap-[.5px] px-2 xl:px-3 py-2.5 justify-stretch"
       :class="{
         'content-start': response,
       }">

--- a/packages/api-reference/src/features/Search/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/SearchButton.vue
@@ -47,7 +47,7 @@ whenever(
     type="button"
     @click="modalState.show">
     <ScalarIcon
-      class="search-icon"
+      class="scalar-search-icon"
       icon="Search"
       size="sm"
       thickness="2.5" />
@@ -111,7 +111,7 @@ whenever(
   color: var(--scalar-sidebar-color-2, var(--scalar-color-2));
 }
 
-.search-icon {
+.scalar-search-icon {
   padding: 0;
   margin-right: 6px;
   width: 12px;


### PR DESCRIPTION
sometimes people apply classes globally to `.grid`, this stretches the content so that the layout doesn't break when people do that