### PR TITLE
fix(api-client): request table tooltip

### DIFF
--- a/.changeset/curvy-files-watch.md
+++ b/.changeset/curvy-files-watch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: avoids index as a key in list rendering

--- a/.changeset/ten-snails-sort.md
+++ b/.changeset/ten-snails-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates param tooltip function and style

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -80,7 +80,7 @@ function handleHistoryClick(historicalRequest: RequestEvent) {
       class="bg-b-1 border-t custom-scroll max-h-[300px] rounded-b-lg p-[3px] grid grid-cols-[44px,1fr,repeat(3,auto)] items-center">
       <ListboxOption
         v-for="(entry, index) in history"
-        :key="index"
+        :key="entry.timestamp"
         class="contents font-code text-sm *:rounded-none first:*:rounded-l last:*:rounded-r *:h-8 *:ui-active:bg-b-2 *:flex *:items-center *:cursor-pointer *:px-1.5 text-c-2 font-medium"
         :value="index"
         @click="handleHistoryClick(entry)">

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -25,7 +25,7 @@ defineProps<{
         :columns="['']">
         <DataTableRow
           v-for="(option, index) in options"
-          :key="index"
+          :key="option.key"
           :class="{ 'border-t': index === 0 }">
           <DataTableInput
             :modelValue="String(data[option.key] ?? '')"

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -207,7 +207,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
       <template v-else>
         <TopNavItem
           v-for="(topNavItem, index) in topNavItems"
-          :key="index"
+          :key="topNavItem.path"
           :active="index === activeNavItemIdxValue"
           :hotkey="(index + 1).toString()"
           :icon="topNavItem.icon"

--- a/packages/api-client/src/views/Collection/Collection.vue
+++ b/packages/api-client/src/views/Collection/Collection.vue
@@ -35,8 +35,8 @@ const data = reactive<{ key: string; value: string; enabled: boolean }[]>([
               </DataTableHeader>
             </DataTableRow>
             <DataTableRow
-              v-for="(item, idx) in data"
-              :key="idx">
+              v-for="item in data"
+              :key="item.key">
               <DataTableCheckbox v-model="item.enabled" />
               <DataTableInput
                 v-model="item.key"

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -73,7 +73,7 @@ const flattenValue = (item: RequestExampleParameter) => {
     :columns="columns">
     <DataTableRow
       v-for="(item, idx) in items"
-      :key="idx">
+      :key="item.key">
       <label class="contents">
         <span class="sr-only">Row Enabled</span>
         <DataTableCheckbox

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -8,6 +8,7 @@ import { ScalarButton, ScalarIcon } from '@scalar/components'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
 import { computed } from 'vue'
 
+import { hasItemProperties } from '../libs/request'
 import RequestTableTooltip from './RequestTableTooltip.vue'
 
 withDefaults(
@@ -43,10 +44,6 @@ const handleSelectVariable = (
 
 const handleFileUpload = (idx: number) => {
   emit('uploadFile', idx)
-}
-
-const showTooltip = (item: RequestExampleParameter) => {
-  return !!(item.description || item.type || item.default || item.format)
 }
 
 const valueOutOfRange = (item: RequestExampleParameter) => {
@@ -103,7 +100,7 @@ const flattenValue = (item: RequestExampleParameter) => {
       <DataTableCell>
         <CodeInput
           :class="{
-            'pr-6': showTooltip(item),
+            'pr-6': hasItemProperties(item),
           }"
           :default="item.default"
           disableCloseBrackets
@@ -129,7 +126,7 @@ const flattenValue = (item: RequestExampleParameter) => {
           </template>
           <template #icon>
             <RequestTableTooltip
-              v-if="showTooltip(item)"
+              v-if="hasItemProperties(item)"
               :item="{ ...item, default: flattenValue(item) }" />
           </template>
         </CodeInput>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -1,20 +1,8 @@
 <script setup lang="ts">
 import { ScalarIcon, ScalarTooltip } from '@scalar/components'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
-import { computed } from 'vue'
 
-const props = defineProps<{ item: RequestExampleParameter }>()
-
-const isDefined = (value: unknown): boolean => value !== undefined
-
-const hasItemProperties = computed(
-  () =>
-    props.item.type ||
-    props.item.format ||
-    isDefined(props.item.minimum) ||
-    isDefined(props.item.maximum) ||
-    isDefined(props.item.default),
-)
+defineProps<{ item: RequestExampleParameter }>()
 </script>
 <template>
   <ScalarTooltip
@@ -35,38 +23,32 @@ const hasItemProperties = computed(
     <template #content>
       <div
         class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 p-2 text-xxs leading-5 text-c-1">
-        <div
-          v-if="hasItemProperties"
-          class="flex items-center text-c-2">
-          <span v-if="props.item.type">{{ props.item.type }}</span>
-          <span
-            v-if="props.item.format"
-            class="before:content-['·'] before:block before:mx-[0.5ch] flex"
-            >{{ props.item.format }}</span
-          >
-          <span
-            v-if="isDefined(props.item.minimum)"
-            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-nowrap"
-            >min: {{ props.item.minimum }}</span
-          >
-          <span
-            v-if="isDefined(props.item.maximum)"
-            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-nowrap"
-            >max: {{ props.item.maximum }}</span
-          >
-          <span
-            v-if="isDefined(props.item.default)"
-            class="before:content-['·'] before:block before:mx-[0.5ch] flex whitespace-nowrap"
-            >default: {{ props.item.default }}</span
-          >
+        <div class="schema flex items-center text-c-2">
+          <span v-if="item.type">{{ item.type }}</span>
+          <span v-if="item.format">{{ item.format }}</span>
+          <span v-if="item.minimum">min: {{ item.minimum }}</span>
+          <span v-if="item.maximum">max: {{ item.maximum }}</span>
+          <span v-if="item.default">default: {{ item.default }}</span>
         </div>
         <span
-          v-if="props.item.description"
+          v-if="item.description"
           class="leading-snug text-pretty text-sm"
           :style="{ maxWidth: '16rem' }"
-          >{{ props.item.description }}</span
+          >{{ item.description }}</span
         >
       </div>
     </template>
   </ScalarTooltip>
 </template>
+<style scoped>
+.schema > span:not(:first-child)::before {
+  content: '·';
+  display: block;
+  margin: 0 0.5ch;
+}
+
+.schema > span {
+  display: flex;
+  white-space: nowrap;
+}
+</style>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseCookies.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseCookies.vue
@@ -17,8 +17,8 @@ defineProps<{
         class="flex-1"
         :columns="['', '']">
         <DataTableRow
-          v-for="(item, idx) in cookies"
-          :key="idx">
+          v-for="item in cookies"
+          :key="item.name">
           <DataTableText :text="item.name" />
           <DataTableText :text="item.value" />
         </DataTableRow>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -32,8 +32,8 @@ const findHeaderInfo = (name: string) => {
         :columns="['minmax(auto, min-content)', 'minmax(50%, 1fr)']"
         scroll>
         <DataTableRow
-          v-for="(item, idx) in headers"
-          :key="idx"
+          v-for="item in headers"
+          :key="item.name"
           class="text-c-1">
           <DataTableText class="sticky left-0 z-1 bg-b-1 max-w-48">
             <template v-if="typeof findHeaderInfo(item.name)?.url === 'string'">

--- a/packages/api-client/src/views/Request/libs/request.test.ts
+++ b/packages/api-client/src/views/Request/libs/request.test.ts
@@ -1,0 +1,55 @@
+import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
+import { describe, expect, it } from 'vitest'
+
+import { hasItemProperties } from './request'
+
+describe('hasAllowedProperties', () => {
+  it('should return true if item has a description', () => {
+    const item: RequestExampleParameter = {
+      key: 'A key',
+      value: 'A value',
+      description: 'A description',
+      enabled: true,
+    }
+    expect(hasItemProperties(item)).toBe(true)
+  })
+
+  it('should return true if item has a type', () => {
+    const item: RequestExampleParameter = {
+      key: 'A key',
+      value: 'A value',
+      type: 'string',
+      enabled: true,
+    }
+    expect(hasItemProperties(item)).toBe(true)
+  })
+
+  it('should return true if item has a default', () => {
+    const item: RequestExampleParameter = {
+      key: 'A key',
+      value: 'A value',
+      default: 'default',
+      enabled: true,
+    }
+    expect(hasItemProperties(item)).toBe(true)
+  })
+
+  it('should return true if item has a format', () => {
+    const item: RequestExampleParameter = {
+      key: 'A key',
+      value: 'A value',
+      format: 'date-time',
+      enabled: true,
+    }
+    expect(hasItemProperties(item)).toBe(true)
+  })
+
+  it('should return false if item has none of the allowed properties', () => {
+    const item: RequestExampleParameter = {
+      key: 'A key',
+      value: 'A value',
+      enabled: true,
+    }
+    expect(hasItemProperties(item)).toBe(false)
+  })
+})

--- a/packages/api-client/src/views/Request/libs/request.ts
+++ b/packages/api-client/src/views/Request/libs/request.ts
@@ -1,0 +1,20 @@
+import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
+
+/**
+ * Check if a RequestExampleParameter has any of the following properties:
+ * - description
+ * - type
+ * - default
+ * - format
+ * - minimum
+ * - maximum
+ */
+export const hasItemProperties = (item: RequestExampleParameter) =>
+  Boolean(
+    item.description ||
+      item.type ||
+      item.default ||
+      item.format ||
+      item.minimum ||
+      item.maximum,
+  )

--- a/packages/api-reference/playground/examples/src/App.vue
+++ b/packages/api-reference/playground/examples/src/App.vue
@@ -73,8 +73,8 @@ watch(url, (newUrl) => {
     <div>
       <select v-model="url">
         <option
-          v-for="(example, index) in urls"
-          :key="index"
+          v-for="example in urls"
+          :key="example.url"
           :value="example.url">
           {{ example.name }}
         </option>

--- a/packages/api-reference/src/components/Content/Introduction/Description.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Description.vue
@@ -76,8 +76,8 @@ const transformHeading = (node: Record<string, any>) => {
     v-if="value"
     class="introduction-description">
     <template
-      v-for="(section, index) in sections"
-      :key="index">
+      v-for="section in sections"
+      :key="section.id">
       <!-- headings -->
       <template v-if="section.id">
         <IntersectionObserver

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -246,8 +246,8 @@ const optimizedValue = computed(() => optimizeValueForDisplay(props.value))
         v-if="optimizedValue?.[discriminator]"
         class="property-rule">
         <template
-          v-for="(schema, index) in optimizedValue[discriminator]"
-          :key="index">
+          v-for="schema in optimizedValue[discriminator]"
+          :key="schema.id">
           <Schema
             :compact="compact"
             :level="level + 1"
@@ -260,8 +260,8 @@ const optimizedValue = computed(() => optimizeValueForDisplay(props.value))
         v-if="value?.items?.[discriminator] && level < 3"
         class="property-rule">
         <Schema
-          v-for="(schema, index) in value.items[discriminator]"
-          :key="index"
+          v-for="schema in value.items[discriminator]"
+          :key="schema.id"
           :compact="compact"
           :level="level + 1"
           :value="schema" />


### PR DESCRIPTION
**Problem**
request table tooltip encountering null item is breaking the client as highlighted in #4418 

**Solution**
this pr fixes #4418 #4427 by updating the request table tooltip logic. still works with #4387

| before | after |
| -------|------|
| <img width="696" alt="image" src="https://github.com/user-attachments/assets/ff8423da-8350-4dfb-92f8-dc6d7988bd09" /> | <img width="696" alt="image" src="https://github.com/user-attachments/assets/e899d1f6-68ea-4931-917e-874c96889b8a" /> |
| header parameter is not displayed  | header is displayed along its tooltip accordingly | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
