### PR TITLE
fix(api-client): search reactivity

### DIFF
--- a/.changeset/polite-bobcats-enjoy.md
+++ b/.changeset/polite-bobcats-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: watches text input to fuse search

--- a/packages/api-client/src/components/Search/useSearch.ts
+++ b/packages/api-client/src/components/Search/useSearch.ts
@@ -60,6 +60,14 @@ export function useSearch() {
     searchResults.value = fuse.search(searchText.value)
   }
 
+  watch(searchText, (newValue) => {
+    if (newValue.length) {
+      fuseSearch()
+    } else {
+      searchResults.value = []
+    }
+  })
+
   const navigateSearchResults = (direction: 'up' | 'down') => {
     const offset = direction === 'up' ? -1 : 1
     const length = searchResultsWithPlaceholderResults.value.length

--- a/packages/api-reference/src/features/Search/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.ts
@@ -54,6 +54,14 @@ export function useSearchIndex({
     searchResults.value = fuse.search(searchText.value)
   }
 
+  watch(searchText, (newValue) => {
+    if (newValue.length) {
+      fuseSearch()
+    } else {
+      searchResults.value = []
+    }
+  })
+
   function resetSearch(): void {
     searchText.value = ''
     selectedSearchResult.value = 0


### PR DESCRIPTION
this pr fixes search results display on first character in reference and client: 

⊢ before / after
<img width="891" alt="image" src="https://github.com/user-attachments/assets/d305f63f-3c67-468a-baac-de903c8aa4f1">
<img width="891" alt="image" src="https://github.com/user-attachments/assets/1820cfda-9d74-4c8b-baba-974402a12204">
