### PR TITLE
fix(api-client): showSidebar config option for the client

### DIFF
--- a/.changeset/sharp-ears-clean.md
+++ b/.changeset/sharp-ears-clean.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: showSidebar config option for client

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -135,7 +135,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
 <template>
   <div
     v-if="activeRequest && activeExample"
-    class="order-last lg:order-none lg:w-auto w-full">
+    class="scalar-address-bar order-last lg:order-none lg:w-auto w-full">
     <div class="m-auto flex flex-row items-center">
       <!-- Address Bar -->
       <Listbox

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -6,10 +6,10 @@ import { ref } from 'vue'
 const props = withDefaults(
   defineProps<{
     title?: string
-    showSideBar?: boolean
+    isSidebarOpen?: boolean
   }>(),
   {
-    showSideBar: true,
+    isSidebarOpen: true,
   },
 )
 const { isReadOnly, sidebarWidth, setSidebarWidth } = useWorkspace()
@@ -61,7 +61,7 @@ const startDrag = (event: MouseEvent) => {
 </script>
 <template>
   <aside
-    v-show="props.showSideBar"
+    v-show="props.isSidebarOpen"
     ref="sidebarRef"
     class="sidebar overflow-hidden relative flex flex-col flex-1 md:flex-none bg-b-1 md:border-b-0 md:border-r-1/2 min-w-full md:min-w-fit leading-3"
     :class="{ dragging: isDragging }"

--- a/packages/api-client/src/components/Sidebar/SidebarToggle.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarToggle.vue
@@ -9,7 +9,7 @@ defineEmits<{
 </script>
 <template>
   <button
-    class="text-c-3 hover:bg-b-2 active:text-c-1 p-2 rounded-lg"
+    class="scalar-sidebar-toggle text-c-3 hover:bg-b-2 active:text-c-1 p-2 rounded-lg"
     type="button"
     @click="$emit('update:modelValue', !modelValue)">
     <span class="sr-only">{{ modelValue ? 'Hide' : 'Show' }} sidebar</span>

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -127,6 +127,7 @@ export const createApiClient = ({
       isReadOnly,
       proxyUrl: configuration.proxyUrl,
       themeId: configuration.themeId,
+      showSidebar: configuration.showSidebar,
       hideClientButton: configuration.hideClientButton,
       useLocalStorage: persistData,
     })

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -58,10 +58,12 @@ type CreateWorkspaceStoreOptions = {
   useLocalStorage: boolean
   /** Puts the client into read only mode, usually reservered for the modal */
   isReadOnly: boolean
-  proxyUrl: ReferenceConfiguration['proxyUrl']
+  /** Should be renamed to theme to match the references config */
   themeId: ReferenceConfiguration['theme']
-  hideClientButton: ReferenceConfiguration['hideClientButton']
-}
+} & Pick<
+  ReferenceConfiguration,
+  'proxyUrl' | 'showSidebar' | 'hideClientButton'
+>
 
 /**
  /**
@@ -73,6 +75,7 @@ type CreateWorkspaceStoreOptions = {
 export const createWorkspaceStore = ({
   useLocalStorage = true,
   isReadOnly = false,
+  showSidebar = true,
   proxyUrl,
   themeId,
   hideClientButton,
@@ -201,11 +204,14 @@ export const createWorkspaceStore = ({
     securitySchemes,
     modalState,
     events,
-    proxyUrl,
     sidebarWidth,
     setSidebarWidth,
+    // ---------------------------------------------------------------------------
+    // CONFIGURATION "PROPS"
     isReadOnly,
     hideClientButton,
+    proxyUrl,
+    showSidebar,
     // ---------------------------------------------------------------------------
     // METHODS
     importSpecFile,

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -206,11 +206,12 @@ export const createWorkspaceStore = ({
     events,
     sidebarWidth,
     setSidebarWidth,
+    proxyUrl,
     // ---------------------------------------------------------------------------
     // CONFIGURATION "PROPS"
+    // TODO: move these to their own store
     isReadOnly,
     hideClientButton,
-    proxyUrl,
     showSidebar,
     // ---------------------------------------------------------------------------
     // METHODS

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -41,6 +41,7 @@ const {
   isReadOnly,
   modalState,
   requestHistory,
+  showSidebar,
   securitySchemes,
   requestMutators,
   serverMutators,
@@ -53,7 +54,7 @@ type ExtendedRequestPayload = RequestPayload & {
   url?: string
 }
 
-const showSideBar = ref(!isReadOnly)
+const isSidebarOpen = ref(!isReadOnly)
 const requestAbortController = ref<AbortController>()
 const parsedCurl = ref<ExtendedRequestPayload>()
 const selectedServerUid = ref('')
@@ -64,7 +65,7 @@ const activeHistoryEntry = computed(() =>
 )
 /** Show / hide the sidebar when we resize the screen */
 const { mediaQueries } = useBreakpoints()
-watch(mediaQueries.xl, (isXL) => (showSideBar.value = isXL), {
+watch(mediaQueries.xl, (isXL) => (isSidebarOpen.value = isXL), {
   immediate: layout !== 'modal',
 })
 
@@ -205,10 +206,6 @@ function handleCurlImport(curl: string) {
   parsedCurl.value = importCurlCommand(curl)
   modalState.show()
 }
-function hello(show: boolean) {
-  console.log('hello', show)
-  showSideBar.value = show
-}
 </script>
 <template>
   <div
@@ -218,14 +215,13 @@ function hello(show: boolean) {
     }">
     <div class="flex h-full">
       <RequestSidebar
-        :isReadonly="isReadOnly"
-        :showSidebar="showSideBar"
+        v-if="showSidebar"
+        :isSidebarOpen="isSidebarOpen"
         @newTab="$emit('newTab', $event)"
-        @update:showSidebar="hello" />
+        @update:isSidebarOpen="(val) => (isSidebarOpen = val)" />
       <div class="flex flex-1 flex-col h-full">
         <RequestSubpageHeader
-          v-model="showSideBar"
-          :isReadonly="isReadOnly"
+          v-model="isSidebarOpen"
           @hideModal="() => modalState.hide()"
           @importCurl="handleCurlImport" />
         <ViewLayout>
@@ -233,7 +229,7 @@ function hello(show: boolean) {
           <ViewLayoutContent
             v-if="activeExample"
             class="flex-1"
-            :class="[showSideBar ? 'sidebar-active-hide-layout' : '']">
+            :class="[isSidebarOpen ? 'sidebar-active-hide-layout' : '']">
             <RequestSection
               :selectedSecuritySchemeUids="selectedSecuritySchemeUids" />
             <ResponseSection :response="activeHistoryEntry?.response" />

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -41,19 +41,17 @@ import RequestSidebarItem from './RequestSidebarItem.vue'
 import { WorkspaceDropdown } from './components'
 
 const props = defineProps<{
-  showSidebar: boolean
-  isReadonly: boolean
+  isSidebarOpen: boolean
 }>()
 
 const emit = defineEmits<{
   (e: 'update:modelValue', v: boolean): void
-  (e: 'update:showSidebar', v: boolean): void
+  (e: 'update:isSidebarOpen', v: boolean): void
   (e: 'newTab', { name, uid }: { name: string; uid: string }): void
   (e: 'clearDrafts'): void
 }>()
 const { layout } = useLayout()
 
-console.log('layout', layout)
 const workspaceContext = useWorkspace()
 const {
   activeWorkspaceCollections,
@@ -110,11 +108,8 @@ const {
 const handleHotKey = (event?: HotKeyEvent) => {
   if (!event) return
 
-  if (event.toggleSidebar) emit('update:showSidebar', props.showSidebar)
-
-  if (event.focusRequestSearch) {
-    searchInputRef.value?.focus()
-  }
+  if (event.toggleSidebar) emit('update:isSidebarOpen', props.isSidebarOpen)
+  if (event.focusRequestSearch) searchInputRef.value?.focus()
 }
 
 onMounted(() => events.hotKeys.on(handleHotKey))
@@ -145,7 +140,7 @@ watch(
     activeWorkspaceCollections.value.map((collection) => collection.watchMode),
   (newWatchModes, oldWatchModes) => {
     newWatchModes.forEach((newWatchMode, index) => {
-      if (!props.isReadonly && newWatchMode !== oldWatchModes[index]) {
+      if (!isReadOnly && newWatchMode !== oldWatchModes[index]) {
         const currentCollection = activeWorkspaceCollections.value[index]
         const message = `${currentCollection.info?.title}: Watch Mode ${newWatchMode ? 'enabled' : 'disabled'}`
         toast(message, 'info')
@@ -211,28 +206,28 @@ const toggleSearch = () => {
 </script>
 <template>
   <Sidebar
-    v-show="showSidebar"
-    :class="[showSidebar ? 'sidebar-active-width' : '']"
-    :showSidebar="showSidebar"
-    @update:showSidebar="$emit('update:showSidebar', $event)">
+    v-show="isSidebarOpen"
+    :class="[isSidebarOpen ? 'sidebar-active-width' : '']"
+    :isSidebarOpen="isSidebarOpen"
+    @update:isSidebarOpen="$emit('update:isSidebarOpen', $event)">
     <template
-      v-if="!isReadonly"
+      v-if="!isReadOnly"
       #header>
     </template>
     <template #content>
       <div class="flex items-center h-[48px] px-3 top-0 bg-b-1 sticky z-20">
         <SidebarToggle
-          class="gitbook-hidden xl:hidden"
+          class="xl:hidden"
           :class="[{ '!flex': layout === 'modal' }]"
-          :modelValue="showSidebar"
-          @update:modelValue="$emit('update:showSidebar', $event)" />
-        <WorkspaceDropdown v-if="!isReadonly" />
+          :modelValue="isSidebarOpen"
+          @update:modelValue="$emit('update:isSidebarOpen', $event)" />
+        <WorkspaceDropdown v-if="!isReadOnly" />
         <span
-          v-if="!isReadonly"
-          class="text-c-3"
-          >/</span
-        >
-        <EnvironmentSelector v-if="!isReadonly" />
+          v-if="!isReadOnly"
+          class="text-c-3">
+          /
+        </span>
+        <EnvironmentSelector v-if="!isReadOnly" />
         <button
           class="ml-auto"
           type="button"
@@ -261,7 +256,7 @@ const toggleSearch = () => {
       <div
         class="flex flex-1 flex-col overflow-visible px-3 pb-3 pt-0"
         :class="{
-          'pb-14': !isReadonly,
+          'pb-14': !isReadOnly,
         }"
         @dragenter.prevent
         @dragover.prevent>
@@ -298,7 +293,7 @@ const toggleSearch = () => {
           <RequestSidebarItem
             v-for="collection in activeWorkspaceCollections"
             :key="collection.uid"
-            :isDraggable="!isReadonly && collection.info?.title !== 'Drafts'"
+            :isDraggable="!isReadOnly && collection.info?.title !== 'Drafts'"
             :isDroppable="isDroppable"
             :menuItem="menuItem"
             :parentUids="[]"
@@ -354,7 +349,7 @@ const toggleSearch = () => {
           </div>
         </div>
         <ScalarButton
-          v-if="!isReadonly"
+          v-if="!isReadOnly"
           class="mb-1.5 w-full h-fit hidden opacity-0 p-1.5"
           :class="{
             'flex opacity-100': activeWorkspaceRequests.length <= 1,
@@ -363,7 +358,7 @@ const toggleSearch = () => {
           Import Collection
         </ScalarButton>
         <SidebarButton
-          v-if="!isReadonly"
+          v-if="!isReadOnly"
           :click="events.commandPalette.emit"
           hotkey="K">
           <template #title>Add Item</template>

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
@@ -1,0 +1,109 @@
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
+import { createStoreEvents } from '@/store/events'
+import { mount } from '@vue/test-utils'
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import RequestSubpageHeader from './RequestSubpageHeader.vue'
+
+// Mock vue-router
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    currentRoute: {
+      query: {},
+    },
+  }),
+}))
+
+// Mock the useWorkspace hook
+vi.mock('@/store', () => ({
+  useWorkspace: vi.fn(),
+}))
+const mockUseWorkspace = useWorkspace as Mock
+const mockWorkspace = {
+  isReadOnly: false,
+  events: createStoreEvents(),
+  hideClientButton: false,
+  showSidebar: true,
+  requestHistory: ref([]),
+}
+
+// Mock useActiveEntities
+vi.mock('@/store/active-entities', () => ({
+  useActiveEntities: vi.fn(),
+}))
+const mockUseActiveEntities = useActiveEntities as Mock
+const mockActiveEntities = {
+  activeCollection: ref({
+    documentUrl: 'https://example.com',
+    integration: 'test',
+  }),
+  activeEnvironment: ref({}),
+  activeRequest: ref({ uid: 'mockRequestUid' }),
+  activeWorkspace: ref({}),
+}
+
+describe('RequestSubpageHeader', () => {
+  const createWrapper = (options = {}) => {
+    return mount(RequestSubpageHeader, {
+      props: {
+        modelValue: false,
+      },
+      ...options,
+    })
+  }
+
+  // Mock our request + example
+  beforeEach(() => {
+    mockUseActiveEntities.mockReturnValue(mockActiveEntities)
+    mockUseWorkspace.mockReturnValue(mockWorkspace)
+  })
+
+  it('renders correctly', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('shows SidebarToggle when showSidebar is true', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(true)
+  })
+
+  it('hides SidebarToggle when showSidebar is false', async () => {
+    mockUseWorkspace.mockReturnValue({ ...mockWorkspace, showSidebar: false })
+    const wrapper = createWrapper()
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(false)
+  })
+
+  it('shows OpenApiClientButton when in readonly mode with document URL', async () => {
+    mockUseWorkspace.mockReturnValue({
+      ...mockWorkspace,
+      isReadOnly: true,
+    })
+    const wrapper = createWrapper()
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.open-api-client-button').exists()).toBe(true)
+  })
+
+  it('emits update:modelValue when SidebarToggle is clicked', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.scalar-sidebar-toggle').trigger('click')
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([true])
+  })
+
+  it('emits hideModal when close button is clicked', async () => {
+    mockUseWorkspace.mockReturnValue({
+      ...mockWorkspace,
+      isReadOnly: true,
+    })
+    const wrapper = createWrapper()
+
+    await wrapper.vm.$nextTick()
+    await wrapper.find('.app-exit-button').trigger('click')
+    expect(wrapper.emitted('hideModal')).toBeTruthy()
+  })
+})

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -11,7 +11,6 @@ import { useRouter } from 'vue-router'
 
 defineProps<{
   modelValue: boolean
-  isReadonly: boolean
 }>()
 
 defineEmits<{
@@ -21,9 +20,7 @@ defineEmits<{
 }>()
 
 const { activeCollection } = useActiveEntities()
-const workspaceContext = useWorkspace()
-
-const { hideClientButton } = workspaceContext
+const { isReadOnly, hideClientButton, showSidebar } = useWorkspace()
 
 const { layout } = useLayout()
 const { currentRoute } = useRouter()
@@ -34,7 +31,8 @@ const { currentRoute } = useRouter()
     <div
       class="flex flex-row items-center gap-1 lg:px-1 lg:mb-0 mb-2 lg:flex-1 w-6/12">
       <SidebarToggle
-        class="gitbook-hidden ml-1"
+        v-if="showSidebar"
+        class="ml-1"
         :class="[
           { hidden: modelValue },
           { 'xl:!flex': !modelValue },
@@ -45,14 +43,14 @@ const { currentRoute } = useRouter()
         @update:modelValue="$emit('update:modelValue', $event)" />
       <!-- todo: only show this env selectorin modal -->
       <EnvironmentSelector
-        v-if="!isReadonly"
+        v-if="!isReadOnly"
         class="hidden" />
     </div>
     <AddressBar @importCurl="$emit('importCurl', $event)" />
     <div
       class="flex flex-row items-center gap-1 lg:px-2.5 lg:mb-0 mb-2 lg:flex-1 justify-end w-6/12">
       <OpenApiClientButton
-        v-if="isReadonly && activeCollection?.documentUrl && !hideClientButton"
+        v-if="isReadOnly && activeCollection?.documentUrl && !hideClientButton"
         buttonSource="modal"
         class="!w-fit lg:-mr-1"
         :integration="activeCollection?.integration"
@@ -62,7 +60,7 @@ const { currentRoute } = useRouter()
         :url="activeCollection?.documentUrl" />
       <!-- TODO: There should be an `ìsModal` flag instead -->
       <button
-        v-if="isReadonly"
+        v-if="isReadOnly"
         class="app-exit-button p-2 rounded-full fixed right-2 top-2 gitbook-hidden"
         type="button"
         @click="$emit('hideModal')">
@@ -74,7 +72,7 @@ const { currentRoute } = useRouter()
       </button>
       <!-- TODO: temporary solution: 2nd button (not fixed position) for our friends at GitBook -->
       <button
-        v-if="isReadonly"
+        v-if="isReadOnly"
         class="text-c-1 hover:bg-b-2 active:text-c-1 p-2 rounded -mr-1.5 gitbook-show"
         type="button"
         @click="$emit('hideModal')">

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { OpenApiClientButton } from '@/components'
 import AddressBar from '@/components/AddressBar/AddressBar.vue'
-import EnvironmentSelector from '@/components/EnvironmentSelector/EnvironmentSelector.vue'
 import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
 import { useLayout } from '@/hooks'
 import { useWorkspace } from '@/store'
@@ -41,10 +40,6 @@ const { currentRoute } = useRouter()
         ]"
         :modelValue="modelValue"
         @update:modelValue="$emit('update:modelValue', $event)" />
-      <!-- todo: only show this env selectorin modal -->
-      <EnvironmentSelector
-        v-if="!isReadOnly"
-        class="hidden" />
     </div>
     <AddressBar @importCurl="$emit('importCurl', $event)" />
     <div


### PR DESCRIPTION
**Problem**
The `showSidebar` config option doesn't do anything in the client

**Solution**
We now do not render the sidebar if that config option is false. Giving us a nice performance boost on big specs. I also renamed the old `showSidebar` var to `isSidebarShowing` to more accurately reflect what it does.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
