### PR TITLE
feat(oas-utils): examples for schemas with `patternProperties`

### DIFF
--- a/.changeset/real-dolls-walk.md
+++ b/.changeset/real-dolls-walk.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: generate examples for objects with patternProperties

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -1035,4 +1035,40 @@ describe('getExampleFromSchema', () => {
       },
     })
   })
+
+  it('handles patternProperties', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        patternProperties: {
+          '^(.*)$': {
+            type: 'object',
+            properties: {
+              dataId: {
+                type: 'string',
+              },
+              link: {
+                anyOf: [
+                  {
+                    format: 'uri',
+                    type: 'string',
+                    example: 'https://example.com',
+                  },
+                  {
+                    type: 'null',
+                  },
+                ],
+              },
+            },
+            required: ['dataId', 'link'],
+          },
+        },
+      }),
+    ).toStrictEqual({
+      '^(.*)$': {
+        dataId: '',
+        link: 'https://example.com',
+      },
+    })
+  })
 })

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -202,6 +202,31 @@ export const getExampleFromSchema = (
       }
     }
 
+    // Pattern properties (regex)
+    if (schema.patternProperties !== undefined) {
+      for (const pattern in schema.patternProperties) {
+        if (
+          Object.prototype.hasOwnProperty.call(
+            schema.patternProperties,
+            pattern,
+          )
+        ) {
+          const property = schema.patternProperties[pattern]
+
+          // Use the regex pattern as an example key
+          const exampleKey = pattern
+
+          response[exampleKey] = getExampleFromSchema(
+            property,
+            options,
+            level + 1,
+            schema,
+            exampleKey,
+          )
+        }
+      }
+    }
+
     // Additional properties
     if (schema.additionalProperties !== undefined) {
       const anyTypeIsValid =


### PR DESCRIPTION
**Problem**
Currently, we don't add anything to the generated examples when the schema has `patternProperties` (just a regex pattern instead of a property name).

**Solution**
With this PR we use the regex pattern as the property name, see the attached test for an example.

Fixes #3911.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
