### PR TITLE
fix(api-client): path params

### DIFF
--- a/.changeset/hip-rockets-sniff.md
+++ b/.changeset/hip-rockets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: updates checkbox style and display in path params

--- a/.changeset/nice-hairs-rescue.md
+++ b/.changeset/nice-hairs-rescue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: handles path variable on request path change

--- a/packages/api-client/src/components/DataTable/DataTableCheckbox.vue
+++ b/packages/api-client/src/components/DataTable/DataTableCheckbox.vue
@@ -19,7 +19,7 @@ defineEmits<{
 }>()
 
 const variants = cva({
-  base: 'w-8 h-8 flex items-center justify-center text-border peer-checked:text-c-2 pointer-events-none absolute',
+  base: 'w-8 h-8 flex items-center justify-center text-border peer-checked:text-c-1 pointer-events-none absolute',
   variants: {
     align: {
       left: 'left-0',
@@ -32,13 +32,17 @@ const variants = cva({
   <DataTableCell class="group/cell relative flex min-w-8">
     <input
       :checked="modelValue"
-      class="peer absolute inset-0 opacity-0 cursor-pointer"
+      class="peer absolute inset-0 opacity-0 disabled:cursor-default cursor-pointer"
       :disabled="disabled"
       type="checkbox"
       @change="(e: any) => $emit('update:modelValue', e.target.checked)" />
     <div :class="variants({ align })">
       <div
-        class="absolute opacity-0 group-hover/cell:opacity-100 group-has-[:focus-visible]/cell:opacity-100 group-has-[:focus-visible]/cell:border-c-accent border-[1px] rounded size-3/4 m-auto" />
+        class="absolute opacity-0 border-[1px] rounded size-3/4 m-auto"
+        :class="
+          !disabled &&
+          'group-hover/cell:opacity-100 group-has-[:focus-visible]/cell:opacity-100 group-has-[:focus-visible]/cell:border-c-accent'
+        " />
       <ScalarIcon
         icon="Checkmark"
         size="xs"

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -120,6 +120,15 @@ watch(
     }
   },
 )
+
+watch(
+  () => activeRequest.value?.path,
+  (newURL) => {
+    if (newURL) {
+      handlePathVariableUpdate(newURL)
+    }
+  },
+)
 </script>
 <template>
   <ViewLayoutCollapse :itemCount="params.length">
@@ -130,7 +139,6 @@ watch(
     <RequestTable
       v-if="params.length"
       class="flex-1"
-      isEnabledHidden
       :items="params"
       @updateRow="updateRow" />
   </ViewLayoutCollapse>

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -139,6 +139,8 @@ watch(
     <RequestTable
       v-if="params.length"
       class="flex-1"
+      :columns="['32px', '', '']"
+      hasCheckboxDisabled
       :items="params"
       @updateRow="updateRow" />
   </ViewLayoutCollapse>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -10,14 +10,14 @@ import { computed } from 'vue'
 
 import RequestTableTooltip from './RequestTableTooltip.vue'
 
-const props = withDefaults(
+withDefaults(
   defineProps<{
     items?: RequestExampleParameter[]
-    /** Hide the enabled column */
-    isEnabledHidden?: boolean
+    /** Disable the checkbox */
+    hasCheckboxDisabled?: boolean
     showUploadButton?: boolean
   }>(),
-  { isEnabledHidden: false, showUploadButton: false },
+  { hasCheckboxDisabled: false, showUploadButton: false },
 )
 
 const emit = defineEmits<{
@@ -31,7 +31,7 @@ const emit = defineEmits<{
   (e: 'removeFile', idx: number): void
 }>()
 
-const columns = props.isEnabledHidden ? ['', ''] : ['', '', '36px']
+const columns = ['', '', '36px']
 
 const handleSelectVariable = (
   idx: number,
@@ -80,8 +80,8 @@ const flattenValue = (item: RequestExampleParameter) => {
       <label class="contents">
         <span class="sr-only">Row Enabled</span>
         <DataTableCheckbox
-          v-if="!isEnabledHidden"
           class="!border-r-1/2"
+          :disabled="hasCheckboxDisabled"
           :modelValue="item.enabled"
           @update:modelValue="(v) => emit('toggleRow', idx, v)" />
       </label>


### PR DESCRIPTION
**Problem**
path param addition in the path are not enabling the path params table visibility. 

**Solution**
this pr:
1. adds path variable table on variable presence in request path change
2. proposes to add back the checkbox while keeping it non updatable for consistency purposes
3. increase color of icon used in enabled checkbox to increase state information perception

| before | after |
| -------|------|
| <img width="632" alt="image" src="https://github.com/user-attachments/assets/c2fd8efc-030d-4112-a370-645fece78818" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/5fe30cac-b345-48f1-8bf7-43a54f4908d8" /> |
| variable table doesn't display checkbox - checked icon dimmed down | displays checkbox for variable + increase checked icon color | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).