### PR TITLE
chore: bump next.js peerDependencies again

### DIFF
--- a/.changeset/weak-schools-train.md
+++ b/.changeset/weak-schools-train.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nextjs-api-reference': patch
+---
+
+chore: bump next.js peerDependencies fr fr

--- a/packages/nextjs-api-reference/package.json
+++ b/packages/nextjs-api-reference/package.json
@@ -54,9 +54,5 @@
     "react-dom": "^18.3.1",
     "vite": "^5.4.10",
     "vite-plugin-dts": "^3.6.3"
-  },
-  "peerDependencies": {
-    "react": "^18.0.0",
-    "next": "^14.0.0"
   }
 }

--- a/packages/nextjs-api-reference/package.json
+++ b/packages/nextjs-api-reference/package.json
@@ -56,7 +56,7 @@
     "vite-plugin-dts": "^3.6.3"
   },
   "peerDependencies": {
-    "react": "^18",
-    "next": "^14"
+    "react": ">=18.0.0",
+    "next": ">=14.0.0"
   }
 }

--- a/packages/nextjs-api-reference/package.json
+++ b/packages/nextjs-api-reference/package.json
@@ -56,7 +56,7 @@
     "vite-plugin-dts": "^3.6.3"
   },
   "peerDependencies": {
-    "react": ">=18.0.0",
-    "next": ">=14.0.0"
+    "react": "^18.0.0",
+    "next": "^14.0.0"
   }
 }

--- a/packages/nextjs-api-reference/vite.config.ts
+++ b/packages/nextjs-api-reference/vite.config.ts
@@ -22,10 +22,7 @@ export default defineConfig({
       },
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: [
-        ...Object.keys(pkg.dependencies),
-        ...Object.keys(pkg.peerDependencies),
-      ],
+      external: Object.keys(pkg.dependencies),
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1618,7 +1618,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       react:
-        specifier: ^18
+        specifier: ^18.0.0
         version: 18.3.1
     devDependencies:
       '@scalar/api-reference':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1617,9 +1617,6 @@ importers:
       '@scalar/types':
         specifier: workspace:*
         version: link:../types
-      react:
-        specifier: ^18.0.0
-        version: 18.3.1
     devDependencies:
       '@scalar/api-reference':
         specifier: workspace:*
@@ -1638,10 +1635,10 @@ importers:
         version: 4.3.1(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))
       next:
         specifier: ^14.2.10
-        version: 14.2.18(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.18(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
       react-dom:
         specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        version: 18.3.1(react@19.0.0)
       vite:
         specifier: ^5.4.10
         version: 5.4.10(@types/node@20.17.10)(terser@5.31.2)


### PR DESCRIPTION
We have a commit hook that keeps changing them, so I just removed it. It is safe to assume that next.js users have next.js and react installed 🙂 