### PR TITLE
fix(Scalar.AspNetCore): typo in ScalarTarget.JavaScript

### DIFF
--- a/.changeset/odd-kids-confess.md
+++ b/.changeset/odd-kids-confess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+fix: Typo in ScalarTarget.JavaScript

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTarget.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTarget.cs
@@ -48,7 +48,7 @@ public enum ScalarTarget
     /// <summary>
     /// JavaScript programming language.
     /// </summary>
-    [Description("javascript")]
+    [Description("js")]
     JavaScript,
 
     /// <summary>


### PR DESCRIPTION
This PR fixes a small typo in the `ScalarTarget.JavaScript` enum by changing the description from `JavaScript` to `js`.

Closes #4223