### PR TITLE
feat(galaxy): add `readOnly`/`writeOnly` attributes

### DIFF
--- a/.changeset/grumpy-beans-sell.md
+++ b/.changeset/grumpy-beans-sell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat: add readOnly/writeOnly attributes

--- a/packages/galaxy/src/specifications/3.1.yaml
+++ b/packages/galaxy/src/specifications/3.1.yaml
@@ -272,7 +272,7 @@ paths:
         content:
           application/json:
             schema:
-              '$ref': '#/components/schemas/NewUser'
+              '$ref': '#/components/schemas/User'
             examples:
               Marc:
                 value:
@@ -483,51 +483,21 @@ components:
           schema:
             '$ref': '#/components/schemas/Error'
   schemas:
-    NewUser:
-      type: object
-      required:
-        - name
-        - email
-        - password
-      properties:
-        name:
-          type: string
-          examples:
-            - Hans
-            - Brynn
-        email:
-          type: string
-          format: email
-          examples:
-            - hans@scalar.com
-            - brynn@scalar.com
-        password:
-          type: string
-          minLength: 8
-          examples:
-            - i-love-scalar
-            - scalar-is-cool
     User:
-      type: object
-      required:
-        - id
-        - name
-        - email
-      properties:
-        id:
-          type: integer
-          format: int64
-          examples:
-            - 1
-        name:
-          type: string
-          examples:
-            - Marc
-        email:
-          type: string
-          format: email
-          examples:
-            - marc@scalar.com
+      allOf:
+        - type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+              readOnly: true
+              examples:
+                - 1
+            name:
+              type: string
+              examples:
+                - Marc
+        - $ref: '#/components/schemas/Credentials'
     Credentials:
       type: object
       required:
@@ -541,6 +511,7 @@ components:
             - marc@scalar.com
         password:
           type: string
+          writeOnly: true
           examples:
             - i-love-scalar
     Token:
@@ -559,6 +530,7 @@ components:
         id:
           type: integer
           format: int64
+          readOnly: true
           examples:
             - 1
           x-variable: planetId


### PR DESCRIPTION
**Problem**
Currently, the Galaxy examples shows read-only attributes (id) in the request, and write-only attributes (password) in the response.

**Solution**
With this PR we’re adding `readOnly: true` and `writeOnly: true` to attributes where applicable. This also made it possible to merge the `NewUser` and the `User` schemas.

Actually, I don’t know why I forgot about this when writing the initial document. 🤔 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
