### PR TITLE
chore: updates migration

### DIFF
--- a/.changeset/breezy-mice-tap.md
+++ b/.changeset/breezy-mice-tap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: returns non drafts collections without changes in 2.4.0 migration

--- a/packages/oas-utils/src/migrations/v-2.4.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.4.0/migration.ts
@@ -27,7 +27,6 @@ export const migrate_v_2_4_0 = (
         }
       })
     }
-    prev[c.uid] = c
     return prev
   }, {})
 


### PR DESCRIPTION
this pr updates the 2.4.0 migration to only return the non drafts collections without changes.