### PR TITLE
feat(api-reference): adds example property in schema heading

### DIFF
--- a/.changeset/ten-dodos-sip.md
+++ b/.changeset/ten-dodos-sip.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+style: displays property example in schemadisplays property example in schema

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -107,6 +107,12 @@ const remainingEnumValues = computed(() =>
         #name>
         {{ name }}
       </template>
+      <template
+        v-if="value?.example"
+        #example>
+        Example:
+        {{ value.example }}
+      </template>
     </SchemaPropertyHeading>
     <!-- Description -->
     <div
@@ -362,7 +368,22 @@ const remainingEnumValues = computed(() =>
 }
 
 .property--compact .property-example {
-  display: none;
+  align-items: center;
+  background: transparent;
+  border: none;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+}
+.property--compact .property-example-label,
+.property--compact .property-example-value {
+  padding: 0;
+}
+.property--compact .property-example-value {
+  background: var(--scalar-background-2);
+  border-top: 0;
+  border-radius: var(--scalar-radius);
+  padding: 2px 6px;
 }
 .property-list {
   border: var(--scalar-border-width) solid var(--scalar-border-color);

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -135,6 +135,11 @@ const flattenDefaultValue = (value: Record<string, any>) => {
       required
     </div>
   </div>
+  <div
+    v-if="$slots.example"
+    class="property-example">
+    <slot name="example" />
+  </div>
 </template>
 <style scoped>
 .property-heading {
@@ -163,6 +168,12 @@ const flattenDefaultValue = (value: Record<string, any>) => {
   font-size: var(--scalar-font-size-3);
   display: flex;
 }
+
+.property-example {
+  margin-top: 8px;
+  font-size: var(--scalar-mini);
+}
+
 .property-additional {
   font-family: var(--scalar-font-code);
 }


### PR DESCRIPTION
this pr fixes #1971 by adding example to the schema heading:

⊢ before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0ab5eaae-6dd0-4c79-98c6-d560e24593d0" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/608d3ff4-032c-44fa-b498-5b8da8f7598f" />
</div>