### PR TITLE
chore(tooling): increase cloudbuild machine 

### DIFF
--- a/cloudbuild.json
+++ b/cloudbuild.json
@@ -525,7 +525,7 @@
     }
   ],
   "options": {
-    "machineType": "E2_HIGHCPU_8",
+    "machineType": "E2_HIGHCPU_32",
     "logging": "CLOUD_LOGGING_ONLY"
   }
 }

--- a/tooling/cloudbuild/generateCloudbuild.ts
+++ b/tooling/cloudbuild/generateCloudbuild.ts
@@ -97,7 +97,7 @@ export default async function generateCloudBuild(
   })
 
   const options = {
-    machineType: 'E2_HIGHCPU_8',
+    machineType: 'E2_HIGHCPU_32',
     logging: 'CLOUD_LOGGING_ONLY',
   }
 


### PR DESCRIPTION
**Problem**
Currently, the cloud build is taking too long (17-21 minutes)

**Solution**
With this PR, we change the cloudbuild machine type from  `E2_HIGHCPU_8` to `E2_HIGHCPU_32`
We will now have more vCPUs to increase the parallel execution. This will also allow us to increase the memory allocated for the build in GCP 

The current breakdown of the build time is 
build base docker image: ~5min
build examples * 10 in parallel 
push examples * 10 in parallel 
deploy examples * 10 in parallel 

**Next Steps**
Optimize builds
Many of the examples take 4-5 minutes to build and some are taking many minutes to push. 
The largest offenders are 
- push nestjs fastify 5:01
- push nestjs express 5:01
- build base 4:51
- build nestjs express 4:14
- build nestjs fastify 4:14
- build hono 4:13
- build galaxy 4:13
- build snippetz 4:13
- build fastify 4:12
- build expressjs 4:12

*Longest path*
1. build base 4:51
2. build nestjs express  4:14
3. push nestjs express 5:01
4. deploy nestjs express 1:54 
~17 minutes

