### PR TITLE
fix(api-client): request sidebar watch toast

### DIFF
--- a/.changeset/swift-beds-hear.md
+++ b/.changeset/swift-beds-hear.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: prevents displaying watch toast on drafts and item deletion

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -24,6 +24,7 @@ import {
   ScalarSearchResultList,
 } from '@scalar/components'
 import { LibraryIcon } from '@scalar/icons'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
 import {
   computed,
@@ -86,7 +87,7 @@ watch(
     if (!request) return
 
     // Ensure the sidebar folders are open
-    findRequestParents(request).forEach((uid) =>
+    findRequestParents(request).forEach((uid: string) =>
       setCollapsedSidebarFolder(uid, true),
     )
   },
@@ -128,7 +129,7 @@ const handleToggleWatchMode = (item?: SidebarItem) => {
   if (item?.documentUrl) {
     item.watchMode = !item.watchMode
     const currentCollection = activeWorkspaceCollections.value.find(
-      (collection) => collection.uid === item.entity.uid,
+      (collection: Collection) => collection.uid === item.entity.uid,
     )
     if (currentCollection) {
       currentCollection.watchMode = item.watchMode
@@ -138,7 +139,9 @@ const handleToggleWatchMode = (item?: SidebarItem) => {
 
 watch(
   () =>
-    activeWorkspaceCollections.value.map((collection) => collection.watchMode),
+    activeWorkspaceCollections.value.map(
+      (collection: Collection) => collection.watchMode,
+    ),
   (newWatchModes, oldWatchModes) => {
     newWatchModes.forEach((newWatchMode, index) => {
       if (!isReadOnly && newWatchMode !== oldWatchModes[index]) {
@@ -160,11 +163,11 @@ const selectedResultId = computed(() => {
 
 const handleClearDrafts = () => {
   const draftCollection = activeWorkspaceCollections.value.find(
-    (collection) => collection.info?.title === 'Drafts',
+    (collection: Collection) => collection.info?.title === 'Drafts',
   )
 
   if (draftCollection) {
-    draftCollection.requests.forEach((requestUid) => {
+    draftCollection.requests.forEach((requestUid: string) => {
       if (requests[requestUid]) {
         requestMutators.delete(requests[requestUid], draftCollection.uid)
       }

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -143,8 +143,13 @@ watch(
       (collection: Collection) => collection.watchMode,
     ),
   (newWatchModes, oldWatchModes) => {
-    newWatchModes.forEach((newWatchMode, index) => {
-      if (!isReadOnly && newWatchMode !== oldWatchModes[index]) {
+    newWatchModes.forEach((newWatchMode: boolean, index: number) => {
+      if (
+        !isReadOnly &&
+        newWatchMode !== oldWatchModes[index] &&
+        activeWorkspaceCollections.value[index]?.info?.title !== 'Drafts' &&
+        activeWorkspaceCollections.value[index]
+      ) {
         const currentCollection = activeWorkspaceCollections.value[index]
         if (!currentCollection) return
 


### PR DESCRIPTION
**Problem**
watch mode state notification get displayed in the desktop app when removing a collection.

**Solution**
this pr prevents displaying watch mode state notification on collection deletion + for drafts collection and add missing type in request sidebar component file.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).