### PR TITLE
fix(api-reference): ensure store exists before trying to create store

### DIFF
--- a/.changeset/thick-flowers-play.md
+++ b/.changeset/thick-flowers-play.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: ensure spec exists before trying to create store

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -39,7 +39,6 @@ import {
   HIDE_TEST_REQUEST_BUTTON_SYMBOL,
   INTEGRATION_SYMBOL,
   OPENAPI_DOCUMENT_URL_SYMBOL,
-  createEmptySpecification,
   downloadSpecBus,
   downloadSpecFile,
   sleep,

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -39,6 +39,7 @@ import {
   HIDE_TEST_REQUEST_BUTTON_SYMBOL,
   INTEGRATION_SYMBOL,
   OPENAPI_DOCUMENT_URL_SYMBOL,
+  createEmptySpecification,
   downloadSpecBus,
   downloadSpecFile,
   sleep,
@@ -261,6 +262,7 @@ const workspaceStore = createWorkspaceStore({
 watch(
   () => props.rawSpec,
   (spec) =>
+    spec &&
     workspaceStore.importSpecFile(spec, 'default', {
       shouldLoad: false,
       documentUrl: props.configuration.spec?.url,


### PR DESCRIPTION
**Problem**
With `immediate: true` we sometimes send an empty spec to the watcher which then tries to create a store from it. 

**Solution**
We ensure a spec exists before trying to do so.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature. - I will add a test in Cam's PR
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.

before:
![image](https://github.com/user-attachments/assets/aad1a03a-b2ad-4b46-95ba-de2c73e03147)
after:
![image](https://github.com/user-attachments/assets/65282c06-bb34-41d1-8125-02f5434c3787)

