### PR TITLE
fix(api-client): favors configuration integration in modal client button

### DIFF
--- a/.changeset/brave-carrots-jam.md
+++ b/.changeset/brave-carrots-jam.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: favors configuration integration in open client modal button

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -42,6 +42,7 @@ export type ClientConfiguration = {
   | 'authentication'
   | 'baseServerURL'
   | 'hideClientButton'
+  | '_integration'
 >
 
 export type OpenClientPayload = {
@@ -129,6 +130,7 @@ export const createApiClient = ({
       themeId: configuration.themeId,
       showSidebar: configuration.showSidebar,
       hideClientButton: configuration.hideClientButton,
+      integration: configuration._integration,
       useLocalStorage: persistData,
     })
 

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -60,6 +60,8 @@ type CreateWorkspaceStoreOptions = {
   isReadOnly: boolean
   /** Should be renamed to theme to match the references config */
   themeId: ReferenceConfiguration['theme']
+  /** Specifies the integration being used. This is primarily for internal purposes and should not be manually set. */
+  integration: ReferenceConfiguration['_integration']
 } & Pick<
   ReferenceConfiguration,
   'proxyUrl' | 'showSidebar' | 'hideClientButton'
@@ -79,6 +81,7 @@ export const createWorkspaceStore = ({
   proxyUrl,
   themeId,
   hideClientButton,
+  integration,
 }: CreateWorkspaceStoreOptions) => {
   // ---------------------------------------------------------------------------
   // Initialize all storage objects
@@ -213,6 +216,7 @@ export const createWorkspaceStore = ({
     isReadOnly,
     hideClientButton,
     showSidebar,
+    integration,
     // ---------------------------------------------------------------------------
     // METHODS
     importSpecFile,

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -19,7 +19,8 @@ defineEmits<{
 }>()
 
 const { activeCollection } = useActiveEntities()
-const { isReadOnly, hideClientButton, showSidebar } = useWorkspace()
+const { isReadOnly, hideClientButton, showSidebar, integration } =
+  useWorkspace()
 
 const { layout } = useLayout()
 const { currentRoute } = useRouter()
@@ -48,7 +49,7 @@ const { currentRoute } = useRouter()
         v-if="isReadOnly && activeCollection?.documentUrl && !hideClientButton"
         buttonSource="modal"
         class="!w-fit lg:-mr-1"
-        :integration="activeCollection?.integration"
+        :integration="integration || activeCollection?.integration"
         :source="
           currentRoute.query.source === 'gitbook' ? 'gitbook' : 'api-reference'
         "

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -256,6 +256,7 @@ const workspaceStore = createWorkspaceStore({
   themeId: props.configuration.theme,
   useLocalStorage: false,
   hideClientButton: props.configuration.hideClientButton,
+  integration: props.configuration._integration,
 })
 // Populate the workspace store
 watch(


### PR DESCRIPTION
**Problem**
currently the client button in the reference client button is relaying on collection integration only and not on the reference configuration, as used in the sidebar button. in some case the client button query is not the same in the reference and in the client.

**Solution**
this pr sets the usage of the reference configuration integration in the client button in modal to ensure value usage parity between reference and client.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
