### PR TITLE
fix: content `null` throws an error

### DIFF
--- a/.changeset/brave-grapes-march.md
+++ b/.changeset/brave-grapes-march.md
@@ -1,0 +1,5 @@
+---
+'@scalar/types': patch
+---
+
+chore: improve the comment for UnknownObject

--- a/.changeset/silent-dingos-hide.md
+++ b/.changeset/silent-dingos-hide.md
@@ -1,5 +1,0 @@
----
-'@scalar/openapi-parser': patch
----
-
-feat: better deal with empty OpenAPI documents

--- a/.changeset/silent-dingos-hide.md
+++ b/.changeset/silent-dingos-hide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+feat: better deal with empty OpenAPI documents

--- a/.changeset/tough-buttons-begin.md
+++ b/.changeset/tough-buttons-begin.md
@@ -1,0 +1,7 @@
+---
+'@scalar/openapi-parser': patch
+'@scalar/api-reference': patch
+'@scalar/oas-utils': patch
+---
+
+feat: better deal with empty OpenAPI documents

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -17,13 +17,19 @@ import type {
   OpenAPIV3_1,
 } from '@scalar/openapi-types'
 import type { Spec } from '@scalar/types/legacy'
+import type { UnknownObject } from '@scalar/types/utils'
 
 import { createEmptySpecification } from '../helpers'
 
 type AnyObject = Record<string, any>
 
+/**
+ * Parse the given specification and return a super custom transformed specification.
+ *
+ * @deprecated Try to use a store instead.
+ */
 export const parse = (
-  specification: any,
+  specification: UnknownObject | string,
   {
     proxyUrl,
   }: {
@@ -96,7 +102,7 @@ const transformResult = (originalSchema: OpenAPI.Document): Spec => {
   if (originalSchema && typeof originalSchema === 'object') {
     schema = structuredClone(originalSchema)
   } else {
-    schema = createEmptySpecification() as AnyObject
+    schema = createEmptySpecification() as OpenAPI.Document
   }
 
   // Create empty tags array

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -150,18 +150,6 @@ const transformResult = (originalSchema: OpenAPI.Document): Spec => {
           ...originalWebhook,
         },
       }
-
-      // Object.assign(
-      //   (schema).webhooks?.[name]?.[httpVerb] ?? {},
-      //   {},
-      // )
-      // Object.assign(
-      //   (schema).webhooks?.[name]?.[httpVerb] ?? {},
-      //   {},
-      // )
-      // information: {
-      //   ...(schema).webhooks?.[name],
-      // },
     })
   })
 

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -29,7 +29,7 @@ type AnyObject = Record<string, any>
  * @deprecated Try to use a store instead.
  */
 export const parse = (
-  specification: UnknownObject | string,
+  specification: UnknownObject | string | undefined,
   {
     proxyUrl,
   }: {

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -122,8 +122,9 @@ if (!specUrlElement && !specElement && !getSpecScriptTag()) {
       _integration: 'html',
       proxyUrl: getProxyUrl(),
       ...getConfiguration(),
-      spec: { ...specOrSpecUrl },
-    },
+      // spec: { ...specOrSpecUrl },
+      spec: { content: null },
+    } satisfies ReferenceConfiguration,
   })
 
   if (getConfiguration().darkMode) {

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -122,8 +122,7 @@ if (!specUrlElement && !specElement && !getSpecScriptTag()) {
       _integration: 'html',
       proxyUrl: getProxyUrl(),
       ...getConfiguration(),
-      // spec: { ...specOrSpecUrl },
-      spec: { content: null },
+      spec: { ...specOrSpecUrl },
     } satisfies ReferenceConfiguration,
   })
 

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -50,7 +50,8 @@
   "dependencies": {
     "@nuxt/kit": "^3.12.3",
     "@scalar/api-client": "workspace:*",
-    "@scalar/api-reference": "workspace:*"
+    "@scalar/api-reference": "workspace:*",
+    "@scalar/types": "workspace:*"
   },
   "devDependencies": {
     "@nuxt/devtools": "^1.3.9",

--- a/packages/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/packages/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -1,12 +1,10 @@
 <script lang="ts" setup>
 import { useHead, useRequestURL, useSeoMeta } from '#imports'
-import {
-  ModernLayout,
-  type ReferenceConfiguration,
-  parse,
-} from '@scalar/api-reference'
+import { ModernLayout, parse } from '@scalar/api-reference'
 import { reactive, ref, toRaw } from 'vue'
 import type { Configuration } from '~/src/types'
+
+import type { ReferenceConfiguration } from '../../../../types/dist/legacy/reference-config'
 
 const props = defineProps<{
   configuration: Configuration

--- a/packages/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/packages/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -1,10 +1,9 @@
 <script lang="ts" setup>
 import { useHead, useRequestURL, useSeoMeta } from '#imports'
 import { ModernLayout, parse } from '@scalar/api-reference'
+import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import { reactive, ref, toRaw } from 'vue'
 import type { Configuration } from '~/src/types'
-
-import type { ReferenceConfiguration } from '../../../../types/dist/legacy/reference-config'
 
 const props = defineProps<{
   configuration: Configuration

--- a/packages/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/packages/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -12,11 +12,14 @@ const props = defineProps<{
 const isDark = ref(props.configuration.darkMode)
 
 // Grab spec if we can
-const content: unknown = props.configuration.spec?.content
-  ? toRaw(props.configuration.spec.content)
-  : props.configuration.spec?.url
-    ? await $fetch(props.configuration.spec?.url)
-    : await $fetch('/_nitro/openapi.json')
+const content =
+  typeof props.configuration.spec?.content === 'function'
+    ? toRaw(props.configuration.spec.content())
+    : props.configuration.spec?.content
+      ? toRaw(props.configuration.spec.content)
+      : props.configuration.spec?.url
+        ? await $fetch<string>(props.configuration.spec?.url)
+        : await $fetch<string>('/_nitro/openapi.json')
 
 // Check for empty spec
 if (!content)

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -38,13 +38,21 @@ export const parseSchema = async (
   spec: string | UnknownObject,
   { shouldLoad = true } = {},
 ) => {
-  // TODO: Plugins for URLs and files with the proxy is missing here.
-  // @see packages/api-reference/src/helpers/parse.ts
+  if (spec === null || (typeof spec === 'string' && spec.trim() === '')) {
+    console.warn('[@scalar/oas-utils] Empty OpenAPI document provided.')
+
+    return {
+      schema: {} as OpenAPIV3.Document | OpenAPIV3_1.Document,
+      errors: [],
+    }
+  }
 
   let filesystem: LoadResult['filesystem'] | string | UnknownObject = spec
   let loadErrors: LoadResult['errors'] = []
 
   if (shouldLoad) {
+    // TODO: Plugins for URLs and files with the proxy is missing here.
+    // @see packages/api-reference/src/helpers/parse.ts
     const resp = await load(spec).catch((e) => ({
       errors: [
         {

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -72,6 +72,7 @@
     "@google-cloud/storage": "^7.12.1",
     "@scalar/build-tooling": "workspace:*",
     "@scalar/openapi-types": "workspace:*",
+    "@scalar/types": "workspace:*",
     "@types/node": "^20.14.10",
     "glob": "^10.3.10",
     "json-to-ast": "^2.1.0",

--- a/packages/openapi-parser/src/types/index.ts
+++ b/packages/openapi-parser/src/types/index.ts
@@ -10,6 +10,8 @@ export type Merge<A, B> = A & Omit<B, keyof A>
 
 export type AnyObject = Record<string, any>
 
+export type UnknownObject = Record<string, unknown>
+
 /**
  * JSON, YAML or object representation of an OpenAPI API definition
  */

--- a/packages/openapi-parser/src/types/index.ts
+++ b/packages/openapi-parser/src/types/index.ts
@@ -10,8 +10,6 @@ export type Merge<A, B> = A & Omit<B, keyof A>
 
 export type AnyObject = Record<string, any>
 
-export type UnknownObject = Record<string, unknown>
-
 /**
  * JSON, YAML or object representation of an OpenAPI API definition
  */

--- a/packages/openapi-parser/src/utils/details.ts
+++ b/packages/openapi-parser/src/utils/details.ts
@@ -1,10 +1,18 @@
 import { OpenApiVersions } from '../configuration'
-import type { AnyObject, DetailsResult } from '../types'
+import type { DetailsResult, UnknownObject } from '../types'
 
 /**
  * Get versions of the OpenAPI document.
  */
-export function details(specification: AnyObject): DetailsResult {
+export function details(specification: UnknownObject): DetailsResult {
+  if (specification === null) {
+    return {
+      version: undefined,
+      specificationType: undefined,
+      specificationVersion: undefined,
+    }
+  }
+
   for (const version of new Set(OpenApiVersions)) {
     const specificationType = version === '2.0' ? 'swagger' : 'openapi'
     const value = specification[specificationType]

--- a/packages/openapi-parser/src/utils/details.ts
+++ b/packages/openapi-parser/src/utils/details.ts
@@ -1,5 +1,7 @@
+import type { UnknownObject } from '@scalar/types/utils'
+
 import { OpenApiVersions } from '../configuration'
-import type { DetailsResult, UnknownObject } from '../types'
+import type { DetailsResult } from '../types'
 
 /**
  * Get versions of the OpenAPI document.

--- a/packages/openapi-parser/src/utils/normalize.test.ts
+++ b/packages/openapi-parser/src/utils/normalize.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalize } from './normalize'
+
+describe('normalize', () => {
+  it('should return an empty object if the specification is null', () => {
+    expect(normalize(null)).toEqual({})
+  })
+
+  it('should return the same filesystem if the specification is already a filesystem', () => {
+    const filesystem = [
+      {
+        isEntrypoint: true,
+        specification: {},
+        filename: null,
+        dir: './',
+        references: [],
+      },
+    ]
+    expect(normalize(filesystem)).toBe(filesystem)
+  })
+
+  it('should parse JSON string specifications', () => {
+    const jsonString = '{"foo": "bar"}'
+    expect(normalize(jsonString)).toEqual({ foo: 'bar' })
+  })
+
+  it('should parse YAML string specifications', () => {
+    const yamlString = 'foo: bar'
+    expect(normalize(yamlString)).toEqual({ foo: 'bar' })
+  })
+
+  it('should handle invalid YAML with custom maxAliasCount', () => {
+    const yamlString = `
+      aliases: &ref
+        - item1
+        - item2
+      items: *ref
+    `
+    expect(() => normalize(yamlString)).not.toThrow()
+  })
+
+  it('should return the same object if specification is already an object', () => {
+    const obj = { foo: 'bar' }
+    expect(normalize(obj)).toBe(obj)
+  })
+
+  it('should handle malformed JSON strings by falling back to YAML parsing', () => {
+    const malformedJson = '{ foo: "bar" }' // Missing quotes around property name
+    expect(normalize(malformedJson)).toEqual({ foo: 'bar' })
+  })
+
+  it('should handle empty string input', () => {
+    expect(normalize('')).toEqual({})
+  })
+
+  it('should handle whitespace-only string input', () => {
+    expect(normalize('   ')).toEqual({})
+  })
+
+  it('should handle complex nested structures', () => {
+    const complex = {
+      nested: {
+        array: [1, 2, 3],
+        object: {
+          foo: 'bar',
+        },
+      },
+    }
+    expect(normalize(complex)).toEqual(complex)
+  })
+
+  it('should handle invalid JSON and YAML strings gracefully', () => {
+    const invalidString = 'not a valid json or yaml'
+    expect(() => normalize(invalidString)).not.toThrow()
+  })
+
+  it('should handle non-string, non-object inputs', () => {
+    // @ts-expect-error testing bad input
+    expect(normalize(42)).toEqual(42)
+    // @ts-expect-error testing bad input
+    expect(normalize(true)).toEqual(true)
+    // @ts-expect-error testing bad input
+    expect(normalize([1, 2, 3])).toEqual([1, 2, 3])
+  })
+
+  it('should handle deeply nested structures', () => {
+    const nested = { a: { b: { c: { d: { e: 'deep' } } } } }
+    expect(normalize(nested)).toEqual(nested)
+  })
+
+  it('should handle large input strings', () => {
+    const largeJson = JSON.stringify({ foo: 'bar'.repeat(10000) })
+    expect(normalize(largeJson)).toEqual({ foo: 'bar'.repeat(10000) })
+  })
+
+  it('should handle circular references', () => {
+    const circularObj: any = {}
+    circularObj.self = circularObj
+    expect(() => normalize(circularObj)).not.toThrow()
+  })
+
+  it('should handle special characters in strings', () => {
+    const specialCharJson = '{"foo": "bar\\n"}'
+    expect(normalize(specialCharJson)).toEqual({ foo: 'bar\n' })
+  })
+})

--- a/packages/openapi-parser/src/utils/normalize.ts
+++ b/packages/openapi-parser/src/utils/normalize.ts
@@ -1,6 +1,7 @@
+import type { UnknownObject } from '@scalar/types/utils'
 import { parse } from 'yaml'
 
-import type { AnyObject, Filesystem } from '../types'
+import type { Filesystem } from '../types'
 import { isFilesystem } from './isFilesystem'
 
 /**
@@ -9,13 +10,17 @@ import { isFilesystem } from './isFilesystem'
  * Doesn’t modify the object if it’s a `Filesystem` (multiple files) already.
  */
 export function normalize(
-  specification: string | AnyObject | Filesystem,
-): AnyObject | Filesystem {
-  if (isFilesystem(specification)) {
-    return specification as Filesystem
+  specification: string | UnknownObject | Filesystem,
+): UnknownObject | Filesystem {
+  if (specification === null) {
+    return {}
   }
 
   if (typeof specification === 'string') {
+    if (specification.trim() === '') {
+      return {}
+    }
+
     try {
       return JSON.parse(specification)
     } catch (error) {
@@ -23,6 +28,10 @@ export function normalize(
         maxAliasCount: 10000,
       })
     }
+  }
+
+  if (isFilesystem(specification)) {
+    return specification as Filesystem
   }
 
   return specification

--- a/packages/openapi-parser/src/utils/upgrade.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade.test.ts
@@ -63,6 +63,6 @@ describe('upgrade', () => {
   it('deals with null', async () => {
     const { specification } = upgrade(null)
 
-    expect(specification).toBe(null)
+    expect(specification).toStrictEqual({})
   })
 })

--- a/packages/openapi-parser/src/utils/upgrade.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade.test.ts
@@ -63,6 +63,6 @@ describe('upgrade', () => {
   it('deals with null', async () => {
     const { specification } = upgrade(null)
 
-    expect(specification).toStrictEqual({})
+    expect(specification).toStrictEqual(null)
   })
 })

--- a/packages/openapi-parser/src/utils/upgrade.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade.test.ts
@@ -59,4 +59,10 @@ describe('upgrade', () => {
 
     expect(specification.openapi).toBe('3.1.1')
   })
+
+  it('deals with null', async () => {
+    const { specification } = upgrade(null)
+
+    expect(specification).toBe(null)
+  })
 })

--- a/packages/openapi-parser/src/utils/upgrade.ts
+++ b/packages/openapi-parser/src/utils/upgrade.ts
@@ -12,6 +12,12 @@ import { upgradeFromTwoToThree } from './upgradeFromTwoToThree'
 export function upgrade(
   value: string | AnyObject | Filesystem,
 ): UpgradeResult<OpenAPIV3_1.Document> {
+  if (!value) {
+    return {
+      specification: null,
+      version: '3.1',
+    }
+  }
   const upgraders = [upgradeFromTwoToThree, upgradeFromThreeToThreeOne]
 
   // TODO: Run upgrade over the whole filesystem

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -1,9 +1,10 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { UnknownObject } from '@scalar/types/utils'
 
 import { traverse } from './traverse'
 
 /**
- * Upgrade from OpenAPI 3.0.x to 3.1.0
+ * Upgrade from OpenAPI 3.0.x to 3.1.1
  *
  * https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0
  */
@@ -121,7 +122,7 @@ export function upgradeFromThreeToThreeOne(
   //   specification.$schema = 'http://json-schema.org/draft-07/schema#'
   // }
 
-  return specification
+  return specification as OpenAPIV3_1.Document
 }
 
 /** Determine if the current path is within a schema */

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -1,4 +1,5 @@
-import type { AnyObject } from '../types'
+import type { UnknownObject } from '@scalar/types/utils'
+
 import { traverse } from './traverse'
 
 /**
@@ -6,11 +7,17 @@ import { traverse } from './traverse'
  *
  * https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0
  */
-export function upgradeFromThreeToThreeOne(originalSpecification: AnyObject) {
+export function upgradeFromThreeToThreeOne(
+  originalSpecification: UnknownObject,
+) {
   let specification = originalSpecification
 
   // Version
-  if (specification.openapi?.startsWith('3.0')) {
+  if (
+    specification !== null &&
+    typeof specification.openapi === 'string' &&
+    specification.openapi.startsWith('3.0')
+  ) {
     specification.openapi = '3.1.1'
   } else {
     // Skip if it’s something else than 3.0.x

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -69,6 +69,7 @@ describe('upgradeFromTwoToThree', () => {
       },
     })
 
+    // @ts-expect-error it’s fine
     expect(result.components?.schemas).toStrictEqual({
       Category: {
         type: 'object',
@@ -430,6 +431,7 @@ describe('upgradeFromTwoToThree', () => {
 
     const result = upgradeFromTwoToThree(input)
 
+    // @ts-expect-error it’s fine
     expect(result.components.securitySchemes).toStrictEqual({
       api_key: {
         type: 'apiKey',

--- a/packages/openapi-parser/src/utils/validate.test.ts
+++ b/packages/openapi-parser/src/utils/validate.test.ts
@@ -74,8 +74,6 @@ paths: {}
       await validate(undefined, {
         throwOnError: true,
       })
-    }).rejects.toThrowError(
-      'Can’t find supported Swagger/OpenAPI version in specification, version must be a string.',
-    )
+    }).rejects.toThrowError('Can’t find JSON, YAML or filename in data')
   })
 })

--- a/packages/openapi-parser/src/utils/validate.test.ts
+++ b/packages/openapi-parser/src/utils/validate.test.ts
@@ -9,7 +9,8 @@ describe('validate', async () => {
     expect(result.valid).toBe(false)
     expect(result.errors).toMatchObject([
       {
-        message: 'Can’t find JSON, YAML or filename in data',
+        message:
+          'Can’t find supported Swagger/OpenAPI version in specification, version must be a string.',
       },
     ])
   })
@@ -73,6 +74,8 @@ paths: {}
       await validate(undefined, {
         throwOnError: true,
       })
-    }).rejects.toThrowError('Can’t find JSON, YAML or filename in data')
+    }).rejects.toThrowError(
+      'Can’t find supported Swagger/OpenAPI version in specification, version must be a string.',
+    )
   })
 })

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -397,7 +397,7 @@ export type SpecConfiguration = {
    *
    * @remark It’s recommended to pass an `url` instead of `content`.
    */
-  content?: string | Record<string, any> | (() => Record<string, any>)
+  content?: string | Record<string, any> | (() => Record<string, any>) | null
 }
 
 export type Schema = {

--- a/packages/types/src/utils/utility-types.ts
+++ b/packages/types/src/utils/utility-types.ts
@@ -1,4 +1,5 @@
 /**
- * When the object values are unknown
+ * Represents an object with string keys and unknown values.
+ * Useful for handling objects with dynamic or unknown value types.
  */
 export type UnknownObject = Record<string, unknown>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: 12.3.2(typescript@5.6.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
+        version: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -1833,6 +1833,9 @@ importers:
       '@scalar/openapi-types':
         specifier: workspace:*
         version: link:../openapi-types
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/node':
         specifier: ^20.14.10
         version: 20.14.10
@@ -31920,7 +31923,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.10
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -34732,7 +34735,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
 
   postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)):
     dependencies:
@@ -34740,7 +34743,7 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2)
 
   postcss-load-config@5.1.0(jiti@2.4.0)(postcss@8.4.39)(tsx@4.19.1):
     dependencies:
@@ -37545,7 +37548,7 @@ snapshots:
       '@swc/core': 1.5.29(@swc/helpers@0.5.5)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.5))(@types/node@20.14.10)(typescript@5.6.2):
+  ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.14.10)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1694,6 +1694,9 @@ importers:
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../api-reference
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       '@nuxt/devtools':
         specifier: ^1.3.9


### PR DESCRIPTION
When passing `null` (or an empty string) as the content, errors are thrown.

![Screenshot 2024-12-13 at 22 03 56](https://github.com/user-attachments/assets/1b317d96-b85e-4750-a46c-8366a63deafb)

This PR fixes it in multiple places to improve the handling for various use cases.

**@scalar/openapi-parser**

* `normalize()` returns `{}` for empty OpenAPI documents
* added tests for the `normalize()` utility, can’t believe we didn’t had any
* `upgrade()` (and the specific upgrade helpers) deal with empty content
* `details()` utility handles empty content
* replaced some uses of `AnyObject` with `UnknownObject` and fixed TS issues

**@scalar/oas-utils**

* skip the parser for empty content, add a console.warning

**@scalar/types**

* explicitly allow `null` in the `SpecConfiguration`

**@scalar/api-reference**

* Slightly improve the types in the horrible `parse` helper

**@scalar/nuxt**

* import `ReferenceConfig` from `@scalar/types` instead of `@scalar/api-reference`

```diff
-  specification: any,
+  specification: UnknownObject | string | undefined,
```