### PR TITLE
ci: limit build process to two processes

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -34,12 +34,20 @@ runs:
       name: Build
       shell: bash
       # GitHub Actions runners have two cores, so we can run two tasks in parallel
-      run: pnpm turbo build --concurrency=2
+      run: pnpm turbo \
+        --concurrency=2 \
+        build
     - if: ${{ inputs.packages-only == 'true' }}
       name: Build packages
       shell: bash
-      run: pnpm build:packages
+      run: pnpm turbo \
+        --concurrency=2 \
+        --filter './packages/**' \
+        build
     - if: ${{ inputs.packages-only != 'true' && inputs.packages-only != 'false' }}
       name: Build package
       shell: bash
-      run: pnpm turbo --filter './packages/${{inputs.packages-only}}' build
+      run: pnpm turbo \
+        --concurrency=2 \
+        --filter './packages/${{inputs.packages-only}}' \
+        build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,14 +22,14 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm install
-    # - name: Restore Turborepo cache
-    #   uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
-    #   with:
-    #     path: .turbo
-    #     key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}-${{ github.sha }}
-    #     restore-keys: |
-    #       turbo-${{ runner.os }}-node-${{ inputs.node-version }}-
-    #       turbo-${{ runner.os }}-node-
+    - name: Restore Turborepo cache
+      uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
+      with:
+        path: .turbo
+        key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}-${{ github.sha }}
+        restore-keys: |
+          turbo-${{ runner.os }}-node-${{ inputs.node-version }}-
+          turbo-${{ runner.os }}-node-
     - if: ${{ inputs.packages-only == 'false' }}
       name: Build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -34,20 +34,12 @@ runs:
       name: Build
       shell: bash
       # GitHub Actions runners have two cores, so we can run two tasks in parallel
-      run: pnpm turbo \
-        --concurrency=2 \
-        build
+      run: pnpm turbo --concurrency=2 build
     - if: ${{ inputs.packages-only == 'true' }}
       name: Build packages
       shell: bash
-      run: pnpm turbo \
-        --concurrency=2 \
-        --filter './packages/**' \
-        build
+      run: pnpm turbo --concurrency=2 --filter './packages/**' build
     - if: ${{ inputs.packages-only != 'true' && inputs.packages-only != 'false' }}
       name: Build package
       shell: bash
-      run: pnpm turbo \
-        --concurrency=2 \
-        --filter './packages/${{inputs.packages-only}}' \
-        build
+      run: pnpm turbo --concurrency=2 --filter './packages/${{inputs.packages-only}}' build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -33,7 +33,8 @@ runs:
     - if: ${{ inputs.packages-only == 'false' }}
       name: Build
       shell: bash
-      run: pnpm turbo build
+      # GitHub Actions runners have two cores, so we can run two tasks in parallel
+      run: pnpm turbo build --concurrency=2
     - if: ${{ inputs.packages-only == 'true' }}
       name: Build packages
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,14 +22,14 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm install
-    - name: Restore Turborepo cache
-      uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
-      with:
-        path: .turbo
-        key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}-${{ github.sha }}
-        restore-keys: |
-          turbo-${{ runner.os }}-node-${{ inputs.node-version }}-
-          turbo-${{ runner.os }}-node-
+    # - name: Restore Turborepo cache
+    #   uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
+    #   with:
+    #     path: .turbo
+    #     key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}-${{ github.sha }}
+    #     restore-keys: |
+    #       turbo-${{ runner.os }}-node-${{ inputs.node-version }}-
+    #       turbo-${{ runner.os }}-node-
     - if: ${{ inputs.packages-only == 'false' }}
       name: Build
       shell: bash


### PR DESCRIPTION
Runners for GitHub Actions have two cores. This PR limits the heavy build job to just use a maximum of two processes to avoid hitting limits.