### PR TITLE
fix(api-reference): circular dependency

### DIFF
--- a/.changeset/breezy-buses-leave.md
+++ b/.changeset/breezy-buses-leave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: circular dependency

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -2,10 +2,10 @@
 import { ScalarIcon } from '@scalar/components'
 import { nextTick, ref, watch } from 'vue'
 
-import { Section } from '.'
 import { scrollToId } from '../../helpers'
 import { useNavState } from '../../hooks'
 import Anchor from '../Anchor/Anchor.vue'
+import Section from './Section.vue'
 
 const props = defineProps<{
   id: string


### PR DESCRIPTION
This PR fixes a circular dependency in the `<CompactSection />` component.

> Export "default" of module "src/components/Section/CompactSection.vue" was reexported through module "src/components/Section/index.ts" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.