### PR TITLE
fix(api-client): request body examples

### DIFF
--- a/.changeset/breezy-flowers-warn.md
+++ b/.changeset/breezy-flowers-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates request body selected example function

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -425,12 +425,13 @@ const selectedExample = computed({
   get: () => {
     const rawValue = activeExample.value?.body.raw?.value ?? '{}'
     const parsedValue = JSON.parse(rawValue)
-    const [key] = Object.keys(parsedValue)
-    const value = parsedValue[key]
-    return (
-      exampleOptions.value.find((example) => example.id === value) ??
-      exampleOptions.value[0]
-    )
+    const getExample = exampleOptions.value.find((example) => {
+      const exampleValue = example.value as {
+        value: Record<string, string>
+      }
+      return JSON.stringify(exampleValue.value) === JSON.stringify(parsedValue)
+    })
+    return getExample ?? exampleOptions.value[0]
   },
   set: (opt) => {
     if (opt?.id) {
@@ -553,6 +554,7 @@ const selectedExample = computed({
         <template v-else>
           <!-- TODO: remove this as type hack when we add syntax highligting -->
           <CodeInput
+            class="border-t-1/2"
             content=""
             :language="codeInputLanguage as CodeMirrorLanguage"
             lineNumbers


### PR DESCRIPTION
this pr adds back the request body border updated in #3981 + fixes broken selected example as seen in #3809

⊢ before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b616b99d-8035-46f2-987e-d414c36db978">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b9d10bda-269f-4540-b6d7-722a72763237">
</div>