### PR TITLE
ci: decrease timeout to 10 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   harden_security:
     name: Check used GitHub Actions
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -19,7 +19,7 @@ jobs:
 
   build:
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [18, 20]
@@ -40,7 +40,7 @@ jobs:
   docker:
     name: Build and Tag Docker Image
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -118,7 +118,7 @@ jobs:
 
   format:
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [20]
@@ -140,7 +140,7 @@ jobs:
   types:
     needs: [build]
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [20]
@@ -158,7 +158,7 @@ jobs:
   test:
     needs: [build]
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [18, 20]
@@ -183,7 +183,7 @@ jobs:
   stats:
     needs: [build]
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [20]
@@ -206,7 +206,7 @@ jobs:
   npm-publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     permissions:
       contents: write
       id-token: write
@@ -252,7 +252,7 @@ jobs:
   todesktop-build:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     needs: [build, test]
     strategy:
       matrix:
@@ -304,7 +304,7 @@ jobs:
   stackblitz:
     if: github.head_ref == 'changeset-release/main'
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     needs: [build]
     strategy:
       matrix:
@@ -344,7 +344,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.event.pull_request.head.repo.full_name == github.repository
     needs: [build]
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [20]
@@ -395,7 +395,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]')
     needs: [build]
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [20]
@@ -432,7 +432,7 @@ jobs:
 
   aspnetcore-build-test:
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     needs: [build]
     steps:
       - name: Checkout repository
@@ -468,7 +468,7 @@ jobs:
   aspnetcore-publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     needs: [aspnetcore-build-test]
 
     steps:


### PR DESCRIPTION
Let’s decrease the timeout from 15 to 10 minutes. A full build should only take 5-6 minutes.