### PR TITLE
style(api-reference): should respect description newlines

### DIFF
--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -128,7 +128,7 @@ const shouldCollapse = computed<boolean>(() => {
   overflow: hidden;
 }
 .parameter-item-trigger-open .parameter-item-type {
-  white-space: normal;
+  white-space: pre-line;
 }
 /* Match font size of markdown for property-detail-value since first child within accordian is displayed as if it were in the markdown section */
 .parameter-item-trigger


### PR DESCRIPTION
Currently, description (`.parameter-item-type`) for `.parameter-item` does not respect the text's newlines, it would be great if the description can render newlines, like Swagger UI.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).

Please help me generate the changeset if the idea is acceptable, I cannot run it currently unfortunately.

Comparision:

Before:
![image](https://github.com/user-attachments/assets/ebc01bd8-df41-4896-b916-b4e6240a5244)

After:
![image](https://github.com/user-attachments/assets/e18e323c-3ece-4372-8871-5f976db25a72)
