### PR TITLE
style(api-client): enhances padding and alignment consistency

### DIFF
--- a/.changeset/khaki-singers-refuse.md
+++ b/.changeset/khaki-singers-refuse.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+style: increases search input gap

--- a/.changeset/tricky-weeks-admire.md
+++ b/.changeset/tricky-weeks-admire.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: fixes spacing and padding inconcistensies

--- a/packages/api-client/src/components/SideNav/SideNav.vue
+++ b/packages/api-client/src/components/SideNav/SideNav.vue
@@ -57,7 +57,7 @@ const { layout } = useLayout()
       </li>
       <li
         v-if="layout !== 'desktop'"
-        class="hidden sm:ml-2 sm:flex items-center justify-center">
+        class="hidden sm:ml-1.5 sm:flex items-center justify-center">
         <DownloadAppButton />
       </li>
     </SideNavGroup>

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -64,8 +64,8 @@ const handleRename = (id: string) => {
 <template>
   <li>
     <router-link
-      class="h-8 text-c-2 hover:bg-b-2 group relative block flex items-center gap-1.5 rounded py-1 pr-2 font-medium no-underline"
-      :class="[variable.color ? 'pl-1' : 'pl-2']"
+      class="h-8 text-c-2 hover:bg-b-2 group relative block flex items-center gap-1.5 rounded py-1 pr-1.5 font-medium no-underline"
+      :class="[variable.color ? 'pl-1' : 'pl-1.5']"
       exactActiveClass="active-link"
       :to="
         collectionId

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -371,7 +371,7 @@ function handleRename(newName: string) {
               :key="collection.uid"
               class="flex flex-col gap-0.25">
               <button
-                class="flex font-medium gap-1.5 group items-center px-2 py-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
+                class="flex font-medium gap-1.5 group items-center p-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
                 type="button"
                 @click="toggleSidebarFolder(collection.uid)">
                 <LibraryIcon

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -490,7 +490,7 @@ const selectedExample = computed({
       <DataTableRow>
         <template v-if="selectedContentType.id === 'none'">
           <div
-            class="text-c-3 flex min-h-10 w-full items-center justify-center p-2 text-sm">
+            class="border-t-1/2 text-c-3 flex min-h-10 w-full items-center justify-center p-2 text-sm">
             <span>No Body</span>
           </div>
         </template>

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -34,7 +34,7 @@ const { currentRoute } = useRouter()
   <div
     class="lg:min-h-client-header flex items-center w-full justify-center p-2 pt-2 lg:pt-1 lg:p-1 flex-wrap t-app__top-container border-b-1/2">
     <div
-      class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 lg:mb-0 mb-2 lg:flex-1 w-6/12">
+      class="flex flex-row items-center gap-1 lg:px-2 lg:mb-0 lg:mb-0 mb-2 lg:flex-1 w-6/12">
       <SidebarToggle
         class="gitbook-hidden"
         :class="[
@@ -48,7 +48,7 @@ const { currentRoute } = useRouter()
     </div>
     <AddressBar @importCurl="$emit('importCurl', $event)" />
     <div
-      class="flex flex-row items-center gap-1 lg:px-2.5 lg:mb-0 mb-2 lg:flex-1 justify-end w-6/12">
+      class="flex flex-row items-center gap-1 lg:px-2 lg:mb-0 mb-2 lg:flex-1 justify-end w-6/12">
       <EnvironmentSelector v-if="!isReadonly" />
       <OpenApiClientButton
         v-if="isReadonly && activeCollection?.documentUrl && !hideClientButton"

--- a/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
+++ b/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
@@ -35,7 +35,7 @@ const variants = cva({
   base: 'search-background flex items-center rounded border text-sm font-medium has-[:focus-visible]:bg-b-1 has-[:focus-visible]:outline',
   variants: {
     sidebar: {
-      true: 'h-8 gap-1.5 px-1.5',
+      true: 'h-8 gap-2 px-1.5',
       false: 'h-10 p-3',
     },
   },


### PR DESCRIPTION
this pr fixes few alignment and padding inconsistencies as seen below:

⊢ workspace dropdown alignment before / after
<img width="622" alt="image" src="https://github.com/user-attachments/assets/7d4d0d3c-71bc-4ed5-af1e-b59c173ebd14" />
<img width="622" alt="image" src="https://github.com/user-attachments/assets/6a9c717d-882e-4792-94f6-2ec9900e2c33" />

⊢ environment dropdown alignment before / after
<img width="622" alt="image" src="https://github.com/user-attachments/assets/338a8aab-baae-434b-9bb5-8dd445383cb8" />
<img width="622" alt="image" src="https://github.com/user-attachments/assets/b633444b-13a6-429f-a48d-ff5a4faa5713" />

⊢ body border before / after
<img width="622" alt="image" src="https://github.com/user-attachments/assets/dd15c3af-6d31-42e9-a093-be66283b7175" />
<img width="622" alt="image" src="https://github.com/user-attachments/assets/0b5d50d9-99f3-4241-8e4f-6e96ed4a377e" />