### PR TITLE
fix(Scalar.AspNetCore): support aot case

### DIFF
--- a/.changeset/five-cups-destroy.md
+++ b/.changeset/five-cups-destroy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+fix: Regex in AOT

--- a/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Books/Book.cs
+++ b/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Books/Book.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Scalar.AspNetCore.Playground.Books;
 
 internal sealed class Book
@@ -10,3 +12,7 @@ internal sealed class Book
 
     public required int Pages { get; set; }
 }
+
+[JsonSerializable(typeof(IEnumerable<Book>))]
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class BookSerializerContext : JsonSerializerContext;

--- a/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Books/BookEndpoints.cs
+++ b/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Books/BookEndpoints.cs
@@ -21,7 +21,7 @@ internal static class BookEndpoints
 
         books
             .MapGet("/", ([FromServices] BookStore bookStore) => bookStore.GetAll())
-            .Produces<Book[]>();
+            .Produces<IEnumerable<Book>>();
 
         books
             .MapGet("/{bookId:guid}", ([FromServices] BookStore bookStore, Guid bookId) =>

--- a/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
+++ b/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
@@ -4,8 +4,13 @@ using Scalar.AspNetCore.Playground;
 using Scalar.AspNetCore.Playground.Books;
 using Scalar.AspNetCore.Playground.Extensions;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateSlimBuilder(args);
 builder.Services.AddSingleton<BookStore>();
+
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Add(BookSerializerContext.Default);
+});
 
 builder.Services.AddApiWeaver(options =>
 {

--- a/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Properties/launchSettings.json
+++ b/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Properties/launchSettings.json
@@ -1,12 +1,12 @@
 ﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "https": {
+    "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "scalar",
-      "applicationUrl": "https://localhost:7201;http://localhost:5056",
+      "applicationUrl": "http://localhost:5056",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj
+++ b/packages/scalar.aspnetcore/playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <PublishAot>true</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="APIWeaver.OpenApi" Version="2.7.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="Bogus" Version="35.6.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -65,7 +65,19 @@ public static class ScalarOptionsExtensions
     /// <remarks>This feature will be public once we support multiple OpenAPI documents.</remarks>
     internal static ScalarOptions WithDocumentNamesProvider(this ScalarOptions options, Func<HttpContext, IEnumerable<string>> provider)
     {
-        options.DocumentNamesProvider = context => Task.FromResult(provider(context));
+        options.DocumentNamesProvider = (context, _) => Task.FromResult(provider(context));
+        return options;
+    }
+    
+    /// <summary>
+    /// Sets a async document names provider.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="provider">The async function to provide document names.</param>
+    /// <remarks>This feature will be public once we support multiple OpenAPI documents.</remarks>
+    internal static ScalarOptions WithDocumentNamesProvider(this ScalarOptions options, Func<HttpContext, CancellationToken, Task<IEnumerable<string>>> provider)
+    {
+        options.DocumentNamesProvider = provider;
         return options;
     }
 
@@ -77,7 +89,7 @@ public static class ScalarOptionsExtensions
     /// <remarks>This feature will be public once we support multiple OpenAPI documents.</remarks>
     internal static ScalarOptions WithDocumentNamesProvider(this ScalarOptions options, Func<HttpContext, Task<IEnumerable<string>>> provider)
     {
-        options.DocumentNamesProvider = provider;
+        options.DocumentNamesProvider = (context, _) => provider.Invoke(context);
         return options;
     }
 

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -16,7 +16,7 @@ public sealed class ScalarOptions
     /// </summary>
     /// <value>A function that returns an <see cref="IEnumerable{T}" /> of document names.</value>
     /// <remarks>This feature will be public once we support multiple OpenAPI documents. If this property is set, the <see cref="DocumentNames" /> property will be ignored.</remarks>
-    internal Func<HttpContext, Task<IEnumerable<string>>>? DocumentNamesProvider { get; set; }
+    internal Func<HttpContext, CancellationToken, Task<IEnumerable<string>>>? DocumentNamesProvider { get; set; }
 
     /// <summary>
     /// Metadata title.

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -15,8 +15,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="FluentAssertions" Version="7.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Program.cs
+++ b/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Program.cs
@@ -1,6 +1,6 @@
 using Scalar.AspNetCore;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateSlimBuilder(args);
 
 builder.Services.AddOpenApi();
 

--- a/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj
+++ b/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\..\src\Scalar.AspNetCore\Scalar.AspNetCore.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Scalar.AspNetCore\Scalar.AspNetCore.csproj"/>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #4490 

**Problem**
With the last major release, we used a regex pattern for handling static assets. However, regex requires additional route policies, which may not exist in AOT (Ahead-Of-Time) compilation scenarios, causing the API to stop working.

**Solution**
In this PR, I have simplified the solution by moving away from using regex pattern. Since we only have two static assets, I have created two dedicated endpoints instead of one with a regex pattern.

**Others**
- Updated some dependencies
- Updated the playground to an AOT API
- Passing a `CancellationToken` to the `DocumentNamesProvider`. This is 💯% internal and not part of the public API.


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] ~I’ve updated the documentation.~ 👀 
