### PR TITLE
fix(api-reference): workspace store uses deprecated proxy attribute

### DIFF
--- a/.changeset/cyan-geese-dream.md
+++ b/.changeset/cyan-geese-dream.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: workspace store uses deprecated proxy attribute

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -253,7 +253,7 @@ provideUseId(() => {
 // Create the workspace store and provide it
 const workspaceStore = createWorkspaceStore({
   isReadOnly: true,
-  proxyUrl: props.configuration.proxy,
+  proxyUrl: props.configuration.proxyUrl || props.configuration.proxy,
   themeId: props.configuration.theme,
   useLocalStorage: false,
   hideClientButton: props.configuration.hideClientButton,


### PR DESCRIPTION
I’ve just found out we’re still using the deprecated ~~proxy~~ attribute in `@scalar/api-reference`, let’s default to the new `proxyUrl` attribute.