### PR TITLE
fix(api-reference): pressing enter in the password input causes the page refresh

### DIFF
--- a/.changeset/unlucky-fireants-hope.md
+++ b/.changeset/unlucky-fireants-hope.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: prevent hitting enter in auth from refreshing page

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -36,7 +36,7 @@ watch(
 )
 </script>
 <template>
-  <form>
+  <form @submit.prevent>
     <div
       v-if="selectedSecuritySchemeUids.length > 1"
       class="border-t flex px-3 flex-wrap gap-x-2.5 overflow-hidden">


### PR DESCRIPTION
fixes #4449

**Problem**
Hitting enter in the auth input in references refreshes the page

**Solution**
We prevent on submit

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
