### PR TITLE
feat(api-reference): one endpoint tag collapsibility

### DIFF
--- a/.changeset/shaggy-peas-begin.md
+++ b/.changeset/shaggy-peas-begin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: adds collabsibility to one endpoint non default tag

--- a/packages/api-reference/src/components/Content/Tag/Tag.vue
+++ b/packages/api-reference/src/components/Content/Tag/Tag.vue
@@ -19,9 +19,13 @@ const contentsRef = ref<HTMLElement>()
 const { collapsedSidebarItems } = useSidebar()
 const { getTagId } = useNavState()
 
+const moreThanOneTag = computed(
+  () => props.spec.tags?.length && props.spec.tags?.length > 1,
+)
+
 const moreThanOneDefaultTag = computed(
   () =>
-    props.spec.tags?.length !== 1 ||
+    moreThanOneTag.value ||
     props.tag?.name !== 'default' ||
     props.tag?.description !== '',
 )
@@ -41,7 +45,7 @@ async function focusContents() {
       :isCollapsed="!collapsedSidebarItems[getTagId(tag)]"
       :tag="tag" />
     <ShowMoreButton
-      v-if="!collapsedSidebarItems[getTagId(tag)] && tag.operations?.length > 1"
+      v-if="!collapsedSidebarItems[getTagId(tag)] && moreThanOneTag"
       :id="id ?? ''"
       :aria-label="`Show all ${tag['x-displayName'] ?? tag.name} endpoints`"
       @click="focusContents" />


### PR DESCRIPTION
**Problem**
Currently if a tag has only one endpoint in a multiple tag reference - it cannot be collapsible (e.g. show more button).

**Solution**
this pr fixes #4409 by enabling collapsibility to non default tag that have one endpoint, this way if a reference has no tag usage the non collapsibility remain.

| before | after |
| -------|------|
|  <img width="1185" alt="image" src="https://github.com/user-attachments/assets/55d260db-2e76-43d5-8c95-6310a3d63fcc" /> | <img width="1185" alt="image" src="https://github.com/user-attachments/assets/0ffbab36-d8c9-4090-ae26-2bec51f81101" /> |
| operations are displayed and are not collapsible | operations remain collapsed by default | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).