### PR TITLE
style(api-client): sidebar views ui consitency

### DIFF
--- a/.changeset/tall-islands-lay.md
+++ b/.changeset/tall-islands-lay.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style: fixes sidebar item consistency in different views

--- a/packages/api-client/src/components/Sidebar/SidebarList.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="flex flex-col gap-px px-3 pt-2.5 pb-[75px]">
+  <ul class="flex flex-col gap-px px-3 pb-[75px]">
     <slot />
   </ul>
 </template>

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -116,32 +116,34 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
           <SidebarList>
             <div
               v-for="(paths, domain) in groupedCookies"
-              :key="domain">
+              :key="domain"
+              class="flex flex-col gap-px">
               <button
-                class="flex font-medium gap-1.5 items-center px-2 py-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
+                class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded text-left text-sm p-1.5 focus-visible:z-10 hover:bg-sidebar-active-b indent-padding-left"
                 type="button"
                 @click="toggleSidebarFolder(domain)">
                 <ScalarIcon
-                  class="text-c-3"
+                  class="h-5 -ml-px text-c-3 w-4"
                   :class="{
                     'rotate-90': collapsedSidebarFolders[domain],
                   }"
                   icon="ChevronRight"
                   size="md" />
-                {{ domain }}
+                <span>{{ domain }}</span>
               </button>
               <div
                 v-show="showChildren(domain)"
-                class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1rem_-_.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-3 before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
                 <div
                   v-for="(cookieList, path) in paths"
-                  :key="path">
+                  :key="path"
+                  class="flex flex-col gap-px">
                   <button
-                    class="flex font-medium gap-1.5 items-center pl-5 pr-2 py-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
+                    class="flex gap-1.5 items-center pl-5 pr-2 py-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
                     type="button"
                     @click="toggleSidebarFolder(domain + path)">
                     <ScalarIcon
-                      class="text-c-3"
+                      class="-ml-px text-c-3"
                       :class="{
                         'rotate-90': collapsedSidebarFolders[domain + path],
                       }"
@@ -151,7 +153,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                   </button>
                   <div
                     v-show="showChildren(domain + path)"
-                    class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1.75rem_-_.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
+                    class="before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1.75rem_-1px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative">
                     <SidebarListElement
                       v-for="cookie in cookieList"
                       :key="cookie.uid"

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -381,25 +381,28 @@ function handleRename(newName: string) {
                 class="flex font-medium gap-1.5 group items-center p-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
                 type="button"
                 @click="toggleSidebarFolder(collection.uid)">
-                <LibraryIcon
-                  class="text-sidebar-c-2 size-3.5 stroke-[2.25] group-hover:hidden"
-                  :src="
-                    collection['x-scalar-icon'] || 'interface-content-folder'
-                  " />
-                <ScalarIcon
-                  class="text-c-3 hidden text-sm group-hover:block"
-                  :class="{
-                    'rotate-90': collapsedSidebarFolders[collection.uid],
-                  }"
-                  icon="ChevronRight"
-                  size="sm"
-                  thickness="2.5" />
+                <span class="flex h-5 items-center justify-center max-w-[14px]">
+                  <LibraryIcon
+                    class="min-w-3.5 text-sidebar-c-2 size-3.5 stroke-2 group-hover:hidden"
+                    :src="
+                      collection['x-scalar-icon'] || 'interface-content-folder'
+                    " />
+                  <div
+                    :class="{
+                      'rotate-90': collapsedSidebarFolders[collection.uid],
+                    }">
+                    <ScalarIcon
+                      class="text-c-3 hidden text-sm group-hover:block"
+                      icon="ChevronRight"
+                      size="md" />
+                  </div>
+                </span>
                 {{ collection.info?.title ?? '' }}
               </button>
               <div
                 v-show="showChildren(collection.uid)"
                 :class="{
-                  'before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(1rem_-_1.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] flex flex-col gap-px mb-[.5px] last:mb-0 relative':
+                  'before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-3 before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative':
                     Object.keys(collection['x-scalar-environments'] || {})
                       .length > 0,
                 }">


### PR DESCRIPTION
**Problem**
recent changes in #4247 broken the consistency through the different pages.

**Solution**
this pr updates sidebar item ui to keep consistency within pages through border re-alignment, spacing updates + icon size consistency.

| before | after |
| -------|------|
| <img width="275" alt="image" src="https://github.com/user-attachments/assets/bccf8308-462e-4df8-909d-cbed23d9bf0e" /> | <img width="275" alt="image" src="https://github.com/user-attachments/assets/2d5eca02-296d-4c58-ac60-0203f14363f7" /> |
| left border not aligned + inconsistent icon size & border top | left border re-aligned + icon size increased & border top removed  |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).