### PR TITLE
ci: update paths of the fastify and express examples

### DIFF
--- a/cloudbuild.json
+++ b/cloudbuild.json
@@ -137,7 +137,7 @@
         "-t",
         "gcr.io/${_PROJECT_ID}/${_SERVICE_FASTIFY}",
         "-f",
-        "./examples/fastify-api-reference/Dockerfile",
+        "./packages/fastify-api-reference/Dockerfile",
         "."
       ]
     },
@@ -287,7 +287,7 @@
         "-t",
         "gcr.io/${_PROJECT_ID}/${_SERVICE_EXPRESS}",
         "-f",
-        "./examples/express-api-reference/Dockerfile",
+        "./packages/express-api-reference/Dockerfile",
         "."
       ]
     },

--- a/tooling/cloudbuild/cloudbuildEnv.json
+++ b/tooling/cloudbuild/cloudbuildEnv.json
@@ -12,7 +12,7 @@
   {
     "name": "fastify",
     "cloudBuildName": "_SERVICE_FASTIFY",
-    "dockerPath": "./examples/fastify-api-reference/Dockerfile"
+    "dockerPath": "./packages/fastify-api-reference/Dockerfile"
   },
   {
     "name": "hono",
@@ -27,7 +27,7 @@
   {
     "name": "express-js",
     "cloudBuildName": "_SERVICE_EXPRESS",
-    "dockerPath": "./examples/express-api-reference/Dockerfile"
+    "dockerPath": "./packages/express-api-reference/Dockerfile"
   },
   {
     "name": "nest-js-fastify",


### PR DESCRIPTION
Some examples have moved from the `examples` folder to `packages`. This is updates the cloudbuild env to use the correct paths. Eventually all examples will be moved to packages. This migration is in progress 😄 
