### PR TITLE
fix(api-client): parse curl query parameters

### DIFF
--- a/.changeset/calm-forks-bake.md
+++ b/.changeset/calm-forks-bake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates parse curl query params type and condition

--- a/packages/api-client/src/libs/parse-curl.ts
+++ b/packages/api-client/src/libs/parse-curl.ts
@@ -17,7 +17,7 @@ export function parseCurlCommand(curlCommand: string) {
     method?: RequestMethod
     headers?: Record<string, string>
     body?: string
-    queryParameters?: Record<string, string>
+    queryParameters?: Array<{ key: string; value: string }>
     servers?: string[]
   } = { url: '' }
 
@@ -26,23 +26,14 @@ export function parseCurlCommand(curlCommand: string) {
 
   while (arg) {
     if (typeof arg === 'object' && 'op' in arg) {
-      if (arg.op === '&') {
-        // Extract query parameters
-        const nextArg = iterator.next().value
-        if (typeof nextArg === 'string') {
-          const queryParametersArray = parseQueryParameters(`?${nextArg}`)
-          const queryParameters = queryParametersArray.reduce(
-            (acc, { key, value }) => {
-              acc[key] = value
-              return acc
-            },
-            {} as Record<string, string>,
-          )
-          result.queryParameters = {
-            ...result.queryParameters,
-            ...queryParameters,
-          }
-        }
+      // Extract query parameters
+      const nextArg = iterator.next().value
+      if (typeof nextArg === 'string') {
+        const queryParametersArray = parseQueryParameters(`?${nextArg}`)
+        result.queryParameters = [
+          ...(result.queryParameters || []),
+          ...queryParametersArray,
+        ]
       }
       arg = iterator.next().value
       continue


### PR DESCRIPTION
**Problem**
as pointed out by @amritk in #3454 there was an unneeded condition and type mistake in the parse curl function.

**Solution**
this pr updates the type and remove the condition accordingly.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).