### PR TITLE
fix(proxy-server): error reading from static assets

### DIFF
--- a/examples/proxy-server/Dockerfile
+++ b/examples/proxy-server/Dockerfile
@@ -9,10 +9,13 @@ RUN go build main.go
 
 # Build distroless image
 FROM gcr.io/distroless/static-debian11
+WORKDIR /app
+
 ENV PORT=9033
 
-# Copy the compiled app binary
+# Copy the compiled app binary and public directory
 COPY --from=build --chown=1001:1001 /app/main /app/
+COPY --from=build --chown=1001:1001 /app/public /app/public
 
 # Run as non-root user
 USER 1001:1001

--- a/examples/proxy-server/package.json
+++ b/examples/proxy-server/package.json
@@ -21,6 +21,8 @@
   "scripts": {
     "build": "go build main.go",
     "dev": "PORT=5051 nodemon --quiet --exec go run main.go --signal SIGTERM",
+    "docker:build": "docker build -t scalar-proxy-server .",
+    "docker:run": "pnpm docker:build && docker run -p 5051:9033 scalar-proxy-server",
     "lint:check": "go fmt ./main.go",
     "lint:fix": "go fmt ./main.go",
     "preview": "pnpm dev",


### PR DESCRIPTION
I’ve tried this already, but let’s try again: The proxy server got an API reference, but it’s not served in production:

```
Error reading index.html
```

This PR should finally add the static assets to the image.