### PR TITLE
fix(snippetz): httpsnippet-lite imports broken

### DIFF
--- a/.changeset/popular-moose-tie.md
+++ b/.changeset/popular-moose-tie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+fix: httpsnippet-lite imports broken

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -213,7 +213,6 @@
   ],
   "module": "./dist/index.js",
   "dependencies": {
-    "httpsnippet-lite": "^3.0.5",
     "stringify-object": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/snippetz/src/core/utils/convertWithHttpSnippetLite.ts
+++ b/packages/snippetz/src/core/utils/convertWithHttpSnippetLite.ts
@@ -1,6 +1,5 @@
+import type { Client } from '@/httpsnippet-lite/dist/types/targets/targets'
 import type { Request } from 'har-format'
-
-import type { Client } from '../../../node_modules/httpsnippet-lite/dist/types/targets/targets'
 
 /**
  * Takes a httpsnippet-lite client and converts the given request to a code example with it.

--- a/packages/snippetz/src/core/utils/convertWithHttpSnippetLite.ts
+++ b/packages/snippetz/src/core/utils/convertWithHttpSnippetLite.ts
@@ -1,6 +1,6 @@
 import type { Request } from 'har-format'
-import type { HarRequest } from 'httpsnippet-lite'
-import type { Client } from '~httpsnippet-lite/dist/types/targets/targets'
+
+import type { Client } from '../../../node_modules/httpsnippet-lite/dist/types/targets/targets'
 
 /**
  * Takes a httpsnippet-lite client and converts the given request to a code example with it.

--- a/packages/snippetz/src/httpsnippet-lite
+++ b/packages/snippetz/src/httpsnippet-lite
@@ -1,0 +1,1 @@
+../../../node_modules/.pnpm/httpsnippet-lite@3.0.5/node_modules/httpsnippet-lite

--- a/packages/snippetz/src/plugins/c/libcurl/libcurl.ts
+++ b/packages/snippetz/src/plugins/c/libcurl/libcurl.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { libcurl } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/c/libcurl/client.mjs'
+import { libcurl } from '@/httpsnippet-lite/dist/esm/targets/c/libcurl/client.mjs'
 
 /**
  * c/libcurl

--- a/packages/snippetz/src/plugins/c/libcurl/libcurl.ts
+++ b/packages/snippetz/src/plugins/c/libcurl/libcurl.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { libcurl } from '~httpsnippet-lite/dist/esm/targets/c/libcurl/client.mjs'
+import { libcurl } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/c/libcurl/client.mjs'
 
 /**
  * c/libcurl

--- a/packages/snippetz/src/plugins/clojure/clj_http/clj_http.ts
+++ b/packages/snippetz/src/plugins/clojure/clj_http/clj_http.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { clj_http } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/clojure/clj_http/client.mjs'
+import { clj_http } from '@/httpsnippet-lite/dist/esm/targets/clojure/clj_http/client.mjs'
 
 /**
  * clojure/clj_http

--- a/packages/snippetz/src/plugins/clojure/clj_http/clj_http.ts
+++ b/packages/snippetz/src/plugins/clojure/clj_http/clj_http.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { clj_http } from '~httpsnippet-lite/dist/esm/targets/clojure/clj_http/client.mjs'
+import { clj_http } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/clojure/clj_http/client.mjs'
 
 /**
  * clojure/clj_http

--- a/packages/snippetz/src/plugins/csharp/httpclient/httpclient.ts
+++ b/packages/snippetz/src/plugins/csharp/httpclient/httpclient.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { httpclient } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/csharp/httpclient/client.mjs'
+import { httpclient } from '@/httpsnippet-lite/dist/esm/targets/csharp/httpclient/client.mjs'
 
 /**
  * csharp/httpclient

--- a/packages/snippetz/src/plugins/csharp/httpclient/httpclient.ts
+++ b/packages/snippetz/src/plugins/csharp/httpclient/httpclient.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { httpclient } from '~httpsnippet-lite/dist/esm/targets/csharp/httpclient/client.mjs'
+import { httpclient } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/csharp/httpclient/client.mjs'
 
 /**
  * csharp/httpclient

--- a/packages/snippetz/src/plugins/csharp/restsharp/restsharp.ts
+++ b/packages/snippetz/src/plugins/csharp/restsharp/restsharp.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { restsharp } from '~httpsnippet-lite/dist/esm/targets/csharp/restsharp/client.mjs'
+import { restsharp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/csharp/restsharp/client.mjs'
 
 /**
  * csharp/restsharp

--- a/packages/snippetz/src/plugins/csharp/restsharp/restsharp.ts
+++ b/packages/snippetz/src/plugins/csharp/restsharp/restsharp.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { restsharp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/csharp/restsharp/client.mjs'
+import { restsharp } from '@/httpsnippet-lite/dist/esm/targets/csharp/restsharp/client.mjs'
 
 /**
  * csharp/restsharp

--- a/packages/snippetz/src/plugins/go/native/native.ts
+++ b/packages/snippetz/src/plugins/go/native/native.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { native } from '~httpsnippet-lite/dist/esm/targets/go/native/client.mjs'
+import { native } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/go/native/client.mjs'
 
 /**
  * go/native

--- a/packages/snippetz/src/plugins/go/native/native.ts
+++ b/packages/snippetz/src/plugins/go/native/native.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { native } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/go/native/client.mjs'
+import { native } from '@/httpsnippet-lite/dist/esm/targets/go/native/client.mjs'
 
 /**
  * go/native

--- a/packages/snippetz/src/plugins/http/http11/http11.ts
+++ b/packages/snippetz/src/plugins/http/http11/http11.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { http11 } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/http/http1.1/client.mjs'
+import { http11 } from '@/httpsnippet-lite/dist/esm/targets/http/http1.1/client.mjs'
 
 /**
  * http/http1.1

--- a/packages/snippetz/src/plugins/http/http11/http11.ts
+++ b/packages/snippetz/src/plugins/http/http11/http11.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { http11 } from '~httpsnippet-lite/dist/esm/targets/http/http1.1/client.mjs'
+import { http11 } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/http/http1.1/client.mjs'
 
 /**
  * http/http1.1

--- a/packages/snippetz/src/plugins/java/asynchttp/asynchttp.ts
+++ b/packages/snippetz/src/plugins/java/asynchttp/asynchttp.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { asynchttp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/java/asynchttp/client.mjs'
+import { asynchttp } from '@/httpsnippet-lite/dist/esm/targets/java/asynchttp/client.mjs'
 
 /**
  * java/asynchttp

--- a/packages/snippetz/src/plugins/java/asynchttp/asynchttp.ts
+++ b/packages/snippetz/src/plugins/java/asynchttp/asynchttp.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { asynchttp } from '~httpsnippet-lite/dist/esm/targets/java/asynchttp/client.mjs'
+import { asynchttp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/java/asynchttp/client.mjs'
 
 /**
  * java/asynchttp

--- a/packages/snippetz/src/plugins/java/nethttp/nethttp.ts
+++ b/packages/snippetz/src/plugins/java/nethttp/nethttp.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { nethttp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/java/nethttp/client.mjs'
+import { nethttp } from '@/httpsnippet-lite/dist/esm/targets/java/nethttp/client.mjs'
 
 /**
  * java/nethttp

--- a/packages/snippetz/src/plugins/java/nethttp/nethttp.ts
+++ b/packages/snippetz/src/plugins/java/nethttp/nethttp.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { nethttp } from '~httpsnippet-lite/dist/esm/targets/java/nethttp/client.mjs'
+import { nethttp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/java/nethttp/client.mjs'
 
 /**
  * java/nethttp

--- a/packages/snippetz/src/plugins/java/okhttp/okhttp.ts
+++ b/packages/snippetz/src/plugins/java/okhttp/okhttp.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { okhttp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/java/okhttp/client.mjs'
+import { okhttp } from '@/httpsnippet-lite/dist/esm/targets/java/okhttp/client.mjs'
 
 /**
  * java/okhttp

--- a/packages/snippetz/src/plugins/java/okhttp/okhttp.ts
+++ b/packages/snippetz/src/plugins/java/okhttp/okhttp.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { okhttp } from '~httpsnippet-lite/dist/esm/targets/java/okhttp/client.mjs'
+import { okhttp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/java/okhttp/client.mjs'
 
 /**
  * java/okhttp

--- a/packages/snippetz/src/plugins/java/unirest/unirest.ts
+++ b/packages/snippetz/src/plugins/java/unirest/unirest.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { unirest } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/java/unirest/client.mjs'
+import { unirest } from '@/httpsnippet-lite/dist/esm/targets/java/unirest/client.mjs'
 
 /**
  * java/unirest

--- a/packages/snippetz/src/plugins/java/unirest/unirest.ts
+++ b/packages/snippetz/src/plugins/java/unirest/unirest.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { unirest } from '~httpsnippet-lite/dist/esm/targets/java/unirest/client.mjs'
+import { unirest } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/java/unirest/client.mjs'
 
 /**
  * java/unirest

--- a/packages/snippetz/src/plugins/js/axios/axios.ts
+++ b/packages/snippetz/src/plugins/js/axios/axios.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { axios } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/javascript/axios/client.mjs'
+import { axios } from '@/httpsnippet-lite/dist/esm/targets/javascript/axios/client.mjs'
 
 /**
  * js/axios

--- a/packages/snippetz/src/plugins/js/axios/axios.ts
+++ b/packages/snippetz/src/plugins/js/axios/axios.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { axios } from '~httpsnippet-lite/dist/esm/targets/javascript/axios/client.mjs'
+import { axios } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/javascript/axios/client.mjs'
 
 /**
  * js/axios

--- a/packages/snippetz/src/plugins/js/jquery/jquery.ts
+++ b/packages/snippetz/src/plugins/js/jquery/jquery.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { jquery } from '~httpsnippet-lite/dist/esm/targets/javascript/jquery/client.mjs'
+import { jquery } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/javascript/jquery/client.mjs'
 
 /**
  * js/jquery

--- a/packages/snippetz/src/plugins/js/jquery/jquery.ts
+++ b/packages/snippetz/src/plugins/js/jquery/jquery.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { jquery } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/javascript/jquery/client.mjs'
+import { jquery } from '@/httpsnippet-lite/dist/esm/targets/javascript/jquery/client.mjs'
 
 /**
  * js/jquery

--- a/packages/snippetz/src/plugins/js/xhr/xhr.ts
+++ b/packages/snippetz/src/plugins/js/xhr/xhr.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { xhr } from '~httpsnippet-lite/dist/esm/targets/javascript/xhr/client.mjs'
+import { xhr } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/javascript/xhr/client.mjs'
 
 /**
  * js/xhr

--- a/packages/snippetz/src/plugins/js/xhr/xhr.ts
+++ b/packages/snippetz/src/plugins/js/xhr/xhr.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { xhr } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/javascript/xhr/client.mjs'
+import { xhr } from '@/httpsnippet-lite/dist/esm/targets/javascript/xhr/client.mjs'
 
 /**
  * js/xhr

--- a/packages/snippetz/src/plugins/kotlin/okhttp/okhttp.ts
+++ b/packages/snippetz/src/plugins/kotlin/okhttp/okhttp.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { okhttp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/kotlin/okhttp/client.mjs'
+import { okhttp } from '@/httpsnippet-lite/dist/esm/targets/kotlin/okhttp/client.mjs'
 
 /**
  * kotlin/okhttp

--- a/packages/snippetz/src/plugins/kotlin/okhttp/okhttp.ts
+++ b/packages/snippetz/src/plugins/kotlin/okhttp/okhttp.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { okhttp } from '~httpsnippet-lite/dist/esm/targets/kotlin/okhttp/client.mjs'
+import { okhttp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/kotlin/okhttp/client.mjs'
 
 /**
  * kotlin/okhttp

--- a/packages/snippetz/src/plugins/node/axios/axios.ts
+++ b/packages/snippetz/src/plugins/node/axios/axios.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { axios } from '~httpsnippet-lite/dist/esm/targets/node/axios/client.mjs'
+import { axios } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/node/axios/client.mjs'
 
 /**
  * node/axios

--- a/packages/snippetz/src/plugins/node/axios/axios.ts
+++ b/packages/snippetz/src/plugins/node/axios/axios.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { axios } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/node/axios/client.mjs'
+import { axios } from '@/httpsnippet-lite/dist/esm/targets/node/axios/client.mjs'
 
 /**
  * node/axios

--- a/packages/snippetz/src/plugins/objc/nsurlsession/nsurlsession.ts
+++ b/packages/snippetz/src/plugins/objc/nsurlsession/nsurlsession.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { nsurlsession } from '~httpsnippet-lite/dist/esm/targets/objc/nsurlsession/client.mjs'
+import { nsurlsession } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/objc/nsurlsession/client.mjs'
 
 /**
  * objc/nsurlsession

--- a/packages/snippetz/src/plugins/objc/nsurlsession/nsurlsession.ts
+++ b/packages/snippetz/src/plugins/objc/nsurlsession/nsurlsession.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { nsurlsession } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/objc/nsurlsession/client.mjs'
+import { nsurlsession } from '@/httpsnippet-lite/dist/esm/targets/objc/nsurlsession/client.mjs'
 
 /**
  * objc/nsurlsession

--- a/packages/snippetz/src/plugins/ocaml/cohttp/cohttp.ts
+++ b/packages/snippetz/src/plugins/ocaml/cohttp/cohttp.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { cohttp } from '~httpsnippet-lite/dist/esm/targets/ocaml/cohttp/client.mjs'
+import { cohttp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/ocaml/cohttp/client.mjs'
 
 /**
  * ocaml/cohttp

--- a/packages/snippetz/src/plugins/ocaml/cohttp/cohttp.ts
+++ b/packages/snippetz/src/plugins/ocaml/cohttp/cohttp.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { cohttp } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/ocaml/cohttp/client.mjs'
+import { cohttp } from '@/httpsnippet-lite/dist/esm/targets/ocaml/cohttp/client.mjs'
 
 /**
  * ocaml/cohttp

--- a/packages/snippetz/src/plugins/php/curl/curl.ts
+++ b/packages/snippetz/src/plugins/php/curl/curl.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { curl } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/php/curl/client.mjs'
+import { curl } from '@/httpsnippet-lite/dist/esm/targets/php/curl/client.mjs'
 
 /**
  * php/curl

--- a/packages/snippetz/src/plugins/php/curl/curl.ts
+++ b/packages/snippetz/src/plugins/php/curl/curl.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { curl } from '~httpsnippet-lite/dist/esm/targets/php/curl/client.mjs'
+import { curl } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/php/curl/client.mjs'
 
 /**
  * php/curl

--- a/packages/snippetz/src/plugins/php/guzzle/guzzle.ts
+++ b/packages/snippetz/src/plugins/php/guzzle/guzzle.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { guzzle } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/php/guzzle/client.mjs'
+import { guzzle } from '@/httpsnippet-lite/dist/esm/targets/php/guzzle/client.mjs'
 
 /**
  * php/guzzle

--- a/packages/snippetz/src/plugins/php/guzzle/guzzle.ts
+++ b/packages/snippetz/src/plugins/php/guzzle/guzzle.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { guzzle } from '~httpsnippet-lite/dist/esm/targets/php/guzzle/client.mjs'
+import { guzzle } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/php/guzzle/client.mjs'
 
 /**
  * php/guzzle

--- a/packages/snippetz/src/plugins/powershell/restmethod/restmethod.ts
+++ b/packages/snippetz/src/plugins/powershell/restmethod/restmethod.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { restmethod } from '~httpsnippet-lite/dist/esm/targets/powershell/restmethod/client.mjs'
+import { restmethod } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/powershell/restmethod/client.mjs'
 
 /**
  * powershell/restmethod

--- a/packages/snippetz/src/plugins/powershell/restmethod/restmethod.ts
+++ b/packages/snippetz/src/plugins/powershell/restmethod/restmethod.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { restmethod } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/powershell/restmethod/client.mjs'
+import { restmethod } from '@/httpsnippet-lite/dist/esm/targets/powershell/restmethod/client.mjs'
 
 /**
  * powershell/restmethod

--- a/packages/snippetz/src/plugins/powershell/webrequest/webrequest.ts
+++ b/packages/snippetz/src/plugins/powershell/webrequest/webrequest.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { webrequest } from '~httpsnippet-lite/dist/esm/targets/powershell/webrequest/client.mjs'
+import { webrequest } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/powershell/webrequest/client.mjs'
 
 /**
  * powershell/webrequest

--- a/packages/snippetz/src/plugins/powershell/webrequest/webrequest.ts
+++ b/packages/snippetz/src/plugins/powershell/webrequest/webrequest.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { webrequest } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/powershell/webrequest/client.mjs'
+import { webrequest } from '@/httpsnippet-lite/dist/esm/targets/powershell/webrequest/client.mjs'
 
 /**
  * powershell/webrequest

--- a/packages/snippetz/src/plugins/python/python3/python3.ts
+++ b/packages/snippetz/src/plugins/python/python3/python3.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { python3 } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/python/python3/client.mjs'
+import { python3 } from '@/httpsnippet-lite/dist/esm/targets/python/python3/client.mjs'
 
 /**
  * python/python3

--- a/packages/snippetz/src/plugins/python/python3/python3.ts
+++ b/packages/snippetz/src/plugins/python/python3/python3.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { python3 } from '~httpsnippet-lite/dist/esm/targets/python/python3/client.mjs'
+import { python3 } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/python/python3/client.mjs'
 
 /**
  * python/python3

--- a/packages/snippetz/src/plugins/python/requests/requests.ts
+++ b/packages/snippetz/src/plugins/python/requests/requests.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { requests } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/python/requests/client.mjs'
+import { requests } from '@/httpsnippet-lite/dist/esm/targets/python/requests/client.mjs'
 
 /**
  * python/requests

--- a/packages/snippetz/src/plugins/python/requests/requests.ts
+++ b/packages/snippetz/src/plugins/python/requests/requests.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { requests } from '~httpsnippet-lite/dist/esm/targets/python/requests/client.mjs'
+import { requests } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/python/requests/client.mjs'
 
 /**
  * python/requests

--- a/packages/snippetz/src/plugins/r/httr/httr.ts
+++ b/packages/snippetz/src/plugins/r/httr/httr.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { httr } from '~httpsnippet-lite/dist/esm/targets/r/httr/client.mjs'
+import { httr } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/r/httr/client.mjs'
 
 /**
  * r/httr

--- a/packages/snippetz/src/plugins/r/httr/httr.ts
+++ b/packages/snippetz/src/plugins/r/httr/httr.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { httr } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/r/httr/client.mjs'
+import { httr } from '@/httpsnippet-lite/dist/esm/targets/r/httr/client.mjs'
 
 /**
  * r/httr

--- a/packages/snippetz/src/plugins/ruby/native/native.ts
+++ b/packages/snippetz/src/plugins/ruby/native/native.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { native } from '~httpsnippet-lite/dist/esm/targets/ruby/native/client.mjs'
+import { native } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/ruby/native/client.mjs'
 
 /**
  * ruby/native

--- a/packages/snippetz/src/plugins/ruby/native/native.ts
+++ b/packages/snippetz/src/plugins/ruby/native/native.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { native } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/ruby/native/client.mjs'
+import { native } from '@/httpsnippet-lite/dist/esm/targets/ruby/native/client.mjs'
 
 /**
  * ruby/native

--- a/packages/snippetz/src/plugins/shell/httpie/httpie.ts
+++ b/packages/snippetz/src/plugins/shell/httpie/httpie.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { httpie } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/shell/httpie/client.mjs'
+import { httpie } from '@/httpsnippet-lite/dist/esm/targets/shell/httpie/client.mjs'
 
 /**
  * shell/httpie

--- a/packages/snippetz/src/plugins/shell/httpie/httpie.ts
+++ b/packages/snippetz/src/plugins/shell/httpie/httpie.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { httpie } from '~httpsnippet-lite/dist/esm/targets/shell/httpie/client.mjs'
+import { httpie } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/shell/httpie/client.mjs'
 
 /**
  * shell/httpie

--- a/packages/snippetz/src/plugins/shell/wget/wget.ts
+++ b/packages/snippetz/src/plugins/shell/wget/wget.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { wget } from '~httpsnippet-lite/dist/esm/targets/shell/wget/client.mjs'
+import { wget } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/shell/wget/client.mjs'
 
 /**
  * shell/wget

--- a/packages/snippetz/src/plugins/shell/wget/wget.ts
+++ b/packages/snippetz/src/plugins/shell/wget/wget.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { wget } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/shell/wget/client.mjs'
+import { wget } from '@/httpsnippet-lite/dist/esm/targets/shell/wget/client.mjs'
 
 /**
  * shell/wget

--- a/packages/snippetz/src/plugins/swift/nsurlsession/nsurlsession.ts
+++ b/packages/snippetz/src/plugins/swift/nsurlsession/nsurlsession.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
-
 // @ts-expect-error no types available
-import { nsurlsession } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/swift/nsurlsession/client.mjs'
+import { nsurlsession } from '@/httpsnippet-lite/dist/esm/targets/swift/nsurlsession/client.mjs'
 
 /**
  * swift/nsurlsession

--- a/packages/snippetz/src/plugins/swift/nsurlsession/nsurlsession.ts
+++ b/packages/snippetz/src/plugins/swift/nsurlsession/nsurlsession.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from '@/core'
 import { convertWithHttpSnippetLite } from '@/core/utils/convertWithHttpSnippetLite'
+
 // @ts-expect-error no types available
-import { nsurlsession } from '~httpsnippet-lite/dist/esm/targets/swift/nsurlsession/client.mjs'
+import { nsurlsession } from '../../../../node_modules/httpsnippet-lite/dist/esm/targets/swift/nsurlsession/client.mjs'
 
 /**
  * swift/nsurlsession

--- a/packages/snippetz/tsconfig.json
+++ b/packages/snippetz/tsconfig.json
@@ -4,8 +4,7 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"],
-      "@test/*": ["./test/*"],
-      "~*": ["./node_modules/*"]
+      "@test/*": ["./test/*"]
     }
   }
 }

--- a/packages/snippetz/vite.config.ts
+++ b/packages/snippetz/vite.config.ts
@@ -1,18 +1,8 @@
 import { alias } from '@scalar/build-tooling'
-import { join } from 'node:path'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
   resolve: {
-    alias: [
-      ...Object.entries(alias(import.meta.url)).map(([find, replacement]) => ({
-        find,
-        replacement,
-      })),
-      {
-        find: /~(.+)/,
-        replacement: join(process.cwd(), 'node_modules/$1'),
-      },
-    ],
+    alias: alias(import.meta.url),
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1998,9 +1998,6 @@ importers:
 
   packages/snippetz:
     dependencies:
-      httpsnippet-lite:
-        specifier: ^3.0.5
-        version: 3.0.5
       stringify-object:
         specifier: ^5.0.0
         version: 5.0.0


### PR DESCRIPTION
I’ve added imports for the specific clients recently, but this doesn’t work in most environments.

With this PR the source files are just copied to the package folder, that was the easiest solution. And we’ll get rid of them soonish anyway.

Increases the bundle size, but this will go away when we remove httpsnippet-lite as a dependency very soon.

Closes #4111