### PR TITLE
fix(mock-server): returns write-only attributes

### DIFF
--- a/.changeset/late-hounds-share.md
+++ b/.changeset/late-hounds-share.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+fix: returns writeOnly attributes

--- a/packages/mock-server/src/createMockServer.test.ts
+++ b/packages/mock-server/src/createMockServer.test.ts
@@ -42,6 +42,66 @@ describe('createMockServer', () => {
     })
   })
 
+  it('GET /foobar -> omits writeOnly properties in responses', async () => {
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: {
+                          type: 'integer',
+                          format: 'int64',
+                          readOnly: true,
+                          example: 1,
+                        },
+                        visible: {
+                          type: 'boolean',
+                          example: true,
+                        },
+                        password: {
+                          type: 'string',
+                          writeOnly: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({
+      specification,
+    })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+
+    expect(data).not.toHaveProperty('password')
+    expect(data).toStrictEqual({
+      id: 1,
+      visible: true,
+    })
+  })
+
   it('GET /foobar -> return HTML if accepted', async () => {
     const specification = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/routes/mockAnyResponse.ts
+++ b/packages/mock-server/src/routes/mockAnyResponse.ts
@@ -72,6 +72,7 @@ export function mockAnyResponse(
       ? getExampleFromSchema(acceptedResponse.schema, {
           emptyString: '…',
           variables: c.req.param(),
+          mode: 'read',
         })
       : null
 


### PR DESCRIPTION
**Problem**
Currently, the mock server returns write-only attributes in the responses.

**Solution**
With this PR we’re generating the response with `mode: 'read'` to omit write-only attributes.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.