### PR TITLE
ci: async todesktop build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,7 @@ jobs:
         run: ls -R ./packages/scalar-app/dist
       - if: steps.changed-files.outputs.api_client_app_any_changed == 'true'
         name: Build in the toDesktop cloud
-        run: pnpm --filter scalar-app todesktop:build
+        run: pnpm --filter scalar-app todesktop:build:ci
         env:
           TODESKTOP_EMAIL: ${{ secrets.TODESKTOP_EMAIL }}
           TODESKTOP_ACCESS_TOKEN: ${{ secrets.TODESKTOP_ACCESS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
   todesktop-build:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     needs: [build, test]
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
   todesktop-build:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 10
     needs: [build, test]
     strategy:
       matrix:

--- a/packages/scalar-app/package.json
+++ b/packages/scalar-app/package.json
@@ -22,6 +22,7 @@
     "preview": "electron-vite preview",
     "test": "vitest",
     "todesktop:build": "todesktop build",
+    "todesktop:build:ci": "todesktop build --async",
     "todesktop:release": "todesktop release",
     "todesktop:release:ci": "todesktop release --latest --force",
     "todesktop:test": "todesktop smoke-test",


### PR DESCRIPTION
The toDesktop build takes too long, and CI is failing when it’s waiting for the build.

But there’s no benefit that we get from waiting for it, so let’s just trigger the build and continue.

Should make the release commits green again.

https://github.com/scalar/scalar/actions/runs/12435977129/job/34723231861

![Screenshot 2024-12-20 at 19 30 47](https://github.com/user-attachments/assets/abcae4de-c6a7-4dcb-b69f-57c3fb445d64)
