### PR TITLE
fix(openapi-parser): correct schema upgrade for "format: binary"

### DIFF
--- a/.changeset/slow-spies-roll.md
+++ b/.changeset/slow-spies-roll.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix(openapi-parser): correct schema upgrade for "format: binary"

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
@@ -254,8 +254,8 @@ describe('upgradeFromThreeToThreeOne', () => {
     })
   })
 
-  describe('describing File Upload Payloads ', () => {
-    it('remove schema for file uploads', async () => {
+  describe('describing File Upload Payloads', () => {
+    it('removes schema for binary file uploads', async () => {
       const result = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -263,8 +263,8 @@ describe('upgradeFromThreeToThreeOne', () => {
           version: '1.0.0',
         },
         paths: {
-          '/test': {
-            get: {
+          '/upload': {
+            post: {
               requestBody: {
                 content: {
                   'application/octet-stream': {
@@ -281,13 +281,13 @@ describe('upgradeFromThreeToThreeOne', () => {
       })
 
       expect(
-        result.paths['/test'].get.requestBody.content[
+        result.paths['/upload'].post.requestBody.content[
           'application/octet-stream'
         ],
       ).toEqual({})
     })
 
-    it('migrates base64 format to contentEncoding', async () => {
+    it('migrates base64 format to contentEncoding for image uploads', async () => {
       const result = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -295,11 +295,11 @@ describe('upgradeFromThreeToThreeOne', () => {
           version: '1.0.0',
         },
         paths: {
-          '/test': {
-            get: {
+          '/upload': {
+            post: {
               requestBody: {
                 content: {
-                  'application/octet-stream': {
+                  'image/png': {
                     schema: {
                       type: 'string',
                       format: 'base64',
@@ -313,9 +313,7 @@ describe('upgradeFromThreeToThreeOne', () => {
       })
 
       expect(
-        result.paths['/test'].get.requestBody.content[
-          'application/octet-stream'
-        ],
+        result.paths['/upload'].post.requestBody.content['image/png'],
       ).toEqual({
         schema: {
           type: 'string',
@@ -332,14 +330,17 @@ describe('upgradeFromThreeToThreeOne', () => {
           version: '1.0.0',
         },
         paths: {
-          '/test': {
-            get: {
+          '/upload': {
+            post: {
               requestBody: {
                 content: {
                   'multipart/form-data': {
                     schema: {
                       type: 'object',
                       properties: {
+                        orderId: {
+                          type: 'integer',
+                        },
                         fileName: {
                           type: 'string',
                           format: 'binary',
@@ -355,14 +356,17 @@ describe('upgradeFromThreeToThreeOne', () => {
       })
 
       expect(
-        result.paths['/test'].get.requestBody.content['multipart/form-data'],
+        result.paths['/upload'].post.requestBody.content['multipart/form-data'],
       ).toEqual({
         schema: {
           type: 'object',
           properties: {
+            orderId: {
+              type: 'integer',
+            },
             fileName: {
               type: 'string',
-              contentEncoding: 'application/octet-stream',
+              contentMediaType: 'application/octet-stream',
             },
           },
         },

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -115,7 +115,7 @@ export function upgradeFromThreeToThreeOne(
     if (schema.type === 'string' && schema.format === 'binary') {
       return {
         type: 'string',
-        contentEncoding: 'application/octet-stream',
+        contentMediaType: 'application/octet-stream',
       }
     }
 

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -76,19 +76,29 @@ export function upgradeFromThreeToThreeOne(
   })
 
   // Multipart file uploads with a binary file
-  specification = traverse(specification, (schema) => {
+  specification = traverse(specification, (schema, path) => {
     if (schema.type === 'object' && schema.properties !== undefined) {
-      // Types
-      const entries: [string, any][] = Object.entries(schema.properties)
+      // Check if this is a multipart request body schema
+      const parentPath = path.slice(0, -1)
+      const isMultipart = parentPath.some((segment, index) => {
+        return (
+          segment === 'content' && path[index + 1] === 'multipart/form-data'
+        )
+      })
 
-      for (const [_, value] of entries) {
-        if (
-          typeof value === 'object' &&
-          value.type === 'string' &&
-          value.format === 'binary'
-        ) {
-          value.contentEncoding = 'application/octet-stream'
-          delete value.format
+      if (isMultipart) {
+        // Types
+        const entries: [string, any][] = Object.entries(schema.properties)
+
+        for (const [_, value] of entries) {
+          if (
+            typeof value === 'object' &&
+            value.type === 'string' &&
+            value.format === 'binary'
+          ) {
+            value.contentMediaType = 'application/octet-stream'
+            delete value.format
+          }
         }
       }
     }
@@ -97,7 +107,11 @@ export function upgradeFromThreeToThreeOne(
   })
 
   // Uploading a binary file in a POST request
-  specification = traverse(specification, (schema) => {
+  specification = traverse(specification, (schema, path) => {
+    if (path.includes('content') && path.includes('application/octet-stream')) {
+      return {}
+    }
+
     if (schema.type === 'string' && schema.format === 'binary') {
       return {
         type: 'string',

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -99,7 +99,10 @@ export function upgradeFromThreeToThreeOne(
   // Uploading a binary file in a POST request
   specification = traverse(specification, (schema) => {
     if (schema.type === 'string' && schema.format === 'binary') {
-      return undefined
+      return {
+        type: 'string',
+        contentEncoding: 'application/octet-stream',
+      }
     }
 
     return schema


### PR DESCRIPTION
**Problem**
Currently, if the schema contains `format: binary`, it will be converted to undefined, resulting in the following error and the API client window will be blank.

![readOnly-undefined-error](https://github.com/user-attachments/assets/432ed3db-fcd2-4b20-8dbd-35bd0485f7b2)

![schema-undefined-debug](https://github.com/user-attachments/assets/55238c15-9da5-4f7c-9202-748a92484f5e)

The content of the schema YAML file is as follows:

![openapi-schema](https://github.com/user-attachments/assets/bbe54365-8a0c-4f39-84d1-3944e47ad83f)

**Solution**

With this PR, I referred to the code in the upgradeFromThreeToThreeOne.ts file and changed the upgrade result of `format: binary`.

![image](https://github.com/user-attachments/assets/f7c62577-7f65-4b09-826d-6f78ed677594)

