### PR TITLE
fix(oas-utils): handles object in examples

### DIFF
--- a/.changeset/modern-onions-live.md
+++ b/.changeset/modern-onions-live.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: handles example objects as array

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -1072,12 +1072,69 @@ describe('getExampleFromSchema', () => {
     })
   })
 
-  it('handles objects in examples and returns them as an array', () => {
+  it('handles multiple examples for a string type', () => {
     expect(
       getExampleFromSchema({
-        type: 'array',
-        example: ['example 1', 'example 2'],
+        type: 'string',
+        examples: {
+          example1: 'example string 1',
+          example2: 'example string 2',
+        },
       }),
-    ).toMatchObject(['example 1', 'example 2'])
+    ).toBe('example string 1') // first example
+  })
+
+  it('handles multiple examples for a number type', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'number',
+        examples: {
+          example1: 42,
+          example2: 100,
+        },
+      }),
+    ).toBe(42) // first example
+  })
+
+  it('handles single example for an object type', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        example: { key: 'value' },
+      }),
+    ).toMatchObject({ key: 'value' })
+  })
+
+  it('handles multiple examples for an object type', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        examples: {
+          example1: { key1: 'value1' },
+          example2: { key2: 'value2' },
+        },
+      }),
+    ).toMatchObject({ key1: 'value1' }) // first example
+  })
+
+  it('handles single example for a boolean type', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'boolean',
+        example: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('handles multiple examples for a boolean type', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'boolean',
+        examples: {
+          example1: true,
+          example2: false,
+        },
+      }),
+    ).toBe(true) // first example
   })
 })

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -3,22 +3,6 @@ import { describe, expect, it } from 'vitest'
 import { getExampleFromSchema } from './getExampleFromSchema'
 
 describe('getExampleFromSchema', () => {
-  it('sets example values', () => {
-    expect(
-      getExampleFromSchema({
-        example: 10,
-      }),
-    ).toMatchObject(10)
-  })
-
-  it('uses first example, if multiple are configured', () => {
-    expect(
-      getExampleFromSchema({
-        examples: [10],
-      }),
-    ).toMatchObject(10)
-  })
-
   it('takes the first enum as example', () => {
     expect(
       getExampleFromSchema({
@@ -1072,69 +1056,118 @@ describe('getExampleFromSchema', () => {
     })
   })
 
-  it('handles multiple examples for a string type', () => {
-    expect(
-      getExampleFromSchema({
-        type: 'string',
-        examples: {
-          example1: 'example string 1',
-          example2: 'example string 2',
-        },
-      }),
-    ).toBe('example string 1') // first example
-  })
+  describe('examples', () => {
+    it('sets example values', () => {
+      expect(
+        getExampleFromSchema({
+          example: 10,
+        }),
+      ).toMatchObject(10)
+    })
 
-  it('handles multiple examples for a number type', () => {
-    expect(
-      getExampleFromSchema({
-        type: 'number',
-        examples: {
-          example1: 42,
-          example2: 100,
-        },
-      }),
-    ).toBe(42) // first example
-  })
+    // Yeah, specification says object, but you know how it is.
+    it('uses first example, if multiple are configured', () => {
+      expect(
+        getExampleFromSchema({
+          examples: [10],
+        }),
+      ).toMatchObject(10)
+    })
 
-  it('handles single example for an object type', () => {
-    expect(
-      getExampleFromSchema({
-        type: 'object',
-        example: { key: 'value' },
-      }),
-    ).toMatchObject({ key: 'value' })
-  })
+    it('handles multiple examples for a string type', () => {
+      expect(
+        getExampleFromSchema({
+          type: 'string',
+          examples: {
+            example1: 'example string 1',
+            example2: 'example string 2',
+          },
+        }),
+      ).toBe('example string 1') // first example
+    })
 
-  it('handles multiple examples for an object type', () => {
-    expect(
-      getExampleFromSchema({
-        type: 'object',
-        examples: {
-          example1: { key1: 'value1' },
-          example2: { key2: 'value2' },
-        },
-      }),
-    ).toMatchObject({ key1: 'value1' }) // first example
-  })
+    it('handles multiple examples for a number type', () => {
+      expect(
+        getExampleFromSchema({
+          type: 'number',
+          examples: {
+            example1: 42,
+            example2: 100,
+          },
+        }),
+      ).toBe(42) // first example
+    })
 
-  it('handles single example for a boolean type', () => {
-    expect(
-      getExampleFromSchema({
-        type: 'boolean',
-        example: true,
-      }),
-    ).toBe(true)
-  })
+    it('handles single example for an array type', () => {
+      expect(
+        getExampleFromSchema({
+          type: 'array',
+          example: ['foo', 'bar'],
+        }),
+      ).toMatchObject(['foo', 'bar'])
+    })
 
-  it('handles multiple examples for a boolean type', () => {
-    expect(
-      getExampleFromSchema({
-        type: 'boolean',
-        examples: {
-          example1: true,
-          example2: false,
-        },
-      }),
-    ).toBe(true) // first example
+    it('handles single example for an object type', () => {
+      expect(
+        getExampleFromSchema({
+          type: 'object',
+          example: { key: 'value' },
+        }),
+      ).toMatchObject({ key: 'value' })
+    })
+
+    it('handles multiple examples for an object type', () => {
+      expect(
+        getExampleFromSchema({
+          type: 'object',
+          examples: {
+            example1: { key1: 'value1' },
+            example2: { key2: 'value2' },
+          },
+        }),
+      ).toMatchObject({ key1: 'value1' }) // first example
+    })
+
+    // Yes, the specification says object, but you know how it is.
+    it('handles examples when it’s an array', () => {
+      expect(
+        getExampleFromSchema({
+          type: 'string',
+          examples: ['foo', 'bar'],
+        }),
+      ).toBe('foo') // first example
+
+      expect(
+        getExampleFromSchema({
+          type: 'object',
+          examples: [
+            {
+              foo: 'bar',
+            },
+          ],
+        }),
+      ).toMatchObject({ foo: 'bar' }) // first example
+    })
+
+    it('handles single example for a boolean type', () => {
+      expect(
+        getExampleFromSchema({
+          type: 'boolean',
+          example: true,
+        }),
+      ).toBe(true)
+    })
+
+    it('handles multiple examples for a boolean type', () => {
+      expect(
+        getExampleFromSchema({
+          type: 'boolean',
+          examples: {
+            example1: true,
+            example2: false,
+          },
+        }),
+      ).toBe(true) // first example
+    })
   })
 })

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -1071,4 +1071,13 @@ describe('getExampleFromSchema', () => {
       },
     })
   })
+
+  it('handles objects in examples and returns them as an array', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'array',
+        example: ['example 1', 'example 2'],
+      }),
+    ).toMatchObject(['example 1', 'example 2'])
+  })
 })

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.test.ts
@@ -1065,7 +1065,6 @@ describe('getExampleFromSchema', () => {
       ).toMatchObject(10)
     })
 
-    // Yeah, specification says object, but you know how it is.
     it('uses first example, if multiple are configured', () => {
       expect(
         getExampleFromSchema({
@@ -1098,13 +1097,22 @@ describe('getExampleFromSchema', () => {
       ).toBe(42) // first example
     })
 
-    it('handles single example for an array type', () => {
+    it('handles example array for an array type', () => {
       expect(
         getExampleFromSchema({
           type: 'array',
           example: ['foo', 'bar'],
         }),
       ).toMatchObject(['foo', 'bar'])
+    })
+
+    it('handles example array for a string type', () => {
+      expect(
+        getExampleFromSchema({
+          type: 'string',
+          example: ['Portfolio1', 'Portfolio2'],
+        }),
+      ).toMatchObject('Portfolio1')
     })
 
     it('handles single example for an object type', () => {

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -133,10 +133,14 @@ export const getExampleFromSchema = (
   }
 
   // Use the first example, if there’s an key value object with multiple examples
-  if (schema.examples && typeof schema.examples === 'object') {
-    const firstExample = Object.values(schema.examples)[0]
-
-    return cache(schema, firstExample)
+  if (schema.examples) {
+    if (schema.type === 'array') {
+      return cache(schema, Object.values(schema.examples[0]))
+    }
+    if (typeof schema.examples === 'object') {
+      const firstExample = Object.values(schema.examples)[0]
+      return cache(schema, firstExample)
+    }
   }
 
   // Use an example, if there’s one
@@ -276,6 +280,15 @@ export const getExampleFromSchema = (
 
   // Array
   if (schema.type === 'array' || schema.items !== undefined) {
+    if (schema.examples) {
+      if (schema.type === 'array') {
+        return cache(schema, Object.values(schema.examples[0]))
+      }
+      if (typeof schema.examples === 'object') {
+        const firstExample = Object.values(schema.examples)[0]
+        return cache(schema, firstExample)
+      }
+    }
     const itemsXmlTagName = schema?.items?.xml?.name
     const wrapItems = !!(options?.xml && schema.xml?.wrapped && itemsXmlTagName)
 

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -132,15 +132,15 @@ export const getExampleFromSchema = (
     }
   }
 
-  // Use the first example, if there’s an array, and handle objects
-  if (Array.isArray(schema.examples) && schema.examples.length > 0) {
-    const firstExample = schema.examples[0]
-    return typeof firstExample === 'object'
-      ? cache(schema, Object.values(firstExample))
-      : cache(schema, firstExample)
+  // Use the first example, if there’s an key value object with multiple examples
+  if (schema.examples && typeof schema.examples === 'object') {
+    const firstExample = Object.values(schema.examples)[0]
+
+    return cache(schema, firstExample)
   }
 
   // Use an example, if there’s one
+  // Deprecated in OpenAPI 3.1
   if (schema.example !== undefined) {
     return cache(schema, schema.example)
   }
@@ -150,7 +150,7 @@ export const getExampleFromSchema = (
     return cache(schema, schema.default)
   }
 
-  // enum: [ 'available', 'pending', 'sold' ]
+  // enum: ['available', 'pending', 'sold']
   if (Array.isArray(schema.enum) && schema.enum.length > 0) {
     return cache(schema, schema.enum[0])
   }

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -145,10 +145,12 @@ export const getExampleFromSchema = (
     // if `example: ['foo', 'bar']` is passed for strings and others
     const isObjectOrArray = ['object', 'array'].includes(schema.type)
 
-    if (isObjectOrArray && typeof schema.example === 'object') {
+    if (!isObjectOrArray && typeof schema.example === 'object') {
       const firstExample = Object.values(schema.example)[0]
       return cache(schema, firstExample)
     }
+
+    return cache(schema, schema.example)
   }
 
   // Use a default value, if there’s one

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -142,6 +142,15 @@ export const getExampleFromSchema = (
   // Use an example, if there’s one
   // Deprecated in OpenAPI 3.1
   if (schema.example !== undefined) {
+    // `example: ['foo', 'bar']` for strings and others
+    if (
+      typeof schema.example === 'object' &&
+      !['object', 'array'].includes(schema.type)
+    ) {
+      const firstExample = Object.values(schema.example)[0]
+      return cache(schema, firstExample)
+    }
+
     return cache(schema, schema.example)
   }
 

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -132,9 +132,12 @@ export const getExampleFromSchema = (
     }
   }
 
-  // Use the first example, if there’s an array
+  // Use the first example, if there’s an array, and handle objects
   if (Array.isArray(schema.examples) && schema.examples.length > 0) {
-    return cache(schema, schema.examples[0])
+    const firstExample = schema.examples[0]
+    return typeof firstExample === 'object'
+      ? cache(schema, Object.values(firstExample))
+      : cache(schema, firstExample)
   }
 
   // Use an example, if there’s one

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -142,16 +142,13 @@ export const getExampleFromSchema = (
   // Use an example, if there’s one
   // Deprecated in OpenAPI 3.1
   if (schema.example !== undefined) {
-    // `example: ['foo', 'bar']` for strings and others
-    if (
-      typeof schema.example === 'object' &&
-      !['object', 'array'].includes(schema.type)
-    ) {
+    // if `example: ['foo', 'bar']` is passed for strings and others
+    const isObjectOrArray = ['object', 'array'].includes(schema.type)
+
+    if (isObjectOrArray && typeof schema.example === 'object') {
       const firstExample = Object.values(schema.example)[0]
       return cache(schema, firstExample)
     }
-
-    return cache(schema, schema.example)
   }
 
   // Use a default value, if there’s one

--- a/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
+++ b/packages/oas-utils/src/spec-getters/getExampleFromSchema.ts
@@ -133,14 +133,10 @@ export const getExampleFromSchema = (
   }
 
   // Use the first example, if there’s an key value object with multiple examples
-  if (schema.examples) {
-    if (schema.type === 'array') {
-      return cache(schema, Object.values(schema.examples[0]))
-    }
-    if (typeof schema.examples === 'object') {
-      const firstExample = Object.values(schema.examples)[0]
-      return cache(schema, firstExample)
-    }
+  if (schema.examples && typeof schema.examples === 'object') {
+    const firstExample = Object.values(schema.examples)[0]
+
+    return cache(schema, firstExample)
   }
 
   // Use an example, if there’s one
@@ -280,15 +276,6 @@ export const getExampleFromSchema = (
 
   // Array
   if (schema.type === 'array' || schema.items !== undefined) {
-    if (schema.examples) {
-      if (schema.type === 'array') {
-        return cache(schema, Object.values(schema.examples[0]))
-      }
-      if (typeof schema.examples === 'object') {
-        const firstExample = Object.values(schema.examples)[0]
-        return cache(schema, firstExample)
-      }
-    }
     const itemsXmlTagName = schema?.items?.xml?.name
     const wrapItems = !!(options?.xml && schema.xml?.wrapped && itemsXmlTagName)
 


### PR DESCRIPTION
**Problem**
Currently, using the following in a document  `"example": ["Portfolio1", "Portfolio2"]` gets returned as an object in the request example.

**Solution**
this pr handles that use case and fixes #3782  in order to turn the object into an array to maintain its original type.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.