### PR TITLE
fix(api-reference): SSG build is broken

### DIFF
--- a/.changeset/shaggy-moons-accept.md
+++ b/.changeset/shaggy-moons-accept.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/use-hooks': patch
+---
+
+feat: make it work in SSG environments

--- a/.changeset/twelve-ducks-matter.md
+++ b/.changeset/twelve-ducks-matter.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: remove RenderedReference export

--- a/examples/ssg/src/App.vue
+++ b/examples/ssg/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ApiReference } from '@scalar/api-reference'
+import '@scalar/api-reference/style.css'
 </script>
 
 <template>

--- a/examples/ssg/src/App.vue
+++ b/examples/ssg/src/App.vue
@@ -1,41 +1,14 @@
 <script setup lang="ts">
-import { RenderedReference, Sidebar } from '@scalar/api-reference'
-import type { Spec } from '@scalar/types/legacy'
-import { reactive } from 'vue'
-
-const reactiveSpec = reactive<Spec>({
-  info: {
-    title: '',
-    description: '',
-    termsOfService: '',
-    version: '',
-    license: {
-      name: '',
-      url: '',
-    },
-    contact: {
-      email: '',
-    },
-  },
-  externalDocs: {
-    description: '',
-    url: '',
-  },
-  servers: [],
-  tags: [],
-})
+import { ApiReference } from '@scalar/api-reference'
 </script>
 
 <template>
   <div>
-    <Sidebar
-      :isDarkMode="true"
-      :parsedSpec="reactiveSpec"
-      @toggleDarkMode="() => {}" />
-    <RenderedReference
-      class="references-rendered"
-      :parsedSpec="reactiveSpec"
-      :rawSpec="''"
-      :ready="true" />
+    <ApiReference
+      :configuration="{
+        spec: {
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+        },
+      }" />
   </div>
 </template>

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -144,12 +144,17 @@ export const createWorkspaceStore = ({
     importSpecFileFactory(storeContext)
 
   /** Helper function to manage the sidebar width */
-  const sidebarWidth = ref(localStorage.getItem('sidebarWidth') || '280px')
+  const sidebarWidth = ref(
+    (useLocalStorage ? localStorage?.getItem('sidebarWidth') : undefined) ||
+      '280px',
+  )
 
   // Set the sidebar width
   const setSidebarWidth = (width: string) => {
     sidebarWidth.value = width
-    localStorage.setItem('sidebarWidth', width)
+    if (useLocalStorage) {
+      localStorage?.setItem('sidebarWidth', width)
+    }
   }
 
   /** This state is to be used by the API Client Modal component to control the modal */

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -167,19 +167,21 @@ export const createWorkspaceStore = ({
   })
 
   /**
-   * For development, expose this method for debugging our data stores
+   * For debugging purposes, expose this method for dumping the data stores
    */
-  window.dataDump = () => ({
-    collections: toRaw(collections),
-    cookies: toRaw(cookies),
-    environments: toRaw(environments),
-    requestExamples: toRaw(requestExamples),
-    requests: toRaw(requests),
-    securitySchemes: toRaw(securitySchemes),
-    servers: toRaw(servers),
-    tags: toRaw(tags),
-    workspaces: toRaw(workspaces),
-  })
+  if (typeof window !== 'undefined') {
+    window.dataDump = () => ({
+      collections: toRaw(collections),
+      cookies: toRaw(cookies),
+      environments: toRaw(environments),
+      requestExamples: toRaw(requestExamples),
+      requests: toRaw(requests),
+      securitySchemes: toRaw(securitySchemes),
+      servers: toRaw(servers),
+      tags: toRaw(tags),
+      workspaces: toRaw(workspaces),
+    })
+  }
 
   // ---------------------------------------------------------------------------
   // Events Busses

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -33,8 +33,6 @@ const customCss = computed(() => {
   return migrateThemeVariables(props.configuration?.customCss)
 })
 
-watch(customCss, () => console.log(customCss.value))
-
 // Set defaults as needed on the provided configuration
 const configuration = computed<ReferenceConfiguration>(() => ({
   spec: {

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -424,8 +424,6 @@ const themeStyleTag = computed(
           name="footer" />
       </div>
     </template>
-    <!-- REST API Client Overlay -->
-    <!-- Fonts are fetched by @scalar/api-reference already, we can safely set `withDefaultFonts: false` -->
     <ApiClientModal :configuration="configuration" />
   </div>
   <ScalarToasts />

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -155,7 +155,6 @@ onMounted(() => {
 
   // This is what updates the hash ref from hash changes
   window.onhashchange = () => {
-    console.log('CHANGED TO: ', getReferenceHash())
     scrollToSection(getReferenceHash())
   }
   // Handle back for path routing

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -1,7 +1,6 @@
 export { default as ApiReference } from './components/ApiReference.vue'
 export { default as ApiReferenceLayout } from './components/ApiReferenceLayout.vue'
 export { default as ModernLayout } from './components/Layouts/ModernLayout.vue'
-export { default as RenderedReference } from './components/Content/Content.vue'
 export * from './features/Search'
 export { default as GettingStarted } from './components/GettingStarted.vue'
 export { createScalarReferences } from './esm'

--- a/packages/use-hooks/src/useBreakpoints/useBreakpoints.test.ts
+++ b/packages/use-hooks/src/useBreakpoints/useBreakpoints.test.ts
@@ -55,4 +55,37 @@ describe('useBreakpoints', () => {
 
     expect(breakpoints.value.md).toEqual(true)
   })
+
+  it('works in SSG environment without window', () => {
+    const originalWindow = global.window
+
+    // Mock SSG environment by removing window
+    // @ts-expect-error
+    delete global.window
+
+    // Mock useMediaQuery to return false since there’s no window
+    vi.mocked(useMediaQuery).mockImplementation(() => ref(false))
+
+    const {
+      screens: exposedScreens,
+      mediaQueries,
+      breakpoints,
+    } = useBreakpoints()
+
+    // Screens should still be exposed since they’re static
+    expect(exposedScreens).toEqual(screens)
+
+    // Media queries should all be false without window
+    Object.values(mediaQueries).forEach((query) => {
+      expect(query.value).toBe(false)
+    })
+
+    // Breakpoints should all be false without window
+    Object.values(breakpoints.value).forEach((value) => {
+      expect(value).toBe(false)
+    })
+
+    // Restore window
+    global.window = originalWindow
+  })
 })

--- a/packages/use-hooks/src/useClipboard/useClipboard.test.ts
+++ b/packages/use-hooks/src/useClipboard/useClipboard.test.ts
@@ -77,4 +77,23 @@ describe('useClipboard', () => {
     expect(notify).toHaveBeenCalledWith('Failed to copy to clipboard')
     expect(mockConsole).toHaveBeenCalledWith('Clipboard error')
   })
+
+  it('works in SSG environment without navigator', async () => {
+    const originalNavigator = global.navigator
+
+    // Mock SSG environment by removing navigator
+    // @ts-expect-error
+    delete global.navigator
+
+    const notify = vi.fn()
+    const { copyToClipboard } = useClipboard({ notify })
+
+    await copyToClipboard('test text')
+
+    // Should show error notification since clipboard is not available
+    expect(notify).toHaveBeenCalledWith('Failed to copy to clipboard')
+
+    // Restore navigator
+    global.navigator = originalNavigator
+  })
 })

--- a/packages/use-hooks/src/useColorMode/useColorMode.test.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.test.ts
@@ -188,4 +188,30 @@ describe('useColorMode', () => {
     expect(document.body.classList.contains('dark-mode')).toBe(true)
     expect(document.body.classList.contains('light-mode')).toBe(false)
   })
+
+  it('works in SSG environment without window/document', () => {
+    const originalWindow = global.window
+    const originalDocument = global.document
+
+    // Mock SSG environment by removing window/document
+    // @ts-expect-error
+    delete global.window
+    // @ts-expect-error
+    delete global.document
+
+    const { colorMode, darkLightMode, setColorMode, toggleColorMode } =
+      useColorMode()
+
+    // Should default to light mode in SSG
+    expect(colorMode.value).toBe('system')
+    expect(darkLightMode.value).toBe('light')
+
+    // Methods should not throw without window/document
+    expect(() => setColorMode('dark')).not.toThrow()
+    expect(() => toggleColorMode()).not.toThrow()
+
+    // Restore window/document/localStorage
+    global.window = originalWindow
+    global.document = originalDocument
+  })
 })

--- a/packages/use-hooks/src/useColorMode/useColorMode.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.ts
@@ -35,6 +35,7 @@ export function useColorMode(opts: UseColorModeOptions = {}) {
 
   /** Gets the system mode preference. */
   function getSystemModePreference(): DarkLightMode {
+    if (typeof window === 'undefined') return 'light'
     if (typeof window?.matchMedia !== 'function') return 'dark'
 
     return window?.matchMedia('(prefers-color-scheme: dark)')?.matches
@@ -51,7 +52,7 @@ export function useColorMode(opts: UseColorModeOptions = {}) {
 
   /** Applies the appropriate color mode class to the body. */
   function applyColorMode(mode: ColorMode): void {
-    if (typeof document === 'undefined') return
+    if (typeof document === 'undefined' || typeof window === 'undefined') return
 
     const classMode =
       overrideColorMode ??
@@ -68,7 +69,9 @@ export function useColorMode(opts: UseColorModeOptions = {}) {
 
   // Priority of initial values is: LocalStorage -> App Config -> initial / Fallback
   const savedColorMode = colorModeSchema.parse(
-    window?.localStorage?.getItem('colorMode'),
+    typeof window !== 'undefined'
+      ? window?.localStorage?.getItem('colorMode')
+      : 'light',
   )
   colorMode.value = savedColorMode ?? initialColorMode
 

--- a/packages/use-hooks/src/useColorMode/useColorMode.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.ts
@@ -71,7 +71,7 @@ export function useColorMode(opts: UseColorModeOptions = {}) {
   const savedColorMode = colorModeSchema.parse(
     typeof window !== 'undefined'
       ? window?.localStorage?.getItem('colorMode')
-      : 'light',
+      : 'system',
   )
   colorMode.value = savedColorMode ?? initialColorMode
 
@@ -80,7 +80,10 @@ export function useColorMode(opts: UseColorModeOptions = {}) {
 
   // Listen to system preference changes
   onMounted(() => {
-    if (typeof window?.matchMedia === 'function') {
+    if (
+      typeof window !== 'undefined' &&
+      typeof window?.matchMedia === 'function'
+    ) {
       const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
       const handleChange = () =>
         colorMode.value === 'system' && applyColorMode('system')


### PR DESCRIPTION
The SSG build is broken, let’s fix it!

## Tasks

- [x] SSG example needs to be updated
- [x] ApiReference/Layout component tree: localStorage not defined
- [x] useColorMode: ReferenceError: window is not defined
- [x] RenderedReference export can be removed
- [x] [ERROR] ReferenceError: document is not defined???
- [x] SSG checks for @scalar/use-hooks?
- [x] Error: Could not parse CSS stylesheet

## Reproduction

```bash
cd examples/ssg
pnpm build
```
## Error: Could not parse CSS stylesheet

**Source**

https://github.com/scalar/scalar/blob/main/packages/api-reference/src/components/ApiReferenceLayout.vue#L321-L329

**Error**

```
Error: Could not parse CSS stylesheet
    at exports.createStylesheet 

…

  @layer scalar-theme {
/* basic theme */
.light-mode {
  --scalar-background-1: #fff;
  --scalar-background-2: #f6f6f6;
  --scalar-background-3: #e7e7e7;
  --scalar-background-accent: #8ab4f81f;

  --scalar-color-1: #2a2f45;
  --scalar-color-2: #757575;
  --scalar-color-3: #8e8e8e;

  --scalar-color-accent: #0099ff;
  --scalar-border-color: #dfdfdf;
}
```