### PR TITLE
feat(api-reference): displays path server in request example

### DIFF
--- a/.changeset/sour-hotels-exist.md
+++ b/.changeset/sour-hotels-exist.md
@@ -1,0 +1,5 @@
+---
+'@scalar/types': patch
+---
+
+feat: adds servers to information reference config

--- a/.changeset/twelve-elephants-smell.md
+++ b/.changeset/twelve-elephants-smell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat(api-reference): displays path server in request example

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -130,10 +130,16 @@ async function generateSnippet() {
     )
   }
 
-  // Generate a request object
+  // Generate a request from operation server or fallback to global server URL
+  const serverUrl = computed(() => {
+    const operationServer = props.operation.information?.servers?.[0]
+    const { modifiedUrl } = getUrlFromServerState(serverState, operationServer)
+    return modifiedUrl
+  })
+
   const harRequest = getHarRequest(
     {
-      url: getUrlFromServerState(serverState).modifiedUrl,
+      url: serverUrl.value,
     },
     getRequestFromOperation(
       props.operation,

--- a/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
+++ b/packages/api-reference/src/legacy/helpers/getUrlFromServerState.ts
@@ -1,25 +1,30 @@
 import type { ServerState } from '#legacy'
 import { REGEX, replaceVariables } from '@scalar/oas-utils/helpers'
+import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/types'
 
 /**
  * Get the URL from the server state.
  */
-export function getUrlFromServerState(state: ServerState) {
-  // Get the selected server and remove trailing slash
-  const server = state?.servers?.[state.selectedServer ?? 0]
+export function getUrlFromServerState(
+  state: ServerState,
+  server?: OpenAPIV3.ServerObject | OpenAPIV3_1.ServerObject,
+) {
+  // Use the provided server or fallback to the selected server in the state
+  const selectedServer = server ?? state?.servers?.[state.selectedServer ?? 0]
 
-  if (server?.url?.endsWith('/')) {
-    server.url = server.url.slice(0, -1)
+  // Get the selected server and remove trailing slash
+  if (selectedServer?.url?.endsWith('/')) {
+    selectedServer.url = selectedServer.url.slice(0, -1)
   }
 
   // Store the original URL before any modifications
-  const originalUrl = server?.url
+  const originalUrl = selectedServer?.url
 
   // Replace variables: {protocol}://{host}:{port}/{basePath}
   const url =
-    typeof server?.url === 'string'
-      ? replaceVariables(server?.url, state.variables)
-      : server?.url
+    typeof selectedServer?.url === 'string'
+      ? replaceVariables(selectedServer?.url, state.variables)
+      : selectedServer?.url
 
   // {id} -> __ID__
   const urlVariables = url?.match(REGEX.PATH)

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -296,6 +296,7 @@ export type Information = {
   'summary'?: string
   'tags'?: string[]
   'deprecated'?: boolean
+  'servers'?: Server[]
   /**
    * Scalar
    */
@@ -326,6 +327,7 @@ export type Operation = {
   name?: string
   description?: string
   information?: Information
+  servers?: Server[]
 }
 
 /**


### PR DESCRIPTION
this pr is a proposal to fix #3964 in order to favor the path server in the request example if it exists:

**⊢ before / after**
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/55f64d25-8e2b-4055-a524-09bd91ad9569">
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/635aed08-5435-4b62-9f8b-6377bc5dfde5">

should be ff with setting the right server in the client modal on test request.
