### PR TITLE
fix(components): rename ScalaConfigurationSerializerContext to Scalar…

### DIFF
--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -50,7 +50,7 @@ public static class ScalarEndpointRouteBuilderExtensions
         var fileProvider = new EmbeddedFileProvider(typeof(ScalarEndpointRouteBuilderExtensions).Assembly, StaticAssets);
         var fileExtensionContentTypeProvider = new FileExtensionContentTypeProvider();
 
-        var configuration = JsonSerializer.Serialize(options.ToScalarConfiguration(), ScalaConfigurationSerializerContext.Default.ScalarConfiguration);
+        var configuration = JsonSerializer.Serialize(options.ToScalarConfiguration(), ScalarConfigurationSerializerContext.Default.ScalarConfiguration);
 
         return endpoints.MapGet(options.EndpointPathPrefix, (string documentName) =>
             {

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
@@ -59,4 +59,4 @@ internal sealed class ScalarConfiguration
 
 [JsonSerializable(typeof(ScalarConfiguration))]
 [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
-internal sealed partial class ScalaConfigurationSerializerContext : JsonSerializerContext;
+internal sealed partial class ScalarConfigurationSerializerContext : JsonSerializerContext;

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -64,7 +64,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
     {
         // Arrange
         var configuration = new ScalarOptions().ToScalarConfiguration();
-        var expectedConfiguration = JsonSerializer.Serialize(configuration, ScalaConfigurationSerializerContext.Default.ScalarConfiguration);
+        var expectedConfiguration = JsonSerializer.Serialize(configuration, ScalarConfigurationSerializerContext.Default.ScalarConfiguration);
         var client = factory.CreateClient();
 
         // Act


### PR DESCRIPTION
…ConfigurationSerializerContext

**Problem**
Currently, the dotnet package uses ScalaConfigurationSerializerContext

**Solution**

I believe this should be Scalar
