### PR TITLE
chore: revert release

### DIFF
--- a/.changeset/gold-cups-compare.md
+++ b/.changeset/gold-cups-compare.md
@@ -1,0 +1,5 @@
+---
+"@scalar/openapi-parser": minor
+---
+
+fix(openapi-parser): improve performance

--- a/.changeset/khaki-hairs-help.md
+++ b/.changeset/khaki-hairs-help.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: increases visible enum value item number

--- a/.changeset/lovely-bikes-lick.md
+++ b/.changeset/lovely-bikes-lick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: displays server path variables

--- a/.changeset/old-berries-chew.md
+++ b/.changeset/old-berries-chew.md
@@ -1,0 +1,6 @@
+---
+'@scalar/openapi-parser': patch
+'@scalar/cli': patch
+---
+
+fix: doesn’t validate files with external references

--- a/.changeset/shaggy-mayflies-sell.md
+++ b/.changeset/shaggy-mayflies-sell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Adds support for hash prefixing. Requires manual control of useNavState.

--- a/.changeset/spicy-islands-enjoy.md
+++ b/.changeset/spicy-islands-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): correct anchor id encoding to ensure correct page scrolling #4173

--- a/.changeset/strong-shoes-retire.md
+++ b/.changeset/strong-shoes-retire.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: sets server variables values in client

--- a/.changeset/tasty-mice-wonder.md
+++ b/.changeset/tasty-mice-wonder.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/snippetz': patch
+'@scalar/types': patch
+---
+
+chore: remove httpsnippet-lite

--- a/packages/api-client-react/CHANGELOG.md
+++ b/packages/api-client-react/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/api-client-react
 
-## 1.0.103
-
-### Patch Changes
-
-- Updated dependencies [29ca97f]
-- Updated dependencies [29ca97f]
-  - @scalar/api-client@2.2.12
-
 ## 1.0.102
 
 ### Patch Changes

--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -19,7 +19,7 @@
     "testing",
     "react"
   ],
-  "version": "1.0.103",
+  "version": "1.0.102",
   "engines": {
     "node": ">=18"
   },

--- a/packages/api-client/CHANGELOG.md
+++ b/packages/api-client/CHANGELOG.md
@@ -1,24 +1,5 @@
 # @scalar/api-client
 
-## 2.2.12
-
-### Patch Changes
-
-- 29ca97f: fix: displays server path variables
-- 29ca97f: fix: sets server variables values in client
-- Updated dependencies [e0f8f21]
-- Updated dependencies [5f77272]
-- Updated dependencies [6852aca]
-  - @scalar/openapi-parser@0.10.0
-  - @scalar/types@0.0.24
-  - @scalar/import@0.2.7
-  - @scalar/oas-utils@0.2.88
-  - @scalar/themes@0.9.55
-  - @scalar/postman-to-openapi@0.1.11
-  - @scalar/components@0.13.5
-  - @scalar/use-hooks@0.1.8
-  - @scalar/use-codemirror@0.11.49
-
 ## 2.2.11
 
 ### Patch Changes

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -18,7 +18,7 @@
     "rest",
     "testing"
   ],
-  "version": "2.2.12",
+  "version": "2.2.11",
   "engines": {
     "node": ">=18"
   },

--- a/packages/api-reference-editor/CHANGELOG.md
+++ b/packages/api-reference-editor/CHANGELOG.md
@@ -1,22 +1,5 @@
 # @scalar/api-reference-editor
 
-## 0.1.140
-
-### Patch Changes
-
-- Updated dependencies [60feddf]
-- Updated dependencies [29ca97f]
-- Updated dependencies [56c1981]
-- Updated dependencies [1766efb]
-- Updated dependencies [29ca97f]
-- Updated dependencies [6852aca]
-  - @scalar/api-reference@1.25.81
-  - @scalar/api-client@2.2.12
-  - @scalar/types@0.0.24
-  - @scalar/oas-utils@0.2.88
-  - @scalar/use-hooks@0.1.8
-  - @scalar/use-codemirror@0.11.49
-
 ## 0.1.139
 
 ### Patch Changes

--- a/packages/api-reference-editor/package.json
+++ b/packages/api-reference-editor/package.json
@@ -13,7 +13,7 @@
   "keywords": [
     "editor openapi swagger api-reference"
   ],
-  "version": "0.1.140",
+  "version": "0.1.139",
   "engines": {
     "node": ">=18"
   },

--- a/packages/api-reference-react/CHANGELOG.md
+++ b/packages/api-reference-react/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @scalar/api-reference-react
 
-## 0.3.157
-
-### Patch Changes
-
-- Updated dependencies [60feddf]
-- Updated dependencies [56c1981]
-- Updated dependencies [1766efb]
-- Updated dependencies [29ca97f]
-- Updated dependencies [6852aca]
-  - @scalar/api-reference@1.25.81
-
 ## 0.3.156
 
 ### Patch Changes

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -18,7 +18,7 @@
     "testing",
     "react"
   ],
-  "version": "0.3.157",
+  "version": "0.3.156",
   "engines": {
     "node": ">=18"
   },

--- a/packages/api-reference/CHANGELOG.md
+++ b/packages/api-reference/CHANGELOG.md
@@ -1,29 +1,5 @@
 # @scalar/api-reference
 
-## 1.25.81
-
-### Patch Changes
-
-- 60feddf: feat: increases visible enum value item number
-- 56c1981: Adds support for hash prefixing. Requires manual control of useNavState.
-- 1766efb: fix(api-reference): correct anchor id encoding to ensure correct page scrolling #4173
-- 29ca97f: fix: sets server variables values in client
-- 6852aca: chore: remove httpsnippet-lite
-- Updated dependencies [e0f8f21]
-- Updated dependencies [29ca97f]
-- Updated dependencies [5f77272]
-- Updated dependencies [29ca97f]
-- Updated dependencies [6852aca]
-  - @scalar/openapi-parser@0.10.0
-  - @scalar/api-client@2.2.12
-  - @scalar/snippetz@0.2.9
-  - @scalar/types@0.0.24
-  - @scalar/oas-utils@0.2.88
-  - @scalar/themes@0.9.55
-  - @scalar/code-highlight@0.0.18
-  - @scalar/components@0.13.5
-  - @scalar/use-hooks@0.1.8
-
 ## 1.25.80
 
 ### Patch Changes

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -20,7 +20,7 @@
     "vue",
     "vue3"
   ],
-  "version": "1.25.81",
+  "version": "1.25.80",
   "engines": {
     "node": ">=18"
   },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,22 +1,5 @@
 # @scalar/cli
 
-## 0.2.264
-
-### Patch Changes
-
-- 5f77272: fix: doesn’t validate files with external references
-- Updated dependencies [e0f8f21]
-- Updated dependencies [60feddf]
-- Updated dependencies [5f77272]
-- Updated dependencies [56c1981]
-- Updated dependencies [1766efb]
-- Updated dependencies [29ca97f]
-- Updated dependencies [6852aca]
-  - @scalar/openapi-parser@0.10.0
-  - @scalar/api-reference@1.25.81
-  - @scalar/mock-server@0.2.93
-  - @scalar/oas-utils@0.2.88
-
 ## 0.2.263
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
     "swagger",
     "cli"
   ],
-  "version": "0.2.264",
+  "version": "0.2.263",
   "engines": {
     "node": ">=18"
   },

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/components
 
-## 0.13.5
-
-### Patch Changes
-
-- @scalar/themes@0.9.55
-- @scalar/code-highlight@0.0.18
-- @scalar/use-hooks@0.1.8
-
 ## 0.13.4
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/components"
   },
-  "version": "0.13.5",
+  "version": "0.13.4",
   "engines": {
     "node": ">=18"
   },

--- a/packages/docusaurus/CHANGELOG.md
+++ b/packages/docusaurus/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/docusaurus
 
-## 0.4.159
-
-### Patch Changes
-
-- @scalar/api-reference-react@0.3.157
-
 ## 0.4.158
 
 ### Patch Changes

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -19,7 +19,7 @@
     "testing",
     "react"
   ],
-  "version": "0.4.159",
+  "version": "0.4.158",
   "engines": {
     "node": ">=18"
   },

--- a/packages/express-api-reference/CHANGELOG.md
+++ b/packages/express-api-reference/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/express-api-reference
 
-## 0.4.172
-
-### Patch Changes
-
-- Updated dependencies [6852aca]
-  - @scalar/types@0.0.24
-
 ## 0.4.171
 
 ### Patch Changes

--- a/packages/express-api-reference/package.json
+++ b/packages/express-api-reference/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/express-api-reference"
   },
-  "version": "0.4.172",
+  "version": "0.4.171",
   "engines": {
     "node": ">=18"
   },

--- a/packages/fastify-api-reference/CHANGELOG.md
+++ b/packages/fastify-api-reference/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/fastify-api-reference
 
-## 1.25.81
-
-### Patch Changes
-
-- Updated dependencies [6852aca]
-  - @scalar/types@0.0.24
-
 ## 1.25.80
 
 ## 1.25.79

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -17,7 +17,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "1.25.81",
+  "version": "1.25.80",
   "engines": {
     "node": ">=18"
   },

--- a/packages/hono-api-reference/CHANGELOG.md
+++ b/packages/hono-api-reference/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/hono-api-reference
 
-## 0.5.164
-
-### Patch Changes
-
-- Updated dependencies [6852aca]
-  - @scalar/types@0.0.24
-
 ## 0.5.163
 
 ### Patch Changes

--- a/packages/hono-api-reference/package.json
+++ b/packages/hono-api-reference/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/hono-api-reference"
   },
-  "version": "0.5.164",
+  "version": "0.5.163",
   "engines": {
     "node": ">=18"
   },

--- a/packages/import/CHANGELOG.md
+++ b/packages/import/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/import
 
-## 0.2.7
-
-### Patch Changes
-
-- Updated dependencies [e0f8f21]
-- Updated dependencies [5f77272]
-  - @scalar/openapi-parser@0.10.0
-  - @scalar/oas-utils@0.2.88
-
 ## 0.2.6
 
 ### Patch Changes

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -16,7 +16,7 @@
     "postman",
     "scalar"
   ],
-  "version": "0.2.7",
+  "version": "0.2.6",
   "engines": {
     "node": ">=18"
   },

--- a/packages/mock-server/CHANGELOG.md
+++ b/packages/mock-server/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/mock-server
 
-## 0.2.93
-
-### Patch Changes
-
-- Updated dependencies [e0f8f21]
-- Updated dependencies [5f77272]
-  - @scalar/openapi-parser@0.10.0
-  - @scalar/oas-utils@0.2.88
-
 ## 0.2.92
 
 ### Patch Changes

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -16,7 +16,7 @@
     "swagger",
     "cli"
   ],
-  "version": "0.2.93",
+  "version": "0.2.92",
   "engines": {
     "node": ">=18"
   },

--- a/packages/nestjs-api-reference/CHANGELOG.md
+++ b/packages/nestjs-api-reference/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/nestjs-api-reference
 
-## 0.3.173
-
-### Patch Changes
-
-- Updated dependencies [6852aca]
-  - @scalar/types@0.0.24
-
 ## 0.3.172
 
 ### Patch Changes

--- a/packages/nestjs-api-reference/package.json
+++ b/packages/nestjs-api-reference/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/nestjs-api-reference"
   },
-  "version": "0.3.173",
+  "version": "0.3.172",
   "engines": {
     "node": ">=18"
   },

--- a/packages/nextjs-api-reference/CHANGELOG.md
+++ b/packages/nextjs-api-reference/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/nextjs-api-reference
 
-## 0.4.105
-
-### Patch Changes
-
-- Updated dependencies [6852aca]
-  - @scalar/types@0.0.24
-
 ## 0.4.104
 
 ### Patch Changes

--- a/packages/nextjs-api-reference/package.json
+++ b/packages/nextjs-api-reference/package.json
@@ -18,7 +18,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "0.4.105",
+  "version": "0.4.104",
   "engines": {
     "node": ">=18"
   },

--- a/packages/nextjs-openapi/CHANGELOG.md
+++ b/packages/nextjs-openapi/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/nextjs-openapi
 
-## 0.0.23
-
-### Patch Changes
-
-- Updated dependencies [6852aca]
-  - @scalar/types@0.0.24
-  - @scalar/nextjs-api-reference@0.4.105
-
 ## 0.0.22
 
 ### Patch Changes

--- a/packages/nextjs-openapi/package.json
+++ b/packages/nextjs-openapi/package.json
@@ -16,7 +16,7 @@
     "scalar",
     "references"
   ],
-  "version": "0.0.23",
+  "version": "0.0.22",
   "engines": {
     "node": ">=18"
   },

--- a/packages/nuxt/CHANGELOG.md
+++ b/packages/nuxt/CHANGELOG.md
@@ -1,18 +1,5 @@
 # @scalar/nuxt
 
-## 0.2.159
-
-### Patch Changes
-
-- Updated dependencies [60feddf]
-- Updated dependencies [29ca97f]
-- Updated dependencies [56c1981]
-- Updated dependencies [1766efb]
-- Updated dependencies [29ca97f]
-- Updated dependencies [6852aca]
-  - @scalar/api-reference@1.25.81
-  - @scalar/api-client@2.2.12
-
 ## 0.2.158
 
 ### Patch Changes

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -20,7 +20,7 @@
     "testing",
     "vue"
   ],
-  "version": "0.2.159",
+  "version": "0.2.158",
   "engines": {
     "node": ">=18"
   },

--- a/packages/oas-utils/CHANGELOG.md
+++ b/packages/oas-utils/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/oas-utils
 
-## 0.2.88
-
-### Patch Changes
-
-- Updated dependencies [6852aca]
-  - @scalar/types@0.0.24
-  - @scalar/themes@0.9.55
-
 ## 0.2.87
 
 ### Patch Changes

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -16,7 +16,7 @@
     "specification",
     "yaml"
   ],
-  "version": "0.2.88",
+  "version": "0.2.87",
   "engines": {
     "node": ">=18"
   },

--- a/packages/openapi-parser/CHANGELOG.md
+++ b/packages/openapi-parser/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/openapi-parser
 
-## 0.10.0
-
-### Minor Changes
-
-- e0f8f21: fix(openapi-parser): improve performance
-
-### Patch Changes
-
-- 5f77272: fix: doesn’t validate files with external references
-
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -17,7 +17,7 @@
     "parser",
     "typescript"
   ],
-  "version": "0.10.0",
+  "version": "0.9.0",
   "engines": {
     "node": ">=18"
   },

--- a/packages/play-button/CHANGELOG.md
+++ b/packages/play-button/CHANGELOG.md
@@ -1,24 +1,5 @@
 # @scalar/play-button
 
-## 0.2.157
-
-### Patch Changes
-
-- Updated dependencies [e0f8f21]
-- Updated dependencies [60feddf]
-- Updated dependencies [29ca97f]
-- Updated dependencies [5f77272]
-- Updated dependencies [56c1981]
-- Updated dependencies [1766efb]
-- Updated dependencies [29ca97f]
-- Updated dependencies [6852aca]
-  - @scalar/openapi-parser@0.10.0
-  - @scalar/api-reference@1.25.81
-  - @scalar/api-client@2.2.12
-  - @scalar/types@0.0.24
-  - @scalar/oas-utils@0.2.88
-  - @scalar/themes@0.9.55
-
 ## 0.2.156
 
 ### Patch Changes

--- a/packages/play-button/package.json
+++ b/packages/play-button/package.json
@@ -13,7 +13,7 @@
   "keywords": [
     ""
   ],
-  "version": "0.2.157",
+  "version": "0.2.156",
   "engines": {
     "node": ">=18"
   },

--- a/packages/postman-to-openapi/CHANGELOG.md
+++ b/packages/postman-to-openapi/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/postman-to-openapi
 
-## 0.1.11
-
-### Patch Changes
-
-- @scalar/oas-utils@0.2.88
-
 ## 0.1.10
 
 ### Patch Changes

--- a/packages/postman-to-openapi/package.json
+++ b/packages/postman-to-openapi/package.json
@@ -19,7 +19,7 @@
     "export",
     "scalar"
   ],
-  "version": "0.1.11",
+  "version": "0.1.10",
   "engines": {
     "node": ">=18"
   },

--- a/packages/scalar-app/CHANGELOG.md
+++ b/packages/scalar-app/CHANGELOG.md
@@ -1,16 +1,5 @@
 # scalar-app
 
-## 0.1.106
-
-### Patch Changes
-
-- Updated dependencies [29ca97f]
-- Updated dependencies [29ca97f]
-  - @scalar/api-client@2.2.12
-  - @scalar/import@0.2.7
-  - @scalar/themes@0.9.55
-  - @scalar/components@0.13.5
-
 ## 0.1.105
 
 ### Patch Changes

--- a/packages/scalar-app/package.json
+++ b/packages/scalar-app/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/scalar-app"
   },
-  "version": "0.1.106",
+  "version": "0.1.105",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/packages/scalar.aspnetcore/CHANGELOG.md
+++ b/packages/scalar.aspnetcore/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @scalar/aspnetcore
 
-## 1.2.54
-
-### Patch Changes
-
-- Updated dependencies [60feddf]
-- Updated dependencies [56c1981]
-- Updated dependencies [1766efb]
-- Updated dependencies [29ca97f]
-- Updated dependencies [6852aca]
-  - @scalar/api-reference@1.25.81
-
 ## 1.2.53
 
 ### Patch Changes

--- a/packages/scalar.aspnetcore/package.json
+++ b/packages/scalar.aspnetcore/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/scalar.aspnetcore"
   },
-  "version": "1.2.54",
+  "version": "1.2.53",
   "private": true,
   "engines": {
     "node": ">=18"

--- a/packages/snippetz/CHANGELOG.md
+++ b/packages/snippetz/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/snippetz
 
-## 0.2.9
-
-### Patch Changes
-
-- 6852aca: chore: remove httpsnippet-lite
-
 ## 0.2.8
 
 ### Patch Changes

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/snippetz"
   },
-  "version": "0.2.9",
+  "version": "0.2.8",
   "engines": {
     "node": ">=18"
   },

--- a/packages/themes/CHANGELOG.md
+++ b/packages/themes/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/themes
 
-## 0.9.55
-
-### Patch Changes
-
-- Updated dependencies [6852aca]
-  - @scalar/types@0.0.24
-
 ## 0.9.54
 
 ### Patch Changes

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -15,7 +15,7 @@
     "css-variables",
     "scalar"
   ],
-  "version": "0.9.55",
+  "version": "0.9.54",
   "engines": {
     "node": ">=18"
   },

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/types
 
-## 0.0.24
-
-### Patch Changes
-
-- 6852aca: chore: remove httpsnippet-lite
-
 ## 0.0.23
 
 ### Patch Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,7 @@
     "scalar",
     "references"
   ],
-  "version": "0.0.24",
+  "version": "0.0.23",
   "engines": {
     "node": ">=18"
   },

--- a/packages/use-codemirror/CHANGELOG.md
+++ b/packages/use-codemirror/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/use-codemirror
 
-## 0.11.49
-
-### Patch Changes
-
-- @scalar/components@0.13.5
-
 ## 0.11.48
 
 ### Patch Changes

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -16,7 +16,7 @@
     "vue",
     "vue3"
   ],
-  "version": "0.11.49",
+  "version": "0.11.48",
   "engines": {
     "node": ">=18"
   },

--- a/packages/use-hooks/CHANGELOG.md
+++ b/packages/use-hooks/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/use-hooks
 
-## 0.1.8
-
-### Patch Changes
-
-- @scalar/themes@0.9.55
-
 ## 0.1.7
 
 ### Patch Changes

--- a/packages/use-hooks/package.json
+++ b/packages/use-hooks/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/scalar/scalar.git",
     "directory": "packages/use-hooks"
   },
-  "version": "0.1.8",
+  "version": "0.1.7",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
This release didn’t pass the build stage. We need to revert, to run it again.

Reverts scalar/scalar#4181