### PR TITLE
ci: no concurrent publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    # Avoid running this job in parallel:
+    # `changesets/action` creates/updates the release branch, which shouldn’t happen in parallel.
+    # npm publish also shouldn’t happen in parallel.
     concurrency:
       group: npm-publish
       cancel-in-progress: false
@@ -460,6 +463,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    # We don’t want to run `nuget push` (publishing to NuGet) in parallel.
     concurrency:
       group: aspnetcore-publish
       cancel-in-progress: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,18 +288,6 @@ jobs:
         env:
           TODESKTOP_EMAIL: ${{ secrets.TODESKTOP_EMAIL }}
           TODESKTOP_ACCESS_TOKEN: ${{ secrets.TODESKTOP_ACCESS_TOKEN }}
-      # - if: steps.changed-files.outputs.api_client_app_any_changed == 'true'
-      #   name: Run smoke tests
-      #   run: pnpm --filter scalar-app todesktop:test:ci
-      #   env:
-      #     TODESKTOP_EMAIL: ${{ secrets.TODESKTOP_EMAIL }}
-      #     TODESKTOP_ACCESS_TOKEN: ${{ secrets.TODESKTOP_ACCESS_TOKEN }}
-      # - if: steps.changed-files.outputs.api_client_app_any_changed == 'true'
-      #   name: Release the app
-      #   run: pnpm --filter scalar-app todesktop:release:ci
-      #   env:
-      #     TODESKTOP_EMAIL: ${{ secrets.TODESKTOP_EMAIL }}
-      #     TODESKTOP_ACCESS_TOKEN: ${{ secrets.TODESKTOP_ACCESS_TOKEN }}
 
   stackblitz:
     if: github.head_ref == 'changeset-release/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    concurrency:
+      group: npm-publish
+      cancel-in-progress: false
     permissions:
       contents: write
       id-token: write
@@ -457,6 +460,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    concurrency:
+      group: aspnetcore-publish
+      cancel-in-progress: false
     needs: [aspnetcore-build-test]
 
     steps:


### PR DESCRIPTION
I think the recent issues we faced with publishing were related to having the `changesets/action` running in parallel doing two different things. 🤔

Anyway, publishing shouldn’t be executed in parallel and existing jobs shouldn’t be canceled, so let’s add this to the CI workflow.

![image](https://github.com/user-attachments/assets/a3530383-8fb3-4e8a-a695-f030b8f7d35c)

EDIT: #4261 should make CI green