### PR TITLE
ci: deploy client to staging by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
         id: deploy-client
         uses: cloudflare/wrangler-action@6d58852c35a27e6034745c5d0bc373d739014f7f
         with:
-          command: pages deploy dist --project-name=client
+          command: pages deploy dist --project-name=client-staging
           workingDirectory: projects/client-scalar-com
           # 1) Log in to the Cloudflare dashboard.
           # 2) Select Workers & Pages.
@@ -377,7 +377,6 @@ jobs:
           # 1) Go to https://dash.cloudflare.com/profile/api-tokens
           # 2) Create a token with the following permissions:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          environment: staging
       - if: github.ref != 'refs/heads/main' && steps.deploy-client.outputs.deployment-url
         name: Add Cloudflare Preview URL to the PR
         uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,8 +363,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - if: steps.changed-files.outputs.api_client_any_changed == 'true'
-        name: Deploy to client.scalar.com
-        id: deploy-client
+        name: Deploy to client.staging.scalar.com (staging)
+        id: deploy-client-staging
         uses: cloudflare/wrangler-action@6d58852c35a27e6034745c5d0bc373d739014f7f
         with:
           command: pages deploy dist --project-name=client-staging
@@ -386,6 +386,29 @@ jobs:
 
             ${{ steps.deploy-client.outputs.deployment-url }}
           comment_tag: 'cloudflare-preview'
+      - if: startsWith(github.event.head_commit.message, 'RELEASING:')
+        name: Check for new NuGet package version
+        id: client-version
+        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        with:
+          files_yaml: |
+            api_client:
+              - packages/api-client/**
+      - if: steps.client-version.outputs.api_client_any_changed == 'true'
+        name: Deploy to client.scalar.com (production)
+        id: deploy-client-production
+        uses: cloudflare/wrangler-action@6d58852c35a27e6034745c5d0bc373d739014f7f
+        with:
+          command: pages deploy dist --project-name=client
+          workingDirectory: projects/client-scalar-com
+          # 1) Log in to the Cloudflare dashboard.
+          # 2) Select Workers & Pages.
+          # 3) See the Account ID in the right sidebar.
+          # Read more: https://developers.cloudflare.com/fundamentals/setup/find-account-and-zone-ids/
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # 1) Go to https://dash.cloudflare.com/profile/api-tokens
+          # 2) Create a token with the following permissions:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
   deploy-examples:
     # Skip for forks and bot PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,7 @@ jobs:
           # 1) Go to https://dash.cloudflare.com/profile/api-tokens
           # 2) Create a token with the following permissions:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          environment: staging
       - if: github.ref != 'refs/heads/main' && steps.deploy-client.outputs.deployment-url
         name: Add Cloudflare Preview URL to the PR
         uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,17 +377,17 @@ jobs:
           # 1) Go to https://dash.cloudflare.com/profile/api-tokens
           # 2) Create a token with the following permissions:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      - if: github.ref != 'refs/heads/main' && steps.deploy-client.outputs.deployment-url
+      - if: github.ref != 'refs/heads/main' && steps.deploy-client-staging.outputs.deployment-url
         name: Add Cloudflare Preview URL to the PR
         uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6
         with:
           message: |
             **Cloudflare Preview for the API Client**
 
-            ${{ steps.deploy-client.outputs.deployment-url }}
+            ${{ steps.deploy-client-staging.outputs.deployment-url }}
           comment_tag: 'cloudflare-preview'
-      - if: startsWith(github.event.head_commit.message, 'RELEASING:')
-        name: Check for new NuGet package version
+      - if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
+        name: Check for new @scalar/api-client version
         id: client-version
         uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
         with:

--- a/projects/client-scalar-com/wrangler.toml
+++ b/projects/client-scalar-com/wrangler.toml
@@ -1,0 +1,5 @@
+name = "client"
+route = "client.scalar.com"
+
+[env.staging]
+route = "client.staging.scalar.com"

--- a/projects/client-scalar-com/wrangler.toml
+++ b/projects/client-scalar-com/wrangler.toml
@@ -1,5 +1,0 @@
-name = "client"
-route = "client.scalar.com"
-
-[env.staging]
-route = "client.staging.scalar.com"


### PR DESCRIPTION
**Problem**
Currently, we deploy everything that lands in main to `client.scalar.com` instantly. So we might break production more often.

**Solution**
With this PR we only deploy to production when a new version of `@scalar/api-client` is released, but deploy every commit in `main` to https://client.staging.scalar.com.

You can’t configure Cloudflare Pages to show different content on different domains. So I’ve created another project for staging.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
