### PR TITLE
chore: make dependabot ignore some dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
       interval: 'weekly'
     # This will disable updates, but still create PRs for security updates.
     open-pull-requests-limit: 0
+    # Ignore updates for some dependencies, that usually require manual updates.
+    ignore:
+      - dependency-name: 'rollup'
+      - dependency-name: 'vite'
+      - dependency-name: 'vitest'
   - package-ecosystem: npm
     directory: /packages/scalar-app
     schedule:


### PR DESCRIPTION
Some dependencies just require manual updates, I was not able to merge one of the dependabot PRs for them without fixing some type mismatches.