### PR TITLE
fix(code-highlight): styling of playground broken

### DIFF
--- a/packages/code-highlight/index.html
+++ b/packages/code-highlight/index.html
@@ -53,7 +53,7 @@
     </style>
     <script type="module"></script>
   </head>
-  <body class="dark-mode">
+  <body class="dark-mode scalar-app">
     <button
       id="dark-mode-btn"
       type="button">


### PR DESCRIPTION
WIP

Requires #4374

> Error:   Failed to scan for dependencies from entries:
>  /Users/hanspagel/Documents/Projects/scalar/packages/code-highlight/index.html
>
>  ✘ [ERROR] Missing "./base.css" specifier in "@scalar/themes" package [plugin vite:dep-scan]
>
>    playground/main.ts:5:7:
>      5 │ import '@scalar/themes/base.css'