### PR TITLE
fix(api-reference): remove incorrect default security requirement

### DIFF
--- a/.changeset/small-bobcats-hear.md
+++ b/.changeset/small-bobcats-hear.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/oas-utils': patch
+---
+
+fix: remove incorrect default security on import

--- a/packages/api-reference/playground/esm/index.html
+++ b/packages/api-reference/playground/esm/index.html
@@ -12,6 +12,7 @@
 
     <script type="module">
       import { createScalarReferences } from '../../src'
+      import test from './test.yml?raw'
 
       // CDN:
       // import { createScalarReferences } from 'https://esm.sh/@scalar/api-reference';
@@ -23,34 +24,34 @@
 
       const reference = createScalarReferences(el, {
         spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+          content: test,
         },
       })
 
       // Replace the OpenAPI document URL
-      let currentOpenApiDocument = 'scalar-galaxy'
+      // let currentOpenApiDocument = 'scalar-galaxy'
 
-      setInterval(() => {
-        currentOpenApiDocument =
-          currentOpenApiDocument === 'scalar-galaxy'
-            ? 'outline'
-            : 'scalar-galaxy'
+      // setInterval(() => {
+      //   currentOpenApiDocument =
+      //     currentOpenApiDocument === 'scalar-galaxy'
+      //       ? 'outline'
+      //       : 'scalar-galaxy'
 
-        reference.updateSpec({
-          url:
-            currentOpenApiDocument === 'scalar-galaxy'
-              ? 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json'
-              : 'https://raw.githubusercontent.com/outline/openapi/refs/heads/main/spec3.yml',
-        })
-      }, 4000)
+      //   reference.updateSpec({
+      //     url:
+      //       currentOpenApiDocument === 'scalar-galaxy'
+      //         ? 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json'
+      //         : 'https://raw.githubusercontent.com/outline/openapi/refs/heads/main/spec3.yml',
+      //   })
+      // }, 4000)
 
-      // Toggle dark mode
-      let isDark = false
+      // // Toggle dark mode
+      // let isDark = false
 
-      setInterval(() => {
-        isDark = !isDark
-        reference.updateConfig({ darkMode: isDark })
-      }, 2000)
+      // setInterval(() => {
+      //   isDark = !isDark
+      //   reference.updateConfig({ darkMode: isDark })
+      // }, 2000)
     </script>
   </body>
 </html>

--- a/packages/api-reference/playground/esm/test.yml
+++ b/packages/api-reference/playground/esm/test.yml
@@ -1,0 +1,100 @@
+{
+  'openapi': '3.1.0',
+  'info': { 'title': 'Hello World', 'version': '1.0.0' },
+  'paths':
+    {
+      '/api/v1/token':
+        {
+          'post':
+            {
+              'tags': ['Authentication'],
+              'summary': 'Get access token.',
+              'requestBody':
+                {
+                  'content':
+                    {
+                      'application/json':
+                        {
+                          'schema':
+                            {
+                              '$ref': '#/components/schemas/AuthenticationRequest',
+                            },
+                        },
+                    },
+                  'required': true,
+                },
+              'responses':
+                {
+                  '200':
+                    {
+                      'description': 'OK',
+                      'content':
+                        {
+                          'application/json':
+                            {
+                              'schema':
+                                {
+                                  '$ref': '#/components/schemas/AuthenticationResponse',
+                                },
+                            },
+                        },
+                    },
+                  '400':
+                    {
+                      'description': 'Bad Request',
+                      'content':
+                        {
+                          'application/json':
+                            {
+                              'schema':
+                                {
+                                  '$ref': '#/components/schemas/AuthenticationFailedResponse',
+                                },
+                            },
+                        },
+                    },
+                  '500': { 'description': 'Internal server error' },
+                },
+            },
+        },
+      '/api/v1/products':
+        {
+          'get':
+            {
+              'tags': ['Product'],
+              'summary': 'Get a product.',
+              'description': 'Get a product.',
+              'responses':
+                {
+                  '200':
+                    {
+                      'description': 'OK',
+                      'content':
+                        {
+                          'application/json':
+                            { 'schema': { 'type': 'string' } },
+                        },
+                    },
+                  '400': { 'description': 'Bad request' },
+                  '500': { 'description': 'Internal server error' },
+                  '401': { 'description': 'Unauthorized' },
+                  '403': { 'description': 'Forbidden' },
+                },
+              'security': [{ 'Bearer': [] }],
+            },
+        },
+    },
+  'components':
+    {
+      'securitySchemes':
+        {
+          'Bearer':
+            {
+              'type': 'http',
+              'scheme': 'bearer',
+              'bearerFormat': 'Json Web Token (JWT)',
+            },
+        },
+    },
+  'tags': [{ 'name': 'Authentication' }],
+}

--- a/packages/api-reference/playground/esm/vite.config.ts
+++ b/packages/api-reference/playground/esm/vite.config.ts
@@ -1,5 +1,5 @@
 import vue from '@vitejs/plugin-vue'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({

--- a/packages/api-reference/playground/esm/vite.config.ts
+++ b/packages/api-reference/playground/esm/vite.config.ts
@@ -1,6 +1,12 @@
 import vue from '@vitejs/plugin-vue'
+import { fileURLToPath } from 'url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('../../src', import.meta.url)),
+    },
+  },
 })

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -56,6 +56,15 @@ describe('importSpecToWorkspace', () => {
       expect(request.parameters?.map((p) => p.name)).toContain('filter')
     })
 
+    it('should set the default security requirements correctly', async () => {
+      const { security, ...rest } = galaxy
+
+      const res = await importSpecToWorkspace(rest)
+      if (res.error) throw res.error
+
+      expect(res.collection.security).toEqual([])
+    })
+
     it('handles requests in the order defined in the OpenAPI document', async () => {
       const res = await importSpecToWorkspace(galaxy)
       if (res.error) throw res.error

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -451,7 +451,7 @@ export async function importSpecToWorkspace(
     servers: servers.map((s) => s.uid),
     tags: tags.map((t) => t.uid),
     children: [...collectionChildren],
-    security: schema.security ?? [{}],
+    security: schema.security ?? [],
     selectedServerUid: servers?.[0]?.uid,
     selectedSecuritySchemeUids,
     components: {


### PR DESCRIPTION
fixes #4300 

**Problem**
We incorrectly set the default security requirement to optional

**Solution**
we set the default security requirement to an empty array (`[]`)

I also fixed the esm playground for easier spec testing

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
