### PR TITLE
fix(api-reference): move client config to ApiReferenceLayout

### DIFF
--- a/.changeset/new-suns-run.md
+++ b/.changeset/new-suns-run.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: moved hidden client config to apiReferenceLayout

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -8,7 +8,6 @@ import { useFavicon } from '@vueuse/core'
 import { computed, toRef, watch } from 'vue'
 
 import { useReactiveSpec } from '../hooks'
-import { useHttpClientStore } from '../stores'
 import type { ReferenceProps } from '../types'
 import { Layouts } from './Layouts'
 
@@ -76,11 +75,6 @@ function mapConfigToState<K extends keyof ReferenceConfiguration>(
 // Prefill authentication
 const { setAuthentication } = useAuthenticationStore()
 mapConfigToState('authentication', setAuthentication)
-
-// Hides any client snippets from the references
-const { setExcludedClients, setDefaultHttpClient } = useHttpClientStore()
-mapConfigToState('defaultHttpClient', setDefaultHttpClient)
-mapConfigToState('hiddenClients', setExcludedClients)
 
 const { parsedSpec, rawSpec } = useReactiveSpec({
   proxyUrl: toRef(

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useHttpClientStore } from '@/stores/useHttpClientStore'
 import { provideUseId } from '@headlessui/vue'
 import { addScalarClassesToHeadless } from '@scalar/components'
 import { ScalarErrorBoundary } from '@scalar/components'
@@ -8,7 +9,7 @@ import {
   getThemeStyles,
   hasObtrusiveScrollbars,
 } from '@scalar/themes'
-import type { SSRState } from '@scalar/types/legacy'
+import type { ReferenceConfiguration, SSRState } from '@scalar/types/legacy'
 import { ScalarToasts, useToasts } from '@scalar/use-toasts'
 import { useDebounceFn, useMediaQuery, useResizeObserver } from '@vueuse/core'
 import {
@@ -256,6 +257,28 @@ provide(INTEGRATION_SYMBOL, () =>
     ? props.configuration._integration
     : 'vue',
 )
+
+// ---------------------------------------------------------------------------/
+// HANDLE MAPPING CONFIGURATION TO INTERNAL REFERENCE STATE
+
+/** Helper utility to map configuration props to the ApiReference internal state */
+function mapConfigToState<K extends keyof ReferenceConfiguration>(
+  key: K,
+  setter: (val: NonNullable<ReferenceConfiguration[K]>) => any,
+) {
+  watch(
+    () => props.configuration[key],
+    (newValue) => {
+      if (typeof newValue !== 'undefined') setter(newValue)
+    },
+    { immediate: true },
+  )
+}
+
+// Hides any client snippets from the references
+const { setExcludedClients, setDefaultHttpClient } = useHttpClientStore()
+mapConfigToState('defaultHttpClient', setDefaultHttpClient)
+mapConfigToState('hiddenClients', setExcludedClients)
 
 hideModels.value = props.configuration.hideModels ?? false
 defaultOpenAllTags.value = props.configuration.defaultOpenAllTags ?? false


### PR DESCRIPTION
In some integrations as well as our docs, we use `ApiReferenceLayout` directly. In these cases setting hidden clients was not working. This PR moves that config mapping into the layout so it works everywhere!