### PR TITLE
feat(api-reference): extend font weights for links and sidebar items

### DIFF
--- a/.changeset/afraid-beds-sneeze.md
+++ b/.changeset/afraid-beds-sneeze.md
@@ -1,0 +1,7 @@
+---
+'@scalar/code-highlight': patch
+'@scalar/api-reference': patch
+'@scalar/themes': patch
+---
+
+feat(api-reference): extend font weights for links and sidebar items

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -183,6 +183,8 @@ onMounted(() => {
 <style scoped>
 .sidebar {
   --scalar-sidebar-indent-base: 12px;
+  --scalar-sidebar-font-weight-active: var(--scalar-semibold);
+  --scalar-sidebar-font-weight: var(--scalar-semibold);
 }
 .sidebar {
   flex: 1;

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -190,6 +190,9 @@ const onAnchorClick = async (ev: Event) => {
     var(--scalar-background-accent)
   );
 }
+.active_page.sidebar-heading p {
+  font-weight: var(--scalar-sidebar-font-weight-active, var(--scalar-semibold));
+}
 .active_page.sidebar-heading:hover .sidebar-heading-link-title {
   color: var(--scalar-sidebar-color-active, var(--scalar-color-accent));
 }
@@ -225,6 +228,7 @@ const onAnchorClick = async (ev: Event) => {
   height: fit-content;
   display: flex;
   align-items: center;
+  font-weight: var(--scalar-sidebar-font-weight, var(--scalar-semibold));
 }
 .sidebar-heading p:empty {
   display: none;

--- a/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
+++ b/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
@@ -52,12 +52,16 @@ const handleDownloadClick = () => {
 }
 
 .download-button {
-  color: var(--scalar-color-accent);
+  color: var(--scalar-link-color, var(--scalar-color-accent));
+  font-weight: var(--scalar-link-font-weight, inherit);
   text-decoration: var(--scalar-text-decoration) !important;
+  text-decoration-color: var(--scalar-text-decoration-color);
   font-size: var(--scalar-paragraph);
   cursor: pointer;
 }
 .download-button:hover {
+  color: var(--scalar-link-color-hover, var(--scalar-color-accent));
   text-decoration: var(--scalar-text-decoration-hover) !important;
+  text-decoration-color: var(--scalar-text-decoration-color-hover);
 }
 </style>

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -152,11 +152,13 @@
     margin-top: 0;
   }
   .markdown a {
-    color: var(--scalar-color-accent);
+    color: var(--scalar-link-color, var(--scalar-color-accent));
+    font-weight: var(--scalar-link-font-weight, inherit);
     text-decoration: var(--scalar-text-decoration);
     cursor: pointer;
   }
   .markdown a:hover {
+    color: var(--scalar-link-color-hover, var(--scalar-color-accent));
     text-decoration: var(--scalar-text-decoration-hover);
   }
   .markdown em {

--- a/packages/themes/src/variables.css
+++ b/packages/themes/src/variables.css
@@ -49,6 +49,7 @@
 
   --scalar-text-decoration: none;
   --scalar-text-decoration-hover: underline;
+  --scalar-link-font-weight: inherit;
 }
 .dark-mode {
   color-scheme: dark;
@@ -68,6 +69,11 @@
   --scalar-sidebar-indent-border: transparent;
   --scalar-sidebar-indent-border-hover: transparent;
   --scalar-sidebar-indent-border-active: transparent;
+
+  --scalar-link-color: var(--scalar-color-accent);
+  --scalar-link-color-hover: var(--scalar-color-accent);
+  --scalar-text-decoration-color: currentColor;
+  --scalar-text-decoration-color-hover: currentColor;
 }
 .light-mode {
   color-scheme: light;
@@ -87,6 +93,11 @@
   --scalar-sidebar-indent-border: transparent;
   --scalar-sidebar-indent-border-hover: transparent;
   --scalar-sidebar-indent-border-active: transparent;
+
+  --scalar-link-color: var(--scalar-color-accent);
+  --scalar-link-color-hover: var(--scalar-color-accent);
+  --scalar-text-decoration-color: currentColor;
+  --scalar-text-decoration-color-hover: currentColor;
 }
 /* On some browsers, the light color scheme takes precedence when the light mode is active */
 .light-mode .dark-mode {


### PR DESCRIPTION
add font weights sidebar items (active, inactive) in a css variable
add link hover colours in a variable
add link weights in a variable
add link text decoration colours in a variable