### PR TITLE
feat(api-client): show tooltip in request params

### DIFF
--- a/.changeset/proud-frogs-shake.md
+++ b/.changeset/proud-frogs-shake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: extracts tooltip display condition in function

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -145,6 +145,8 @@ const itemCount = computed(
   () => params.value.filter((param) => param.key || param.value).length,
 )
 
+const showTooltip = computed(() => params.value.length > 1)
+
 watch(
   () => activeExample.value,
   (newVal, oldVal) => {
@@ -164,7 +166,7 @@ watch(
       <div
         class="text-c-2 flex whitespace-nowrap opacity-0 group-hover/params:opacity-100 has-[:focus-visible]:opacity-100 request-meta-buttons">
         <ScalarTooltip
-          v-if="params.length > 1"
+          v-if="showTooltip"
           side="right"
           :sideOffset="12">
           <template #trigger>


### PR DESCRIPTION
**Problem**
following #4387  runtime error were displayed in the client and saucing #4418.

**Solution**
this pr extracts the tooltip display in a function and update the condition to check values and fixes #4418. 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).