### PR TITLE
docs: add Django integration to the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ And there’s an ever-growing list of plugins and integrations:
 - [HTML](documentation/integrations/html.md) (works everywhere)
 - [.NET](packages/scalar.aspnetcore/README.md)
 - [AdonisJS](documentation/integrations/adonisjs.md)
+- [Django](https://github.com/m1guer/django-scalar)
 - [Django Ninja](packages/scalar_django_ninja/README.md)
 - [Docusaurus](packages/docusaurus/README.md)
 - [Express](packages/express-api-reference/README.md)


### PR DESCRIPTION
I’ve just discovered a new Scalar Django integration by @m1guer! Let’s add it to the root README. :)