### PR TITLE
style(api-client): auth table pill

### DIFF
--- a/.changeset/lucky-steaks-do.md
+++ b/.changeset/lucky-steaks-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: fixes dark auth pill ui

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -428,9 +428,6 @@ export default {
   font-size: var(--scalar-mini);
   background: color-mix(in srgb, var(--tw-bg-base), transparent 94%) !important;
 }
-.cm-pill.bg-grey {
-  background: var(--scalar-background-3) !important;
-}
 .dark-mode .cm-pill {
   background: color-mix(in srgb, var(--tw-bg-base), transparent 80%) !important;
 }

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -241,7 +241,7 @@ function handleDeleteScheme(option: { id: string; label: string }) {
                     <span
                       v-for="auth in selectedAuth"
                       :key="auth.id"
-                      class="cm-pill flex items-center mx-0 h-fit pr-0.5 !bg-b-2 text-c-1">
+                      class="flex items-center mx-0 h-fit pr-0.5 bg-b-2 text-c-1 px-2.25 rounded-full">
                       {{ auth.label }}
                       <ScalarIconButton
                         class="cursor-pointer -ml-0.5 text-c-3 hover:text-c-1 rounded-full"


### PR DESCRIPTION
**Problem**
selected auth background in darkmode is not highlighted as being sometime overloaded by the `cm-pill` utility usage that includes background property.

**Solution**
this pr removes the `cm-pill` utility usage while maintaining the style in order to only rely on the rightful background regarding auth type pill.

| before | after |
| -------|------|
|  <img width="594" alt="image" src="https://github.com/user-attachments/assets/1712c000-8866-4d0f-a4dd-f1e886829cf9" /> | <img width="594" alt="image" src="https://github.com/user-attachments/assets/e85e6b31-7763-4160-9fc0-a0afc1e890d6" /> |
| auth type background is missing | auth type pill background is now displayed  |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).