### PR TITLE
feat(api-reference): enum value visible item number increase

### DIFF
--- a/.changeset/khaki-hairs-help.md
+++ b/.changeset/khaki-hairs-help.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: increases visible enum value item number

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -167,4 +167,69 @@ describe('SchemaProperty sub-schema', () => {
     expect(button.exists()).toBe(false)
     expect(schemas).toHaveLength(0)
   })
+
+  it('shows all enum values when there are 9 or fewer', () => {
+    const wrapper = mount(SchemaProperty, {
+      props: {
+        value: {
+          enum: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
+        },
+      },
+    })
+
+    const enumValues = wrapper.findAll('.property-enum-value')
+    const toggleButton = wrapper.find('.enum-toggle-button')
+
+    expect(enumValues).toHaveLength(9)
+    expect(toggleButton.exists()).toBe(false)
+  })
+
+  it('shows only first 5 enum values and toggle button when there are more than 9', () => {
+    const wrapper = mount(SchemaProperty, {
+      props: {
+        value: {
+          enum: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+        },
+      },
+    })
+
+    const enumValues = wrapper.findAll('.property-enum-value')
+    const toggleButton = wrapper.find('.enum-toggle-button')
+
+    expect(enumValues).toHaveLength(5)
+    expect(toggleButton.exists()).toBe(true)
+    expect(toggleButton.text()).toBe('Show all values')
+  })
+
+  it('shows all enum values when toggle button is clicked', async () => {
+    const wrapper = mount(SchemaProperty, {
+      props: {
+        value: {
+          enum: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+        },
+      },
+    })
+
+    const toggleButton = wrapper.find('.enum-toggle-button')
+    await toggleButton.trigger('click')
+
+    const enumValues = wrapper.findAll('.property-enum-value')
+    expect(enumValues).toHaveLength(10)
+    expect(toggleButton.text()).toBe('Hide values')
+  })
+
+  it('handles enum values from items property', () => {
+    const wrapper = mount(SchemaProperty, {
+      props: {
+        value: {
+          items: {
+            enum: ['a', 'b', 'c'],
+          },
+        },
+      },
+    })
+
+    const enumValues = wrapper.findAll('.property-enum-value')
+    expect(enumValues).toHaveLength(3)
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -157,17 +157,20 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
       <template v-else>
         <ul class="property-enum-values">
           <li
-            v-for="enumValue in getEnumFromValue(value).slice(0, 4)"
+            v-for="enumValue in getEnumFromValue(value).slice(
+              0,
+              getEnumFromValue(value).length > 9 ? 5 : 9,
+            )"
             :key="enumValue"
             class="property-enum-value">
             {{ enumValue }}
           </li>
           <Disclosure
-            v-if="getEnumFromValue(value).length > 4"
+            v-if="getEnumFromValue(value).length > 9"
             v-slot="{ open }">
             <DisclosurePanel>
               <li
-                v-for="enumValue in getEnumFromValue(value).slice(4)"
+                v-for="enumValue in getEnumFromValue(value).slice(5)"
                 :key="enumValue"
                 class="property-enum-value">
                 {{ enumValue }}

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -1,11 +1,12 @@
 <script lang="ts" setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
+import { computed } from 'vue'
 
 import Schema from './Schema.vue'
 import SchemaPropertyHeading from './SchemaPropertyHeading.vue'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     value?: Record<string, any>
     level?: number
@@ -71,6 +72,20 @@ const getEnumFromValue = function (value?: Record<string, any>): any[] | [] {
 }
 
 const rules = ['oneOf', 'anyOf', 'allOf', 'not']
+
+// These helpers manage how enum values are displayed:
+//
+// - For enums with 9 or fewer values, all values are shown.
+// - For enums with more than 9 values, only first 5 are shown initially.
+// - A “Show more” button reveals the remaining values.
+const hasLongEnumList = computed(() => getEnumFromValue(props.value).length > 9)
+const initialEnumCount = computed(() => (hasLongEnumList.value ? 5 : 9))
+const visibleEnumValues = computed(() =>
+  getEnumFromValue(props.value).slice(0, initialEnumCount.value),
+)
+const remainingEnumValues = computed(() =>
+  getEnumFromValue(props.value).slice(initialEnumCount.value),
+)
 </script>
 <template>
   <div
@@ -157,20 +172,17 @@ const rules = ['oneOf', 'anyOf', 'allOf', 'not']
       <template v-else>
         <ul class="property-enum-values">
           <li
-            v-for="enumValue in getEnumFromValue(value).slice(
-              0,
-              getEnumFromValue(value).length > 9 ? 5 : 9,
-            )"
+            v-for="enumValue in visibleEnumValues"
             :key="enumValue"
             class="property-enum-value">
             {{ enumValue }}
           </li>
           <Disclosure
-            v-if="getEnumFromValue(value).length > 9"
+            v-if="hasLongEnumList"
             v-slot="{ open }">
             <DisclosurePanel>
               <li
-                v-for="enumValue in getEnumFromValue(value).slice(5)"
+                v-for="enumValue in remainingEnumValues"
                 :key="enumValue"
                 class="property-enum-value">
                 {{ enumValue }}


### PR DESCRIPTION
this pr increases the number of enum item visible in the api reference:

![image](https://github.com/user-attachments/assets/e51ded1b-94f6-4ea3-af7f-fcf5607aa048)

_initially requested [in discord by @Arthur](https://discord.com/channels/1135330207960678410/1135330208627564597/1311623771710296074)_
