### PR TITLE
feat(api-reference): version prefix

### DIFF
--- a/.changeset/seven-eels-compete.md
+++ b/.changeset/seven-eels-compete.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: version prefix

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.test.ts
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.test.ts
@@ -112,6 +112,27 @@ describe('Introduction', () => {
     })
 
     expect(wrapper.html()).not.toContain('vbeta')
+    expect(wrapper.html()).toContain('beta')
+  })
+
+  it('doesn’t prefix version with v when version is already prefixed', () => {
+    const example = {
+      openapi: '3.1.1',
+      info: {
+        title: 'Test API',
+        description: '',
+        version: 'v1.0.0',
+      },
+    } satisfies Spec
+
+    const wrapper = mount(Introduction, {
+      props: {
+        parsedSpec: example,
+        info: example.info,
+      },
+    })
+
+    expect(wrapper.html()).toContain('v1.0.0')
   })
 
   it('doesn’t output the version if something is wrong with the version', () => {

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.test.ts
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.test.ts
@@ -1,0 +1,179 @@
+import { DownloadLink } from '@/features/DownloadLink'
+import type { Spec } from '@scalar/types/legacy'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import Introduction from './Introduction.vue'
+
+describe('Introduction', () => {
+  it('renders the given information', () => {
+    const example = {
+      openapi: '3.1.1',
+      info: {
+        title: 'Hello World',
+        description: 'Example description',
+        version: '1.0.0',
+      },
+    } satisfies Spec
+
+    const wrapper = mount(Introduction, {
+      props: {
+        parsedSpec: example,
+        info: {
+          title: 'Hello World',
+          description: 'Example description',
+          version: '1.0.0',
+        },
+      },
+    })
+
+    expect(wrapper.html()).toContain('Hello World')
+    expect(wrapper.html()).toContain('Example description')
+    expect(wrapper.html()).toContain('v1.0.0')
+    expect(wrapper.html()).toContain('OAS 3.1.1')
+  })
+
+  it('renders loading state when info is empty', () => {
+    const example = {
+      openapi: '3.1.1',
+      info: {
+        title: '',
+        description: '',
+        version: '',
+      },
+    } satisfies Spec
+
+    const wrapper = mount(Introduction, {
+      props: {
+        parsedSpec: example,
+        info: example.info,
+      },
+    })
+
+    expect(wrapper.find('.loading').exists()).toBe(true)
+  })
+
+  it('generates filename from title', () => {
+    const example = {
+      openapi: '3.1.1',
+      info: {
+        title: 'Hello World API!',
+        description: '',
+        version: '1.0.0',
+      },
+    } satisfies Spec
+
+    const wrapper = mount(Introduction, {
+      props: {
+        parsedSpec: example,
+        info: example.info,
+      },
+    })
+
+    const downloadLink = wrapper.findComponent(DownloadLink)
+    expect(downloadLink.props('specTitle')).toBe('hello-world-api')
+  })
+
+  it('shows version badge when version exists', () => {
+    const example = {
+      openapi: '3.1.1',
+      info: {
+        title: 'Test API',
+        description: '',
+        version: '2.0.0',
+      },
+    } satisfies Spec
+
+    const wrapper = mount(Introduction, {
+      props: {
+        parsedSpec: example,
+        info: example.info,
+      },
+    })
+
+    expect(wrapper.html()).toContain('v2.0.0')
+  })
+
+  it('doesn’t prefix version with v when version is not a number', () => {
+    const example = {
+      openapi: '3.1.1',
+      info: {
+        title: 'Test API',
+        description: '',
+        version: 'beta',
+      },
+    } satisfies Spec
+
+    const wrapper = mount(Introduction, {
+      props: {
+        parsedSpec: example,
+        info: example.info,
+      },
+    })
+
+    expect(wrapper.html()).not.toContain('vbeta')
+  })
+
+  it('doesn’t output the version if something is wrong with the version', () => {
+    const example = {
+      openapi: '3.1.1',
+      info: {
+        title: 'Test API',
+        description: '',
+        // @ts-expect-error testing invalid type
+        version: ['foobar'],
+      },
+    } satisfies Spec
+
+    const wrapper = mount(Introduction, {
+      props: {
+        // @ts-expect-error testing invalid type
+        parsedSpec: example,
+        // @ts-expect-error testing invalid type
+        info: example.info,
+      },
+    })
+
+    expect(wrapper.html()).not.toContain('foobar')
+  })
+
+  it('shows OpenAPI version badge for OpenAPI spec', () => {
+    const example = {
+      openapi: '3.0.0',
+      info: {
+        title: 'Test API',
+        description: '',
+        version: '1.0.0',
+      },
+    } satisfies Spec
+
+    const wrapper = mount(Introduction, {
+      props: {
+        parsedSpec: example,
+        info: example.info,
+      },
+    })
+
+    expect(wrapper.html()).toContain('OAS 3.0.0')
+  })
+
+  it('shows OpenAPI version badge for Swagger spec', () => {
+    const example = {
+      swagger: '2.0',
+      info: {
+        title: 'Test API',
+        description: '',
+        version: '1.0.0',
+      },
+    } satisfies Spec
+
+    const wrapper = mount(Introduction, {
+      props: {
+        parsedSpec: example,
+        info: example.info,
+      },
+    })
+
+    expect(wrapper.html()).toContain('OAS 2.0')
+  })
+})

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -38,10 +38,8 @@ const formattedSpecTitle = computed(() => {
     <Section class="introduction-section">
       <SectionContent :loading="!info.description && !info.title">
         <div class="badges">
-          <Badge v-if="info.version">
-            {{ info.version }}
-          </Badge>
-          <Badge v-if="specVersion"> OAS {{ specVersion }}</Badge>
+          <Badge v-if="info.version">v{{ info.version }}</Badge>
+          <Badge v-if="specVersion">OAS {{ specVersion }}</Badge>
         </div>
         <SectionHeader
           :level="1"

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -42,11 +42,11 @@ const filenameFromTitle = computed(() => slugger.slug(props.info?.title ?? ''))
 const version = computed(() => {
   // Prefix the version with “v” if the first character is a number, don’t prefix if it’s not.
   // Don’t output anything when version is not a string.
-  return props.info?.version
-    ? `v${props.info.version.toString().match(/^\d/)?.input}`
-    : typeof props.info?.version === 'string'
-      ? props.info.version
-      : undefined
+  return typeof props.info?.version === 'string'
+    ? props.info.version.toString().match(/^\d/)
+      ? `v${props.info.version}`
+      : props.info.version
+    : undefined
 })
 </script>
 <template>

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Spec } from '@scalar/types/legacy'
-import GithubSlugger from 'github-slugger'
+import GitHubSlugger from 'github-slugger'
 import { computed } from 'vue'
 
 import DownloadLink from '../../../features/DownloadLink/DownloadLink.vue'
@@ -23,23 +23,40 @@ const props = defineProps<{
   parsedSpec: Spec
 }>()
 
-const slugger = new GithubSlugger()
-
-const specVersion = computed(() => {
-  return props.parsedSpec.openapi ?? props.parsedSpec.swagger ?? ''
+/**
+ * Get the OpenAPI/Swagger specification version from the API definition.
+ */
+const oasVersion = computed(() => {
+  return props.parsedSpec?.openapi ?? props.parsedSpec?.swagger ?? ''
 })
 
-const formattedSpecTitle = computed(() => {
-  return slugger.slug(props.info.title ?? '')
+/**
+ * Format the title to be displayed in the badge.
+ *
+ * TODO: We should move this logic to the DownloadLink component
+ */
+const slugger = new GitHubSlugger()
+const filenameFromTitle = computed(() => slugger.slug(props.info?.title ?? ''))
+
+/** Format the version number to be displayed in the badge */
+const version = computed(() => {
+  // Prefix the version with “v” if the first character is a number, don’t prefix if it’s not.
+  // Don’t output anything when version is not a string.
+  return props.info?.version
+    ? `v${props.info.version.toString().match(/^\d/)?.input}`
+    : typeof props.info?.version === 'string'
+      ? props.info.version
+      : undefined
 })
 </script>
 <template>
   <SectionContainer>
-    <Section class="introduction-section">
-      <SectionContent :loading="!info.description && !info.title">
+    <!-- If the #after slot is used, we need to add a gap to the section. -->
+    <Section class="gap-12">
+      <SectionContent :loading="!info?.description && !info?.title">
         <div class="badges">
-          <Badge v-if="info.version">v{{ info.version }}</Badge>
-          <Badge v-if="specVersion">OAS {{ specVersion }}</Badge>
+          <Badge v-if="version">{{ version }}</Badge>
+          <Badge v-if="oasVersion">OAS {{ oasVersion }}</Badge>
         </div>
         <SectionHeader
           :level="1"
@@ -47,7 +64,7 @@ const formattedSpecTitle = computed(() => {
           tight>
           {{ info.title }}
         </SectionHeader>
-        <DownloadLink :specTitle="formattedSpecTitle" />
+        <DownloadLink :specTitle="filenameFromTitle" />
         <SectionColumns>
           <SectionColumn>
             <Description :value="info.description" />
@@ -64,31 +81,9 @@ const formattedSpecTitle = computed(() => {
   </SectionContainer>
 </template>
 <style scoped>
-.heading {
-  margin-top: 0px !important;
-  word-wrap: break-word;
-}
-.loading {
-  background: var(--scalar-background-3);
-  animation: loading-skeleton 1.5s infinite alternate;
-  border-radius: var(--scalar-radius-lg);
-}
-.badges {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  margin-bottom: 3px;
-}
-.heading.loading {
-  width: 80%;
-}
-.introduction-section {
-  gap: 48px;
-}
 .sticky-cards {
   display: flex;
   flex-direction: column;
-
   position: sticky;
   top: calc(var(--refs-header-height) + 24px);
 }

--- a/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
+++ b/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
@@ -11,8 +11,14 @@ const props = defineProps<{
   specTitle?: string
 }>()
 
-const getHideDownloadButtonSymbol = inject(HIDE_DOWNLOAD_BUTTON_SYMBOL)
-const getOpenApiDocumentUrlSymbol = inject(OPENAPI_DOCUMENT_URL_SYMBOL)
+const getHideDownloadButtonSymbol = inject(
+  HIDE_DOWNLOAD_BUTTON_SYMBOL,
+  () => true,
+)
+const getOpenApiDocumentUrlSymbol = inject(
+  OPENAPI_DOCUMENT_URL_SYMBOL,
+  () => undefined,
+)
 
 // id is retrieved at the layout level
 const handleDownloadClick = () => {


### PR DESCRIPTION
**Problem**
Currently, a lot of people just having something like `1` or `2` as the version in their API definition, but I think the rendering might be a bit confusing. The number is just shown without any context.

<img width="364" alt="Screenshot 2025-01-14 at 12 07 53" src="https://github.com/user-attachments/assets/d2fa844a-a4bd-4e7d-9a44-abc7bacdb89f" />


**Solution**
With this PR it’s rendered as `v1`, which might be enough to make it look like a version number.

<img width="364" alt="Screenshot 2025-01-14 at 12 07 39" src="https://github.com/user-attachments/assets/e16690ae-d9a1-49b0-a490-363b0d40961f" />

Wdyt?

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
