### PR TITLE
feat(api-client): request body example selector

### DIFF
--- a/.changeset/rich-vans-fold.md
+++ b/.changeset/rich-vans-fold.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds request body example selector


### PR DESCRIPTION
this pr adds a selector to the api client request body in order to be able to switch examples from an OAD:

<img width="730" alt="image" src="https://github.com/user-attachments/assets/54412ca4-43ba-473e-a5f7-5ca8bd7ed221">

course of action:
- [ ] enhances focus outline