### PR TITLE
test(api-reference): add SSR/SSG tests

### DIFF
--- a/.changeset/great-dots-approve.md
+++ b/.changeset/great-dots-approve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: ScalarFloating breaks SSG/SSR environments

--- a/.changeset/mean-fishes-grin.md
+++ b/.changeset/mean-fishes-grin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: SSG/SSR builds break

--- a/packages/api-reference/src/components/ApiReferenceLayout.test.ts
+++ b/packages/api-reference/src/components/ApiReferenceLayout.test.ts
@@ -1,6 +1,6 @@
 import { parse } from '@/helpers'
 import { renderToString } from '@vue/server-renderer'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createSSRApp, h } from 'vue'
 
 import ApiReferenceLayout from './ApiReferenceLayout.vue'
@@ -30,6 +30,11 @@ describe('ApiReferenceLayout', () => {
   })
 
   it('can render the GitHub REST API reference', async () => {
+    // Spy for console.error to avoid errors in the console
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
     const definition = await fetch(
       'https://raw.githubusercontent.com/github/rest-api-description/refs/heads/main/descriptions/api.github.com/api.github.com.json',
     ).then((res) => res.json())
@@ -47,6 +52,13 @@ describe('ApiReferenceLayout', () => {
 
     const html = await renderToString(app)
 
+    // Check if console.error was called
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+    // Restore the original console.error
+    consoleErrorSpy.mockRestore()
+
+    // Verify it renders the title in the HTML output
     expect(html).toContain(`GitHub's v3 REST API.`)
   })
 })

--- a/packages/api-reference/src/components/ApiReferenceLayout.test.ts
+++ b/packages/api-reference/src/components/ApiReferenceLayout.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { parse } from '@/helpers'
 import { renderToString } from '@vue/server-renderer'
 import { describe, expect, it, vi } from 'vitest'

--- a/packages/api-reference/src/components/ApiReferenceLayout.test.ts
+++ b/packages/api-reference/src/components/ApiReferenceLayout.test.ts
@@ -1,3 +1,4 @@
+import { parse } from '@/helpers'
 import { renderToString } from '@vue/server-renderer'
 import { describe, expect, it } from 'vitest'
 import { createSSRApp, h } from 'vue'
@@ -26,5 +27,26 @@ describe('ApiReferenceLayout', () => {
     const html = await renderToString(app)
 
     expect(html).toContain('Test API')
+  })
+
+  it('can render the GitHub REST API reference', async () => {
+    const definition = await fetch(
+      'https://raw.githubusercontent.com/github/rest-api-description/refs/heads/main/descriptions/api.github.com/api.github.com.json',
+    ).then((res) => res.json())
+
+    const result = await parse(definition)
+
+    const app = createSSRApp({
+      render: () =>
+        h(ApiReferenceLayout, {
+          configuration: {},
+          parsedSpec: result,
+          rawSpec: definition,
+        }),
+    })
+
+    const html = await renderToString(app)
+
+    expect(html).toContain(`GitHub's v3 REST API.`)
   })
 })

--- a/packages/api-reference/src/components/ApiReferenceLayout.test.ts
+++ b/packages/api-reference/src/components/ApiReferenceLayout.test.ts
@@ -1,0 +1,30 @@
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it } from 'vitest'
+import { createSSRApp, h } from 'vue'
+
+import ApiReferenceLayout from './ApiReferenceLayout.vue'
+
+describe('ApiReferenceLayout', () => {
+  it('has the title in the HTML output', async () => {
+    const app = createSSRApp({
+      render: () =>
+        h(ApiReferenceLayout, {
+          configuration: {},
+          parsedSpec: {
+            info: {
+              title: 'Test API',
+            },
+          },
+          rawSpec: JSON.stringify({
+            info: {
+              title: 'Test API',
+            },
+          }),
+        }),
+    })
+
+    const html = await renderToString(app)
+
+    expect(html).toContain('Test API')
+  })
+})

--- a/packages/api-reference/src/components/ApiReferenceLayout.test.ts
+++ b/packages/api-reference/src/components/ApiReferenceLayout.test.ts
@@ -36,6 +36,10 @@ describe('ApiReferenceLayout', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => {})
 
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {})
+
     const definition = await fetch(
       'https://raw.githubusercontent.com/github/rest-api-description/refs/heads/main/descriptions/api.github.com/api.github.com.json',
     ).then((res) => res.json())
@@ -58,6 +62,13 @@ describe('ApiReferenceLayout', () => {
 
     // Restore the original console.error
     consoleErrorSpy.mockRestore()
+
+    // Check if console.warn was called
+    // TODO: In the future, we should fix the warnings.
+    // expect(consoleWarnSpy).not.toHaveBeenCalled()
+
+    // Restore the original console.warn
+    consoleWarnSpy.mockRestore()
 
     // Verify it renders the title in the HTML output
     expect(html).toContain(`GitHub's v3 REST API.`)

--- a/packages/components/src/components/ScalarFloating/ScalarFloating.vue
+++ b/packages/components/src/components/ScalarFloating/ScalarFloating.vue
@@ -37,15 +37,19 @@ const floatingRef: Ref<HTMLElement | null> = ref(null)
 const wrapperRef: Ref<HTMLElement | null> = ref(null)
 
 const targetRef = computed(() => {
-  // If target is a string (id), try to find it in the document
-  if (typeof props.target === 'string') {
-    const target = document.getElementById(props.target)
-    if (target) return target
-    else
-      console.warn(`ScalarFloating: Target with id="${props.target}" not found`)
+  if (typeof window !== 'undefined') {
+    // If target is a string (id), try to find it in the document
+    if (typeof props.target === 'string') {
+      const target = document.getElementById(props.target)
+      if (target) return target
+      else
+        console.warn(
+          `ScalarFloating: Target with id="${props.target}" not found`,
+        )
+    }
+    // If target is an HTMLElement, return it
+    else if (props.target instanceof HTMLElement) return props.target
   }
-  // If target is an HTMLElement, return it
-  else if (props.target instanceof HTMLElement) return props.target
   // Fallback to div wrapper if no child element is provided
   if (wrapperRef.value)
     return wrapperRef.value.children?.[0] || wrapperRef.value


### PR DESCRIPTION
**Problem**
Currently, we don't have proper SSG/SSR tests and don’t even notice when we break SSG/SSR builds.

**Solution**
This PR adds two basic tests which render a super simple OpenAPI document and a big real-world OpenAPI document (GitHub’s REST API).

See #4458

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.