### PR TITLE
feat(openapi-parser): support `onDereference` option on `dereference`

### DIFF
--- a/packages/openapi-parser/src/utils/dereference.ts
+++ b/packages/openapi-parser/src/utils/dereference.ts
@@ -2,14 +2,16 @@ import type {
   AnyApiDefinitionFormat,
   DereferenceResult,
   Filesystem,
-  ThrowOnErrorOption,
 } from '../types'
 import { details } from './details'
 import { getEntrypoint } from './getEntrypoint'
 import { makeFilesystem } from './makeFilesystem'
-import { resolveReferences } from './resolveReferences'
+import {
+  type ResolveReferencesOptions,
+  resolveReferences,
+} from './resolveReferences'
 
-export type DereferenceOptions = ThrowOnErrorOption
+export type DereferenceOptions = ResolveReferencesOptions
 
 /**
  * Resolves all references in an OpenAPI document

--- a/packages/openapi-parser/src/utils/resolveReferences.ts
+++ b/packages/openapi-parser/src/utils/resolveReferences.ts
@@ -28,6 +28,10 @@ export type ResolveReferencesResult = {
   schema: OpenAPI.Document
 }
 
+export type ResolveReferencesOptions = ThrowOnErrorOption & {
+  onDereference?: (schema: AnyObject, $ref: string) => void
+}
+
 // TODO: Exists already, clean up
 type DereferenceResult = {
   errors: ErrorObject[]
@@ -40,7 +44,7 @@ export function resolveReferences(
   // Just a specification, or a set of files.
   input: AnyObject | Filesystem,
   // Additional options to control the behaviour
-  options?: ThrowOnErrorOption,
+  options?: ResolveReferencesOptions,
   // Fallback to the entrypoint
   file?: FilesystemEntry,
   // Errors that occurred during the process
@@ -65,6 +69,7 @@ export function resolveReferences(
     file?.specification ?? entrypoint.specification,
     filesystem,
     file ?? entrypoint,
+    options?.onDereference,
   )
 
   // If we replace references with content, that includes a reference, we can’t deal with that right-away.
@@ -73,6 +78,7 @@ export function resolveReferences(
     file?.specification ?? entrypoint.specification,
     filesystem,
     file ?? entrypoint,
+    options?.onDereference,
   )
 
   // Remove duplicats (according to message) from errors
@@ -99,6 +105,7 @@ export function resolveReferences(
     schema: AnyObject,
     resolveFilesystem: Filesystem,
     resolveFile: FilesystemEntry,
+    onResolve?: (schema: AnyObject, $ref: string) => void,
   ): DereferenceResult {
     let result: DereferenceResult | undefined
 
@@ -119,6 +126,8 @@ export function resolveReferences(
           return undefined
         }
 
+        onResolve?.(schema, schema.$ref)
+
         // Get rid of the reference
         delete schema.$ref
 
@@ -132,7 +141,7 @@ export function resolveReferences(
       }
 
       if (typeof value === 'object' && !isCircular(value)) {
-        result = resolve(value, resolveFilesystem, resolveFile)
+        result = resolve(value, resolveFilesystem, resolveFile, onResolve)
       }
     })
 


### PR DESCRIPTION
**Problem**
Currently, the `dereference` function only supports `ThrowOnErrorOption` which isn't enough for migrating codebases from other ref parsers to scalar, some useful options like `onDereference` are missing.

**Solution**
With this PR, it adds a `onDereference` option to `dereference` function, the callback is fired when a schema is dereferenced, reproducing the same effect as on `@apidevtools/json-schema-ref-parser`.

```ts
dereference('', {
   onDereference(schema, $ref) {
     console.log(schema, $ref)
    }
},
```