### PR TITLE
docs: fixed small typos in go.md

### DIFF
--- a/documentation/integrations/go.md
+++ b/documentation/integrations/go.md
@@ -6,6 +6,6 @@
 <https://github.com/MarceloPetrucio/go-scalar-api-reference/>
 
 - [scalar-go](https://github.com/bdpiprava/scalar-go) by [@bdpiprava](https://github.com/bdpiprava)
-  - The offers convenient way to generate the API references in Go for micro services.
+  - This offers a convenient way to generate the API references in Go for microservices.
   - Allows [splitting(https://github.com/bdpiprava/scalar-go/tree/main/data/loader-multiple-files) big OpenAPI specs into smaller files for schemas and paths.
   - Supports [xTagGroups](https://github.com/bdpiprava/scalar-go/tree/main/data/xTagGroups)


### PR DESCRIPTION
This fixed some small typos in go integrations related docs.