### PR TITLE
fix(api-reference): hide darkmode toggle only

### DIFF
--- a/.changeset/rotten-lobsters-lick.md
+++ b/.changeset/rotten-lobsters-lick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: hides dark mode toggle only if configured

--- a/packages/api-reference/src/components/DarkModeToggle/DarkModeToggle.vue
+++ b/packages/api-reference/src/components/DarkModeToggle/DarkModeToggle.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 defineProps<{
   isDarkMode: boolean
+  hideDarkModeToggle?: boolean
 }>()
 
 defineEmits<{
@@ -16,6 +17,7 @@ defineEmits<{
       Powered by Scalar
     </a>
     <button
+      v-if="!hideDarkModeToggle"
       aria-label="Toggle dark mode"
       :aria-pressed="isDarkMode"
       class="darklight"

--- a/packages/api-reference/src/components/Layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ClassicLayout.vue
@@ -41,7 +41,7 @@ const config = computed(() => ({ ...props.configuration, showSidebar: false }))
           :spec="spec" />
         <template #dark-mode-toggle>
           <DarkModeIconToggle
-            v-if="!!!props.configuration.hideDarkModeToggle"
+            v-if="!props.configuration.hideDarkModeToggle"
             :isDarkMode="isDark"
             @toggleDarkMode="$emit('toggleDarkMode')" />
         </template>

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -73,7 +73,7 @@ watch(hash, (newHash, oldHash) => {
           :isDevelopment="isDevelopment"
           :url="configuration.spec?.url" />
         <DarkModeToggle
-          v-if="!!!props.configuration.hideDarkModeToggle"
+          :hideDarkModeToggle="configuration.hideDarkModeToggle"
           :isDarkMode="isDark"
           @toggleDarkMode="$emit('toggleDarkMode')" />
       </div>


### PR DESCRIPTION
this pr fixes the sidebar footer being totally hidden on modern layout `hideDarkModeToggle` configuration:

⊢ before / after
<div>
<img width="390" alt="image" src="https://github.com/user-attachments/assets/e1308f98-6be0-41c7-be52-7108e1fa5af5" />
<img width="390" alt="image" src="https://github.com/user-attachments/assets/a48c71ed-2e56-470e-bea4-5dade9f91bb9" />
</div>