### PR TITLE
fix(api-reference): correct `hash.value` encoding to ensure scrolling

### DIFF
--- a/.changeset/poor-toys-sip.md
+++ b/.changeset/poor-toys-sip.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): correct `hash.value` encoding to ensure scrolling

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -72,7 +72,9 @@ const updateHash = () => {
   hash.value = pathRouting.value
     ? getPathRoutingId(window.location.pathname)
     : // Must remove the prefix from the hash as the internal hash value should be pure
-      window.location.hash.replace(/^#/, '').slice(hashPrefix.value.length)
+      decodeURIComponent(window.location.hash.replace(/^#/, '')).slice(
+        hashPrefix.value.length,
+      )
 }
 
 const replaceUrlState = (


### PR DESCRIPTION
**Problem**
Currently, manually refreshing the page or using a URL with a hash to open a new tab does not cause the corresponding section to scroll into the view. I have fixed similar issue in PR #4173.

I found that this issue is caused by this commit:
https://github.com/scalar/scalar/commit/56c1981d9a1e0b38837fa6881f6f76a17cc7b616#diff-ccdd228d6187612f62c06d9aaafbc4c0c9fa973ca37de2d80744df2b7dccdb43L68-R77

![image](https://github.com/user-attachments/assets/dda54e00-ae20-49c8-88b6-71168a991e74)

**Solution**
With this PR, the section id and `hash.value` are both raw values that have not been encoded with `encodeURIComponent()`, allowing the browser to correctly find the section and scroll it into view.

