### PR TITLE
fix(oas-utils): throws an error for relative file paths

### DIFF
--- a/.changeset/slimy-bananas-prove.md
+++ b/.changeset/slimy-bananas-prove.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: allow to pass relative file names

--- a/packages/oas-utils/src/helpers/isLocalUrl.test.ts
+++ b/packages/oas-utils/src/helpers/isLocalUrl.test.ts
@@ -42,4 +42,8 @@ describe('isLocalUrl ', () => {
     expect(isLocalUrl('http://localhost/api/data')).toBe(true)
     expect(isLocalUrl('https://127.0.0.1/search?q=test')).toBe(true)
   })
+
+  it('returns true for relative file paths', () => {
+    expect(isLocalUrl('openapi.json')).toBe(true)
+  })
 })

--- a/packages/oas-utils/src/helpers/isLocalUrl.ts
+++ b/packages/oas-utils/src/helpers/isLocalUrl.ts
@@ -1,8 +1,17 @@
+/** Obviously local hostnames */
+const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]', '0.0.0.0']
+
 /**
  * Detect requests to localhost
  */
 export function isLocalUrl(url: string) {
-  const { hostname } = new URL(url)
-  const listOfLocalUrls = ['localhost', '127.0.0.1', '[::1]', '0.0.0.0']
-  return listOfLocalUrls.includes(hostname)
+  try {
+    const { hostname } = new URL(url)
+
+    return LOCAL_HOSTNAMES.includes(hostname)
+  } catch {
+    // If it’s not a valid URL, we can’t use the proxy anyway,
+    // but it also covers cases like relative URLs (e.g. `openapi.json`).
+    return true
+  }
 }

--- a/packages/oas-utils/src/helpers/redirectToProxy.test.ts
+++ b/packages/oas-utils/src/helpers/redirectToProxy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { redirectToProxy } from './redirectToProxy'
+import { isRelativePath, redirectToProxy } from './redirectToProxy'
 
 describe('redirectToProxy', () => {
   it('rewrites URLs', async () => {
@@ -32,5 +32,33 @@ describe('redirectToProxy', () => {
 
   it('skips the proxy for relative URLs not starting with a slash', async () => {
     expect(redirectToProxy('https://proxy.scalar.com', 'api')).toBe('api')
+  })
+
+  it('skips the proxy for relative URLs not starting with a slash, but containing a dot', async () => {
+    expect(redirectToProxy('https://proxy.scalar.com', 'openapi.json')).toBe(
+      'openapi.json',
+    )
+  })
+})
+
+describe('isRelativePath', () => {
+  it('returns true for relative paths starting with a slash', () => {
+    expect(isRelativePath('/api')).toBe(true)
+  })
+
+  it('returns true for relative paths without a slash', () => {
+    expect(isRelativePath('api')).toBe(true)
+  })
+
+  it('returns false for absolute URLs with http', () => {
+    expect(isRelativePath('http://example.com')).toBe(false)
+  })
+
+  it('returns false for absolute URLs with https', () => {
+    expect(isRelativePath('https://example.com')).toBe(false)
+  })
+
+  it('returns false for domain-like URLs without protocol', () => {
+    expect(isRelativePath('example.com/api')).toBe(false)
   })
 })


### PR DESCRIPTION
When we added support for requests to URLs without the http/https protocol prefix, we’ve added a check that was looking for dots in URLs to detect domains.

Turns out, relative file paths with a dot in them look like valid URLs (without a protocol). That led to an exception when e.g. `openapi.yaml` was passed as an OpenAPI document URL.

This PR tries to create a new `URL` object in the `isLocalUrl` check, which will fail for a bunch of cases and then return false - which eventually makes our packages to skip the proxy. Which is what we want for relative URLs (but also for invalid URLs).

**Example**

```html
<script
  id="api-reference"
  data-url="openapi.yaml"></script>
```

**Exception**

<img width="673" alt="Screenshot 2024-12-03 at 09 05 23" src="https://github.com/user-attachments/assets/73e0093e-ae92-4a41-8819-0d002645de31">



