### PR TITLE
feat(api-reference): remove examples from responses

### DIFF
--- a/.changeset/violet-bugs-hammer.md
+++ b/.changeset/violet-bugs-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: remove examples from responses

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -16,11 +16,13 @@ const props = withDefaults(
     compact?: boolean
     description?: string
     additional?: boolean
+    withExamples?: boolean
   }>(),
   {
     level: 0,
     required: false,
     compact: false,
+    withExamples: true,
   },
 )
 
@@ -128,7 +130,7 @@ const remainingEnumValues = computed(() =>
     </div>
     <!-- Example -->
     <div
-      v-if="value?.example || value?.items?.example"
+      v-if="withExamples && (value?.example || value?.items?.example)"
       class="property-example custom-scroll">
       <span class="property-example-label">Example</span>
       <code class="property-example-value">{{

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { formatExample } from '@/components/Content/Schema/helpers/formatExample'
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
 import { computed } from 'vue'
@@ -86,12 +87,6 @@ const visibleEnumValues = computed(() =>
 const remainingEnumValues = computed(() =>
   getEnumFromValue(props.value).slice(initialEnumCount.value),
 )
-
-const formatExample = (example: string) => {
-  return Array.isArray(example)
-    ? `[${example.map((item) => `"${item.trim()}"`).join(', ')}]`
-    : example
-}
 </script>
 <template>
   <div

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.test.ts
@@ -57,20 +57,20 @@ describe('formatExample', () => {
   })
 
   it('handles non-string/non-array input', () => {
-    const input = 123 as any
+    const input = 123
     const result = formatExample(input)
-    expect(result).toBe(123)
+    expect(result).toBe('123')
   })
 
   it('handles undefined input', () => {
-    const input = undefined as any
+    const input = undefined
     const result = formatExample(input)
-    expect(result).toBe(undefined)
+    expect(result).toBe('undefined')
   })
 
   it('handles null input', () => {
-    const input = null as any
+    const input = null
     const result = formatExample(input)
-    expect(result).toBe(null)
+    expect(result).toBe('null')
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.test.ts
@@ -1,0 +1,76 @@
+import { formatExample } from '@/components/Content/Schema/helpers/formatExample'
+import { describe, expect, it } from 'vitest'
+
+describe('formatExample', () => {
+  it('formats array examples by wrapping items in quotes and brackets', () => {
+    const input = ['foo', 'bar', ' baz ']
+    const result = formatExample(input)
+    expect(result).toBe('["foo", "bar", "baz"]')
+  })
+
+  it('returns non-array examples unchanged', () => {
+    const input = 'just a string'
+    const result = formatExample(input)
+    expect(result).toBe('just a string')
+  })
+
+  it('handles empty array', () => {
+    const input: string[] = []
+    const result = formatExample(input)
+    expect(result).toBe('[]')
+  })
+
+  it('handles single item array', () => {
+    const input = ['single']
+    const result = formatExample(input)
+    expect(result).toBe('["single"]')
+  })
+
+  it('handles array with number values', () => {
+    const input = ['123', '456.789']
+    const result = formatExample(input)
+    expect(result).toBe('["123", "456.789"]')
+  })
+
+  it('handles array with object values', () => {
+    const input = [{ foo: 'bar' }, { baz: 123 }]
+    const result = formatExample(input as any)
+    expect(result).toBe('[{"foo":"bar"}, {"baz":123}]')
+  })
+
+  it('handles array with mixed value types', () => {
+    const input = ['string', { obj: 'val' }, '123']
+    const result = formatExample(input as any)
+    expect(result).toBe('["string", {"obj":"val"}, "123"]')
+  })
+
+  it('handles array with null/undefined values', () => {
+    const input = [null, undefined] as any
+    const result = formatExample(input)
+    expect(result).toBe('[null, undefined]')
+  })
+
+  it('handles array with whitespace strings', () => {
+    const input = ['  leading', 'trailing  ', '  both  ']
+    const result = formatExample(input)
+    expect(result).toBe('["leading", "trailing", "both"]')
+  })
+
+  it('handles non-string/non-array input', () => {
+    const input = 123 as any
+    const result = formatExample(input)
+    expect(result).toBe(123)
+  })
+
+  it('handles undefined input', () => {
+    const input = undefined as any
+    const result = formatExample(input)
+    expect(result).toBe(undefined)
+  })
+
+  it('handles null input', () => {
+    const input = null as any
+    const result = formatExample(input)
+    expect(result).toBe(null)
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
@@ -1,7 +1,7 @@
 /**
  * Converts an example value to a string that can be displayed in the UI.
  */
-export function formatExample(example: any) {
+export function formatExample(example: unknown) {
   if (Array.isArray(example)) {
     return `[${example
       .map((item) => {

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
@@ -1,7 +1,7 @@
 /**
  * Converts an example value to a string that can be displayed in the UI.
  */
-export function formatExample(example: unknown) {
+export function formatExample(example: unknown): string {
   if (Array.isArray(example)) {
     return `[${example
       .map((item) => {
@@ -26,5 +26,9 @@ export function formatExample(example: unknown) {
       .join(', ')}]`
   }
 
-  return example
+  if (!example) {
+    return ''
+  }
+
+  return example.toString().trim()
 }

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
@@ -26,7 +26,7 @@ export function formatExample(example: unknown): string {
       .join(', ')}]`
   }
 
-  if (!example) {
+  if (example === null || example === undefined) {
     return ''
   }
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
@@ -1,0 +1,30 @@
+/**
+ * Converts an example value to a string that can be displayed in the UI.
+ */
+export function formatExample(example: any) {
+  if (Array.isArray(example)) {
+    return `[${example
+      .map((item) => {
+        if (typeof item === 'string' || typeof item === 'number') {
+          return `"${item.toString().trim()}"`
+        }
+
+        if (typeof item === 'object') {
+          return JSON.stringify(item)
+        }
+
+        if (item === undefined) {
+          return 'undefined'
+        }
+
+        if (item === null) {
+          return 'null'
+        }
+
+        return item
+      })
+      .join(', ')}]`
+  }
+
+  return example
+}

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
@@ -1,7 +1,7 @@
 /**
  * Converts an example value to a string that can be displayed in the UI.
  */
-export function formatExample(example: unknown): string {
+export function formatExample(example: unknown): string | number {
   if (Array.isArray(example)) {
     return `[${example
       .map((item) => {
@@ -26,8 +26,20 @@ export function formatExample(example: unknown): string {
       .join(', ')}]`
   }
 
-  if (example === null || example === undefined) {
-    return ''
+  if (typeof example === 'object') {
+    return JSON.stringify(example)
+  }
+
+  if (example === null) {
+    return 'null'
+  }
+
+  if (example === undefined) {
+    return 'undefined'
+  }
+
+  if (typeof example === 'string') {
+    return example.trim()
   }
 
   return example.toString().trim()

--- a/packages/api-reference/src/features/Operation/components/OperationResponses.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationResponses.vue
@@ -19,7 +19,8 @@ const { responses } = useResponses(props.operation)
 <template>
   <ParameterList
     :collapsableItems="collapsableItems"
-    :parameters="responses">
+    :parameters="responses"
+    :withExamples="false">
     <template #title>Responses</template>
   </ParameterList>
 </template>

--- a/packages/api-reference/src/features/Operation/components/ParameterList.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterList.vue
@@ -8,10 +8,12 @@ withDefaults(
     parameters?: Parameter[]
     showChildren?: boolean
     collapsableItems?: boolean
+    withExamples?: boolean
   }>(),
   {
     showChildren: false,
     collapsableItems: false,
+    withExamples: true,
   },
 )
 </script>
@@ -28,7 +30,8 @@ withDefaults(
         :key="item.name"
         :collapsableItems="collapsableItems"
         :parameter="item"
-        :showChildren="showChildren" />
+        :showChildren="showChildren"
+        :withExamples="withExamples" />
     </ul>
   </div>
 </template>

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -14,10 +14,12 @@ const props = withDefaults(
     parameter: Parameter
     showChildren?: boolean
     collapsableItems?: boolean
+    withExamples?: boolean
   }>(),
   {
     showChildren: false,
     collapsableItems: false,
+    withExamples: true,
   },
 )
 
@@ -87,7 +89,8 @@ const shouldCollapse = computed<boolean>(() => {
             parameter.content
               ? parameter.content?.[selectedContentType]?.schema
               : parameter.schema
-          " />
+          "
+          :withExamples="withExamples" />
       </DisclosurePanel>
     </Disclosure>
   </li>


### PR DESCRIPTION
**Problem**
As a response to #1971 we’ve added the examples to all sections in the operation in #4162.

Turns out, it doesn’t really make sense to have the examples in the response list. It’s redundant with the box on the right side of the operation, and the formatting helper wasn’t really meant to deal with that kind of data.

Fixes #4438

**Solution**
With this PR the response list on the left doesn't show the example responses anymore and  the formatting helper is moved to a separate helper, got some tests and some better handling for other data types.

**Before**

<img width="761" alt="Screenshot 2025-01-13 at 16 38 13" src="https://github.com/user-attachments/assets/e1868466-275e-4ef5-a44f-e467a5269338" />

**After**

<img width="1158" alt="Screenshot 2025-01-13 at 16 26 23" src="https://github.com/user-attachments/assets/8f144a0a-5e50-48d7-8629-de2e4f3e6dc8" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
