### PR TITLE
fix(proxy-server): doesn’t deploy public assets

### DIFF
--- a/examples/proxy-server/Dockerfile
+++ b/examples/proxy-server/Dockerfile
@@ -3,6 +3,8 @@ FROM golang:1.22-alpine as build
 WORKDIR /app
 
 COPY ./main.go ./
+COPY ./public ./public
+
 RUN go build main.go
 
 # Build distroless image


### PR DESCRIPTION
With #3848 we added an API reference to the proxy server, but I forgot to add the static assets in the Dockerfile and the server now shows `Error reading index.html` on `/`.

This PR adds the assets to fix the issue.