### PR TITLE
fix(api-client): request params tooltip runtime error

### DIFF
--- a/.changeset/odd-timers-end.md
+++ b/.changeset/odd-timers-end.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: displays request params clear button if params only

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -163,7 +163,6 @@ watch(
     <template #actions>
       <div
         class="text-c-2 flex whitespace-nowrap opacity-0 group-hover/params:opacity-100 has-[:focus-visible]:opacity-100 request-meta-buttons">
-        <!-- TODO fix this DOC-2740 -->
         <ScalarTooltip
           v-if="params.length > 1"
           side="right"

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -164,7 +164,8 @@ watch(
       <div
         class="text-c-2 flex whitespace-nowrap opacity-0 group-hover/params:opacity-100 has-[:focus-visible]:opacity-100 request-meta-buttons">
         <!-- TODO fix this DOC-2740 -->
-        <!-- <ScalarTooltip
+        <ScalarTooltip
+          v-if="params.length > 1"
           side="right"
           :sideOffset="12">
           <template #trigger>
@@ -185,7 +186,7 @@ watch(
               </div>
             </div>
           </template>
-        </ScalarTooltip> -->
+        </ScalarTooltip>
       </div>
     </template>
     <div ref="tableWrapperRef">


### PR DESCRIPTION
**Problem**
currently empty api client usage through reference is throwing the following error:
![image](https://github.com/user-attachments/assets/42f523cf-6a35-4f1d-8ee1-dc651e05a111)

**Solution**
this pr fixes #4334 as a follow of #4341 and makes sure to only have the clear action available in parameter presence.

tested using api client react playground as highlighted by @marclave.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).