### PR TITLE
feat(components): create useBindCx hook

### DIFF
--- a/.changeset/twelve-seahorses-know.md
+++ b/.changeset/twelve-seahorses-know.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat(components): create useBindCx hook

--- a/packages/components/src/components/ScalarButton/ScalarButton.stories.ts
+++ b/packages/components/src/components/ScalarButton/ScalarButton.stories.ts
@@ -12,6 +12,7 @@ const meta = {
   component: ScalarButton,
   tags: ['autodocs'],
   argTypes: {
+    class: { control: 'text' },
     size: { control: 'select', options: ['md'] },
     variant: {
       control: 'select',

--- a/packages/components/src/components/ScalarButton/ScalarButton.vue
+++ b/packages/components/src/components/ScalarButton/ScalarButton.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { computed, useAttrs } from 'vue'
-
-import { cx } from '../../cva'
+import { useBindCx } from '../../hooks/useBindCx'
 import { type LoadingState, ScalarLoading } from '../ScalarLoading'
 import { type Variants, variants } from './variants'
 
@@ -26,25 +24,17 @@ withDefaults(
 )
 
 defineOptions({ inheritAttrs: false })
-
-/* Extract the classes so they can be merged by `cx` */
-const attrs = computed(() => {
-  const { class: className, ...rest } = useAttrs()
-  return { class: className || '', rest }
-})
+const { cx } = useBindCx()
 </script>
 <template>
   <button
-    v-bind="attrs.rest"
     :ariaDisabled="disabled || undefined"
-    :class="
-      cx(
-        variants({ fullWidth, disabled, size, variant }),
-        { relative: loading?.isLoading },
-        `${attrs.class}`,
-      )
-    "
-    :type="type">
+    :type="type"
+    v-bind="
+      cx(variants({ fullWidth, disabled, size, variant }), {
+        relative: loading?.isLoading,
+      })
+    ">
     <div
       v-if="$slots.icon"
       class="mr-2 h-4 w-4"

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
@@ -18,6 +18,7 @@ const meta = {
       control: 'select',
       options: placements,
     },
+    class: { control: 'text' },
   },
 } satisfies Meta<typeof ScalarCombobox>
 
@@ -166,6 +167,40 @@ export const MultiselectGroups: Story = {
       </div>
     </ScalarButton>
   </ScalarComboboxMultiselect>
+</div>
+`,
+  }),
+}
+
+/**
+ * Applies a custom class to the combobox popover
+ */
+export const CustomClasses: Story = {
+  args: {
+    options,
+    class: 'border-red',
+  },
+  render: (args) => ({
+    components: {
+      ScalarCombobox,
+      ScalarButton,
+      ScalarIcon,
+    },
+    setup() {
+      const selected = ref<Option>()
+      return { args, selected }
+    },
+    template: `
+<div class="flex justify-center w-full min-h-96">
+  <ScalarCombobox v-model="selected" placeholder="Change fruit..." v-bind="args">
+    <ScalarButton class="w-48 px-3" variant="outlined">
+      <div class="flex flex-1 items-center min-w-0">
+        <span class="inline-block truncate flex-1 min-w-0 text-left">
+        {{ selected?.label ?? 'Select a fruit' }}
+        </span>
+      </div>
+    </ScalarButton>
+  </ScalarCombobox>
 </div>
 `,
   }),

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
@@ -2,6 +2,7 @@
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
 import { ref } from 'vue'
 
+import { useBindCx } from '../../hooks/useBindCx'
 import { ScalarFloating, type ScalarFloatingOptions } from '../ScalarFloating'
 import type { ScalarPopoverSlots } from '../ScalarPopover'
 
@@ -10,6 +11,7 @@ defineProps<ScalarFloatingOptions>()
 defineSlots<ScalarPopoverSlots>()
 
 defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
 
 /** Expose the popover button so we can close the popup */
 const popoverButtonRef = ref<typeof PopoverButton | null>(null)
@@ -39,10 +41,9 @@ defineExpose({ popoverButtonRef })
         #floating="{ width }">
         <PopoverPanel
           v-slot="{ close }"
-          class="relative flex w-40 flex-col rounded border text-sm"
           focus
           :style="{ width }"
-          v-bind="$attrs">
+          v-bind="cx('relative flex w-40 flex-col rounded border text-sm')">
           <slot
             :close="close"
             name="popover"

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.stories.ts
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.stories.ts
@@ -17,6 +17,9 @@ const meta = {
       control: 'select',
       options: placements,
     },
+    class: {
+      control: 'text',
+    },
   },
   render: (args) => ({
     components: {
@@ -49,3 +52,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Base: Story = {}
+
+export const CustomClasses: Story = {
+  args: { class: 'border-red' },
+}

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdown.vue
@@ -20,6 +20,7 @@ export default {}
 import { Menu, MenuButton, MenuItems } from '@headlessui/vue'
 import type { Slot } from 'vue'
 
+import { useBindCx } from '../../hooks/useBindCx'
 import { ScalarFloating, type ScalarFloatingOptions } from '../ScalarFloating'
 import ScalarDropdownMenu from './ScalarDropdownMenu.vue'
 
@@ -39,6 +40,7 @@ defineSlots<{
 }>()
 
 defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
 </script>
 <template>
   <Menu v-slot="{ open }">
@@ -55,9 +57,8 @@ defineOptions({ inheritAttrs: false })
         <!-- Background container -->
         <ScalarDropdownMenu
           :is="MenuItems"
-          v-bind="$attrs"
-          class="max-h-[inherit]"
-          :style="{ width }">
+          :style="{ width }"
+          v-bind="cx('max-h-[inherit]')">
           <slot
             name="items"
             :open="open" />

--- a/packages/components/src/components/ScalarIcon/ScalarIcon.stories.ts
+++ b/packages/components/src/components/ScalarIcon/ScalarIcon.stories.ts
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from '@storybook/vue3'
 import IconList from './IconList.vue'
 import ScalarIcon from './ScalarIcon.vue'
 import { ICONS } from './icons'
-import { LOGOS } from './logos'
 
 const meta = {
   component: ScalarIcon,
@@ -40,6 +39,10 @@ type Story = StoryObj<typeof meta>
 
 export const Base: Story = {
   args: { icon: 'Logo' },
+}
+
+export const CustomClasses: Story = {
+  args: { icon: 'Logo', class: 'size-2' },
 }
 
 export const AllSizes: Story = {

--- a/packages/components/src/components/ScalarIcon/ScalarIcon.vue
+++ b/packages/components/src/components/ScalarIcon/ScalarIcon.vue
@@ -2,7 +2,8 @@
 import type { VariantProps } from 'cva'
 import { computed } from 'vue'
 
-import { cva, cx } from '../../cva'
+import { cva } from '../../cva'
+import { useBindCx } from '../../hooks/useBindCx'
 import { type Icon, type Logo, getIcon, getLogo } from './utils'
 
 /**
@@ -18,6 +19,9 @@ const props = defineProps<{
   thickness?: string
   label?: string
 }>()
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
 
 const iconProps = cva({
   variants: {
@@ -58,8 +62,10 @@ const svg = computed(() => {
 <template>
   <component
     :is="svg"
-    :class="cx('scalar-icon', iconProps({ size }))"
-    v-bind="accessibilityAttrs" />
+    v-bind="{
+      ...cx('scalar-icon', iconProps({ size })),
+      ...accessibilityAttrs,
+    }" />
 </template>
 <style scoped>
 .scalar-icon,

--- a/packages/components/src/components/ScalarIconButton/ScalarIconButton.stories.ts
+++ b/packages/components/src/components/ScalarIconButton/ScalarIconButton.stories.ts
@@ -3,6 +3,9 @@ import type { Meta, StoryObj } from '@storybook/vue3'
 import { ICONS } from '../ScalarIcon/icons'
 import ScalarIconButton from './ScalarIconButton.vue'
 
+/**
+ * A helper wrapper around the icon only ScalarButton
+ */
 const meta = {
   component: ScalarIconButton,
   tags: ['autodocs'],
@@ -14,13 +17,8 @@ const meta = {
       control: 'select',
       options: ['solid', 'outlined', 'ghost', 'danger'],
     },
-  },
-  parameters: {
-    docs: {
-      description: {
-        component: 'A helper wrapper around the icon only ScalarButton',
-      },
-    },
+    disabled: { control: 'boolean' },
+    class: { control: 'text' },
   },
 } satisfies Meta<typeof ScalarIconButton>
 
@@ -33,4 +31,8 @@ export const Base: Story = {
 
 export const Disabled: Story = {
   args: { icon: 'Logo', label: 'Logo button', disabled: true },
+}
+
+export const CustomClasses: Story = {
+  args: { icon: 'Logo', label: 'Logo button', class: 'size-3 p-0' },
 }

--- a/packages/components/src/components/ScalarIconButton/ScalarIconButton.vue
+++ b/packages/components/src/components/ScalarIconButton/ScalarIconButton.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { VariantProps } from 'cva'
-import { computed, useAttrs } from 'vue'
 
-import { cva, cx } from '../../cva'
+import { cva } from '../../cva'
+import { useBindCx } from '../../hooks/useBindCx'
 import { styles } from '../ScalarButton'
 import { type Icon, ScalarIcon } from '../ScalarIcon'
 
@@ -23,6 +23,9 @@ withDefaults(
   },
 )
 
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+
 const variants = cva({
   base: 'scalar-icon-button grid aspect-square cursor-pointer rounded',
   variants: {
@@ -39,19 +42,12 @@ const variants = cva({
     variant: styles,
   },
 })
-
-/* Extract the classes so they can be merged by `cx` */
-const attrs = computed(() => {
-  const { class: className, ...rest } = useAttrs()
-  return { class: className || '', rest }
-})
 </script>
 <template>
   <button
-    v-bind="attrs.rest"
     :ariaDisabled="disabled || undefined"
-    :class="cx(variants({ size, variant, disabled }), attrs.class)"
-    type="button">
+    type="button"
+    v-bind="cx(variants({ size, variant, disabled }))">
     <ScalarIcon
       :icon="icon"
       :thickness="thickness" />

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.stories.ts
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.stories.ts
@@ -12,6 +12,7 @@ const meta = {
   argTypes: {
     resize: { control: 'boolean' },
     placement: { control: 'select', options: placements },
+    class: { control: 'text' },
   },
 } satisfies Meta<typeof ScalarListbox>
 
@@ -80,6 +81,42 @@ export const Multiselect: Story = {
       <div class="flex flex-1 items-center min-w-0">
         <span class="inline-block truncate flex-1 min-w-0 text-left">
         {{ selected?.length ? selected.map(o => o.label).join(', ') : 'Select an option' }}
+        </span>
+        <ScalarIcon icon="ChevronDown" size="sm" class="ml-1 ui-open:rotate-180" />
+      </div>
+    </ScalarButton>
+  </ScalarListbox>
+</div>
+`,
+  }),
+}
+
+export const CustomClasses: Story = {
+  args: {
+    class: 'border-red',
+    options: [
+      { id: '1', label: 'Option 1' },
+      { id: '2', label: 'Option 2' },
+      { id: '3', label: 'Option 3' },
+    ],
+  },
+  render: (args) => ({
+    components: {
+      ScalarListbox,
+      ScalarButton,
+      ScalarIcon,
+    },
+    setup() {
+      const selected = ref<Option>()
+      return { args, selected }
+    },
+    template: `
+<div class="flex justify-center w-full min-h-96">
+  <ScalarListbox v-model="selected" v-bind="args">
+    <ScalarButton class="w-48 min-w-max px-3" variant="outlined">
+      <div class="flex flex-1 items-center min-w-0">
+        <span class="inline-block truncate flex-1 min-w-0 text-left">
+        {{ selected?.label ?? 'Select an option' }}
         </span>
         <ScalarIcon icon="ChevronDown" size="sm" class="ml-1 ui-open:rotate-180" />
       </div>

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -7,6 +7,7 @@ import {
 } from '@headlessui/vue'
 import type { Slot } from 'vue'
 
+import { useBindCx } from '../../hooks/useBindCx'
 import { ScalarFloating, type ScalarFloatingOptions } from '../ScalarFloating'
 import ScalarListboxOption from './ScalarListboxItem.vue'
 import type { Option } from './types'
@@ -43,6 +44,7 @@ defineSlots<{
 }>()
 
 defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
 </script>
 <template>
   <Listbox
@@ -71,9 +73,10 @@ defineOptions({ inheritAttrs: false })
         <!-- Background container -->
         <div
           v-if="open"
-          v-bind="$attrs"
-          class="relative flex max-h-[inherit] w-40 rounded border text-sm"
-          :style="{ width }">
+          :style="{ width }"
+          v-bind="
+            cx('relative flex max-h-[inherit] w-40 rounded border text-sm')
+          ">
           <!-- Scroll container -->
           <div class="custom-scroll min-h-0 flex-1">
             <!-- Options list -->

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.stories.ts
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.stories.ts
@@ -9,17 +9,23 @@ import ScalarLoading, { useLoadingState } from './ScalarLoading.vue'
 const meta = {
   component: ScalarLoading,
   tags: ['autodocs'],
-  argTypes: {},
-  render: () => ({
+  argTypes: {
+    class: { control: 'text' },
+    size: {
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', 'full'],
+    },
+  },
+  render: (args) => ({
     components: { ScalarButton, ScalarLoading },
     setup() {
       const loadingState = useLoadingState()
       loadingState.startLoading()
-      return { loadingState }
+      return { args, loadingState }
     },
     template: `
       <div className="row gap-16 items-center">
-        <ScalarLoading size="xl" :loadingState="loadingState" />
+        <ScalarLoading :loadingState="loadingState" v-bind="args" />
         <div className="row gap-4 items-center">
           <ScalarButton @click="loadingState.validate()">Validate</ScalarButton>
           <ScalarButton variant="danger" @click="loadingState.invalidate()">Invalidate</ScalarButton>
@@ -33,4 +39,6 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Base: Story = {} as any
+export const Base: Story = { args: { size: 'lg' } }
+
+export const CustomClasses: Story = { args: { class: 'size-3 text-red' } }

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.vue
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.vue
@@ -1,14 +1,18 @@
 <script setup lang="ts">
 import type { VariantProps } from 'cva'
-import { cva, cx } from '../../cva'
+import { cva } from '../../cva'
+import { useBindCx } from '../../hooks/useBindCx'
 import { reactive } from 'vue'
 
 type Variants = VariantProps<typeof variants>
 
 defineProps<{
-  loadingState: LoadingState
+  loadingState?: LoadingState
   size?: Variants['size']
 }>()
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
 
 const variants = cva({
   variants: {
@@ -86,7 +90,7 @@ export function useLoadingState() {
 <template>
   <div
     v-if="loadingState"
-    :class="cx('loader-wrapper', variants({ size }))">
+    v-bind="cx('loader-wrapper', variants({ size }))">
     <svg
       class="svg-loader"
       :class="{

--- a/packages/components/src/components/ScalarMenu/ScalarMenuButton.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuButton.vue
@@ -1,14 +1,23 @@
 <script setup lang="ts">
 import { ScalarIcon } from '../../'
+import { useBindCx } from '../../hooks/useBindCx'
 
 defineProps<{
   open?: boolean
 }>()
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
 </script>
 <template>
   <button
-    class="group/button flex items-center gap-1 rounded bg-transparent px-2.5 py-2 hover:bg-b-2"
-    type="button">
+    class=""
+    type="button"
+    v-bind="
+      cx(
+        'group/button flex items-center gap-1 rounded bg-transparent px-2.5 py-2 hover:bg-b-2',
+      )
+    ">
     <div class="h-5 w-auto">
       <slot><ScalarIcon icon="Logo" /></slot>
     </div>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
@@ -1,15 +1,24 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
 
+import { useBindCx } from '../../hooks/useBindCx'
+
 defineProps<{
   is?: string | Component
 }>()
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
 </script>
 <template>
   <component
     :is="is ?? 'a'"
-    class="relative flex cursor-pointer rounded px-2.5 py-1 font-medium leading text-c-2 no-underline hover:bg-b-2 focus:text-c-1"
-    :type="is === 'button' ? 'button' : undefined">
+    :type="is === 'button' ? 'button' : undefined"
+    v-bind="
+      cx(
+        'relative flex cursor-pointer rounded px-2.5 py-1 font-medium leading text-c-2 no-underline hover:bg-b-2 focus:text-c-1',
+      )
+    ">
     <slot />
   </component>
 </template>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuProduct.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuProduct.vue
@@ -1,20 +1,30 @@
 <script setup lang="ts">
 import { type Icon, ScalarIcon } from '../../'
+import { cva } from '../../cva'
+import { useBindCx } from '../../hooks/useBindCx'
 
 defineProps<{
   selected?: boolean
   icon: Icon
 }>()
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+
+const variants = cva({
+  base: 'relative flex min-w-0 flex-1 items-center gap-2 overflow-hidden rounded px-2 py-1.5 leading no-underline flex-row',
+  variants: {
+    selected: {
+      true: 'pointer-events-none bg-b-2',
+      false: 'cursor-pointer bg-b-1 hover:bg-b-2',
+    },
+  },
+})
 </script>
 <template>
   <a
-    class="relative flex min-w-0 flex-1 items-center gap-2 overflow-hidden rounded px-2 py-1.5 leading no-underline flex-row"
-    :class="
-      selected
-        ? 'pointer-events-none bg-b-2'
-        : 'cursor-pointer bg-b-1 hover:bg-b-2'
-    "
-    target="_blank">
+    target="_blank"
+    v-bind="cx(variants({ selected }))">
     <ScalarIcon
       :icon="icon"
       size="xs"

--- a/packages/components/src/components/ScalarMenu/ScalarMenuProducts.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuProducts.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useBindCx } from '../../hooks/useBindCx'
 import ScalarMenuProduct from './ScalarMenuProduct.vue'
 
 type Product = 'dashboard' | 'docs' | 'client'
@@ -11,9 +12,12 @@ defineProps<{
 defineEmits<{
   (e: 'open', event: Event, product: Product): void
 }>()
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
 </script>
 <template>
-  <div class="flex flex-col">
+  <div v-bind="cx('flex flex-col')">
     <ScalarMenuProduct
       :href="hrefs?.dashboard ?? 'https://dashboard.scalar.com'"
       icon="House"

--- a/packages/components/src/components/ScalarMenu/ScalarMenuSection.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuSection.vue
@@ -1,6 +1,11 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { useBindCx } from '../../hooks/useBindCx'
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+</script>
 <template>
-  <div class="flex flex-col gap-1.5">
+  <div v-bind="cx('flex flex-col gap-1.5')">
     <div class="px-2.5 font-medium leading text-c-3">
       <slot name="title" />
     </div>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
@@ -7,6 +7,7 @@ import {
   ScalarListbox,
   type ScalarListboxOption,
 } from '../..'
+import { useBindCx } from '../../hooks/useBindCx'
 
 const props = defineProps<{
   team?: ScalarListboxOption | undefined
@@ -21,9 +22,12 @@ const model = computed<ScalarListboxOption | undefined>({
   get: () => props.team,
   set: (v) => emit('update:team', v),
 })
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
 </script>
 <template>
-  <div class="flex flex-col pb-px">
+  <div v-bind="cx('flex flex-col pb-px')">
     <ScalarListbox
       v-model="model"
       :options="teams"

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.stories.ts
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.stories.ts
@@ -15,6 +15,9 @@ const meta = {
       control: 'select',
       options: placements,
     },
+    class: {
+      control: 'text',
+    },
   },
   render: (args) => ({
     components: {
@@ -43,3 +46,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Base: Story = {}
+
+export const CustomClasses: Story = {
+  args: { class: 'border border-red' },
+}

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.vue
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
 
+import { useBindCx } from '../../hooks/useBindCx'
 import { ScalarFloating, type ScalarFloatingOptions } from '../ScalarFloating'
 import type { Slots } from './types'
 
@@ -9,6 +10,7 @@ defineProps<ScalarFloatingOptions>()
 defineSlots<Slots>()
 
 defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
 </script>
 <template>
   <Popover
@@ -21,9 +23,8 @@ defineOptions({ inheritAttrs: false })
       <template #floating="{ width, height }">
         <PopoverPanel
           v-slot="{ close }"
-          class="relative flex flex-col p-0.75"
           :style="{ width, height }"
-          v-bind="$attrs">
+          v-bind="cx('relative flex flex-col p-0.75')">
           <slot
             :close="() => close()"
             name="popover"

--- a/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.stories.ts
+++ b/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.stories.ts
@@ -7,7 +7,9 @@ import ScalarSearchInput from './ScalarSearchInput.vue'
 const meta = {
   component: ScalarSearchInput,
   tags: ['autodocs'],
-  argTypes: {},
+  argTypes: {
+    class: { control: 'text' },
+  },
   render: (args) => ({
     components: { ScalarSearchInput },
     setup() {
@@ -33,4 +35,8 @@ export const Loading: Story = {
     },
     template: `<ScalarSearchInput modelValue="My search query" :loading="loadingState" />`,
   }),
+}
+
+export const CustomClasses: Story = {
+  args: { class: 'border-red' },
 }

--- a/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
+++ b/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
@@ -28,7 +28,7 @@ defineOptions({ inheritAttrs: false })
 /* Extract the classes so they can be merged by `cx` */
 const attrs = computed(() => {
   const { class: className, ...rest } = useAttrs()
-  return { className: className || '', rest }
+  return { class: className || '', rest }
 })
 
 const variants = cva({
@@ -51,7 +51,7 @@ defineExpose({
 })
 </script>
 <template>
-  <label :class="cx(variants({ sidebar }), attrs.className)">
+  <label :class="cx(variants({ sidebar }), attrs.class)">
     <ScalarIcon
       v-if="sidebar"
       class="text-c-2"

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { computed, useAttrs } from 'vue'
-
-import { cx } from '../../cva'
+import { useBindCx } from '../../hooks/useBindCx'
 import { type Icon, ScalarIcon } from '../ScalarIcon'
 
 defineProps<{
@@ -10,26 +8,19 @@ defineProps<{
 }>()
 
 defineOptions({ inheritAttrs: false })
-
-/* Extract the classes so they can be merged by `cx` */
-const attrs = computed(() => {
-  const { class: className, ...rest } = useAttrs()
-  return { className: className || '', rest }
-})
+const { cx } = useBindCx()
 </script>
 <template>
   <li
     class="contents"
     role="option">
     <a
-      v-bind="attrs.rest"
-      :class="
+      v-bind="
         cx(
           'group flex cursor-pointer gap-2.5 rounded px-3 py-1.5 no-underline hover:bg-b-2',
           {
             'bg-b-2': active,
           },
-          attrs.className,
         )
       ">
       <!-- Icon -->

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultList.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultList.vue
@@ -1,25 +1,17 @@
 <script setup lang="ts">
-import { computed, useAttrs } from 'vue'
-
-import { cx } from '../../cva'
+import { useBindCx } from '../../hooks/useBindCx'
 
 defineProps<{
   noResults?: boolean
 }>()
 
 defineOptions({ inheritAttrs: false })
-
-/* Extract the classes so they can be merged by `cx` */
-const attrs = computed(() => {
-  const { class: className, ...rest } = useAttrs()
-  return { className: className || '', rest }
-})
+const { cx } = useBindCx()
 </script>
 <template>
   <ul
-    v-bind="attrs.rest"
-    :class="cx('flex flex-col', attrs.className)"
-    role="listbox">
+    role="listbox"
+    v-bind="cx('flex flex-col')">
     <slot
       v-if="noResults"
       name="noResults">

--- a/packages/components/src/components/ScalarToggle/ScalarToggle.spec.ts
+++ b/packages/components/src/components/ScalarToggle/ScalarToggle.spec.ts
@@ -23,18 +23,16 @@ describe('ScalarToggle', () => {
     const wrapper = mount(ScalarToggle, {
       props: { modelValue: false, disabled: false },
     })
-    const input = wrapper.find('input[type="checkbox"]')
-    expect(input.attributes('aria-checked')).toBe('false')
-    expect(input.attributes('aria-disabled')).toBe('false')
+    expect(wrapper.attributes('aria-checked')).toBe('false')
+    expect(wrapper.attributes('aria-disabled')).toBe('false')
   })
 
   it('applies the correct classes when checked and disabled', () => {
     const wrapper = mount(ScalarToggle, {
       props: { modelValue: true, disabled: true },
     })
-    const toggleDiv = wrapper.find('div[role="switch"]')
-    expect(toggleDiv.classes()).toContain('bg-c-accent')
-    expect(toggleDiv.classes()).toContain('cursor-not-allowed')
-    expect(toggleDiv.classes()).toContain('opacity-40')
+    expect(wrapper.classes()).toContain('bg-c-accent')
+    expect(wrapper.classes()).toContain('cursor-not-allowed')
+    expect(wrapper.classes()).toContain('opacity-40')
   })
 })

--- a/packages/components/src/components/ScalarToggle/ScalarToggle.stories.ts
+++ b/packages/components/src/components/ScalarToggle/ScalarToggle.stories.ts
@@ -6,8 +6,9 @@ import ScalarToggle from './ScalarToggle.vue'
 const meta = {
   component: ScalarToggle,
   tags: ['autodocs'],
+  args: { modelValue: false },
   argTypes: {
-    modelValue: { control: 'boolean' },
+    label: { control: 'text' },
     disabled: { control: 'boolean' },
   },
   render: (args) => ({
@@ -23,10 +24,8 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Base: Story = {
-  args: { modelValue: false, disabled: false },
-}
+export const Base: Story = { args: { label: 'My Toggle' } }
 
 export const Disabled: Story = {
-  args: { modelValue: false, disabled: true },
+  args: { disabled: true },
 }

--- a/packages/components/src/components/ScalarToggle/ScalarToggle.vue
+++ b/packages/components/src/components/ScalarToggle/ScalarToggle.vue
@@ -2,11 +2,9 @@
 import { cva, cx } from '../../cva'
 
 const props = defineProps<{
-  modelValue: boolean
+  modelValue?: boolean
   disabled?: boolean
-  id?: string
-  ariaLabel?: string
-  ariaLabelledBy?: string
+  label?: string
 }>()
 
 const emit = defineEmits<{
@@ -14,12 +12,11 @@ const emit = defineEmits<{
 }>()
 
 function toggle() {
-  if (!props.disabled) {
-    emit('update:modelValue', !props.modelValue)
-  }
+  if (props.disabled) return
+  emit('update:modelValue', !props.modelValue)
 }
 
-const toggleClasses = cva({
+const variants = cva({
   base: 'relative h-3.5 w-6 cursor-pointer rounded-full bg-b-3 transition-colors duration-300',
   variants: {
     checked: { true: 'bg-c-accent' },
@@ -28,25 +25,20 @@ const toggleClasses = cva({
 })
 </script>
 <template>
-  <div
-    :class="cx(toggleClasses({ checked: modelValue, disabled }))"
+  <button
+    :aria-checked="modelValue"
+    :aria-disabled="disabled"
+    :class="cx(variants({ checked: modelValue, disabled }))"
     role="switch"
-    tabindex="0"
-    @keydown.enter.prevent="toggle"
-    @keydown.space.prevent="toggle">
-    <input
-      :id="props.id"
-      :aria-checked="modelValue"
-      :aria-disabled="disabled"
-      :aria-label="props.ariaLabel"
-      :aria-labelledby="props.ariaLabelledBy"
-      :checked="modelValue"
-      class="hidden"
-      :disabled="disabled"
-      type="checkbox"
-      @change="toggle" />
+    type="button"
+    @click="toggle">
     <div
       class="absolute left-px top-px flex h-3 w-3 items-center justify-center rounded-full bg-white text-c-accent transition-transform duration-300"
-      :class="{ 'translate-x-2.5': modelValue }"></div>
-  </div>
+      :class="{ 'translate-x-2.5': modelValue }" />
+    <span
+      v-if="label"
+      class="sr-only">
+      {{ label }}
+    </span>
+  </button>
 </template>

--- a/packages/components/src/hooks/useBindCx.stories.ts
+++ b/packages/components/src/hooks/useBindCx.stories.ts
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { computed, defineComponent, ref, watch } from 'vue'
+
+import { cva } from '../cva'
+import { useBindCx } from './useBindCx'
+
+const attrsToList = (attrs?: Record<string, any>) =>
+  Object.entries(attrs || {})
+    .map(([key, value]) =>
+      typeof value === 'string' ? `${key}="${value}"` : `:${key}="${value}"`,
+    )
+    .join(' ')
+
+const variants = cva({
+  base: 'border rounded p-2 bg-b-1',
+  variants: { active: { true: 'bg-b-2' } },
+})
+
+const MockComponent = defineComponent({
+  props: {
+    active: { type: Boolean, default: false },
+  },
+  inheritAttrs: false,
+  setup() {
+    const { cx } = useBindCx()
+    return { cx, variants }
+  },
+  template: `<div v-bind="cx(variants({ active }))">MockComponent</div>`,
+})
+
+/**
+ * Provides a wrapper around the `cx` function that merges the
+ * component's class attribute with the provided classes.
+ *
+ * This allows you to override tailwind classes from the parent component and `cx`
+ * will intelligently merge them while passing through other attributes.
+ *
+ * ### Example
+ *
+ * Scroll down for a working playground which mounts `MockComponent`.
+ *
+ * ```html
+ * <script setup>
+ * import { useBindCx, cva } from '@scalar/components'
+ *
+ * defineProps<{ active?: boolean }>()
+ *
+ * // Important: disable inheritance of attributes
+ * defineOptions({ inheritAttrs: false })
+ *
+ * const { cx } = useBindCx()
+ *
+ * const variants = cva({
+ *   base: 'border rounded p-2 bg-b-1',
+ *   variants: { active: { true: 'bg-b-2' } },
+ * })
+ * </script>
+ * <template>
+ *   <div v-bind="cx(variants({ active }))">MockComponent</div>
+ * </template>
+ * ```
+ */
+const meta = {
+  tags: ['autodocs'],
+  argTypes: {
+    active: { control: 'boolean', description: 'Applies the active variant' },
+    class: { control: 'text', description: 'Additional classes to apply' },
+    attrs: { control: 'object', description: 'Additional attributes to apply' },
+  },
+  render: (args) => ({
+    components: { MockComponent },
+    setup() {
+      const mock = ref<InstanceType<typeof MockComponent>>()
+
+      const rendered = ref('')
+      const observer = new MutationObserver((mutations) => {
+        rendered.value = (mutations[0].target as HTMLElement).outerHTML
+      })
+      watch(
+        mock,
+        () => {
+          observer.disconnect()
+
+          if (!mock.value) return
+          rendered.value = mock.value.$el.outerHTML
+          observer.observe(mock.value.$el, { attributes: true })
+        },
+        { immediate: true },
+      )
+
+      const passedIn = computed(() => {
+        return `<MockComponent ${args.class ? `class="${args.class}"` : ''} ${args.active ? 'active' : ''} ${attrsToList(args.attrs)}/>`
+      })
+      const bind = computed(() => ({
+        ...args,
+        attrs: undefined,
+        ...args.attrs,
+      }))
+      return { bind, passedIn, rendered, mock }
+    },
+    template: `
+<table class="grid grid-cols-[auto_1fr] items-center gap-y-8 gap-x-4">
+  <span class="font-medium">Template</span>
+  <code class="font-code">{{ passedIn }}</code>
+  <span class="font-medium">HTML</span>
+  <code class="font-code">{{ rendered }}</code>
+  <span class="font-medium">Rendered</span>
+  <MockComponent ref="mock" v-bind="bind" />
+</table>
+`,
+  }),
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Base: Story = {}

--- a/packages/components/src/hooks/useBindCx.test.ts
+++ b/packages/components/src/hooks/useBindCx.test.ts
@@ -1,0 +1,88 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
+
+import { cva } from '../cva'
+import { useBindCx } from './useBindCx'
+
+describe('useBindCx', () => {
+  const variants = cva({
+    base: 'bg-base',
+    variants: {
+      active: { true: 'bg-active' },
+    },
+  })
+
+  const TestComponent = defineComponent({
+    props: {
+      active: Boolean,
+    },
+    inheritAttrs: false,
+    setup() {
+      const { cx } = useBindCx()
+      return { cx, variants }
+    },
+    template: '<div v-bind="cx(variants({ active }))">Test</div>',
+  })
+
+  it('should merge base classes correctly', () => {
+    const wrapper = mount(TestComponent)
+    expect(wrapper.attributes('class')).toBe('bg-base')
+  })
+
+  it('should apply variant tailwind classes', () => {
+    const wrapper = mount(TestComponent, {
+      props: { active: true },
+    })
+    expect(wrapper.attributes('class')).toBe('bg-active')
+  })
+
+  it('should merge external classes with internal classes', () => {
+    const wrapper = mount(TestComponent, {
+      attrs: { class: 'external-class' },
+    })
+    expect(wrapper.attributes('class')).toBe('bg-base external-class')
+  })
+
+  it('should handle multiple class combinations', () => {
+    const wrapper = mount(TestComponent, {
+      props: { active: true },
+      attrs: { class: 'external-class another-class' },
+    })
+    expect(wrapper.attributes('class')).toBe(
+      'bg-active external-class another-class',
+    )
+  })
+
+  it('should apply external tailwind classes', () => {
+    const wrapper = mount(TestComponent, {
+      attrs: { class: 'bg-external' },
+    })
+    expect(wrapper.attributes('class')).toBe('bg-external')
+  })
+
+  it('should apply classes in arrays', () => {
+    const wrapper = mount(TestComponent, {
+      attrs: { class: ['external-class', 'another-class'] },
+    })
+    expect(wrapper.attributes('class')).toBe(
+      'bg-base external-class another-class',
+    )
+  })
+
+  it('should apply classes in objects', () => {
+    const wrapper = mount(TestComponent, {
+      attrs: { class: { 'truthy-class': true, 'falsy-class': false } },
+    })
+    expect(wrapper.attributes('class')).toBe('bg-base truthy-class')
+  })
+
+  it('should pass through other attributes', () => {
+    const wrapper = mount(TestComponent, {
+      attrs: { 'data-testid': 'test', 'aria-label': 'test label' },
+    })
+    expect(wrapper.attributes('class')).toBe('bg-base')
+    expect(wrapper.attributes('data-testid')).toBe('test')
+    expect(wrapper.attributes('aria-label')).toBe('test label')
+  })
+})

--- a/packages/components/src/hooks/useBindCx.ts
+++ b/packages/components/src/hooks/useBindCx.ts
@@ -1,0 +1,63 @@
+import type { CXOptions } from 'cva'
+import { computed, useAttrs } from 'vue'
+
+import { cx } from '../cva'
+
+/**
+ * Provides a wrapper around the `cx` function that merges the
+ * component's class attribute with the provided classes
+ *
+ * @see https://beta.cva.style/api-reference#cx
+ *
+ * @example
+ * <script setup>
+ * import { useBindCx, cva } from '@scalar/components'
+ *
+ * defineProps<{ active?: boolean }>()
+ *
+ * // Important: disable inheritance of attributes
+ * defineOptions({ inheritAttrs: false })
+ *
+ * const { cx } = useBindCx()
+ *
+ * const variants = cva({
+ *   base: 'border rounded p-2 bg-b-1',
+ *   variants: { active: { true: 'bg-b-2' } },
+ * })
+ * </script>
+ * <template>
+ *   <div v-bind="cx(variants({ active }))">MockComponent</div>
+ * </template>
+ */
+export function useBindCx() {
+  const attrs = computed(() => {
+    const { class: className, ...rest } = useAttrs()
+    return { class: className || '', rest }
+  })
+
+  function bindCx(...args: CXOptions) {
+    return {
+      class: cx(...args, attrs.value.class),
+      ...attrs.value.rest,
+    }
+  }
+
+  return {
+    /**
+     * Provides a wrapper around the `cx` function that merges the
+     * component's class attribute with the provided classes
+     *
+     * See stories for a complete example
+     *
+     * @example
+     * <script setup>
+     * ...
+     * const { cx } = useBindCx()
+     * </script>
+     * <template>
+     *   <div v-bind="cx(...)">...</div>
+     * </template>
+     */
+    cx: bindCx,
+  }
+}

--- a/packages/components/src/hooks/useBindCx.ts
+++ b/packages/components/src/hooks/useBindCx.ts
@@ -5,7 +5,8 @@ import { cx } from '../cva'
 
 /**
  * Provides a wrapper around the `cx` function that merges the
- * component's class attribute with the provided classes
+ * component's class attribute with the provided classes and binds the
+ * remaining attributes
  *
  * @see https://beta.cva.style/api-reference#cx
  *
@@ -35,7 +36,12 @@ export function useBindCx() {
     return { class: className || '', rest }
   })
 
-  function bindCx(...args: CXOptions) {
+  function bindCx(...args: CXOptions): {
+    /** The merged class attribute */
+    class: string
+    /** The remaining attributes */
+    [key: string]: any
+  } {
     return {
       class: cx(...args, attrs.value.class),
       ...attrs.value.rest,
@@ -45,9 +51,8 @@ export function useBindCx() {
   return {
     /**
      * Provides a wrapper around the `cx` function that merges the
-     * component's class attribute with the provided classes
-     *
-     * See stories for a complete example
+     * component's class attribute with the provided classes and binds the
+     * remaining attributes
      *
      * @example
      * <script setup>

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -22,4 +22,6 @@ export * from './components/ScalarToggle'
 export * from './components/ScalarTooltip'
 export * from './components/ScalarVirtualText'
 
+export * from './hooks/useBindCx'
+
 export * from './helpers'


### PR DESCRIPTION
Adds a `useBindCx` hook which wraps cx and merges the tailwind classes applied to the components. See video for an example or `pnpm dev:components` to try it yourself (it's at the bottom under hooks).

Fixes DOC-2613

https://github.com/user-attachments/assets/5f4715c6-3f4a-4908-8191-efd5462a7b0e

