### PR TITLE
docs(openapi): update x-tagGroup -> x-tagGroups

### DIFF
--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -87,9 +87,9 @@ paths:
         - pl4n3t5
 ```
 
-## x-tagGroup
+## x-tagGroups
 
-You can group your tags with `x-tagGroup`.
+You can group your tags with `x-tagGroups`.
 
 ```diff
 openapi: 3.1.0


### PR DESCRIPTION
Updates our docs to match:
* [Redocly](https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-tag-groups)
* [Our config](https://github.com/scalar/scalar/blob/main/packages/types/src/legacy/reference-config.ts#L544)
* [Our implementation](https://github.com/scalar/scalar/blob/main/packages/api-reference/src/hooks/useSidebar.ts#L268)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] ~I’ve added a changeset (`pnpm changeset`).~
- [ ] ~I’ve added tests for the regression or new feature.~
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
