### PR TITLE
fix(proxy-server): remove original `Origin` header

### DIFF
--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"strings"
 )
 
 // corsMiddleware adds CORS headers to the response and handles pre-flight requests.
@@ -77,6 +78,13 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	proxy.Director = func(req *http.Request) {
 		req.Header = r.Header
+		// Remove Origin header
+		for key := range req.Header {
+			if !strings.EqualFold(strings.ToLower(key), "origin") {
+				req.Header.Del(key)
+			}
+		}
+
 		req.Host = remote.Host
 		req.URL.Scheme = remote.Scheme
 		req.URL.Host = remote.Host


### PR DESCRIPTION
For cross-origin requests, the browser adds an `Origin` header with the original URL the request is coming from. That might confuse some target servers, because the request is then coming from the proxy and not from the original URL anymore.

As the whole point of the proxy is to make it work like same-site requests, we might be able to just delete the `Origin` header. This PR does that.

ℹ️ The same fix was applied to #3848.