### PR TITLE
fix(api-client): filename overwrites key/value in multipart form body

### DIFF
--- a/.changeset/blue-bags-dance.md
+++ b/.changeset/blue-bags-dance.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix uploading file in multipart form overwrites key already set

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -341,10 +341,10 @@ const handleFileUploadFormData = async (rowIdx: number) => {
         const currentParams = formParams.value
         const updatedParams = [...currentParams]
         updatedParams[rowIdx] = {
+          key: file.name,
           ...updatedParams[rowIdx],
           file,
           value: file.name,
-          key: file.name,
           enabled: true,
         }
         requestExampleMutators.edit(

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -341,10 +341,10 @@ const handleFileUploadFormData = async (rowIdx: number) => {
         const currentParams = formParams.value
         const updatedParams = [...currentParams]
         updatedParams[rowIdx] = {
-          key: file.name,
           ...updatedParams[rowIdx],
           file,
-          value: file.name,
+          value: updatedParams[rowIdx]?.value || file.name,
+          key: updatedParams[rowIdx]?.key || file.name,
           enabled: true,
         }
         requestExampleMutators.edit(


### PR DESCRIPTION
**Problem**
Currently, when settings data (key and value) in the multipart form body and uploading a file after. The file will overwrite the existing data you might have already set.

**Solution**
With this PR, I made sure the body will select key or value first if it exists already, otherwise it will default back to the filename for both fields.

**Issues**
solves #4357 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.

---

Feel free to let me know if this change is what we would want. Or if I can change/improve anything.
