### PR TITLE
fix(api-reference): schema example duplication

### DIFF
--- a/.changeset/pink-vans-repair.md
+++ b/.changeset/pink-vans-repair.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: removes schema example duplication

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -86,6 +86,12 @@ const visibleEnumValues = computed(() =>
 const remainingEnumValues = computed(() =>
   getEnumFromValue(props.value).slice(initialEnumCount.value),
 )
+
+const formatExample = (example: string) => {
+  return Array.isArray(example)
+    ? `[${example.map((item) => `"${item.trim()}"`).join(', ')}]`
+    : example
+}
 </script>
 <template>
   <div
@@ -131,7 +137,7 @@ const remainingEnumValues = computed(() =>
       class="property-example custom-scroll">
       <span class="property-example-label">Example</span>
       <code class="property-example-value">{{
-        value.example || value?.items.example
+        formatExample(value.example || value?.items.example)
       }}</code>
     </div>
     <template
@@ -337,7 +343,6 @@ const remainingEnumValues = computed(() =>
 .property-example-value {
   all: unset;
   font-family: var(--scalar-font-code);
-  white-space: pre;
   padding: 6px;
   border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
@@ -368,7 +373,6 @@ const remainingEnumValues = computed(() =>
 }
 
 .property--compact .property-example {
-  align-items: center;
   background: transparent;
   border: none;
   display: flex;
@@ -377,13 +381,13 @@ const remainingEnumValues = computed(() =>
 }
 .property--compact .property-example-label,
 .property--compact .property-example-value {
-  padding: 0;
+  padding: 3px 0 0 0;
 }
 .property--compact .property-example-value {
   background: var(--scalar-background-2);
   border-top: 0;
   border-radius: var(--scalar-radius);
-  padding: 2px 6px;
+  padding: 3px 4px;
 }
 .property-list {
   border: var(--scalar-border-width) solid var(--scalar-border-color);

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -135,11 +135,6 @@ const flattenDefaultValue = (value: Record<string, any>) => {
       required
     </div>
   </div>
-  <div
-    v-if="$slots.example"
-    class="property-example">
-    <slot name="example" />
-  </div>
 </template>
 <style scoped>
 .property-heading {
@@ -167,11 +162,6 @@ const flattenDefaultValue = (value: Record<string, any>) => {
   font-weight: var(--scalar-semibold);
   font-size: var(--scalar-font-size-3);
   display: flex;
-}
-
-.property-example {
-  margin-top: 8px;
-  font-size: var(--scalar-mini);
 }
 
 .property-additional {


### PR DESCRIPTION
**Problem**
a duplication has been introduced in #4162 for schema property example, being now shown twice.

**Solution**
this pr removes the duplication and update the style for array value.

| before | after |
| -------|------|
| <img width="491" alt="image" src="https://github.com/user-attachments/assets/f6bb288d-82f0-4f8f-b651-02e50d2fb704" /> | <img width="491" alt="image" src="https://github.com/user-attachments/assets/eec90e11-2733-43d5-855b-033d03ea0a72" /> |
| description of the issue in image | description of the change in image | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).s