### PR TITLE
fix(api-client): duplicate query params

### DIFF
--- a/.changeset/mighty-penguins-invite.md
+++ b/.changeset/mighty-penguins-invite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: duplicate query params

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -278,6 +278,20 @@ describe('create-request-operation', () => {
     })
   })
 
+  it('creates query parameters from the url', async () => {
+    const [error, requestOperation] = createRequestOperation(
+      createRequestPayload({
+        serverPayload: { url: VOID_URL },
+        requestPayload: {
+          path: '/path?test=query',
+        },
+      }),
+    )
+    if (error) throw error
+
+    expect(requestOperation.request.url).toBe(`${VOID_URL}/path?test=query`)
+  })
+
   it('returns the request object with an uppercase method', async () => {
     const [error, requestOperation] = createRequestOperation(
       createRequestPayload({

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -350,37 +350,72 @@ describe('create-request-operation', () => {
     })
   })
 
-  it('merges query parameters', async () => {
-    const [error, requestOperation] = createRequestOperation(
-      createRequestPayload({
-        serverPayload: {
-          url: `${VOID_URL}/api?orange=apple`,
-        },
-        requestPayload: {
-          path: '?example=parameter',
-        },
-        requestExamplePayload: {
-          parameters: {
-            query: [
-              {
-                key: 'foo',
-                value: 'bar',
-                enabled: true,
-              },
-            ],
+  describe('merges query parameters', () => {
+    it('with server url', async () => {
+      const [error, requestOperation] = createRequestOperation(
+        createRequestPayload({
+          serverPayload: {
+            url: `${VOID_URL}/api?orange=apple`,
           },
-        },
-      }),
-    )
-    if (error) throw error
+          requestPayload: {
+            path: '?example=parameter',
+          },
+          requestExamplePayload: {
+            parameters: {
+              query: [
+                {
+                  key: 'foo',
+                  value: 'bar',
+                  enabled: true,
+                },
+              ],
+            },
+          },
+        }),
+      )
+      if (error) throw error
 
-    const [requestError, result] = await requestOperation.sendRequest()
+      const [requestError, result] = await requestOperation.sendRequest()
 
-    expect(requestError).toBe(null)
-    expect(JSON.parse(result?.response.data as string).query).toStrictEqual({
-      example: 'parameter',
-      foo: 'bar',
-      orange: 'apple',
+      expect(requestError).toBe(null)
+      expect(JSON.parse(result?.response.data as string).query).toStrictEqual({
+        example: 'parameter',
+        foo: 'bar',
+        orange: 'apple',
+      })
+    })
+
+    it('without server url', async () => {
+      const [error, requestOperation] = createRequestOperation(
+        createRequestPayload({
+          serverPayload: {
+            url: '',
+          },
+          requestPayload: {
+            path: `${VOID_URL}/?example=parameter`,
+          },
+          requestExamplePayload: {
+            parameters: {
+              query: [
+                {
+                  key: 'foo',
+                  value: 'bar',
+                  enabled: true,
+                },
+              ],
+            },
+          },
+        }),
+      )
+      if (error) throw error
+
+      const [requestError, result] = await requestOperation.sendRequest()
+
+      expect(requestError).toBe(null)
+      expect(JSON.parse(result?.response.data as string).query).toStrictEqual({
+        example: 'parameter',
+        foo: 'bar',
+      })
     })
   })
 

--- a/packages/api-client/src/libs/send-request/send-request.ts
+++ b/packages/api-client/src/libs/send-request/send-request.ts
@@ -375,11 +375,11 @@ export const createRequestOperation = ({
       }
 
       // Combines all query params
-      combinedURL.search = new URLSearchParams([
-        ...serverURL.searchParams,
-        ...pathURL.searchParams,
-        ...urlParams,
-      ]).toString()
+      const searchParams = server?.url
+        ? [...serverURL.searchParams, ...pathURL.searchParams, ...urlParams]
+        : [...pathURL.searchParams, ...urlParams]
+
+      combinedURL.search = new URLSearchParams(searchParams).toString()
 
       url = combinedURL.toString()
     }

--- a/packages/api-client/src/libs/send-request/send-request.ts
+++ b/packages/api-client/src/libs/send-request/send-request.ts
@@ -364,12 +364,14 @@ export const createRequestOperation = ({
       const serverURL = new URL(base)
       /** We create a separate path URL to grab the path params */
       const pathURL = new URL(pathString, serverURL.origin)
+      /** Now we remove the query params from the path to ensure there's no duplicate query params */
+      const pathname = pathString.split('?')[0] ?? ''
 
       /** Finally we combine the two but make sure that we keep the path from server */
       const combinedURL = new URL(serverURL)
       if (server?.url) {
-        if (serverURL.pathname === '/') combinedURL.pathname = pathString
-        else combinedURL.pathname = serverURL.pathname + pathString
+        if (serverURL.pathname === '/') combinedURL.pathname = pathname
+        else combinedURL.pathname = serverURL.pathname + pathname
       }
 
       // Combines all query params


### PR DESCRIPTION
**Problem**
Query params are duplicated when they are in the path string

**Solution**
We remove any query params from the path string

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.

closes #4428
