### PR TITLE
ci: increase memory limit for build step

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -35,11 +35,17 @@ runs:
       shell: bash
       # GitHub Actions runners have two cores, so we can run two tasks in parallel
       run: pnpm turbo --concurrency=2 build
+      env:
+        NODE_OPTIONS: "--max_old_space_size=4096"
     - if: ${{ inputs.packages-only == 'true' }}
       name: Build packages
       shell: bash
       run: pnpm turbo --concurrency=2 --filter './packages/**' build
+      env:
+        NODE_OPTIONS: "--max_old_space_size=4096"
     - if: ${{ inputs.packages-only != 'true' && inputs.packages-only != 'false' }}
       name: Build package
       shell: bash
       run: pnpm turbo --concurrency=2 --filter './packages/${{inputs.packages-only}}' build
+      env:
+        NODE_OPTIONS: "--max_old_space_size=4096"


### PR DESCRIPTION
Another attempt to fix CI by increasing the Node memory limit. 👀 

EDIT: This looks good, there’s a high chance this actually fixes it.