### PR TITLE
chore: make repository url full git url

### DIFF
--- a/examples/cdn-api-reference/package.json
+++ b/examples/cdn-api-reference/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/cdn-api-reference"
   },
   "version": "0.1.0",

--- a/examples/docusaurus/package.json
+++ b/examples/docusaurus/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/docusaurus"
   },
   "version": "0.0.0",

--- a/examples/express-api-reference/package.json
+++ b/examples/express-api-reference/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/express-api-reference"
   },
   "version": "0.1.0",

--- a/examples/fastify-api-reference/package.json
+++ b/examples/fastify-api-reference/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/fastify-api-reference"
   },
   "version": "0.5.2",

--- a/examples/nestjs-api-reference-express/package.json
+++ b/examples/nestjs-api-reference-express/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/nestjs-api-reference-express"
   },
   "version": "1.0.0",

--- a/examples/nestjs-api-reference-fastify/package.json
+++ b/examples/nestjs-api-reference-fastify/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/nestjs-api-reference-fastify"
   },
   "version": "1.0.0",

--- a/examples/nextjs-api-reference/package.json
+++ b/examples/nextjs-api-reference/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/nextjs-api-reference"
   },
   "version": "0.1.0",

--- a/examples/proxy-server/package.json
+++ b/examples/proxy-server/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/proxy-server"
   },
   "keywords": [

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/react"
   },
   "version": "0.0.0",

--- a/examples/ssg/package.json
+++ b/examples/ssg/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/ssg"
   },
   "version": "0.1.0",

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "examples/web"
   },
   "version": "0.4.2",

--- a/packages/api-client-proxy/package.json
+++ b/packages/api-client-proxy/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/api-client-proxy"
   },
   "keywords": [

--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/api-client-react"
   },
   "keywords": [

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/api-client"
   },
   "keywords": [

--- a/packages/api-reference-editor/package.json
+++ b/packages/api-reference-editor/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/api-reference-editor"
   },
   "keywords": [

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/api-reference-react"
   },
   "keywords": [

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/api-reference"
   },
   "keywords": [

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/build-tooling"
   },
   "keywords": [],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/cli"
   },
   "keywords": [

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/code-highlight"
   },
   "keywords": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/components"
   },
   "version": "0.13.5",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/config"
   },
   "keywords": [],

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/docusaurus"
   },
   "keywords": [

--- a/packages/draggable/package.json
+++ b/packages/draggable/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/draggable"
   },
   "keywords": [

--- a/packages/echo-server/package.json
+++ b/packages/echo-server/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/echo-server"
   },
   "keywords": [

--- a/packages/express-api-reference/package.json
+++ b/packages/express-api-reference/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/express-api-reference"
   },
   "version": "0.4.172",

--- a/packages/fastify-api-reference/package.json
+++ b/packages/fastify-api-reference/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/fastify-api-reference"
   },
   "keywords": [

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/fetch"
   },
   "keywords": [],

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/galaxy"
   },
   "keywords": [

--- a/packages/hono-api-reference/package.json
+++ b/packages/hono-api-reference/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/hono-api-reference"
   },
   "version": "0.5.164",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/icons"
   },
   "version": "0.1.2",

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/import"
   },
   "keywords": [

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/mock-server"
   },
   "keywords": [

--- a/packages/nestjs-api-reference/package.json
+++ b/packages/nestjs-api-reference/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/nestjs-api-reference"
   },
   "version": "0.3.173",

--- a/packages/nextjs-api-reference/package.json
+++ b/packages/nextjs-api-reference/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/nextjs-api-reference"
   },
   "keywords": [

--- a/packages/nextjs-openapi/package.json
+++ b/packages/nextjs-openapi/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/nextjs-openapi"
   },
   "keywords": [

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/nuxt"
   },
   "keywords": [

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/oas-utils"
   },
   "keywords": [

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/object-utils"
   },
   "keywords": [

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/openapi-parser"
   },
   "keywords": [

--- a/packages/openapi-types/package.json
+++ b/packages/openapi-types/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/openapi-types"
   },
   "keywords": [

--- a/packages/play-button/package.json
+++ b/packages/play-button/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/play-button"
   },
   "keywords": [

--- a/packages/postman-to-openapi/package.json
+++ b/packages/postman-to-openapi/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/postman-to-openapi"
   },
   "keywords": [

--- a/packages/scalar-app/package.json
+++ b/packages/scalar-app/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/scalar-app"
   },
   "version": "0.1.106",

--- a/packages/scalar.aspnetcore/package.json
+++ b/packages/scalar.aspnetcore/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/scalar.aspnetcore"
   },
   "version": "1.2.55",

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/snippetz"
   },
   "version": "0.2.9",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/themes"
   },
   "keywords": [

--- a/packages/ts-to-openapi/package.json
+++ b/packages/ts-to-openapi/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/ts-to-openapi"
   },
   "keywords": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/types"
   },
   "keywords": [

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/use-codemirror"
   },
   "keywords": [

--- a/packages/use-hooks/package.json
+++ b/packages/use-hooks/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/use-hooks"
   },
   "version": "0.1.8",

--- a/packages/use-toasts/package.json
+++ b/packages/use-toasts/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/use-toasts"
   },
   "keywords": [

--- a/packages/use-tooltip/package.json
+++ b/packages/use-tooltip/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/use-tooltip"
   },
   "keywords": [

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalar/scalar.git",
+    "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/void-server"
   },
   "keywords": [

--- a/scripts/format-package.ts
+++ b/scripts/format-package.ts
@@ -126,7 +126,7 @@ async function formatPackage(filepath: string) {
 
   formattedData['repository'] = {
     type: 'git',
-    url: 'https://github.com/scalar/scalar.git',
+    url: 'git+https://github.com/scalar/scalar.git',
     directory,
   }
 


### PR DESCRIPTION
> GitHub or GitLab links should be prefixed with `git+` and postfixed with `.git`. (This is also warned by npm when publishing a package).

https://publint.dev/rules#invalid_repository_value