### PR TITLE
fix: initial workspace load

### DIFF
--- a/.changeset/mean-starfishes-kick.md
+++ b/.changeset/mean-starfishes-kick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: add immediete to load the workspace store

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -267,6 +267,7 @@ watch(
       setCollectionSecurity: true,
       ...props.configuration,
     }),
+  { immediate: true },
 )
 
 provide(WORKSPACE_SYMBOL, workspaceStore)


### PR DESCRIPTION
:)

we need to add an immediate here for the case where we directly pass in a parsed spec, vs the usual way we do things (it loads after it starts empty 