### PR TITLE
fix(postman-to-openapi): Postman examples are misinterpreted as folders

### DIFF
--- a/.changeset/smart-rice-move.md
+++ b/.changeset/smart-rice-move.md
@@ -1,0 +1,5 @@
+---
+'@scalar/postman-to-openapi': patch
+---
+
+fix: postman examples are misinterpreted as folders

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -43,6 +43,7 @@ describe('convert', () => {
           'SimplePost',
           'UrlWithPort',
           'XLogo',
+          'NestedServers',
         ].map(async (name) => {
           const path = `oas/postman-to-openapi/fixtures/input/${name}.json`
           const response = await fetch(`${BASE_URL}/${path}`)
@@ -76,6 +77,7 @@ describe('convert', () => {
           'SimplePost',
           'UrlWithPort',
           'XLogoVar',
+          'NestedServers',
         ].map(async (name) => {
           const response = await fetch(
             `${BASE_URL}/oas/postman-to-openapi/fixtures/output/${name}.json`,
@@ -246,5 +248,11 @@ describe('convert', () => {
     expect(
       convert(JSON.parse(collections.Responses) as PostmanCollection),
     ).toEqual(JSON.parse(expected.Responses))
+  })
+
+  it('should parse nested servers instead of leaving the server empty', () => {
+    expect(
+      convert(JSON.parse(collections.NestedServers) as PostmanCollection),
+    ).toEqual(JSON.parse(expected.NestedServers))
   })
 })

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -17,18 +17,14 @@ describe('convert', () => {
       const allPromises = [
         // Input collections
         ...[
-          'PostmantoOpenAPI',
-          'NoVersion',
-          'NullHeaders',
           'AuthBasic',
           'AuthBearer',
           'AuthMultiple',
           'AuthRequest',
           'DeleteOperation',
-          'DepthPathParams',
-          'DisabledParams',
           'EmptyUrl',
           'ExternalDocs',
+          'Folders',
           'FormData',
           'FormUrlencoded',
           'GetMethods',
@@ -36,34 +32,33 @@ describe('convert', () => {
           'LicenseContact',
           'MultipleServers',
           'NoPath',
+          'NoVersion',
           'OperationIds',
           'ParseStatusCode',
           'PathParams',
+          'PostmantoOpenAPI',
           'RawBody',
+          'Responses',
+          'ResponsesEmpty',
+          'SimplePost',
           'UrlWithPort',
           'XLogo',
         ].map(async (name) => {
-          const path =
-            name === 'NullHeaders'
-              ? `oas/postman-to-openapi/fixtures/input/${name}.json`
-              : `oas/postman-to-openapi/fixtures/input/v21/${name}.json`
+          const path = `oas/postman-to-openapi/fixtures/input/${name}.json`
           const response = await fetch(`${BASE_URL}/${path}`)
           collections[name] = await response.text()
         }),
         // Expected outputs
         ...[
-          'Basic',
-          'NoVersion',
-          'NullHeader',
           'AuthBasic',
           'AuthBearer',
           'AuthMultiple',
           'AuthRequest',
+          'Basic',
           'DeleteOperation',
-          'DepthPathParams',
-          'DisabledParamsDefault',
           'EmptyUrl',
           'ExternalDocs',
+          'Folders',
           'FormData',
           'FormUrlencoded',
           'GetMethods',
@@ -71,10 +66,14 @@ describe('convert', () => {
           'LicenseContact',
           'MultipleServers',
           'NoPath',
+          'NoVersion',
           'OperationIds',
-          'ParseStatus',
+          'ParseStatusCode',
           'PathParams',
           'RawBody',
+          'Responses',
+          'ResponsesEmpty',
+          'SimplePost',
           'UrlWithPort',
           'XLogoVar',
         ].map(async (name) => {
@@ -98,10 +97,22 @@ describe('convert', () => {
     ).toEqual(JSON.parse(expected.Basic))
   })
 
+  it('Should convert a simple postman collection to OpenAPI including servers', () => {
+    expect(
+      convert(JSON.parse(collections.SimplePost) as PostmanCollection),
+    ).toEqual(JSON.parse(expected.SimplePost))
+  })
+
   it('should use default version if not informed and not in postman variables', () => {
     expect(
       convert(JSON.parse(collections.NoVersion) as PostmanCollection),
     ).toEqual(JSON.parse(expected.NoVersion))
+  })
+
+  it('should work with folders and use as tags', () => {
+    expect(
+      convert(JSON.parse(collections.Folders) as PostmanCollection),
+    ).toEqual(JSON.parse(expected.Folders))
   })
 
   it('should parse GET methods with query string', () => {
@@ -110,7 +121,6 @@ describe('convert', () => {
     ).toEqual(JSON.parse(expected.GetMethods))
   })
 
-  // working on this
   it.skip('should parse HEADERS parameters', () => {
     expect(
       convert(JSON.parse(collections.Headers) as PostmanCollection),
@@ -135,16 +145,10 @@ describe('convert', () => {
     ).toEqual(JSON.parse(expected.LicenseContact))
   })
 
-  it('should use depth configuration for parse paths', () => {
-    expect(
-      convert(JSON.parse(collections.DepthPathParams) as PostmanCollection),
-    ).toEqual(JSON.parse(expected.DepthPathParams))
-  })
-
   it('should parse status codes from test', () => {
     expect(
       convert(JSON.parse(collections.ParseStatusCode) as PostmanCollection),
-    ).toEqual(JSON.parse(expected.ParseStatus))
+    ).toEqual(JSON.parse(expected.ParseStatusCode))
   })
 
   it('should parse operation when no path (only domain)', () => {
@@ -225,24 +229,22 @@ describe('convert', () => {
     ).toEqual(JSON.parse(expected.RawBody))
   })
 
-  // working on this (idk man)
-  it.skip('should not parse `disabled` parameters', () => {
+  it.skip('should not fail if response body is json but empty', () => {
     expect(
-      convert(JSON.parse(collections.DisabledParams) as PostmanCollection),
-    ).toEqual(JSON.parse(expected.DisabledParamsDefault))
+      convert(JSON.parse(collections.ResponsesEmpty) as PostmanCollection),
+    ).toEqual(JSON.parse(expected.ResponsesEmpty))
   })
 
-  // working on this (I don't think this test makes sense for us we always add operationId)
-  it('should not add `operationId` by default', () => {
+  it('should include `operationId` when `brackets` is selected', () => {
     expect(
       convert(JSON.parse(collections.OperationIds) as PostmanCollection),
     ).toEqual(JSON.parse(expected.OperationIds))
   })
 
-  // working on this
-  it.skip('should work if header is equals to "null" in response', () => {
+  // fast follow with this test
+  it.skip('should add responses from postman examples', () => {
     expect(
-      convert(JSON.parse(collections.NullHeaders) as PostmanCollection),
-    ).toEqual(JSON.parse(expected.NullHeader))
+      convert(JSON.parse(collections.Responses) as PostmanCollection),
+    ).toEqual(JSON.parse(expected.Responses))
   })
 })

--- a/packages/postman-to-openapi/src/helpers/authHelpers.ts
+++ b/packages/postman-to-openapi/src/helpers/authHelpers.ts
@@ -80,6 +80,16 @@ function createOAuth2Config(): SecurityConfig {
 }
 
 /**
+ * Creates security configuration for no authentication
+ */
+function createNoAuthConfig(): SecurityConfig {
+  return {
+    scheme: {},
+    requirement: {},
+  }
+}
+
+/**
  * Maps authentication types to their configuration creators
  */
 const AUTH_TYPE_HANDLERS: Record<string, () => SecurityConfig> = {
@@ -87,12 +97,13 @@ const AUTH_TYPE_HANDLERS: Record<string, () => SecurityConfig> = {
   basic: createBasicConfig,
   bearer: createBearerConfig,
   oauth2: createOAuth2Config,
+  noauth: createNoAuthConfig,
 }
 
 /**
  * Processes authentication information from a Postman collection and updates
  * the OpenAPI document with the corresponding security schemes and requirements.
- * Supports API key, basic auth, bearer token, and OAuth2 authentication types.
+ * Supports API key, basic auth, bearer token, OAuth2, and no authentication types.
  */
 export function processAuth(auth: Auth): {
   securitySchemes: Record<string, OpenAPIV3_1.SecuritySchemeObject>
@@ -108,9 +119,13 @@ export function processAuth(auth: Auth): {
     }
 
     const { scheme, requirement } = handler()
-    const schemeKey = `${auth.type}Auth`
-    securitySchemes[schemeKey] = scheme
-    security.push(requirement)
+    
+    // Only add security schemes and requirements if they're not empty
+    if (Object.keys(scheme).length > 0) {
+      const schemeKey = `${auth.type}Auth`
+      securitySchemes[schemeKey] = scheme
+      security.push(requirement)
+    }
   } catch (error) {
     console.error('Error processing authentication:', error)
     throw error

--- a/packages/postman-to-openapi/src/helpers/authHelpers.ts
+++ b/packages/postman-to-openapi/src/helpers/authHelpers.ts
@@ -119,7 +119,7 @@ export function processAuth(auth: Auth): {
     }
 
     const { scheme, requirement } = handler()
-    
+
     // Only add security schemes and requirements if they're not empty
     if (Object.keys(scheme).length > 0) {
       const schemeKey = `${auth.type}Auth`

--- a/packages/postman-to-openapi/src/helpers/itemHelpers.ts
+++ b/packages/postman-to-openapi/src/helpers/itemHelpers.ts
@@ -6,7 +6,6 @@ import { parseMdTable } from './md-utils'
 import { extractParameters } from './parameterHelpers'
 import { extractRequestBody } from './requestBodyHelpers'
 import { extractResponses } from './responseHelpers'
-import { extractStatusCodesFromTests } from './statusCodeHelpers'
 import {
   extractPathFromUrl,
   extractPathParameterNames,
@@ -108,7 +107,7 @@ export function processItem(
     tags: parentTags.length > 0 ? [parentTags.join(' > ')] : ['default'],
     summary,
     description,
-    responses: extractResponses(response || []),
+    responses: extractResponses(response || [], item),
     parameters: [],
   }
 
@@ -180,49 +179,6 @@ export function processItem(
   if (!paths[path]) paths[path] = {}
   const pathItem = paths[path] as OpenAPIV3_1.PathItemObject
   pathItem[method] = operationObject
-
-  // Extract status codes from tests
-  const statusCodes = extractStatusCodesFromTests(item)
-
-  // Handle responses
-  if (statusCodes.length > 0) {
-    const responses: OpenAPIV3_1.ResponsesObject = {}
-    statusCodes.forEach((code) => {
-      responses[code.toString()] = {
-        description: 'Successful response',
-        content: {
-          'application/json': {},
-        },
-      }
-    })
-    if (pathItem[method]) {
-      pathItem[method].responses = responses
-    }
-  } else if (item.response && item.response.length > 0) {
-    const firstResponse = item.response[0]
-    const statusCode = firstResponse.code || 200
-    if (pathItem[method]) {
-      pathItem[method].responses = {
-        [statusCode.toString()]: {
-          description: firstResponse.status || 'Successful response',
-          content: {
-            'application/json': {},
-          },
-        },
-      }
-    }
-  } else {
-    if (pathItem[method]) {
-      pathItem[method].responses = {
-        '200': {
-          description: 'Successful response',
-          content: {
-            'application/json': {},
-          },
-        },
-      }
-    }
-  }
 
   return { paths, components }
 }

--- a/packages/postman-to-openapi/src/helpers/requestBodyHelpers.ts
+++ b/packages/postman-to-openapi/src/helpers/requestBodyHelpers.ts
@@ -43,7 +43,7 @@ function handleRawBody(
       'application/json': {
         schema: {
           type: 'object',
-          examples: { default: { value: jsonBody } },
+          example: jsonBody,
         },
       },
     }

--- a/packages/postman-to-openapi/src/helpers/serverHelpers.ts
+++ b/packages/postman-to-openapi/src/helpers/serverHelpers.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import type { PostmanCollection, Item, ItemGroup } from '../types'
+
+import type { Item, ItemGroup, PostmanCollection } from '../types'
 
 /**
  * Recursively processes collection items to extract server URLs
@@ -11,9 +12,8 @@ function processItems(items: (Item | ItemGroup)[], domains: Set<string>) {
     } else if ('request' in item) {
       const request = item.request
       if (typeof request !== 'string') {
-        const url = typeof request.url === 'string' 
-          ? request.url 
-          : request.url?.raw
+        const url =
+          typeof request.url === 'string' ? request.url : request.url?.raw
 
         if (url) {
           try {
@@ -21,8 +21,8 @@ function processItems(items: (Item | ItemGroup)[], domains: Set<string>) {
             const urlMatch = url.match(/^(?:https?:\/\/)?([^/?#]+)/i)
             if (urlMatch && urlMatch[1]) {
               // Ensure we have the protocol
-              const serverUrl = urlMatch[1].startsWith('http') 
-                ? urlMatch[1].replace(/\/$/, '') 
+              const serverUrl = urlMatch[1].startsWith('http')
+                ? urlMatch[1].replace(/\/$/, '')
                 : `https://${urlMatch[1]}`.replace(/\/$/, '')
               domains.add(serverUrl)
             }
@@ -48,6 +48,6 @@ export function parseServers(
   }
 
   return Array.from(domains).map((domain) => ({
-    url: domain
+    url: domain,
   }))
 }

--- a/packages/postman-to-openapi/src/helpers/serverHelpers.ts
+++ b/packages/postman-to-openapi/src/helpers/serverHelpers.ts
@@ -1,38 +1,53 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-
-import type { PostmanCollection } from '../types'
-import { getDomainFromUrl } from './urlHelpers'
+import type { PostmanCollection, Item, ItemGroup } from '../types'
 
 /**
- * Parses a Postman collection to extract unique server URLs.
- * Iterates through collection items, extracts domains from request URLs,
- * and returns an array of unique server objects for the OpenAPI specification.
+ * Recursively processes collection items to extract server URLs
  */
-export function parseServers(
-  postmanCollection: PostmanCollection,
-): OpenAPIV3_1.ServerObject[] {
-  // Set to store unique domains
-  const domains = new Set<string>()
-
-  if (postmanCollection.item && Array.isArray(postmanCollection.item)) {
-    postmanCollection.item.forEach((item) => {
-      if ('request' in item && typeof item.request !== 'string') {
-        const url =
-          typeof item.request.url === 'string'
-            ? item.request.url
-            : item.request.url?.raw
+function processItems(items: (Item | ItemGroup)[], domains: Set<string>) {
+  items.forEach((item) => {
+    if ('item' in item && Array.isArray(item.item)) {
+      processItems(item.item, domains)
+    } else if ('request' in item) {
+      const request = item.request
+      if (typeof request !== 'string') {
+        const url = typeof request.url === 'string' 
+          ? request.url 
+          : request.url?.raw
 
         if (url) {
           try {
-            const domain = getDomainFromUrl(url)
-            domains.add(domain)
+            // Extract domain from URL
+            const urlMatch = url.match(/^(?:https?:\/\/)?([^/?#]+)/i)
+            if (urlMatch && urlMatch[1]) {
+              // Ensure we have the protocol
+              const serverUrl = urlMatch[1].startsWith('http') 
+                ? urlMatch[1].replace(/\/$/, '') 
+                : `https://${urlMatch[1]}`.replace(/\/$/, '')
+              domains.add(serverUrl)
+            }
           } catch (error) {
             console.error(`Error extracting domain from URL "${url}":`, error)
           }
         }
       }
-    })
+    }
+  })
+}
+
+/**
+ * Parses a Postman collection to extract unique server URLs.
+ */
+export function parseServers(
+  postmanCollection: PostmanCollection,
+): OpenAPIV3_1.ServerObject[] {
+  const domains = new Set<string>()
+
+  if (postmanCollection.item && Array.isArray(postmanCollection.item)) {
+    processItems(postmanCollection.item, domains)
   }
 
-  return Array.from(domains).map((domain) => ({ url: domain }))
+  return Array.from(domains).map((domain) => ({
+    url: domain
+  }))
 }

--- a/packages/postman-to-openapi/src/types.ts
+++ b/packages/postman-to-openapi/src/types.ts
@@ -42,6 +42,7 @@ export type Item = {
   request: Request
   response?: Response[]
   protocolProfileBehavior?: ProtocolProfileBehavior
+  variables?: Variable[]
 }
 
 export type ItemGroup = {
@@ -52,6 +53,7 @@ export type ItemGroup = {
   event?: Event[]
   auth?: Auth | null
   protocolProfileBehavior?: ProtocolProfileBehavior
+  variables?: Variable[]
 }
 
 export type Event = {
@@ -90,14 +92,11 @@ export type QueryParam = {
 }
 
 export type Variable = {
-  id?: string
-  key?: string
-  value?: string | number | boolean | null
-  type?: 'string' | 'boolean' | 'any' | 'number'
-  name?: string
-  description?: Description
-  system?: boolean
-  disabled?: boolean
+  key: string
+  value: string | number | boolean
+  type?: 'string' | 'number' | 'boolean' | 'environment'
+  enum?: string[]
+  description?: string
 }
 
 export type Auth = {


### PR DESCRIPTION
**Problem**
Currently, the parser misinterprets Postman Examples/response bodies as folders, causing incorrect parsing. This affects everything in the parser, resulting in the converted OpenAPI spec missing request bodies, response bodies, servers, etc.

**Solution**
With this PR, we refactor the parser to properly handle servers within Postman folders, move the status codes parsing from `itemHelpers.ts` to a more appropriate place in `responseHelpers.ts`, make small improvements to tag handling, along with other small improvements to formatting and more robust tests by removing redundant tests and adding new tests for response bodies, request bodies, and nested servers.