### PR TITLE
feat(openapi-types): add HTTP methods

### DIFF
--- a/.changeset/pink-mugs-repair.md
+++ b/.changeset/pink-mugs-repair.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-types': patch
+---
+
+feat: add http methods

--- a/packages/openapi-types/src/openapi-types.test-d.ts
+++ b/packages/openapi-types/src/openapi-types.test-d.ts
@@ -1,6 +1,11 @@
 import { describe, expectTypeOf, it } from 'vitest'
 
-import type { OpenAPI, OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from './index'
+import type {
+  OpenAPI,
+  OpenAPIV2,
+  OpenAPIV3,
+  OpenAPIV3_1,
+} from './openapi-types'
 
 describe('OpenAPI', () => {
   it('has a generic type', () => {
@@ -58,5 +63,18 @@ describe('OpenAPI', () => {
 
     expectTypeOf(specification['random-attribute']).toEqualTypeOf<any>()
     expectTypeOf(specification['x-custom']).toEqualTypeOf<boolean | undefined>()
+  })
+
+  it('has a HttpMethod type', () => {
+    const validMethod: OpenAPI.HttpMethod = 'GET'
+    const anotherValidMethod: Lowercase<OpenAPI.HttpMethod> = 'get'
+
+    expectTypeOf(validMethod).toMatchTypeOf<OpenAPI.HttpMethod>()
+    expectTypeOf(anotherValidMethod).toMatchTypeOf<
+      Lowercase<OpenAPI.HttpMethod>
+    >()
+
+    // @ts-expect-error name is a string
+    assertType('NOT_A_METHOD' as OpenAPI.HttpMethod)
   })
 })

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -72,6 +72,11 @@ export namespace OpenAPI {
     | OpenAPIV2.SchemaObject
     | OpenAPIV3.SchemaObject
     | OpenAPIV3_1.SchemaObject
+
+  export type HttpMethods =
+    | OpenAPIV3_1.HttpMethods
+    | OpenAPIV3.HttpMethods
+    | OpenAPIV2.HttpMethods
 }
 
 export namespace OpenAPIV3_1 {

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -73,10 +73,10 @@ export namespace OpenAPI {
     | OpenAPIV3.SchemaObject
     | OpenAPIV3_1.SchemaObject
 
-  export type HttpMethods =
+  export type HttpMethod =
+    | keyof typeof OpenAPIV2.HttpMethods
+    | keyof typeof OpenAPIV3.HttpMethods
     | OpenAPIV3_1.HttpMethods
-    | OpenAPIV3.HttpMethods
-    | OpenAPIV2.HttpMethods
 }
 
 export namespace OpenAPIV3_1 {


### PR DESCRIPTION
I’m splitting https://github.com/scalar/scalar/pull/4281 in a few smaller PRs.

**Problem**
Currently, we have a few places where keep a type for the HTTP methods.

**Solution**
With this PR we’re adding them to the `@scalar/openapi-types` package, so we’ll have a central place for it.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
