### PR TITLE
style(api-client): http method variants

### DIFF
--- a/.changeset/old-pumpkins-chew.md
+++ b/.changeset/old-pumpkins-chew.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: updates http method variants

--- a/packages/api-client/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/api-client/src/components/HttpMethod/HttpMethod.vue
@@ -36,8 +36,8 @@ const variants = cva({
       false: 'rounded-full',
     },
     isEditable: {
-      true: 'px-0 http-bg-gradient rounded-md border-1/2 border-r-1/2',
-      false: 'cusor-pointer',
+      true: 'http-bg-gradient rounded-md border-1/2 border-r-1/2',
+      false: 'cursor-auto',
     },
   },
 })


### PR DESCRIPTION
this pr updates http method variants according to the fix in #4036:

**before / after**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/894c0f69-0f25-48ee-b365-7c2c6f9b7687">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ca8091e1-c7ff-43c8-960a-a099330b65cc">
</div>
