### PR TITLE
chore: use composite build action instead of pnpm script

### DIFF
--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -25,7 +25,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
       - name: Build packages
-        run: pnpm build:packages
+        uses: ./.github/actions/build
+        with:
+          packages-only: true
+          node-version: ${{ matrix.node-version }}
       - name: Get Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -24,18 +24,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Restore Turborepo cache
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build packages
         run: pnpm build:packages
       - name: Get Playwright version

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -17,20 +17,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+      - name: Build
+        uses: ./.github/actions/build
         with:
+          packages-only: true
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Restore Turborepo cache
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
-      - name: Build packages
-        run: pnpm build:packages
       - name: Get Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-      - name: Build
+      - name: Build packages
         uses: ./.github/actions/build
         with:
           packages-only: true

--- a/.github/workflows/test-electron-app.yml
+++ b/.github/workflows/test-electron-app.yml
@@ -21,20 +21,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+      - name: Build
+        uses: ./.github/actions/build
         with:
+          packages-only: true
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Turborepo cache
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
-      - name: Build packages
-        run: pnpm build:packages
       - name: Get Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-electron-app.yml
+++ b/.github/workflows/test-electron-app.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-      - name: Build
+      - name: Build packages
         uses: ./.github/actions/build
         with:
           packages-only: true

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -17,20 +17,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+      - name: Build
+        uses: ./.github/actions/build
         with:
+          packages-only: true
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Restore Turborepo cache
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
-      - name: Build packages
-        run: pnpm build:packages
       - name: Get Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -20,20 +20,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+      - name: Build
+        uses: ./.github/actions/build
         with:
+          packages-only: true
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Restore Turborepo cache
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
-      - name: Build packages
-        run: pnpm build:packages
       - name: Format OpenAPI File
         run: pnpm @scalar/cli format ../../packages/galaxy/src/specifications/3.1.yaml
       - name: Validate OpenAPI File

--- a/.github/workflows/validate-openapi-file.yml
+++ b/.github/workflows/validate-openapi-file.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-      - name: Build
+      - name: Build packages
         uses: ./.github/actions/build
         with:
           packages-only: true


### PR DESCRIPTION
With this PR, workflows use the composite build action for building packages. 
