### PR TITLE
feat(api-client): request creation from sidebar

### DIFF
--- a/.changeset/bright-bugs-shake.md
+++ b/.changeset/bright-bugs-shake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: updates chevron up icon

--- a/.changeset/cool-parrots-kiss.md
+++ b/.changeset/cool-parrots-kiss.md
@@ -1,0 +1,9 @@
+---
+'@scalar/code-highlight': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+'@scalar/docusaurus': patch
+---
+
+feat: updates chevron down icon

--- a/.changeset/dirty-cherries-check.md
+++ b/.changeset/dirty-cherries-check.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+feat: updates add icon

--- a/.changeset/nasty-insects-destroy.md
+++ b/.changeset/nasty-insects-destroy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds request creation from sidebar

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -106,8 +106,8 @@ const serverUrlWithoutTrailingSlash = computed(() => {
             @click="handleAddServer">
             <div class="flex items-center justify-center h-4 w-4">
               <ScalarIcon
-                class="h-2.5"
-                icon="Add" />
+                icon="Add"
+                size="sm" />
             </div>
             <span>Add Server</span>
           </div>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -83,7 +83,7 @@ const handleSubmit = () => {
             <ScalarIcon
               class="text-c-3"
               icon="ChevronDown"
-              size="xs" />
+              size="md" />
           </div>
         </ScalarButton>
         <template #items>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
@@ -145,11 +145,15 @@ const handleSubmit = () => {
           <ScalarButton
             class="justify-between p-2 ml-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
             variant="outlined">
-            <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
-              selectedCollection
-                ? selectedCollection.label
-                : 'Select Collection'
-            }}</span>
+            <span
+              class="whitespace-nowrap"
+              :class="selectedCollection ? 'text-c-1' : 'text-c-3'"
+              >{{
+                selectedCollection
+                  ? selectedCollection.label
+                  : 'Select Collection'
+              }}</span
+            >
             <ScalarIcon
               class="text-c-3"
               icon="ChevronDown"

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
@@ -157,7 +157,7 @@ const handleSubmit = () => {
             <ScalarIcon
               class="text-c-3"
               icon="ChevronDown"
-              size="xs" />
+              size="md" />
           </ScalarButton>
         </ScalarListbox>
         <ScalarListbox
@@ -173,7 +173,7 @@ const handleSubmit = () => {
             <ScalarIcon
               class="text-c-3"
               icon="ChevronDown"
-              size="xs" />
+              size="md" />
           </ScalarButton>
         </ScalarListbox>
       </div>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
@@ -81,7 +81,7 @@ const redirectToCreateCollection = () => {
         :options="collections">
         <ScalarButton
           v-if="collections.length > 0"
-          class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+          class="justify-between p-2 max-h-8 w-fit gap-1 text-xs hover:bg-b-2"
           variant="outlined">
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
             selectedCollection ? selectedCollection.label : 'Select Collection'
@@ -89,7 +89,7 @@ const redirectToCreateCollection = () => {
           <ScalarIcon
             class="text-c-3"
             icon="ChevronDown"
-            size="xs" />
+            size="md" />
         </ScalarButton>
         <ScalarButton
           v-else

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
@@ -66,7 +66,7 @@ const handleSubmit = () => {
         v-model="selectedCollection"
         :options="availableCollections">
         <ScalarButton
-          class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+          class="justify-between p-2 max-h-8 w-fit gap-1 text-xs hover:bg-b-2"
           variant="outlined">
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
             selectedCollection ? selectedCollection.label : 'Select Collection'
@@ -74,7 +74,7 @@ const handleSubmit = () => {
           <ScalarIcon
             class="text-c-3"
             icon="ChevronDown"
-            size="xs" />
+            size="md" />
         </ScalarButton>
       </ScalarListbox>
     </template>

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -90,7 +90,7 @@ const initialValue = computed(() => {
           <span class="text-c-1">{{ initialValue || 'Select a value' }}</span>
           <ScalarIcon
             icon="ChevronDown"
-            size="xs" />
+            size="md" />
         </ScalarButton>
         <template #items>
           <ScalarDropdownItem

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -121,8 +121,8 @@ const initialValue = computed(() => {
               @click="addingCustomValue = true">
               <div class="flex items-center justify-center h-4 w-4">
                 <ScalarIcon
-                  class="h-2.5"
-                  icon="Add" />
+                  icon="Add"
+                  size="sm" />
               </div>
               <span>Add value</span>
             </ScalarDropdownItem>

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -45,9 +45,8 @@ const envs = computed(() => [
         <h2 class="font-medium m-0 flex gap-1.5 items-center whitespace-nowrap">
           {{ activeEnvironment?.name ?? 'No Environment' }}
           <ScalarIcon
-            class="size-3"
             icon="ChevronDown"
-            thickness="3" />
+            size="md" />
         </h2>
       </ScalarButton>
       <!-- Workspace list -->

--- a/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
+++ b/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
@@ -105,9 +105,8 @@ const handleCreateWorkspace = () => {
           @click="modal.show()">
           <div class="flex items-center justify-center h-4 w-4">
             <ScalarIcon
-              class="h-2.5"
               icon="Add"
-              thickness="3" />
+              size="sm" />
           </div>
           <span>New Workspace</span>
         </ScalarDropdownItem>

--- a/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
+++ b/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
@@ -68,9 +68,8 @@ const handleCreateWorkspace = () => {
             {{ activeWorkspace.name }}
           </h2>
           <ScalarIcon
-            class="size-3"
             icon="ChevronDown"
-            thickness="3" />
+            size="md" />
         </div>
       </ScalarButton>
 

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -25,8 +25,7 @@ withDefaults(
         <ScalarIcon
           class="text-c-3 group-hover:text-c-1 group-focus-visible:outline ui-open:rotate-90 ui-not-open:rotate-0 rounded-[1px] outline-offset-2"
           icon="ChevronRight"
-          size="sm"
-          thickness="2.5" />
+          size="md" />
         <div class="flex flex-1 items-center gap-1.5 text-c-1">
           <slot
             name="title"

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -116,13 +116,12 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                     'rotate-90': collapsedSidebarFolders[domain],
                   }"
                   icon="ChevronRight"
-                  size="sm"
-                  thickness="2.5" />
+                  size="md" />
                 {{ domain }}
               </button>
               <div
                 v-show="showChildren(domain)"
-                class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1rem_-_.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
                 <div
                   v-for="(cookieList, path) in paths"
                   :key="path">
@@ -136,13 +135,12 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                         'rotate-90': collapsedSidebarFolders[domain + path],
                       }"
                       icon="ChevronRight"
-                      size="sm"
-                      thickness="2.5" />
+                      size="md" />
                     {{ path }}
                   </button>
                   <div
                     v-show="showChildren(domain + path)"
-                    class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1.75rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                    class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1.75rem_-_.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
                     <SidebarListElement
                       v-for="cookie in cookieList"
                       :key="cookie.uid"

--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -161,8 +161,8 @@ onClickOutside(
         variant="secondary"
         @click="redirectToEnvironment">
         <ScalarIcon
-          class="w-2.5"
-          icon="Add" />
+          icon="Add"
+          size="sm" />
         Add Variable
       </ScalarButton>
       <!-- Backdrop for the dropdown -->

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -289,9 +289,9 @@ function handleDeleteScheme(option: { id: string; label: string }) {
                   None
                 </div>
                 <ScalarIcon
-                  class="min-w-3 ml-auto mr-2.5"
+                  class="mr-[9px]"
                   icon="ChevronDown"
-                  size="xs" />
+                  size="md" />
               </ScalarButton>
             </ScalarComboboxMultiselect>
           </DataTableHeader>

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -460,8 +460,7 @@ const selectedExample = computed({
               <span>{{ selectedContentType?.label }}</span>
               <ScalarIcon
                 icon="ChevronDown"
-                size="xs"
-                thickness="2.5" />
+                size="md" />
             </ScalarButton>
           </ScalarListbox>
           <ScalarListbox
@@ -477,8 +476,7 @@ const selectedExample = computed({
               <span>{{ selectedExample?.label }}</span>
               <ScalarIcon
                 icon="ChevronDown"
-                size="xs"
-                thickness="2.5" />
+                size="md" />
             </ScalarButton>
           </ScalarListbox>
         </DataTableHeader>

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -251,7 +251,7 @@ const handleClearDrafts = () => {
                 <ScalarIcon
                   class="text-c-3 hidden text-sm group-hover:block"
                   icon="ChevronRight"
-                  size="sm"
+                  size="md"
                   thickness="2" />
               </div>
             </template>

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -251,8 +251,7 @@ const handleClearDrafts = () => {
                 <ScalarIcon
                   class="text-c-3 hidden text-sm group-hover:block"
                   icon="ChevronRight"
-                  size="md"
-                  thickness="2" />
+                  size="md" />
               </div>
             </template>
           </RequestSidebarItem>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -339,7 +339,7 @@ const hasDraftRequests = computed(() => {
                 ">
                 <ScalarIcon
                   icon="Ellipses"
-                  size="sm" />
+                  size="md" />
               </ScalarButton>
             </div>
             <span class="flex items-start">
@@ -387,54 +387,46 @@ const hasDraftRequests = computed(() => {
             {{ item.title }}
           </span>
           <div class="relative flex h-fit">
-            <ScalarButton
-              v-if="!isReadOnly && !isDraftCollection"
-              class="px-0.5 py-0 hover:bg-b-3 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
+            <div
+              class="flex items-center opacity-0 gap-px group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 absolute -translate-y-1/2 -right-px inset-y-2/4"
               :class="{
                 'flex':
                   menuItem.item?.entity.uid === item.entity.uid &&
                   menuItem.open,
-                'right-5': item.watchMode,
-              }"
-              size="sm"
-              variant="ghost"
-              @click.stop.prevent="
-                (ev) =>
-                  $emit('openMenu', {
-                    item,
-                    parentUids,
-                    targetRef: ev.currentTarget.parentNode,
-                    open: true,
-                  })
-              ">
-              <ScalarIcon
-                icon="Ellipses"
-                size="sm" />
-            </ScalarButton>
-            <ScalarButton
-              v-if="isDraftCollection && hasDraftRequests"
-              class="px-0.5 py-0 hover:bg-b-3 hidden group-hover:flex absolute -translate-y-1/2 right-0 aspect-square inset-y-2/4 h-fit"
-              :class="{
-                'flex':
-                  menuItem.item?.entity.uid === item.entity.uid &&
-                  menuItem.open,
-                'right-5': item.watchMode,
-              }"
-              size="sm"
-              variant="ghost"
-              @click.stop.prevent="
-                (ev) =>
-                  $emit('openMenu', {
-                    item,
-                    parentUids,
-                    targetRef: ev.currentTarget.parentNode,
-                    open: true,
-                  })
-              ">
-              <ScalarIcon
-                icon="Ellipses"
-                size="sm" />
-            </ScalarButton>
+                '!right-5': item.watchMode,
+              }">
+              <ScalarButton
+                v-if="
+                  (!isReadOnly && !isDraftCollection) ||
+                  (isDraftCollection && hasDraftRequests)
+                "
+                class="px-0.5 py-0 hover:bg-b-3 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 aspect-square h-fit"
+                size="sm"
+                variant="ghost"
+                @click.stop.prevent="
+                  (ev) =>
+                    $emit('openMenu', {
+                      item,
+                      parentUids,
+                      targetRef: ev.currentTarget.parentNode,
+                      open: true,
+                    })
+                ">
+                <ScalarIcon
+                  icon="Ellipses"
+                  size="md" />
+              </ScalarButton>
+              <ScalarButton
+                class="px-0.5 py-0 hover:bg-b-3 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 aspect-square h-fit"
+                size="sm"
+                variant="ghost"
+                @click.stop.prevent="openCommandPaletteRequest()">
+                <ScalarIcon
+                  icon="Add"
+                  size="md"
+                  thickness="2" />
+              </ScalarButton>
+            </div>
             <ScalarTooltip
               v-if="item.watchMode"
               side="right"
@@ -444,8 +436,8 @@ const hasDraftRequests = computed(() => {
                   class="text-sm"
                   :class="watchIconColor"
                   icon="Watch"
-                  size="sm"
-                  thickness="2.5" />
+                  size="md"
+                  thickness="2" />
               </template>
               <template #content>
                 <div

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -371,8 +371,7 @@ const hasDraftRequests = computed(() => {
               <ScalarIcon
                 class="text-c-3 text-sm"
                 icon="ChevronRight"
-                size="sm"
-                thickness="2.5" />
+                size="md" />
             </div>
           </slot>
           &hairsp;

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -101,9 +101,8 @@ const deleteWorkspace = async () => {
               {{ activeWorkspace.name }}
             </h2>
             <ScalarIcon
-              class="size-3"
               icon="ChevronDown"
-              thickness="3" />
+              size="md" />
           </div>
         </ScalarButton>
 

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -192,9 +192,8 @@ const deleteWorkspace = async () => {
             @click="createNewWorkspace">
             <div class="flex items-center justify-center h-4 w-4">
               <ScalarIcon
-                class="h-2.5"
                 icon="Add"
-                thickness="3" />
+                size="sm" />
             </div>
             <span>Create Workspace</span>
           </ScalarDropdownItem>

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -70,10 +70,10 @@ const handleClick = (e: MouseEvent) =>
           <template v-if="compact">
             <ScalarIcon
               v-if="shouldShowToggle"
-              class="schema-card-title-icon h-2.5"
+              class="schema-card-title-icon"
               :class="{ 'schema-card-title-icon--open': open }"
               icon="Add"
-              thickness="3" />
+              size="sm" />
             <template v-if="open">
               Hide {{ value?.title ?? 'Child Attributes' }}
             </template>
@@ -87,8 +87,7 @@ const handleClick = (e: MouseEvent) =>
               class="schema-card-title-icon"
               :class="{ 'schema-card-title-icon--open': open }"
               icon="Add"
-              size="xs"
-              thickness="2.5" />
+              size="sm" />
             <SchemaHeading
               :name="(value?.title ?? name) as string"
               :value="value" />
@@ -235,7 +234,7 @@ button.schema-card-title:hover {
 
 .schema-card-title--compact {
   color: var(--scalar-color-2);
-  padding: 6px 10px;
+  padding: 6px 8px;
   height: auto;
   border-bottom: none;
 }
@@ -245,8 +244,6 @@ button.schema-card-title:hover {
 }
 
 .schema-card-title--compact > .schema-card-title-icon {
-  width: 10px;
-  height: 10px;
   margin: 0;
 }
 .schema-card-title--compact > .schema-card-title-icon--open {

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -175,10 +175,10 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
             </DisclosurePanel>
             <DisclosureButton class="enum-toggle-button">
               <ScalarIcon
-                class="enum-toggle-button-icon h-2.5"
+                class="enum-toggle-button-icon"
                 :class="{ 'enum-toggle-button-icon--open': open }"
                 icon="Add"
-                thickness="3" />
+                size="sm" />
               {{ open ? 'Hide values' : 'Show all values' }}
             </DisclosureButton>
           </Disclosure>

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -37,7 +37,8 @@ watch(
       @click="open = !open">
       <ScalarIcon
         :icon="open ? 'ChevronDown' : 'ChevronRight'"
-        size="sm" />
+        size="md"
+        thickness="1.5" />
       <Anchor
         :id="id"
         class="collapsible-section-header">
@@ -80,8 +81,7 @@ watch(
 .collapsible-section-trigger svg {
   color: var(--scalar-color-3);
   position: absolute;
-  left: -18px;
-  margin-top: 1px;
+  left: -19px;
 }
 .collapsible-section:hover .collapsible-section-trigger svg {
   color: var(--scalar-color-1);

--- a/packages/api-reference/src/components/ShowMoreButton.vue
+++ b/packages/api-reference/src/components/ShowMoreButton.vue
@@ -46,8 +46,8 @@ const { setCollapsedSidebarItem } = useSidebar()
 }
 .show-more-icon {
   /* todo remove but its for docusaurus */
-  width: 14px !important;
-  height: 14px !important;
+  width: 16px !important;
+  height: 16px !important;
   margin-left: 3px;
 }
 .show-more:active {

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -105,6 +105,7 @@ const onAnchorClick = async (ev: Event) => {
           :icon="open ? 'ChevronDown' : 'ChevronRight'"
           :label="`${open ? 'Collapse' : 'Expand'} ${item.title}`"
           size="xs"
+          thickness="1.5"
           @click.stop="handleClick" />
         &hairsp;
       </p>
@@ -274,7 +275,7 @@ const onAnchorClick = async (ev: Event) => {
 .toggle-nested-icon {
   border: none;
   color: currentColor;
-  padding: 3px;
+  padding: 2px;
   color: var(--scalar-sidebar-color-2);
 }
 .active_page .toggle-nested-icon {

--- a/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerUrlSelect.vue
@@ -53,7 +53,7 @@ const selected = computed<ScalarListboxOption | undefined>({
       <ScalarIcon
         v-if="options.length > 1"
         icon="ChevronDown"
-        size="xs" />
+        size="sm" />
     </ScalarButton>
   </ScalarListbox>
 </template>

--- a/packages/api-reference/src/features/BaseUrl/ServerVariablesSelect.vue
+++ b/packages/api-reference/src/features/BaseUrl/ServerVariablesSelect.vue
@@ -45,7 +45,7 @@ const selected = computed<ScalarListboxOption | undefined>({
       </span>
       <ScalarIcon
         icon="ChevronDown"
-        size="xs" />
+        size="sm" />
     </ScalarButton>
   </ScalarListbox>
 </template>

--- a/packages/api-reference/src/features/Operation/components/ParameterHeaders.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterHeaders.vue
@@ -31,7 +31,7 @@ function hasSchema(
             class="headers-card-title-icon"
             :class="{ 'headers-card-title-icon--open': open }"
             icon="Add"
-            thickness="3" />
+            size="sm" />
           <template v-if="open"> Hide Headers </template>
           <template v-else> Show Headers </template>
         </DisclosureButton>

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -50,8 +50,7 @@ const shouldCollapse = computed<boolean>(() => {
         <ScalarIcon
           class="parameter-item-icon"
           :icon="open ? 'ChevronDown' : 'ChevronRight'"
-          size="md"
-          thickness="1.75" />
+          thickness="1.5" />
         <ScreenReader>
           {{ open ? 'Collapse' : 'Expand' }}
         </ScreenReader>
@@ -190,8 +189,11 @@ const shouldCollapse = computed<boolean>(() => {
 }
 .parameter-item-icon {
   color: var(--scalar-color-3);
+  height: 18px;
+  left: -19px;
   position: absolute;
-  left: -18px;
+  top: 11px;
+  width: 18px;
 }
 .parameter-item-trigger:hover .parameter-item-icon,
 .parameter-item-trigger:focus-visible .parameter-item-icon {

--- a/packages/api-reference/src/features/Operation/components/RequestBodyPropertiesChild.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBodyPropertiesChild.vue
@@ -23,8 +23,8 @@ defineProps<{ contentProperties: ContentProperties }>()
         class="parameter-child parameter-child__on">
         <div class="parameter-child-trigger">
           <ScalarIcon
-            class="h-2.5"
-            icon="Add" />
+            icon="Add"
+            size="sm" />
           <span>Child Attributes</span>
         </div>
       </div>

--- a/packages/api-reference/src/legacy/components/SecuritySchemeSelector.vue
+++ b/packages/api-reference/src/legacy/components/SecuritySchemeSelector.vue
@@ -164,7 +164,7 @@ const selected = computed<ScalarListboxOption | undefined>({
         }}
         <ScalarIcon
           icon="ChevronDown"
-          size="xs" />
+          size="sm" />
       </ScalarButton>
     </ScalarListbox>
   </template>

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -46,14 +46,14 @@
     content: '';
 
     position: absolute;
-    top: 1px;
-    left: 1px;
+    top: -1px;
+    left: -1px;
 
-    width: 16px;
-    height: 16px;
+    width: 20px;
+    height: 20px;
 
     background-color: var(--scalar-color-3);
-    mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.25 19.5L15.75 12L8.25 4.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+    mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m9 18 6-6-6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
   }
 
   .markdown summary:hover::after {

--- a/packages/components/src/components/ScalarIcon/icons/Add.svg
+++ b/packages/components/src/components/ScalarIcon/icons/Add.svg
@@ -1,3 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path d="M2 12h20M12 2v20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" />
-</svg>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5 11.988h14M12.006 5v14" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/components/src/components/ScalarIcon/icons/ChevronDown.svg
+++ b/packages/components/src/components/ScalarIcon/icons/ChevronDown.svg
@@ -1,3 +1,1 @@
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M4.5 8.25L12 15.75L19.5 8.25" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" />
-</svg>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m18 10-6 6-6-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/components/src/components/ScalarIcon/icons/ChevronRight.svg
+++ b/packages/components/src/components/ScalarIcon/icons/ChevronRight.svg
@@ -1,3 +1,1 @@
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M8.25 19.5L15.75 12L8.25 4.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" />
-</svg>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m9 18 6-6-6-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/components/src/components/ScalarIcon/icons/ChevronUp.svg
+++ b/packages/components/src/components/ScalarIcon/icons/ChevronUp.svg
@@ -1,3 +1,1 @@
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M19.5 15.75L12 8.25L4.5 15.75" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" />
-</svg>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m18 15-6-6-6 6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuButton.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuButton.vue
@@ -18,7 +18,6 @@ defineProps<{
     <ScalarIcon
       class="text-c-3 group-hover/button:text-c-1"
       :icon="open ? 'ChevronUp' : 'ChevronDown'"
-      size="sm"
-      thickness="2.5" />
+      size="sm" />
   </button>
 </template>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
@@ -36,8 +36,7 @@ const model = computed<ScalarListboxOption | undefined>({
         <ScalarIcon
           class="ml-auto text-c-2"
           icon="ChevronDown"
-          size="xs"
-          thickness="2.5" />
+          size="sm" />
       </ScalarButton>
     </ScalarListbox>
   </div>

--- a/packages/docusaurus/src/theme.css
+++ b/packages/docusaurus/src/theme.css
@@ -531,8 +531,8 @@ html[data-theme='light'] body .api-client-drawer {
     top: 1px;
     left: 1px;
 
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
 
     background-color: var(--scalar-color-3);
     mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.25 19.5L15.75 12L8.25 4.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>');


### PR DESCRIPTION
this pr adds request creation button from the sidebar collection item as seen below:

<img width="452" alt="image" src="https://github.com/user-attachments/assets/2c8efd81-3e18-49f6-90e1-95a53d00b8ff">

along:
- updating add icon
- updating chevron right icon

in order to fix icon size and thickness inconsistencies below:

⊢ before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/307aa5f1-ae21-472f-9b23-46689aa93289">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/6eb494d7-0e93-4ce5-ab5b-91cd81c252b0">
</div>

