### PR TITLE
refactor(mock-server): use path aliases

### DIFF
--- a/.changeset/twelve-berries-tap.md
+++ b/.changeset/twelve-berries-tap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+refactor: use path aliases

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -55,6 +55,7 @@
     "@hono/node-server": "^1.11.0",
     "@scalar/build-tooling": "workspace:*",
     "@scalar/hono-api-reference": "workspace:*",
-    "@types/node": "^20.14.10"
+    "@types/node": "^20.14.10",
+    "vite": "^5.4.10"
   }
 }

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -1,3 +1,10 @@
+import type { HttpMethod, MockServerOptions } from '@/types'
+import { getOperations } from '@/utils/getOperations'
+import { handleAuthentication } from '@/utils/handleAuthentication'
+import { honoRouteFromPath } from '@/utils/honoRouteFromPath'
+import { isAuthenticationRequired } from '@/utils/isAuthenticationRequired'
+import { logAuthenticationInstructions } from '@/utils/logAuthenticationInstructions'
+import { setupAuthenticationRoutes } from '@/utils/setupAuthenticationRoutes'
 import { openapi } from '@scalar/openapi-parser'
 import type { OpenAPI, OpenAPIV3_1 } from '@scalar/openapi-types'
 import { type Context, Hono } from 'hono'
@@ -5,13 +12,6 @@ import { cors } from 'hono/cors'
 
 import { mockAnyResponse } from './routes/mockAnyResponse'
 import { respondWithOpenApiDocument } from './routes/respondWithOpenApiDocument'
-import type { HttpMethod, MockServerOptions } from './types'
-import { getOperations } from './utils/getOperations'
-import { handleAuthentication } from './utils/handleAuthentication'
-import { honoRouteFromPath } from './utils/honoRouteFromPath'
-import { isAuthenticationRequired } from './utils/isAuthenticationRequired'
-import { logAuthenticationInstructions } from './utils/logAuthenticationInstructions'
-import { setupAuthenticationRoutes } from './utils/setupAuthenticationRoutes'
 
 /**
  * Create a mock server instance

--- a/packages/mock-server/src/routes/mockAnyResponse.ts
+++ b/packages/mock-server/src/routes/mockAnyResponse.ts
@@ -1,3 +1,5 @@
+import type { MockServerOptions } from '@/types'
+import { findPreferredResponseKey } from '@/utils/findPreferredResponseKey'
 import { getExampleFromSchema } from '@scalar/oas-utils/spec-getters'
 import type { OpenAPI } from '@scalar/openapi-types'
 import type { Context } from 'hono'
@@ -5,9 +7,6 @@ import { accepts } from 'hono/accepts'
 import type { StatusCode } from 'hono/utils/http-status'
 // @ts-expect-error Doesn’t come with types
 import objectToXML from 'object-to-xml'
-
-import type { MockServerOptions } from '../types'
-import { findPreferredResponseKey } from '../utils'
 
 /**
  * Mock any response

--- a/packages/mock-server/src/utils/createOpenApiDefinition.ts
+++ b/packages/mock-server/src/utils/createOpenApiDefinition.ts
@@ -1,14 +1,14 @@
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 
 /** Helper function create an OpenAPI document with security schemss */
-export function createOpenAPIDocument(
+export function createOpenApiDefinition(
   securitySchemes: Record<
     string,
     OpenAPIV3.SecuritySchemeObject | OpenAPIV3_1.SecuritySchemeObject
   >,
-): OpenAPIV3.Document {
+): OpenAPIV3_1.Document {
   return {
-    openapi: '3.0.0',
+    openapi: '3.1.1',
     info: { title: 'Test API', version: '1.0.0' },
     components: { securitySchemes },
   }

--- a/packages/mock-server/src/utils/getOpenAuthTokenUrls.test.ts
+++ b/packages/mock-server/src/utils/getOpenAuthTokenUrls.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
-import { createOpenAPIDocument } from './createOpenAPIDocument'
+import { createOpenApiDefinition } from './createOpenApiDefinition'
 import { getOpenAuthTokenUrls, getPathFromUrl } from './getOpenAuthTokenUrls'
 
 describe('getOpenAuthTokenUrls', () => {
   it('returns an empty array for schema without securitySchemes', () => {
-    const schema = createOpenAPIDocument({})
+    const schema = createOpenApiDefinition({})
     expect(getOpenAuthTokenUrls(schema)).toEqual([])
   })
 
   it('returns token URLs from OAuth2 password flow', () => {
-    const schema = createOpenAPIDocument({
+    const schema = createOpenApiDefinition({
       oauth2Password: {
         type: 'oauth2',
         flows: {
@@ -24,7 +24,7 @@ describe('getOpenAuthTokenUrls', () => {
   })
 
   it('returns token URLs from OAuth2 clientCredentials flow', () => {
-    const schema = createOpenAPIDocument({
+    const schema = createOpenApiDefinition({
       oauth2ClientCredentials: {
         type: 'oauth2',
         flows: {
@@ -38,7 +38,7 @@ describe('getOpenAuthTokenUrls', () => {
   })
 
   it('returns token URLs from OAuth2 authorizationCode flow', () => {
-    const schema = createOpenAPIDocument({
+    const schema = createOpenApiDefinition({
       oauth2AuthCode: {
         type: 'oauth2',
         flows: {
@@ -53,7 +53,7 @@ describe('getOpenAuthTokenUrls', () => {
   })
 
   it('returns multiple token URLs from different OAuth2 flows', () => {
-    const schema = createOpenAPIDocument({
+    const schema = createOpenApiDefinition({
       oauth2Password: {
         type: 'oauth2',
         flows: {
@@ -78,7 +78,7 @@ describe('getOpenAuthTokenUrls', () => {
   })
 
   it('ignores non-OAuth2 security schemes', () => {
-    const schema = createOpenAPIDocument({
+    const schema = createOpenApiDefinition({
       basicAuth: {
         type: 'http',
         scheme: 'basic',
@@ -96,7 +96,7 @@ describe('getOpenAuthTokenUrls', () => {
   })
 
   it('returns unique token URLs', () => {
-    const schema = createOpenAPIDocument({
+    const schema = createOpenApiDefinition({
       oauth2Password: {
         type: 'oauth2',
         flows: {

--- a/packages/mock-server/src/utils/getOperations.ts
+++ b/packages/mock-server/src/utils/getOperations.ts
@@ -1,11 +1,10 @@
+import { type HttpMethod, httpMethods } from '@/types'
 import type {
   OpenAPI,
   OpenAPIV2,
   OpenAPIV3,
   OpenAPIV3_1,
 } from '@scalar/openapi-types'
-
-import { type HttpMethod, httpMethods } from '../types'
 
 /**
  * Takes a dereferenced OpenAPI document and returns all operations.

--- a/packages/mock-server/src/utils/index.ts
+++ b/packages/mock-server/src/utils/index.ts
@@ -1,5 +1,0 @@
-export * from './findPreferredResponseKey'
-export * from './getOpenAuthTokenUrls'
-export * from './getOperations'
-export * from './honoRouteFromPath'
-export * from './isAuthenticationRequired'

--- a/packages/mock-server/src/utils/setupAuthenticationRoutes.ts
+++ b/packages/mock-server/src/utils/setupAuthenticationRoutes.ts
@@ -1,8 +1,8 @@
+import { respondWithAuthorizePage } from '@/routes/respondWithAuthorizePage'
+import { respondWithToken } from '@/routes/respondWithToken'
 import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Hono } from 'hono'
 
-import { respondWithAuthorizePage } from '../routes/respondWithAuthorizePage'
-import { respondWithToken } from '../routes/respondWithToken'
 import { getOpenAuthTokenUrls, getPathFromUrl } from './getOpenAuthTokenUrls'
 
 /**

--- a/packages/mock-server/tests/authentication/apiKey.test.ts
+++ b/packages/mock-server/tests/authentication/apiKey.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { createMockServer } from '../../src/createMockServer'
-import { createOpenAPIDocument } from '../../src/utils/createOpenAPIDocument'
+import { createOpenApiDefinition } from '../../src/utils/createOpenApiDefinition'
 
 describe('API Key Authentication', () => {
   it('succeeds with API key in header', async () => {
-    const specification = createOpenAPIDocument({
+    const specification = createOpenApiDefinition({
       apiKey: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
     })
     specification.paths = {
@@ -30,7 +30,7 @@ describe('API Key Authentication', () => {
   })
 
   it('fails without API key in header', async () => {
-    const specification = createOpenAPIDocument({
+    const specification = createOpenApiDefinition({
       apiKey: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
     })
     specification.paths = {

--- a/packages/mock-server/tests/authentication/basicAuthentication.test.ts
+++ b/packages/mock-server/tests/authentication/basicAuthentication.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { createMockServer } from '../../src/createMockServer'
-import { createOpenAPIDocument } from '../../src/utils/createOpenAPIDocument'
+import { createOpenApiDefinition } from '../../src/utils/createOpenApiDefinition'
 
 describe('HTTP Basic Authentication', () => {
   it('succeeds with valid basic auth credentials', async () => {
-    const specification = createOpenAPIDocument({
+    const specification = createOpenApiDefinition({
       basicAuth: { type: 'http', scheme: 'basic' },
     })
     specification.paths = {
@@ -26,7 +26,7 @@ describe('HTTP Basic Authentication', () => {
   })
 
   it('fails without basic auth credentials', async () => {
-    const specification = createOpenAPIDocument({
+    const specification = createOpenApiDefinition({
       basicAuth: { type: 'http', scheme: 'basic' },
     })
     specification.paths = {

--- a/packages/mock-server/tests/authentication/bearerAuthentication.test.ts
+++ b/packages/mock-server/tests/authentication/bearerAuthentication.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { createMockServer } from '../../src/createMockServer'
-import { createOpenAPIDocument } from '../../src/utils/createOpenAPIDocument'
+import { createOpenApiDefinition } from '../../src/utils/createOpenApiDefinition'
 
 describe('Bearer Token Authentication', () => {
   it('succeeds with valid bearer token', async () => {
-    const specification = createOpenAPIDocument({
+    const specification = createOpenApiDefinition({
       bearerAuth: { type: 'http', scheme: 'bearer' },
     })
     specification.paths = {
@@ -27,7 +27,7 @@ describe('Bearer Token Authentication', () => {
   })
 
   it('fails without bearer token', async () => {
-    const specification = createOpenAPIDocument({
+    const specification = createOpenApiDefinition({
       bearerAuth: { type: 'http', scheme: 'bearer' },
     })
 

--- a/packages/mock-server/tests/authentication/oAuth.test.ts
+++ b/packages/mock-server/tests/authentication/oAuth.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { createMockServer } from '../../src/createMockServer'
-import { createOpenAPIDocument } from '../../src/utils/createOpenAPIDocument'
+import { createOpenApiDefinition } from '../../src/utils/createOpenApiDefinition'
 
 describe('OAuth 2.0 Authentication', () => {
   describe('Authorization Code Flow', () => {
-    const specification = createOpenAPIDocument({
+    const specification = createOpenApiDefinition({
       oauth2: {
         type: 'oauth2',
         flows: {
@@ -44,7 +44,7 @@ describe('OAuth 2.0 Authentication', () => {
   })
 
   describe('Implicit Flow', () => {
-    const specification = createOpenAPIDocument({
+    const specification = createOpenApiDefinition({
       oauth2: {
         type: 'oauth2',
         flows: {
@@ -82,7 +82,7 @@ describe('OAuth 2.0 Authentication', () => {
   })
 
   describe('Client Credentials Flow', () => {
-    const specification = createOpenAPIDocument({
+    const specification = createOpenApiDefinition({
       oauth2: {
         type: 'oauth2',
         flows: {
@@ -120,7 +120,7 @@ describe('OAuth 2.0 Authentication', () => {
   })
 
   describe('Password Flow', () => {
-    const specification = createOpenAPIDocument({
+    const specification = createOpenApiDefinition({
       oauth2: {
         type: 'oauth2',
         flows: {

--- a/packages/mock-server/tests/authentication/openIdConnect.test.ts
+++ b/packages/mock-server/tests/authentication/openIdConnect.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import { createMockServer } from '../../src/createMockServer'
-import { createOpenAPIDocument } from '../../src/utils/createOpenAPIDocument'
+import { createOpenApiDefinition } from '../../src/utils/createOpenApiDefinition'
 
 describe('OpenID Connect', () => {
-  const specification = createOpenAPIDocument({
+  const specification = createOpenApiDefinition({
     openIdConnect: {
       type: 'openIdConnect',
       openIdConnectUrl: 'https://example.com/.well-known/openid-configuration',

--- a/packages/mock-server/tsconfig.build.json
+++ b/packages/mock-server/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["**/*.test.ts"],
+  "exclude": ["dist", "test", "vite.config.ts", "**/*.test.ts"],
   "compilerOptions": {
     "skipLibCheck": true,
     "declaration": true,

--- a/packages/mock-server/tsconfig.json
+++ b/packages/mock-server/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {},
-  "include": ["src", "playground", "rollup.config.ts", "env.d.ts"]
+  "include": ["src", "test"],
+  "exclude": ["dist", "**/*.test.ts"],
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"],
+      "@test/*": ["./test/*"]
+    }
+  }
 }

--- a/packages/mock-server/vite.config.ts
+++ b/packages/mock-server/vite.config.ts
@@ -1,0 +1,10 @@
+import { alias } from '@scalar/build-tooling'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [],
+  resolve: {
+    alias: alias(import.meta.url),
+    dedupe: ['vue'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,79 +243,6 @@ importers:
         version: 10.3.2(@swc/cli@0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0))(@swc/core@1.5.29(@swc/helpers@0.5.5))
       '@nestjs/schematics':
         specifier: ^10.0.1
-        version: 10.1.1(chokidar@3.6.0)(typescript@5.6.2)
-      '@nestjs/testing':
-        specifier: ^10.0.0
-        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9))
-      '@swc/cli':
-        specifier: ^0.1.62
-        version: 0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0)
-      '@swc/core':
-        specifier: ^1.3.64
-        version: 1.5.29(@swc/helpers@0.5.5)
-      '@types/jest':
-        specifier: ^29.5.2
-        version: 29.5.12
-      '@types/node':
-        specifier: ^20.14.10
-        version: 20.14.10
-      '@types/supertest':
-        specifier: ^2.0.12
-        version: 2.0.16
-      '@typescript-eslint/parser':
-        specifier: ^6.21.0
-        version: 6.21.0(eslint@8.57.0)(typescript@5.6.2)
-      eslint-config-prettier:
-        specifier: ^9.1.0
-        version: 9.1.0(eslint@8.57.0)
-      eslint-plugin-prettier:
-        specifier: ^5.1.3
-        version: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3)
-      jest:
-        specifier: ^29.5.0
-        version: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2))
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
-      supertest:
-        specifier: ^6.3.3
-        version: 6.3.4
-      ts-jest:
-        specifier: ^29.1.0
-        version: 29.1.4(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)))(typescript@5.6.2)
-      ts-loader:
-        specifier: ^9.4.3
-        version: 9.5.1(typescript@5.6.2)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.5)))
-
-  examples/nestjs-api-reference-fastify:
-    dependencies:
-      '@nestjs/common':
-        specifier: ^10.3.8
-        version: 10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/core':
-        specifier: ^10.3.8
-        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      '@nestjs/platform-fastify':
-        specifier: ^10.3.8
-        version: 10.3.9(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))
-      '@nestjs/swagger':
-        specifier: ^7.3.1
-        version: 7.3.1(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)
-      '@scalar/nestjs-api-reference':
-        specifier: workspace:*
-        version: link:../../packages/nestjs-api-reference
-      reflect-metadata:
-        specifier: ^0.1.13
-        version: 0.1.14
-      rxjs:
-        specifier: ^7.8.1
-        version: 7.8.1
-    devDependencies:
-      '@nestjs/cli':
-        specifier: ^10.0.1
-        version: 10.3.2(@swc/cli@0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0))(@swc/core@1.5.29(@swc/helpers@0.5.5))
-      '@nestjs/schematics':
-        specifier: ^10.0.1
         version: 10.1.1(chokidar@3.6.0)(typescript@5.3.3)
       '@nestjs/testing':
         specifier: ^10.0.0
@@ -359,6 +286,79 @@ importers:
       ts-loader:
         specifier: ^9.4.3
         version: 9.5.1(typescript@5.3.3)(webpack@5.90.1(@swc/core@1.5.29(@swc/helpers@0.5.5)))
+
+  examples/nestjs-api-reference-fastify:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^10.3.8
+        version: 10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/core':
+        specifier: ^10.3.8
+        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1)
+      '@nestjs/platform-fastify':
+        specifier: ^10.3.8
+        version: 10.3.9(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))
+      '@nestjs/swagger':
+        specifier: ^7.3.1
+        version: 7.3.1(@fastify/static@7.0.4)(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(reflect-metadata@0.1.14)
+      '@scalar/nestjs-api-reference':
+        specifier: workspace:*
+        version: link:../../packages/nestjs-api-reference
+      reflect-metadata:
+        specifier: ^0.1.13
+        version: 0.1.14
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
+    devDependencies:
+      '@nestjs/cli':
+        specifier: ^10.0.1
+        version: 10.3.2(@swc/cli@0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0))(@swc/core@1.5.29(@swc/helpers@0.5.5))
+      '@nestjs/schematics':
+        specifier: ^10.0.1
+        version: 10.1.1(chokidar@3.6.0)(typescript@5.6.2)
+      '@nestjs/testing':
+        specifier: ^10.0.0
+        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.1.14)(rxjs@7.8.1))(@nestjs/core@10.3.9))
+      '@swc/cli':
+        specifier: ^0.1.62
+        version: 0.1.65(@swc/core@1.5.29(@swc/helpers@0.5.5))(chokidar@3.6.0)
+      '@swc/core':
+        specifier: ^1.3.64
+        version: 1.5.29(@swc/helpers@0.5.5)
+      '@types/jest':
+        specifier: ^29.5.2
+        version: 29.5.12
+      '@types/node':
+        specifier: ^20.14.10
+        version: 20.14.10
+      '@types/supertest':
+        specifier: ^2.0.12
+        version: 2.0.16
+      '@typescript-eslint/parser':
+        specifier: ^6.21.0
+        version: 6.21.0(eslint@8.57.0)(typescript@5.6.2)
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.0)
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3)
+      jest:
+        specifier: ^29.5.0
+        version: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2))
+      source-map-support:
+        specifier: ^0.5.21
+        version: 0.5.21
+      supertest:
+        specifier: ^6.3.3
+        version: 6.3.4
+      ts-jest:
+        specifier: ^29.1.0
+        version: 29.1.4(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)))(typescript@5.6.2)
+      ts-loader:
+        specifier: ^9.4.3
+        version: 9.5.1(typescript@5.6.2)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.5)))
 
   examples/nextjs-api-reference:
     dependencies:
@@ -1577,6 +1577,9 @@ importers:
       '@types/node':
         specifier: ^20.14.10
         version: 20.14.10
+      vite:
+        specifier: ^5.4.10
+        version: 5.4.10(@types/node@20.14.10)(terser@5.31.2)
 
   packages/nestjs-api-reference:
     dependencies:


### PR DESCRIPTION
This PR introduces the path aliases we already have in other packages to the `@scalar/mock-server`.

Easier to move files around without modifying the imports.

Stole the configuration from `@scalar/oas-utils`.

Also removes the barrel file from `./utils`.