### PR TITLE
fix(nuxt): new OpenAPI endpoint

### DIFF
--- a/.changeset/dry-cars-listen.md
+++ b/.changeset/dry-cars-listen.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nuxt': patch
+---
+
+fix OpenAPI integration

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -75,7 +75,11 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Also check for Nitro OpenAPI auto generation
     _nuxt.hook('nitro:config', (config) => {
-      if (config.experimental?.openAPI) isOpenApiEnabled = true
+      if (config.experimental?.openAPI) {
+        isOpenApiEnabled = true
+        config.openAPI ||= {}
+        config.openAPI.production ||= 'prerender'
+      }
     })
 
     // Load the component so it can be used directly

--- a/packages/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/packages/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -19,7 +19,7 @@ const content =
       ? toRaw(props.configuration.spec.content)
       : props.configuration.spec?.url
         ? await $fetch<string>(props.configuration.spec?.url)
-        : await $fetch<string>('/_nitro/openapi.json')
+        : await $fetch<string>('/_openapi.json')
 
 // Check for empty spec
 if (!content)


### PR DESCRIPTION
**Problem**

Fixes #4204

The experimental OpenAPI feature in Nitro currently breaks this module. This is becasue the OpenAPI endpoint has moved from `/_nitro/openapi.json` to `/_openapi.json`

**Solution**
This PR updates the endpoint in the code. However, since the feature is experimental, it may change again. The documentation is here: https://nitro.build/config#openapi

I've also updated the `nitro:config` hook to set the `production` key to `prerender`. By default, the OpenAPI specification is only available during development. Setting this option will ensure the json file is prerendered and available in production. I've conditionally set the option as to not overwrite the user's configuration if they choose `runtime`.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
