### PR TITLE
fix(api-client): fix incorrect multipart form key

### DIFF
--- a/.changeset/small-camels-share.md
+++ b/.changeset/small-camels-share.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix multipart form body keys not being updated correctly

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -106,10 +106,10 @@ const updateRow = (rowIdx: number, field: 'key' | 'value', value: string) => {
     const updatedParams = [...currentParams]
     updatedParams[rowIdx] = {
       ...updatedParams[rowIdx],
-      [field]: value || '',
       value: updatedParams[rowIdx]?.value || '',
       key: updatedParams[rowIdx]?.key || '',
       enabled: updatedParams[rowIdx]?.enabled ?? false,
+      [field]: value || '',
     }
 
     /** enable row key or value is filled */


### PR DESCRIPTION
**Problem**
1. Upload file to multipart form body
2. Change key of the file
3. Do API call

=> Key of the file in multipart form body is still filename, while it should be updated key
#4350 

**Solution**
With this PR, I've updated the `updateRow` method in `RequestBody.vue` to do the update last, instead of first and it being over written later.

Tests still works and nothing else seems to be affected.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
  > is this needed for this change?
- [ ] I’ve updated the documentation.
  > is this needed for this change?

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.

---

This is my first PR here, sorry if I didn't follow proper protocol.
Feel free to let me know what I can do differently to fix this PR or improve my PRs in the future.
