### PR TITLE
feat(components): add create team button to team picker

### DIFF
--- a/.changeset/perfect-crews-greet.md
+++ b/.changeset/perfect-crews-greet.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat(components): add create team button to team picker

--- a/packages/components/src/components/ScalarMenu/ScalarMenu.stories.ts
+++ b/packages/components/src/components/ScalarMenu/ScalarMenu.stories.ts
@@ -57,11 +57,14 @@ export const TeamPicker: Story = {
         },
         {
           label: 'C Team',
+          src: 'https://picsum.photos/seed/3/100',
           id: 'team-c',
         },
       ]
       const team = ref(teams[0])
-      return { args, teams, team }
+      const handleAddTeam = () => alert('Add team!')
+
+      return { args, teams, team, handleAddTeam }
     },
     template: `
 <ScalarMenu v-bind="args">
@@ -71,7 +74,7 @@ export const TeamPicker: Story = {
   <template #sections>
     <ScalarMenuSection>
       <template #title>Account</template>
-      <ScalarMenuTeamPicker :teams="teams" v-model:team="team" />
+      <ScalarMenuTeamPicker :teams="teams" v-model:team="team" @add="handleAddTeam" />
       <ScalarMenuLink icon="Cog" >Settings</ScalarMenuLink>
       <ScalarMenuLink icon="Leave">Logout</ScalarMenuLink>
     </ScalarMenuSection>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
@@ -12,12 +12,17 @@ import { ScalarMenuLink, type ScalarMenuTeamOption } from './'
 import ScalarMenuTeamProfile from './ScalarMenuTeamProfile.vue'
 
 const props = defineProps<{
+  /** The currently selected team */
   team?: ScalarMenuTeamOption | undefined
+  /** The list of teams to choose from */
   teams: ScalarMenuTeamOption[]
 }>()
 
 const emit = defineEmits<{
+  /** Emitted when the selected team changes */
   (e: 'update:team', value: ScalarMenuTeamOption | undefined): void
+  /** Emitted when the user clicks the "Create new team" button */
+  (e: 'add'): void
 }>()
 
 /** A model that tracks the team id */
@@ -67,6 +72,15 @@ defineOptions({ inheritAttrs: false })
               :selected="t.id === model" />
           </DropdownMenu.RadioItem>
         </DropdownMenu.RadioGroup>
+        <DropdownMenu.Item
+          :as="ScalarDropdownButton"
+          @click="emit('add')">
+          <ScalarIcon
+            class="bg-b-3 -ml-0.75 rounded p-0.75 size-5 text-c-3"
+            icon="Add"
+            thickness="1.75" />
+          Create new team
+        </DropdownMenu.Item>
       </DropdownMenu.SubContent>
     </DropdownMenu.Portal>
   </DropdownMenu.Sub>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
@@ -7,7 +7,6 @@ import {
   ScalarDropdownMenu,
   ScalarIcon,
   ScalarListboxCheckbox,
-  type ScalarListboxOption,
 } from '../..'
 import { ScalarMenuLink, type ScalarMenuTeamOption } from './'
 import ScalarMenuTeamProfile from './ScalarMenuTeamProfile.vue'
@@ -18,12 +17,17 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: 'update:team', value: ScalarListboxOption | undefined): void
+  (e: 'update:team', value: ScalarMenuTeamOption | undefined): void
 }>()
 
-const model = computed<ScalarListboxOption | undefined>({
-  get: () => props.team,
-  set: (v) => emit('update:team', v),
+/** A model that tracks the team id */
+const model = computed<string | undefined>({
+  get: () => props.team?.id,
+  set: (v) =>
+    emit(
+      'update:team',
+      props.teams.find((t) => t.id === v),
+    ),
 })
 
 defineOptions({ inheritAttrs: false })
@@ -45,19 +49,24 @@ defineOptions({ inheritAttrs: false })
         :as="ScalarDropdownMenu"
         class="max-h-radix-popper"
         :sideOffset="3">
-        <ScalarDropdownButton
-          v-for="t in teams"
-          :key="t.id"
-          class="group/item"
-          @click="model = t">
-          <ScalarMenuTeamProfile
-            class="-ml-0.75 flex-1 min-w-0"
-            :label="t.label"
-            :src="t.src" />
-          <ScalarListboxCheckbox
-            class="ml-auto"
-            :selected="t.id === model?.id" />
-        </ScalarDropdownButton>
+        <DropdownMenu.RadioGroup
+          v-model="model"
+          as="template">
+          <DropdownMenu.RadioItem
+            v-for="t in teams"
+            :key="t.id"
+            :as="ScalarDropdownButton"
+            class="group/item"
+            :value="t.id">
+            <ScalarMenuTeamProfile
+              class="-ml-0.75 flex-1 min-w-0"
+              :label="t.label"
+              :src="t.src" />
+            <ScalarListboxCheckbox
+              class="ml-auto"
+              :selected="t.id === model" />
+          </DropdownMenu.RadioItem>
+        </DropdownMenu.RadioGroup>
       </DropdownMenu.SubContent>
     </DropdownMenu.Portal>
   </DropdownMenu.Sub>


### PR DESCRIPTION
I remembered @marclave wanted a create new team button, also realized I should switch the radio menu to use the accessible Radix Vue radio group.

![Google Chrome-2025-01-09-20-59-24@2x](https://github.com/user-attachments/assets/69a3c732-6bdb-48d5-b087-5ab14f0c9ad8)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
