### PR TITLE
fix(api-client): request body

### DIFF
--- a/.changeset/odd-parrots-lick.md
+++ b/.changeset/odd-parrots-lick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: prevents raw removal when binary

--- a/.changeset/pink-ways-protect.md
+++ b/.changeset/pink-ways-protect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates request body style

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -480,7 +480,7 @@ const selectedExample = computed({
             :options="contentTypeOptions"
             teleport>
             <ScalarButton
-              class="flex gap-1.5 h-full px-2 text-c-2 font-normal hover:text-c-1 w-fit"
+              class="flex gap-1.5 h-full px-3 text-c-2 font-normal hover:text-c-1 w-fit"
               fullWidth
               variant="ghost">
               <span>{{ selectedContentType?.label }}</span>
@@ -515,10 +515,11 @@ const selectedExample = computed({
           </div>
         </template>
         <template v-else-if="selectedContentType?.id === 'binaryFile'">
-          <div class="flex items-center justify-center p-1.5 overflow-hidden">
+          <div
+            class="border-t flex items-center justify-center p-1.5 overflow-hidden">
             <template v-if="activeExample?.body.binary">
               <span
-                class="text-c-2 text-xs w-full border rounded p-1 max-w-full overflow-hidden whitespace-nowrap">
+                class="text-c-2 text-xs w-full border rounded py-1 px-1.5 max-w-full overflow-hidden whitespace-nowrap">
                 {{ (activeExample?.body.binary as File).name }}
               </span>
               <ScalarButton
@@ -574,7 +575,7 @@ const selectedExample = computed({
         <template v-else>
           <!-- TODO: remove this as type hack when we add syntax highligting -->
           <CodeInput
-            class="border-t-1/2"
+            class="border-t-1/2 px-1"
             content=""
             :language="codeInputLanguage as CodeMirrorLanguage"
             lineNumbers

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -296,8 +296,8 @@ const updateActiveBody = (type: Content) => {
       encoding,
       value: activeExample.value.body.formData?.value ?? [],
     })
-  // Remove raw if no encoding
-  else if (!encoding) {
+  // Remove raw if no encoding and not binary
+  else if (!encoding && activeBody !== 'binary') {
     const { raw: deleteMe, ...body } = activeExample.value.body
     requestExampleMutators.edit(activeExample.value.uid, 'body', body)
   }
@@ -364,6 +364,7 @@ function removeBinaryFile() {
   if (!activeRequest.value || !activeExample.value) return
   requestExampleMutators.edit(activeExample.value.uid, 'body.binary', undefined)
 }
+
 function handleRemoveFileFormData(rowIdx: number) {
   if (!activeRequest.value || !activeExample.value) return
   const currentParams = formParams.value


### PR DESCRIPTION
**Problem**
when selecting binary as a request body content type, raw value are being removed + style inconsistencies.

**Solution**
this pr prevents raw value from being removed on binary type selection in order to be able to come back to it, and updates ui.

| before | after |
| -------|------|
| <img width="632" alt="image" src="https://github.com/user-attachments/assets/61e30eb7-324a-4694-a1f5-b1e943c406db" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/8766d60b-e4f6-42e0-aa4b-e5dce53e6273" /> |
| missing top border + wrong alignment of the label | border added and alignment straight | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
