### PR TITLE
fix(use-codemirror): dispatch value frame

### DIFF
--- a/.changeset/great-timers-provide.md
+++ b/.changeset/great-timers-provide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-codemirror': patch
+---
+
+fix: requests animation frame to dispatched value

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -193,8 +193,10 @@ export const useCodeMirror = (
           provider,
         })
 
-        codeMirror.value.dispatch({
-          effects: StateEffect.reconfigure.of(extensions),
+        requestAnimationFrame(() => {
+          codeMirror.value?.dispatch({
+            effects: StateEffect.reconfigure.of(extensions),
+          })
         })
       }
     },


### PR DESCRIPTION
this pr fixes the error fired when changing request along using a variable in code mirror input:

```json
Error: Calls to EditorView.update are not allowed while an update is in progress
```