### PR TITLE
fix(api-client): deletes all cookies

### DIFF
--- a/.changeset/stupid-gifts-call.md
+++ b/.changeset/stupid-gifts-call.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: all cookies are deleted

--- a/packages/api-client/src/libs/send-request/send-request.ts
+++ b/packages/api-client/src/libs/send-request/send-request.ts
@@ -121,8 +121,11 @@ export function setRequestCookies({
     secure: true,
   } as const
 
-  const allCookies = Cookies.get()
-  Object.keys(allCookies).forEach((c) => Cookies.remove(c))
+  // TODO: I think this was added to remove previously added cookies,
+  // but it shouldn’t remove cookies that are not added by us.
+  // As a quick fix, to not break existing functionality, we’ll comment this out.
+  // const allCookies = Cookies.get()
+  // Object.keys(allCookies).forEach((c) => Cookies.remove(c))
 
   example.parameters.cookies.forEach((c) => {
     if (c.enabled) Cookies.set(c.key, replaceTemplateVariables(c.value, env))


### PR DESCRIPTION
**Problem**
Currently, *all* cookies are deleted, even if they weren’t created by the API client. This breaks authentication in apps embedded our API reference.

**Solution**
With this PR we just don't delete cookies anymore. Not a real solution, but the quickest fix I could think of.

Fixes #3989

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
