### PR TITLE
fix(api-client): UI breaking when response body too big

### DIFF
--- a/.changeset/empty-pants-love.md
+++ b/.changeset/empty-pants-love.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fixed UI breaking when response body is too above threshold

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -12,8 +12,7 @@ const textContent = computed(() => formatJsonOrYamlString(props.content))
 </script>
 
 <template>
-  <ViewLayoutCollapse
-    class="a!max-h-[calc(100%-32px)] overflow-x-auto response-body-virtual">
+  <ViewLayoutCollapse class="!max-h-100% overflow-x-auto response-body-virtual">
     <template #title>Body</template>
     <div
       class="py-1.5 px-2.5 font-code text-xxs border-1/2 rounded-t border-b-0">
@@ -21,7 +20,7 @@ const textContent = computed(() => formatJsonOrYamlString(props.content))
     </div>
     <ScalarVirtualText
       containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1"
-      contentClass="hljs language-plaintext"
+      contentClass="language-plaintext whitespace-pre font-code text-base inline-block"
       :lineHeight="20"
       :text="textContent" />
   </ViewLayoutCollapse>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -13,7 +13,7 @@ const textContent = computed(() => formatJsonOrYamlString(props.content))
 
 <template>
   <ViewLayoutCollapse
-    class="a!max-h-[calc(100%)] overflow-x-auto response-body-virtual">
+    class="a!max-h-[calc(100%-32px)] overflow-x-auto response-body-virtual">
     <template #title>Body</template>
     <div
       class="py-1.5 px-2.5 font-code text-xxs border-1/2 rounded-t border-b-0">

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -12,14 +12,15 @@ const textContent = computed(() => formatJsonOrYamlString(props.content))
 </script>
 
 <template>
-  <ViewLayoutCollapse class="!max-h-[calc(100%-32px)] response-body-virtual">
+  <ViewLayoutCollapse
+    class="a!max-h-[calc(100%)] overflow-x-auto response-body-virtual">
     <template #title>Body</template>
     <div
-      class="mx-1 py-1.5 px-2.5 font-code text-xxs border-1/2 rounded-t border-b-0">
+      class="py-1.5 px-2.5 font-code text-xxs border-1/2 rounded-t border-b-0">
       This response body is massive! Syntax highlighting won’t work here.
     </div>
     <ScalarVirtualText
-      containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1 mx-1"
+      containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1"
       contentClass="hljs language-plaintext"
       :lineHeight="20"
       :text="textContent" />

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -20,7 +20,7 @@ const textContent = computed(() => formatJsonOrYamlString(props.content))
     </div>
     <ScalarVirtualText
       containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1"
-      contentClass="language-plaintext whitespace-pre font-code text-base inline-block"
+      contentClass="language-plaintext whitespace-pre font-code text-base"
       :lineHeight="20"
       :text="textContent" />
   </ViewLayoutCollapse>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -58,7 +58,7 @@ type ActiveSections = (typeof sections)[number]
 const activeSection = ref<ActiveSections>('All')
 
 /** Threshold for virtualizing response bodies in bytes */
-const VIRTUALIZATION_THRESHOLD = 1_000 // TODO: Change back to 200_000
+const VIRTUALIZATION_THRESHOLD = 200_000
 const shouldVirtualize = computed(() => {
   if (!props.response) return false
 

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -58,7 +58,7 @@ type ActiveSections = (typeof sections)[number]
 const activeSection = ref<ActiveSections>('All')
 
 /** Threshold for virtualizing response bodies in bytes */
-const VIRTUALIZATION_THRESHOLD = 200_000
+const VIRTUALIZATION_THRESHOLD = 1_000 // TODO: Change back to 200_000
 const shouldVirtualize = computed(() => {
   if (!props.response) return false
 

--- a/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.vue
+++ b/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.vue
@@ -94,12 +94,12 @@ watchEffect(() => {
 <template>
   <div
     ref="containerRef"
-    class="scalar-virtual-text relative min-h-[200px] overflow-auto"
+    class="scalar-virtual-text overflow-auto"
     :class="containerClass"
     @scroll="handleScroll">
     <code
       ref="contentRef"
-      class="scalar-virtual-text-content absolute"
+      class="scalar-virtual-text-content"
       :class="contentClass"
       :style="contentStyle">
       <div


### PR DESCRIPTION
**Problem**
Currently, when receiving a response body above the virtualization threshold, the UI breaks, leaving the user unable to view the actual response body.

**Solution**
With this PR, I've updated the CSS from the component to fix this issue.

**Linked Issue**
closes #4365 

**Changes**

1. Added `overflow-x-auto` on the `ResponseBodyVirtual` component to fix the actual issue
2. Removed `mx-1` on the subcomponents to remove gap around containers

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.

---

Feel free to let me know if I can improve anything.
