### PR TITLE
fix(api-client): address bar background

### DIFF
--- a/.changeset/honest-cooks-push.md
+++ b/.changeset/honest-cooks-push.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates tailwind config content

--- a/packages/api-client/tailwind.config.ts
+++ b/packages/api-client/tailwind.config.ts
@@ -7,7 +7,12 @@ import { desktopVariants } from './src/tailwind/desktop-variants'
 
 export default {
   presets: [scalarPreset],
-  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx,vue}'],
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx,vue}',
+    // Include oas-utils for http method colors
+    '../oas-utils/src/**/*.{js,ts,vue}',
+  ],
   corePlugins: { preflight: false },
   darkMode: ['selector', '.dark-mode'],
   theme: {


### PR DESCRIPTION
this pr fixes the address bar background color that was not showing up anymore by safelisting tailwing background utilities:

⊢ before / after
<img width="891" alt="image" src="https://github.com/user-attachments/assets/07d50d4d-d3f8-41a3-80cb-eee64a45789a">
<img width="891" alt="image" src="https://github.com/user-attachments/assets/0b69af22-9238-406f-a9c9-f2c4bac78cec">
