### PR TITLE
chore: ci jobs timeout after 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   harden_security:
     name: Check used GitHub Actions
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -18,6 +19,7 @@ jobs:
 
   build:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [18, 20]
@@ -38,6 +40,7 @@ jobs:
   docker:
     name: Build and Tag Docker Image
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -115,6 +118,7 @@ jobs:
 
   format:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]
@@ -136,6 +140,7 @@ jobs:
   types:
     needs: [build]
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]
@@ -153,6 +158,7 @@ jobs:
   test:
     needs: [build]
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [18, 20]
@@ -177,6 +183,7 @@ jobs:
   stats:
     needs: [build]
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]
@@ -199,6 +206,7 @@ jobs:
   npm-publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write
@@ -244,6 +252,7 @@ jobs:
   todesktop-build:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     needs: [build, test]
     strategy:
       matrix:
@@ -295,6 +304,7 @@ jobs:
   stackblitz:
     if: github.head_ref == 'changeset-release/main'
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     needs: [build]
     strategy:
       matrix:
@@ -334,6 +344,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.event.pull_request.head.repo.full_name == github.repository
     needs: [build]
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]
@@ -384,6 +395,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]')
     needs: [build]
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]
@@ -420,6 +432,7 @@ jobs:
 
   aspnetcore-build-test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     needs: [build]
     steps:
       - name: Checkout repository
@@ -455,6 +468,7 @@ jobs:
   aspnetcore-publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     needs: [aspnetcore-build-test]
 
     steps:

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -11,6 +11,7 @@ jobs:
   release:
     name: Deploy Scalar examples
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]

--- a/.github/workflows/lint-icons.yml
+++ b/.github/workflows/lint-icons.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]

--- a/.github/workflows/lint-markdown-files.yml
+++ b/.github/workflows/lint-markdown-files.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       # https://github.com/marketplace/actions/semantic-pull-request
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]

--- a/.github/workflows/test-electron-app.yml
+++ b/.github/workflows/test-electron-app.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -10,6 +10,7 @@ jobs:
     name: Update the README
     if: ${{ github.repository_owner == 'scalar' }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
       - name: Update the list of contributors

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]


### PR DESCRIPTION
**Problem**
Currently, some CI jobs are running for an extended period of time.

**Solution**
With this PR, CI jobs run for a maximum of 15 minutes before they timeout. This is a stop-gap solution while we improve our workflows. In the meantime, this will stop our workflows running for too long. 
