### PR TITLE
feat(scalar-app): adds dialog box on check for updates

### DIFF
--- a/.changeset/calm-ties-relate.md
+++ b/.changeset/calm-ties-relate.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+feat: adds dialog box on check for updates

--- a/packages/scalar-app/src/main/index.ts
+++ b/packages/scalar-app/src/main/index.ts
@@ -160,6 +160,14 @@ function createWindow(): void {
                     if (result?.updateInfo) {
                       console.log('Update:', result.updateInfo.version)
                       todesktop.autoUpdater?.restartAndInstall()
+                    } else {
+                      console.log('No updates available')
+                      dialog.showMessageBox({
+                        type: 'info',
+                        title: 'No Updates Available',
+                        message: 'You are currently using the latest version.',
+                        detail: app.getVersion(),
+                      })
                     }
                   } catch (e) {
                     console.log('Update check failed:', e)


### PR DESCRIPTION
this pr fixes #4099 adds a dialog box on check for updates action to display information that the app is up to date along its version.