### PR TITLE
feat(oas-utils): request example parse enum array

### DIFF
--- a/.changeset/silent-papayas-call.md
+++ b/.changeset/silent-papayas-call.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: updates parse enum to include array

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -307,11 +307,13 @@ export function createParamInstance(param: RequestParameter) {
       '',
   )
 
-  // Handle non-string enums
+  // Handle non-string enums and enums within items for array types
   const parseEnum =
     schema?.enum && schema?.type !== 'string'
       ? schema.enum?.map(String)
-      : schema?.enum
+      : schema?.items?.enum && schema?.type === 'array'
+        ? schema.items.enum.map(String)
+        : schema?.enum
 
   // safe parse the example
   const example = schemaModel(


### PR DESCRIPTION
this pr fixes #4142 by update parse enum in request example entity to include array:

⊢ before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/cb159348-a492-4d78-96db-f38317544f5d" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/03e26f1f-2973-4dce-af8b-c91fbc4ab15e" />
</div>