### PR TITLE
fix(snippetz): types are wrong

### DIFF
--- a/.changeset/chilled-wasps-camp.md
+++ b/.changeset/chilled-wasps-camp.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+refactor: new plugin API

--- a/packages/api-reference/src/helpers/getExampleCode.test.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.test.ts
@@ -52,7 +52,6 @@ describe('getExampleCode', () => {
         method: 'POST',
         url: 'https://example.com',
       }),
-      // @ts-expect-error Fails, but shouldn’t be necessary soon anway.
       'js',
       'jquery',
     )

--- a/packages/api-reference/src/helpers/getExampleCode.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.ts
@@ -29,7 +29,7 @@ export async function getExampleCode<T extends SnippetzTargetId>(
   if (snippetz().hasPlugin(snippetzTargetKey, client)) {
     return snippetz().print(
       snippetzTargetKey as SnippetzTargetId,
-      client,
+      client as SnippetzClientId<typeof snippetzTargetKey>,
       request,
     )
   }

--- a/packages/api-reference/src/helpers/getExampleCode.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.ts
@@ -29,7 +29,6 @@ export async function getExampleCode<T extends SnippetzTargetId>(
   if (snippetz().hasPlugin(snippetzTargetKey, client)) {
     return snippetz().print(
       snippetzTargetKey as SnippetzTargetId,
-      // @ts-expect-error Typecasting fails, but shouldn’t be necessary soon anway.
       client,
       request,
     )

--- a/packages/snippetz/README.md
+++ b/packages/snippetz/README.md
@@ -69,13 +69,13 @@ const snippet = snippetz().hasPlugin('node', 'undici')
 You can also just use one specific plugin to keep your bundle size small.
 
 ```ts
-import { undici } from '@scalar/snippetz/plugins/node/undici'
+import { nodeUndici } from '@scalar/snippetz/plugins/node/undici'
 
-const source = undici({
+const result = nodeUndici.generate({
   url: 'https://example.com',
 })
 
-console.log(source.code)
+console.log(source)
 
 // import { request } from 'undici'
 

--- a/packages/snippetz/src/core/types.ts
+++ b/packages/snippetz/src/core/types.ts
@@ -3,7 +3,7 @@ export type { Request } from 'har-format'
 /**
  * List of available clients
  */
-export type Clients = [
+export type AvailableClients = [
   'js/fetch',
   'js/ofetch',
   'node/fetch',
@@ -12,12 +12,17 @@ export type Clients = [
   'shell/curl',
 ]
 
-export type TargetId = Clients[number] extends `${infer T}/${string}`
+/** Programming language */
+export type TargetId = AvailableClients[number] extends `${infer T}/${string}`
   ? T
   : never
 
+/** HTTP client */
 export type ClientId<T extends string> = T extends TargetId
-  ? Extract<Clients[number], `${T}/${string}`> extends `${T}/${infer C}`
+  ? Extract<
+      AvailableClients[number],
+      `${T}/${string}`
+    > extends `${T}/${infer C}`
     ? C
     : never
   : never

--- a/packages/snippetz/src/core/types.ts
+++ b/packages/snippetz/src/core/types.ts
@@ -1,20 +1,26 @@
 export type { Request } from 'har-format'
 
-declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface Clients {}
-}
+/**
+ * List of available clients
+ */
+export type Clients = [
+  'js/fetch',
+  'js/ofetch',
+  'node/fetch',
+  'node/ofetch',
+  'node/undici',
+  'shell/curl',
+]
 
-export type AddClient<T extends string, C extends string> = {
-  [K in `${T}/${C}`]: C
-}
-
-export type TargetId = keyof Clients & string extends `${infer T}/${string}`
+export type TargetId = Clients[number] extends `${infer T}/${string}`
   ? T
   : never
 
-export type ClientId<T extends TargetId> = Clients[keyof Clients &
-  `${T}/${string}`]
+export type ClientId<T extends string> = T extends TargetId
+  ? Extract<Clients[number], `${T}/${string}`> extends `${T}/${infer C}`
+    ? C
+    : never
+  : never
 
 /** What any plugins needs to return */
 export type Source = {

--- a/packages/snippetz/src/core/types.ts
+++ b/packages/snippetz/src/core/types.ts
@@ -1,3 +1,5 @@
+import type { Request } from 'har-format'
+
 export type { Request } from 'har-format'
 
 /**
@@ -28,13 +30,16 @@ export type ClientId<T extends string> = T extends TargetId
   : never
 
 /** What any plugins needs to return */
-export type Source = {
+export type Plugin = {
   /** The language or environment. */
   target: TargetId
   /** The identifier of the client. */
   client: ClientId<TargetId>
   /** The actual source code. */
-  code: string
+  generate: (
+    request?: Partial<Request>,
+    configuration?: PluginConfiguration,
+  ) => string
 }
 
 /**

--- a/packages/snippetz/src/plugins/js/fetch/fetch.test.ts
+++ b/packages/snippetz/src/plugins/js/fetch/fetch.test.ts
@@ -1,29 +1,29 @@
 import { describe, expect, it } from 'vitest'
 
-import { fetch } from './fetch'
+import { jsFetch } from './fetch'
 
-describe('fetch', () => {
+describe('jsFetch', () => {
   it('returns a basic request', () => {
-    const source = fetch({
+    const result = jsFetch.generate({
       url: 'https://example.com',
     })
 
-    expect(source.code).toBe(`fetch('https://example.com')`)
+    expect(result).toBe(`fetch('https://example.com')`)
   })
 
   it('returns a POST request', () => {
-    const source = fetch({
+    const result = jsFetch.generate({
       url: 'https://example.com',
       method: 'post',
     })
 
-    expect(source.code).toBe(`fetch('https://example.com', {
+    expect(result).toBe(`fetch('https://example.com', {
   method: 'POST'
 })`)
   })
 
   it('has headers', () => {
-    const source = fetch({
+    const result = jsFetch.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -33,7 +33,7 @@ describe('fetch', () => {
       ],
     })
 
-    expect(source.code).toBe(`fetch('https://example.com', {
+    expect(result).toBe(`fetch('https://example.com', {
   headers: {
     'Content-Type': 'application/json'
   }
@@ -41,16 +41,16 @@ describe('fetch', () => {
   })
 
   it('doesn’t add empty headers', () => {
-    const source = fetch({
+    const result = jsFetch.generate({
       url: 'https://example.com',
       headers: [],
     })
 
-    expect(source.code).toBe(`fetch('https://example.com')`)
+    expect(result).toBe(`fetch('https://example.com')`)
   })
 
   it('has JSON body', () => {
-    const source = fetch({
+    const result = jsFetch.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -66,7 +66,7 @@ describe('fetch', () => {
       },
     })
 
-    expect(source.code).toBe(`fetch('https://example.com', {
+    expect(result).toBe(`fetch('https://example.com', {
   headers: {
     'Content-Type': 'application/json'
   },
@@ -77,7 +77,7 @@ describe('fetch', () => {
   })
 
   it('has query string', () => {
-    const source = fetch({
+    const result = jsFetch.generate({
       url: 'https://example.com',
       queryString: [
         {
@@ -91,11 +91,11 @@ describe('fetch', () => {
       ],
     })
 
-    expect(source.code).toBe(`fetch('https://example.com?foo=bar&bar=foo')`)
+    expect(result).toBe(`fetch('https://example.com?foo=bar&bar=foo')`)
   })
 
   it('has cookies', () => {
-    const source = fetch({
+    const result = jsFetch.generate({
       url: 'https://example.com',
       cookies: [
         {
@@ -109,7 +109,7 @@ describe('fetch', () => {
       ],
     })
 
-    expect(source.code).toBe(`fetch('https://example.com', {
+    expect(result).toBe(`fetch('https://example.com', {
   headers: {
     'Set-Cookie': 'foo=bar; bar=foo'
   }
@@ -117,11 +117,11 @@ describe('fetch', () => {
   })
 
   it('doesn’t add empty cookies', () => {
-    const source = fetch({
+    const result = jsFetch.generate({
       url: 'https://example.com',
       cookies: [],
     })
 
-    expect(source.code).toBe(`fetch('https://example.com')`)
+    expect(result).toBe(`fetch('https://example.com')`)
   })
 })

--- a/packages/snippetz/src/plugins/js/fetch/fetch.ts
+++ b/packages/snippetz/src/plugins/js/fetch/fetch.ts
@@ -1,5 +1,6 @@
 import {
   type AddClient,
+  type PluginConfiguration,
   type Request,
   type Source,
   arrayToObject,
@@ -14,7 +15,10 @@ declare global {
 /**
  * js/fetch
  */
-export function fetch(request?: Partial<Request>): Source {
+export function fetch(
+  request?: Partial<Request>,
+  configuration?: PluginConfiguration,
+): Source {
   // Defaults
   const normalizedRequest = {
     method: 'GET',

--- a/packages/snippetz/src/plugins/js/fetch/fetch.ts
+++ b/packages/snippetz/src/plugins/js/fetch/fetch.ts
@@ -1,16 +1,10 @@
 import {
-  type AddClient,
   type PluginConfiguration,
   type Request,
   type Source,
   arrayToObject,
   objectToString,
 } from '../../../core'
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface Clients extends AddClient<'js', 'fetch'> {}
-}
 
 /**
  * js/fetch

--- a/packages/snippetz/src/plugins/js/fetch/fetch.ts
+++ b/packages/snippetz/src/plugins/js/fetch/fetch.ts
@@ -1,92 +1,83 @@
-import {
-  type PluginConfiguration,
-  type Request,
-  type Source,
-  arrayToObject,
-  objectToString,
-} from '../../../core'
+import { type Plugin, arrayToObject, objectToString } from '../../../core'
 
 /**
  * js/fetch
  */
-export function fetch(
-  request?: Partial<Request>,
-  configuration?: PluginConfiguration,
-): Source {
-  // Defaults
-  const normalizedRequest = {
-    method: 'GET',
-    ...request,
-  }
-
-  // Normalization
-  normalizedRequest.method = normalizedRequest.method.toUpperCase()
-
-  // Reset fetch defaults
-  const options: Record<string, any> = {
-    method:
-      normalizedRequest.method === 'GET' ? undefined : normalizedRequest.method,
-  }
-
-  // Query
-  const searchParams = new URLSearchParams(
-    normalizedRequest.queryString
-      ? arrayToObject(normalizedRequest.queryString)
-      : undefined,
-  )
-  const queryString = searchParams.size ? `?${searchParams.toString()}` : ''
-
-  // Headers
-  if (normalizedRequest.headers?.length) {
-    options.headers = {}
-
-    normalizedRequest.headers.forEach((header) => {
-      options.headers![header.name] = header.value
-    })
-  }
-
-  // Cookies
-  if (normalizedRequest.cookies?.length) {
-    options.headers = options.headers || {}
-
-    normalizedRequest.cookies.forEach((cookie) => {
-      options.headers!['Set-Cookie'] = options.headers!['Set-Cookie']
-        ? `${options.headers!['Set-Cookie']}; ${cookie.name}=${cookie.value}`
-        : `${cookie.name}=${cookie.value}`
-    })
-  }
-
-  // Remove undefined keys
-  Object.keys(options).forEach((key) => {
-    if (options[key] === undefined) {
-      delete options[key]
+export const jsFetch: Plugin = {
+  target: 'js',
+  client: 'fetch',
+  generate(request) {
+    // Defaults
+    const normalizedRequest = {
+      method: 'GET',
+      ...request,
     }
-  })
 
-  // Add body
-  if (normalizedRequest.postData) {
-    // Plain text
-    options.body = normalizedRequest.postData.text
+    // Normalization
+    normalizedRequest.method = normalizedRequest.method.toUpperCase()
 
-    // JSON
-    if (normalizedRequest.postData.mimeType === 'application/json') {
-      options.body = `JSON.stringify(${objectToString(
-        JSON.parse(options.body),
-      )})`
+    // Reset fetch defaults
+    const options: Record<string, any> = {
+      method:
+        normalizedRequest.method === 'GET'
+          ? undefined
+          : normalizedRequest.method,
     }
-  }
 
-  // Transform to JSON
-  const jsonOptions = Object.keys(options).length
-    ? `, ${objectToString(options)}`
-    : ''
+    // Query
+    const searchParams = new URLSearchParams(
+      normalizedRequest.queryString
+        ? arrayToObject(normalizedRequest.queryString)
+        : undefined,
+    )
+    const queryString = searchParams.size ? `?${searchParams.toString()}` : ''
 
-  // Code Template
-  const code = `fetch('${normalizedRequest.url}${queryString}'${jsonOptions})`
+    // Headers
+    if (normalizedRequest.headers?.length) {
+      options.headers = {}
 
-  return {
-    target: 'js',
-    client: 'fetch',
-    code,
-  }
+      normalizedRequest.headers.forEach((header) => {
+        options.headers![header.name] = header.value
+      })
+    }
+
+    // Cookies
+    if (normalizedRequest.cookies?.length) {
+      options.headers = options.headers || {}
+
+      normalizedRequest.cookies.forEach((cookie) => {
+        options.headers!['Set-Cookie'] = options.headers!['Set-Cookie']
+          ? `${options.headers!['Set-Cookie']}; ${cookie.name}=${cookie.value}`
+          : `${cookie.name}=${cookie.value}`
+      })
+    }
+
+    // Remove undefined keys
+    Object.keys(options).forEach((key) => {
+      if (options[key] === undefined) {
+        delete options[key]
+      }
+    })
+
+    // Add body
+    if (normalizedRequest.postData) {
+      // Plain text
+      options.body = normalizedRequest.postData.text
+
+      // JSON
+      if (normalizedRequest.postData.mimeType === 'application/json') {
+        options.body = `JSON.stringify(${objectToString(
+          JSON.parse(options.body),
+        )})`
+      }
+    }
+
+    // Transform to JSON
+    const jsonOptions = Object.keys(options).length
+      ? `, ${objectToString(options)}`
+      : ''
+
+    // Code Template
+    return `fetch('${normalizedRequest.url}${queryString}'${jsonOptions})`
+  },
 }

--- a/packages/snippetz/src/plugins/js/ofetch/ofetch.test.ts
+++ b/packages/snippetz/src/plugins/js/ofetch/ofetch.test.ts
@@ -1,25 +1,25 @@
 import { describe, expect, it } from 'vitest'
 
-import { ofetch } from './ofetch'
+import { jsOfetch } from './ofetch'
 
-describe('ofetch', () => {
+describe('jsOfetch', () => {
   it('returns a basic request', () => {
-    const source = ofetch({
+    const result = jsOfetch.generate({
       url: 'https://example.com',
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com')`)
   })
 
   it('returns a POST request', () => {
-    const source = ofetch({
+    const result = jsOfetch.generate({
       url: 'https://example.com',
       method: 'post',
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
   method: 'POST'
@@ -27,7 +27,7 @@ ofetch('https://example.com', {
   })
 
   it('has headers', () => {
-    const source = ofetch({
+    const result = jsOfetch.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -37,7 +37,7 @@ ofetch('https://example.com', {
       ],
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
   headers: {
@@ -47,18 +47,18 @@ ofetch('https://example.com', {
   })
 
   it('doesn’t add empty headers', () => {
-    const source = ofetch({
+    const result = jsOfetch.generate({
       url: 'https://example.com',
       headers: [],
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com')`)
   })
 
   it('has JSON body', () => {
-    const source = ofetch({
+    const result = jsOfetch.generate({
       url: 'https://example.com',
       postData: {
         mimeType: 'application/json',
@@ -68,7 +68,7 @@ ofetch('https://example.com')`)
       },
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
   body: {
@@ -78,7 +78,7 @@ ofetch('https://example.com', {
   })
 
   it('has query string', () => {
-    const source = ofetch({
+    const result = jsOfetch.generate({
       url: 'https://example.com',
       queryString: [
         {
@@ -92,7 +92,7 @@ ofetch('https://example.com', {
       ],
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
   query: {
@@ -103,7 +103,7 @@ ofetch('https://example.com', {
   })
 
   it('has cookies', () => {
-    const source = ofetch({
+    const result = jsOfetch.generate({
       url: 'https://example.com',
       cookies: [
         {
@@ -117,7 +117,7 @@ ofetch('https://example.com', {
       ],
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
   headers: {
@@ -127,12 +127,12 @@ ofetch('https://example.com', {
   })
 
   it('doesn’t add empty cookies', () => {
-    const source = ofetch({
+    const result = jsOfetch.generate({
       url: 'https://example.com',
       cookies: [],
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com')`)
   })

--- a/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
@@ -1,4 +1,5 @@
 import {
+  type Plugin,
   type PluginConfiguration,
   type Request,
   type Source,
@@ -9,90 +10,87 @@ import {
 /**
  * js/ofetch
  */
-export function ofetch(
-  request?: Partial<Request>,
-  configuration?: PluginConfiguration,
-): Source {
-  // Defaults
-  const normalizedRequest = {
-    method: 'GET',
-    ...request,
-  }
-
-  // Normalization
-  normalizedRequest.method = normalizedRequest.method.toUpperCase()
-
-  // Reset fetch defaults
-  const options: Record<string, any> = {
-    method:
-      normalizedRequest.method === 'GET' ? undefined : normalizedRequest.method,
-  }
-
-  // Query
-  const searchParams = new URLSearchParams(
-    normalizedRequest.queryString
-      ? arrayToObject(normalizedRequest.queryString)
-      : undefined,
-  )
-
-  if (searchParams.size) {
-    options.query = {}
-    searchParams.forEach((value, key) => {
-      options.query[key] = value
-    })
-  }
-
-  // Headers
-  if (normalizedRequest.headers?.length) {
-    options.headers = {}
-
-    normalizedRequest.headers.forEach((header) => {
-      options.headers![header.name] = header.value
-    })
-  }
-
-  // Cookies
-  if (normalizedRequest.cookies?.length) {
-    options.headers = options.headers || {}
-
-    normalizedRequest.cookies.forEach((cookie) => {
-      options.headers!['Set-Cookie'] = options.headers!['Set-Cookie']
-        ? `${options.headers!['Set-Cookie']}; ${cookie.name}=${cookie.value}`
-        : `${cookie.name}=${cookie.value}`
-    })
-  }
-
-  // Remove undefined keys
-  Object.keys(options).forEach((key) => {
-    if (options[key] === undefined) {
-      delete options[key]
+export const jsOfetch: Plugin = {
+  target: 'js',
+  client: 'ofetch',
+  generate(request) {
+    // Defaults
+    const normalizedRequest = {
+      method: 'GET',
+      ...request,
     }
-  })
 
-  // Add body
-  if (normalizedRequest.postData) {
-    // Plain text
-    options.body = normalizedRequest.postData.text
+    // Normalization
+    normalizedRequest.method = normalizedRequest.method.toUpperCase()
 
-    // JSON
-    if (normalizedRequest.postData.mimeType === 'application/json') {
-      options.body = JSON.parse(options.body)
+    // Reset fetch defaults
+    const options: Record<string, any> = {
+      method:
+        normalizedRequest.method === 'GET'
+          ? undefined
+          : normalizedRequest.method,
     }
-  }
 
-  // Transform to JSON
-  const jsonOptions = Object.keys(options).length
-    ? `, ${objectToString(options)}`
-    : ''
+    // Query
+    const searchParams = new URLSearchParams(
+      normalizedRequest.queryString
+        ? arrayToObject(normalizedRequest.queryString)
+        : undefined,
+    )
 
-  // Code Template
-  const code = `import { ofetch } from 'ofetch'
+    if (searchParams.size) {
+      options.query = {}
+      searchParams.forEach((value, key) => {
+        options.query[key] = value
+      })
+    }
+
+    // Headers
+    if (normalizedRequest.headers?.length) {
+      options.headers = {}
+
+      normalizedRequest.headers.forEach((header) => {
+        options.headers![header.name] = header.value
+      })
+    }
+
+    // Cookies
+    if (normalizedRequest.cookies?.length) {
+      options.headers = options.headers || {}
+
+      normalizedRequest.cookies.forEach((cookie) => {
+        options.headers!['Set-Cookie'] = options.headers!['Set-Cookie']
+          ? `${options.headers!['Set-Cookie']}; ${cookie.name}=${cookie.value}`
+          : `${cookie.name}=${cookie.value}`
+      })
+    }
+
+    // Remove undefined keys
+    Object.keys(options).forEach((key) => {
+      if (options[key] === undefined) {
+        delete options[key]
+      }
+    })
+
+    // Add body
+    if (normalizedRequest.postData) {
+      // Plain text
+      options.body = normalizedRequest.postData.text
+
+      // JSON
+      if (normalizedRequest.postData.mimeType === 'application/json') {
+        options.body = JSON.parse(options.body)
+      }
+    }
+
+    // Transform to JSON
+    const jsonOptions = Object.keys(options).length
+      ? `, ${objectToString(options)}`
+      : ''
+
+    // Code Template
+    return `import { ofetch } from 'ofetch'
 
 ofetch('${normalizedRequest.url}'${jsonOptions})`
-
-  return {
-    target: 'js',
-    client: 'ofetch',
-    code,
-  }
+  },
 }

--- a/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
@@ -1,5 +1,6 @@
 import {
   type AddClient,
+  type PluginConfiguration,
   type Request,
   type Source,
   arrayToObject,
@@ -14,7 +15,10 @@ declare global {
 /**
  * js/ofetch
  */
-export function ofetch(request?: Partial<Request>): Source {
+export function ofetch(
+  request?: Partial<Request>,
+  configuration?: PluginConfiguration,
+): Source {
   // Defaults
   const normalizedRequest = {
     method: 'GET',

--- a/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
@@ -1,11 +1,4 @@
-import {
-  type Plugin,
-  type PluginConfiguration,
-  type Request,
-  type Source,
-  arrayToObject,
-  objectToString,
-} from '../../../core'
+import { type Plugin, arrayToObject, objectToString } from '../../../core'
 
 /**
  * js/ofetch

--- a/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
@@ -1,16 +1,10 @@
 import {
-  type AddClient,
   type PluginConfiguration,
   type Request,
   type Source,
   arrayToObject,
   objectToString,
 } from '../../../core'
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface Clients extends AddClient<'js', 'ofetch'> {}
-}
 
 /**
  * js/ofetch

--- a/packages/snippetz/src/plugins/node/fetch/fetch.test.ts
+++ b/packages/snippetz/src/plugins/node/fetch/fetch.test.ts
@@ -1,29 +1,29 @@
 import { describe, expect, it } from 'vitest'
 
-import { fetch } from './fetch'
+import { nodeFetch } from './fetch'
 
-describe('fetch', () => {
+describe('nodeFetch', () => {
   it('returns a basic request', () => {
-    const source = fetch({
+    const result = nodeFetch.generate({
       url: 'https://example.com',
     })
 
-    expect(source.code).toBe(`fetch('https://example.com')`)
+    expect(result).toBe(`fetch('https://example.com')`)
   })
 
   it('returns a POST request', () => {
-    const source = fetch({
+    const result = nodeFetch.generate({
       url: 'https://example.com',
       method: 'post',
     })
 
-    expect(source.code).toBe(`fetch('https://example.com', {
+    expect(result).toBe(`fetch('https://example.com', {
   method: 'POST'
 })`)
   })
 
   it('has headers', () => {
-    const source = fetch({
+    const result = nodeFetch.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -33,7 +33,7 @@ describe('fetch', () => {
       ],
     })
 
-    expect(source.code).toBe(`fetch('https://example.com', {
+    expect(result).toBe(`fetch('https://example.com', {
   headers: {
     'Content-Type': 'application/json'
   }
@@ -41,16 +41,16 @@ describe('fetch', () => {
   })
 
   it('doesn’t add empty headers', () => {
-    const source = fetch({
+    const result = nodeFetch.generate({
       url: 'https://example.com',
       headers: [],
     })
 
-    expect(source.code).toBe(`fetch('https://example.com')`)
+    expect(result).toBe(`fetch('https://example.com')`)
   })
 
   it('has JSON body', () => {
-    const source = fetch({
+    const result = nodeFetch.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -66,7 +66,7 @@ describe('fetch', () => {
       },
     })
 
-    expect(source.code).toBe(`fetch('https://example.com', {
+    expect(result).toBe(`fetch('https://example.com', {
   headers: {
     'Content-Type': 'application/json'
   },
@@ -77,7 +77,7 @@ describe('fetch', () => {
   })
 
   it('has query string', () => {
-    const source = fetch({
+    const result = nodeFetch.generate({
       url: 'https://example.com',
       queryString: [
         {
@@ -91,11 +91,11 @@ describe('fetch', () => {
       ],
     })
 
-    expect(source.code).toBe(`fetch('https://example.com?foo=bar&bar=foo')`)
+    expect(result).toBe(`fetch('https://example.com?foo=bar&bar=foo')`)
   })
 
   it('has cookies', () => {
-    const source = fetch({
+    const result = nodeFetch.generate({
       url: 'https://example.com',
       cookies: [
         {
@@ -109,7 +109,7 @@ describe('fetch', () => {
       ],
     })
 
-    expect(source.code).toBe(`fetch('https://example.com', {
+    expect(result).toBe(`fetch('https://example.com', {
   headers: {
     'Set-Cookie': 'foo=bar; bar=foo'
   }
@@ -117,11 +117,11 @@ describe('fetch', () => {
   })
 
   it('doesn’t add empty cookies', () => {
-    const source = fetch({
+    const result = nodeFetch.generate({
       url: 'https://example.com',
       cookies: [],
     })
 
-    expect(source.code).toBe(`fetch('https://example.com')`)
+    expect(result).toBe(`fetch('https://example.com')`)
   })
 })

--- a/packages/snippetz/src/plugins/node/fetch/fetch.ts
+++ b/packages/snippetz/src/plugins/node/fetch/fetch.ts
@@ -1,5 +1,6 @@
 import {
   type AddClient,
+  type PluginConfiguration,
   type Request,
   type Source,
   arrayToObject,
@@ -14,7 +15,10 @@ declare global {
 /**
  * node/fetch
  */
-export function fetch(request?: Partial<Request>): Source {
+export function fetch(
+  request?: Partial<Request>,
+  configuration?: PluginConfiguration,
+) {
   // Defaults
   const normalizedRequest = {
     method: 'GET',

--- a/packages/snippetz/src/plugins/node/fetch/fetch.ts
+++ b/packages/snippetz/src/plugins/node/fetch/fetch.ts
@@ -1,92 +1,83 @@
-import {
-  type PluginConfiguration,
-  type Request,
-  type Source,
-  arrayToObject,
-  objectToString,
-} from '../../../core'
+import { type Plugin, arrayToObject, objectToString } from '../../../core'
 
 /**
  * node/fetch
  */
-export function fetch(
-  request?: Partial<Request>,
-  configuration?: PluginConfiguration,
-): Source {
-  // Defaults
-  const normalizedRequest = {
-    method: 'GET',
-    ...request,
-  }
-
-  // Normalization
-  normalizedRequest.method = normalizedRequest.method.toUpperCase()
-
-  // Reset fetch defaults
-  const options: Record<string, any> = {
-    method:
-      normalizedRequest.method === 'GET' ? undefined : normalizedRequest.method,
-  }
-
-  // Query
-  const searchParams = new URLSearchParams(
-    normalizedRequest.queryString
-      ? arrayToObject(normalizedRequest.queryString)
-      : undefined,
-  )
-  const queryString = searchParams.size ? `?${searchParams.toString()}` : ''
-
-  // Headers
-  if (normalizedRequest.headers?.length) {
-    options.headers = {}
-
-    normalizedRequest.headers.forEach((header) => {
-      options.headers![header.name] = header.value
-    })
-  }
-
-  // Cookies
-  if (normalizedRequest.cookies?.length) {
-    options.headers = options.headers || {}
-
-    normalizedRequest.cookies.forEach((cookie) => {
-      options.headers!['Set-Cookie'] = options.headers!['Set-Cookie']
-        ? `${options.headers!['Set-Cookie']}; ${cookie.name}=${cookie.value}`
-        : `${cookie.name}=${cookie.value}`
-    })
-  }
-
-  // Remove undefined keys
-  Object.keys(options).forEach((key) => {
-    if (options[key] === undefined) {
-      delete options[key]
+export const nodeFetch: Plugin = {
+  target: 'node',
+  client: 'fetch',
+  generate(request) {
+    // Defaults
+    const normalizedRequest = {
+      method: 'GET',
+      ...request,
     }
-  })
 
-  // Add body
-  if (normalizedRequest.postData) {
-    // Plain text
-    options.body = normalizedRequest.postData.text
+    // Normalization
+    normalizedRequest.method = normalizedRequest.method.toUpperCase()
 
-    // JSON
-    if (normalizedRequest.postData.mimeType === 'application/json') {
-      options.body = `JSON.stringify(${objectToString(
-        JSON.parse(options.body),
-      )})`
+    // Reset fetch defaults
+    const options: Record<string, any> = {
+      method:
+        normalizedRequest.method === 'GET'
+          ? undefined
+          : normalizedRequest.method,
     }
-  }
 
-  // Transform to JSON
-  const jsonOptions = Object.keys(options).length
-    ? `, ${objectToString(options)}`
-    : ''
+    // Query
+    const searchParams = new URLSearchParams(
+      normalizedRequest.queryString
+        ? arrayToObject(normalizedRequest.queryString)
+        : undefined,
+    )
+    const queryString = searchParams.size ? `?${searchParams.toString()}` : ''
 
-  // Code Template
-  const code = `fetch('${normalizedRequest.url}${queryString}'${jsonOptions})`
+    // Headers
+    if (normalizedRequest.headers?.length) {
+      options.headers = {}
 
-  return {
-    target: 'node',
-    client: 'fetch',
-    code,
-  }
+      normalizedRequest.headers.forEach((header) => {
+        options.headers![header.name] = header.value
+      })
+    }
+
+    // Cookies
+    if (normalizedRequest.cookies?.length) {
+      options.headers = options.headers || {}
+
+      normalizedRequest.cookies.forEach((cookie) => {
+        options.headers!['Set-Cookie'] = options.headers!['Set-Cookie']
+          ? `${options.headers!['Set-Cookie']}; ${cookie.name}=${cookie.value}`
+          : `${cookie.name}=${cookie.value}`
+      })
+    }
+
+    // Remove undefined keys
+    Object.keys(options).forEach((key) => {
+      if (options[key] === undefined) {
+        delete options[key]
+      }
+    })
+
+    // Add body
+    if (normalizedRequest.postData) {
+      // Plain text
+      options.body = normalizedRequest.postData.text
+
+      // JSON
+      if (normalizedRequest.postData.mimeType === 'application/json') {
+        options.body = `JSON.stringify(${objectToString(
+          JSON.parse(options.body),
+        )})`
+      }
+    }
+
+    // Transform to JSON
+    const jsonOptions = Object.keys(options).length
+      ? `, ${objectToString(options)}`
+      : ''
+
+    // Code Template
+    return `fetch('${normalizedRequest.url}${queryString}'${jsonOptions})`
+  },
 }

--- a/packages/snippetz/src/plugins/node/fetch/fetch.ts
+++ b/packages/snippetz/src/plugins/node/fetch/fetch.ts
@@ -1,5 +1,4 @@
 import {
-  type AddClient,
   type PluginConfiguration,
   type Request,
   type Source,
@@ -7,18 +6,13 @@ import {
   objectToString,
 } from '../../../core'
 
-declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface Clients extends AddClient<'node', 'fetch'> {}
-}
-
 /**
  * node/fetch
  */
 export function fetch(
   request?: Partial<Request>,
   configuration?: PluginConfiguration,
-) {
+): Source {
   // Defaults
   const normalizedRequest = {
     method: 'GET',

--- a/packages/snippetz/src/plugins/node/ofetch/ofetch.test.ts
+++ b/packages/snippetz/src/plugins/node/ofetch/ofetch.test.ts
@@ -1,25 +1,25 @@
 import { describe, expect, it } from 'vitest'
 
-import { ofetch } from './ofetch'
+import { nodeOfetch } from './ofetch'
 
-describe('ofetch', () => {
+describe('nodeOfetch', () => {
   it('returns a basic request', () => {
-    const source = ofetch({
+    const result = nodeOfetch.generate({
       url: 'https://example.com',
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com')`)
   })
 
   it('returns a POST request', () => {
-    const source = ofetch({
+    const result = nodeOfetch.generate({
       url: 'https://example.com',
       method: 'post',
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
   method: 'POST'
@@ -27,7 +27,7 @@ ofetch('https://example.com', {
   })
 
   it('has headers', () => {
-    const source = ofetch({
+    const result = nodeOfetch.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -37,7 +37,7 @@ ofetch('https://example.com', {
       ],
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
   headers: {
@@ -47,18 +47,18 @@ ofetch('https://example.com', {
   })
 
   it('doesn’t add empty headers', () => {
-    const source = ofetch({
+    const result = nodeOfetch.generate({
       url: 'https://example.com',
       headers: [],
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com')`)
   })
 
   it('has JSON body', () => {
-    const source = ofetch({
+    const result = nodeOfetch.generate({
       url: 'https://example.com',
       postData: {
         mimeType: 'application/json',
@@ -68,7 +68,7 @@ ofetch('https://example.com')`)
       },
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
   body: {
@@ -78,7 +78,7 @@ ofetch('https://example.com', {
   })
 
   it('has query string', () => {
-    const source = ofetch({
+    const result = nodeOfetch.generate({
       url: 'https://example.com',
       queryString: [
         {
@@ -92,7 +92,7 @@ ofetch('https://example.com', {
       ],
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
   query: {
@@ -103,7 +103,7 @@ ofetch('https://example.com', {
   })
 
   it('has cookies', () => {
-    const source = ofetch({
+    const result = nodeOfetch.generate({
       url: 'https://example.com',
       cookies: [
         {
@@ -117,7 +117,7 @@ ofetch('https://example.com', {
       ],
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
   headers: {
@@ -127,12 +127,12 @@ ofetch('https://example.com', {
   })
 
   it('doesn’t add empty cookies', () => {
-    const source = ofetch({
+    const result = nodeOfetch.generate({
       url: 'https://example.com',
       cookies: [],
     })
 
-    expect(source.code).toBe(`import { ofetch } from 'ofetch'
+    expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com')`)
   })

--- a/packages/snippetz/src/plugins/node/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/node/ofetch/ofetch.ts
@@ -1,98 +1,89 @@
-import {
-  type PluginConfiguration,
-  type Request,
-  type Source,
-  arrayToObject,
-  objectToString,
-} from '../../../core'
+import { type Plugin, arrayToObject, objectToString } from '../../../core'
 
 /**
  * node/ofetch
  */
-export function ofetch(
-  request?: Partial<Request>,
-  configuration?: PluginConfiguration,
-): Source {
-  // Defaults
-  const normalizedRequest = {
-    method: 'GET',
-    ...request,
-  }
-
-  // Normalization
-  normalizedRequest.method = normalizedRequest.method.toUpperCase()
-
-  // Reset fetch defaults
-  const options: Record<string, any> = {
-    method:
-      normalizedRequest.method === 'GET' ? undefined : normalizedRequest.method,
-  }
-
-  // Query
-  const searchParams = new URLSearchParams(
-    normalizedRequest.queryString
-      ? arrayToObject(normalizedRequest.queryString)
-      : undefined,
-  )
-
-  if (searchParams.size) {
-    options.query = {}
-    searchParams.forEach((value, key) => {
-      options.query[key] = value
-    })
-  }
-
-  // Headers
-  if (normalizedRequest.headers?.length) {
-    options.headers = {}
-
-    normalizedRequest.headers.forEach((header) => {
-      options.headers![header.name] = header.value
-    })
-  }
-
-  // Cookies
-  if (normalizedRequest.cookies?.length) {
-    options.headers = options.headers || {}
-
-    normalizedRequest.cookies.forEach((cookie) => {
-      options.headers!['Set-Cookie'] = options.headers!['Set-Cookie']
-        ? `${options.headers!['Set-Cookie']}; ${cookie.name}=${cookie.value}`
-        : `${cookie.name}=${cookie.value}`
-    })
-  }
-
-  // Remove undefined keys
-  Object.keys(options).forEach((key) => {
-    if (options[key] === undefined) {
-      delete options[key]
+export const nodeOfetch: Plugin = {
+  target: 'node',
+  client: 'ofetch',
+  generate(request) {
+    // Defaults
+    const normalizedRequest = {
+      method: 'GET',
+      ...request,
     }
-  })
 
-  // Add body
-  if (normalizedRequest.postData) {
-    // Plain text
-    options.body = normalizedRequest.postData.text
+    // Normalization
+    normalizedRequest.method = normalizedRequest.method.toUpperCase()
 
-    // JSON
-    if (normalizedRequest.postData.mimeType === 'application/json') {
-      options.body = JSON.parse(options.body)
+    // Reset fetch defaults
+    const options: Record<string, any> = {
+      method:
+        normalizedRequest.method === 'GET'
+          ? undefined
+          : normalizedRequest.method,
     }
-  }
 
-  // Transform to JSON
-  const jsonOptions = Object.keys(options).length
-    ? `, ${objectToString(options)}`
-    : ''
+    // Query
+    const searchParams = new URLSearchParams(
+      normalizedRequest.queryString
+        ? arrayToObject(normalizedRequest.queryString)
+        : undefined,
+    )
 
-  // Code Template
-  const code = `import { ofetch } from 'ofetch'
+    if (searchParams.size) {
+      options.query = {}
+      searchParams.forEach((value, key) => {
+        options.query[key] = value
+      })
+    }
+
+    // Headers
+    if (normalizedRequest.headers?.length) {
+      options.headers = {}
+
+      normalizedRequest.headers.forEach((header) => {
+        options.headers![header.name] = header.value
+      })
+    }
+
+    // Cookies
+    if (normalizedRequest.cookies?.length) {
+      options.headers = options.headers || {}
+
+      normalizedRequest.cookies.forEach((cookie) => {
+        options.headers!['Set-Cookie'] = options.headers!['Set-Cookie']
+          ? `${options.headers!['Set-Cookie']}; ${cookie.name}=${cookie.value}`
+          : `${cookie.name}=${cookie.value}`
+      })
+    }
+
+    // Remove undefined keys
+    Object.keys(options).forEach((key) => {
+      if (options[key] === undefined) {
+        delete options[key]
+      }
+    })
+
+    // Add body
+    if (normalizedRequest.postData) {
+      // Plain text
+      options.body = normalizedRequest.postData.text
+
+      // JSON
+      if (normalizedRequest.postData.mimeType === 'application/json') {
+        options.body = JSON.parse(options.body)
+      }
+    }
+
+    // Transform to JSON
+    const jsonOptions = Object.keys(options).length
+      ? `, ${objectToString(options)}`
+      : ''
+
+    // Code Template
+    return `import { ofetch } from 'ofetch'
 
 ofetch('${normalizedRequest.url}'${jsonOptions})`
-
-  return {
-    target: 'node',
-    client: 'ofetch',
-    code,
-  }
+  },
 }

--- a/packages/snippetz/src/plugins/node/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/node/ofetch/ofetch.ts
@@ -1,5 +1,6 @@
 import {
   type AddClient,
+  type PluginConfiguration,
   type Request,
   type Source,
   arrayToObject,
@@ -14,7 +15,10 @@ declare global {
 /**
  * node/ofetch
  */
-export function ofetch(request?: Partial<Request>): Source {
+export function ofetch(
+  request?: Partial<Request>,
+  configuration?: PluginConfiguration,
+): Source {
   // Defaults
   const normalizedRequest = {
     method: 'GET',

--- a/packages/snippetz/src/plugins/node/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/node/ofetch/ofetch.ts
@@ -1,16 +1,10 @@
 import {
-  type AddClient,
   type PluginConfiguration,
   type Request,
   type Source,
   arrayToObject,
   objectToString,
 } from '../../../core'
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface Clients extends AddClient<'node', 'ofetch'> {}
-}
 
 /**
  * node/ofetch

--- a/packages/snippetz/src/plugins/node/undici/undici.test.ts
+++ b/packages/snippetz/src/plugins/node/undici/undici.test.ts
@@ -1,33 +1,33 @@
 import { describe, expect, it } from 'vitest'
 
-import { undici } from './undici'
+import { nodeUndici } from './undici'
 
-describe('undici', () => {
+describe('nodeUndici', () => {
   it('has import', () => {
-    const source = undici({
+    const result = nodeUndici.generate({
       url: 'https://example.com',
     })
 
-    expect(source.code).toContain(`import { request } from 'undici'`)
+    expect(result).toContain(`import { request } from 'undici'`)
   })
 
   it('returns a basic request', () => {
-    const source = undici({
+    const result = nodeUndici.generate({
       url: 'https://example.com',
     })
 
-    expect(source.code).toBe(`import { request } from 'undici'
+    expect(result).toBe(`import { request } from 'undici'
 
 const { statusCode, body } = await request('https://example.com')`)
   })
 
   it('returns a POST request', () => {
-    const source = undici({
+    const result = nodeUndici.generate({
       url: 'https://example.com',
       method: 'post',
     })
 
-    expect(source.code).toBe(`import { request } from 'undici'
+    expect(result).toBe(`import { request } from 'undici'
 
 const { statusCode, body } = await request('https://example.com', {
   method: 'POST'
@@ -35,7 +35,7 @@ const { statusCode, body } = await request('https://example.com', {
   })
 
   it('has headers', () => {
-    const source = undici({
+    const result = nodeUndici.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -45,7 +45,7 @@ const { statusCode, body } = await request('https://example.com', {
       ],
     })
 
-    expect(source.code).toBe(`import { request } from 'undici'
+    expect(result).toBe(`import { request } from 'undici'
 
 const { statusCode, body } = await request('https://example.com', {
   headers: {
@@ -55,18 +55,18 @@ const { statusCode, body } = await request('https://example.com', {
   })
 
   it('doesn’t add empty headers', () => {
-    const source = undici({
+    const result = nodeUndici.generate({
       url: 'https://example.com',
       headers: [],
     })
 
-    expect(source.code).toBe(`import { request } from 'undici'
+    expect(result).toBe(`import { request } from 'undici'
 
 const { statusCode, body } = await request('https://example.com')`)
   })
 
   it('has JSON body', () => {
-    const source = undici({
+    const result = nodeUndici.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -82,7 +82,7 @@ const { statusCode, body } = await request('https://example.com')`)
       },
     })
 
-    expect(source.code).toBe(`import { request } from 'undici'
+    expect(result).toBe(`import { request } from 'undici'
 
 const { statusCode, body } = await request('https://example.com', {
   headers: {
@@ -95,7 +95,7 @@ const { statusCode, body } = await request('https://example.com', {
   })
 
   it('has query string', () => {
-    const source = undici({
+    const result = nodeUndici.generate({
       url: 'https://example.com',
       queryString: [
         {
@@ -109,13 +109,13 @@ const { statusCode, body } = await request('https://example.com', {
       ],
     })
 
-    expect(source.code).toBe(`import { request } from 'undici'
+    expect(result).toBe(`import { request } from 'undici'
 
 const { statusCode, body } = await request('https://example.com?foo=bar&bar=foo')`)
   })
 
   it('has cookies', () => {
-    const source = undici({
+    const result = nodeUndici.generate({
       url: 'https://example.com',
       cookies: [
         {
@@ -129,7 +129,7 @@ const { statusCode, body } = await request('https://example.com?foo=bar&bar=foo'
       ],
     })
 
-    expect(source.code).toBe(`import { request } from 'undici'
+    expect(result).toBe(`import { request } from 'undici'
 
 const { statusCode, body } = await request('https://example.com', {
   headers: {
@@ -139,12 +139,12 @@ const { statusCode, body } = await request('https://example.com', {
   })
 
   it('doesn’t add empty cookies', () => {
-    const source = undici({
+    const result = nodeUndici.generate({
       url: 'https://example.com',
       cookies: [],
     })
 
-    expect(source.code).toBe(`import { request } from 'undici'
+    expect(result).toBe(`import { request } from 'undici'
 
 const { statusCode, body } = await request('https://example.com')`)
   })

--- a/packages/snippetz/src/plugins/node/undici/undici.ts
+++ b/packages/snippetz/src/plugins/node/undici/undici.ts
@@ -1,94 +1,85 @@
-import {
-  type PluginConfiguration,
-  type Request,
-  type Source,
-  arrayToObject,
-  objectToString,
-} from '../../../core'
+import { type Plugin, arrayToObject, objectToString } from '../../../core'
 
 /**
  * node/undici
  */
-export function undici(
-  request?: Partial<Request>,
-  configuration?: PluginConfiguration,
-): Source {
-  // Defaults
-  const normalizedRequest = {
-    method: 'GET',
-    ...request,
-  }
-
-  // Normalization
-  normalizedRequest.method = normalizedRequest.method.toUpperCase()
-
-  // Reset undici defaults
-  const options: Record<string, any> = {
-    method:
-      normalizedRequest.method === 'GET' ? undefined : normalizedRequest.method,
-  }
-
-  // Query
-  const searchParams = new URLSearchParams(
-    normalizedRequest.queryString
-      ? arrayToObject(normalizedRequest.queryString)
-      : undefined,
-  )
-  const queryString = searchParams.size ? `?${searchParams.toString()}` : ''
-
-  // Headers
-  if (normalizedRequest.headers?.length) {
-    options.headers = {}
-
-    normalizedRequest.headers.forEach((header) => {
-      options.headers![header.name] = header.value
-    })
-  }
-
-  // Cookies
-  if (normalizedRequest.cookies?.length) {
-    options.headers = options.headers || {}
-
-    normalizedRequest.cookies.forEach((cookie) => {
-      options.headers!['Set-Cookie'] = options.headers!['Set-Cookie']
-        ? `${options.headers!['Set-Cookie']}; ${cookie.name}=${cookie.value}`
-        : `${cookie.name}=${cookie.value}`
-    })
-  }
-
-  // Remove undefined keys
-  Object.keys(options).forEach((key) => {
-    if (options[key] === undefined) {
-      delete options[key]
+export const nodeUndici: Plugin = {
+  target: 'node',
+  client: 'undici',
+  generate(request) {
+    // Defaults
+    const normalizedRequest = {
+      method: 'GET',
+      ...request,
     }
-  })
 
-  // Add body
-  if (normalizedRequest.postData) {
-    // Plain text
-    options.body = normalizedRequest.postData.text
+    // Normalization
+    normalizedRequest.method = normalizedRequest.method.toUpperCase()
 
-    // JSON
-    if (normalizedRequest.postData.mimeType === 'application/json') {
-      options.body = `JSON.stringify(${objectToString(
-        JSON.parse(options.body),
-      )})`
+    // Reset undici defaults
+    const options: Record<string, any> = {
+      method:
+        normalizedRequest.method === 'GET'
+          ? undefined
+          : normalizedRequest.method,
     }
-  }
 
-  // Transform to JSON
-  const jsonOptions = Object.keys(options).length
-    ? `, ${objectToString(options)}`
-    : ''
+    // Query
+    const searchParams = new URLSearchParams(
+      normalizedRequest.queryString
+        ? arrayToObject(normalizedRequest.queryString)
+        : undefined,
+    )
+    const queryString = searchParams.size ? `?${searchParams.toString()}` : ''
 
-  // Code Template
-  const code = `import { request } from 'undici'
+    // Headers
+    if (normalizedRequest.headers?.length) {
+      options.headers = {}
+
+      normalizedRequest.headers.forEach((header) => {
+        options.headers![header.name] = header.value
+      })
+    }
+
+    // Cookies
+    if (normalizedRequest.cookies?.length) {
+      options.headers = options.headers || {}
+
+      normalizedRequest.cookies.forEach((cookie) => {
+        options.headers!['Set-Cookie'] = options.headers!['Set-Cookie']
+          ? `${options.headers!['Set-Cookie']}; ${cookie.name}=${cookie.value}`
+          : `${cookie.name}=${cookie.value}`
+      })
+    }
+
+    // Remove undefined keys
+    Object.keys(options).forEach((key) => {
+      if (options[key] === undefined) {
+        delete options[key]
+      }
+    })
+
+    // Add body
+    if (normalizedRequest.postData) {
+      // Plain text
+      options.body = normalizedRequest.postData.text
+
+      // JSON
+      if (normalizedRequest.postData.mimeType === 'application/json') {
+        options.body = `JSON.stringify(${objectToString(
+          JSON.parse(options.body),
+        )})`
+      }
+    }
+
+    // Transform to JSON
+    const jsonOptions = Object.keys(options).length
+      ? `, ${objectToString(options)}`
+      : ''
+
+    // Code Template
+    return `import { request } from 'undici'
 
 const { statusCode, body } = await request('${normalizedRequest.url}${queryString}'${jsonOptions})`
-
-  return {
-    target: 'node',
-    client: 'undici',
-    code,
-  }
+  },
 }

--- a/packages/snippetz/src/plugins/node/undici/undici.ts
+++ b/packages/snippetz/src/plugins/node/undici/undici.ts
@@ -1,16 +1,10 @@
 import {
-  type AddClient,
   type PluginConfiguration,
   type Request,
   type Source,
   arrayToObject,
   objectToString,
 } from '../../../core'
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface Clients extends AddClient<'node', 'undici'> {}
-}
 
 /**
  * node/undici

--- a/packages/snippetz/src/plugins/node/undici/undici.ts
+++ b/packages/snippetz/src/plugins/node/undici/undici.ts
@@ -1,5 +1,6 @@
 import {
   type AddClient,
+  type PluginConfiguration,
   type Request,
   type Source,
   arrayToObject,
@@ -14,7 +15,10 @@ declare global {
 /**
  * node/undici
  */
-export function undici(request?: Partial<Request>): Source {
+export function undici(
+  request?: Partial<Request>,
+  configuration?: PluginConfiguration,
+): Source {
   // Defaults
   const normalizedRequest = {
     method: 'GET',

--- a/packages/snippetz/src/plugins/shell/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.test.ts
@@ -1,28 +1,28 @@
 import { describe, expect, it } from 'vitest'
 
-import { curl } from './curl'
+import { shellCurl } from './curl'
 
-describe('curl', () => {
+describe('shellCurl', () => {
   it('returns a basic request', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
     })
 
-    expect(source.code).toBe('curl https://example.com')
+    expect(result).toBe('curl https://example.com')
   })
 
   it('returns a POST request', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       method: 'post',
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --request POST`)
   })
 
   it('has headers', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -32,21 +32,21 @@ describe('curl', () => {
       ],
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --header 'Content-Type: application/json'`)
   })
 
   it('doesn’t add empty headers', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       headers: [],
     })
 
-    expect(source.code).toBe('curl https://example.com')
+    expect(result).toBe('curl https://example.com')
   })
 
   it('has JSON body', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       method: 'POST',
       headers: [
@@ -63,7 +63,7 @@ describe('curl', () => {
       },
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --request POST \\
   --header 'Content-Type: application/json' \\
   --data '{
@@ -72,7 +72,7 @@ describe('curl', () => {
   })
 
   it('has query string', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       queryString: [
         {
@@ -86,11 +86,11 @@ describe('curl', () => {
       ],
     })
 
-    expect(source.code).toBe(`curl 'https://example.com?foo=bar&bar=foo'`)
+    expect(result).toBe(`curl 'https://example.com?foo=bar&bar=foo'`)
   })
 
   it('has cookies', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       cookies: [
         {
@@ -104,21 +104,21 @@ describe('curl', () => {
       ],
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --cookie 'foo=bar; bar=foo'`)
   })
 
   it('doesn’t add empty cookies', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       cookies: [],
     })
 
-    expect(source.code).toBe('curl https://example.com')
+    expect(result).toBe('curl https://example.com')
   })
 
   it('adds basic auth credentials', () => {
-    const source = curl(
+    const result = shellCurl.generate(
       {
         url: 'https://example.com',
       },
@@ -130,20 +130,20 @@ describe('curl', () => {
       },
     )
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --user 'user:pass'`)
   })
 
   it('omits auth when not provided', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
     })
 
-    expect(source.code).toBe('curl https://example.com')
+    expect(result).toBe('curl https://example.com')
   })
 
   it('omits auth when username is missing', () => {
-    const source = curl(
+    const result = shellCurl.generate(
       {
         url: 'https://example.com',
       },
@@ -155,11 +155,11 @@ describe('curl', () => {
       },
     )
 
-    expect(source.code).toBe('curl https://example.com')
+    expect(result).toBe('curl https://example.com')
   })
 
   it('omits auth when password is missing', () => {
-    const source = curl(
+    const result = shellCurl.generate(
       {
         url: 'https://example.com',
       },
@@ -171,11 +171,11 @@ describe('curl', () => {
       },
     )
 
-    expect(source.code).toBe('curl https://example.com')
+    expect(result).toBe('curl https://example.com')
   })
 
   it('handles special characters in auth credentials', () => {
-    const source = curl(
+    const result = shellCurl.generate(
       {
         url: 'https://example.com',
       },
@@ -187,12 +187,12 @@ describe('curl', () => {
       },
     )
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --user 'user@example.com:pass:word!'`)
   })
 
   it('handles undefined auth object', () => {
-    const source = curl(
+    const result = shellCurl.generate(
       {
         url: 'https://example.com',
       },
@@ -201,11 +201,11 @@ describe('curl', () => {
       },
     )
 
-    expect(source.code).toBe('curl https://example.com')
+    expect(result).toBe('curl https://example.com')
   })
 
   it('handles multipart form data with files', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       method: 'POST',
       postData: {
@@ -223,14 +223,14 @@ describe('curl', () => {
       },
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --request POST \\
   --form 'file=@test.txt' \\
   --form 'field=value'`)
   })
 
   it('handles url-encoded form data with special characters', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       method: 'POST',
       postData: {
@@ -244,13 +244,13 @@ describe('curl', () => {
       },
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --request POST \\
   --data-urlencode 'special%20chars!%40%23=value'`)
   })
 
   it('handles binary data flag', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       method: 'POST',
       postData: {
@@ -259,13 +259,13 @@ describe('curl', () => {
       },
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --request POST \\
   --data-binary 'binary content'`)
   })
 
   it('handles compressed response', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -275,23 +275,23 @@ describe('curl', () => {
       ],
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --header 'Accept-Encoding: gzip, deflate' \\
   --compressed`)
   })
 
   it('handles special characters in URL', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
 
-    expect(source.code).toBe(
+    expect(result).toBe(
       `curl 'https://example.com/path with spaces/[brackets]'`,
     )
   })
 
   it('handles special characters in query parameters', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       queryString: [
         {
@@ -305,29 +305,29 @@ describe('curl', () => {
       ],
     })
 
-    expect(source.code).toBe(
+    expect(result).toBe(
       `curl 'https://example.com?q=hello%20world%20%26%20more&special=!%40%23%24%25%5E%26*()'`,
     )
   })
 
   it('handles empty URL', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: '',
     })
 
-    expect(source.code).toBe('curl ')
+    expect(result).toBe('curl ')
   })
 
   it('handles extremely long URLs', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com/' + 'a'.repeat(2000),
     })
 
-    expect(source.code).toBe(`curl https://example.com/${'a'.repeat(2000)}`)
+    expect(result).toBe(`curl https://example.com/${'a'.repeat(2000)}`)
   })
 
   it('handles multiple headers with same name', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       headers: [
         { name: 'X-Custom', value: 'value1' },
@@ -335,23 +335,23 @@ describe('curl', () => {
       ],
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --header 'X-Custom: value1' \\
   --header 'X-Custom: value2'`)
   })
 
   it('handles headers with empty values', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       headers: [{ name: 'X-Empty', value: '' }],
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --header 'X-Empty: '`)
   })
 
   it('handles multipart form data with empty file names', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       method: 'POST',
       postData: {
@@ -365,13 +365,13 @@ describe('curl', () => {
       },
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --request POST \\
   --form 'file=@'`)
   })
 
   it('handles JSON body with special characters', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       method: 'POST',
       headers: [
@@ -391,7 +391,7 @@ describe('curl', () => {
       },
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --request POST \\
   --header 'Content-Type: application/json' \\
   --data '{
@@ -407,7 +407,7 @@ describe('curl', () => {
   })
 
   it('handles cookies with special characters', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       cookies: [
         {
@@ -417,12 +417,12 @@ describe('curl', () => {
       ],
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --cookie 'special%3Bcookie=value%20with%20spaces'`)
   })
 
   it('prettifies JSON body', () => {
-    const source = curl({
+    const result = shellCurl.generate({
       url: 'https://example.com',
       method: 'POST',
       headers: [
@@ -443,7 +443,7 @@ describe('curl', () => {
       },
     })
 
-    expect(source.code).toBe(`curl https://example.com \\
+    expect(result).toBe(`curl https://example.com \\
   --request POST \\
   --header 'Content-Type: application/json' \\
   --data '{

--- a/packages/snippetz/src/plugins/shell/curl/curl.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.ts
@@ -1,125 +1,122 @@
-import type { PluginConfiguration, Request, Source } from '../../../core'
+import type { Plugin } from '../../../core'
 
 /**
  * shell/curl
  */
-export function curl(
-  request?: Partial<Request>,
-  configuration?: PluginConfiguration,
-): Source {
-  // Defaults
-  const normalizedRequest = {
-    method: 'GET',
-    ...request,
-  }
+export const shellCurl: Plugin = {
+  target: 'shell',
+  client: 'curl',
+  generate(request, configuration) {
+    // Defaults
+    const normalizedRequest = {
+      method: 'GET',
+      ...request,
+    }
 
-  // Normalization
-  normalizedRequest.method = normalizedRequest.method.toUpperCase()
+    // Normalization
+    normalizedRequest.method = normalizedRequest.method.toUpperCase()
 
-  // Build curl command parts
-  const parts: string[] = ['curl']
+    // Build curl command parts
+    const parts: string[] = ['curl']
 
-  // URL (quote if has query parameters or special characters)
-  const queryString = normalizedRequest.queryString?.length
-    ? '?' +
-      normalizedRequest.queryString
-        .map((param) => {
-          // Ensure both name and value are fully URI encoded
-          const encodedName = encodeURIComponent(param.name)
-          const encodedValue = encodeURIComponent(param.value)
+    // URL (quote if has query parameters or special characters)
+    const queryString = normalizedRequest.queryString?.length
+      ? '?' +
+        normalizedRequest.queryString
+          .map((param) => {
+            // Ensure both name and value are fully URI encoded
+            const encodedName = encodeURIComponent(param.name)
+            const encodedValue = encodeURIComponent(param.value)
+            return `${encodedName}=${encodedValue}`
+          })
+          .join('&')
+      : ''
+    const url = `${normalizedRequest.url}${queryString}`
+    const hasSpecialChars = /[\s<>[\]{}|\\^%]/.test(url)
+    const urlPart = queryString || hasSpecialChars ? `'${url}'` : url
+    parts[0] = `curl ${urlPart}`
+
+    // Method
+    if (normalizedRequest.method !== 'GET') {
+      parts.push(`--request ${normalizedRequest.method}`)
+    }
+
+    // Basic Auth
+    if (configuration?.auth?.username && configuration?.auth?.password) {
+      parts.push(
+        `--user '${configuration.auth.username}:${configuration.auth.password}'`,
+      )
+    }
+
+    // Headers
+    if (normalizedRequest.headers?.length) {
+      normalizedRequest.headers.forEach((header) => {
+        parts.push(`--header '${header.name}: ${header.value}'`)
+      })
+
+      // Add compressed flag if Accept-Encoding header includes compression
+      const acceptEncoding = normalizedRequest.headers.find(
+        (header) => header.name.toLowerCase() === 'accept-encoding',
+      )
+      if (acceptEncoding && /gzip|deflate/.test(acceptEncoding.value)) {
+        parts.push('--compressed')
+      }
+    }
+
+    // Cookies
+    if (normalizedRequest.cookies?.length) {
+      const cookieString = normalizedRequest.cookies
+        .map((cookie) => {
+          // Encode both cookie name and value to handle special characters
+          const encodedName = encodeURIComponent(cookie.name)
+          const encodedValue = encodeURIComponent(cookie.value)
           return `${encodedName}=${encodedValue}`
         })
-        .join('&')
-    : ''
-  const url = `${normalizedRequest.url}${queryString}`
-  const hasSpecialChars = /[\s<>[\]{}|\\^%]/.test(url)
-  const urlPart = queryString || hasSpecialChars ? `'${url}'` : url
-  parts[0] = `curl ${urlPart}`
-
-  // Method
-  if (normalizedRequest.method !== 'GET') {
-    parts.push(`--request ${normalizedRequest.method}`)
-  }
-
-  // Basic Auth
-  if (configuration?.auth?.username && configuration?.auth?.password) {
-    parts.push(
-      `--user '${configuration.auth.username}:${configuration.auth.password}'`,
-    )
-  }
-
-  // Headers
-  if (normalizedRequest.headers?.length) {
-    normalizedRequest.headers.forEach((header) => {
-      parts.push(`--header '${header.name}: ${header.value}'`)
-    })
-
-    // Add compressed flag if Accept-Encoding header includes compression
-    const acceptEncoding = normalizedRequest.headers.find(
-      (header) => header.name.toLowerCase() === 'accept-encoding',
-    )
-    if (acceptEncoding && /gzip|deflate/.test(acceptEncoding.value)) {
-      parts.push('--compressed')
+        .join('; ')
+      parts.push(`--cookie '${cookieString}'`)
     }
-  }
 
-  // Cookies
-  if (normalizedRequest.cookies?.length) {
-    const cookieString = normalizedRequest.cookies
-      .map((cookie) => {
-        // Encode both cookie name and value to handle special characters
-        const encodedName = encodeURIComponent(cookie.name)
-        const encodedValue = encodeURIComponent(cookie.value)
-        return `${encodedName}=${encodedValue}`
-      })
-      .join('; ')
-    parts.push(`--cookie '${cookieString}'`)
-  }
-
-  // Body
-  if (normalizedRequest.postData) {
-    if (normalizedRequest.postData.mimeType === 'application/json') {
-      // Pretty print JSON data
-      if (normalizedRequest.postData.text) {
-        const jsonData = JSON.parse(normalizedRequest.postData.text)
-        const prettyJson = JSON.stringify(jsonData, null, 2)
-        parts.push(`--data '${prettyJson}'`)
-      }
-    } else if (
-      normalizedRequest.postData.mimeType === 'application/octet-stream'
-    ) {
-      parts.push(`--data-binary '${normalizedRequest.postData.text}'`)
-    } else if (
-      normalizedRequest.postData.mimeType ===
-        'application/x-www-form-urlencoded' &&
-      normalizedRequest.postData.params
-    ) {
-      // Handle URL-encoded form data
-      normalizedRequest.postData.params.forEach((param) => {
-        parts.push(
-          `--data-urlencode '${encodeURIComponent(param.name)}=${param.value}'`,
-        )
-      })
-    } else if (
-      normalizedRequest.postData.mimeType === 'multipart/form-data' &&
-      normalizedRequest.postData.params
-    ) {
-      // Handle multipart form data
-      normalizedRequest.postData.params.forEach((param) => {
-        if (param.fileName !== undefined) {
-          parts.push(`--form '${param.name}=@${param.fileName}'`)
-        } else {
-          parts.push(`--form '${param.name}=${param.value}'`)
+    // Body
+    if (normalizedRequest.postData) {
+      if (normalizedRequest.postData.mimeType === 'application/json') {
+        // Pretty print JSON data
+        if (normalizedRequest.postData.text) {
+          const jsonData = JSON.parse(normalizedRequest.postData.text)
+          const prettyJson = JSON.stringify(jsonData, null, 2)
+          parts.push(`--data '${prettyJson}'`)
         }
-      })
-    } else {
-      parts.push(`--data "${normalizedRequest.postData.text}"`)
+      } else if (
+        normalizedRequest.postData.mimeType === 'application/octet-stream'
+      ) {
+        parts.push(`--data-binary '${normalizedRequest.postData.text}'`)
+      } else if (
+        normalizedRequest.postData.mimeType ===
+          'application/x-www-form-urlencoded' &&
+        normalizedRequest.postData.params
+      ) {
+        // Handle URL-encoded form data
+        normalizedRequest.postData.params.forEach((param) => {
+          parts.push(
+            `--data-urlencode '${encodeURIComponent(param.name)}=${param.value}'`,
+          )
+        })
+      } else if (
+        normalizedRequest.postData.mimeType === 'multipart/form-data' &&
+        normalizedRequest.postData.params
+      ) {
+        // Handle multipart form data
+        normalizedRequest.postData.params.forEach((param) => {
+          if (param.fileName !== undefined) {
+            parts.push(`--form '${param.name}=@${param.fileName}'`)
+          } else {
+            parts.push(`--form '${param.name}=${param.value}'`)
+          }
+        })
+      } else {
+        parts.push(`--data "${normalizedRequest.postData.text}"`)
+      }
     }
-  }
 
-  return {
-    target: 'shell',
-    client: 'curl',
-    code: parts.join(' \\\n  '),
-  }
+    return parts.join(' \\\n  ')
+  },
 }

--- a/packages/snippetz/src/plugins/shell/curl/curl.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.ts
@@ -1,14 +1,4 @@
-import type {
-  AddClient,
-  PluginConfiguration,
-  Request,
-  Source,
-} from '../../../core'
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface Clients extends AddClient<'shell', 'curl'> {}
-}
+import type { PluginConfiguration, Request, Source } from '../../../core'
 
 /**
  * shell/curl

--- a/packages/snippetz/src/snippetz.ts
+++ b/packages/snippetz/src/snippetz.ts
@@ -1,59 +1,52 @@
-import type { ClientId, Request, TargetId } from './core'
-import { fetch as jsFetch } from './plugins/js/fetch'
-import { ofetch as jsOFetch } from './plugins/js/ofetch'
-import { fetch as nodeFetch } from './plugins/node/fetch'
-import { ofetch as nodeOFetch } from './plugins/node/ofetch'
-import { undici } from './plugins/node/undici'
-import { curl } from './plugins/shell/curl'
+import type { ClientId, Plugin, Request, TargetId } from './core'
+import { jsFetch } from './plugins/js/fetch'
+import { jsOfetch } from './plugins/js/ofetch'
+import { nodeFetch } from './plugins/node/fetch'
+import { nodeOfetch } from './plugins/node/ofetch'
+import { nodeUndici } from './plugins/node/undici'
+import { shellCurl } from './plugins/shell/curl'
 
 /**
  * Generate code examples for HAR requests
  */
 export function snippetz() {
-  const plugins = [undici, nodeFetch, jsFetch, jsOFetch, nodeOFetch, curl]
+  const plugins: Plugin[] = [
+    nodeUndici,
+    nodeFetch,
+    jsFetch,
+    jsOfetch,
+    nodeOfetch,
+    shellCurl,
+  ]
 
   return {
-    get(
-      target: TargetId,
-      client: ClientId<TargetId>,
-      request: Partial<Request>,
-    ) {
-      const plugin = this.findPlugin(target, client)
-
-      if (plugin) {
-        return plugin(request)
-      }
-
-      return {
-        code: '',
-      }
+    get(target: TargetId, client: ClientId<TargetId>) {
+      return this.findPlugin(target, client)
     },
     print<T extends TargetId>(
       target: T,
       client: ClientId<T>,
       request: Partial<Request>,
     ) {
-      return this.get(target, client, request)?.code
+      return this.get(target, client)?.generate(request)
     },
     targets() {
       return (
         plugins
           // all targets
-          .map((plugin) => plugin().target)
+          .map((plugin) => plugin.target)
           // unique values
           .filter((value, index, self) => self.indexOf(value) === index)
       )
     },
     clients() {
-      return plugins.map((plugin) => plugin().client)
+      return plugins.map((plugin) => plugin.client)
     },
     plugins() {
       return plugins.map((plugin) => {
-        const details = plugin()
-
         return {
-          target: details.target,
-          client: details.client,
+          target: plugin.target,
+          client: plugin.client,
         }
       })
     },
@@ -62,9 +55,7 @@ export function snippetz() {
       client: ClientId<T> | string,
     ) {
       return plugins.find((plugin) => {
-        const details = plugin()
-
-        return details.target === target && details.client === client
+        return plugin.target === target && plugin.client === client
       })
     },
     hasPlugin<T extends TargetId>(


### PR DESCRIPTION
We recently added a way to dynamically extend the list of available clients in TypeScript. Turns out the types were wrong in the build: The output only had one plugin import, instead of all. So as a result only this one client was in the types, all the others were missing:

<img width="583" alt="Screenshot 2024-11-27 at 12 52 41" src="https://github.com/user-attachments/assets/76fb3705-3109-4ee5-8eb7-72a77ca45de8">

I don’t know exactly why that is. But I don’t want to bother, so I went back to a simpler approach of just a list of available clients.

I’ve also changed the plugin API to make it simpler. This is what changed:

* No function invocation needed (I don't know what I was thinking)
* The function name includes the target to avoid conflicts
* No types for the parameters needed, just one type for the whole object including the generator

```diff
-export function curl(
-  request?: Partial<Request>,
-  configuration?: PluginConfiguration,
-): Source {
-  // …
- 
-  return {
-    target: 'shell',
-    client: 'curl',
-    generate(request, configuration) {
-  }
-}
+export const shellCurl: Plugin = {
+  target: 'shell',
+  client: 'curl',
+  generate(request, configuration) {
+    // …
+    return code
+  }
+}
```

