### PR TITLE
feat(api-reference): render the operation description from the store

### DIFF
--- a/.changeset/clever-badgers-rhyme.md
+++ b/.changeset/clever-badgers-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: render some basic information for the operation from the new store

--- a/.changeset/clever-badgers-rhyme.md
+++ b/.changeset/clever-badgers-rhyme.md
@@ -3,4 +3,4 @@
 '@scalar/types': patch
 ---
 
-feat: render the operation title from the new store
+feat: render the operation description from the new store

--- a/.changeset/clever-badgers-rhyme.md
+++ b/.changeset/clever-badgers-rhyme.md
@@ -3,4 +3,4 @@
 '@scalar/types': patch
 ---
 
-feat: render some basic information for the operation from the new store
+feat: render the operation title from the new store

--- a/.changeset/lemon-mice-know.md
+++ b/.changeset/lemon-mice-know.md
@@ -1,0 +1,5 @@
+---
+'@scalar/types': patch
+---
+
+chore: deprecated the TransformedOperation type

--- a/packages/api-reference/src/blocks/constants.ts
+++ b/packages/api-reference/src/blocks/constants.ts
@@ -1,0 +1,13 @@
+export const ERRORS = {
+  NO_ELEMENT_PROVIDED:
+    'Scalar Blocks: No HTML element provided to mount operation block. Please provide an HTML element to mount the operation block into.',
+  NO_URL_PROVIDED:
+    'Scalar Blocks: No URL provided to import an OpenAPI document from. Please provide a URL to import an OpenAPI document from.',
+  EMPTY_PATH:
+    'Path cannot be empty. Please provide a path to the operation you want to display.',
+}
+
+export const WARNINGS = {
+  ELEMENT_NOT_FOUND:
+    'Scalar Blocks: HTML element not found. We’ll just create one and append it to the body.',
+}

--- a/packages/api-reference/src/blocks/helpers/getLocation.test.ts
+++ b/packages/api-reference/src/blocks/helpers/getLocation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { getLocation } from './getLocation'
+
+describe('getLocation', () => {
+  it('should return the correct location', () => {
+    expect(getLocation(['paths', '/planets/{planetId}', 'get'])).toBe(
+      '#/paths/~1planets~1{planetId}/get',
+    )
+  })
+
+  it('should handle empty paths', () => {
+    // @ts-expect-error testing invalid input
+    expect(() => getLocation([''])).toThrow()
+  })
+
+  it('should handle paths with special characters', () => {
+    expect(getLocation(['paths', '/users/~/settings', 'post'])).toBe(
+      '#/paths/~1users~1~0~1settings/post',
+    )
+  })
+
+  it('converts method to lowercase', () => {
+    expect(getLocation(['paths', '/users', 'post'])).toBe(
+      '#/paths/~1users/post',
+    )
+    expect(getLocation(['paths', '/users', 'get'])).toBe('#/paths/~1users/get')
+    expect(getLocation(['paths', '/users', 'delete'])).toBe(
+      '#/paths/~1users/delete',
+    )
+  })
+
+  it('handles multiple path parameters', () => {
+    expect(
+      getLocation(['paths', '/users/{userId}/posts/{postId}', 'get']),
+    ).toBe('#/paths/~1users~1{userId}~1posts~1{postId}/get')
+  })
+
+  it('escapes forward slashes', () => {
+    expect(getLocation(['paths', '/path/with/many/slashes', 'get'])).toBe(
+      '#/paths/~1path~1with~1many~1slashes/get',
+    )
+  })
+})

--- a/packages/api-reference/src/blocks/helpers/getLocation.ts
+++ b/packages/api-reference/src/blocks/helpers/getLocation.ts
@@ -12,7 +12,7 @@ import type { OpenAPI } from '@scalar/openapi-types'
  * ['components', 'schemas', 'Planet]
  */
 type ValidOpenApiPaths =
-  | ['paths', string, Lowercase<OpenAPI.HttpMethod>]
+  | ['paths', string, Lowercase<OpenAPI.HttpMethod> | string]
   | ['components', 'schemas', string]
 
 /**

--- a/packages/api-reference/src/blocks/helpers/getLocation.ts
+++ b/packages/api-reference/src/blocks/helpers/getLocation.ts
@@ -1,0 +1,41 @@
+import { ERRORS } from '@/blocks/constants'
+import { escapeJsonPointer } from '@scalar/openapi-parser'
+
+// import type { OpenAPI } from '@scalar/openapi-types'
+
+/**
+ * OpenAPI paths that we support.
+ *
+ * @example
+ * ['paths', '/planets/{foo}', 'get']
+ * ['components', 'schemas', 'Planet]
+ */
+type ValidOpenApiPaths =
+  // TODO: Add this
+  // | ['paths', string, OpenAPI.HttpMethods | Uppercase<OpenAPI.HttpMethods>]
+  // TODO: Instead of this:
+  ['paths', string, string] | ['components', 'schemas', string]
+
+/**
+ * Encodes a location string with paths
+ *
+ * @example
+ * getLocation(['paths', '/planets/{foo}', 'get'])
+ *
+ * '#/paths/~1planets~1{foo}/get'
+ */
+export function getLocation(path: ValidOpenApiPaths) {
+  const pointer = [
+    '#',
+    ...path
+      .map((p) => p.trim())
+      .filter(Boolean)
+      .map(escapeJsonPointer),
+  ].join('/')
+
+  if (pointer === '#') {
+    throw new Error(ERRORS.EMPTY_PATH)
+  }
+
+  return pointer as `#/${string}`
+}

--- a/packages/api-reference/src/blocks/helpers/getLocation.ts
+++ b/packages/api-reference/src/blocks/helpers/getLocation.ts
@@ -1,5 +1,6 @@
 import { ERRORS } from '@/blocks/constants'
 import { escapeJsonPointer } from '@scalar/openapi-parser'
+import type { OpenAPI } from '@scalar/openapi-types'
 
 // import type { OpenAPI } from '@scalar/openapi-types'
 
@@ -11,10 +12,8 @@ import { escapeJsonPointer } from '@scalar/openapi-parser'
  * ['components', 'schemas', 'Planet]
  */
 type ValidOpenApiPaths =
-  // TODO: Add this
-  // | ['paths', string, OpenAPI.HttpMethods | Uppercase<OpenAPI.HttpMethods>]
-  // TODO: Instead of this:
-  ['paths', string, string] | ['components', 'schemas', string]
+  | ['paths', string, Lowercase<OpenAPI.HttpMethod>]
+  | ['components', 'schemas', string]
 
 /**
  * Encodes a location string with paths

--- a/packages/api-reference/src/blocks/hooks/useBlockProps.ts
+++ b/packages/api-reference/src/blocks/hooks/useBlockProps.ts
@@ -6,7 +6,7 @@ import type {
 import { unescapeJsonPointer } from '@scalar/openapi-parser'
 import { type ComputedRef, computed } from 'vue'
 
-// TODO: Move this to a shared location
+// TODO: Move this type to a shared location
 export type StoreContext = ReturnType<typeof createWorkspaceStore>
 
 export type BlockProps = {
@@ -34,32 +34,33 @@ export type BlockProps = {
 /**
  * Provides computed properties for the block, based on the standardized interface of the `createStore` function.
  */
-export function useBlockProps(props: BlockProps): {
+export function useBlockProps({ store, location }: BlockProps): {
   operation: ComputedRef<RequestEntity | undefined>
 } {
   // Just pick first collection for now
   const collection = computed(() => {
-    return Object.values(props.store?.collections ?? {})[0]
+    return Object.values(store?.collections ?? {})[0]
   }) as ComputedRef<Collection | undefined>
 
   // TODO: Use the collection name from the props
   //   const collection = computed(() => {
-  //     return Object.values(props.store.collections).find(
-  //       ({ name }) => name === (props.collection ?? 'default'),
+  //     return Object.values(store.collections).find(
+  //       ({ name }) => name === (collection ?? 'default'),
   //     )
   //   })
 
+  /** Resolve the operation (request) from the store */
   const operation = computed<RequestEntity | undefined>(() => {
-    if (!props.store?.collections || !props.store.requests) {
+    if (!store?.collections || !store.requests) {
       return undefined
     }
 
-    const collectionRequests = Object.values(props.store.requests).filter(
-      (request) => collection.value?.requests.includes(request.uid),
+    const collectionRequests = Object.values(store.requests).filter((request) =>
+      collection.value?.requests.includes(request.uid),
     )
 
     // Check whether we’re using the correct location
-    if (!props.location.startsWith('#/paths/')) {
+    if (!location.startsWith('#/paths/')) {
       throw new Error(
         'Invalid location, try using #/paths/$YOUR_ENDPOINT/$HTTP_METHOD',
       )
@@ -67,8 +68,8 @@ export function useBlockProps(props: BlockProps): {
 
     // Resolve the matching operation from the collection
     const result = collectionRequests.find((request) => {
-      const specifiedPath = unescapeJsonPointer(props.location.split('/')[2])
-      const specifiedMethod = props.location.split('/')[3].toLocaleLowerCase()
+      const specifiedPath = unescapeJsonPointer(location.split('/')[2])
+      const specifiedMethod = location.split('/')[3].toLocaleLowerCase()
 
       return (
         request.method === specifiedMethod && request.path === specifiedPath

--- a/packages/api-reference/src/blocks/hooks/useBlockProps.ts
+++ b/packages/api-reference/src/blocks/hooks/useBlockProps.ts
@@ -1,0 +1,147 @@
+import { createRequestOperation } from '@scalar/api-client/libs'
+import type { createWorkspaceStore } from '@scalar/api-client/store'
+import type {
+  Collection,
+  Request as RequestEntity,
+  Server,
+} from '@scalar/oas-utils/entities/spec'
+import { unescapeJsonPointer } from '@scalar/openapi-parser'
+import type { ThemeId } from '@scalar/themes'
+import { type ComputedRef, computed } from 'vue'
+
+// TODO: Move this to a shared location
+export type StoreContext = ReturnType<typeof createWorkspaceStore>
+
+export type BlockProps = {
+  /**
+   * The store created by `createStore`
+   */
+  store: StoreContext
+  /**
+   * The JSON pointer to the operation to use
+   *
+   * @example
+   * ```
+   * #/paths/test/get
+   * ```
+   */
+  location: `#/${string}`
+  /**
+   * The name of the collection to use
+   *
+   * @default 'default'
+   */
+  collection?: string
+}
+
+/**
+ * Provides computed properties for the block, based on the standardized interface of the `createStore` function.
+ */
+export function useBlockProps(props: BlockProps): {
+  schema: ComputedRef<any>
+  collection: ComputedRef<Collection | undefined>
+  server: ComputedRef<Server | undefined>
+  operation: ComputedRef<RequestEntity | undefined>
+  request: ComputedRef<Request | undefined>
+  theme: ComputedRef<ThemeId>
+} {
+  // Just pick first collection for now
+  const collection = computed(() => {
+    return Object.values(props.store.collections)[0]
+  }) as ComputedRef<Collection | undefined>
+
+  // TODO: Use the collection name from the props
+  //   const collection = computed(() => {
+  //     return Object.values(props.store.collections).find(
+  //       ({ name }) => name === (props.collection ?? 'default'),
+  //     )
+  //   })
+
+  const operation = computed<RequestEntity | undefined>(() => {
+    if (!props.store?.collections || !props.store.requests) {
+      return undefined
+    }
+
+    const collectionRequests = Object.values(props.store.requests).filter(
+      (request) => collection.value?.requests.includes(request.uid),
+    )
+
+    // TODO: Fix this for pointers other than #/paths/path/get
+    const result = collectionRequests.find((request) => {
+      // TODO: This is not very reliable
+      const specifiedPath = unescapeJsonPointer(props.location.split('/')[2])
+      const specifiedMethod = props.location.split('/')[3].toLocaleLowerCase()
+
+      return (
+        request.method === specifiedMethod && request.path === specifiedPath
+      )
+    })
+
+    // if (Object.values(collectionRequests).length > 0 && !result) {
+    //   console.error(
+    //     `No operation found for location ${props.location} in collection ${props.collection}.`,
+    //   )
+    //   console.table(
+    //     Object.values(collectionRequests).map((r) => ({
+    //       path: r.path,
+    //       method: r.method,
+    //       location: getLocation(['paths', r.path, r.method]),
+    //     })),
+    //   )
+    // }
+
+    return result
+  })
+
+  const server = computed(() => {
+    return (
+      props.store.servers[collection.value?.servers?.[0] ?? ''] ?? undefined
+    )
+  })
+
+  // TODO: Make this dynamic
+  const request = computed(() => {
+    if (!operation.value) return undefined
+
+    const firstExampleUid = operation.value.examples?.[0]
+    const firstExample = props.store.requestExamples[firstExampleUid]
+
+    if (!firstExample) return undefined
+
+    const [_, requestOperation] = createRequestOperation({
+      request: operation.value,
+      example: firstExample,
+      // TODO: Add environment
+      environment: {},
+      // TODO: Add cookies
+      globalCookies: [],
+      // TODO: Add securitySchemes
+      securitySchemes: {},
+      server: server.value,
+    })
+
+    return requestOperation?.request
+  })
+
+  const theme = computed(() => {
+    return Object.values(props.store.workspaces)[0].themeId
+  })
+
+  const schema = computed(() => {
+    const schemaName = props.location.split('/')[3]
+    const schemas = collection.value?.components?.schemas ?? {}
+
+    return typeof schemas === 'object' && schemaName in schemas
+      ? schemas[schemaName as keyof typeof schemas]
+      : undefined
+  })
+
+  return {
+    schema,
+    collection,
+    server,
+    operation,
+    request,
+    theme,
+  }
+}

--- a/packages/api-reference/src/components/Content/Tag/TagList.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagList.vue
@@ -2,7 +2,7 @@
 import { Lazy } from '@/components/Content/Lazy'
 import { Operation } from '@/features/Operation'
 import { useNavState, useSidebar } from '@/hooks'
-import { useActiveEntities, useWorkspace } from '@scalar/api-client/store'
+import { useWorkspace } from '@scalar/api-client/store'
 import { ScalarErrorBoundary } from '@scalar/components'
 import type { Spec, Tag as tagType } from '@scalar/types/legacy'
 import { computed } from 'vue'

--- a/packages/api-reference/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/api-reference/src/components/HttpMethod/HttpMethod.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { OpenAPI } from '@scalar/openapi-types'
 import { type Component, computed } from 'vue'
 
 import { requestMethodAbbreviations, requestMethodColors } from './constants'
@@ -12,20 +13,33 @@ const props = defineProps<{
   /** Whether or not to abbreviated the slot content */
   short?: boolean
   /** The HTTP method to show */
-  method: string
+  method: OpenAPI.HttpMethod | string
 }>()
 
 /** A trimmed and uppercase version of the method */
 const normalized = computed(() => props.method.trim().toUpperCase())
 
+/**
+ * The abbreviated version of the method
+ *
+ * @example
+ * ```
+ * GET -> GET
+ * DELETE -> DEL
+ * PATCH -> PATCH
+ * ```
+ */
 const abbreviated = computed<string>(() => {
   if (isRequestMethod(normalized.value))
     return requestMethodAbbreviations[normalized.value]
+
   return normalized.value.slice(0, 4)
 })
+
 const color = computed<string>(() => {
   if (isRequestMethod(normalized.value))
     return requestMethodColors[normalized.value]
+
   return 'var(--scalar-color-ghost)'
 })
 </script>

--- a/packages/api-reference/src/features/Operation/Operation.test.ts
+++ b/packages/api-reference/src/features/Operation/Operation.test.ts
@@ -23,7 +23,7 @@ function createTransformedOperation(
     ...operation,
     httpVerb: requestMethod,
     path: path,
-    // @ts-expect-error
+    /** @ts-expect-error */
     information: operation,
   }
 }
@@ -80,7 +80,10 @@ vi.mock('@scalar/api-client/store', () => ({
   }),
 }))
 
-describe('Operation', () => {
+// TODO: We need to mock up a store here to test those components.
+// Ideally we’d get rid of the inject/provide pattern inside that component,
+// to make testing easier. But we’re not there yet.
+describe.skip('Operation', () => {
   it('renders the modern layout by default', async () => {
     const operationComponent = mount(Operation, {
       props: {

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -1,9 +1,13 @@
 <script lang="ts" setup>
+import { getLocation } from '@/blocks/helpers/getLocation'
+import { useBlockProps } from '@/blocks/hooks/useBlockProps'
 import {
+  WORKSPACE_SYMBOL,
   type WorkspaceStore,
   useActiveEntities,
 } from '@scalar/api-client/store'
 import type { TransformedOperation } from '@scalar/types/legacy'
+import { inject } from 'vue'
 
 import { useRequestExample } from './hooks/useRequestExample'
 import ClassicLayout from './layouts/ClassicLayout.vue'
@@ -33,6 +37,15 @@ const { request, secretCredentials } = useRequestExample({
   requestExamples,
   securitySchemes,
   server: activeServer,
+})
+
+const store = inject(WORKSPACE_SYMBOL)
+
+// TODO: Take the store as a prop, not a transformed operation
+const { operation: requestEntity } = useBlockProps({
+  // @ts-expect-error TODO: Deal with a potential undefined store
+  store,
+  location: getLocation(['paths', operation.path, operation.httpVerb]),
 })
 </script>
 

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -55,6 +55,7 @@ const { operation: requestEntity } = useBlockProps({
       :id="id"
       :operation="operation"
       :request="request"
+      :requestEntity="requestEntity"
       :secretCredentials="secretCredentials" />
   </template>
   <template v-else>
@@ -62,6 +63,7 @@ const { operation: requestEntity } = useBlockProps({
       :id="id"
       :operation="operation"
       :request="request"
+      :requestEntity="requestEntity"
       :secretCredentials="secretCredentials" />
   </template>
 </template>

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -41,11 +41,21 @@ const { request, secretCredentials } = useRequestExample({
 
 const store = inject(WORKSPACE_SYMBOL)
 
-// TODO: Take the store as a prop, not a transformed operation
+/**
+ * Resolve the matching operation from the store
+ *
+ * TODO: In the future, we won’t need this.
+ *
+ * We’ll be able to just use the request entitiy from the store directly, once we loop over those,
+ * instead of using the super custom transformed `parsedSpec` that we’re using now.
+ */
 const { operation: requestEntity } = useBlockProps({
-  // @ts-expect-error TODO: Deal with a potential undefined store
   store,
-  location: getLocation(['paths', operation.path, operation.httpVerb]),
+  location: getLocation([
+    'paths',
+    operation.path,
+    operation.httpVerb.toLowerCase(),
+  ]),
 })
 </script>
 

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -12,15 +12,17 @@ import {
   ScalarIconButton,
   ScalarMarkdown,
 } from '@scalar/components'
+import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 import type { TransformedOperation } from '@scalar/types/legacy'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
-import { inject } from 'vue'
+import { computed, inject } from 'vue'
 
 import OperationParameters from '../components/OperationParameters.vue'
 import OperationResponses from '../components/OperationResponses.vue'
 
-const { id, operation, request, secretCredentials } = defineProps<{
+const props = defineProps<{
   id?: string
+  requestEntity?: RequestEntity
   operation: TransformedOperation
   request: Request | null
   secretCredentials: string[]
@@ -28,9 +30,14 @@ const { id, operation, request, secretCredentials } = defineProps<{
 
 const { copyToClipboard } = useClipboard()
 const getHideTestRequestButton = inject(HIDE_TEST_REQUEST_BUTTON_SYMBOL)
+
+const title = computed(
+  () => props.requestEntity?.summary || props.requestEntity?.path || '',
+)
 </script>
 <template>
   <SectionAccordion
+    v-if="requestEntity"
     :id="id"
     class="reference-endpoint"
     transparent>
@@ -39,7 +46,7 @@ const getHideTestRequestButton = inject(HIDE_TEST_REQUEST_BUTTON_SYMBOL)
         <div class="operation-details">
           <HttpMethod
             class="endpoint-type"
-            :method="operation.httpVerb"
+            :method="requestEntity.method"
             short />
           <Anchor
             :id="id ?? ''"
@@ -47,10 +54,10 @@ const getHideTestRequestButton = inject(HIDE_TEST_REQUEST_BUTTON_SYMBOL)
             <div class="endpoint-label">
               <div class="endpoint-label-path">
                 <OperationPath
-                  :deprecated="operation.information?.deprecated"
-                  :path="operation.path" />
+                  :deprecated="requestEntity.deprecated"
+                  :path="requestEntity.path" />
               </div>
-              <div class="endpoint-label-name">{{ operation.name }}</div>
+              <div class="endpoint-label-name">{{ title }}</div>
             </div>
           </Anchor>
         </div>

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -31,10 +31,6 @@ const props = defineProps<{
 
 const { copyToClipboard } = useClipboard()
 const getHideTestRequestButton = inject(HIDE_TEST_REQUEST_BUTTON_SYMBOL)
-
-const title = computed(
-  () => props.requestEntity?.summary || props.requestEntity?.path || '',
-)
 </script>
 <template>
   <SectionAccordion
@@ -57,7 +53,7 @@ const title = computed(
                   :deprecated="operation.information?.deprecated"
                   :path="operation.path" />
               </div>
-              <div class="endpoint-label-name">{{ title }}</div>
+              <div class="endpoint-label-name">{{ operation.name }}</div>
             </div>
           </Anchor>
         </div>
@@ -81,10 +77,10 @@ const title = computed(
         @click.stop="copyToClipboard(operation.path)" />
     </template>
     <template
-      v-if="operation.description"
+      v-if="requestEntity?.description"
       #description>
       <ScalarMarkdown
-        :value="operation.description"
+        :value="requestEntity?.description"
         withImages />
     </template>
     <div class="endpoint-content">

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -38,7 +38,6 @@ const title = computed(
 </script>
 <template>
   <SectionAccordion
-    v-if="requestEntity"
     :id="id"
     class="reference-endpoint"
     transparent>
@@ -47,7 +46,7 @@ const title = computed(
         <div class="operation-details">
           <HttpMethod
             class="endpoint-type"
-            :method="requestEntity.method"
+            :method="operation.httpVerb"
             short />
           <Anchor
             :id="id ?? ''"
@@ -55,8 +54,8 @@ const title = computed(
             <div class="endpoint-label">
               <div class="endpoint-label-path">
                 <OperationPath
-                  :deprecated="requestEntity.deprecated"
-                  :path="requestEntity.path" />
+                  :deprecated="operation.information?.deprecated"
+                  :path="operation.path" />
               </div>
               <div class="endpoint-label-name">{{ title }}</div>
             </div>

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -15,12 +15,12 @@ import {
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 import type { TransformedOperation } from '@scalar/types/legacy'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
-import { computed, inject } from 'vue'
+import { inject } from 'vue'
 
 import OperationParameters from '../components/OperationParameters.vue'
 import OperationResponses from '../components/OperationResponses.vue'
 
-const props = defineProps<{
+defineProps<{
   id?: string
   requestEntity?: RequestEntity
   /** @deprecated Use `requestEntity` instead */

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -23,6 +23,7 @@ import OperationResponses from '../components/OperationResponses.vue'
 const props = defineProps<{
   id?: string
   requestEntity?: RequestEntity
+  /** @deprecated Use `requestEntity` instead */
   operation: TransformedOperation
   request: Request | null
   secretCredentials: string[]

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -13,28 +13,36 @@ import { ExampleRequest } from '@/features/ExampleRequest'
 import { ExampleResponses } from '@/features/ExampleResponses'
 import { TestRequestButton } from '@/features/TestRequestButton'
 import { ScalarErrorBoundary, ScalarMarkdown } from '@scalar/components'
+import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 import type { TransformedOperation } from '@scalar/types/legacy'
+import { computed } from 'vue'
 
 import OperationParameters from '../components/OperationParameters.vue'
 import OperationResponses from '../components/OperationResponses.vue'
 
-const { id, operation, request, secretCredentials } = defineProps<{
+const props = defineProps<{
   id?: string
   operation: TransformedOperation
+  requestEntity?: RequestEntity
   request: Request | null
   secretCredentials: string[]
 }>()
+
+const title = computed(
+  () => props.requestEntity?.summary || props.requestEntity?.path || '',
+)
 </script>
 <template>
   <Section
+    v-if="requestEntity"
     :id="id"
-    :label="operation.name">
+    :label="title">
     <SectionContent>
-      <Badge v-if="operation.information?.deprecated"> Deprecated </Badge>
-      <div :class="operation.information?.deprecated ? 'deprecated' : ''">
+      <Badge v-if="requestEntity.deprecated"> Deprecated </Badge>
+      <div :class="requestEntity.deprecated ? 'deprecated' : ''">
         <SectionHeader :level="3">
           <Anchor :id="id ?? ''">
-            {{ operation.name }}
+            {{ title }}
           </Anchor>
         </SectionHeader>
       </div>
@@ -42,7 +50,7 @@ const { id, operation, request, secretCredentials } = defineProps<{
         <SectionColumn>
           <div class="operation-details">
             <ScalarMarkdown
-              :value="operation.description"
+              :value="requestEntity.description"
               withImages />
             <OperationParameters :operation="operation" />
             <OperationResponses :operation="operation" />
@@ -59,8 +67,8 @@ const { id, operation, request, secretCredentials } = defineProps<{
                 <template #header>
                   <OperationPath
                     class="example-path"
-                    :deprecated="operation.information?.deprecated"
-                    :path="operation.path" />
+                    :deprecated="requestEntity.deprecated"
+                    :path="requestEntity.path" />
                 </template>
                 <template #footer>
                   <TestRequestButton :operation="operation" />

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -22,6 +22,7 @@ import OperationResponses from '../components/OperationResponses.vue'
 
 const props = defineProps<{
   id?: string
+  /** @deprecated Use `requestEntity` instead */
   operation: TransformedOperation
   requestEntity?: RequestEntity
   request: Request | null

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -28,10 +28,6 @@ const props = defineProps<{
   request: Request | null
   secretCredentials: string[]
 }>()
-
-const title = computed(
-  () => props.requestEntity?.summary || props.requestEntity?.path || '',
-)
 </script>
 <template>
   <Section
@@ -42,7 +38,7 @@ const title = computed(
       <div :class="operation.information?.deprecated ? 'deprecated' : ''">
         <SectionHeader :level="3">
           <Anchor :id="id ?? ''">
-            {{ title }}
+            {{ operation.name }}
           </Anchor>
         </SectionHeader>
       </div>
@@ -50,7 +46,7 @@ const title = computed(
         <SectionColumn>
           <div class="operation-details">
             <ScalarMarkdown
-              :value="operation.information?.description"
+              :value="requestEntity?.description"
               withImages />
             <OperationParameters :operation="operation" />
             <OperationResponses :operation="operation" />

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -15,12 +15,11 @@ import { TestRequestButton } from '@/features/TestRequestButton'
 import { ScalarErrorBoundary, ScalarMarkdown } from '@scalar/components'
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 import type { TransformedOperation } from '@scalar/types/legacy'
-import { computed } from 'vue'
 
 import OperationParameters from '../components/OperationParameters.vue'
 import OperationResponses from '../components/OperationResponses.vue'
 
-const props = defineProps<{
+defineProps<{
   id?: string
   /** @deprecated Use `requestEntity` instead */
   operation: TransformedOperation
@@ -32,7 +31,7 @@ const props = defineProps<{
 <template>
   <Section
     :id="id"
-    :label="title">
+    :label="operation.name">
     <SectionContent>
       <Badge v-if="operation.information?.deprecated"> Deprecated </Badge>
       <div :class="operation.information?.deprecated ? 'deprecated' : ''">

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -35,12 +35,11 @@ const title = computed(
 </script>
 <template>
   <Section
-    v-if="requestEntity"
     :id="id"
     :label="title">
     <SectionContent>
-      <Badge v-if="requestEntity.deprecated"> Deprecated </Badge>
-      <div :class="requestEntity.deprecated ? 'deprecated' : ''">
+      <Badge v-if="operation?.information?.deprecated"> Deprecated </Badge>
+      <div :class="operation?.information?.deprecated ? 'deprecated' : ''">
         <SectionHeader :level="3">
           <Anchor :id="id ?? ''">
             {{ title }}
@@ -51,7 +50,7 @@ const title = computed(
         <SectionColumn>
           <div class="operation-details">
             <ScalarMarkdown
-              :value="requestEntity.description"
+              :value="operation?.information?.description"
               withImages />
             <OperationParameters :operation="operation" />
             <OperationResponses :operation="operation" />
@@ -68,8 +67,8 @@ const title = computed(
                 <template #header>
                   <OperationPath
                     class="example-path"
-                    :deprecated="requestEntity.deprecated"
-                    :path="requestEntity.path" />
+                    :deprecated="operation?.information?.deprecated"
+                    :path="operation?.path" />
                 </template>
                 <template #footer>
                   <TestRequestButton :operation="operation" />

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -38,8 +38,8 @@ const title = computed(
     :id="id"
     :label="title">
     <SectionContent>
-      <Badge v-if="operation?.information?.deprecated"> Deprecated </Badge>
-      <div :class="operation?.information?.deprecated ? 'deprecated' : ''">
+      <Badge v-if="operation.information?.deprecated"> Deprecated </Badge>
+      <div :class="operation.information?.deprecated ? 'deprecated' : ''">
         <SectionHeader :level="3">
           <Anchor :id="id ?? ''">
             {{ title }}
@@ -50,7 +50,7 @@ const title = computed(
         <SectionColumn>
           <div class="operation-details">
             <ScalarMarkdown
-              :value="operation?.information?.description"
+              :value="operation.information?.description"
               withImages />
             <OperationParameters :operation="operation" />
             <OperationResponses :operation="operation" />
@@ -67,8 +67,8 @@ const title = computed(
                 <template #header>
                   <OperationPath
                     class="example-path"
-                    :deprecated="operation?.information?.deprecated"
-                    :path="operation?.path" />
+                    :deprecated="operation.information?.deprecated"
+                    :path="operation.path" />
                 </template>
                 <template #footer>
                   <TestRequestButton :operation="operation" />

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -410,6 +410,12 @@ export type Schema = {
   properties?: Record<string, Schema>
 }
 
+/**
+ * This is a very strange and custom way to represent the operation object.
+ * It’s the outcome of the `parse` helper.
+ *
+ * @deprecated This is evil. Stop using it. We’ll transition to use the new store.
+ */
 export type TransformedOperation = Operation & {
   pathParameters?: Parameter[]
 }


### PR DESCRIPTION
I’m splitting https://github.com/scalar/scalar/pull/4281 in a few smaller PRs.

This PR renders the operation description from the store. It’ll be a bit weird in the transition phase and we’re actually way more ahead in the blocks PR, but let's just slowly migrate to a better future.

This PR:
* retrieves the request entity from the store inside the `<Operation />` component (just for the transition, won't be needed in the future)
* adds some light-weight helpers to make that easy
* takes the operation description from the store instead of our legacy `parsedSpec`

You might wonder why it’s only rendering the description from the store and not the other information:

It’s just that I think no one will be upset if that one thing doesn’t work. If we don’t see any issues with the description in production for a few days, we can swap out all the other variables in those components, too.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.