### PR TITLE
fix(api-client): request sidebar search toggle

### DIFF
--- a/.changeset/angry-boxes-argue.md
+++ b/.changeset/angry-boxes-argue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: allows request sidebar search toggle

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -77,6 +77,7 @@ const searchResultsId = useId()
 const { toast } = useToasts()
 /** The currently selected sidebarMenuItem for the context menu */
 const menuItem = reactive<SidebarMenuItem>({ open: false })
+const isSearchVisible = ref(false)
 
 /** Watch to see if activeRequest changes and ensure we open any folders */
 watch(
@@ -193,8 +194,6 @@ const handleClearDrafts = () => {
   }
 }
 
-const isSearchVisible = ref(false)
-
 const toggleSearch = () => {
   // Simply toggle the visibility
   isSearchVisible.value = !isSearchVisible.value
@@ -246,7 +245,7 @@ const toggleSearch = () => {
         </button>
       </div>
       <div
-        v-show="isSearchVisible || searchText"
+        v-show="isSearchVisible"
         class="search-button-fade sticky px-3 py-2.5 z-10 pt-0 top-[48px] focus-within:z-20"
         role="search">
         <ScalarSearchInput
@@ -255,7 +254,6 @@ const toggleSearch = () => {
           :aria-activedescendant="selectedResultId"
           :aria-controls="searchResultsId"
           sidebar
-          @blur="isSearchVisible = searchText.length > 0"
           @input="fuseSearch"
           @keydown.down.stop="navigateSearchResults('down')"
           @keydown.enter.stop="selectSearchResult()"


### PR DESCRIPTION
**Problem**
request sidebar search cannot be toggle back when opened and not being populated.

**Solution**
this pr updates the code and removes blur action that was keeping the visibility to true in order to be able to be able to toggle the search visibility back.

| before | after |
| -------|------|
|  <video src="https://github.com/user-attachments/assets/930eed9a-4a77-4870-b506-09bdc6cc2f40" /> |  <video src="https://github.com/user-attachments/assets/bff92df1-ad46-4885-94f1-6fa2593e6717" /> |
| search visibility is always true | search visibility toggle back |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
