### PR TITLE
feat(Scalar.AspNetCore): add HideClientButton configuration

### DIFF
--- a/.changeset/shaggy-paws-argue.md
+++ b/.changeset/shaggy-paws-argue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feat: Add HideClientButton configuration property

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -396,4 +396,15 @@ public static class ScalarOptionsExtensions
         options.DotNetFlag = expose;
         return options;
     }
+    
+    /// <summary>
+    /// Sets whether the client button from the reference sidebar should be shown.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="showButton">Whether to show the client button.</param>
+    public static ScalarOptions WithClientButton(this ScalarOptions options, bool showButton)
+    {
+        options.HideClientButton = !showButton;
+        return options;
+    }
 }

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -53,7 +53,8 @@ internal static class ScalarOptionsMapper
                 ClientKey = options.DefaultHttpClient.Value.ToStringFast(),
                 TargetKey = options.DefaultHttpClient.Key.ToStringFast()
             },
-            Integration = options.DotNetFlag ? "dotnet" : null
+            Integration = options.DotNetFlag ? "dotnet" : null,
+            HideClientButton = options.HideClientButton
         };
     }
 

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -183,4 +183,10 @@ public sealed class ScalarOptions
     /// </summary>
     /// <value>A boolean that indicates if 'dotnet' should be exposed to the configuration. The default value is <c>true</c>.</value>
     public bool DotNetFlag { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether the client button from the reference sidebar should be hidden.
+    /// </summary>
+    /// <value>A boolean that indicates if the client button should be hidden. The default value is <c>false</c>.</value>
+    public bool HideClientButton { get; set; }
 }

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
@@ -53,6 +53,8 @@ internal sealed class ScalarConfiguration
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     [JsonPropertyName("_integration")]
     public required string? Integration { get; init; }
+
+    public required bool HideClientButton { get; init; }
 }
 
 [JsonSerializable(typeof(ScalarConfiguration))]

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -15,9 +15,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -48,7 +48,8 @@ public class ScalarOptionsExtensionsTests
             .AddServer(new ScalarServer("https://example.org", "My other server"))
             .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
             .WithFavicon("/favicon.png")
-            .WithDotNetFlag(false);
+            .WithDotNetFlag(false)
+            .WithClientButton(false);
 
         // Assert
         options.Title.Should().Be("My title");
@@ -86,5 +87,6 @@ public class ScalarOptionsExtensionsTests
         options.DefaultHttpClient.Should().Be(new KeyValuePair<ScalarTarget, ScalarClient>(ScalarTarget.CSharp, ScalarClient.HttpClient));
         options.Favicon.Should().Be("/favicon.png");
         options.DotNetFlag.Should().BeFalse();
+        options.HideClientButton.Should().BeTrue();
     }
 }

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -69,7 +69,8 @@ public class ScalarOptionsMapperTests
             DefaultOpenAllTags = true,
             TagSorter = TagSorter.Alpha,
             OperationSorter = OperationSorter.Method,
-            DotNetFlag = false
+            DotNetFlag = false,
+            HideClientButton = true
         };
 
         // Act
@@ -101,6 +102,7 @@ public class ScalarOptionsMapperTests
         configuration.OperationsSorter.Should().Be(OperationSorter.Method.ToStringFast());
         configuration.Theme.Should().Be(ScalarTheme.Saturn.ToStringFast());
         configuration.Integration.Should().BeNull();
+        configuration.HideClientButton.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
This PR adds support for the recently introduced (https://github.com/scalar/scalar/pull/4047) `hideClientButton` option to the `Scalar.AspNetCore` integration.