### PR TITLE
chore: add geoff to CI codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 * @hanspagel @amritk @geoffgscott
 
 # Root level code owners
-/.github @hanspagel @tmastrom
+/.github @hanspagel @tmastrom @geoffgscott
 /*.md @hanspagel
 
 # Documentation


### PR DESCRIPTION
Let’s add @geoffgscott to the CODEOWNERS file for /.github (CI). :)