### PR TITLE
feat(api-reference): Adds optional hash prefixing

### DIFF
--- a/.changeset/shaggy-mayflies-sell.md
+++ b/.changeset/shaggy-mayflies-sell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Adds support for hash prefixing. Requires manual control of useNavState.

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -11,7 +11,6 @@ defineProps<{
 const { copyToClipboard } = useClipboard()
 const { getHashedUrl } = useNavState()
 const getUrlWithId = (id: string) => {
-  console.log(window.location.href, getHashedUrl(id))
   return getHashedUrl(id)
 }
 </script>

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useNavState } from '@/hooks'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 
 import ScreenReader from '../ScreenReader.vue'
@@ -8,13 +9,10 @@ defineProps<{
 }>()
 
 const { copyToClipboard } = useClipboard()
-
+const { getHashedUrl } = useNavState()
 const getUrlWithId = (id: string) => {
-  const url = new URL(window.location.href)
-
-  url.hash = id
-
-  return url.toString()
+  console.log(window.location.href, getHashedUrl(id))
+  return getHashedUrl(id)
 }
 </script>
 <template>

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -7,8 +7,10 @@ import {
   createActiveEntitiesStore,
   createWorkspaceStore,
 } from '@scalar/api-client/store'
-import { addScalarClassesToHeadless } from '@scalar/components'
-import { ScalarErrorBoundary } from '@scalar/components'
+import {
+  ScalarErrorBoundary,
+  addScalarClassesToHeadless,
+} from '@scalar/components'
 import { defaultStateFactory } from '@scalar/oas-utils/helpers'
 import {
   type ThemeId,
@@ -97,6 +99,7 @@ const {
 } = useSidebar()
 
 const {
+  getReferenceHash,
   getPathRoutingId,
   getSectionId,
   getTagId,
@@ -104,8 +107,11 @@ const {
   isIntersectionEnabled,
   pathRouting,
   updateHash,
+  setHashPrefix,
+  replaceUrlState,
 } = useNavState()
 
+setHashPrefix('some/prefix/is-good/')
 pathRouting.value = props.configuration.pathRouting
 
 // Ideally this triggers absolutely first on the client so we can set hash value
@@ -150,9 +156,10 @@ onMounted(() => {
   }
 
   // This is what updates the hash ref from hash changes
-  window.onhashchange = () =>
-    scrollToSection(decodeURIComponent(window.location.hash.replace(/^#/, '')))
-
+  window.onhashchange = () => {
+    console.log('CHANGED TO: ', getReferenceHash())
+    scrollToSection(getReferenceHash())
+  }
   // Handle back for path routing
   window.onpopstate = () =>
     pathRouting.value &&
@@ -171,8 +178,7 @@ const debouncedScroll = useDebounceFn((value) => {
       ? props.configuration.pathRouting.basePath
       : window.location.pathname
 
-    window.history.replaceState({}, '', basePath + window.location.search)
-    hash.value = ''
+    replaceUrlState('', basePath + window.location.search)
   }
 })
 

--- a/packages/api-reference/src/components/Content/Introduction/Description.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Description.vue
@@ -45,24 +45,12 @@ const sections = computed(() => {
   return items
 })
 
-const { getHeadingId, hash, isIntersectionEnabled, pathRouting } = useNavState()
+const { getHeadingId, isIntersectionEnabled, replaceUrlState } = useNavState()
 
 function handleScroll(headingId = '') {
   if (!isIntersectionEnabled.value) return
 
-  const newUrl = new URL(window.location.href)
-
-  // If we are pathrouting, set path instead of hash
-  if (pathRouting.value) {
-    newUrl.pathname = joinWithSlash(pathRouting.value.basePath, headingId)
-  } else {
-    newUrl.hash = headingId
-  }
-  hash.value = headingId
-
-  // We use replaceState so we don't trigger the url hash watcher and trigger a scroll
-  // this is why we set the hash value directly
-  window.history.replaceState({}, '', newUrl)
+  replaceUrlState(headingId)
 }
 
 const slugger = new GithubSlugger()

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -32,6 +32,7 @@ watch(
     :aria-expanded="open"
     class="collapsible-section">
     <div
+      :id="id"
       class="collapsible-section-trigger"
       :class="{ 'collapsible-section-trigger-open': open }"
       @click="open = !open">
@@ -47,7 +48,6 @@ watch(
     </div>
     <Section
       v-if="open"
-      :id="id"
       class="collapsible-section-content"
       :label="label">
       <slot />

--- a/packages/api-reference/src/components/Section/Section.vue
+++ b/packages/api-reference/src/components/Section/Section.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { joinWithSlash } from '../../helpers'
 import { useNavState, useSidebar } from '../../hooks'
 import IntersectionObserver from '../IntersectionObserver.vue'
 
@@ -8,26 +7,13 @@ const props = defineProps<{
   label?: string
 }>()
 
-const { getSectionId, hash, isIntersectionEnabled, pathRouting } = useNavState()
+const { getSectionId, isIntersectionEnabled, replaceUrlState } = useNavState()
 const { setCollapsedSidebarItem } = useSidebar()
 
 function handleScroll() {
   if (!props.label || !isIntersectionEnabled.value) return
 
-  // We use replaceState so we don't trigger the url hash watcher and trigger a scroll
-  // this is why we set the hash value directly
-  const newUrl = new URL(window.location.href)
-  const id = props.id ?? ''
-
-  // If we are pathrouting, set path instead of hash
-  if (pathRouting.value) {
-    newUrl.pathname = joinWithSlash(pathRouting.value.basePath, id)
-  } else {
-    newUrl.hash = id
-  }
-  hash.value = id
-
-  window.history.replaceState({}, '', newUrl)
+  replaceUrlState(props.id ?? '')
 
   // Open models and webhooks on scroll
   if (props.id?.startsWith('model') || props.id?.startsWith('webhook'))

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -27,7 +27,8 @@ const emit = defineEmits<{
   (e: 'toggleOpen'): void
 }>()
 
-const { hash, isIntersectionEnabled, pathRouting } = useNavState()
+const { getFullHash, isIntersectionEnabled, pathRouting, replaceUrlState } =
+  useNavState()
 
 // We disable intersection observer on click
 const handleClick = async () => {
@@ -48,9 +49,9 @@ const generateLink = () => {
     return joinWithSlash(pathRouting.value.basePath, props.item.id)
   } else if (typeof window !== 'undefined') {
     const newUrl = new URL(window.location.href)
-    newUrl.hash = props.item.id
+    newUrl.hash = getFullHash(props.item.id)
     return `${newUrl.pathname}${newUrl.search}${newUrl.hash}`
-  } else return `#${props.item.id}`
+  } else return `#${getFullHash(props.item.id)}`
 }
 
 // For path routing we want to handle the clicks
@@ -68,13 +69,7 @@ const onAnchorClick = async (ev: Event) => {
     // Disable intersection observer before we scroll
     isIntersectionEnabled.value = false
 
-    // Manually update "hash"
-    hash.value = props.item.id
-
-    const url = new URL(window.location.href)
-    url.pathname = joinWithSlash(pathRouting.value.basePath, props.item.id)
-
-    window.history.pushState({}, '', url)
+    replaceUrlState(props.item.id)
     scrollToId(props.item.id)
 
     await sleep(100)

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -1,9 +1,12 @@
+import { joinWithSlash } from '@/helpers'
 import { ssrState } from '@scalar/oas-utils/helpers'
 import type { Heading, Tag, TransformedOperation } from '@scalar/types/legacy'
 import { slug } from 'github-slugger'
 import { ref } from 'vue'
 
 import type { PathRouting } from '../types'
+
+const hashPrefix = ref('')
 
 // Keeps track of the URL hash without the #
 const hash = ref(ssrState.hash ?? '')
@@ -75,7 +78,55 @@ const getSectionId = (hashStr = hash.value) => {
 const updateHash = () => {
   hash.value = pathRouting.value
     ? getPathRoutingId(window.location.pathname)
-    : decodeURIComponent(window.location.hash.replace(/^#/, ''))
+    : // Must remove the prefix from the hash as the internal hash value should be pure
+      window.location.hash.replace(/^#/, '').slice(hashPrefix.value.length)
+}
+
+const replaceUrlState = (
+  replacementHash: string,
+  url = window.location.href,
+) => {
+  const newUrl = new URL(url)
+
+  // If we are pathrouting, set path instead of hash
+  if (pathRouting.value) {
+    newUrl.pathname = joinWithSlash(pathRouting.value.basePath, replacementHash)
+  } else {
+    newUrl.hash = hashPrefix.value + replacementHash
+  }
+
+  // Update the hash ref
+  hash.value = replacementHash
+
+  // We use replaceState so we don't trigger the url hash watcher and trigger a scroll
+  // this is why we set the hash value directly
+  window.history.replaceState({}, '', newUrl)
+}
+
+const getHashedUrl = (
+  replacementHash: string,
+  url = window.location.href,
+  search = window.location.search,
+) => {
+  const newUrl = new URL(url)
+  newUrl.hash = hashPrefix.value + replacementHash
+  newUrl.search = search
+  return newUrl.toString()
+}
+
+const getFullHash = (hashTarget: string = hash.value) => {
+  return `${hashPrefix.value}${hashTarget}`
+}
+
+/**
+ * Gets the portion of the hash used by the references
+ *
+ * @returns The hash without the prefix
+ */
+const getReferenceHash = () => {
+  return decodeURIComponent(
+    window.location.hash.replace(/^#/, '').slice(hashPrefix.value.length),
+  )
 }
 
 /**
@@ -87,6 +138,30 @@ const updateHash = () => {
  */
 export const useNavState = () => ({
   hash,
+  /** Sets the prefix for the hash */
+  setHashPrefix: (prefix: string) => {
+    hashPrefix.value = prefix
+  },
+  /**
+   * Gets the full hash with the prefix
+   * @param hashTarget The hash to target with the return
+   * @returns The full hash
+   */
+  getFullHash,
+  /**
+   * Gets the hashed url with the prefix
+   * @param replacementHash The hash to replace the current hash with
+   * @param url The url to get the hashed url from
+   * @returns The hashed url
+   */
+  getHashedUrl,
+  /**
+   * Replaces the URL state with the new url and hash
+   * Replacement is used so that hash changes don't trigger the url hash watcher and cause a scroll
+   */
+  replaceUrlState,
+  /** Gets the portion of the hash used by the references */
+  getReferenceHash,
   getWebhookId,
   getModelId,
   getHeadingId,


### PR DESCRIPTION
We have no ability to use hashes in a consuming app due to API Reference force overwriting them.

This allows an integration to a set a hash prefix that will be ignored by the references. 
