### PR TITLE
style(api-client): empty response action order

### DIFF
--- a/.changeset/chilled-ducks-wave.md
+++ b/.changeset/chilled-ducks-wave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: re-orders empty response actions

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -94,19 +94,19 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
         <ScalarHotkey hotkey="k" />
       </button>
       <button
-        class="flex items-center gap-1.5"
-        type="button"
-        @click="events.executeRequest.emit()">
-        Send Request
-        <ScalarHotkey hotkey="↵" />
-      </button>
-      <button
         v-if="layout === 'desktop'"
         class="flex items-center gap-1.5"
         type="button"
         @click="openCommandPaletteRequest">
         New Request
         <ScalarHotkey hotkey="N" />
+      </button>
+      <button
+        class="flex items-center gap-1.5"
+        type="button"
+        @click="events.executeRequest.emit()">
+        Send Request
+        <ScalarHotkey hotkey="↵" />
       </button>
     </div>
   </div>


### PR DESCRIPTION
this pr re-orders the empty response actions as seen below, nit/ocd but feels better:

⊢ before / after
<div>
<img width="363" alt="image" src="https://github.com/user-attachments/assets/d616b91a-dbe9-4070-8d45-67339c8079a8">
<img width="363" alt="image" src="https://github.com/user-attachments/assets/d9e5a606-31b6-454d-85b4-d8e30e7ce218">
</div>