### PR TITLE
feat(api-reference): support wildcard notation for mediatype

### DIFF
--- a/.changeset/clean-badgers-push.md
+++ b/.changeset/clean-badgers-push.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: adds wilcard content type for responses

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
@@ -55,6 +55,8 @@ const currentJsonResponse = computed(() => {
   return (
     // OpenAPI 3.x
     normalizedContent?.['application/json'] ??
+    normalizedContent?.['application/*'] ??
+    normalizedContent?.['*/*'] ??
     normalizedContent?.['text/plain'] ??
     // Swagger 2.0
     currentResponse.value

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -276,7 +276,9 @@ export type ContentType =
   | `text/html${OptionalCharset}`
   | `application/octet-stream${OptionalCharset}`
   | `application/x-www-form-urlencoded${OptionalCharset}`
+  | `application/*${OptionalCharset}`
   | `multipart/form-data${OptionalCharset}`
+  | `*/*${OptionalCharset}`
 
 export type Cookie = {
   name: string


### PR DESCRIPTION
this pr adds first stepping stones into fixing #1790 by introducing `*/*` and `application/*` content type support to the example responses.

course of action:
- [ ] content header updates
- [ ] request