### PR TITLE
feat(api-client): adds servers page back

### DIFF
--- a/.changeset/long-beans-punch.md
+++ b/.changeset/long-beans-punch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds server page

--- a/.changeset/loud-boats-poke.md
+++ b/.changeset/loud-boats-poke.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: global sidebar and misc overhaul

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
@@ -93,7 +93,7 @@ const redirectToCreateCollection = () => {
         </ScalarButton>
         <ScalarButton
           v-else
-          class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+          class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2 w-fit"
           variant="outlined"
           @click="redirectToCreateCollection">
           <span class="text-c-1">Create Collection</span>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
@@ -13,6 +13,13 @@ import { computed, ref } from 'vue'
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
 
+const props = defineProps<{
+  metaData?: {
+    itemUid?: string
+    parentUid?: string
+  }
+}>()
+
 const emits = defineEmits<{
   (event: 'close'): void
   (event: 'back', e: KeyboardEvent): void
@@ -38,9 +45,15 @@ const collections = computed(() =>
 
 /** Currently selected collection with a reasonable default */
 const selectedCollection = ref<ScalarComboboxOption | undefined>(
-  collections.value.find(
-    (collection) => collection.id === activeCollection.value?.uid,
-  ),
+  props.metaData
+    ? collections.value.find(
+        (collection) =>
+          collection.id === props.metaData?.itemUid ||
+          collection.id === props.metaData?.parentUid,
+      )
+    : collections.value.find(
+        (collection) => collection.id === activeCollection.value?.uid,
+      ),
 )
 
 const handleSubmit = () => {

--- a/packages/api-client/src/components/DataTable/DataTable.vue
+++ b/packages/api-client/src/components/DataTable/DataTable.vue
@@ -13,7 +13,7 @@ const { cx } = useBindCx()
     v-bind="
       cx(
         scroll ? 'overflow-x-auto custom-scroll' : 'overflow-visible',
-        'scalar-data-table border-t-1/2 bg-b-1',
+        'scalar-data-table bg-b-1',
       )
     ">
     <table

--- a/packages/api-client/src/components/DataTable/DataTableCell.vue
+++ b/packages/api-client/src/components/DataTable/DataTableCell.vue
@@ -17,7 +17,7 @@ const { cx } = useBindCx()
     :is="is"
     v-bind="
       cx(
-        'max-h-8 min-h-8 min-w-8 border-l-0 group-[:not(:first-child)]:border-t-1/2 border-b-0 border-r-1/2 flex text-sm last:border-r-0 group-last:border-b-transparent p-0 m-0 relative',
+        'max-h-8 min-h-8 min-w-8 border-l-0 border-t border-b-0 border-r flex text-sm last:border-r-0 group-last:border-b-transparent p-0 m-0 relative',
       )
     "
     role="cell">

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -19,7 +19,7 @@ defineProps<{
         v-else
         name="title" />
     </template>
-    <div class="custom-scroll flex flex-1 flex-col gap-1.5 p-2 md:p-5">
+    <div class="custom-scroll flex flex-1 flex-col gap-1.5">
       <DataTable
         v-if="Object.keys(data).length > 0"
         :columns="['']">

--- a/packages/api-client/src/components/SideNav/SideNavLink.vue
+++ b/packages/api-client/src/components/SideNav/SideNavLink.vue
@@ -14,9 +14,9 @@ const { layout } = useLayout()
 <template>
   <component
     :is="is ?? 'a'"
-    class="hover:bg-b-3 no-underline min-w-[37px] max-w-[37px] flex items-center justify-center rounded-lg p-2"
+    class="hover:bg-b-2 no-underline min-w-[37px] max-w-[37px] flex items-center justify-center rounded-lg p-2"
     :class="{
-      'bg-b-3 transition-none hover:cursor-auto text-c-1': active,
+      'bg-b-2 transition-none hover:cursor-auto text-c-1': active,
       'sm:min-w-max sm:max-w-max sm:rounded sm:py-1.5': layout === 'web',
     }">
     <slot name="icon">

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -69,7 +69,7 @@ const startDrag = (event: MouseEvent) => {
     <slot name="header" />
     <div
       v-if="!isReadOnly && title"
-      class="min-h-12 xl:min-h-client-header flex items-center justify-between px-3 py-1.5 md:px-4 md:py-2.5 text-sm">
+      class="min-h-12 xl:min-h-client-header flex items-center justify-between px-3 py-1.5 md:px-[18px] md:py-2.5 text-sm">
       <h2 class="font-medium m-0 text-sm whitespace-nowrap">
         {{ title }}
       </h2>

--- a/packages/api-client/src/components/Sidebar/SidebarList.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="flex flex-col gap-px px-3 pb-[75px]">
+  <ul class="flex flex-col px-3 pb-[75px]">
     <slot />
   </ul>
 </template>

--- a/packages/api-client/src/components/Sidebar/SidebarList.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="flex flex-col px-3 pb-[75px]">
+  <ul class="gap-1/2 flex flex-col px-3 pb-[75px]">
     <slot />
   </ul>
 </template>

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -87,7 +87,10 @@ const handleRename = (id: string) => {
         v-if="variable.icon"
         class="text-sidebar-c-2 size-3.5 stroke-[2.25]"
         :icon="variable.icon" />
-      <span class="empty-variable-name text-sm">{{ variable.name }}</span>
+      <span
+        class="empty-variable-name text-sm line-clamp-1 break-all group-hover:pr-5"
+        >{{ variable.name }}</span
+      >
       <SidebarListElementActions
         :isCopyable="isCopyable"
         :isDeletable="isDeletable"

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -17,7 +17,7 @@ const props = defineProps<{
   isDeletable?: boolean
   isCopyable?: boolean
   isRenameable?: boolean
-  type: 'environment' | 'cookies' | 'server'
+  type: 'environment' | 'cookies' | 'servers'
 }>()
 
 const emit = defineEmits<{

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -19,7 +19,7 @@ withDefaults(
   <Disclosure
     v-slot="{ open }"
     as="div"
-    class="focus-within:text-c-1 text-c-2 request-item border-b"
+    class="focus-within:text-c-1 text-c-2 request-item border-b first:border-t"
     :defaultOpen="defaultOpen"
     :static="layout === 'reference'">
     <div class="bg-b-2 flex items-center">

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -2,7 +2,7 @@
   <section
     class="flex xl:h-full xl:min-w-0 flex-1 flex-col xl:custom-scroll bg-b-1">
     <div
-      class="min-h-11 flex items-center border-b-1/2 px-2.5 text-sm font-medium sticky top-0 bg-b-1 xl:rounded-none z-1">
+      class="min-h-11 flex items-center px-2.5 text-sm font-medium sticky top-0 bg-b-1 xl:rounded-none z-1">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/constants.ts
+++ b/packages/api-client/src/constants.ts
@@ -3,6 +3,6 @@ export const ROUTES = [
   { prettyName: 'Cookies', name: 'cookies', icon: 'Cookie' },
   { prettyName: 'Environment', name: 'environment', icon: 'Brackets' },
   { prettyName: 'Settings', name: 'settings', icon: 'Settings' },
-  // { prettyName: 'Servers', name: 'servers', icon: 'Server' },
+  { prettyName: 'Servers', name: 'servers', icon: 'Server' },
   // { label: 'Git Sync', icon: 'Branch', path: '/git-sync' },
 ] as const

--- a/packages/api-client/src/routes.ts
+++ b/packages/api-client/src/routes.ts
@@ -192,13 +192,18 @@ export const routes = [
         path: 'servers',
         redirect: (to) => ({
           name: 'servers',
-          params: { ...to.params, servers: 'default' },
+          params: {
+            ...to.params,
+            collectionId: 'default',
+            servers: 'default',
+          },
         }),
       },
       {
         name: 'servers',
-        path: `servers/:${PathId.Servers}`,
+        path: `servers/:collectionId/:${PathId.Servers}`,
         component: () => import('@/views/Servers/Servers.vue'),
+        props: true,
       },
       {
         name: 'settings.default',
@@ -207,11 +212,6 @@ export const routes = [
           name: 'settings',
           params: { ...to.params, settings: 'general' },
         }),
-      },
-      {
-        name: 'settings',
-        path: `settings/:${PathId.Settings}`,
-        component: () => import('@/views/Settings/Settings.vue'),
       },
     ],
   },

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -41,7 +41,7 @@ const updateCookie = (key: any, value: any) => {
     <template #title>
       <div class="flex items-center pointer-events-none">
         <label
-          class="absolute w-full h-full top-0 left-0 pointer-events-auto opacity-0 cursor-text"
+          class="absolute border-b w-full h-full top-0 left-0 pointer-events-auto opacity-0 cursor-text"
           for="cookiename"></label>
         <input
           id="cookiename"

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -117,7 +117,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
             <div
               v-for="(paths, domain) in groupedCookies"
               :key="domain"
-              class="flex flex-col gap-px">
+              class="flex flex-col gap-1/2">
               <button
                 class="hover:bg-b-2 group relative flex w-full flex-row justify-start gap-1.5 rounded text-left text-sm p-1.5 focus-visible:z-10 hover:bg-sidebar-active-b indent-padding-left"
                 type="button"
@@ -137,7 +137,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                 <div
                   v-for="(cookieList, path) in paths"
                   :key="path"
-                  class="flex flex-col gap-px">
+                  class="flex flex-col gap-1/2">
                   <button
                     class="flex gap-1.5 items-center pl-5 pr-2 py-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
                     type="button"

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -291,8 +291,8 @@ const handleNavigation = (
   collectionId?: string,
 ) => {
   const path = collectionId
-    ? `/workspace/${activeWorkspace.value.uid}/environment/${collectionId}/${uid}`
-    : `/workspace/${activeWorkspace.value.uid}/environment/${uid}`
+    ? `/workspace/${activeWorkspace?.value?.uid}/environment/${collectionId}/${uid}`
+    : `/workspace/${activeWorkspace?.value?.uid}/environment/${uid}`
   if (event.metaKey) {
     window.open(path, '_blank')
   } else {
@@ -468,7 +468,7 @@ function handleRename(newName: string) {
         </template>
         <CodeInput
           v-if="currentEnvironmentId"
-          class="pl-px pr-2 md:px-4 py-2"
+          class="border-t pl-px pr-2 md:px-4 py-2"
           isCopyable
           language="json"
           lineNumbers

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -291,8 +291,8 @@ const handleNavigation = (
   collectionId?: string,
 ) => {
   const path = collectionId
-    ? `/workspace/default/environment/${collectionId}/${uid}`
-    : `/workspace/default/environment/${uid}`
+    ? `/workspace/${activeWorkspace.value.uid}/environment/${collectionId}/${uid}`
+    : `/workspace/${activeWorkspace.value.uid}/environment/${uid}`
   if (event.metaKey) {
     window.open(path, '_blank')
   } else {

--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -124,7 +124,7 @@ onClickOutside(
       :style="dropdownStyle">
       <ul
         v-if="filteredVariables.length"
-        class="flex flex-col gap-px">
+        class="flex flex-col gap-1/2">
         <template
           v-for="(item, index) in filteredVariables"
           :key="item.key">

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -268,7 +268,7 @@ const toggleSearch = () => {
           @keydown.up.stop="navigateSearchResults('up')" />
       </div>
       <div
-        class="flex flex-1 flex-col overflow-visible px-3 pb-3 pt-0"
+        class="gap-1/2 flex flex-1 flex-col overflow-visible px-3 pb-3 pt-0"
         :class="{
           'pb-14': !isReadOnly,
         }"

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -302,7 +302,7 @@ const hasDraftRequests = computed(() => {
       :id="item.entity.uid"
       ref="draggableRef"
       :ceiling="getDraggableOffsets.ceiling"
-      class="flex flex-1 flex-col gap-[.5px] text-sm"
+      class="flex flex-1 flex-col gap-1/2 text-sm"
       :floor="getDraggableOffsets.floor"
       :isDraggable="isDraggable"
       :isDroppable="isDroppable"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -31,7 +31,7 @@ onMounted(() => events.hotKeys.on(handleHotKey))
 onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
 </script>
 <template>
-  <div class="relative col-1 flex-center gap-6 p-2 capitalize">
+  <div class="border-t relative col-1 flex-center gap-6 p-2 capitalize">
     <div
       class="flex h-[calc(100%_-_50px)] flex-col items-center justify-center"
       :class="{

--- a/packages/api-client/src/views/Servers/ServerForm.vue
+++ b/packages/api-client/src/views/Servers/ServerForm.vue
@@ -3,10 +3,20 @@ import Form from '@/components/Form/Form.vue'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 import type { Server } from '@scalar/oas-utils/entities/spec'
-import { computed } from 'vue'
-import { useRoute } from 'vue-router'
+import { computed, withDefaults } from 'vue'
 
-const { activeCollection } = useActiveEntities()
+const props = withDefaults(
+  defineProps<{
+    collectionId: string | string[]
+    serverUid: string | string[]
+  }>(),
+  {
+    collectionId: '',
+    serverUid: '',
+  },
+)
+
+const { activeWorkspaceCollections } = useActiveEntities()
 const { servers, serverMutators } = useWorkspace()
 
 const options = [
@@ -18,65 +28,32 @@ const options = [
   },
 ]
 
-const route = useRoute()
-
-const activeServer = computed(
-  () =>
-    servers[
-      (activeCollection.value && route.params.server === 'default'
-        ? activeCollection.value?.servers[0]
-        : activeCollection.value?.servers.find(
-            (uid) => uid === route.params.server,
-          )) ?? ''
-    ],
-)
+const activeServer = computed(() => {
+  const activeCollection = activeWorkspaceCollections.value.find(
+    (collection) => collection.uid === props.collectionId,
+  )
+  return servers[
+    activeCollection &&
+    typeof props.serverUid === 'string' &&
+    props.serverUid === 'default'
+      ? (activeCollection.servers[0] ?? '')
+      : (activeCollection?.servers.find((uid) => uid === props.serverUid) ?? '')
+  ]
+})
 
 const updateServer = (key: string, value: string) => {
-  if (!activeCollection.value || !activeServer.value) return
+  if (!activeWorkspaceCollections.value || !activeServer.value) return
   serverMutators.edit(activeServer.value.uid, key as keyof Server, value)
 }
-
-const updateVariable = (key: string, value: any) => {
-  if (!activeCollection.value || !activeServer.value) return
-  serverMutators.edit(activeServer.value.uid, `variables.${key}.value`, value)
-}
-
-/** Fields for the table */
-const variableOptions = computed(() =>
-  Object.entries(activeServer.value?.variables ?? {}).map(
-    ([key, variable]) => ({
-      key,
-      label: key,
-      placeholder: (variable.default ?? variable?.enum?.[0] ?? '').toString(),
-    }),
-  ),
-)
-
-/** Values from the workspace, use `default` or `enum[0]` as fallback */
-const variablesData = computed(() =>
-  Object.entries(activeServer.value?.variables ?? {}).reduce<
-    Record<string, string>
-  >((acc, [key, variable]) => {
-    acc[key] = (variable.default ?? variable?.enum?.[0] ?? '').toString()
-    return acc
-  }, {}),
-)
 </script>
 <template>
-  <div class="w-full">
+  <div class="divide-0.5 divide-x flex w-full">
     <template v-if="activeServer">
       <Form
         :data="activeServer"
         :onUpdate="updateServer"
         :options="options"
         title="Server" />
-
-      <Form
-        v-if="Object.keys(variablesData).length"
-        :data="variablesData"
-        :onUpdate="updateVariable"
-        :options="variableOptions"
-        title="Variables" />
     </template>
   </div>
 </template>

--- a/packages/api-client/src/views/Servers/Servers.vue
+++ b/packages/api-client/src/views/Servers/Servers.vue
@@ -8,7 +8,7 @@ import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import { useSidebar } from '@/hooks'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import { ScalarIcon } from '@scalar/components'
+import { ScalarButton, ScalarIcon } from '@scalar/components'
 import { LibraryIcon } from '@scalar/icons'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { computed } from 'vue'
@@ -30,9 +30,10 @@ const showChildren = (key: string) => {
   return collapsedSidebarFolders[key]
 }
 
-function openCommandPaletteServer() {
+function openCommandPaletteServer(collectionId?: string) {
   events.commandPalette.emit({
     commandName: 'Add Server',
+    metaData: { parentUid: collectionId },
   })
 }
 
@@ -115,6 +116,17 @@ function handleDelete(uid: string) {
                   }"
                   @click="handleNavigation($event, serverUid, collection.uid)"
                   @delete="handleDelete" />
+                <ScalarButton
+                  v-if="Object.keys(collection['servers'] || {}).length === 0"
+                  class="mb-[.5px] flex gap-1.5 h-8 text-c-1 pl-6 py-0 justify-start text-xs w-full hover:bg-b-2"
+                  variant="ghost"
+                  @click="openCommandPaletteServer(collection.uid)">
+                  <ScalarIcon
+                    class="ml-0.5 h-2.5 w-2.5"
+                    icon="Add"
+                    thickness="3" />
+                  <span>Add Server</span>
+                </ScalarButton>
               </div>
             </div>
           </SidebarList>

--- a/packages/api-client/src/views/Servers/Servers.vue
+++ b/packages/api-client/src/views/Servers/Servers.vue
@@ -69,7 +69,7 @@ function handleDelete(uid: string) {
             <div
               v-for="collection in collections"
               :key="collection.uid"
-              class="flex flex-col gap-px">
+              class="flex flex-col gap-1/2">
               <button
                 class="flex font-medium gap-1.5 group items-center p-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
                 type="button"
@@ -99,7 +99,7 @@ function handleDelete(uid: string) {
               <div
                 v-show="showChildren(collection.uid)"
                 :class="{
-                  'before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-3 before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] flex flex-col gap-px mb-[.5px] last:mb-0 relative':
+                  'before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-3 before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] flex flex-col gap-1/2 mb-[.5px] last:mb-0 relative':
                     Object.keys(collection['servers'] || {}).length > 0,
                 }">
                 <SidebarListElement

--- a/packages/api-client/src/views/Servers/Servers.vue
+++ b/packages/api-client/src/views/Servers/Servers.vue
@@ -96,6 +96,18 @@ function handleDelete(uid: string) {
                   class="break-all line-clamp-1 font-medium text-left w-full"
                   >{{ collection.info?.title ?? '' }}</span
                 >
+                <ScalarButton
+                  class="hidden group-hover:block px-0.5 py-0 hover:bg-b-3 hover:text-c-1 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 aspect-square h-fit"
+                  size="sm"
+                  variant="ghost"
+                  @click.stop.prevent="
+                    openCommandPaletteServer(collection.uid)
+                  ">
+                  <ScalarIcon
+                    icon="Add"
+                    size="md"
+                    thickness="2" />
+                </ScalarButton>
               </button>
               <div
                 v-show="showChildren(collection.uid)"

--- a/packages/api-client/tailwind.config.ts
+++ b/packages/api-client/tailwind.config.ts
@@ -46,6 +46,7 @@ export default {
         },
       },
       spacing: {
+        '1/2': '.5px',
         /** Client headers including the address bar and the section headers */
         'client-header': '48px',
       },


### PR DESCRIPTION
**Problem**
it is not currently possible to add, update or delete server per collection.

**Solution**
this pr brings back initial work done by @hanspagel in a global server page. server variables including enum will follow along request server management that is currently under design tinkering.

| after |
| -------|
| <img width="889" alt="image" src="https://github.com/user-attachments/assets/a0099cd7-3abe-4f8a-805d-a0e2d08b63bd" /> |
| server page brought back along add, update, delete capability |


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`)
