### PR TITLE
feat(fastify-api-reference): dynamic fastify schema modifications

### DIFF
--- a/.changeset/proud-flowers-march.md
+++ b/.changeset/proud-flowers-march.md
@@ -1,0 +1,6 @@
+---
+'@scalar/fastify-api-reference': minor
+'@scalar/openapi-parser': minor
+---
+
+Add a hook to `fastify-api-reference` to conditionally modify schema

--- a/examples/fastify-api-reference/src/index.ts
+++ b/examples/fastify-api-reference/src/index.ts
@@ -67,15 +67,14 @@ fastify.get(
   '/hidden',
   {
     schema: {
-      'description': 'Hidden route',
-      'tags': ['user'],
-      'summary': 'A route which should not be visible',
-      'response': {
+      description: 'Hidden route',
+      tags: ['user'],
+      summary: 'A route which should not be visible',
+      response: {
         204: {
           type: 'null',
         },
       },
-      'x-private': true,
     },
   },
   (_, reply) => {
@@ -87,10 +86,14 @@ fastify.get(
 await fastify.register(fastifyApiReference, {
   routePrefix: '/',
   processSpec: (spec, request) => {
-    if (request.query.private === 'true') {
+    const privateSpec = request.query.private === 'true'
+    if (privateSpec) {
       return spec
     } else {
-      return spec.filter((schema) => !schema?.['x-private'])
+      return spec.map((s) => {
+        delete s.paths['/hidden']
+        return s
+      })
     }
   },
 } satisfies FastifyApiReferenceOptions)

--- a/examples/fastify-api-reference/src/index.ts
+++ b/examples/fastify-api-reference/src/index.ts
@@ -63,9 +63,36 @@ fastify.put<{ Body: { name: string } }>(
   },
 )
 
+fastify.get(
+  '/hidden',
+  {
+    schema: {
+      'description': 'Hidden route',
+      'tags': ['user'],
+      'summary': 'A route which should not be visible',
+      'response': {
+        204: {
+          type: 'null',
+        },
+      },
+      'x-private': true,
+    },
+  },
+  (_, reply) => {
+    reply.code(204).send()
+  },
+)
+
 // Add the plugin
 await fastify.register(fastifyApiReference, {
   routePrefix: '/',
+  processSpec: (spec, request) => {
+    if (request.query.private === 'true') {
+      return spec
+    } else {
+      return spec.filter((schema) => !schema?.['x-private'])
+    }
+  },
 } satisfies FastifyApiReferenceOptions)
 
 const PORT = Number(process.env.PORT) || 5053

--- a/packages/fastify-api-reference/README.md
+++ b/packages/fastify-api-reference/README.md
@@ -52,6 +52,10 @@ We wrote a [detailed integration guide for Fastify](https://github.com/scalar/sc
 
 The fastify plugin takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/tree/main/documentation/configuration.md) in the core package README.
 
+## Advanced
+
+You can use the `processSpec` hook in the configuration to modify your spec on the fly before sending it out, e.g. by checking for a specific query parameter.
+
 ## Themes
 
 By default, we’re using a custom Fastify theme and it’s beautiful. But you can choose [one of our other themes](https://github.com/scalar/scalar/tree/main/packages/themes), too:

--- a/packages/fastify-api-reference/src/types.ts
+++ b/packages/fastify-api-reference/src/types.ts
@@ -1,5 +1,13 @@
+import type { openapi } from '@scalar/openapi-parser'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
-import type { onRequestHookHandler, preHandlerHookHandler } from 'fastify'
+import type {
+  FastifyRequest,
+  onRequestHookHandler,
+  preHandlerHookHandler,
+} from 'fastify'
+
+export type LoadedSpec = ReturnType<ReturnType<typeof openapi>['load']>
+export type ProcessedSpec = Pick<LoadedSpec, 'get' | 'toJson' | 'toYaml'>
 
 export type FastifyApiReferenceOptions = {
   /**
@@ -58,6 +66,17 @@ export type FastifyApiReferenceOptions = {
    * The hooks for the API Reference.
    */
   hooks?: FastifyApiReferenceHooksOptions
+  /**
+   * Allow to process the specification before it’s rendered out.
+   *
+   * @param spec The loaded spec.
+   * @param request The fastify request objec.
+   * @returns The modified spec.
+   */
+  processSpec?: (
+    spec: LoadedSpec,
+    request: FastifyRequest<any, any, any, any, any, any, any, any>,
+  ) => ProcessedSpec | Promise<ProcessedSpec>
 }
 
 export type FastifyApiReferenceHooksOptions = Partial<{

--- a/packages/openapi-parser/README.md
+++ b/packages/openapi-parser/README.md
@@ -80,7 +80,7 @@ const { schema, errors } = await dereference(specification, {
 ### Modify an OpenAPI document
 
 ```ts
-import { filter } from '@scalar/openapi-parser'
+import { filter, map } from '@scalar/openapi-parser'
 
 const specification = `{
   "openapi": "3.1.0",
@@ -92,6 +92,11 @@ const specification = `{
 }`
 
 const { specification } = filter(specification, (schema) => !schema?.['x-internal'])
+
+const { specification2 } = map(specification, (schema) => {
+  delete schema.paths['/hidden']
+  return schema
+}
 ```
 
 ### Upgrade your OpenAPI document

--- a/packages/openapi-parser/src/types/index.ts
+++ b/packages/openapi-parser/src/types/index.ts
@@ -38,6 +38,10 @@ export type FilterResult = {
   specification: AnyObject
 }
 
+export type MapResult = {
+  specification: AnyObject
+}
+
 export type DetailsResult = {
   version: OpenApiVersion
   specificationType: string

--- a/packages/openapi-parser/src/utils/filter.test.ts
+++ b/packages/openapi-parser/src/utils/filter.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { filter } from './filter'
+import { openapi } from './openapi'
+
+describe('filter', () => {
+  const spec = {
+    openapi: '3.1.0',
+    paths: {
+      '/test': {
+        get: {
+          responses: {
+            '200': {
+              description: 'visible',
+            },
+          },
+        },
+      },
+      '/hidden': {
+        get: {
+          'responses': {
+            '200': {
+              description: 'hidden',
+            },
+          },
+          'x-internal': true,
+        },
+      },
+    },
+  }
+
+  it('filters spec', async () => {
+    const result = filter(spec, (schema) => !schema['x-internal'])
+    expect(result).toEqual({
+      specification: {
+        openapi: '3.1.0',
+        paths: {
+          '/test': {
+            get: { responses: { '200': { description: 'visible' } } },
+          },
+          '/hidden': {},
+        },
+      },
+    })
+  })
+
+  it('filters spec with queue', async () => {
+    const result = await openapi()
+      .load(spec)
+      .filter((schema) => !schema['x-internal'])
+      .toJson()
+    expect(JSON.parse(result)).toEqual({
+      openapi: '3.1.0',
+      paths: {
+        '/test': {
+          get: { responses: { '200': { description: 'visible' } } },
+        },
+        '/hidden': {},
+      },
+    })
+  })
+})

--- a/packages/openapi-parser/src/utils/load/load.test.ts
+++ b/packages/openapi-parser/src/utils/load/load.test.ts
@@ -427,4 +427,20 @@ describe('load', async () => {
       })
     }).rejects.toThrowError('Can’t resolve external reference: INVALID')
   })
+
+  it('creates clone of supplied object', async () => {
+    const data = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {},
+    }
+    const { specification } = await load(data)
+
+    data.info.title = 'Changed'
+
+    expect(specification.info.title).toBe('Hello World')
+  })
 })

--- a/packages/openapi-parser/src/utils/load/load.ts
+++ b/packages/openapi-parser/src/utils/load/load.ts
@@ -101,6 +101,9 @@ export async function load(
     }
   }
 
+  // Deep-clone to prevent side-effects when the queue modifies the content
+  content = structuredClone(content)
+
   let filesystem = makeFilesystem(content, {
     filename: options?.filename ?? null,
   })

--- a/packages/openapi-parser/src/utils/map.ts
+++ b/packages/openapi-parser/src/utils/map.ts
@@ -1,0 +1,19 @@
+import type { AnyApiDefinitionFormat, AnyObject, MapResult } from '../types'
+import { getEntrypoint } from './getEntrypoint'
+import { makeFilesystem } from './makeFilesystem'
+
+export type MapCallback = (schema: AnyObject) => AnyObject
+
+/**
+ * Filter the specification based on the callback
+ */
+export function map(
+  specification: AnyApiDefinitionFormat,
+  callback: MapCallback,
+): MapResult {
+  const filesystem = makeFilesystem(specification)
+
+  return {
+    specification: callback(getEntrypoint(filesystem).specification),
+  }
+}

--- a/packages/openapi-parser/src/utils/openapi/actions/toJson.ts
+++ b/packages/openapi-parser/src/utils/openapi/actions/toJson.ts
@@ -1,5 +1,4 @@
 import type { Queue, Task } from '../../../types'
-import { getEntrypoint } from '../../getEntrypoint'
 import { toJson as toJsonUtility } from '../../toJson'
 import { workThroughQueue } from '../utils/workThroughQueue'
 
@@ -9,7 +8,7 @@ import { workThroughQueue } from '../utils/workThroughQueue'
 export async function toJson<T extends Task[]>(
   queue: Queue<T>,
 ): Promise<string | undefined> {
-  const { filesystem } = await workThroughQueue(queue)
+  const { specification } = await workThroughQueue(queue)
 
-  return toJsonUtility(getEntrypoint(filesystem).specification)
+  return toJsonUtility(specification)
 }

--- a/packages/openapi-parser/src/utils/openapi/actions/toYaml.ts
+++ b/packages/openapi-parser/src/utils/openapi/actions/toYaml.ts
@@ -1,5 +1,4 @@
 import type { Queue, Task } from '../../../types'
-import { getEntrypoint } from '../../getEntrypoint'
 import { toYaml as toYamlUtility } from '../../toYaml'
 import { workThroughQueue } from '../utils/workThroughQueue'
 
@@ -9,7 +8,7 @@ import { workThroughQueue } from '../utils/workThroughQueue'
 export async function toYaml<T extends Task[]>(
   queue: Queue<T>,
 ): Promise<string> {
-  const { filesystem } = await workThroughQueue(queue)
+  const { specification } = await workThroughQueue(queue)
 
-  return toYamlUtility(getEntrypoint(filesystem).specification)
+  return toYamlUtility(specification)
 }

--- a/packages/openapi-parser/src/utils/openapi/commands/loadCommand.ts
+++ b/packages/openapi-parser/src/utils/openapi/commands/loadCommand.ts
@@ -16,6 +16,7 @@ import { toYaml } from '../actions/toYaml'
 import { queueTask } from '../utils/queueTask'
 import { dereferenceCommand } from './dereferenceCommand'
 import { filterCommand } from './filterCommand'
+import { mapCommand } from './mapCommand'
 import { upgradeCommand } from './upgradeCommand'
 import { validateCommand } from './validateCommand'
 
@@ -64,6 +65,8 @@ export function loadCommand<T extends Task[]>(
     files: () => files(queue),
     filter: (callback: (specification: AnyObject) => boolean) =>
       filterCommand(queue, callback),
+    map: (callback: (specification: AnyObject) => AnyObject) =>
+      mapCommand(queue, callback),
     get: () => get(queue),
     upgrade: () => upgradeCommand(queue),
     toJson: () => toJson(queue),

--- a/packages/openapi-parser/src/utils/openapi/commands/mapCommand.ts
+++ b/packages/openapi-parser/src/utils/openapi/commands/mapCommand.ts
@@ -1,0 +1,48 @@
+import type { MapResult, Queue, Task } from '../../../types'
+import type { DereferenceOptions } from '../../dereference'
+import { details } from '../../details'
+import type { MapCallback } from '../../map'
+import { files } from '../actions/files'
+import { get } from '../actions/get'
+import { toJson } from '../actions/toJson'
+import { toYaml } from '../actions/toYaml'
+import { queueTask } from '../utils/queueTask'
+import { dereferenceCommand } from './dereferenceCommand'
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface Commands {
+    map: {
+      task: {
+        name: 'map'
+        options?: MapCallback
+      }
+      result: MapResult
+    }
+  }
+}
+
+/**
+ * Map the given OpenAPI document
+ */
+export function mapCommand<T extends Task[]>(
+  previousQueue: Queue<T>,
+  options?: MapCallback,
+) {
+  const task: Task = {
+    name: 'map',
+    options,
+  }
+
+  const queue = queueTask<[...T, typeof task]>(previousQueue, task as Task)
+
+  return {
+    dereference: (dereferenceOptions?: DereferenceOptions) =>
+      dereferenceCommand(queue, dereferenceOptions),
+    details: () => details(queue),
+    files: () => files(queue),
+    get: () => get(queue),
+    toJson: () => toJson(queue),
+    toYaml: () => toYaml(queue),
+  }
+}

--- a/packages/openapi-parser/src/utils/openapi/utils/workThroughQueue.test.ts
+++ b/packages/openapi-parser/src/utils/openapi/utils/workThroughQueue.test.ts
@@ -249,4 +249,132 @@ describe('workThroughQueue', () => {
       ],
     })
   })
+
+  it('filters a specification', async () => {
+    const result = await workThroughQueue({
+      input: {
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/public': {
+            get: {
+              responses: { 200: { description: 'OK' } },
+            },
+          },
+          '/private': {
+            get: {
+              'responses': { 200: { description: 'OK' } },
+              'x-internal': true,
+            },
+          },
+        },
+      },
+      specification: {
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {},
+      },
+      tasks: [
+        {
+          name: 'load',
+        },
+        {
+          name: 'filter',
+          options: (schema) => !schema?.['x-internal'],
+        },
+      ],
+    })
+
+    expect(result.specification).toStrictEqual({
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/public': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+        '/private': {
+          get: undefined,
+        },
+      },
+    })
+  })
+
+  it('maps a specification', async () => {
+    const result = await workThroughQueue({
+      input: {
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/public': {
+            get: {
+              responses: { 200: { description: 'OK' } },
+            },
+          },
+          '/private': {
+            get: {
+              'responses': { 200: { description: 'OK' } },
+              'x-internal': true,
+            },
+          },
+        },
+      },
+      specification: {
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {},
+      },
+      tasks: [
+        {
+          name: 'load',
+        },
+        {
+          name: 'map',
+          options: (schema) => {
+            delete schema.paths['/private']
+            return schema
+          },
+        },
+      ],
+    })
+
+    expect(result.specification).toStrictEqual({
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/public': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+    })
+  })
 })

--- a/packages/openapi-parser/src/utils/openapi/utils/workThroughQueue.ts
+++ b/packages/openapi-parser/src/utils/openapi/utils/workThroughQueue.ts
@@ -2,6 +2,7 @@ import type { CommandChain, Merge, Queue, Task } from '../../../types'
 import { dereference } from '../../dereference'
 import { filter } from '../../filter'
 import { load } from '../../load'
+import { map } from '../../map'
 import { upgrade } from '../../upgrade'
 import { validate } from '../../validate'
 
@@ -37,7 +38,7 @@ export async function workThroughQueue<T extends Task[]>(
       } as Merge<typeof result, Awaited<typeof load>>
     }
 
-    // validate
+    // filter
     else if (name === 'filter') {
       result = {
         ...result,
@@ -46,6 +47,17 @@ export async function workThroughQueue<T extends Task[]>(
           options as Commands['filter']['task']['options'],
         ),
       } as Merge<typeof result, ReturnType<typeof filter>>
+    }
+
+    // map
+    else if (name === 'map') {
+      result = {
+        ...result,
+        ...map(
+          currentSpecification,
+          options as Commands['map']['task']['options'],
+        ),
+      }
     }
 
     // dereference


### PR DESCRIPTION
**Problem**
See #3434 

**Solution**
* Adds a hook `processSpec` to fastify-api-reference to modify a schema on the fly. The hook has access to the current request, so it can e.g. check for a query parameter to modify the schema.
* Any query parameters on the request URL to the HTML frontend are passed on to the spec. URL. (I thought if this should be behind an explicit toggle, but I don’t assume any breaking change)
* Fixes the queue’s filter functionality (see #4322)
* Adds a `map` operation to the queue which allows arbitrary modifications to the schema (more flexible than filtering)

![Bildschirmfoto 2024-12-25 um 19 19 13](https://github.com/user-attachments/assets/b127bd98-688e-4d77-92ac-f35d3d754f94)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
