### PR TITLE
fix(fastify-api-reference): export map needs explicit types condition

### DIFF
--- a/.changeset/quick-turkeys-sniff.md
+++ b/.changeset/quick-turkeys-sniff.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: explicit export map is missing the type export

--- a/examples/fastify-api-reference/src/index.ts
+++ b/examples/fastify-api-reference/src/index.ts
@@ -1,5 +1,7 @@
 import fastifySwagger from '@fastify/swagger'
-import fastifyApiReference from '@scalar/fastify-api-reference'
+import fastifyApiReference, {
+  type FastifyApiReferenceOptions,
+} from '@scalar/fastify-api-reference'
 import Fastify from 'fastify'
 
 // Init Fastify
@@ -64,7 +66,7 @@ fastify.put<{ Body: { name: string } }>(
 // Add the plugin
 await fastify.register(fastifyApiReference, {
   routePrefix: '/reference',
-})
+} satisfies FastifyApiReferenceOptions)
 
 const PORT = Number(process.env.PORT) || 5053
 const HOST = process.env.HOST || '0.0.0.0'

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -31,7 +31,7 @@
   },
   "type": "module",
   "main": "./dist/index.cjs",
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     "types": "./dist/index.d.ts",
     "import": "./dist/index.js",

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -33,6 +33,7 @@
   "main": "./dist/index.cjs",
   "types": "dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.js",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
**Problem**
While I'm working on my Fastify project, I noticed that `FastifyApiReferenceOptions` can not be resolved.

```ts
import type { FastifyApiReferenceOptions } from '@scalar/fastify-api-reference'
```

Above import statement shows a bellow error.

```
Module '"@scalar/fastify-api-reference"' has no exported member 'FastifyApiReferenceOptions'. Did you mean to use 'import FastifyApiReferenceOptions from "@scalar/fastify-api-reference"' instead?ts(2614)
```

**Solution**

I'm not 100% sure, but some `moduleResolution` mode does not read `types` field in `package.json` when export map exists, and export map needs `types` condition to properly resolve TypeScript types.

https://www.typescriptlang.org/docs/handbook/modules/reference.html#the-moduleresolution-compiler-option

According to the spec, IIUC, it should be able to resolve type via file extension substitution, but it can't be resolved in my environment and needs `types` condition.
