### PR TITLE
fix: path params disapearing

### DIFF
--- a/.changeset/three-toys-breathe.md
+++ b/.changeset/three-toys-breathe.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: path params missing from client

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -85,9 +85,9 @@ const setPathVariable = (url: string) => {
 
   parameters.splice(0, parameters.length, ...updatedParameters)
 
-  if (pathVariables.length === 0) {
-    parameters.splice(0, parameters.length)
-  }
+  // if (pathVariables.length === 0) {
+  //   parameters.splice(0, parameters.length)
+  // }
 
   requestExampleMutators.edit(
     activeExample.value.uid,


### PR DESCRIPTION
This line seems to be deleting path params, @antlio what was it for?

Before:
![image](https://github.com/user-attachments/assets/dcc58271-64c4-48ce-a2d8-126826e1b9b7)

After:
![image](https://github.com/user-attachments/assets/0fbb4999-ca1d-4bef-a4f1-617e2705109e)
