### PR TITLE
fix(api-client): sidebar request button

### DIFF
--- a/.changeset/thin-tools-cheer.md
+++ b/.changeset/thin-tools-cheer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: displays sidebar request button on client only

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -412,6 +412,7 @@ const hasDraftRequests = computed(() => {
                   size="md" />
               </ScalarButton>
               <ScalarButton
+                v-if="!isReadOnly"
                 class="px-0.5 py-0 hover:bg-b-3 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 aspect-square h-fit"
                 size="sm"
                 variant="ghost"


### PR DESCRIPTION
this pr fixes the sidebar request button being displayed in modal:

⊢ before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/fa49eea0-28a7-4682-aa6d-3a3758871215">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1da7f1b7-f5c6-433c-b8df-ac5d26ebf1b3">
</div>