### PR TITLE
fix(api-client): settings route

### DIFF
--- a/.changeset/smooth-cooks-chew.md
+++ b/.changeset/smooth-cooks-chew.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: adds back setting route

--- a/packages/api-client/src/routes.test.ts
+++ b/packages/api-client/src/routes.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+import { createRouter, createWebHistory } from 'vue-router'
+
+import { routes } from './routes'
+
+describe('Routes', () => {
+  const mockRouteLocation = {
+    params: {},
+    matched: [],
+    fullPath: '',
+    query: {},
+    hash: '',
+    name: undefined,
+    path: '',
+    redirectedFrom: undefined,
+    meta: {},
+  }
+
+  const router = createRouter({
+    history: createWebHistory(),
+    routes,
+  })
+
+  it('should contain the workspace route', () => {
+    const workspaceRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'workspace')
+    expect(workspaceRoute).toBeDefined()
+    expect(workspaceRoute?.path).toBe('/workspace/:workspace')
+  })
+
+  it('should contain the default workspace redirect', () => {
+    const workspaceDefaultRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'workspace.default')
+    expect(workspaceDefaultRoute).toBeDefined()
+
+    const redirectResult =
+      typeof workspaceDefaultRoute?.redirect === 'function'
+        ? workspaceDefaultRoute.redirect(mockRouteLocation)
+        : workspaceDefaultRoute?.redirect
+
+    expect(redirectResult).toEqual(
+      expect.objectContaining({
+        name: 'request.default',
+        params: { workspace: 'default' },
+      }),
+    )
+  })
+
+  it('should contain the request route', () => {
+    const requestRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'request')
+    expect(requestRoute).toBeDefined()
+    expect(requestRoute?.path).toBe('/workspace/:workspace/request/:request')
+  })
+
+  it('should contain the default request redirect', () => {
+    const requestDefaultRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'request.default')
+    expect(requestDefaultRoute).toBeDefined()
+
+    const redirectResult =
+      typeof requestDefaultRoute?.redirect === 'function'
+        ? requestDefaultRoute.redirect(mockRouteLocation)
+        : requestDefaultRoute?.redirect
+
+    expect(redirectResult).toEqual(
+      expect.objectContaining({
+        name: 'request',
+        params: { request: 'default' },
+      }),
+    )
+  })
+
+  it('should contain the environment route', () => {
+    const environmentRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'environment')
+    expect(environmentRoute).toBeDefined()
+    expect(environmentRoute?.path).toBe(
+      '/workspace/:workspace/environment/:environment',
+    )
+  })
+
+  it('should contain the default environment redirect', () => {
+    const environmentDefaultRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'environment.default')
+    expect(environmentDefaultRoute).toBeDefined()
+
+    const redirectResult =
+      typeof environmentDefaultRoute?.redirect === 'function'
+        ? environmentDefaultRoute.redirect(mockRouteLocation)
+        : environmentDefaultRoute?.redirect
+
+    expect(redirectResult).toEqual(
+      expect.objectContaining({
+        name: 'environment',
+        params: { environment: 'default' },
+      }),
+    )
+  })
+
+  it('should contain the cookies route', () => {
+    const cookiesRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'cookies')
+    expect(cookiesRoute).toBeDefined()
+    expect(cookiesRoute?.path).toBe('/workspace/:workspace/cookies/:cookies')
+  })
+
+  it('should contain the default cookies redirect', () => {
+    const cookiesDefaultRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'cookies.default')
+    expect(cookiesDefaultRoute).toBeDefined()
+
+    const redirectResult =
+      typeof cookiesDefaultRoute?.redirect === 'function'
+        ? cookiesDefaultRoute.redirect(mockRouteLocation)
+        : cookiesDefaultRoute?.redirect
+
+    expect(redirectResult).toEqual(
+      expect.objectContaining({
+        name: 'cookies',
+        params: { cookies: 'default' },
+      }),
+    )
+  })
+
+  it('should contain the servers route', () => {
+    const serversRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'servers')
+    expect(serversRoute).toBeDefined()
+    expect(serversRoute?.path).toBe(
+      '/workspace/:workspace/servers/:collectionId/:servers',
+    )
+  })
+
+  it('should contain the default servers redirect', () => {
+    const serversDefaultRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'servers.default')
+    expect(serversDefaultRoute).toBeDefined()
+
+    const redirectResult =
+      typeof serversDefaultRoute?.redirect === 'function'
+        ? serversDefaultRoute.redirect(mockRouteLocation)
+        : serversDefaultRoute?.redirect
+
+    expect(redirectResult).toEqual(
+      expect.objectContaining({
+        name: 'servers',
+        params: { collectionId: 'default', servers: 'default' },
+      }),
+    )
+  })
+
+  it('should contain the settings route', () => {
+    const settingsRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'settings')
+    expect(settingsRoute).toBeDefined()
+    expect(settingsRoute?.path).toBe('/workspace/:workspace/settings/:settings')
+  })
+
+  it('should contain the default settings redirect', () => {
+    const settingsDefaultRoute = router
+      .getRoutes()
+      .find((route) => route.name === 'settings.default')
+    expect(settingsDefaultRoute).toBeDefined()
+
+    const redirectResult =
+      typeof settingsDefaultRoute?.redirect === 'function'
+        ? settingsDefaultRoute.redirect(mockRouteLocation)
+        : settingsDefaultRoute?.redirect
+
+    expect(redirectResult).toEqual(
+      expect.objectContaining({
+        name: 'settings',
+        params: { settings: 'general' },
+      }),
+    )
+  })
+})

--- a/packages/api-client/src/routes.ts
+++ b/packages/api-client/src/routes.ts
@@ -213,6 +213,11 @@ export const routes = [
           params: { ...to.params, settings: 'general' },
         }),
       },
+      {
+        name: 'settings',
+        path: `settings/:${PathId.Settings}`,
+        component: () => import('@/views/Settings/Settings.vue'),
+      },
     ],
   },
 ] satisfies RouteRecordRaw[]


### PR DESCRIPTION
**Problem**
the settings route is accessible anymore as it has somehow been removed in #4450

**Solution**
this par adds back the missing settings route.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
