### PR TITLE
fix(api-client): allows enabled empty parameters in request

### DIFF
--- a/.changeset/new-spiders-hammer.md
+++ b/.changeset/new-spiders-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: allows enabled empty query params and omits disabled ones

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -386,7 +386,34 @@ describe('create-request-operation', () => {
     expect(JSON.parse(result?.response.data as string).query).toStrictEqual({})
   })
 
-  it('should ignore query parameters with empty values', async () => {
+  it('should ignore query parameters with empty values that are not enabled', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: {
+          url: VOID_URL,
+        },
+        requestExamplePayload: {
+          parameters: {
+            query: [
+              {
+                key: 'foo',
+                value: '',
+                enabled: false,
+              },
+            ],
+          },
+        },
+      }),
+    )
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(JSON.parse(result?.response.data as string).query).toStrictEqual({})
+  })
+
+  it('should maintain query parameters with empty values that are enabled', async () => {
     const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: {
@@ -410,7 +437,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(JSON.parse(result?.response.data as string).query).toStrictEqual({})
+    expect(JSON.parse(result?.response.data as string).query).toStrictEqual({
+      foo: '',
+    })
   })
 
   it('works with no content', async () => {

--- a/packages/api-client/src/libs/send-request/send-request.ts
+++ b/packages/api-client/src/libs/send-request/send-request.ts
@@ -70,8 +70,8 @@ export function createFetchQueryParams(
 ) {
   const params = new URLSearchParams()
   example.parameters.query.forEach((p) => {
-    if (p.enabled && p.value)
-      params.append(p.key, replaceTemplateVariables(p.value, env))
+    if (p.enabled)
+      params.append(p.key, replaceTemplateVariables(p.value ?? '', env))
   })
 
   return params

--- a/packages/api-client/src/libs/send-request/send-request.ts
+++ b/packages/api-client/src/libs/send-request/send-request.ts
@@ -14,12 +14,12 @@ import type {
   Server,
 } from '@scalar/oas-utils/entities/spec'
 import {
+  REGEX,
   canMethodHaveBody,
   concatenateUrlAndPath,
   isRelativePath,
   shouldUseProxy,
 } from '@scalar/oas-utils/helpers'
-import { REGEX } from '@scalar/oas-utils/helpers'
 import Cookies from 'js-cookie'
 import MimeTypeParser from 'whatwg-mimetype'
 


### PR DESCRIPTION
**Problem**
Currently empty parameters are not sent through request rather enabled or not.

**Solution**
this pr fixes #4406 in order to allows enabled empty parameters to be sent while keep omitting the non enabled ones.

nb. we should make sure that this still provide a solution for #3291

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
