### PR TITLE
fix(api-client): sets form parameter key request body

### DIFF
--- a/.changeset/real-cheetahs-end.md
+++ b/.changeset/real-cheetahs-end.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: sets form request examples defaulting

--- a/.changeset/silver-boats-mate.md
+++ b/.changeset/silver-boats-mate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates default row for request body

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -158,7 +158,12 @@ const formParams = computed(
 )
 
 /** ensure one empty row by default */
-const defaultRow = () => formParams.value.length === 0 && addRow()
+const defaultRow = () => {
+  const lastParam = formParams.value[formParams.value.length - 1]
+  if (!lastParam || lastParam.key !== '' || lastParam.value !== '') {
+    addRow()
+  }
+}
 
 /** Add a new row to a given parameter list */
 const addRow = () => {

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -412,12 +412,22 @@ export function createExampleFromRequest(
       body.binary = undefined
     }
 
-    /**
-     * TODO: How are handling form data examples from the spec
-     */
-    if (requestBody?.body?.mimeType === 'application/x-www-form-urlencoded') {
+    if (
+      requestBody?.body?.mimeType === 'application/x-www-form-urlencoded' ||
+      requestBody?.body?.mimeType === 'multipart/form-data'
+    ) {
       body.activeBody = 'formData'
-      body.formData = undefined
+      body.formData = {
+        encoding:
+          requestBody.body.mimeType === 'application/x-www-form-urlencoded'
+            ? 'urlencoded'
+            : 'form-data',
+        value: (requestBody.body.params || []).map((param) => ({
+          key: param.name,
+          value: param.value || '',
+          enabled: true,
+        })),
+      }
     }
   }
 


### PR DESCRIPTION
this pr is a proposal to get the key/value form parameter displayed in the request body of the api client:

⊢ before / after
<img width="591" alt="image" src="https://github.com/user-attachments/assets/bec90b14-a6cb-4624-a231-e42be19d229c">
<img width="591" alt="image" src="https://github.com/user-attachments/assets/c7514d80-2eb5-470d-9fe0-9e54461bffe5">
