### PR TITLE
fix(api-client): request example auth flow

### DIFF
--- a/.changeset/neat-onions-destroy.md
+++ b/.changeset/neat-onions-destroy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: hides flow row for unique scheme flow

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestExampleAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestExampleAuth.vue
@@ -153,6 +153,7 @@ const getReferenceClass = (className = '') =>
     <template v-else-if="scheme.type === 'oauth2'">
       <DataTableRow>
         <div
+          v-if="Object.keys(scheme.flows).length > 1"
           class="min-h-8 min-w-8 flex text-sm border-t-1/2 last:border-r-0 p-0 m-0 relative row"
           :class="{
             'border-1/2 border-b-0 rounded-t bg-b-2': layout === 'reference',


### PR DESCRIPTION
this pr hides flow row for unique scheme flow:

⊢ before / after
<div>
<img width="579" alt="image" src="https://github.com/user-attachments/assets/2c053dea-8bb3-41ed-b4ea-80ab89499a95" />
<img width="579" alt="image" src="https://github.com/user-attachments/assets/4d955ccd-4181-46bc-91ba-c45deb02902f" />
</div>