### PR TITLE
feat(api-reference): flatten discriminators containing `'null'`

### DIFF
--- a/.changeset/five-lizards-change.md
+++ b/.changeset/five-lizards-change.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: flatten discriminators containing null

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -15,7 +15,7 @@ withDefaults(
   },
 )
 
-const rules = ['oneOf', 'anyOf', 'allOf', 'not']
+const discriminators = ['oneOf', 'anyOf', 'allOf', 'not']
 
 const flattenDefaultValue = (value: Record<string, any>) => {
   return Array.isArray(value?.default) && value.default.length === 1
@@ -53,7 +53,6 @@ const flattenDefaultValue = (value: Record<string, any>) => {
     </div>
     <template v-else-if="value?.type">
       <SchemaPropertyDetail>
-        <!-- prettier-ignore -->
         <template v-if="value?.items?.type">
           {{ value.type }}
           {{ value.items.type }}[]
@@ -114,6 +113,12 @@ const flattenDefaultValue = (value: Record<string, any>) => {
         {{ flattenDefaultValue(value) }}
       </SchemaPropertyDetail>
     </template>
+    <template v-else>
+      <!-- Shows only when a discriminator is used (so value?.type is undefined) -->
+      <SchemaPropertyDetail v-if="value?.nullable === true">
+        nullable
+      </SchemaPropertyDetail>
+    </template>
     <div
       v-if="value?.writeOnly"
       class="property-write-only">
@@ -125,9 +130,14 @@ const flattenDefaultValue = (value: Record<string, any>) => {
       read-only
     </div>
     <template
-      v-for="rule in rules.filter((r) => value?.[r] || value?.items?.[r])"
-      :key="rule">
-      <Badge>{{ rule }}</Badge>
+      v-for="discriminator in discriminators.filter(
+        (r) => value?.[r] || value?.items?.[r],
+      )"
+      :key="discriminator">
+      <!-- Only show anyOf, oneOf, allOf if there are more than one schema -->
+      <template v-if="value?.[discriminator]?.length > 1">
+        <Badge>{{ discriminator }}</Badge>
+      </template>
     </template>
     <div
       v-if="required"

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimizeValueForDisplay.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimizeValueForDisplay.test.ts
@@ -28,7 +28,7 @@ describe('optimizeValueForDisplay', () => {
       oneOf: [{ type: 'string' }, { type: 'null' }],
     }
     expect(optimizeValueForDisplay(input)).toEqual({
-      oneOf: [{ type: 'string' }],
+      type: 'string',
       nullable: true,
     })
   })
@@ -81,7 +81,7 @@ describe('optimizeValueForDisplay', () => {
       allOf: [{ type: 'string' }, { type: 'null' }],
     }
     expect(optimizeValueForDisplay(input)).toEqual({
-      allOf: [{ type: 'string' }],
+      type: 'string',
       nullable: true,
     })
   })

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimizeValueForDisplay.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimizeValueForDisplay.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import { optimizeValueForDisplay } from './optimizeValueForDisplay'
+
+describe('optimizeValueForDisplay', () => {
+  it('should return the original value if it is not an object', () => {
+    // @ts-expect-error
+    expect(optimizeValueForDisplay(1)).toEqual(1)
+  })
+
+  it('should return the original value if there is no discriminator type', () => {
+    const input = { type: 'string' }
+    expect(optimizeValueForDisplay(input)).toEqual(input)
+  })
+
+  it('should return the original value if discriminator schemas is not an array', () => {
+    const input = { oneOf: 'not an array' }
+    expect(optimizeValueForDisplay(input)).toEqual(input)
+  })
+
+  it('should ignore the not discriminator type', () => {
+    const input = { not: [{ type: 'string' }] }
+    expect(optimizeValueForDisplay(input)).toEqual(input)
+  })
+
+  it('should mark as nullable if schema contains null type', () => {
+    const input = {
+      oneOf: [{ type: 'string' }, { type: 'null' }],
+    }
+    expect(optimizeValueForDisplay(input)).toEqual({
+      oneOf: [{ type: 'string' }],
+      nullable: true,
+    })
+  })
+
+  it('should remove null types from schemas', () => {
+    const input = {
+      anyOf: [{ type: 'string' }, { type: 'null' }, { type: 'number' }],
+    }
+    expect(optimizeValueForDisplay(input)).toEqual({
+      anyOf: [{ type: 'string' }, { type: 'number' }],
+      nullable: true,
+    })
+  })
+
+  it('should merge single remaining schema after null removal', () => {
+    const input = {
+      oneOf: [{ type: 'string', format: 'date-time' }, { type: 'null' }],
+    }
+    expect(optimizeValueForDisplay(input)).toEqual({
+      type: 'string',
+      format: 'date-time',
+      nullable: true,
+    })
+  })
+
+  it('should handle multiple remaining schemas', () => {
+    const input = {
+      anyOf: [{ type: 'string' }, { type: 'number' }, { type: 'null' }],
+    }
+    expect(optimizeValueForDisplay(input)).toEqual({
+      anyOf: [{ type: 'string' }, { type: 'number' }],
+      nullable: true,
+    })
+  })
+
+  it('should preserve other properties when optimizing', () => {
+    const input = {
+      description: 'test field',
+      oneOf: [{ type: 'string' }, { type: 'null' }],
+    }
+    expect(optimizeValueForDisplay(input)).toEqual({
+      description: 'test field',
+      type: 'string',
+      nullable: true,
+    })
+  })
+
+  it('should handle allOf discriminator', () => {
+    const input = {
+      allOf: [{ type: 'string' }, { type: 'null' }],
+    }
+    expect(optimizeValueForDisplay(input)).toEqual({
+      allOf: [{ type: 'string' }],
+      nullable: true,
+    })
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimizeValueForDisplay.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimizeValueForDisplay.ts
@@ -1,0 +1,65 @@
+import type { UnknownObject } from '@scalar/types/utils'
+
+export const discriminators = ['oneOf', 'anyOf', 'allOf', 'not']
+
+/**
+ * Optimize the value by removing nulls from discriminators.
+ */
+export function optimizeValueForDisplay(value: UnknownObject | undefined) {
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+
+  // Clone the value to avoid mutating the original value
+  let newValue = { ...value }
+
+  // Find the discriminator type
+  const discriminatorType = discriminators.find((r) => newValue?.[r])
+
+  // If there’s no discriminator type, return the original value
+  if (!discriminatorType) {
+    return newValue
+  }
+
+  // Ignore the 'not' discriminator type
+  if (discriminatorType === 'not') {
+    return newValue
+  }
+
+  // Get the schemas for the discriminator type
+  const schemas = newValue?.[discriminatorType]
+
+  if (!Array.isArray(schemas)) {
+    return newValue
+  }
+
+  // If there’s an object with type 'null' in the anyOf, oneOf, allOf, mark the property as nullable
+
+  if (schemas?.some((schema: any) => schema.type === 'null')) {
+    newValue.nullable = true
+  }
+
+  // Remove objects with type 'null' from the schemas
+  const newSchemas = schemas?.filter((schema: any) => !(schema.type === 'null'))
+
+  // If there’s only one schema, overwrite the original value with the schema
+  // Skip it for arrays for now, need to handle that specifically.
+  if (newSchemas.length === 1 && newValue?.[discriminatorType]) {
+    newValue = { ...newValue, ...newSchemas[0] }
+
+    // Delete the original discriminator type
+    delete newValue?.[discriminatorType]
+
+    return newValue
+  }
+
+  // Overwrite the original schemas with the new schemas
+  if (
+    Array.isArray(newValue?.[discriminatorType]) &&
+    newValue?.[discriminatorType]?.length > 1
+  ) {
+    newValue[discriminatorType] = newSchemas
+  }
+
+  return newValue
+}

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimizeValueForDisplay.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimizeValueForDisplay.ts
@@ -34,13 +34,12 @@ export function optimizeValueForDisplay(value: UnknownObject | undefined) {
   }
 
   // If there’s an object with type 'null' in the anyOf, oneOf, allOf, mark the property as nullable
-
-  if (schemas?.some((schema: any) => schema.type === 'null')) {
+  if (schemas.some((schema: any) => schema.type === 'null')) {
     newValue.nullable = true
   }
 
   // Remove objects with type 'null' from the schemas
-  const newSchemas = schemas?.filter((schema: any) => !(schema.type === 'null'))
+  const newSchemas = schemas.filter((schema: any) => !(schema.type === 'null'))
 
   // If there’s only one schema, overwrite the original value with the schema
   // Skip it for arrays for now, need to handle that specifically.


### PR DESCRIPTION
**Problem**
Currently, the rendering for discriminators containing `null` is super verbose. Let’s be smarter and flatten them when possible.

Thanks @frankie567 for the idea!

**Before**

<img width="817" alt="Screenshot 2025-01-10 at 11 45 57" src="https://github.com/user-attachments/assets/62c51ab9-8a40-4f5f-89e8-e46d2d6a204a" />

**After**

<img width="817" alt="Screenshot 2025-01-10 at 11 46 09" src="https://github.com/user-attachments/assets/db4b6eac-5129-47e5-a26d-155113807a89" />

**Example**

```json
{
  "openapi": "3.1.1",
  "info": {
    "title": "API Reference",
    "version": "1.0.0"
  },
  "components": {
    "schemas": {
      "User": {
        "type": "object",
        "properties": {
          "modified_at": { "anyOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }] },
          "created_at": { "oneOf": [{ "type": "string", "format": "date-time" }, { "type": "number" }, { "type": "null" }] },
          "not_created_at": { "not": [{ "type": "string", "format": "date-time" }, { "type": "number" }, { "type": "null" }] }
        },
        "required": ["modified_at"]
      }
    }
  }
}
```

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
