### PR TITLE
fix(scalar-client): import collection workspace modal

### DIFF
--- a/.changeset/blue-parents-hunt.md
+++ b/.changeset/blue-parents-hunt.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+fix: updates scalar modal body class specificity

--- a/.changeset/twenty-cows-sleep.md
+++ b/.changeset/twenty-cows-sleep.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates workspace modal style in import collection

--- a/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
+++ b/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
@@ -113,12 +113,13 @@ const handleCreateWorkspace = () => {
     </ScalarDropdown>
   </div>
   <ScalarModal
-    bodyClass="!m-0 !p-1"
+    bodyClass="m-0 p-1 rounded-lg border-t-0"
+    class="absolute z-overlay"
     :size="'xxs'"
     :state="modal"
     variant="form">
     <form
-      class="flex gap-1 rounded"
+      class="flex gap-1"
       @submit.prevent="handleCreateWorkspace">
       <input
         v-model="workspaceName"

--- a/packages/api-client/src/views/Environment/EnvironmentModal.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentModal.vue
@@ -101,7 +101,7 @@ const redirectToCreateCollection = () => {
 
 <template>
   <ScalarModal
-    bodyClass="!border-t-0 !rounded-t-lg"
+    bodyClass="border-t-0 rounded-t-lg"
     size="xs"
     :state="state">
     <CommandActionForm

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -119,7 +119,7 @@ export function useModal() {
         </div>
         <DialogDescription
           v-else
-          :class="cx(bodyClass, body({ size, variant }))">
+          :class="cx(body({ size, variant }), bodyClass)">
           <slot />
         </DialogDescription>
       </DialogPanel>


### PR DESCRIPTION
**Problem**
when opening the workspace creation modal form the import collection, the modal is not style nor displayed correctly.

**Solution**
this pr updates the style of the workspace creation modal as seen below:

| before | after |
| -------|------|
| <img width="590" alt="image" src="https://github.com/user-attachments/assets/89ace468-1815-4053-a3a6-8193263c396a" /> | <img width="590" alt="image" src="https://github.com/user-attachments/assets/51184595-cc4f-4637-8782-76a39b591b8c" /> |
| modal border, radius are off + index  | modal has now consistent ui and proper context displayed | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
