### PR TITLE
revert(api-reference): sets server variables values in client

### DIFF
--- a/.changeset/fresh-geckos-peel.md
+++ b/.changeset/fresh-geckos-peel.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: reverts sets server variables values in client

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -271,35 +271,15 @@ export const createApiClient = ({
       }
     },
     /** Update the currently selected server via URL */
-    updateServer: (serverUrl: string, variables?: Record<string, string>) => {
+    updateServer: (serverUrl: string) => {
       const server = Object.values(servers).find((s) => s.url === serverUrl)
-      if (!server || !activeCollection.value) return
 
-      collectionMutators.edit(
-        activeCollection.value.uid,
-        'selectedServerUid',
-        server.uid,
-      )
-
-      if (!variables) return
-
-      // Iterate through the variables
-      const variableEntries = Object.entries(variables).map(([key, value]) => ({
-        key,
-        value,
-        enabled: true,
-      }))
-
-      // Iterate through the requests and adds the variable values to the path parameters
-      activeCollection?.value?.requests.forEach((request) => {
-        const foundRequest = requests[request]
-        if (!foundRequest) return
-        requestExampleMutators.edit(
-          foundRequest.examples[0],
-          'parameters.path',
-          variableEntries,
+      if (server && activeCollection.value)
+        collectionMutators.edit(
+          activeCollection.value?.uid,
+          'selectedServerUid',
+          server.uid,
         )
-      })
     },
     /** Update the currently selected server via URL */
     onUpdateServer: (callback: (url: string) => void) => {

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -38,9 +38,7 @@ onMounted(async () => {
 // Update the server on select
 watch(server, (newServer) => {
   const { originalUrl } = getUrlFromServerState(newServer)
-  if (originalUrl && client.value) {
-    client.value.updateServer(originalUrl, server.variables)
-  }
+  if (originalUrl && client.value) client.value.updateServer(originalUrl)
 })
 
 // Update the config on change


### PR DESCRIPTION
This reverts [commit 51bfd5f](https://github.com/scalar/scalar/pull/4160/commits/51bfd5f7d5258881ae3a852df6b70be3a784b0fb) which is preventing the path parameters to be displayed in the api reference client modal.

Will get back to it with a better approach based in that case on retrieving the server variables.

<img width="705" alt="image" src="https://github.com/user-attachments/assets/021c965a-0ea5-4868-967d-af909e009363" />

