### PR TITLE
fix(oas-utils): order of imported operations

### DIFF
--- a/.changeset/tender-mirrors-do.md
+++ b/.changeset/tender-mirrors-do.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: adds isHttpMethod to helpers

--- a/.changeset/wet-brooms-drop.md
+++ b/.changeset/wet-brooms-drop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: sorts method based on path in import spec

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { isHTTPMethod } from '@/components/HttpMethod'
 import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
@@ -9,6 +8,7 @@ import {
   ScalarIcon,
   ScalarListbox,
 } from '@scalar/components'
+import { isHttpMethod } from '@scalar/oas-utils/helpers'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
@@ -96,7 +96,7 @@ const handleSubmit = () => {
     toast('Please enter a name before creating a request.', 'error')
     return
   }
-  if (!selectedCollection.value?.id || !isHTTPMethod(requestMethod.value))
+  if (!selectedCollection.value?.id || !isHttpMethod(requestMethod.value))
     return
 
   const newRequest = requestMutators.add(

--- a/packages/api-client/src/components/HttpMethod/helpers.ts
+++ b/packages/api-client/src/components/HttpMethod/helpers.ts
@@ -1,8 +1,0 @@
-import {
-  type RequestMethod,
-  requestMethods,
-} from '@scalar/oas-utils/entities/spec'
-
-/** Type guard which takes in a string and returns true if it is in fact an HTTPMethod */
-export const isHTTPMethod = (method: string): method is RequestMethod =>
-  requestMethods.includes(method as RequestMethod)

--- a/packages/api-client/src/components/HttpMethod/index.ts
+++ b/packages/api-client/src/components/HttpMethod/index.ts
@@ -1,2 +1,1 @@
 export { default as HttpMethod } from './HttpMethod.vue'
-export * from './helpers'

--- a/packages/api-client/src/views/Request/libs/live-sync.ts
+++ b/packages/api-client/src/views/Request/libs/live-sync.ts
@@ -1,4 +1,3 @@
-import { isHTTPMethod } from '@/components/HttpMethod/helpers'
 import type { WorkspaceStore } from '@/store'
 import type { ActiveEntitiesStore } from '@/store/active-entities'
 import {
@@ -14,7 +13,7 @@ import {
   serverSchema,
   tagSchema,
 } from '@scalar/oas-utils/entities/spec'
-import { schemaModel } from '@scalar/oas-utils/helpers'
+import { isHttpMethod, schemaModel } from '@scalar/oas-utils/helpers'
 import {
   type Path,
   type PathValue,
@@ -407,7 +406,7 @@ export const mutateRequestDiff = (
 
     const requestPayload: RequestPayload = {
       ...operationWithoutSecurity,
-      method: isHTTPMethod(newMethod) ? newMethod : 'get',
+      method: isHttpMethod(newMethod) ? newMethod : 'get',
       path,
       parameters: (operation.parameters ?? []) as RequestParameterPayload[],
       servers: operationServers.map((s) => s.uid),

--- a/packages/oas-utils/src/helpers/httpMethods.ts
+++ b/packages/oas-utils/src/helpers/httpMethods.ts
@@ -1,4 +1,4 @@
-import type { RequestMethod } from '@/entities/spec/requests'
+import { type RequestMethod, requestMethods } from '@/entities/spec/requests'
 
 /**
  * HTTP methods in a specific order
@@ -80,3 +80,7 @@ export const getHttpMethodInfo = (methodName: string) => {
     }
   )
 }
+
+/** Type guard which takes in a string and returns true if it is in fact an HTTPMethod */
+export const isHttpMethod = (method: string): method is RequestMethod =>
+  requestMethods.includes(method as RequestMethod)

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -55,6 +55,23 @@ describe('importSpecToWorkspace', () => {
       expect(request.parameters?.map((p) => p.name)).toContain('id')
       expect(request.parameters?.map((p) => p.name)).toContain('filter')
     })
+
+    it('handles requests in the order defined in the OpenAPI document', async () => {
+      const res = await importSpecToWorkspace(galaxy)
+      if (res.error) throw res.error
+
+      expect(res.requests.map((r) => r.operationId)).toEqual([
+        'getAllData',
+        'createPlanet',
+        'getPlanet',
+        'updatePlanet',
+        'deletePlanet',
+        'uploadImage',
+        'createUser',
+        'getToken',
+        'getMe',
+      ])
+    })
   })
 
   describe('tags', () => {

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -254,77 +254,79 @@ export async function importSpecToWorkspace(
     const pathServers = serverSchema.array().parse(path.servers ?? [])
     servers.push(...pathServers)
 
-    requestMethods.forEach((method) => {
-      const operation: OpenAPIV3_1.OperationObject<{
-        tags?: string[]
-        security?: OpenAPIV3_1.SecurityRequirementObject[]
-      }> = path[method as keyof typeof path]
-      if (operation && typeof operation === 'object') {
-        const operationServers = serverSchema
-          .array()
-          .parse(operation.servers ?? [])
+    // Creates a sorted array of methods based on the path object.
+    const methods = Object.keys(path).filter((method) =>
+      requestMethods.includes(method as any),
+    )
 
-        servers.push(...operationServers)
+    methods.forEach((method) => {
+      const operation = path[method]
+      const operationServers = serverSchema
+        .array()
+        .parse(operation.servers ?? [])
 
-        // We will save a list of all tags to ensure they exists at the top level
-        // TODO: make sure we add any loose requests with no tags to the collection children
-        operation.tags?.forEach((t) => tagNames.add(t))
+      servers.push(...operationServers)
 
-        // Remove security here and add it correctly below
-        const { security: operationSecurity, ...operationWithoutSecurity } =
-          operation
+      // We will save a list of all tags to ensure they exists at the top level
+      // TODO: make sure we add any loose requests with no tags to the collection children
+      operation.tags?.forEach((t: string) => tagNames.add(t))
 
-        // Grab the security requirements for this operation
-        const securityRequirements = (
-          operationSecurity ??
-          (schema.security as OpenAPIV3_1.SecurityRequirementObject[]) ??
-          []
-        ).flatMap((s) => {
-          const keys = Object.keys(s)
-          if (keys.length) return keys[0]
-          else return []
-        })
+      // Remove security here and add it correctly below
+      const { security: operationSecurity, ...operationWithoutSecurity } =
+        operation
 
-        let selectedSecuritySchemeUids: string[] = []
+      // Grab the security requirements for this operation
+      const securityRequirements = (
+        operationSecurity ??
+        (schema.security as OpenAPIV3_1.SecurityRequirementObject[]) ??
+        []
+      ).flatMap((s: OpenAPIV3_1.SecurityRequirementObject) => {
+        const keys = Object.keys(s)
+        if (keys.length) return keys[0]
+        else return []
+      })
 
-        // Set the initially selected security scheme
-        if (securityRequirements.length && !setCollectionSecurity) {
-          const name =
-            authentication?.preferredSecurityScheme &&
-            securityRequirements.includes(
-              authentication.preferredSecurityScheme ?? '',
-            )
-              ? authentication.preferredSecurityScheme
-              : securityRequirements[0]
-          const uid = securitySchemeMap[name]
-          selectedSecuritySchemeUids = [uid]
-        }
+      let selectedSecuritySchemeUids: string[] = []
 
-        const requestPayload: RequestPayload = {
-          ...operationWithoutSecurity,
-          method,
-          path: pathString,
-          selectedSecuritySchemeUids,
-          // Merge path and operation level parameters
-          parameters: [
-            ...(path?.parameters ?? []),
-            ...(operation.parameters ?? []),
-          ] as RequestParameterPayload[],
-          servers: [...pathServers, ...operationServers].map((s) => s.uid),
-        }
-
-        // Remove any examples from the request payload as they conflict with our examples property and are not valid
-        if (requestPayload.examples) {
-          console.warn(
-            '[@scalar/api-client] operation.examples is not a valid openapi property',
+      // Set the initially selected security scheme
+      if (securityRequirements.length && !setCollectionSecurity) {
+        const name =
+          authentication?.preferredSecurityScheme &&
+          securityRequirements.includes(
+            authentication.preferredSecurityScheme ?? '',
           )
-          delete requestPayload.examples
-        }
+            ? authentication.preferredSecurityScheme
+            : securityRequirements[0]
+        const uid = securitySchemeMap[name]
+        selectedSecuritySchemeUids = [uid]
+      }
 
-        // Add list of UIDs to associate security schemes
-        // As per the spec if there is operation level security we ignore the top level requirements
-        if (operationSecurity?.length)
-          requestPayload.security = operationSecurity.map((s) => {
+      const requestPayload: RequestPayload = {
+        ...operationWithoutSecurity,
+        method,
+        path: pathString,
+        selectedSecuritySchemeUids,
+        // Merge path and operation level parameters
+        parameters: [
+          ...(path?.parameters ?? []),
+          ...(operation.parameters ?? []),
+        ] as RequestParameterPayload[],
+        servers: [...pathServers, ...operationServers].map((s) => s.uid),
+      }
+
+      // Remove any examples from the request payload as they conflict with our examples property and are not valid
+      if (requestPayload.examples) {
+        console.warn(
+          '[@scalar/api-client] operation.examples is not a valid openapi property',
+        )
+        delete requestPayload.examples
+      }
+
+      // Add list of UIDs to associate security schemes
+      // As per the spec if there is operation level security we ignore the top level requirements
+      if (operationSecurity?.length)
+        requestPayload.security = operationSecurity.map(
+          (s: OpenAPIV3_1.SecurityRequirementObject) => {
             const keys = Object.keys(s)
 
             // Handle the case of {} for optional
@@ -334,15 +336,15 @@ export async function importSpecToWorkspace(
                 [key]: s[key],
               }
             } else return s
-          })
+          },
+        )
 
-        // Save parse the request
-        const request = schemaModel(requestPayload, requestSchema, false)
+      // Save parse the request
+      const request = schemaModel(requestPayload, requestSchema, false)
 
-        if (!request)
-          importWarnings.push(`${method} Request at ${path} is invalid.`)
-        else requests.push(request)
-      }
+      if (!request)
+        importWarnings.push(`${method} Request at ${path} is invalid.`)
+      else requests.push(request)
     })
   })
 

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -9,7 +9,6 @@ import {
   type Tag,
   collectionSchema,
   createExampleFromRequest,
-  requestMethods,
   requestSchema,
   serverSchema,
   tagSchema,
@@ -20,6 +19,7 @@ import {
   type SecuritySchemePayload,
   securitySchemeSchema,
 } from '@/entities/spec/security'
+import { isHttpMethod } from '@/helpers/httpMethods'
 import { schemaModel } from '@/helpers/schema-model'
 import { keysOf } from '@scalar/object-utils/arrays'
 import { dereference, load, upgrade } from '@scalar/openapi-parser'
@@ -255,9 +255,7 @@ export async function importSpecToWorkspace(
     servers.push(...pathServers)
 
     // Creates a sorted array of methods based on the path object.
-    const methods = Object.keys(path).filter((method) =>
-      requestMethods.includes(method as any),
-    )
+    const methods = Object.keys(path).filter(isHttpMethod)
 
     methods.forEach((method) => {
       const operation = path[method]


### PR DESCRIPTION
this pr fixes #4088 in order to sort method based on path VS prior method iteration as it was altering the operation order:

⊢ before / after for [galaxy](https://galaxy.scalar.com/)
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/a6edee2b-5756-4a80-ba3b-8ed27e4a06dd">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0a87c51b-3cb2-4b9e-b997-b689e951a0e2">
</div>
