### PR TITLE
fix(api-reference): Incorrect prefix

### DIFF
--- a/.changeset/tiny-turkeys-thank.md
+++ b/.changeset/tiny-turkeys-thank.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Removes hardcoded test prefix

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -107,11 +107,9 @@ const {
   isIntersectionEnabled,
   pathRouting,
   updateHash,
-  setHashPrefix,
   replaceUrlState,
 } = useNavState()
 
-setHashPrefix('some/prefix/is-good/')
 pathRouting.value = props.configuration.pathRouting
 
 // Ideally this triggers absolutely first on the client so we can set hash value


### PR DESCRIPTION
Hotfix for hardocoded test prefix