### PR TITLE
chore(components): ScalarMenu component cleanup

### DIFF
--- a/.changeset/strong-flowers-melt.md
+++ b/.changeset/strong-flowers-melt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+chore(components): ScalarMenu component cleanup

--- a/packages/components/src/components/ScalarMenu/ScalarMenuButton.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuButton.vue
@@ -7,8 +7,8 @@ defineProps<{
 }>()
 </script>
 <template>
-  <ScalarHeaderButton class="px-2">
-    <div class="h-5 w-auto">
+  <ScalarHeaderButton class="gap-0.5 px-2">
+    <div class="size-5">
       <slot><ScalarIcon icon="Logo" /></slot>
     </div>
     <span class="sr-only">
@@ -17,6 +17,6 @@ defineProps<{
     <ScalarIcon
       class="text-c-3 group-hover/button:text-c-1"
       :icon="open ? 'ChevronUp' : 'ChevronDown'"
-      size="sm" />
+      size="md" />
   </ScalarHeaderButton>
 </template>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuProduct.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuProduct.vue
@@ -15,8 +15,8 @@ const variants = cva({
   base: 'relative flex min-w-0 flex-1 items-center gap-2 overflow-hidden rounded px-2 py-1.5 leading no-underline flex-row',
   variants: {
     selected: {
-      true: 'pointer-events-none bg-b-2',
-      false: 'cursor-pointer bg-b-1 hover:bg-b-2',
+      true: 'pointer-events-none bg-b-2 dark:bg-b-3',
+      false: 'cursor-pointer hover:bg-b-2 dark:hover:bg-b-3',
     },
   },
 })


### PR DESCRIPTION
Just cleans up a couple little issues with the ScalarMenu.

## Dropdown icon and spacing

Before:
<img width="200" src="https://github.com/user-attachments/assets/f63767af-8dc2-4771-8b17-728938da6053" /><img width="200" src="https://github.com/user-attachments/assets/8f908038-90a9-41c7-843c-88a13efbff6b" />

After:
<img width="200" src="https://github.com/user-attachments/assets/131bc6bc-a24a-43bc-ae23-df15ddbd40c5" /><img width="200" src="https://github.com/user-attachments/assets/64ad8f90-a275-436e-becb-9a7c1af5c7de" />

## Dark mode ScalarMenu product highlight

Before and after:


<img width="300" src="https://github.com/user-attachments/assets/dfcfa955-e651-41e9-952a-8dd14034ae62" />

<img width="300" src="https://github.com/user-attachments/assets/bcad425d-5c07-46f7-bbab-424a84de6ccd" />
