### PR TITLE
fix(api-reference): correct anchor id encoding to ensure correct page scrolling

### DIFF
--- a/.changeset/spicy-islands-enjoy.md
+++ b/.changeset/spicy-islands-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): correct anchor id encoding to ensure correct page scrolling #4173

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -37,9 +37,7 @@ const getWebhookId = (name?: string, httpVerb?: string) => {
     return 'webhooks'
   }
 
-  const webhookSlug = slug(name)
-  const encodedSlug = encodeURIComponent(webhookSlug)
-  return `webhook/${httpVerb}/${encodedSlug}`
+  return `webhook/${httpVerb}/${slug(name)}`
 }
 
 const getModelId = (name?: string) => {
@@ -47,19 +45,14 @@ const getModelId = (name?: string) => {
     return 'models'
   }
 
-  const modelSlug = slug(name)
-  const encodedSlug = encodeURIComponent(modelSlug)
-  return `model/${encodedSlug}`
+  return `model/${slug(name)}`
 }
 
 const getOperationId = (operation: TransformedOperation, parentTag: Tag) =>
   `${getTagId(parentTag)}/${operation.httpVerb}${operation.path}`
 
 const getTagId = ({ name }: Tag) => {
-  const tagSlug = slug(name)
-  const encodedSlug = encodeURIComponent(tagSlug)
-
-  return `tag/${encodedSlug}`
+  return `tag/${slug(name)}`
 }
 
 // Grabs the sectionId of the hash to open the section before scrolling


### PR DESCRIPTION
**Problem**

The id attribute value of the `<section>` element is being encoded using encodeURIComponent(), for example:

![image](https://github.com/user-attachments/assets/dfca875e-8c3b-498d-90b1-7bc4a06f6636)

When a document link with a hash is opened in a new tab, the browser attempts to find the element corresponding to the hash and scroll to it. This behavior is similar to the following code:

![image](https://github.com/user-attachments/assets/d07ace26-b643-4019-b486-cb129f680103)

However, because the element cannot be found due to the encoding, the browser does not scroll to the intended section.

**Solution**

Remove `encodeURIComponent()` from [packages/api-reference/src/hooks/useNavState.ts](https://github.com/scalar/scalar/compare/main...lc-soft:scalar:lcsoft/fix-nav-id?expand=1#diff-ccdd228d6187612f62c06d9aaafbc4c0c9fa973ca37de2d80744df2b7dccdb43)

The id attribute value of the `<section>` element will then be set as follows:

![image](https://github.com/user-attachments/assets/73a3a415-1264-4147-afe4-d86b2fc7b8b6)

With this change, the browser can correctly find and scroll to the intended element.

![image](https://github.com/user-attachments/assets/e3633335-d0fe-4e1f-90c9-60e2c7822131)



