### PR TITLE
fix(api-client): image response preview

### DIFF
--- a/.changeset/giant-teachers-smile.md
+++ b/.changeset/giant-teachers-smile.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates overflow and height for image response preview

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyPreview.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyPreview.vue
@@ -21,11 +21,11 @@ watch(
 <template>
   <div
     v-if="!error && src"
-    class="flex justify-center overflow-hidden rounded-b"
+    class="flex justify-center overflow-auto rounded-b"
     :class="{ 'p-2 bg-preview': alpha }">
     <img
       v-if="mode === 'image'"
-      class="max-w-full"
+      class="h-full max-w-full"
       :class="{ rounded: alpha }"
       :src="src"
       @error="error = true" />


### PR DESCRIPTION
this pr fixes #4060 updates the image style in response preview to avoid them from shrinking:

⊢ before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/c14f30b2-a0c2-45ea-90fe-50e23e1d96b8">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e906d973-014c-46bf-b0d6-8af2a7ee2dc2">
</div>