### PR TITLE
fix(api-client): watch mode toast

### DIFF
--- a/.changeset/slow-waves-own.md
+++ b/.changeset/slow-waves-own.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates watch mode toast watcher

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -137,7 +137,7 @@ watch(
     activeWorkspaceCollections.value.map((collection) => collection.watchMode),
   (newWatchModes, oldWatchModes) => {
     newWatchModes.forEach((newWatchMode, index) => {
-      if (newWatchMode !== oldWatchModes[index]) {
+      if (!props.isReadonly && newWatchMode !== oldWatchModes[index]) {
         const currentCollection = activeWorkspaceCollections.value[index]
         const message = `${currentCollection.info?.title}: Watch Mode ${newWatchMode ? 'enabled' : 'disabled'}`
         toast(message, 'info')


### PR DESCRIPTION
this pr updates the watch mode toast watcher to prevent them from being displayed in editor/sandbox context:

<img width="538" alt="image" src="https://github.com/user-attachments/assets/bfad1853-1349-4c41-86bd-5bfe6945de13">