### PR TITLE
fix(api-client): linux enter hotkey

### DIFF
--- a/.changeset/tame-news-grow.md
+++ b/.changeset/tame-news-grow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: ctrl enter key on linux

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
-import type { HotKeyEvent } from '@/libs'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 import { Listbox } from '@headlessui/vue'
 import { ScalarButton, ScalarIcon } from '@scalar/components'
 import type { RequestMethod } from '@scalar/oas-utils/entities/spec'
 import { REQUEST_METHODS } from '@scalar/oas-utils/helpers'
-import { isMacOS } from '@scalar/use-tooltip'
-import { useMagicKeys, whenever } from '@vueuse/core'
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 
 import HttpMethod from '../HttpMethod/HttpMethod.vue'
 import AddressBarHistory from './AddressBarHistory.vue'
@@ -25,12 +22,6 @@ const { isReadOnly, requestMutators, requestHistory, events } = useWorkspace()
 
 const selectedRequest = ref(requestHistory[0])
 const addressBarRef = ref<typeof CodeInput | null>(null)
-
-const keys = useMagicKeys()
-const executeKey = computed(() =>
-  isMacOS() ? keys.meta_enter : keys.ctrl_enter,
-)
-whenever(executeKey.value, () => events.executeRequest.emit())
 
 /** update the instance path parameters on change */
 const onUrlChange = (newPath: string) => {
@@ -114,6 +105,12 @@ function handleExecuteRequest() {
   events.executeRequest.emit()
 }
 
+/** Handle hotkeys */
+events.hotKeys.on((event) => {
+  if (event?.focusAddressBar) addressBarRef.value?.focus()
+  if (event?.executeRequest) handleExecuteRequest()
+})
+
 /**
  * TODO: Should we handle query params here somehow?
  */
@@ -122,16 +119,6 @@ function updateRequestPath(url: string) {
 
   requestMutators.edit(activeRequest.value.uid, 'path', url)
 }
-
-/** Handle hotkeys */
-function handleHotKey(event?: HotKeyEvent) {
-  if (event?.focusAddressBar) {
-    addressBarRef.value?.focus()
-  }
-}
-
-onMounted(() => events.hotKeys.on(handleHotKey))
-onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
 </script>
 <template>
   <div

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -30,7 +30,7 @@ const keys = useMagicKeys()
 const executeKey = computed(() =>
   isMacOS() ? keys.meta_enter : keys.ctrl_enter,
 )
-whenever(executeKey, () => events.executeRequest.emit())
+whenever(executeKey.value, () => events.executeRequest.emit())
 
 /** update the instance path parameters on change */
 const onUrlChange = (newPath: string) => {

--- a/packages/api-client/src/libs/hot-keys.ts
+++ b/packages/api-client/src/libs/hot-keys.ts
@@ -49,6 +49,7 @@ const inputHotkeys = [
  */
 export const DEFAULT_HOTKEYS: HotKeyConfig = {
   Escape: { event: 'closeModal' },
+  Enter: { event: 'executeRequest', modifiers: ['default'] },
   b: { event: 'toggleSidebar', modifiers: ['default'] },
   k: { event: 'openCommandPalette', modifiers: ['default'] },
 }

--- a/packages/oas-utils/src/entities/hotkeys/hotkeys.ts
+++ b/packages/oas-utils/src/entities/hotkeys/hotkeys.ts
@@ -2,21 +2,22 @@
  * Array of all of the events that we support
  */
 export const HOTKEY_EVENT_NAMES = [
-  'closeModal',
-  'navigateSearchResultsDown',
-  'selectSearchResult',
-  'navigateSearchResultsUp',
-  'openCommandPalette',
-  'createNew',
-  'toggleSidebar',
   'addTopNav',
+  'closeModal',
   'closeTopNav',
+  'createNew',
+  'executeRequest',
+  'focusAddressBar',
+  'focusRequestSearch',
+  'jumpToLastTab',
+  'jumpToTab',
+  'navigateSearchResultsDown',
+  'navigateSearchResultsUp',
   'navigateTopNavLeft',
   'navigateTopNavRight',
-  'focusAddressBar',
-  'jumpToTab',
-  'jumpToLastTab',
-  'focusRequestSearch',
+  'openCommandPalette',
+  'selectSearchResult',
+  'toggleSidebar',
 ] as const
 export type HotkeyEventName = (typeof HOTKEY_EVENT_NAMES)[number]
 


### PR DESCRIPTION
**Problem**
ctrl + enter doesnt work on linux anymore

**Solution**
ideally we would remove whenever + magic keys as they have caused issues in the past, but this is a quick fix that works

Update: did the proper fix and removed magic keys + whenever

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
