### PR TITLE
refactor(api-reference): remove `httpsnippet-lite`

### DIFF
--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -158,10 +158,7 @@ async function generateSnippet() {
   const clientKey = httpClient.clientKey
   const targetKey = httpClient.targetKey
 
-  return (
-    (await getExampleCode(harRequest as any, targetKey, clientKey as string)) ??
-    ''
-  )
+  return (await getExampleCode(harRequest as any, targetKey, clientKey)) ?? ''
 }
 
 const generatedCode = asyncComputed<string>(async () => {

--- a/packages/api-reference/src/helpers/getExampleCode.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.ts
@@ -1,63 +1,29 @@
 import {
+  type ClientId,
   type Request,
-  type ClientId as SnippetzClientId,
-  type TargetId as SnippetzTargetId,
+  type TargetId,
   snippetz,
 } from '@scalar/snippetz'
-import {
-  HTTPSnippet,
-  type ClientId as HttpSnippetLiteClientId,
-  type TargetId as HttpSnippetLiteTargetId,
-} from 'httpsnippet-lite'
-
-export type TargetId = HttpSnippetLiteTargetId | SnippetzTargetId
-export type ClientId<T extends SnippetzTargetId> =
-  | HttpSnippetLiteClientId
-  | SnippetzClientId<T>
 
 /**
  * Returns a code example for given HAR request
  */
-export async function getExampleCode<T extends SnippetzTargetId>(
+export async function getExampleCode<T extends TargetId>(
   request: Request,
   target: TargetId,
   client: ClientId<T>,
 ) {
-  // @scalar/snippetz
-  const snippetzTargetKey = target
-
-  if (snippetz().hasPlugin(snippetzTargetKey, client)) {
-    return snippetz().print(
-      snippetzTargetKey as SnippetzTargetId,
-      client as SnippetzClientId<typeof snippetzTargetKey>,
-      request,
-    )
-  }
-
   // Prevent snippet generation if starting by a variable
   if (request.url.startsWith('__')) {
     return request.url
   }
 
-  // httpsnippet-lite
-  try {
-    const httpSnippetLiteTargetKey = target?.replace(
-      'js',
-      'javascript',
-    ) as HttpSnippetLiteTargetId
-    const httpSnippetLiteClientKey = client as HttpSnippetLiteClientId
-
-    // HTTPSnippet will return type string[] if passed input type HarEntry
-    // Since we are passing type HarRequest output is a string
-    const code = await new HTTPSnippet(request).convert(
-      httpSnippetLiteTargetKey,
-      httpSnippetLiteClientKey,
-    )
-    if (typeof code === 'string') return code
-  } catch (error) {
-    console.error(
-      '[getExampleCode] Failed to generate example code with httpsnippet-lite:',
-      error,
+  // Generate the code example
+  if (snippetz().hasPlugin(target, client)) {
+    return snippetz().print(
+      target as TargetId,
+      client as ClientId<typeof target>,
+      request,
     )
   }
 

--- a/packages/api-reference/src/helpers/getExampleCode.ts
+++ b/packages/api-reference/src/helpers/getExampleCode.ts
@@ -9,12 +9,12 @@ import {
  * Returns a code example for given HAR request
  */
 export async function getExampleCode<T extends TargetId>(
-  request: Request,
-  target: TargetId,
-  client: ClientId<T>,
+  request: Partial<Request>,
+  target: TargetId | string,
+  client: ClientId<T> | string,
 ) {
   // Prevent snippet generation if starting by a variable
-  if (request.url.startsWith('__')) {
+  if (request.url?.startsWith('__')) {
     return request.url
   }
 

--- a/packages/snippetz/src/snippetz.test.ts
+++ b/packages/snippetz/src/snippetz.test.ts
@@ -13,19 +13,10 @@ describe('snippetz', async () => {
 const { statusCode, body } = await request('https://example.com')`)
   })
 
-  it('loads some clients by default', async () => {
-    const targets = snippetz().targets()
-    expect(targets).toStrictEqual(['node', 'js', 'shell'])
+  it('returns clients for a specific target', async () => {
+    const clients = snippetz().clients('node')
 
-    const clients = snippetz().clients()
-    expect(clients).toStrictEqual([
-      'undici',
-      'fetch',
-      'fetch',
-      'ofetch',
-      'ofetch',
-      'curl',
-    ])
+    expect(clients).toStrictEqual(['undici', 'fetch', 'ofetch'])
   })
 })
 

--- a/packages/snippetz/src/snippetz.ts
+++ b/packages/snippetz/src/snippetz.ts
@@ -39,8 +39,14 @@ export function snippetz() {
           .filter((value, index, self) => self.indexOf(value) === index)
       )
     },
-    clients() {
-      return plugins.map((plugin) => plugin.client)
+    clients(target: string) {
+      return (
+        plugins
+          // Only for the specified target
+          .filter((plugin) => plugin.target === target)
+          // Only the client key
+          .map((plugin) => plugin.client)
+      )
     },
     plugins() {
       return plugins.map((plugin) => {


### PR DESCRIPTION
WIP

⚠️ Merge #4044 first.

We’ve integrated `httpsnippet-lite` into `@scalar/snippetz` (and will eventually remove it), but we can already remove it from the API reference and make the code simpler.