### PR TITLE
fix(api-reference): displays array enum of one

### DIFF
--- a/.changeset/tough-pillows-kick.md
+++ b/.changeset/tough-pillows-kick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: shows enum value when there is only one

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -232,4 +232,17 @@ describe('SchemaProperty sub-schema', () => {
     const enumValues = wrapper.findAll('.property-enum-value')
     expect(enumValues).toHaveLength(3)
   })
+
+  it('shows enum value when there is only one', () => {
+    const wrapper = mount(SchemaProperty, {
+      props: {
+        value: {
+          enum: ['a'],
+        },
+      },
+    })
+
+    const enumValues = wrapper.findAll('.property-enum-value')
+    expect(enumValues).toHaveLength(1)
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -99,7 +99,7 @@ const remainingEnumValues = computed(() =>
     ]">
     <SchemaPropertyHeading
       :additional="additional"
-      :enum="getEnumFromValue(value).length > 1"
+      :enum="getEnumFromValue(value).length > 0"
       :required="required"
       :value="value">
       <template
@@ -156,7 +156,7 @@ const remainingEnumValues = computed(() =>
     </template>
     <!-- Enum -->
     <div
-      v-if="getEnumFromValue(value)?.length > 1"
+      v-if="getEnumFromValue(value)?.length > 0"
       class="property-enum">
       <template v-if="value?.['x-enumDescriptions']">
         <div class="property-list">


### PR DESCRIPTION
**Problem**
Currently when using only one enum value, the value doesn't get displayed in the api reference schema property.

**Solution**
this pr fixes #2006 by showing enum of 1 value in the reference.

| before | after |
| -------|------|
| <img width="439" alt="image" src="https://github.com/user-attachments/assets/6eb20e7b-23f6-4722-ac33-59b343d38682" /> | <img width="439" alt="image" src="https://github.com/user-attachments/assets/7aaf8536-f40e-453d-acdc-1f76de078db6" /> |
| enum list value is not being displayed | enum list value is displaying the one value |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.