### PR TITLE
ci: do not cache playwright binaries

### DIFF
--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -29,15 +29,7 @@ jobs:
         with:
           packages-only: true
           node-version: ${{ matrix.node-version }}
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
-      - name: Playwright binary cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
+      # Caching browser binaries is not recommended, since the amount of time it takes to restore the cache is comparable to the time it takes to download the binaries.
       - name: Install Playwright browsers
         run: npx playwright install
       - name: Install Playwright dependencies

--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -34,14 +34,12 @@ jobs:
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
       - name: Playwright binary cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        id: playwright-cache
         with:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
       - name: Install Playwright browsers
         run: npx playwright install
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
         run: npx playwright install-deps
       - name: Start HTML server

--- a/.github/workflows/test-cdn-local.yml
+++ b/.github/workflows/test-cdn-local.yml
@@ -27,14 +27,12 @@ jobs:
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
       - name: Playwright binary cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        id: playwright-cache
         with:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
       - name: Install Playwright browsers
         run: npx playwright install
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
         run: npx playwright install-deps
       - name: Start HTML server

--- a/.github/workflows/test-electron-app.yml
+++ b/.github/workflows/test-electron-app.yml
@@ -26,19 +26,9 @@ jobs:
         with:
           packages-only: true
           node-version: ${{ matrix.node-version }}
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
-      - name: Playwright binary cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        id: playwright-cache
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
+      # Caching browser binaries is not recommended, since the amount of time it takes to restore the cache is comparable to the time it takes to download the binaries.
       - name: Install chromium browser
         run: npx playwright install chromium
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
         run: npx playwright install-deps
       - name: Check whether appFiles are there

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -27,14 +27,12 @@ jobs:
         run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
       - name: Playwright binary cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        id: playwright-cache
         with:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
       - name: Install Playwright browsers
         run: npx playwright install
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
       - name: Install Playwright dependencies
         run: npx playwright install-deps
       - name: Start nuxt server

--- a/.github/workflows/test-nuxt-integration.yml
+++ b/.github/workflows/test-nuxt-integration.yml
@@ -22,15 +22,7 @@ jobs:
         with:
           packages-only: true
           node-version: ${{ matrix.node-version }}
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(npx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
-      - name: Playwright binary cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
+      # Caching browser binaries is not recommended, since the amount of time it takes to restore the cache is comparable to the time it takes to download the binaries.
       - name: Install Playwright browsers
         run: npx playwright install
       - name: Install Playwright dependencies


### PR DESCRIPTION
We’ve added a check whether the playwright dependencies (browsers) were restored from cache, but that check failed for Playwright version updates (for whatever reason) - and with it all tests.

https://github.com/scalar/scalar/actions/runs/12375837584/job/34541570648?pr=4255

It turns out, we don’t need to cache Playwright binaries.

> Caching browser binaries is not recommended, since the amount of time it takes to restore the cache is comparable to the time it takes to download the binaries.

Source: https://playwright.dev/docs/ci#caching-browsers
