### PR TITLE
fix(api-client): address bar servers dropdown display

### DIFF
--- a/.changeset/new-falcons-enjoy.md
+++ b/.changeset/new-falcons-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates address bar servers dropdown display logic

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -19,7 +19,8 @@ defineEmits<{
   (e: 'importCurl', value: string): void
 }>()
 
-const { activeRequest, activeExample, activeServer } = useActiveEntities()
+const { activeRequest, activeExample, activeServer, activeCollection } =
+  useActiveEntities()
 const { isReadOnly, requestMutators, requestHistory, events } = useWorkspace()
 
 const selectedRequest = ref(requestHistory[0])
@@ -165,7 +166,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
             <div class="fade-left"></div>
 
             <!-- Servers -->
-            <AddressBarServers />
+            <AddressBarServers v-if="activeCollection?.servers?.length" />
 
             <!-- Path + URL + env vars -->
             <CodeInput
@@ -179,7 +180,11 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
               :emitOnBlur="false"
               importCurl
               :modelValue="activeRequest.path"
-              :placeholder="activeServer ? '' : 'Enter a URL or cURL command'"
+              :placeholder="
+                activeCollection?.servers?.includes(activeServer?.uid)
+                  ? ''
+                  : 'Enter a URL or cURL command'
+              "
               server
               @curl="$emit('importCurl', $event)"
               @submit="handleExecuteRequest"

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -61,10 +61,6 @@ const serverUrlWithoutTrailingSlash = computed(() => {
 </script>
 <template>
   <ScalarDropdown
-    v-if="
-      (requestServerOptions && requestServerOptions?.length > 1) ||
-      (collectionServerOptions && collectionServerOptions?.length > 1)
-    "
     class="w-max"
     teleport>
     <button
@@ -115,9 +111,4 @@ const serverUrlWithoutTrailingSlash = computed(() => {
       </template>
     </template>
   </ScalarDropdown>
-  <div
-    v-else-if="serverUrlWithoutTrailingSlash"
-    class="flex whitespace-nowrap items-center font-code lg:text-sm text-xs">
-    {{ serverUrlWithoutTrailingSlash }}
-  </div>
 </template>


### PR DESCRIPTION
this pr fixes the address bar servers component being display even on active collection without servers as we were fallbacking on activeServer anyway :pedro-laugh-cry: . I also propose in that PR to get the dropdown displayed for unique server in order to get access easily to the `Add Server` button.

⊢ draft request before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/07e18cef-4573-4718-9cb7-12f08661923b" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/2b7a4b28-13e3-497b-9d2d-c8527bc4d6c1" />
</div>



⊢ request with unique server before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ec95c2c1-a750-49b4-b3db-ba9a1827ee7e" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/49c4c80f-cf99-464b-8af2-df5ffb33e208" />
</div>