### PR TITLE
fix(api-client): sidebar request examples

### DIFF
--- a/.changeset/fluffy-spies-glow.md
+++ b/.changeset/fluffy-spies-glow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: filters out first request example

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -124,7 +124,7 @@ const item = computed<SidebarItem>(() => {
       entity: request,
       resourceTitle: 'Request',
       warning: 'This cannot be undone. You’re about to delete the request.',
-      children: request.examples,
+      children: request.examples.slice(1),
       edit: (name: string) =>
         requestMutators.edit(request.uid, 'summary', name),
       delete: () => requestMutators.delete(request, props.parentUids[0]),


### PR DESCRIPTION
this pr is a proposal to filter out the first request example in order to avoid duplicating the main request data, this way we only access main request example from the request, and show up manually created examples:

⊢ before / after
<div>
<img width="378" alt="image" src="https://github.com/user-attachments/assets/75ce8dd8-97e7-4352-b535-04d2fc3c89a3">
<img width="378" alt="image" src="https://github.com/user-attachments/assets/d82b2f75-ea03-462c-98e5-ff46f5a54e75">
</div>