### PR TITLE
feat(api-client): use just the request path as a fallback for the sidebar

### DIFF
--- a/.changeset/gentle-adults-grab.md
+++ b/.changeset/gentle-adults-grab.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: fall back to just the request path in the sidebar

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -112,7 +112,7 @@ const item = computed<SidebarItem>(() => {
 
   if (request)
     return {
-      title: request.summary ?? [request.method, request.path].join(' - '),
+      title: request.summary ?? request.path,
       link: {
         name: 'request',
         params: {


### PR DESCRIPTION
We’re using `${method} - ${path}` as a fallback for the title of the request in the sidebar. But already show the request method, so using just the `request.path` should be good.

**Before**

<img width="274" alt="Screenshot 2024-12-04 at 09 42 13" src="https://github.com/user-attachments/assets/56a296d1-7446-442c-855b-3524f1d702f8">

**After**

<img width="283" alt="Screenshot 2024-12-04 at 09 42 48" src="https://github.com/user-attachments/assets/aaf3a144-011e-4845-ba80-a8d572d497ea">
