### PR TITLE
fix(api-reference): cookie parameters don’t show up

### DIFF
--- a/.changeset/heavy-pugs-remain.md
+++ b/.changeset/heavy-pugs-remain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: cookie parameters don’t show up

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.vue
@@ -27,6 +27,11 @@ const { parameterMap } = useOperation(props.operation)
     <template #title>Headers</template>
   </ParameterList>
 
+  <!-- Cookies -->
+  <ParameterList :parameters="parameterMap.cookie">
+    <template #title>Cookies</template>
+  </ParameterList>
+
   <!-- Body parameters -->
   <ParameterList
     :parameters="parameterMap.body"

--- a/packages/api-reference/src/hooks/useOperation.ts
+++ b/packages/api-reference/src/hooks/useOperation.ts
@@ -5,6 +5,7 @@ export type ParamMap = {
   path: Parameter[]
   query: Parameter[]
   header: Parameter[]
+  cookie: Parameter[]
   body: Parameter[]
   formData: Parameter[]
 }
@@ -18,6 +19,7 @@ export function useOperation(operation: TransformedOperation) {
       path: [],
       query: [],
       header: [],
+      cookie: [],
       body: [],
       formData: [],
     }
@@ -30,6 +32,8 @@ export function useOperation(operation: TransformedOperation) {
           map.query.push(parameter)
         } else if (parameter.in === 'header') {
           map.header.push(parameter)
+        } else if (parameter.in === 'cookie') {
+          map.cookie.push(parameter)
         } else if (parameter.in === 'body') {
           map.body.push(parameter)
         } else if (parameter.in === 'formData') {
@@ -48,6 +52,8 @@ export function useOperation(operation: TransformedOperation) {
           map.query.push(parameter)
         } else if (parameter.in === 'header') {
           map.header.push(parameter)
+        } else if (parameter.in === 'cookie') {
+          map.cookie.push(parameter)
         } else if (parameter.in === 'body') {
           map.body.push(parameter)
         } else if (parameter.in === 'formData') {


### PR DESCRIPTION
**Problem**
Currently, cookie parameters don’t show up in the list of parameters. 

See #4397 for more context

**Solution**
With this PR we’re adding the cookie parameters, so they don’t feel excluded anymore.

<img width="565" alt="Screenshot 2025-01-08 at 10 53 26" src="https://github.com/user-attachments/assets/ed573e8e-4d0a-4c17-9f57-4d84ba2baeb7" />

**Example**

```yaml
openapi: 3.1.0
info:
  title: Hello World
  version: 1.0.0
components:
  parameters:
    CSRFCookie:
      name: csrf
      in: cookie
      description: Anti-CSRF cookie
      required: true
      schema:
        type: string
paths:
  /example:
    post:
      parameters:
        - $ref: '#/components/parameters/CSRFCookie'
```

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

I’ll add this fix and a test to #4281, where I modified the relevant components already.

EDIT: Done.
