### PR TITLE
fix(openapi-parser): example arrays are transformed to objects

### DIFF
--- a/.changeset/silent-panthers-rescue.md
+++ b/.changeset/silent-panthers-rescue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: example arrays are transformed to objects

--- a/packages/openapi-parser/src/utils/traverse.test.ts
+++ b/packages/openapi-parser/src/utils/traverse.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { traverse } from './traverse'
+
+describe('traverse', () => {
+  it('applies transform function to a flat object', () => {
+    const definition = { a: 1, b: 2 }
+    const transform = (schema: any) => {
+      return Object.fromEntries(
+        Object.entries(schema).map(([key, value]) => {
+          if (typeof value !== 'number') {
+            return [key, value]
+          }
+
+          return [key, value * 2]
+        }),
+      )
+    }
+
+    const result = traverse(definition, transform)
+    expect(result).toEqual({ a: 2, b: 4 })
+  })
+
+  it('applies transform function to nested objects', () => {
+    const definition = { a: { b: 2, c: 3 }, d: 4 }
+    const transform = (schema: any) => {
+      return Object.fromEntries(
+        Object.entries(schema).map(([key, value]) => {
+          if (typeof value === 'object' && value !== null) {
+            return [key, value]
+          }
+
+          if (typeof value !== 'number') {
+            return [key, value]
+          }
+
+          return [key, value * 2]
+        }),
+      )
+    }
+    const result = traverse(definition, transform)
+    expect(result).toEqual({ a: { b: 4, c: 6 }, d: 8 })
+  })
+
+  it('applies transform function to arrays within objects', () => {
+    const definition = { a: [1, 2, { b: 3 }], c: 4 }
+    const transform = (schema: any) => {
+      return Object.fromEntries(
+        Object.entries(schema).map(([key, value]) => {
+          if (Array.isArray(value)) {
+            return [
+              key,
+              value.map((v: any) => (typeof v === 'number' ? v * 2 : v)),
+            ]
+          }
+
+          if (typeof value !== 'number') {
+            return [key, value]
+          }
+
+          return [key, value * 2]
+        }),
+      )
+    }
+
+    const result = traverse(definition, transform)
+
+    expect(result).toEqual({ a: [2, 4, { b: 6 }], c: 8 })
+  })
+
+  it('handles empty objects', () => {
+    const definition = {}
+    const transform = (schema: any) => schema
+    const result = traverse(definition, transform)
+
+    expect(result).toEqual({})
+  })
+
+  it('handles objects with null values', () => {
+    const definition = { a: null, b: 2 }
+    const transform = (schema: any) => schema
+    const result = traverse(definition, transform)
+
+    expect(result).toEqual({ a: null, b: 2 })
+  })
+})

--- a/packages/openapi-parser/src/utils/traverse.ts
+++ b/packages/openapi-parser/src/utils/traverse.ts
@@ -14,12 +14,17 @@ export function traverse(
     const currentPath = [...path, key]
     if (Array.isArray(value)) {
       result[key] = value.map((item, index) => {
-        if (typeof item === 'object' && item !== null) {
+        if (typeof item === 'object' && !Array.isArray(item) && item !== null) {
           return traverse(item, transform, [...currentPath, index.toString()])
         }
+
         return item
       })
-    } else if (typeof value === 'object' && value !== null) {
+    } else if (
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      value !== null
+    ) {
       result[key] = traverse(value, transform, currentPath)
     } else {
       result[key] = value

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
@@ -252,6 +252,63 @@ describe('upgradeFromThreeToThreeOne', () => {
         },
       })
     })
+
+    it('doesn’t transform arrays into objects', () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Sample API',
+          version: '1.0.0',
+          description: 'A simple example API',
+        },
+        tags: [
+          {
+            'name': 'users',
+            'description': 'Operations about users',
+            'x-internal': true,
+          },
+        ],
+        paths: {
+          '/users': {
+            post: {
+              tags: ['users'],
+              summary: 'hello',
+              description: 'Returns a list of users',
+              operationId: 'getUsers',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        foobar: {
+                          type: 'array',
+                          example: ['Portfolio1', 'Portfolio2'],
+                          items: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(
+        result.paths['/users'].post.requestBody.content['application/json']
+          .schema.properties.foobar,
+      ).toStrictEqual({
+        type: 'array',
+        examples: [['Portfolio1', 'Portfolio2']],
+        items: {
+          type: 'string',
+        },
+      })
+    })
   })
 
   describe('describing File Upload Payloads', () => {


### PR DESCRIPTION
**Problem**
Currently, in some cases arrays are converted to objects during in the `upgrade` helper.

**Solution**
With this PR arrays will be arrays after the upgrade.

Fixes #4075 #3782.

**Example**

https://sandbox.scalar.com/e/fi5lT

**Before**

<img width="348" alt="Screenshot 2025-01-13 at 15 11 53" src="https://github.com/user-attachments/assets/66e53439-f7c5-40c6-8df3-88b37c5a23f8" />

**After**

<img width="490" alt="Screenshot 2025-01-13 at 15 12 18" src="https://github.com/user-attachments/assets/86db4b0b-cb0c-4636-912f-a7fdd739c51a" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
