### PR TITLE
feat(api-reference): import from embedded OpenAPI documents

### DIFF
--- a/.changeset/young-sloths-beg.md
+++ b/.changeset/young-sloths-beg.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+feat: fall back to the API reference URL for the import

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
@@ -73,7 +73,7 @@ watch(
         // Check whether the URL is pointing to an OpenAPI document
         const { error } = await prefetchUrl(
           value,
-          activeWorkspace.value.proxyUrl,
+          activeWorkspace.value?.proxyUrl,
         )
 
         if (error) {

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
@@ -236,7 +236,9 @@ function handleImportFinished() {
           <template v-if="version">
             <div class="inline-flex flex-col gap-2 items-center z-10 w-full">
               <ImportNowButton
-                :source="prefetchResult?.url ?? source"
+                :source="
+                  prefetchResult?.url ?? prefetchResult?.content ?? source
+                "
                 variant="button"
                 :watchMode="watchMode"
                 @importFinished="handleImportFinished" />

--- a/packages/api-client/src/components/ImportCollection/hooks/useUrlPrefetcher.ts
+++ b/packages/api-client/src/components/ImportCollection/hooks/useUrlPrefetcher.ts
@@ -80,8 +80,6 @@ export function useUrlPrefetcher() {
         }
       }
 
-      console.log('urlOrDocument', urlOrDocument)
-
       if (!isUrl(urlOrDocument)) {
         return {
           state: 'idle',
@@ -93,7 +91,6 @@ export function useUrlPrefetcher() {
       }
 
       const url = urlOrDocument
-      console.log('prefetchUrl', url)
 
       // Okay, we've got an URL. Let's fetch it:
       const result = await fetchWithProxyFallback(url, {

--- a/packages/api-client/src/components/ImportCollection/hooks/useUrlPrefetcher.ts
+++ b/packages/api-client/src/components/ImportCollection/hooks/useUrlPrefetcher.ts
@@ -57,10 +57,16 @@ export function useUrlPrefetcher() {
         },
       })
 
-      // If the input is an object, we're done
+      // If the input is an object, we’re done
       if (typeof urlOrDocument === 'object' && urlOrDocument !== null) {
         const json = JSON.stringify(urlOrDocument, null, 2)
-        return { state: 'idle', content: json, url: input, error: null }
+
+        return {
+          state: 'idle',
+          content: json,
+          url: null,
+          error: null,
+        }
       }
 
       // Nothing was found.
@@ -74,6 +80,8 @@ export function useUrlPrefetcher() {
         }
       }
 
+      console.log('urlOrDocument', urlOrDocument)
+
       if (!isUrl(urlOrDocument)) {
         return {
           state: 'idle',
@@ -85,6 +93,7 @@ export function useUrlPrefetcher() {
       }
 
       const url = urlOrDocument
+      console.log('prefetchUrl', url)
 
       // Okay, we've got an URL. Let's fetch it:
       const result = await fetchWithProxyFallback(url, {

--- a/packages/api-client/src/components/OpenApiClientButton.vue
+++ b/packages/api-client/src/components/OpenApiClientButton.vue
@@ -12,7 +12,14 @@ const { integration, isDevelopment, url, buttonSource } = defineProps<{
 
 /** Link to import an OpenAPI document */
 const href = computed((): string | undefined => {
-  const absoluteUrl = makeUrlAbsolute(url)
+  /**
+   * The URL we want to pass to client.scalar.com for the import.
+   * Might be an OpenAPI document URL, but could also just be the URL of the API reference.
+   */
+  const urlToImportFrom =
+    (url ?? typeof window !== 'undefined') ? window.location.href : undefined
+
+  const absoluteUrl = makeUrlAbsolute(urlToImportFrom)
 
   if (!absoluteUrl?.length) {
     return undefined

--- a/packages/api-client/src/components/OpenApiClientButton.vue
+++ b/packages/api-client/src/components/OpenApiClientButton.vue
@@ -17,7 +17,7 @@ const href = computed((): string | undefined => {
    * Might be an OpenAPI document URL, but could also just be the URL of the API reference.
    */
   const urlToImportFrom =
-    (url ?? typeof window !== 'undefined') ? window.location.href : undefined
+    url ?? (typeof window !== 'undefined' ? window.location.href : undefined)
 
   const absoluteUrl = makeUrlAbsolute(urlToImportFrom)
 


### PR DESCRIPTION
This PR makes it possible to import embedded API definitions to the API client:

* always shows _the button_, even for embedded content
* fixes the import for embedded content
* falls back to passing the API reference URL for the import (if we don’t have an OpenAPI document URL)