### PR TITLE
fix(api-reference): meta + k holding search modal

### DIFF
--- a/.changeset/funny-hornets-arrive.md
+++ b/.changeset/funny-hornets-arrive.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: favors use event listener for meta k command

--- a/packages/api-reference/src/features/Search/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/SearchButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ScalarIcon, useModal } from '@scalar/components'
 import type { Spec } from '@scalar/types/legacy'
-import { useMagicKeys, whenever } from '@vueuse/core'
+import { useEventListener, useMagicKeys } from '@vueuse/core'
 
 import { isMacOs } from '../../helpers'
 import { useApiClient } from '../ApiClientModal'
@@ -31,14 +31,13 @@ const keys = useMagicKeys({
   },
 })
 
-whenever(
-  keys[`${isMacOs() ? 'meta' : 'control'}_${props.searchHotKey}`],
-  () => {
+useEventListener(document, 'keydown', (event) => {
+  if ((isMacOs() ? keys.meta.value : keys.ctrl.value) && event.key === 'k') {
     if (!client.value?.modalState.open) {
       modalState.open ? modalState.hide() : modalState.show()
     }
-  },
-)
+  }
+})
 </script>
 <template>
   <button


### PR DESCRIPTION
this pr fixes #2740 and updates `meta + k` command in api reference in order to trigger the command even while holding the meta key and re-pushing `k`.