### PR TITLE
docs(changeset): react 19 upgrade minor bump

### DIFF
--- a/.changeset/brave-hornets-look.md
+++ b/.changeset/brave-hornets-look.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client-react': minor
+'@scalar/api-reference-react': minor
+'@scalar/nextjs-api-reference': minor
+---
+
+chore: react 19 upgrade minor bump

--- a/packages/api-client-react/README.md
+++ b/packages/api-client-react/README.md
@@ -11,6 +11,11 @@
 npm install @scalar/api-client-react
 ```
 
+## Compatibility
+
+This package is compatible with React 19 and is untested on React 18. If you want guaranteed React 18 support please use
+version `1.0.107` of this package.
+
 ## Usage
 
 First we need to add the provider, you should add it in the highest place you have a unique spec.

--- a/packages/api-reference-react/README.md
+++ b/packages/api-reference-react/README.md
@@ -11,6 +11,11 @@
 npm install @scalar/api-reference-react
 ```
 
+## Compatibility
+
+This package is compatible with React 19 and is untested on React 18. If you want guaranteed React 18 support please use
+version `1.0.107` of this package.
+
 ## Usage
 
 The API Reference package is written in Vue. That shouldn’t stop you from using it in React, though. We have created a client side wrapper in React:

--- a/packages/nextjs-api-reference/README.md
+++ b/packages/nextjs-api-reference/README.md
@@ -19,6 +19,11 @@ This plugin provides an easy way to render a beautiful API reference based on an
 npm install @scalar/nextjs-api-reference
 ```
 
+## Compatibility
+
+This package is compatible with Next.js 15 and is untested on Next.js 14. If you want guaranteed Next.js 14 support
+please use version `0.4.106` of this package.
+
 ## Usage
 
 If you have a OpenAPI/Swagger file already, you can pass a URL to the plugin in an API [Route](https://nextjs.org/docs/app/building-your-application/routing/route-handlers):


### PR DESCRIPTION
Should have made the react 19 upgrade a minor bump due to it not being backwards compatible with older react versions. This PR gives it a minor bump + updates the readmes