### PR TITLE
fix(api-client): removes server in drafts requests

### DIFF
--- a/.changeset/dull-otters-lay.md
+++ b/.changeset/dull-otters-lay.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sets active server on send request for non draft request only

--- a/.changeset/lovely-carrots-guess.md
+++ b/.changeset/lovely-carrots-guess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+chore: adds drafts server migration

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -107,6 +107,12 @@ const executeRequest = async () => {
     activeWorkspace.value?.cookies.map((c) => cookies[c]).filter(isDefined) ??
     []
 
+  // Sets server to non drafts request only
+  const server =
+    activeCollection.value?.info?.title === 'Drafts'
+      ? undefined
+      : activeServer.value
+
   const [error, requestOperation] = createRequestOperation({
     request: activeRequest.value,
     example: activeExample.value,
@@ -116,7 +122,7 @@ const executeRequest = async () => {
     globalCookies,
     status: events.requestStatus,
     securitySchemes: securitySchemes,
-    server: activeServer.value,
+    server,
   })
 
   // Error from createRequestOperation

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -50,6 +50,11 @@
       "types": "./dist/migrations/index.d.ts",
       "default": "./dist/migrations/index.js"
     },
+    "./migrations/v-2.4.0": {
+      "import": "./dist/migrations/v-2.4.0/index.js",
+      "types": "./dist/migrations/v-2.4.0/index.d.ts",
+      "default": "./dist/migrations/v-2.4.0/index.js"
+    },
     "./migrations/v-2.3.0": {
       "import": "./dist/migrations/v-2.3.0/index.js",
       "types": "./dist/migrations/v-2.3.0/index.d.ts",

--- a/packages/oas-utils/src/migrations/data-version.ts
+++ b/packages/oas-utils/src/migrations/data-version.ts
@@ -6,8 +6,10 @@
  * - 0.0.0
  * - 2.1.0 - refactor
  * - 2.2.0 - auth compliancy
+ * - 2.3.0 - environments
+ * - 2.4.0 - draft collection servers
  */
-export const DATA_VERSION = '2.3.0'
+export const DATA_VERSION = '2.4.0'
 
 /** The localStorage key under which the data version is stored */
 export const DATA_VERSION_LS_LEY = 'scalar_api_client_data_version'

--- a/packages/oas-utils/src/migrations/migrator.ts
+++ b/packages/oas-utils/src/migrations/migrator.ts
@@ -6,9 +6,10 @@ import { semverLessThan } from '@/migrations/semver'
 import { migrate_v_2_1_0 } from '@/migrations/v-2.1.0'
 import { migrate_v_2_2_0 } from '@/migrations/v-2.2.0'
 import { migrate_v_2_3_0, type v_2_3_0 } from '@/migrations/v-2.3.0'
+import { migrate_v_2_4_0, type v_2_4_0 } from '@/migrations/v-2.4.0'
 
 /** Handles all data migrations per entity */
-export const migrator = (): v_2_3_0.DataArray => {
+export const migrator = (): v_2_4_0.DataArray => {
   const dataVersion = getLocalStorageVersion()
   console.info('Data version: ' + dataVersion)
 
@@ -31,6 +32,8 @@ export const migrator = (): v_2_3_0.DataArray => {
   if (semverLessThan(dataVersion, '2.2.0')) data = migrate_v_2_2_0(data)
   // 2.2.0 -> 2.3.0 migration
   if (semverLessThan(dataVersion, '2.3.0')) data = migrate_v_2_3_0(data)
+  // 2.3.0 -> 2.4.0 migration
+  if (semverLessThan(dataVersion, '2.4.0')) data = migrate_v_2_4_0(data)
 
   // Convert to data array
   data = {
@@ -43,7 +46,7 @@ export const migrator = (): v_2_3_0.DataArray => {
     servers: Object.values(data.servers),
     tags: Object.values(data.tags),
     workspaces: Object.values(data.workspaces),
-  } satisfies v_2_3_0.DataArray
+  } satisfies v_2_4_0.DataArray
 
   return data
 }

--- a/packages/oas-utils/src/migrations/v-2.4.0/index.ts
+++ b/packages/oas-utils/src/migrations/v-2.4.0/index.ts
@@ -1,0 +1,2 @@
+export * from './migration'
+export * from './types.generated'

--- a/packages/oas-utils/src/migrations/v-2.4.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.4.0/migration.ts
@@ -1,0 +1,38 @@
+import type { v_2_3_0 } from '@/migrations/v-2.3.0/types.generated'
+
+import type { v_2_4_0 } from './types.generated'
+
+/** V-2.3.0 to V-2.4.0 migration */
+export const migrate_v_2_4_0 = (
+  data: v_2_3_0.DataRecord,
+): v_2_4_0.DataRecord => {
+  console.info('Performing data migration v-2.3.0 to v-2.4.0')
+
+  const collections = Object.values(data.collections).reduce<
+    v_2_4_0.DataRecord['collections']
+  >((prev, c) => {
+    if (c.info?.title === 'Drafts') {
+      // Remove the servers from the draft collection
+      c.servers = []
+
+      Object.values(data.requests).forEach((request) => {
+        if (request.selectedServerUid && c.requests.includes(request.uid)) {
+          const server = data.servers[request.selectedServerUid]
+          if (server) {
+            // Update the request paths to include the server URL
+            request.path = `${server.url}${request.path}`
+          }
+          // Remove the selected server UID from the draft request
+          request.selectedServerUid = ''
+        }
+      })
+    }
+    prev[c.uid] = c
+    return prev
+  }, {})
+
+  return {
+    ...data,
+    collections,
+  } satisfies v_2_4_0.DataRecord
+}

--- a/packages/oas-utils/src/migrations/v-2.4.0/types.generated.ts
+++ b/packages/oas-utils/src/migrations/v-2.4.0/types.generated.ts
@@ -1,0 +1,47 @@
+import type { Cookie as Ck } from '@/entities/cookie'
+import type { Environment as E } from '@/entities/environment'
+import type {
+  Collection as Co,
+  Request as R,
+  RequestExample as RE,
+  Server as S,
+  SecurityScheme as SS,
+  Tag as T,
+} from '@/entities/spec'
+import type { Workspace as W } from '@/entities/workspace'
+
+export namespace v_2_4_0 {
+  export type Cookie = Ck
+  export type Environment = E
+  export type Collection = Co
+  export type Request = R
+  export type RequestExample = RE
+  export type SecurityScheme = SS
+  export type Server = S
+  export type Tag = T
+  export type Workspace = W
+
+  export type DataRecord = {
+    collections: Record<string, Collection>
+    cookies: Record<string, Cookie>
+    environments: Record<string, Environment>
+    requestExamples: Record<string, RequestExample>
+    requests: Record<string, Request>
+    securitySchemes: Record<string, SecurityScheme>
+    servers: Record<string, Server>
+    tags: Record<string, Tag>
+    workspaces: Record<string, Workspace>
+  }
+
+  export type DataArray = {
+    collections: Collection[]
+    cookies: Cookie[]
+    environments: Environment[]
+    requestExamples: RequestExample[]
+    requests: Request[]
+    securitySchemes: SecurityScheme[]
+    servers: Server[]
+    tags: Tag[]
+    workspaces: Workspace[]
+  }
+}


### PR DESCRIPTION
this PR is the final touch in fixing #4240 and includes:
- send request updates
- drafts requests migration

⊢ send request updates
+ sets active server only for non drafts requests in order to avoid issue on draft usages

⊢ drafts requests migration
+ removes server from drafts request 
+ moves previously used server to the path