### PR TITLE
fix(api-client): variant danger style

### DIFF
--- a/.changeset/polite-zoos-fly.md
+++ b/.changeset/polite-zoos-fly.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: scopes scalar button danger overload style

--- a/packages/api-client/src/components/Sidebar/Actions/SidebarListElementForm.vue
+++ b/packages/api-client/src/components/Sidebar/Actions/SidebarListElementForm.vue
@@ -34,12 +34,12 @@ const emit = defineEmits<{
   </form>
 </template>
 <style scoped>
-.scalar-button-danger {
+.scalar-modal-layout .scalar-button-danger {
   background: color-mix(in srgb, var(--scalar-color-red), transparent 95%);
   color: var(--scalar-color-red);
 }
-.scalar-button-danger:hover,
-.scalar-button-danger:focus {
+.scalar-modal-layout .scalar-button-danger:hover,
+.scalar-modal-layout .scalar-button-danger:focus {
   background: color-mix(in srgb, var(--scalar-color-red), transparent 90%);
 }
 </style>


### PR DESCRIPTION
this pr fixes variant danger style in use that display filled background by removing unused utilities:

⊢ before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1a339400-c18f-469d-9ebd-db0c9694acc3">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/5b329885-0263-434e-8e1e-b3dc166fb012">
</div>
