### PR TITLE
ci: make important jobs a requirement for the publish process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,21 +3,11 @@ name: CI
 # This workflow runs on:
 # 1. Push events to the main branch
 # 2. Pull request events
-#
-# We explicitly ignore the 'changeset-release/main' branch in both cases
-# because this branch is created by our release workflow.
-#
-# Note: GitHub Actions doesn’t run workflows triggered by bot accounts.
-# We keep the ignore rule for clarity, but the bot’s PR would be skipped anyway.
-#
-# ⚠️ That could become a problem if we filter for specific files in the trigger.
 on:
   push:
     branches:
       - main
   pull_request:
-    branches-ignore:
-      - changeset-release/main
 
 jobs:
   harden_security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    needs: [build, test]
+    needs: [harden_security, build, format, types, test]
     strategy:
       matrix:
         node-version: [20]
@@ -480,7 +480,7 @@ jobs:
     concurrency:
       group: aspnetcore-publish
       cancel-in-progress: false
-    needs: [aspnetcore-build-test]
+    needs: [harden_security, build, format, types, test, aspnetcore-build-test]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ name: CI
 #
 # Note: GitHub Actions doesn’t run workflows triggered by bot accounts.
 # We keep the ignore rule for clarity, but the bot’s PR would be skipped anyway.
+#
+# ⚠️ That could become a problem if we filter for specific files in the trigger.
 on:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ on:
   push:
     branches:
       - main
-    branches-ignore:
-      - changeset-release/main
   pull_request:
     branches-ignore:
       - changeset-release/main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,23 @@
 name: CI
 
+# This workflow runs on:
+# 1. Push events to the main branch
+# 2. Pull request events
+#
+# We explicitly ignore the 'changeset-release/main' branch in both cases
+# because this branch is created by our release workflow.
+#
+# Note: GitHub Actions doesn’t run workflows triggered by bot accounts.
+# We keep the ignore rule for clarity, but the bot’s PR would be skipped anyway.
 on:
   push:
     branches:
       - main
+    branches-ignore:
+      - changeset-release/main
   pull_request:
+    branches-ignore:
+      - changeset-release/main
 
 jobs:
   harden_security:


### PR DESCRIPTION
Let’s not skip CI for release PRs, I’m not really convinced this is the right solution.

But let’s make the important jobs a requirement for the publish jobs.

---

~~Release PRs are created automatically by GitHub Actions. But GitHub Actions doesn’t trigger workflows for actions performed by bots (to avoid infinite loops), that’s why they don’t run when the release PR is (automatically) updated (by the bot).~~

~~This looks like CI is hanging, so let’s just skip CI for the release PR.~~

~~**But, Hans, isn’t that dangerous?**~~

~~I don’t think so! Code has passed CI three times before being published:~~

~~1. In the PR branch (the UI warns if it’s not rebased on main)
2. When it’s in main (and the release PR is created eventually)
3. Once it’s in main again (after the release PR is merged, the publishing process gets kicked off after main passed CI)~~