### PR TITLE
fix(api-reference): debounce client config updates to increase perf

### DIFF
--- a/.changeset/popular-peas-listen.md
+++ b/.changeset/popular-peas-listen.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add debounce to client config update to improve perf

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -2,6 +2,7 @@
 import { getUrlFromServerState, useExampleStore, useServerStore } from '#legacy'
 import type { ClientConfiguration } from '@scalar/api-client/libs'
 import { useWorkspace } from '@scalar/api-client/store'
+import { watchDebounced } from '@vueuse/core'
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import { useApiClient } from './useApiClient'
@@ -42,10 +43,11 @@ watch(server, (newServer) => {
 })
 
 // Update the config on change
-watch(
+// We temporarily just debounce this but we should switch to the diff from live sync for updates
+watchDebounced(
   () => configuration,
   (_config) => _config && client.value?.updateConfig(_config),
-  { deep: true },
+  { deep: true, debounce: 300 },
 )
 
 watch(selectedExampleKey, (newKey) => {


### PR DESCRIPTION
This is just a quick fix to reduce typing lag. The actual fix should be to switch to the live sync diff as stated in [this ticket](https://github.com/scalar/scalar/issues/4290) but this does the job for now 🙂 

to test:
```bash
pnpx turbo dev --filter @scalar/api-reference-editor
```