### PR TITLE
fix(api-reference): request server in example

### DIFF
--- a/.changeset/bright-starfishes-mix.md
+++ b/.changeset/bright-starfishes-mix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: updates address bar server ui for multi server type

--- a/.changeset/spicy-deers-allow.md
+++ b/.changeset/spicy-deers-allow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates selected server logic on collection server selection

--- a/.changeset/spicy-needles-design.md
+++ b/.changeset/spicy-needles-design.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: fix(api-reference): sets request server in request example hook

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -22,10 +22,15 @@ const requestServerOptions = computed(() =>
 )
 
 const collectionServerOptions = computed(() =>
-  activeCollection.value?.servers?.map((serverUid: string) => ({
-    id: serverUid,
-    label: servers[serverUid]?.url ?? 'Unknown server',
-  })),
+  // Filters out servers already present in the request
+  activeCollection.value?.servers
+    ?.filter(
+      (serverUid: string) => !activeRequest.value?.servers?.includes(serverUid),
+    )
+    .map((serverUid: string) => ({
+      id: serverUid,
+      label: servers[serverUid]?.url ?? 'Unknown server',
+    })),
 )
 
 /** If we have both request and collection servers we show the labels */
@@ -73,8 +78,8 @@ const serverUrlWithoutTrailingSlash = computed(() => {
       <!-- Request -->
       <div
         v-if="showDropdownLabels"
-        class="text-xxs text-c-2 ml-8">
-        Request Servers
+        class="text-xxs text-c-2 px-2.5 py-1">
+        Request
       </div>
       <AddressBarServerItem
         v-for="serverOption in requestServerOptions"
@@ -84,7 +89,7 @@ const serverUrlWithoutTrailingSlash = computed(() => {
 
       <template v-if="showDropdownLabels">
         <ScalarDropdownDivider />
-        <div class="text-xxs text-c-2 ml-8">Collection Servers</div>
+        <div class="text-xxs text-c-2 px-2.5 py-1">Collection</div>
       </template>
 
       <!-- Collection -->

--- a/packages/api-client/src/components/AddressBar/AddressBarServerItem.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServerItem.vue
@@ -17,6 +17,10 @@ const { collectionMutators, requestMutators } = useWorkspace()
 /** Update the currently selected server on the collection or request */
 const updateSelectedServer = (serverUid: string) => {
   if (props.type === 'collection' && activeCollection.value) {
+    // Clear the selected server on the request so that the collection can be updated
+    if (activeRequest.value?.servers?.length) {
+      activeRequest.value.selectedServerUid = ''
+    }
     collectionMutators.edit(
       activeCollection.value.uid,
       'selectedServerUid',

--- a/packages/api-reference/src/features/Operation/hooks/useRequestExample.ts
+++ b/packages/api-reference/src/features/Operation/hooks/useRequestExample.ts
@@ -57,14 +57,22 @@ export const useRequestExample = ({
     }
   })
 
+  // Generate a request from operation server or fallback to global server URL
+  const serverUrl = computed(() => {
+    const operationServer = operation.information?.servers?.[0]
+    const { modifiedUrl } = getUrlFromServerState(serverState, operationServer)
+    return modifiedUrl
+  })
+
   const serverWithVariables = computed(() => {
     const operationServer = server.value
-    const { modifiedUrl } = getUrlFromServerState(serverState, operationServer)
     return {
       uid: operationServer?.uid || '',
-      url: modifiedUrl || '',
+      url: serverUrl.value || '',
     }
   })
+
+  console.log('SERVER URL', serverUrl.value)
 
   /** The request object to use for the code snippet */
   const httpRequest = computed(() => {


### PR DESCRIPTION
this pr brings back the previous fix for #3964 following changes that occurred in #3981 by:
- displaying request server in the request example reference
- fixing the collection server selection
- updating address bar server style

| before | after |
| -------|------|
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/27bf818e-ffba-43df-b028-f85af95dd19f" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/340300f8-ac40-4711-bc96-f721891d3d25" /> |
| alignment of the label to the text creates a big left gap  at the top | alignment now sets to the check icon and create child parent gap |
