### PR TITLE
ci: wait for the build to run the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,21 +160,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Build @scalar/cli
+      - name: Build packages
         uses: ./.github/actions/build
         with:
           node-version: ${{ matrix.node-version }}
-          packages-only: 'cli'
-      - name: Build @scalar/fastify-api-reference
-        uses: ./.github/actions/build
-        with:
-          node-version: ${{ matrix.node-version }}
-          packages-only: 'fastify-api-reference'
-      - name: Build @scalar/echo-server
-        uses: ./.github/actions/build
-        with:
-          node-version: ${{ matrix.node-version }}
-          packages-only: 'echo-server'
+          packages-only: 'true'
       - name: Run tests
         run: pnpm test:ci
       - name: Setup Go


### PR DESCRIPTION
Reverts scalar/scalar#4086

Wow, I submitted #4086, but I think something got lost when I rebased the PR. It’s still waiting for the build.

```
  test:
    needs: [build]
```

Also, I came to the conclusion that we actually need to wait for the build. 😁 All packages require other workspace packages, that need to be build before the tests can run. Turbo does a great job at caching, but we’ll actually have better CI times when waiting for the build.