### PR TITLE
fix(api-client): revert migration change

### DIFF
--- a/.changeset/tiny-colts-tickle.md
+++ b/.changeset/tiny-colts-tickle.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+fix: revert migration change from earlier

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -70,12 +70,13 @@ const setInitialEnvironment = (collection: Collection) => {
   }
 }
 
-watch(activeCollection, (newCollection) => {
-  setInitialEnvironment(newCollection as Collection)
-})
+watch(
+  activeCollection,
+  (newCollection) => newCollection && setInitialEnvironment(newCollection),
+)
 
 onMounted(() => {
-  setInitialEnvironment(activeCollection.value as Collection)
+  activeCollection.value && setInitialEnvironment(activeCollection.value)
 })
 </script>
 <template>

--- a/packages/oas-utils/src/migrations/v-2.4.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.4.0/migration.ts
@@ -27,7 +27,11 @@ export const migrate_v_2_4_0 = (
         }
       })
     }
-    return prev
+
+    return {
+      ...prev,
+      [c.uid]: c,
+    }
   }, {})
 
   return {

--- a/packages/oas-utils/src/migrations/v-2.4.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.4.0/migration.ts
@@ -28,10 +28,8 @@ export const migrate_v_2_4_0 = (
       })
     }
 
-    return {
-      ...prev,
-      [c.uid]: c,
-    }
+    prev[c.uid] = c
+    return prev
   }, {})
 
   return {


### PR DESCRIPTION
Rolls back the migration bug from earlier. Also removes `as`