### PR TITLE
fix(api-client): server variables

### DIFF
--- a/.changeset/lovely-bikes-lick.md
+++ b/.changeset/lovely-bikes-lick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: displays server path variables

--- a/.changeset/strong-shoes-retire.md
+++ b/.changeset/strong-shoes-retire.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: sets server variables values in client

--- a/packages/api-client/src/components/AddressBar/AddressBarServerItem.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServerItem.vue
@@ -38,20 +38,21 @@ const isSelectedServer = (serverId: string) =>
 
 <template>
   <ScalarDropdownItem
-    class="flex !gap-1.5 group font-code text-xxs whitespace-nowrap text-ellipsis overflow-hidden"
+    key="serverOption.id"
+    class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden w-full"
     :value="serverOption.id"
     @click="updateSelectedServer(serverOption.id)">
     <div
-      class="flex size-4 items-center justify-center rounded-full p-[3px]"
+      class="flex size-4 items-center justify-center p-0.75 text-b-1 rounded-full"
       :class="
         isSelectedServer(serverOption.id)
           ? 'bg-c-accent text-b-1'
-          : 'group-hover:shadow-border text-transparent'
+          : 'group-hover/item:shadow-border text-transparent'
       ">
       <ScalarIcon
-        class="relative top-[0.5px] size-2.5"
         icon="Checkmark"
-        thickness="3.5" />
+        size="xs"
+        thickness="2.5" />
     </div>
     <span class="whitespace-nowrap text-ellipsis overflow-hidden">
       {{ serverOption.label }}

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -271,15 +271,35 @@ export const createApiClient = ({
       }
     },
     /** Update the currently selected server via URL */
-    updateServer: (serverUrl: string) => {
+    updateServer: (serverUrl: string, variables?: Record<string, string>) => {
       const server = Object.values(servers).find((s) => s.url === serverUrl)
+      if (!server || !activeCollection.value) return
 
-      if (server && activeCollection.value)
-        collectionMutators.edit(
-          activeCollection.value?.uid,
-          'selectedServerUid',
-          server.uid,
+      collectionMutators.edit(
+        activeCollection.value.uid,
+        'selectedServerUid',
+        server.uid,
+      )
+
+      if (!variables) return
+
+      // Iterate through the variables
+      const variableEntries = Object.entries(variables).map(([key, value]) => ({
+        key,
+        value,
+        enabled: true,
+      }))
+
+      // Iterate through the requests and adds the variable values to the path parameters
+      activeCollection?.value?.requests.forEach((request) => {
+        const foundRequest = requests[request]
+        if (!foundRequest) return
+        requestExampleMutators.edit(
+          foundRequest.examples[0],
+          'parameters.path',
+          variableEntries,
         )
+      })
     },
     /** Update the currently selected server via URL */
     onUpdateServer: (callback: (url: string) => void) => {

--- a/packages/api-client/src/libs/send-request/send-request.ts
+++ b/packages/api-client/src/libs/send-request/send-request.ts
@@ -19,6 +19,7 @@ import {
   isRelativePath,
   shouldUseProxy,
 } from '@scalar/oas-utils/helpers'
+import { REGEX } from '@scalar/oas-utils/helpers'
 import Cookies from 'js-cookie'
 import MimeTypeParser from 'whatwg-mimetype'
 
@@ -224,7 +225,11 @@ type SendRequestResponse = Promise<
 
 /** Ensure URL has a protocol prefix */
 function ensureProtocol(url: string): string {
-  if (url.startsWith('http://') || url.startsWith('https://')) {
+  if (
+    REGEX.PATH.test(url) ||
+    url.startsWith('http://') ||
+    url.startsWith('https://')
+  ) {
     return url
   }
   // Default to http if no protocol is specified
@@ -289,7 +294,9 @@ export const createRequestOperation = ({
     // lets set the server variables
     // for now we only support default values
     Object.entries(server?.variables ?? {}).forEach(([k, v]) => {
-      url = replaceTemplateVariables(url, { [k]: v.default })
+      url = replaceTemplateVariables(url, {
+        [k]: pathVariables[k] || v.default,
+      })
     })
 
     const urlParams = createFetchQueryParams(example, env)

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -105,7 +105,7 @@ const updateRequestNameHandler = (event: Event) => {
           activeExample?.parameters?.path?.length
         "
         paramKey="path"
-        title="Path Variables" />
+        title="Variables" />
       <RequestParams
         v-show="activeSection === 'All' || activeSection === 'Cookies'"
         paramKey="cookies"

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -38,7 +38,9 @@ onMounted(async () => {
 // Update the server on select
 watch(server, (newServer) => {
   const { originalUrl } = getUrlFromServerState(newServer)
-  if (originalUrl && client.value) client.value.updateServer(originalUrl)
+  if (originalUrl && client.value) {
+    client.value.updateServer(originalUrl, server.variables)
+  }
 })
 
 // Update the config on change


### PR DESCRIPTION
this pr fixes #4158 by :
- bringing back the variables table on server using path variable
- fixes send request to include variable values
- style address bar server dropdown
- sets values from reference to client modal

⊢ variables before / after
<div>
<img width="390" alt="image" src="https://github.com/user-attachments/assets/04101725-a282-4341-9b23-0aee81c0b93f">
<img width="390" alt="image" src="https://github.com/user-attachments/assets/5a3e9a74-8a43-49f2-aa6d-7aa417e352d4" />
</div>

⊢ address bar dropdown before / after
<div>
<img width="390" alt="image" src="https://github.com/user-attachments/assets/6750da66-dc58-4c50-b698-9fb6d4a8ff5d">
<img width="390" alt="image" src="https://github.com/user-attachments/assets/1d124db8-f0ab-46ac-8cde-afc8a72c5a6b">
</div>