### PR TITLE
style(api-client): removes add item hotkey style

### DIFF
--- a/.changeset/five-sheep-fetch.md
+++ b/.changeset/five-sheep-fetch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: removes add item hotkey style

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -314,11 +314,6 @@ const handleClearDrafts = () => {
     transparent
   );
 }
-.empty-sidebar-item:deep(.add-item-hotkey) {
-  color: var(--scalar-button-1-color);
-  background: color-mix(in srgb, var(--scalar-button-1), white 20%);
-  border-color: transparent;
-}
 .empty-sidebar-item-content {
   display: none;
 }


### PR DESCRIPTION
this pr fixes the add item hotkey style issue on desktop, however we might also maintain it and fix it for darkmode:

⊢ before / after
<div>
<img width="378" alt="image" src="https://github.com/user-attachments/assets/fde56b44-804d-4b5f-b7ff-db48088d794e">
<img width="378" alt="image" src="https://github.com/user-attachments/assets/a06d6de9-43f9-49dd-8c99-9f42cb0d04bd">
</div>