### PR TITLE
feat(configuration): adds hideClientButton option

### DIFF
--- a/.changeset/perfect-turtles-do.md
+++ b/.changeset/perfect-turtles-do.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/types': patch
+---
+
+feat: adds hideClientButton option configuration

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -385,3 +385,15 @@ Can be one of: **alternate**, **default**, **moon**, **purple**, **solarized**, 
   theme: 'default'
 }
 ```
+
+#### hideClientButton?: boolean
+
+Whether to show the client button from the reference sidebar and modal
+
+`@default false`
+
+```js
+{
+  hideClientButton: true
+}
+```

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -41,6 +41,7 @@ export type ClientConfiguration = {
   | 'searchHotKey'
   | 'authentication'
   | 'baseServerURL'
+  | 'hideClientButton'
 >
 
 export type OpenClientPayload = {
@@ -125,6 +126,7 @@ export const createApiClient = ({
       isReadOnly,
       proxyUrl: configuration.proxyUrl,
       themeId: configuration.themeId,
+      hideClientButton: configuration.hideClientButton,
       useLocalStorage: persistData,
     })
 

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -60,6 +60,7 @@ type CreateWorkspaceStoreOptions = {
   isReadOnly: boolean
   proxyUrl: ReferenceConfiguration['proxyUrl']
   themeId: ReferenceConfiguration['theme']
+  hideClientButton: ReferenceConfiguration['hideClientButton']
 }
 
 /**
@@ -74,6 +75,7 @@ export const createWorkspaceStore = ({
   isReadOnly = false,
   proxyUrl,
   themeId,
+  hideClientButton,
 }: CreateWorkspaceStoreOptions) => {
   // ---------------------------------------------------------------------------
   // Initialize all storage objects
@@ -194,6 +196,7 @@ export const createWorkspaceStore = ({
     sidebarWidth,
     setSidebarWidth,
     isReadOnly,
+    hideClientButton,
     // ---------------------------------------------------------------------------
     // METHODS
     importSpecFile,

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -4,6 +4,7 @@ import AddressBar from '@/components/AddressBar/AddressBar.vue'
 import EnvironmentSelector from '@/components/EnvironmentSelector/EnvironmentSelector.vue'
 import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
 import { useLayout } from '@/hooks'
+import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 import { ScalarIcon } from '@scalar/components'
 
@@ -21,6 +22,10 @@ defineEmits<{
 }>()
 
 const { activeCollection } = useActiveEntities()
+const workspaceContext = useWorkspace()
+
+const { hideClientButton } = workspaceContext
+
 const { layout } = useLayout()
 </script>
 <template>
@@ -49,9 +54,8 @@ const { layout } = useLayout()
     <div
       class="flex flex-row items-center gap-1 lg:px-2.5 lg:mb-0 mb-2 lg:flex-1 justify-end w-6/12">
       <EnvironmentSelector v-if="!isReadonly" />
-
       <OpenApiClientButton
-        v-if="isReadonly && activeCollection?.documentUrl"
+        v-if="isReadonly && activeCollection?.documentUrl && !hideClientButton"
         buttonSource="modal"
         class="gitbook-hidden !w-fit lg:-mr-1"
         :integration="activeCollection?.integration"

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -67,6 +67,7 @@ watch(hash, (newHash, oldHash) => {
     <template #sidebar-end>
       <div class="darklight-reference">
         <OpenApiClientButton
+          v-if="!props.configuration.hideClientButton"
           buttonSource="sidebar"
           :integration="configuration._integration"
           :isDevelopment="isDevelopment"

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -249,6 +249,12 @@ export type ReferenceConfiguration = {
     | 'react' // ✅
     | 'rust'
     | 'vue' // ✅
+  /**
+   * Whether to show the client button from the reference sidebar and modal
+   *
+   * @default false
+   */
+  hideClientButton?: boolean
 }
 
 export type Server = OpenAPIV3.ServerObject | OpenAPIV3_1.ServerObject


### PR DESCRIPTION
this pr adds the `hideClient?` option to the configuration in order to be able to hide the api client button from the reference as seen below:

**⊢ sidebar hideClient: false (default) / hideClient: true**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7716d9e8-cbb6-4aee-99aa-76e34e0991d2">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e3b9943e-0c23-4242-a4e7-2e441c06d7e5">
</div>

<br>
**⊢ modal hideClient: false (default) / hideClient: true**
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/c8b89a78-abf2-46d7-bce4-2c63530d3f91">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e9ba753b-ee0a-4083-905f-3d675fbb1fa1">
</div>