### PR TITLE
ci: don’t wait for the build to run the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Build packages
-        uses: ./.github/actions/build
-        with:
-          node-version: ${{ matrix.node-version }}
-          packages-only: 'true'
+      # - name: Build packages
+      #   uses: ./.github/actions/build
+      #   with:
+      #     node-version: ${{ matrix.node-version }}
+      #     packages-only: 'true'
       - name: Run tests
         run: pnpm test:ci
       - name: Setup Go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      # - name: Build packages
-      #   uses: ./.github/actions/build
-      #   with:
-      #     node-version: ${{ matrix.node-version }}
-      #     packages-only: 'true'
+      - name: Build @scalar/cli
+        uses: ./.github/actions/build
+        with:
+          node-version: ${{ matrix.node-version }}
+          packages-only: 'cli'
       - name: Run tests
         run: pnpm test:ci
       - name: Setup Go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           packages-only: 'cli'
+      - name: Build @scalar/fastify-api-reference
+        uses: ./.github/actions/build
+        with:
+          node-version: ${{ matrix.node-version }}
+          packages-only: 'fastify-api-reference'
       - name: Run tests
         run: pnpm test:ci
       - name: Setup Go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           packages-only: 'fastify-api-reference'
+      - name: Build @scalar/echo-server
+        uses: ./.github/actions/build
+        with:
+          node-version: ${{ matrix.node-version }}
+          packages-only: 'echo-server'
       - name: Run tests
         run: pnpm test:ci
       - name: Setup Go


### PR DESCRIPTION
We just had a galaxy brain idea: We don’t need to wait for the build to run the tests. 👀 

Let’s run them in parallel. This should shave off 60s CI time, but even better:

We’ll get the feedback for failed tests way earlier.

I think we need to build at least two packages, the CLI and the fastify package, because they test the build. Let’s see.