### PR TITLE
fix(api-client): tooltips have wrong z-index

### DIFF
--- a/.changeset/cuddly-berries-remain.md
+++ b/.changeset/cuddly-berries-remain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: favors scalar teleport in scalar tooltip

--- a/.changeset/itchy-lemons-wait.md
+++ b/.changeset/itchy-lemons-wait.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates workspace dropdown tooltip index

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -143,7 +143,7 @@ const deleteWorkspace = async () => {
                 </ScalarDropdownItem>
                 <ScalarTooltip
                   v-if="isLastWorkspace"
-                  class="z-10"
+                  class="z-overlay"
                   side="bottom">
                   <template #trigger>
                     <ScalarDropdownItem
@@ -161,7 +161,7 @@ const deleteWorkspace = async () => {
                   </template>
                   <template #content>
                     <div
-                      class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
+                      class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 z-context p-2 text-xxs leading-5 z-10 text-c-1">
                       <div class="flex items-center text-c-2">
                         <span>Only workspace cannot be deleted.</span>
                       </div>

--- a/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
+++ b/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import {
   TooltipContent,
-  TooltipPortal,
   TooltipProvider,
   TooltipRoot,
   TooltipTrigger,
 } from 'radix-vue'
+
+import { ScalarTeleport } from '../ScalarTeleport'
 
 const props = withDefaults(
   defineProps<{
@@ -46,7 +47,7 @@ defineEmits<{
         @click="props.click">
         <slot name="trigger" />
       </TooltipTrigger>
-      <TooltipPortal>
+      <ScalarTeleport>
         <TooltipContent
           v-if="!props.disabled"
           :align="props.align"
@@ -56,7 +57,7 @@ defineEmits<{
           :sideOffset="props.sideOffset">
           <slot name="content" />
         </TooltipContent>
-      </TooltipPortal>
+      </ScalarTeleport>
     </TooltipRoot>
   </TooltipProvider>
 </template>


### PR DESCRIPTION
this pr updates the tooltip component in order to fix the tooltip visibility within client modal as seen below:

⊢ before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/830e9555-3b33-44cf-b08a-09d9455957cc">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/431a81fe-09cc-4755-88fd-4aafccf14860">
</div>


and also fix index issue in api client:

⊢ before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/df97d714-1d95-4377-820f-5913e0a6efa2">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/987db20f-649c-4b8b-9c1a-fb769ea3a8f0">
</div>
