### PR TITLE
chore(docker): trigger the initial release

### DIFF
--- a/.changeset/nervous-candles-hide.md
+++ b/.changeset/nervous-candles-hide.md
@@ -1,5 +1,5 @@
 ---
-'@scalarapi/api-reference': patch
+'@scalarapi/api-reference': minor
 ---
 
 chore: trigger initial release

--- a/.changeset/nervous-candles-hide.md
+++ b/.changeset/nervous-candles-hide.md
@@ -1,0 +1,5 @@
+---
+'@scalarapi/api-reference': patch
+---
+
+chore: trigger initial release

--- a/packages/api-reference/docker/package.json
+++ b/packages/api-reference/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalarapi/api-reference",
-  "version": "0.1.1",
+  "version": "0.0.0",
   "description": "Official Docker image for @scalar/api-reference",
   "private": true,
   "scripts": {


### PR DESCRIPTION
This PR should trigger the initial release for the @scalar/api-reference Docker image.

Last time we attempted it, the repository didn’t exist on Docker Hub, but it does now.

Using the changeset, it should be tagged as 0.1.0.

Fixes #4356