### PR TITLE
feat(api-client): cookies 🍪

### DIFF
--- a/.changeset/nine-walls-search.md
+++ b/.changeset/nine-walls-search.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: cookies 🍪

--- a/examples/proxy-server/README.md
+++ b/examples/proxy-server/README.md
@@ -19,6 +19,7 @@ in browser environments.
 - Health check endpoint at `/ping`
 - Configurable port via environment variable (`PORT`)
 - Preserves original request headers and body (except `Origin` header)
+- Forwards `X-Scalar-Cookie` as `Cookie` header to circumvent the browser’s cookie policy
 - Forwards all HTTP methods (GET, POST, PUT, DELETE, PATCH)
 - Zero external dependencies (only using Go standard libraries)
 

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -161,9 +161,6 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 
 	// Redirect X-Scalar-Cookie header as Cookie header
 	if xScalarCookie := r.Header.Get("X-Scalar-Cookie"); xScalarCookie != "" {
-		// Log the cookie
-		log.Println("X-Scalar-Cookie", xScalarCookie)
-
 		// Set the cookie
 		outreq.Header.Set("Cookie", xScalarCookie)
 		// Remove the X-Scalar-Cookie header

--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -159,6 +159,17 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	// Redirect X-Scalar-Cookie header as Cookie header
+	if xScalarCookie := r.Header.Get("X-Scalar-Cookie"); xScalarCookie != "" {
+		// Log the cookie
+		log.Println("X-Scalar-Cookie", xScalarCookie)
+
+		// Set the cookie
+		outreq.Header.Set("Cookie", xScalarCookie)
+		// Remove the X-Scalar-Cookie header
+		outreq.Header.Del("X-Scalar-Cookie")
+	}
+
 	// Make the request
 	resp, err := client.Do(outreq)
 

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -196,7 +196,6 @@
     "@vueuse/integrations": "^11.2.0",
     "focus-trap": "^7",
     "fuse.js": "^7.0.0",
-    "js-cookie": "^3.0.5",
     "microdiff": "^1.4.0",
     "nanoid": "^5.0.7",
     "pretty-bytes": "^6.1.1",
@@ -211,7 +210,6 @@
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
     "@scalar/galaxy": "workspace:*",
-    "@types/js-cookie": "^3.0.6",
     "@types/shell-quote": "^1.7.5",
     "@types/whatwg-mimetype": "^3.0.2",
     "@vitejs/plugin-vue": "^5.0.4",

--- a/packages/api-client/playground/app/main.ts
+++ b/packages/api-client/playground/app/main.ts
@@ -1,5 +1,5 @@
 import { createApiClientApp } from '@/layouts/App'
 
 createApiClientApp(document.getElementById('scalar-client'), {
-  proxyUrl: 'https://proxy.scalar.com',
+  proxyUrl: 'http://localhost:5051',
 })

--- a/packages/api-client/playground/app/main.ts
+++ b/packages/api-client/playground/app/main.ts
@@ -1,5 +1,5 @@
 import { createApiClientApp } from '@/layouts/App'
 
 createApiClientApp(document.getElementById('scalar-client'), {
-  proxyUrl: 'http://localhost:5051',
+  proxyUrl: 'https://proxy.scalar.com',
 })

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -20,6 +20,7 @@ import { useActiveEntities } from '@/store/active-entities'
 const props = withDefaults(
   defineProps<{
     colorPicker?: boolean
+    disabled?: boolean
     modelValue: string | number
     error?: boolean
     emitOnBlur?: boolean
@@ -50,6 +51,7 @@ const props = withDefaults(
     nullable: false,
     withVariables: true,
     isCopyable: false,
+    disabled: false,
   },
 )
 const emit = defineEmits<{
@@ -211,7 +213,12 @@ export default {
 }
 </script>
 <template>
-  <template v-if="props.enum && props.enum.length">
+  <template v-if="props.disabled">
+    <div class="flex items-center justify-center p-2">
+      <span class="text-c-2 text-xs font-code">{{ modelValue }}</span>
+    </div>
+  </template>
+  <template v-else-if="props.enum && props.enum.length">
     <DataTableInputSelect
       :default="props.default"
       :modelValue="props.modelValue"

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -213,23 +213,22 @@ export default {
 }
 </script>
 <template>
-  <template v-if="props.disabled">
+  <template v-if="disabled">
     <div class="flex items-center justify-center p-2">
-      <span class="text-c-2 text-xs font-code">{{ modelValue }}</span>
+      <span class="text-c-2 text-sm">{{ modelValue }}</span>
     </div>
   </template>
   <template v-else-if="props.enum && props.enum.length">
     <DataTableInputSelect
       :default="props.default"
-      :modelValue="props.modelValue"
+      :modelValue="modelValue"
       :value="props.enum"
       @update:modelValue="emit('update:modelValue', $event)" />
   </template>
-  <template
-    v-else-if="props.type === 'boolean' || props.type?.includes('boolean')">
+  <template v-else-if="type === 'boolean' || type?.includes('boolean')">
     <DataTableInputSelect
       :default="props.default"
-      :modelValue="props.modelValue"
+      :modelValue="modelValue"
       :value="booleanOptions"
       @update:modelValue="emit('update:modelValue', $event)" />
   </template>
@@ -251,8 +250,9 @@ export default {
         <button
           class="copy-button"
           type="button"
-          @click="copyToClipboard(prettyPrintJson(props.modelValue))">
+          @click="copyToClipboard(prettyPrintJson(modelValue))">
           <span class="sr-only">Copy content</span>
+
           <ScalarIcon
             icon="Clipboard"
             size="md" />
@@ -272,9 +272,7 @@ export default {
     Required
   </div>
   <EnvironmentVariableDropdown
-    v-if="
-      showDropdown && props.withVariables && !isReadOnly && activeEnvironment
-    "
+    v-if="showDropdown && withVariables && !isReadOnly && activeEnvironment"
     ref="dropdownRef"
     :dropdownPosition="dropdownPosition"
     :envVariables="activeEnvVariables"

--- a/packages/api-client/src/components/CommandPalette/CommandActionInput.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandActionInput.vue
@@ -4,6 +4,7 @@ import { computed, nextTick, onMounted, ref } from 'vue'
 const props = defineProps<{
   modelValue?: string
   placeholder?: string
+  autofocus?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -14,7 +15,13 @@ const emit = defineEmits<{
 defineOptions({ inheritAttrs: false })
 
 const input = ref<HTMLInputElement | null>(null)
-onMounted(() => nextTick(() => input.value?.focus()))
+onMounted(() =>
+  nextTick(() => {
+    if (!props.autofocus) {
+      input.value?.focus()
+    }
+  }),
+)
 
 const model = computed<string>({
   get: () => props.modelValue ?? '',

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -90,12 +90,12 @@ const availableCommands = [
       {
         name: 'Add Environment',
         icon: 'Brackets',
-        path: 'environment',
+        path: 'environment.default',
       },
       {
         name: 'Add Cookie',
         icon: 'Cookie',
-        path: 'cookies',
+        path: 'cookies.default',
       },
     ],
   },
@@ -161,6 +161,7 @@ const executeCommand = (
         workspace: activeWorkspace.value?.uid,
       },
     })
+
     closeHandler()
   }
 

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
+import DataTableCheckbox from '@/components/DataTable/DataTableCheckbox.vue'
 import type { VueClassProp } from '@/types/vue'
 import { ScalarIconButton } from '@scalar/components'
 import { computed, ref } from 'vue'
@@ -14,7 +15,7 @@ const props = withDefaults(
     /** Class for the wrapping cell because attrs is bound to the input */
     containerClass?: VueClassProp
     required?: boolean
-    modelValue: string | number
+    modelValue: string | number | boolean
     /** Allows adding a custom value to the enum dropdown, defaults to true */
     canAddCustomEnumValue?: boolean
     readOnly?: boolean
@@ -66,6 +67,11 @@ const inputType = computed(() =>
           :canAddCustomValue="canAddCustomEnumValue"
           :modelValue="props.modelValue"
           :value="props.enum"
+          @update:modelValue="emit('update:modelValue', $event)" />
+      </template>
+      <template v-else-if="props.type === 'boolean'">
+        <DataTableCheckbox
+          :modelValue="props.modelValue"
           @update:modelValue="emit('update:modelValue', $event)" />
       </template>
       <template v-else>

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -15,7 +15,7 @@ const props = withDefaults(
     /** Class for the wrapping cell because attrs is bound to the input */
     containerClass?: VueClassProp
     required?: boolean
-    modelValue: string | number | boolean
+    modelValue: string | number
     /** Allows adding a custom value to the enum dropdown, defaults to true */
     canAddCustomEnumValue?: boolean
     readOnly?: boolean
@@ -67,11 +67,6 @@ const inputType = computed(() =>
           :canAddCustomValue="canAddCustomEnumValue"
           :modelValue="props.modelValue"
           :value="props.enum"
-          @update:modelValue="emit('update:modelValue', $event)" />
-      </template>
-      <template v-else-if="props.type === 'boolean'">
-        <DataTableCheckbox
-          :modelValue="props.modelValue"
           @update:modelValue="emit('update:modelValue', $event)" />
       </template>
       <template v-else>

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -6,7 +6,12 @@ import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
 
 defineProps<{
   title?: string
-  options: { key: string; label: string; placeholder: string }[]
+  options: {
+    key: string
+    label: string
+    placeholder: string
+    type?: 'boolean' | 'string'
+  }[]
   data: Record<string, any>
   onUpdate: (key: string, value: any) => void
 }>()
@@ -28,8 +33,9 @@ defineProps<{
           :key="option.key"
           :class="{ 'border-t': index === 0 }">
           <DataTableInput
-            :modelValue="String(data[option.key] ?? '')"
+            :modelValue="data[option.key]"
             :placeholder="option.placeholder"
+            :type="option.type"
             @update:modelValue="onUpdate(option.key, $event)">
             {{ option.label }}
           </DataTableInput>

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -10,7 +10,6 @@ defineProps<{
     key: string
     label: string
     placeholder: string
-    type?: 'boolean' | 'string'
   }[]
   data: Record<string, any>
   onUpdate: (key: string, value: any) => void
@@ -35,7 +34,6 @@ defineProps<{
           <DataTableInput
             :modelValue="data[option.key]"
             :placeholder="option.placeholder"
-            :type="option.type"
             @update:modelValue="onUpdate(option.key, $event)">
             {{ option.label }}
           </DataTableInput>

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -107,10 +107,7 @@ const handleRename = (id: string) => {
   @apply bg-b-2 text-c-1;
 }
 .empty-variable-name:empty:before {
-  content: 'No Name';
+  content: 'Untitled';
   color: var(--scalar-color-3);
-}
-.cookie > a {
-  @apply pl-10;
 }
 </style>

--- a/packages/api-client/src/libs/send-request/send-request.ts
+++ b/packages/api-client/src/libs/send-request/send-request.ts
@@ -311,18 +311,13 @@ export const createRequestOperation = ({
       url = combinedURL.toString()
     }
 
-    // TODO: Only add custom header or original header, depending on whether the proxy is used
-    // TODO: Add other properties to the cookie
-
-    const cookieHeaders = cookieParams.map((c) => `${c.name}=${c.value}`)
-
     // Add custom header for the proxy
     if (shouldUseProxy(proxyUrl, url)) {
-      headers['X-Scalar-Cookie'] = cookieHeaders.join('; ')
+      headers['X-Scalar-Cookie'] = getCookieHeader(cookieParams)
     }
     // or stick to the original header (which might be removed by the browser)
     else {
-      headers['Cookie'] = cookieHeaders.join('; ')
+      headers['Cookie'] = getCookieHeader(cookieParams)
     }
 
     const proxyPath = new URLSearchParams([['scalar_url', url.toString()]])

--- a/packages/api-client/src/libs/send-request/send-request.ts
+++ b/packages/api-client/src/libs/send-request/send-request.ts
@@ -313,7 +313,10 @@ export const createRequestOperation = ({
     }
 
     /** Cookie header */
-    const cookieHeader = getCookieHeader(cookieParams, headers['Cookie'])
+    const cookieHeader = replaceTemplateVariables(
+      getCookieHeader(cookieParams, headers['Cookie']),
+      env,
+    )
 
     if (cookieHeader) {
       // Add a custom header for the proxy (that’s then forwarded as `Cookie`)

--- a/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
@@ -78,12 +78,12 @@ describe('matchesDomain', () => {
 })
 
 describe('getCookieHeader', () => {
-  it('should generate a cookie header from the cookie params', () => {
+  it('generates a cookie header from the cookie params', () => {
     const cookieParams: Cookie[] = [createCookie('foo', 'bar')]
     expect(getCookieHeader(cookieParams)).toBe('foo=bar')
   })
 
-  it('should generate a cookie header with multiple cookies', () => {
+  it('generates a cookie header with multiple cookies', () => {
     const cookieParams: Cookie[] = [
       createCookie('foo', 'bar'),
       createCookie('baz', 'qux'),
@@ -91,7 +91,7 @@ describe('getCookieHeader', () => {
     expect(getCookieHeader(cookieParams)).toBe('foo=bar; baz=qux')
   })
 
-  it('should handle cookies with special characters in values', () => {
+  it('handles cookies with special characters in values', () => {
     const cookieParams: Cookie[] = [
       createCookie('test', 'hello world!@#$%^&*()'),
       createCookie('complex', '{"key": "value"}'),
@@ -101,7 +101,7 @@ describe('getCookieHeader', () => {
     )
   })
 
-  it('should handle cookies with empty values', () => {
+  it('handles cookies with empty values', () => {
     const cookieParams: Cookie[] = [
       createCookie('empty', ''),
       createCookie('normal', 'value'),
@@ -109,39 +109,48 @@ describe('getCookieHeader', () => {
     expect(getCookieHeader(cookieParams)).toBe('empty=; normal=value')
   })
 
-  it('should handle cookies with various attributes without including them in header', () => {
-    const cookieParams: Cookie[] = [
-      createCookie('test', 'value', {
-        domain: 'test.com',
-        path: '/api',
-        httpOnly: true,
-        secure: true,
-        sameSite: 'Strict',
-        expires: new Date('2024-01-01'),
-      }),
-    ]
-    expect(getCookieHeader(cookieParams)).toBe('test=value')
-  })
-
-  it('should handle an empty cookie array', () => {
+  it('handles an empty cookie array', () => {
     const cookieParams: Cookie[] = []
     expect(getCookieHeader(cookieParams)).toBe('')
   })
 
-  it('should handle cookies with same names but different domains', () => {
-    const cookieParams: Cookie[] = [
-      createCookie('session', 'abc123', { domain: 'example.com' }),
-      createCookie('session', 'def456', { domain: 'api.example.com' }),
-    ]
-    expect(getCookieHeader(cookieParams)).toBe('session=abc123; session=def456')
-  })
-
-  it('should handle cookies with unicode values', () => {
+  it('handles cookies with unicode values', () => {
     const cookieParams: Cookie[] = [
       createCookie('greeting', '你好'),
       createCookie('emoji', '👋'),
     ]
     expect(getCookieHeader(cookieParams)).toBe('greeting=你好; emoji=👋')
+  })
+
+  it('merges with original cookie header', () => {
+    const cookieParams: Cookie[] = [createCookie('foo', 'bar')]
+    expect(getCookieHeader(cookieParams, 'existing=value')).toBe(
+      'existing=value; foo=bar',
+    )
+  })
+
+  it('merges multiple cookies with original cookie header', () => {
+    const cookieParams: Cookie[] = [
+      createCookie('foo', 'bar'),
+      createCookie('baz', 'qux'),
+    ]
+    expect(getCookieHeader(cookieParams, 'existing=value')).toBe(
+      'existing=value; foo=bar; baz=qux',
+    )
+  })
+
+  it('handles empty cookie params with original cookie header', () => {
+    const cookieParams: Cookie[] = []
+    expect(getCookieHeader(cookieParams, 'existing=value')).toBe(
+      'existing=value;',
+    )
+  })
+
+  it('handles original cookie header with multiple cookies', () => {
+    const cookieParams: Cookie[] = [createCookie('foo', 'bar')]
+    expect(getCookieHeader(cookieParams, 'first=one; second=two')).toBe(
+      'first=one; second=two; foo=bar',
+    )
   })
 })
 
@@ -158,11 +167,6 @@ function createCookie(
     value,
     domain: 'example.com',
     path: '/',
-    // tomorrow
-    expires: new Date(Date.now() + 24 * 60 * 60 * 1000),
-    httpOnly: true,
-    secure: true,
-    sameSite: 'None',
     uid: 'globalCookie',
     // overwrite (optional)
     ...options,

--- a/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
@@ -23,49 +23,54 @@ describe('setRequestCookies', () => {
     })
 
     // Global
-    const globalCookies: Cookie[] = [createCookie('globalCookie', 'bar')]
+    const globalCookies: Cookie[] = [
+      createCookie('globalCookie', 'bar', {
+        domain: 'example.com',
+      }),
+    ]
 
     const { cookieParams } = setRequestCookies({
       example,
       env: {},
       globalCookies,
       serverUrl: 'https://example.com/v1',
+      proxyUrl: '',
     })
 
     expect(cookieParams).toMatchObject([
       {
-        name: 'localCookie',
-        value: 'foo',
-      },
-      {
         name: 'globalCookie',
         value: 'bar',
+        domain: 'example.com',
+      },
+      {
+        name: 'localCookie',
+        value: 'foo',
+        domain: '.example.com',
       },
     ])
-
-    console.log(cookieParams)
   })
 })
 
 describe('matchesDomain', () => {
   it('should match the current host', () => {
-    expect(matchesDomain('example.com', 'example.com')).toBe(true)
+    expect(matchesDomain('https://example.com', 'example.com')).toBe(true)
   })
 
   it('should match the current host with a wildcard', () => {
-    expect(matchesDomain('example.com', '.example.com')).toBe(true)
+    expect(matchesDomain('https://example.com', '.example.com')).toBe(true)
   })
 
   it('should not match the current host', () => {
-    expect(matchesDomain('example.com', 'scalar.com')).toBe(false)
+    expect(matchesDomain('https://example.com', 'scalar.com')).toBe(false)
   })
 
   it('should match the current host with a wildcard', () => {
-    expect(matchesDomain('void.scalar.com', '.scalar.com')).toBe(true)
+    expect(matchesDomain('https://void.scalar.com', '.scalar.com')).toBe(true)
   })
 
   it('shouldn’t match the current host without a wildcard', () => {
-    expect(matchesDomain('void.scalar.com', 'scalar.com')).toBe(false)
+    expect(matchesDomain('https://void.scalar.com', 'scalar.com')).toBe(false)
   })
 })
 

--- a/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
@@ -2,7 +2,11 @@ import type { Cookie } from '@scalar/oas-utils/entities/cookie'
 import type { RequestExample } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
-import { matchesDomain, setRequestCookies } from './set-request-cookies'
+import {
+  getCookieHeader,
+  matchesDomain,
+  setRequestCookies,
+} from './set-request-cookies'
 
 describe('setRequestCookies', () => {
   it('should set local and global cookies', () => {
@@ -34,7 +38,6 @@ describe('setRequestCookies', () => {
       env: {},
       globalCookies,
       serverUrl: 'https://example.com/v1',
-      proxyUrl: '',
     })
 
     expect(cookieParams).toMatchObject([
@@ -71,6 +74,74 @@ describe('matchesDomain', () => {
 
   it('shouldn’t match the current host without a wildcard', () => {
     expect(matchesDomain('https://void.scalar.com', 'scalar.com')).toBe(false)
+  })
+})
+
+describe('getCookieHeader', () => {
+  it('should generate a cookie header from the cookie params', () => {
+    const cookieParams: Cookie[] = [createCookie('foo', 'bar')]
+    expect(getCookieHeader(cookieParams)).toBe('foo=bar')
+  })
+
+  it('should generate a cookie header with multiple cookies', () => {
+    const cookieParams: Cookie[] = [
+      createCookie('foo', 'bar'),
+      createCookie('baz', 'qux'),
+    ]
+    expect(getCookieHeader(cookieParams)).toBe('foo=bar; baz=qux')
+  })
+
+  it('should handle cookies with special characters in values', () => {
+    const cookieParams: Cookie[] = [
+      createCookie('test', 'hello world!@#$%^&*()'),
+      createCookie('complex', '{"key": "value"}'),
+    ]
+    expect(getCookieHeader(cookieParams)).toBe(
+      'test=hello world!@#$%^&*(); complex={"key": "value"}',
+    )
+  })
+
+  it('should handle cookies with empty values', () => {
+    const cookieParams: Cookie[] = [
+      createCookie('empty', ''),
+      createCookie('normal', 'value'),
+    ]
+    expect(getCookieHeader(cookieParams)).toBe('empty=; normal=value')
+  })
+
+  it('should handle cookies with various attributes without including them in header', () => {
+    const cookieParams: Cookie[] = [
+      createCookie('test', 'value', {
+        domain: 'test.com',
+        path: '/api',
+        httpOnly: true,
+        secure: true,
+        sameSite: 'Strict',
+        expires: new Date('2024-01-01'),
+      }),
+    ]
+    expect(getCookieHeader(cookieParams)).toBe('test=value')
+  })
+
+  it('should handle an empty cookie array', () => {
+    const cookieParams: Cookie[] = []
+    expect(getCookieHeader(cookieParams)).toBe('')
+  })
+
+  it('should handle cookies with same names but different domains', () => {
+    const cookieParams: Cookie[] = [
+      createCookie('session', 'abc123', { domain: 'example.com' }),
+      createCookie('session', 'def456', { domain: 'api.example.com' }),
+    ]
+    expect(getCookieHeader(cookieParams)).toBe('session=abc123; session=def456')
+  })
+
+  it('should handle cookies with unicode values', () => {
+    const cookieParams: Cookie[] = [
+      createCookie('greeting', '你好'),
+      createCookie('emoji', '👋'),
+    ]
+    expect(getCookieHeader(cookieParams)).toBe('greeting=你好; emoji=👋')
   })
 })
 

--- a/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
@@ -2,7 +2,7 @@ import type { Cookie } from '@scalar/oas-utils/entities/cookie'
 import type { RequestExample } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
-import { setRequestCookies } from './set-request-cookies'
+import { matchesDomain, setRequestCookies } from './set-request-cookies'
 
 describe('setRequestCookies', () => {
   it('should set local and global cookies', () => {
@@ -44,6 +44,28 @@ describe('setRequestCookies', () => {
     ])
 
     console.log(cookieParams)
+  })
+})
+
+describe('matchesDomain', () => {
+  it('should match the current host', () => {
+    expect(matchesDomain('example.com', 'example.com')).toBe(true)
+  })
+
+  it('should match the current host with a wildcard', () => {
+    expect(matchesDomain('example.com', '.example.com')).toBe(true)
+  })
+
+  it('should not match the current host', () => {
+    expect(matchesDomain('example.com', 'scalar.com')).toBe(false)
+  })
+
+  it('should match the current host with a wildcard', () => {
+    expect(matchesDomain('void.scalar.com', '.scalar.com')).toBe(true)
+  })
+
+  it('shouldn’t match the current host without a wildcard', () => {
+    expect(matchesDomain('void.scalar.com', 'scalar.com')).toBe(false)
   })
 })
 

--- a/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
@@ -1,0 +1,97 @@
+import type { Cookie } from '@scalar/oas-utils/entities/cookie'
+import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import { describe, expect, it } from 'vitest'
+
+import { setRequestCookies } from './set-request-cookies'
+
+describe('setRequestCookies', () => {
+  it('should set local and global cookies', () => {
+    // Local cookie
+    const localCookieParameter = {
+      key: 'localCookie',
+      value: 'foo',
+      enabled: true,
+    }
+
+    const example: RequestExample = createRequestExample({
+      parameters: {
+        cookies: [localCookieParameter],
+        path: [],
+        query: [],
+        headers: [],
+      },
+    })
+
+    // Global
+    const globalCookies: Cookie[] = [createCookie('globalCookie', 'bar')]
+
+    const { cookieParams } = setRequestCookies({
+      example,
+      env: {},
+      globalCookies,
+      serverUrl: 'https://example.com/v1',
+    })
+
+    expect(cookieParams).toMatchObject([
+      {
+        name: 'localCookie',
+        value: 'foo',
+      },
+      {
+        name: 'globalCookie',
+        value: 'bar',
+      },
+    ])
+
+    console.log(cookieParams)
+  })
+})
+
+/**
+ * Create a cookie with default values and optional overrides
+ */
+function createCookie(
+  name: string,
+  value: string,
+  options: Partial<Exclude<Cookie, 'name' | 'value'>> = {},
+): Cookie {
+  return {
+    name,
+    value,
+    domain: 'example.com',
+    path: '/',
+    // tomorrow
+    expires: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    httpOnly: true,
+    secure: true,
+    sameSite: 'None',
+    uid: 'globalCookie',
+    // overwrite (optional)
+    ...options,
+  }
+}
+
+function createRequestExample(
+  example: Partial<RequestExample> = {},
+): RequestExample {
+  return {
+    type: 'requestExample' as const,
+    uid: 'example',
+    name: 'Example',
+    requestUid: 'request',
+    parameters: {
+      cookies: [],
+      path: [],
+      query: [],
+      headers: [],
+    },
+    body: {
+      activeBody: 'raw' as const,
+      raw: {
+        encoding: 'json',
+        value: '',
+      },
+    },
+    ...example,
+  }
+}

--- a/packages/api-client/src/libs/send-request/set-request-cookies.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.ts
@@ -54,32 +54,36 @@ export function setRequestCookies({
       return
     }
 
+    if (!name) {
+      return
+    }
+
     cookieParams.push({
       uid: name,
       name,
       value,
       domain: configuredHostname,
       path: params.path,
-      expires: params.expires ?? undefined,
-      httpOnly: params.httpOnly,
-      secure: params.secure,
-      sameSite: params.sameSite,
     })
   })
 
   // Add local cookies
   example.parameters.cookies.forEach((c) => {
-    if (c.enabled) {
-      cookieParams.push({
-        uid: c.key,
-        name: c.key,
-        value: replaceTemplateVariables(c.value, env),
-        domain: defaultDomain,
-        path: defaultPath,
-        secure: true,
-        sameSite: defaultSameSite,
-      })
+    if (!c.enabled) {
+      return
     }
+
+    if (!c.key) {
+      return
+    }
+
+    cookieParams.push({
+      uid: c.key,
+      name: c.key,
+      value: replaceTemplateVariables(c.value, env),
+      domain: defaultDomain,
+      path: defaultPath,
+    })
   })
 
   return {
@@ -120,7 +124,7 @@ const determineCookieDomain = (url: string) => {
 export const matchesDomain = (
   givenUrl?: string,
   configuredHostname?: string,
-) => {
+): boolean => {
   if (!givenUrl || !configuredHostname) return true
 
   try {

--- a/packages/api-client/src/libs/send-request/set-request-cookies.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.ts
@@ -33,7 +33,7 @@ export function setRequestCookies({
   env: object
   globalCookies: Cookie[]
   serverUrl: string
-  proxyUrl: string
+  proxyUrl?: string
 }): {
   cookieParams: Cookie[]
 } {
@@ -43,7 +43,7 @@ export function setRequestCookies({
 
   // Try to add the target domain with a wildcard dot
   const defaultDomain = determineCookieDomain(
-    isUsingTheProxy ? proxyUrl : (serverUrl ?? 'http://localhost'),
+    isUsingTheProxy ? (proxyUrl as string) : (serverUrl ?? 'http://localhost'),
   )
 
   // Add global cookies that match the current domain
@@ -136,4 +136,11 @@ export const matchesDomain = (
   } catch {
     return false
   }
+}
+
+/**
+ * Generate a cookie header from the cookie params
+ */
+export const getCookieHeader = (cookieParams: Cookie[]): string => {
+  return cookieParams.map((c) => `${c.name}=${c.value}`).join('; ')
 }

--- a/packages/api-client/src/libs/send-request/set-request-cookies.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.ts
@@ -98,7 +98,8 @@ export function setRequestCookies({
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
  */
 const determineCookieDomain = (url: string) => {
-  const hostname = new URL(url).hostname
+  const hostname = new URL(url.startsWith('http') ? url : `http://${url}`)
+    .hostname
 
   // If it’s an IP, just return it
   if (hostname.match(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)) {
@@ -128,7 +129,9 @@ export const matchesDomain = (
   if (!givenUrl || !configuredHostname) return true
 
   try {
-    const givenHostname = new URL(givenUrl).hostname
+    const givenHostname = new URL(
+      givenUrl.startsWith('http') ? givenUrl : `http://${givenUrl}`,
+    ).hostname
 
     return (
       !configuredHostname ||

--- a/packages/api-client/src/libs/send-request/set-request-cookies.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.ts
@@ -141,6 +141,19 @@ export const matchesDomain = (
 /**
  * Generate a cookie header from the cookie params
  */
-export const getCookieHeader = (cookieParams: Cookie[]): string => {
-  return cookieParams.map((c) => `${c.name}=${c.value}`).join('; ')
+export const getCookieHeader = (
+  cookieParams: Cookie[],
+  originalCookieHeader?: string,
+): string => {
+  // Generate the cookie header from the cookie params
+  const cookieHeader = cookieParams
+    .map((c) => `${c.name}=${c.value}`)
+    .join('; ')
+
+  // Merge with the original cookie header
+  if (originalCookieHeader) {
+    return `${originalCookieHeader}; ${cookieHeader}`.trim()
+  }
+
+  return cookieHeader.trim()
 }

--- a/packages/api-client/src/libs/send-request/set-request-cookies.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.ts
@@ -1,0 +1,107 @@
+import { replaceTemplateVariables } from '@/libs/string-template'
+import type { Cookie } from '@scalar/oas-utils/entities/cookie'
+import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import { shouldUseProxy } from '@scalar/oas-utils/helpers'
+
+/**
+ * The %x2F ("/") character is considered a directory separator, and subdirectories match as well.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
+ */
+const defaultPath = '/'
+
+/**
+ * The SameSite attribute lets servers specify whether/when cookies are sent with cross-site requests.
+ *
+ * None specifies that cookies are sent on both originating and cross-site requests.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#controlling_third-party_cookies_with_samesite
+ */
+const defaultSameSite = 'None'
+
+/**
+ * Set all cookie params and workspace level cookies that are applicable
+ */
+export function setRequestCookies({
+  example,
+  env,
+  globalCookies,
+  serverUrl,
+  proxyUrl,
+}: {
+  example: RequestExample
+  env: object
+  globalCookies: Cookie[]
+  serverUrl: string
+  proxyUrl?: string
+}): {
+  cookieParams: Cookie[]
+} {
+  const cookieParams: Cookie[] = []
+
+  // Handle domain with or without leading dot
+  const defaultDomain = determineCookieDomain(
+    // TODO: Should we do this in the parent function? We have this logic there anyway.
+    proxyUrl && shouldUseProxy(proxyUrl, serverUrl)
+      ? proxyUrl
+      : (serverUrl ?? 'http://localhost'),
+  )
+
+  // Process local cookies
+  example.parameters.cookies.forEach((c) => {
+    if (c.enabled) {
+      cookieParams.push({
+        uid: c.key,
+        name: c.key,
+        value: replaceTemplateVariables(c.value, env),
+        domain: defaultDomain,
+        path: defaultPath,
+        secure: true,
+        sameSite: defaultSameSite,
+      })
+    }
+  })
+
+  // Process global cookies
+  globalCookies.forEach((c) => {
+    const { name, value, ...params } = c
+
+    // // We only attach global cookies relevant to the current domain
+    // const hasDomainMatch =
+    //   params.domain === defaultDomain ||
+    //   (params.domain?.startsWith('.') && domain.endsWith(params.domain ?? ''))
+
+    // if (hasDomainMatch) {
+    cookieParams.push({
+      uid: name,
+      name,
+      value,
+      // TODO: What’s with params.domain?
+      domain: defaultDomain,
+      path: params.path,
+      // expires: params.expires ? new Date(params.expires) : undefined,
+      // httpOnly: params.httpOnly,
+      secure: params.secure,
+      // TODO: What’s with params.sameSite?
+      sameSite: defaultSameSite,
+    })
+    // }
+  })
+
+  return {
+    cookieParams,
+  }
+}
+
+/**
+ * If the Set-Cookie header does not specify a Domain attribute, the cookies are available on the server that sets it
+ * but not on its subdomains. Therefore, specifying Domain is less restrictive than omitting it.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
+ */
+const determineCookieDomain = (url: string) => {
+  return 'localhost:5065'
+  // const domain = new URL(url).hostname
+  // // TODO: Can’t prefix IPs
+  // return domain.startsWith('.') ? domain : `.${domain}`
+}

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -198,8 +198,10 @@ export const createActiveEntitiesStore = ({
   )
 
   /** Cookie associated with the current route */
-  const activeCookieId = computed(
-    () => activeRouterParams.value[PathId.Cookies],
+  const activeCookieId = computed(() =>
+    activeRouterParams.value[PathId.Cookies] === 'default'
+      ? (activeWorkspace.value?.cookies[0] ?? 'default')
+      : activeRouterParams.value[PathId.Cookies],
   )
 
   /**

--- a/packages/api-client/src/store/cookies.ts
+++ b/packages/api-client/src/store/cookies.ts
@@ -1,4 +1,4 @@
-import { type Cookie, cookieSchema } from '@scalar/oas-utils/entities/cookie'
+import type { Cookie } from '@scalar/oas-utils/entities/cookie'
 import { LS_KEYS } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { reactive } from 'vue'
@@ -12,19 +12,6 @@ export function createStoreCookies(useLocalStorage: boolean) {
     reactive({}),
     useLocalStorage && LS_KEYS.COOKIE,
   )
-
-  // cookieMutators.add(
-  //   cookieSchema.parse({
-  //     uid: 'default',
-  //     name: 'Cookie',
-  //     value: '',
-  //     domain: '',
-  //     path: '/',
-  //     secure: false,
-  //     httpOnly: false,
-  //     sameSite: 'None',
-  //   }),
-  // )
 
   return {
     cookies,

--- a/packages/api-client/src/store/cookies.ts
+++ b/packages/api-client/src/store/cookies.ts
@@ -13,18 +13,18 @@ export function createStoreCookies(useLocalStorage: boolean) {
     useLocalStorage && LS_KEYS.COOKIE,
   )
 
-  cookieMutators.add(
-    cookieSchema.parse({
-      uid: 'default',
-      name: 'Cookie',
-      value: '',
-      domain: '',
-      path: '/',
-      secure: false,
-      httpOnly: false,
-      sameSite: 'None',
-    }),
-  )
+  // cookieMutators.add(
+  //   cookieSchema.parse({
+  //     uid: 'default',
+  //     name: 'Cookie',
+  //     value: '',
+  //     domain: '',
+  //     path: '/',
+  //     secure: false,
+  //     httpOnly: false,
+  //     sameSite: 'None',
+  //   }),
+  // )
 
   return {
     cookies,

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -12,24 +12,8 @@ const fields = [
   { label: 'Name', key: 'name', placeholder: 'session_id' },
   { label: 'Value', key: 'value', placeholder: 'my-cookie-session-id' },
   { label: 'Domain', key: 'domain', placeholder: 'example.com' },
-  { label: 'Path', key: 'path', placeholder: '/' },
-  {
-    label: 'Expires',
-    key: 'expires',
-    placeholder: new Date(Date.now() + 24 * 60 * 60 * 1000).toUTCString(),
-  },
-  {
-    label: 'Secure',
-    key: 'secure',
-    placeholder: 'True/False',
-    type: 'boolean',
-  },
-  {
-    label: 'HttpOnly',
-    key: 'httpOnly',
-    placeholder: 'True/False',
-    type: 'boolean',
-  },
+  // TODO: We don’t check the path (yet), so we don’t need to show it.
+  // { label: 'Path', key: 'path', placeholder: '/' },
 ]
 
 const activeCookie = computed<Cookie>(
@@ -38,7 +22,6 @@ const activeCookie = computed<Cookie>(
       value: '',
       uid: '',
       name: '',
-      sameSite: 'Lax' as const,
     },
 )
 const updateCookie = (key: any, value: any) => {
@@ -53,20 +36,7 @@ const updateCookie = (key: any, value: any) => {
     :onUpdate="updateCookie"
     :options="fields">
     <template #title>
-      <div class="flex items-center pointer-events-none">
-        <label
-          class="absolute border-b w-full h-full top-0 left-0 pointer-events-auto opacity-0 cursor-text"
-          for="cookiename"></label>
-        <input
-          id="cookiename"
-          class="md:pl-1 outline-none border-0 text-c-2 rounded pointer-events-auto relative w-full"
-          placeholder="Cookie Name"
-          :value="activeCookie.name"
-          @input="
-            (event) =>
-              updateCookie('name', (event.target as HTMLInputElement).value)
-          " />
-      </div>
+      <span class="text-c-2">Edit Cookie</span>
     </template>
   </Form>
 </template>

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -19,9 +19,11 @@ const fields = [
 const activeCookie = computed<Cookie>(
   () =>
     cookies[activeCookieId.value as string] || {
-      value: '',
       uid: '',
       name: '',
+      value: '',
+      domain: '',
+      path: '',
     },
 )
 const updateCookie = (key: any, value: any) => {

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -8,14 +8,28 @@ import { computed } from 'vue'
 const { activeCookieId } = useActiveEntities()
 const { cookies, cookieMutators } = useWorkspace()
 
-const options = [
-  { label: 'Key', key: 'key', placeholder: 'Username' },
-  { label: 'Value', key: 'value', placeholder: '123' },
-  { label: 'Domain', key: 'domain', placeholder: 'scalar.com' },
+const fields = [
+  { label: 'Name', key: 'name', placeholder: 'session_id' },
+  { label: 'Value', key: 'value', placeholder: 'my-cookie-session-id' },
+  { label: 'Domain', key: 'domain', placeholder: 'example.com' },
   { label: 'Path', key: 'path', placeholder: '/' },
-  { label: 'Expires', key: 'expires', placeholder: 'Tomorrow' },
-  { label: 'Secure', key: 'secure', placeholder: 'True/False' },
-  { label: 'HttpOnly', key: 'httpOnly', placeholder: 'True/False' },
+  {
+    label: 'Expires',
+    key: 'expires',
+    placeholder: new Date(Date.now() + 24 * 60 * 60 * 1000).toUTCString(),
+  },
+  {
+    label: 'Secure',
+    key: 'secure',
+    placeholder: 'True/False',
+    type: 'boolean',
+  },
+  {
+    label: 'HttpOnly',
+    key: 'httpOnly',
+    placeholder: 'True/False',
+    type: 'boolean',
+  },
 ]
 
 const activeCookie = computed<Cookie>(
@@ -37,7 +51,7 @@ const updateCookie = (key: any, value: any) => {
   <Form
     :data="activeCookie"
     :onUpdate="updateCookie"
-    :options="options">
+    :options="fields">
     <template #title>
       <div class="flex items-center pointer-events-none">
         <label

--- a/packages/api-client/src/views/Cookies/CookieModal.vue
+++ b/packages/api-client/src/views/Cookies/CookieModal.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import CommandActionForm from '@/components/CommandPalette/CommandActionForm.vue'
+import CommandActionInput from '@/components/CommandPalette/CommandActionInput.vue'
+import { type ModalState, ScalarModal } from '@scalar/components'
+import { useToasts } from '@scalar/use-toasts'
+import { ref, watch } from 'vue'
+
+const props = defineProps<{
+  state: ModalState
+}>()
+
+const emit = defineEmits<{
+  (event: 'cancel'): void
+  (
+    event: 'submit',
+    cookieData: {
+      name: string
+      value: string
+      domain: string
+    },
+  ): void
+}>()
+
+const cookieData = ref({
+  name: '',
+  value: '',
+  domain: '',
+})
+
+const { toast } = useToasts()
+
+const handleSubmit = () => {
+  if (
+    !cookieData.value.name ||
+    !cookieData.value.value ||
+    !cookieData.value.domain
+  ) {
+    toast('Please fill in all fields before adding a cookie.', 'error')
+    return
+  }
+
+  emit('submit', cookieData.value)
+  props.state.hide()
+}
+
+// Reset cookie data
+watch(
+  () => props.state.open,
+  (isOpen) => {
+    if (isOpen) {
+      cookieData.value = {
+        name: '',
+        value: '',
+        domain: '',
+      }
+    }
+  },
+)
+</script>
+
+<template>
+  <ScalarModal
+    size="xs"
+    :state="state"
+    title="Add Cookie">
+    <CommandActionForm
+      :disabled="!cookieData.name || !cookieData.value || !cookieData.domain"
+      @cancel="emit('cancel')"
+      @submit="handleSubmit">
+      <div class="flex gap-2 h-8 items-start text-sm">
+        Name:
+        <CommandActionInput
+          v-model="cookieData.name"
+          autofocus
+          class="!p-0"
+          placeholder="session_id" />
+      </div>
+      <div class="flex gap-2 h-8 items-start text-sm">
+        Value:
+        <CommandActionInput
+          v-model="cookieData.value"
+          autofocus
+          class="!p-0"
+          placeholder="my-cookie-session-id" />
+      </div>
+      <div class="flex gap-2 h-8 items-start text-sm">
+        Domain:
+        <CommandActionInput
+          v-model="cookieData.domain"
+          autofocus
+          class="!p-0"
+          placeholder="example.com" />
+      </div>
+      <template #submit>Add Cookie</template>
+    </CommandActionForm>
+  </ScalarModal>
+</template>
+
+<style scoped>
+.form-group {
+  margin-bottom: 1rem;
+}
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+</style>

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -7,11 +7,13 @@ import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
 import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import type { HotKeyEvent } from '@/libs'
 import { useActiveEntities, useWorkspace } from '@/store'
+import { useModal } from '@scalar/components'
 import { type Cookie, cookieSchema } from '@scalar/oas-utils/entities/cookie'
 import { computed, onBeforeUnmount, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import CookieForm from './CookieForm.vue'
+import CookieModal from './CookieModal.vue'
 
 // import CookieRaw from './CookieRaw.vue'
 
@@ -19,13 +21,17 @@ const { cookies, cookieMutators, events, workspaceMutators } = useWorkspace()
 const { activeWorkspace, activeCookieId } = useActiveEntities()
 const router = useRouter()
 const route = useRoute()
+const cookieModal = useModal()
 
-const addCookieHandler = () => {
-  // Create cookie
+const addCookieHandler = (cookieData: {
+  name: string
+  value: string
+  domain: string
+}) => {
   const cookie = cookieSchema.parse({
-    name: '',
-    value: '',
-    domain: '',
+    name: cookieData.name,
+    value: cookieData.value,
+    domain: cookieData.domain,
     path: '/',
   })
 
@@ -73,9 +79,13 @@ const removeCookie = (uid: string) => {
   }
 }
 
+const openCookieModal = () => {
+  cookieModal.show()
+}
+
 const handleHotKey = (event?: HotKeyEvent) => {
   if (event?.createNew && route.name === 'cookies') {
-    addCookieHandler()
+    openCookieModal()
   }
 }
 
@@ -129,7 +139,7 @@ const hasCookies = computed(
       </template>
       <template #button>
         <SidebarButton
-          :click="addCookieHandler"
+          :click="openCookieModal"
           hotkey="N">
           <template #title>Add Cookie</template>
         </SidebarButton>
@@ -143,5 +153,10 @@ const hasCookies = computed(
         <!-- <CookieRaw /> -->
       </template>
     </ViewLayoutContent>
+
+    <CookieModal
+      :state="cookieModal"
+      @cancel="cookieModal.hide()"
+      @submit="addCookieHandler" />
   </ViewLayout>
 </template>

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -16,7 +16,7 @@ import CookieForm from './CookieForm.vue'
 // import CookieRaw from './CookieRaw.vue'
 
 const { cookies, cookieMutators, events, workspaceMutators } = useWorkspace()
-const { activeWorkspace } = useActiveEntities()
+const { activeWorkspace, activeCookieId } = useActiveEntities()
 const router = useRouter()
 const route = useRoute()
 
@@ -44,9 +44,17 @@ const addCookieHandler = () => {
 
 const removeCookie = (uid: string) => {
   cookieMutators.delete(uid)
+
+  // Delete cookie from workspace
+  workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'cookies', [
+    ...(activeWorkspace.value?.cookies ?? []).filter((c) => c !== uid),
+  ])
+
+  // Navigate to the last cookie
   const remainingCookies: Cookie[] = Object.values(cookies).filter(
     (cookie) => (cookie as Cookie).uid !== uid,
   ) as Cookie[]
+
   if (remainingCookies.length > 1) {
     const lastCookie = remainingCookies[remainingCookies.length - 1]
     if (lastCookie) {
@@ -81,7 +89,13 @@ onMounted(() => events.hotKeys.on(handleHotKey))
 /** Unbind keyboard shortcuts */
 onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
 
-const hasCookies = computed(() => Object.keys(cookies).length > 0)
+const activeCookie = computed<Cookie | undefined>(
+  () => cookies[activeCookieId.value],
+)
+
+const hasCookies = computed(
+  () => Object.keys(cookies).length > 0 && activeCookie.value,
+)
 </script>
 <template>
   <ViewLayout>

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -27,9 +27,6 @@ const addCookieHandler = () => {
     value: '',
     domain: '',
     path: '/',
-    secure: true,
-    httpOnly: false,
-    sameSite: 'None',
   })
 
   // Store cookie

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -8,7 +8,7 @@ import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import type { HotKeyEvent } from '@/libs'
 import { useActiveEntities, useWorkspace } from '@/store'
 import { type Cookie, cookieSchema } from '@scalar/oas-utils/entities/cookie'
-import { onBeforeUnmount, onMounted } from 'vue'
+import { computed, onBeforeUnmount, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import CookieForm from './CookieForm.vue'
@@ -83,6 +83,8 @@ const handleNavigation = (event: MouseEvent, uid: string) => {
 onMounted(() => events.hotKeys.on(handleHotKey))
 /** Unbind keyboard shortcuts */
 onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
+
+const hasCookies = computed(() => Object.keys(cookies).length > 0)
 </script>
 <template>
   <ViewLayout>
@@ -119,11 +121,9 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
     </Sidebar>
 
     <ViewLayoutContent class="flex-1">
-      <template v-if="Object.keys(cookies).length > 0">
-        <div class="w-50">
-          {{ cookies }}
-          <CookieForm />
-        </div>
+      <template v-if="hasCookies">
+        <CookieForm />
+        <!--  Untested and disabled for now. -->
         <!-- <CookieRaw /> -->
       </template>
     </ViewLayoutContent>

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -89,14 +89,28 @@ const handleHotKey = (event?: HotKeyEvent) => {
   }
 }
 
+/**
+ * Navigate to specific cookies
+ */
 const handleNavigation = (event: MouseEvent, uid: string) => {
-  // TODO: Use named routes
-  const path = `/workspace/default/cookies/${uid}`
-  if (event.metaKey) {
-    window.open(path, '_blank')
-  } else {
-    router.push({ path })
+  const to = {
+    name: 'cookies',
+    params: {
+      workspace: activeWorkspace.value?.uid ?? 'default',
+      cookies: uid,
+    },
   }
+
+  // Open in new tab if meta key is pressed
+  if (event.metaKey) {
+    const path = router.resolve(to).href
+
+    window.open(path, '_blank')
+
+    return
+  }
+
+  router.push(to)
 }
 
 /** Bind keyboard shortcuts */

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -32,14 +32,19 @@ const addCookieHandler = () => {
   // Store cookie
   cookieMutators.add(cookie)
 
-  // Add cookie to workspace
+  // Attach cookie to workspace
   workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'cookies', [
     ...(activeWorkspace.value?.cookies ?? []),
     cookie.uid,
   ])
 
-  // TODO: Use named routes
-  router.push(cookie.uid)
+  // Redirect to the new cookie
+  router.push({
+    name: 'cookies',
+    params: {
+      cookies: cookie.uid,
+    },
+  })
 }
 
 const removeCookie = (uid: string) => {

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -13,9 +13,14 @@ import { computed, nextTick, onMounted, ref, watch } from 'vue'
 const props = defineProps<{
   title: string
   paramKey: keyof RequestExample['parameters']
+  readOnlyEntries?: {
+    key: string
+    value: string
+    enabled: boolean
+  }[]
 }>()
 
-const { activeRequest, activeExample, activeWorkspace } = useActiveEntities()
+const { activeRequest, activeExample } = useActiveEntities()
 const { requestExampleMutators } = useWorkspace()
 
 const params = computed(
@@ -156,6 +161,10 @@ watch(
   },
   { immediate: true },
 )
+
+const hasReadOnlyEntries = computed(
+  () => (props.readOnlyEntries ?? []).length > 0,
+)
 </script>
 <template>
   <ViewLayoutCollapse
@@ -191,18 +200,15 @@ watch(
       </div>
     </template>
     <div ref="tableWrapperRef">
-      <!-- {{ activeWorkspace?.cookies }} -->
+      <!-- Read-only entries pinned to the top -->
       <RequestTable
+        v-if="hasReadOnlyEntries"
         class="flex-1"
         :columns="['32px', '', '']"
-        global
-        :items="[
-          {
-            key: 'globalCOokie',
-            value: 'foobar',
-            enabled: true,
-          },
-        ]" />
+        isGlobal
+        isReadOnly
+        :items="readOnlyEntries" />
+      <!-- Dynamic entries -->
       <RequestTable
         class="flex-1"
         :columns="['32px', '', '']"

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -9,6 +9,7 @@ import {
   requestExampleParametersSchema,
 } from '@scalar/oas-utils/entities/spec'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
 
 const props = defineProps<{
   title: string
@@ -17,6 +18,7 @@ const props = defineProps<{
     key: string
     value: string
     enabled: boolean
+    route: RouteLocationRaw
   }[]
 }>()
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
   paramKey: keyof RequestExample['parameters']
 }>()
 
-const { activeRequest, activeExample } = useActiveEntities()
+const { activeRequest, activeExample, activeWorkspace } = useActiveEntities()
 const { requestExampleMutators } = useWorkspace()
 
 const params = computed(
@@ -181,7 +181,7 @@ watch(
           </template>
           <template #content>
             <div
-              class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 z-context p-2 text-xxs leading-5 z-10 text-c-1">
+              class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 p-2 text-xxs leading-5 z-10 text-c-1">
               <div class="flex items-center text-c-2">
                 <span>Clear optional parameters</span>
               </div>
@@ -191,6 +191,18 @@ watch(
       </div>
     </template>
     <div ref="tableWrapperRef">
+      <!-- {{ activeWorkspace?.cookies }} -->
+      <RequestTable
+        class="flex-1"
+        :columns="['32px', '', '']"
+        global
+        :items="[
+          {
+            key: 'globalCOokie',
+            value: 'foobar',
+            enabled: true,
+          },
+        ]" />
       <RequestTable
         class="flex-1"
         :columns="['32px', '', '']"

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -76,7 +76,7 @@ const updateRequestNameHandler = (event: Event) => {
         <input
           v-if="!isReadOnly"
           id="requestname"
-          class="text-c-1 rounded pointer-events-auto relative w-full pl-1.25 -ml-0.5 md:-ml-1.25 has-[:focus-visible]:outline h-8 group-hover-input has-[:focus-visible]:outline z-10"
+          class="text-c-1 rounded pointer-events-auto relative w-full pl-1.25 -ml-0.5 md:-ml-1.25 h-8 group-hover-input has-[:focus-visible]:outline z-10"
           placeholder="Request Name"
           :value="activeRequest?.summary"
           @input="updateRequestNameHandler" />
@@ -107,6 +107,7 @@ const updateRequestNameHandler = (event: Event) => {
         title="Variables" />
       <RequestParams
         v-show="activeSection === 'All' || activeSection === 'Cookies'"
+        globalParamKey="globalCookies"
         paramKey="cookies"
         title="Cookies" />
       <RequestParams

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -83,6 +83,12 @@ const activeWorkspaceCookies = computed(() =>
     .map((cookie) => ({
       key: cookie.name,
       value: cookie.value,
+      route: {
+        name: 'cookies',
+        params: {
+          cookies: cookie.uid,
+        },
+      },
       enabled: true,
     })),
 )

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -89,7 +89,6 @@ const activeWorkspaceCookies = computed(() =>
 <template>
   <ViewLayoutSection :aria-label="`Request: ${activeRequest?.summary}`">
     <template #title>
-      url: {{ activeServer?.url }} path: {{ activeRequest?.path }}
       <div
         class="flex-1 flex gap-1 items-center lg:pr-24 pointer-events-none group">
         <label

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -73,6 +73,7 @@ const activeWorkspaceCookies = computed(() =>
   (activeWorkspace.value?.cookies ?? [])
     .map((uid) => cookies[uid])
     .filter(isDefined)
+    .filter((cookie) => cookie.name)
     .filter((cookie) =>
       matchesDomain(
         activeServer?.value?.url || activeRequest.value?.path,

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -7,13 +7,14 @@ import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
 import { computed } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
 
 import { hasItemProperties } from '../libs/request'
 import RequestTableTooltip from './RequestTableTooltip.vue'
 
 withDefaults(
   defineProps<{
-    items?: RequestExampleParameter[]
+    items?: RequestExampleParameter[] & { route?: RouteLocationRaw }
     /** Disable the checkbox */
     hasCheckboxDisabled?: boolean
     showUploadButton?: boolean
@@ -83,7 +84,9 @@ const flattenValue = (item: RequestExampleParameter) => {
       :key="item.key">
       <label class="contents">
         <template v-if="isGlobal">
-          <div class="!border-r-1/2 border-t-1/2 flex-center text-c-2">
+          <RouterLink
+            class="!border-r-1/2 border-t-1/2 text-c-2 flex justify-center items-center"
+            :to="item.route">
             <span class="sr-only">Global</span>
             <ScalarTooltip
               as="div"
@@ -105,7 +108,7 @@ const flattenValue = (item: RequestExampleParameter) => {
                 </div>
               </template>
             </ScalarTooltip>
-          </div>
+          </RouterLink>
         </template>
         <template v-else>
           <span class="sr-only">

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -90,7 +90,6 @@ const flattenValue = (item: RequestExampleParameter) => {
             <span class="sr-only">Global</span>
             <ScalarTooltip
               as="div"
-              class="z-[10001]"
               side="top">
               <template #trigger>
                 <ScalarIcon

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -4,22 +4,28 @@ import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableCell from '@/components/DataTable/DataTableCell.vue'
 import DataTableCheckbox from '@/components/DataTable/DataTableCheckbox.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
-import { ScalarButton, ScalarIcon } from '@scalar/components'
+import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
 import { computed } from 'vue'
 
 import { hasItemProperties } from '../libs/request'
 import RequestTableTooltip from './RequestTableTooltip.vue'
 
-const props = withDefaults(
+withDefaults(
   defineProps<{
     items?: RequestExampleParameter[]
     /** Disable the checkbox */
     hasCheckboxDisabled?: boolean
     showUploadButton?: boolean
-    global?: boolean
+    isGlobal?: boolean
+    isReadOnly?: boolean
   }>(),
-  { hasCheckboxDisabled: false, showUploadButton: false, global: false },
+  {
+    hasCheckboxDisabled: false,
+    showUploadButton: false,
+    isGlobal: false,
+    isReadOnly: false,
+  },
 )
 
 const emit = defineEmits<{
@@ -67,10 +73,6 @@ const flattenValue = (item: RequestExampleParameter) => {
     ? item.default[0]
     : item.default
 }
-
-const isReadOnly = computed(() => {
-  return props.global
-})
 </script>
 <template>
   <DataTable
@@ -80,18 +82,35 @@ const isReadOnly = computed(() => {
       v-for="(item, idx) in items"
       :key="item.key">
       <label class="contents">
-        <template v-if="isReadOnly">
-          <span class="sr-only">Global</span>
-          <div class="flex-center">
-            <!-- TODO: Add a tooltip -->
-            <!-- TODO: Make fields read-only -->
-            <ScalarIcon
-              icon="Globe"
-              size="xs" />
+        <template v-if="isGlobal">
+          <div class="!border-r-1/2 border-t-1/2 flex-center text-c-2">
+            <span class="sr-only">Global</span>
+            <ScalarTooltip
+              as="div"
+              class="z-[10001]"
+              side="top">
+              <template #trigger>
+                <ScalarIcon
+                  icon="Globe"
+                  size="xs" />
+              </template>
+              <template #content>
+                <div
+                  class="grid gap-1.5 pointer-events-none max-w-[320px] w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
+                  <div class="flex items-center text-c-2">
+                    <span class="text-pretty">
+                      Global cookies are shared across the whole workspace.
+                    </span>
+                  </div>
+                </div>
+              </template>
+            </ScalarTooltip>
           </div>
         </template>
         <template v-else>
-          <span class="sr-only">Row Enabled</span>
+          <span class="sr-only">
+            Row {{ item.enabled ? 'Enabled' : 'Disabled' }}
+          </span>
           <DataTableCheckbox
             class="!border-r-1/2"
             :disabled="hasCheckboxDisabled"
@@ -102,6 +121,7 @@ const isReadOnly = computed(() => {
       <DataTableCell>
         <CodeInput
           disableCloseBrackets
+          :disabled="isReadOnly"
           disableEnter
           disableTabIndent
           :modelValue="item.key"
@@ -121,6 +141,7 @@ const isReadOnly = computed(() => {
           }"
           :default="item.default"
           disableCloseBrackets
+          :disabled="isReadOnly"
           disableEnter
           disableTabIndent
           :enum="item.enum"

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -14,8 +14,8 @@ import RequestTableTooltip from './RequestTableTooltip.vue'
 
 withDefaults(
   defineProps<{
-    items?: RequestExampleParameter[] & { route?: RouteLocationRaw }
-    /** Disable the checkbox */
+    items?: (RequestExampleParameter & { route?: RouteLocationRaw })[]
+    /** Hide the enabled column */
     hasCheckboxDisabled?: boolean
     showUploadButton?: boolean
     isGlobal?: boolean
@@ -86,7 +86,7 @@ const flattenValue = (item: RequestExampleParameter) => {
         <template v-if="isGlobal">
           <RouterLink
             class="!border-r-1/2 border-t-1/2 text-c-2 flex justify-center items-center"
-            :to="item.route">
+            :to="item.route ?? {}">
             <span class="sr-only">Global</span>
             <ScalarTooltip
               as="div"

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -11,14 +11,15 @@ import { computed } from 'vue'
 import { hasItemProperties } from '../libs/request'
 import RequestTableTooltip from './RequestTableTooltip.vue'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     items?: RequestExampleParameter[]
     /** Disable the checkbox */
     hasCheckboxDisabled?: boolean
     showUploadButton?: boolean
+    global?: boolean
   }>(),
-  { hasCheckboxDisabled: false, showUploadButton: false },
+  { hasCheckboxDisabled: false, showUploadButton: false, global: false },
 )
 
 const emit = defineEmits<{
@@ -66,6 +67,10 @@ const flattenValue = (item: RequestExampleParameter) => {
     ? item.default[0]
     : item.default
 }
+
+const isReadOnly = computed(() => {
+  return props.global
+})
 </script>
 <template>
   <DataTable
@@ -75,12 +80,24 @@ const flattenValue = (item: RequestExampleParameter) => {
       v-for="(item, idx) in items"
       :key="item.key">
       <label class="contents">
-        <span class="sr-only">Row Enabled</span>
-        <DataTableCheckbox
-          class="!border-r-1/2"
-          :disabled="hasCheckboxDisabled"
-          :modelValue="item.enabled"
-          @update:modelValue="(v) => emit('toggleRow', idx, v)" />
+        <template v-if="isReadOnly">
+          <span class="sr-only">Global</span>
+          <div class="flex-center">
+            <!-- TODO: Add a tooltip -->
+            <!-- TODO: Make fields read-only -->
+            <ScalarIcon
+              icon="Globe"
+              size="xs" />
+          </div>
+        </template>
+        <template v-else>
+          <span class="sr-only">Row Enabled</span>
+          <DataTableCheckbox
+            class="!border-r-1/2"
+            :disabled="hasCheckboxDisabled"
+            :modelValue="item.enabled"
+            @update:modelValue="(v) => emit('toggleRow', idx, v)" />
+        </template>
       </label>
       <DataTableCell>
         <CodeInput

--- a/packages/api-client/vite.config.ts
+++ b/packages/api-client/vite.config.ts
@@ -24,6 +24,12 @@ export default defineConfig({
   },
   server: {
     port: 5065,
+    /**
+     * We proxy requests to void.scalar.com to test same-domain cookies.
+     */
+    proxy: {
+      '/void': 'https://void.scalar.com',
+    },
   },
   build: createViteBuildOptions({
     entry: await findEntryPoints({ allowCss: true }),

--- a/packages/oas-utils/src/entities/cookie/cookie.ts
+++ b/packages/oas-utils/src/entities/cookie/cookie.ts
@@ -5,42 +5,12 @@ import { nanoidSchema } from '../shared'
 export const cookieSchema = z.object({
   uid: nanoidSchema,
   /**  Defines the cookie name and its value. A cookie definition begins with a name-value pair.  */
-  name: z.string().default('Default Cookie'),
-  value: z.string().default('Default Value'),
+  name: z.string().default(''),
+  value: z.string().default(''),
   /** Defines the host to which the cookie will be sent. */
   domain: z.string().optional(),
-  /** Indicates the maximum lifetime of the cookie as an HTTP-date timestamp. See Date for the required formatting. */
-  expires: z.date().optional(),
-  /**
-   * Forbids JavaScript from accessing the cookie, for example, through the Document.cookie property. Note that a cookie
-   * that has been created with HttpOnly will still be sent with JavaScript-initiated requests, for example, when
-   * calling XMLHttpRequest.send() or fetch(). This mitigates attacks against cross-site scripting (XSS).
-   */
-  httpOnly: z.boolean().optional(),
-  /**
-   * Indicates the number of seconds until the cookie expires. A zero or negative number will expire the cookie
-   * immediately. If both Expires and Max-Age are set, Max-Age has precedence.
-   */
-  maxAge: z.number().optional(),
-  /**
-   * Indicates that the cookie should be stored using partitioned storage. See Cookies Having Independent Partitioned
-   * State (CHIPS) for more details.
-   */
-  partitioned: z.boolean().optional(),
   /** Indicates the path that must exist in the requested URL for the browser to send the Cookie header. */
   path: z.string().optional(),
-  /**
-   * Controls whether or not a cookie is sent with cross-site requests, providing some protection against cross-site
-   * request forgery attacks (CSRF).
-   */
-  sameSite: z
-    .union([z.literal('Lax'), z.literal('Strict'), z.literal('None')])
-    .default('None'),
-  /**
-   * Indicates that the cookie is sent to the server only when a request is made with the https: scheme (except on
-   * localhost), and therefore, is more resistant to man-in-the-middle attacks.
-   */
-  secure: z.boolean().optional(),
 })
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,9 +556,6 @@ importers:
       fuse.js:
         specifier: ^7.0.0
         version: 7.0.0
-      js-cookie:
-        specifier: ^3.0.5
-        version: 3.0.5
       microdiff:
         specifier: ^1.4.0
         version: 1.4.0
@@ -596,9 +593,6 @@ importers:
       '@scalar/galaxy':
         specifier: workspace:*
         version: link:../galaxy
-      '@types/js-cookie':
-        specifier: ^3.0.6
-        version: 3.0.6
       '@types/shell-quote':
         specifier: ^1.7.5
         version: 1.7.5
@@ -7536,9 +7530,6 @@ packages:
 
   '@types/jest@29.5.12':
     resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
-
-  '@types/js-cookie@3.0.6':
-    resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
 
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
@@ -25872,8 +25863,6 @@ snapshots:
     dependencies:
       expect: 29.7.0
       pretty-format: 29.7.0
-
-  '@types/js-cookie@3.0.6': {}
 
   '@types/jsdom@21.1.7':
     dependencies:


### PR DESCRIPTION
**Problem**
Currently, cookies don’t work at all. 🫨

**Solution**
With this PR cookies work. :) This is what changed:

* The cookie name for global cookies is stored.
* The cookie attributes that only the server can set are removed (expires, httpsonly, secure …).
* The global cookies are available in the request. 💥 
* The sidebar on the global cookie page is just a list now (the collapsing/expanding was broken).
* Global cookies are rendered as read-only in the list of request cookies (if they’ll be added to the request).
* The proxy can forward a custom `X-Scalar-Cookie` as a `Cookie` header (to circumvent browser policies).
* Cookie authentication works.
* When I click on the global cookie in the request view, I’m redirected to the cookie form.
* The commands “Add Cookie” and “Add Environment” work again.
* Cookies are only added to the request when the configured domain matches.
* Cookies use environment variables now.

Fixes #3701 
See #3220

**Testing**

The proxy isn’t rolled out. So if you want to test it, you need to spin up the local proxy `pnpm dev:proxy-server` and point your playground to it.

**Preview**

<img width="890" alt="Screenshot 2025-01-17 at 16 49 59" src="https://github.com/user-attachments/assets/184b96a2-8a1d-4a2b-8af6-d286d40f0aa3" />

<img width="1122" alt="Screenshot 2025-01-17 at 16 49 50" src="https://github.com/user-attachments/assets/8f4c3e9d-1e04-4409-8029-ccaac0e26a65" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.