### PR TITLE
fix(api-client): layout fixtures

### DIFF
--- a/.changeset/clever-rocks-allow.md
+++ b/.changeset/clever-rocks-allow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: fixtures layout and utility usages

--- a/packages/api-client/src/components/ContextBar.vue
+++ b/packages/api-client/src/components/ContextBar.vue
@@ -38,7 +38,7 @@ const model = computed<string>({
           :value="section" />
       </label>
       <div
-        class="flex items-center context-bar-group-hover:text-c-1 absolute -right-6 top-1/2 -translate-y-1/2">
+        class="flex items-center context-bar-group-hover:text-c-1 absolute -right-[30px] top-1/2 -translate-y-1/2">
         <span class="mr-1.5 context-bar-group-hover:hidden">{{ model }}</span>
         <ScalarIcon
           icon="FilterList"

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -44,7 +44,7 @@ const selectedEnvironment = computed(() => {
   return (
     environment?.uid ||
     collection?.['x-scalar-active-environment'] ||
-    'Environment'
+    'No Environment'
   )
 })
 

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -19,7 +19,7 @@ withDefaults(
   <Disclosure
     v-slot="{ open }"
     as="div"
-    class="focus-within:text-c-1 text-c-2 request-item border-b-1/2"
+    class="focus-within:text-c-1 text-c-2 request-item border-b"
     :defaultOpen="defaultOpen"
     :static="layout === 'reference'">
     <div class="bg-b-2 flex items-center">
@@ -42,7 +42,7 @@ withDefaults(
             :open="open" />
           <span
             v-if="!open && itemCount"
-            class="bg-b-2 text-c-2 text-3xs inline-flex h-4 w-4 items-center justify-center rounded-full font-semibold border-1/2">
+            class="bg-b-2 text-c-2 text-3xs inline-flex h-4 w-4 items-center justify-center rounded-full font-semibold border">
             {{ itemCount }}
           </span>
         </div>

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -2,7 +2,7 @@
   <section
     class="flex xl:h-full xl:min-w-0 flex-1 flex-col xl:custom-scroll bg-b-1">
     <div
-      class="min-h-11 flex items-center border-b-1/2 px-4 text-sm font-medium sticky top-0 bg-b-1 xl:rounded-none z-1">
+      class="min-h-11 flex items-center border-b-1/2 px-2.5 text-sm font-medium sticky top-0 bg-b-1 xl:rounded-none z-1">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -76,7 +76,7 @@ const updateRequestNameHandler = (event: Event) => {
         <input
           v-if="!isReadOnly"
           id="requestname"
-          class="text-c-1 rounded pointer-events-auto relative w-full pl-2 -ml-0.5 md:-ml-1 xl:-ml-2 has-[:focus-visible]:outline h-8 group-hover-input has-[:focus-visible]:outline z-10"
+          class="text-c-1 rounded pointer-events-auto relative w-full pl-1.25 -ml-0.5 md:-ml-1.25 has-[:focus-visible]:outline h-8 group-hover-input has-[:focus-visible]:outline z-10"
           placeholder="Request Name"
           :value="activeRequest?.summary"
           @input="updateRequestNameHandler" />

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -222,7 +222,7 @@ const toggleSearch = () => {
       #header>
     </template>
     <template #content>
-      <div class="flex items-center h-[48px] px-3 top-0 bg-b-1 sticky z-20">
+      <div class="flex items-center h-12 px-3 top-0 bg-b-1 sticky z-20">
         <SidebarToggle
           class="xl:hidden"
           :class="[{ '!flex': layout === 'modal' }]"
@@ -246,7 +246,7 @@ const toggleSearch = () => {
       </div>
       <div
         v-show="isSearchVisible"
-        class="search-button-fade sticky px-3 py-2.5 z-10 pt-0 top-[48px] focus-within:z-20"
+        class="search-button-fade sticky px-3 py-2.5 z-10 pt-0 top-12 focus-within:z-20"
         role="search">
         <ScalarSearchInput
           ref="searchInputRef"

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -195,9 +195,6 @@ const handleClearDrafts = () => {
 }
 
 const toggleSearch = () => {
-  // Simply toggle the visibility
-  isSearchVisible.value = !isSearchVisible.value
-
   // If we're hiding the search, clear the text
   if (!isSearchVisible.value) {
     searchText.value = ''
@@ -209,6 +206,9 @@ const toggleSearch = () => {
       searchInputRef.value?.focus()
     })
   }
+
+  // Simply toggle the visibility
+  isSearchVisible.value = !isSearchVisible.value
 }
 </script>
 <template>

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -28,7 +28,7 @@ const { currentRoute } = useRouter()
   <div
     class="lg:min-h-client-header flex items-center w-full justify-center p-2 pt-2 lg:pt-1 lg:p-1 flex-wrap t-app__top-container border-b-1/2">
     <div
-      class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-2 lg:flex-1 w-6/12">
+      class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-2 lg:flex-1 w-1/2">
       <SidebarToggle
         v-if="showSidebar"
         class="ml-1"
@@ -43,7 +43,7 @@ const { currentRoute } = useRouter()
     </div>
     <AddressBar @importCurl="$emit('importCurl', $event)" />
     <div
-      class="flex flex-row items-center gap-1 lg:px-2.5 lg:mb-0 mb-2 lg:flex-1 justify-end w-6/12">
+      class="flex flex-row items-center gap-1 lg:px-2.5 lg:mb-0 mb-2 lg:flex-1 justify-end w-1/2">
       <OpenApiClientButton
         v-if="isReadOnly && activeCollection?.documentUrl && !hideClientButton"
         buttonSource="modal"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -26,7 +26,7 @@ const findHeaderInfo = (name: string) => {
     <template #title>Headers</template>
     <div
       v-if="headers.length"
-      class="border-t-1/2 border-b-1/20 max-h-[calc(100%-32px)] overflow-y-auto">
+      class="border-t-1/2 border-b-1/2 max-h-[calc(100%-32px)] overflow-y-auto">
       <DataTable
         class="!border-0 !mx-0"
         :columns="['minmax(auto, min-content)', 'minmax(50%, 1fr)']"


### PR DESCRIPTION
this pr is updating utilities + removing some left over from #4247 as discussed w/ @cameronrohani and according to @hwkr post merge review.

i fixed some alignment in the last commit:

⊢ before / after
<div>
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0f5ac296-f08f-4e89-babd-09466b1e6b3d" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8de44e90-8582-4ae5-83db-5380adae4a05" />
</div>