### PR TITLE
fix(scalar-app): drag self importation

### DIFF
--- a/.changeset/loud-terms-pay.md
+++ b/.changeset/loud-terms-pay.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: prevents self importation on drag

--- a/packages/scalar-app/src/renderer/src/main.ts
+++ b/packages/scalar-app/src/renderer/src/main.ts
@@ -78,6 +78,12 @@ async function drop(e: DragEvent) {
   // Check if the user dropped an URL
   if (e.dataTransfer?.getData('text/uri-list')) {
     const url = e.dataTransfer.getData('text/uri-list')
+    const appOrigin = window.location.origin
+
+    // Prevents self importation that is causing collection creation
+    if (url.startsWith(appOrigin)) {
+      return
+    }
 
     if (url) {
       client.store.importSpecFromUrl(url, 'default')


### PR DESCRIPTION
**Problem**
when using the desktop app, drop event creates empty collection as seen in #4349 - as relying on `text/uri-list` that is available in the app context.

to reproduce: 
- using the desktop app
- drag a request from a collection to another

| before | after |
| -------|------|
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/6ca0d2a6-385a-492d-b12d-26312a202bac" /> | <img width="280" alt="image" src="https://github.com/user-attachments/assets/702d34f4-6653-453e-9392-e3b389492c53" /> |
| an empty collection is created on drop event | no empty collection is created on drop event |

**Solution**
prevents self importation on drop event by avoiding import action for url origin.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).