### PR TITLE
fix(openapi-parser): call `onDereference` after dereference process

### DIFF
--- a/.changeset/sour-cougars-sing.md
+++ b/.changeset/sour-cougars-sing.md
@@ -1,0 +1,5 @@
+---
+"@scalar/openapi-parser": patch
+---
+
+Call `onDereference` after dereference process

--- a/packages/openapi-parser/src/utils/dereference.test.ts
+++ b/packages/openapi-parser/src/utils/dereference.test.ts
@@ -322,22 +322,22 @@ describe('dereference', async () => {
 
     const result = await dereference(openapi, {
       onDereference: ({ schema, ref }) => {
+        expect(schema).toEqual({
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+          },
+        })
+
+        expect(ref).toEqual('#/components/schemas/Test')
+
         dereferencedSchemas.push({ schema, ref })
       },
     })
 
     expect(result.errors).toStrictEqual([])
     expect(dereferencedSchemas).toHaveLength(1)
-    expect(dereferencedSchemas[0]).toEqual({
-      schema: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string',
-          },
-        },
-      },
-      ref: '#/components/schemas/Test',
-    })
   })
 })


### PR DESCRIPTION
**Problem**
fix #4347 

**Solution**
Call the hook after dereferencing the schema, and add docs about the behaviours.

Also added `errors` array to parameter instead of return value of `dereference`, so it reduces a little memory usage

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
