### PR TITLE
fix(api-reference): complex security requirements

### DIFF
--- a/.changeset/thick-poets-design.md
+++ b/.changeset/thick-poets-design.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: add back complex security requirements

--- a/packages/api-client/src/libs/send-request/create-fetch-auth.test.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-auth.test.ts
@@ -172,6 +172,43 @@ describe('authentication', () => {
     ).toEqual('Bearer YOUR_SECRET_TOKEN')
   })
 
+  it('handles complex auth', async () => {
+    const [error, requestOperation] = createRequestOperation({
+      ...createRequestPayload({
+        serverPayload: { url: VOID_URL },
+      }),
+      securitySchemes: {
+        'api-key': {
+          type: 'apiKey',
+          name: 'api_key',
+          in: 'query',
+          value: 'xxxx',
+          uid: 'api-key',
+          nameKey: 'api_key',
+        },
+        'bearer-auth': {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'Bearer',
+          username: '',
+          password: '',
+          uid: 'bearer-auth',
+          nameKey: 'Authorization',
+          token: 'xxxx',
+        },
+      },
+      selectedSecuritySchemeUids: [['bearer-auth', 'api-key']],
+    })
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    const parsed = JSON.parse(result?.response.data as string)
+    expect(parsed.headers.authorization).toEqual('Bearer xxxx')
+    expect(parsed.query.api_key).toEqual('xxxx')
+  })
+
   it('adds oauth2 token header', async () => {
     const [error, requestOperation] = createRequestOperation({
       ...createRequestPayload({

--- a/packages/api-client/src/libs/send-request/send-request.ts
+++ b/packages/api-client/src/libs/send-request/send-request.ts
@@ -9,8 +9,7 @@ import { replaceTemplateVariables } from '@/libs/string-template'
 import { textMediaTypes } from '@/views/Request/consts'
 import type { Cookie } from '@scalar/oas-utils/entities/cookie'
 import type {
-  /** Renamed due to conflict with the global Request class */
-  Request as HarRequest,
+  Operation,
   RequestExample,
   RequestMethod,
   ResponseInstance,
@@ -171,25 +170,25 @@ const EMPTY_TOKEN_PLACEHOLDER = 'YOUR_SECRET_TOKEN'
 
 /** Execute the request */
 export const createRequestOperation = ({
-  request,
+  environment,
   example,
-  server,
+  globalCookies,
+  proxyUrl,
+  request,
   securitySchemes,
   selectedSecuritySchemeUids = [],
-  proxyUrl,
+  server,
   status,
-  environment,
-  globalCookies,
 }: {
-  request: HarRequest
-  example: RequestExample
-  selectedSecuritySchemeUids?: string[]
-  proxyUrl?: string
-  status?: EventBus<RequestStatus>
   environment: object | undefined
-  server?: Server
-  securitySchemes: Record<string, SecurityScheme>
+  example: RequestExample
   globalCookies: Cookie[]
+  proxyUrl?: string
+  request: Operation
+  securitySchemes: Record<string, SecurityScheme>
+  selectedSecuritySchemeUids?: Operation['selectedSecuritySchemeUids']
+  server?: Server
+  status?: EventBus<RequestStatus>
 }): ErrorResponse<{
   controller: AbortController
   sendRequest: () => SendRequestResponse
@@ -240,8 +239,11 @@ export const createRequestOperation = ({
       proxyUrl,
     })
 
+    // We flatten the array of arrays for complex auth
+    const flatSelectedSecuritySchemeUids = selectedSecuritySchemeUids.flat()
+
     // Populate all forms of auth to the request segments
-    selectedSecuritySchemeUids?.forEach((uid) => {
+    flatSelectedSecuritySchemeUids?.forEach((uid) => {
       const scheme = securitySchemes[uid]
       if (!scheme) return
 

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -270,6 +270,8 @@ export const ACTIVE_ENTITIES_SYMBOL =
  *
  * This store returns anything related to the currently active entities
  * The only reason this is a store and not a simple hook is due to storing the current router here
+ *
+ * @deprecated due to components being used outside of the client now, we should prop drill instead of this hook/store
  */
 export const useActiveEntities = (): ActiveEntitiesStore => {
   const store = inject(ACTIVE_ENTITIES_SYMBOL)

--- a/packages/api-client/src/store/security-schemes.ts
+++ b/packages/api-client/src/store/security-schemes.ts
@@ -76,11 +76,16 @@ export function extendedSecurityDataFactory({
         )
       }
       // Remove from any requests that have it selected
-      if (r.selectedSecuritySchemeUids.includes(schemeUid))
+      if (r.selectedSecuritySchemeUids.flat().includes(schemeUid))
         requestMutators.edit(
           r.uid,
           'selectedSecuritySchemeUids',
-          r.selectedSecuritySchemeUids?.filter((uid) => uid !== schemeUid),
+          r.selectedSecuritySchemeUids?.filter((uid) => {
+            if (Array.isArray(uid)) {
+              return !uid.includes(schemeUid)
+            }
+            return uid !== schemeUid
+          }),
         )
     })
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/DeleteRequestAuthModal.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/DeleteRequestAuthModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useWorkspace } from '@/store'
+import { useWorkspace } from '@/store/store'
 import { ScalarButton, ScalarModal } from '@scalar/components'
 
 const props = defineProps<{

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.test.ts
@@ -1,0 +1,150 @@
+import {
+  type Collection,
+  collectionSchema,
+  requestSchema,
+  serverSchema,
+} from '@scalar/oas-utils/entities/spec'
+import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import RequestAuth from './RequestAuth.vue'
+
+const securitySchemeMutators = {
+  add: vi.fn(),
+  edit: vi.fn(),
+}
+const requestMutators = {
+  edit: vi.fn(),
+}
+const collectionMutators = {
+  edit: vi.fn(),
+}
+
+// Mock useWorkspace
+vi.mock('@/store/store', () => ({
+  useWorkspace: () => ({
+    securitySchemes: {
+      'bearer-auth': {
+        uid: 'bearer-auth',
+        type: 'http',
+        nameKey: 'bearerAuth',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        username: 'user',
+        password: 'pass',
+        token: '123456',
+      },
+      'api-key': {
+        uid: 'api-key',
+        type: 'apiKey',
+        nameKey: 'apiKeyAuth',
+        in: 'header',
+        value: '123456',
+      },
+      'basic-auth': {
+        uid: 'basic-auth',
+        type: 'http',
+        scheme: 'basic',
+        nameKey: 'basicAuth',
+        bearerFormat: 'JWT',
+        username: 'user',
+        password: 'pass',
+        token: '123456',
+      },
+    },
+    collectionMutators,
+    requestMutators,
+    securitySchemeMutators,
+  }),
+}))
+
+describe('RequestAuth.vue', () => {
+  const createBaseProps = () =>
+    ({
+      collection: collectionSchema.parse({
+        uid: 'test-collection',
+        securitySchemes: ['bearer-auth', 'api-key-auth', 'basic-auth'],
+        security: [{ bearerAuth: [] }, { apiKeyAuth: [] }, { basicAuth: [] }],
+      }),
+      operation: requestSchema.parse({
+        uid: 'test-operation',
+        security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
+      }),
+      selectedSecuritySchemeUids: [] as Collection['securitySchemes'],
+      server: serverSchema.parse({
+        url: 'https://api.example.com',
+      }),
+      title: 'Authentication',
+      layout: 'client',
+      workspace: workspaceSchema.parse({
+        uid: 'test-workspace',
+        proxyUrl: 'https://proxy.scalar.com',
+      }),
+    }) as const
+
+  it('renders the basics', async () => {
+    const wrapper = mount(RequestAuth, {
+      props: createBaseProps(),
+    })
+
+    expect(wrapper.text()).toContain('Authentication')
+    expect(wrapper.text()).toContain('Required')
+    expect(wrapper.text()).toContain('Auth Type')
+    expect(wrapper.text()).toContain('No authentication selected')
+  })
+
+  it('calls correct mutator when selecting auth scheme', async () => {
+    const wrapper = mount(RequestAuth, {
+      props: createBaseProps(),
+    })
+
+    // Find and click the combobox
+    const dropdownButton = wrapper
+      .findAll('button')
+      .filter((node) => node.text() === 'Auth Type')
+      .at(0)
+    expect(dropdownButton?.text()).toContain('Auth Type')
+    await dropdownButton?.trigger('click')
+
+    // Select a security scheme
+    const option = wrapper
+      .findAll('li')
+      .filter((node) => node.text() === 'bearerAuth')
+      .at(0)
+    expect(option?.text()).toContain('bearerAuth')
+    await option?.trigger('click')
+
+    // Verify mutation
+    expect(requestMutators.edit).toHaveBeenCalledWith(
+      'test-operation',
+      'selectedSecuritySchemeUids',
+      ['bearer-auth'],
+    )
+  })
+
+  it('shows optional status when security is optional', async () => {
+    const props = createBaseProps()
+    props.operation.security = [{}]
+
+    const wrapper = mount(RequestAuth, {
+      props,
+    })
+
+    expect(wrapper.text()).toContain('Optional')
+  })
+
+  it('displays multiple when multiple schemes are selected', async () => {
+    const props = {
+      ...createBaseProps(),
+      selectedSecuritySchemeUids: ['bearer-auth', 'api-key'],
+    }
+
+    const wrapper = mount(RequestAuth, {
+      props,
+    })
+
+    expect(wrapper.text()).toContain('Multiple')
+    expect(wrapper.text()).toContain('Bearer Token')
+  })
+})

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -1,22 +1,31 @@
 <script setup lang="ts">
 import { DataTableCell, DataTableRow } from '@/components/DataTable'
-import { useWorkspace } from '@/store'
-import type { SecurityScheme } from '@scalar/oas-utils/entities/spec'
+import { useWorkspace } from '@/store/store'
+import type { Workspace } from '@scalar/oas-utils/entities'
+import type {
+  Collection,
+  SecurityScheme,
+  Server,
+} from '@scalar/oas-utils/entities/spec'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import { capitalize, computed, ref } from 'vue'
 
 import OAuth2 from './OAuth2.vue'
 import RequestAuthDataTableInput from './RequestAuthDataTableInput.vue'
 
-const { selectedSecuritySchemeUids, layout } = defineProps<{
-  selectedSecuritySchemeUids: string[]
-  layout: 'client' | 'reference'
-}>()
+const { collection, layout, securitySchemeUids, server, workspace } =
+  defineProps<{
+    collection: Collection
+    layout: 'client' | 'reference'
+    securitySchemeUids: string[]
+    server: Server | undefined
+    workspace: Workspace
+  }>()
 
 const { securitySchemes, securitySchemeMutators } = useWorkspace()
 
 const security = computed(() =>
-  selectedSecuritySchemeUids.map((uid) => ({
+  securitySchemeUids.map((uid) => ({
     scheme: securitySchemes[uid],
   })),
 )
@@ -167,8 +176,11 @@ const updateScheme = <U extends string, P extends Path<SecurityScheme>>(
         :key="key">
         <OAuth2
           v-if="activeFlow === key || (ind === 0 && !activeFlow)"
+          :collection="collection"
           :flow="flow!"
-          :scheme="scheme" />
+          :scheme="scheme"
+          :server="server"
+          :workspace="workspace" />
       </template>
     </template>
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -8,17 +8,23 @@ import { useActiveEntities } from '@/store/active-entities'
 import RequestBody from '@/views/Request/RequestSection/RequestBody.vue'
 import RequestParams from '@/views/Request/RequestSection/RequestParams.vue'
 import RequestPathParams from '@/views/Request/RequestSection/RequestPathParams.vue'
+import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
 import { canMethodHaveBody, isDefined } from '@scalar/oas-utils/helpers'
 import { computed, ref, watch } from 'vue'
 
 import RequestAuth from './RequestAuth/RequestAuth.vue'
 
 defineProps<{
-  selectedSecuritySchemeUids: string[]
+  selectedSecuritySchemeUids: SelectedSecuritySchemeUids
 }>()
 
-const { activeRequest, activeExample, activeWorkspace, activeServer } =
-  useActiveEntities()
+const {
+  activeRequest,
+  activeCollection,
+  activeExample,
+  activeWorkspace,
+  activeServer,
+} = useActiveEntities()
 const { requestMutators, cookies } = useWorkspace()
 const { layout } = useLayout()
 
@@ -124,12 +130,17 @@ const activeWorkspaceCookies = computed(() =>
     </template>
     <div class="request-section-content custom-scroll flex flex-1 flex-col">
       <RequestAuth
+        v-if="activeCollection && activeWorkspace"
         v-show="
           !isAuthHidden && (activeSection === 'All' || activeSection === 'Auth')
         "
+        :collection="activeCollection"
         layout="client"
+        :operation="activeRequest"
         :selectedSecuritySchemeUids="selectedSecuritySchemeUids"
-        title="Authentication" />
+        :server="activeServer"
+        title="Authentication"
+        :workspace="activeWorkspace" />
       <RequestPathParams
         v-show="
           (activeSection === 'All' || activeSection === 'Variables') &&

--- a/packages/api-client/src/views/Request/libs/auth.test.ts
+++ b/packages/api-client/src/views/Request/libs/auth.test.ts
@@ -1,0 +1,302 @@
+import {
+  ADD_AUTH_OPTIONS,
+  type SecuritySchemeGroup,
+} from '@/views/Request/consts'
+import type { Collection, Request } from '@scalar/oas-utils/entities/spec'
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatComplexScheme,
+  formatScheme,
+  getSchemeOptions,
+  getSecurityRequirements,
+} from './auth'
+
+const securitySchemes = {
+  apiKeyUid: {
+    type: 'apiKey',
+    nameKey: 'apiKey',
+    uid: 'apiKeyUid',
+  },
+  basicUid: {
+    type: 'http',
+    nameKey: 'basic',
+    uid: 'basicUid',
+  },
+  oauth2Uid: {
+    type: 'oauth2',
+    nameKey: 'oauth2',
+    uid: 'oauth2Uid',
+  },
+} as const
+
+describe('auth utilities', () => {
+  describe('formatScheme', () => {
+    it('formats regular security scheme', () => {
+      const scheme = {
+        uid: 'auth1',
+        type: 'http',
+        nameKey: 'Basic Auth',
+      } as const
+
+      expect(formatScheme(scheme)).toEqual({
+        id: 'auth1',
+        label: 'Basic Auth',
+      })
+    })
+
+    it('adds "coming soon" to openIdConnect schemes', () => {
+      const scheme = {
+        uid: 'auth2',
+        type: 'openIdConnect',
+        nameKey: 'OAuth',
+      } as const
+
+      expect(formatScheme(scheme)).toEqual({
+        id: 'auth2',
+        label: 'OAuth (coming soon)',
+      })
+    })
+  })
+
+  describe('formatComplexScheme', () => {
+    it('combines multiple schemes into a single complex scheme', () => {
+      expect(
+        formatComplexScheme(['apiKeyUid', 'oauth2Uid'], securitySchemes),
+      ).toEqual({
+        id: 'apiKeyUid,oauth2Uid',
+        label: 'apiKey & oauth2',
+      })
+    })
+
+    it('handles missing schemes gracefully', () => {
+      expect(
+        formatComplexScheme(['apiKeyUid', 'missing'], securitySchemes),
+      ).toEqual({
+        id: 'apiKeyUid',
+        label: 'apiKey',
+      })
+    })
+
+    it('returns empty complex scheme when no valid schemes provided', () => {
+      expect(formatComplexScheme(['missing1', 'missing2'], {})).toEqual({
+        id: '',
+        label: '',
+      })
+    })
+  })
+
+  describe('getSecurityRequirements', () => {
+    it('returns empty arrays when no security is defined', () => {
+      const request = {} as Request
+      const collection = {} as Collection
+
+      expect(getSecurityRequirements(request, collection)).toEqual([])
+    })
+
+    it('uses request security when available', () => {
+      const request = {
+        security: [{ apiKey: [] }],
+        // We can force the types here cuz testing
+      } as unknown as Request
+      const collection = {
+        security: [{ basic: [] }],
+      } as unknown as Collection
+
+      expect(getSecurityRequirements(request, collection)).toEqual([
+        { apiKey: [] },
+      ])
+    })
+
+    it('falls back to collection security when request security is not defined', () => {
+      const request = undefined
+      const collection = {
+        security: [{ basic: [] }, { apiKey: [] }],
+      } as unknown as Collection
+
+      expect(getSecurityRequirements(request, collection)).toEqual([
+        { basic: [] },
+        { apiKey: [] },
+      ])
+    })
+
+    it('handles optional security in request', () => {
+      const request = {
+        security: [{}],
+      } as unknown as Request
+      const collection = {
+        security: [{ basic: [] }, { apiKey: [] }],
+      } as unknown as Collection
+
+      expect(getSecurityRequirements(request, collection)).toEqual([
+        { basic: [] },
+        { apiKey: [] },
+        {},
+      ])
+    })
+
+    it('preserves existing optional security in collection', () => {
+      const request = {
+        security: [{}],
+      } as unknown as Request
+      const collection = {
+        security: [{ basic: [] }, {}],
+      } as unknown as Collection
+
+      expect(getSecurityRequirements(request, collection)).toEqual([
+        { basic: [] },
+        {},
+      ])
+    })
+
+    it('handles complex security requirements', () => {
+      const request = {
+        security: [{ apiKey: [], basic: [] }],
+      } as unknown as Request
+      const collection = {} as unknown as Collection
+
+      expect(getSecurityRequirements(request, collection)).toEqual([
+        { basic: [], apiKey: [] },
+      ])
+    })
+  })
+})
+
+describe('getSchemeOptions', () => {
+  const collectionSchemeUids = Object.values(securitySchemes).map((s) => s.uid)
+
+  it('returns flat list when readonly and theres no required schemes', () => {
+    const filteredRequirements: Record<string, string[]>[] = []
+    const result = getSchemeOptions(
+      filteredRequirements,
+      collectionSchemeUids,
+      securitySchemes,
+      true,
+    )
+
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).toHaveLength(3)
+    expect(result[0]).toMatchObject({
+      id: 'apiKeyUid',
+      label: 'apiKey',
+    })
+  })
+
+  it('returns 2 grouped options when there are required + available and readonly', () => {
+    const filteredRequirements = [{ apiKey: [] }]
+    const result = getSchemeOptions(
+      filteredRequirements,
+      collectionSchemeUids,
+      securitySchemes,
+      true,
+    )
+
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({
+      label: 'Required authentication',
+      options: [{ id: 'apiKeyUid', label: 'apiKey' }],
+    })
+    expect(result[1]).toMatchObject({
+      label: 'Available authentication',
+      options: [
+        { id: 'basicUid', label: 'basic' },
+        { id: 'oauth2Uid', label: 'oauth2' },
+      ],
+    })
+  })
+
+  it('returns 3 grouped options when there are required + available + add new', () => {
+    const filteredRequirements = [{ apiKey: [] }]
+    const result = getSchemeOptions(
+      filteredRequirements,
+      collectionSchemeUids,
+      securitySchemes,
+    )
+
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).toHaveLength(3)
+    expect(result[0]).toMatchObject({
+      label: 'Required authentication',
+      options: [{ id: 'apiKeyUid', label: 'apiKey' }],
+    })
+    expect(result[1]).toMatchObject({
+      label: 'Available authentication',
+      options: [
+        { id: 'basicUid', label: 'basic' },
+        { id: 'oauth2Uid', label: 'oauth2' },
+      ],
+    })
+    expect(result[2]).toMatchObject({
+      label: 'Add new authentication',
+      options: ADD_AUTH_OPTIONS,
+    })
+  })
+
+  it('includes "Add new authentication" group only when not readonly', () => {
+    const filteredRequirements: Record<string, string[]>[] = []
+
+    const readonlyResult = getSchemeOptions(
+      filteredRequirements,
+      collectionSchemeUids,
+      securitySchemes,
+      true,
+    )
+    const editableResult = getSchemeOptions(
+      filteredRequirements,
+      collectionSchemeUids,
+      securitySchemes,
+      false,
+    )
+
+    expect(readonlyResult).not.toContainEqual(
+      expect.objectContaining({
+        label: 'Add new authentication',
+      }),
+    )
+
+    expect(editableResult[2]).toMatchObject({
+      label: 'Add new authentication',
+      options: ADD_AUTH_OPTIONS,
+    })
+  })
+
+  it('handles empty filtered requirements when not readonly', () => {
+    const filteredRequirements: Record<string, string[]>[] = []
+    const result = getSchemeOptions(
+      filteredRequirements,
+      collectionSchemeUids,
+      securitySchemes,
+    )
+
+    expect(result).toHaveLength(3)
+    expect((result[0] as SecuritySchemeGroup).options).toHaveLength(0)
+    expect(result[2]).toMatchObject({
+      label: 'Add new authentication',
+      options: expect.any(Array),
+    })
+  })
+
+  it('handles complex security requirements', () => {
+    const filteredRequirements = [{ apiKey: [], basic: [] }]
+    const result = getSchemeOptions(
+      filteredRequirements,
+      collectionSchemeUids,
+      securitySchemes,
+      false,
+    )
+
+    expect(result[0]).toMatchObject({
+      label: 'Required authentication',
+      options: [{ id: 'apiKeyUid,basicUid', label: 'apiKey & basic' }],
+    })
+    expect(result[1]).toMatchObject({
+      label: 'Available authentication',
+      options: [
+        { id: 'apiKeyUid', label: 'apiKey' },
+        { id: 'basicUid', label: 'basic' },
+        { id: 'oauth2Uid', label: 'oauth2' },
+      ],
+    })
+  })
+})

--- a/packages/api-client/src/views/Request/libs/auth.ts
+++ b/packages/api-client/src/views/Request/libs/auth.ts
@@ -1,7 +1,133 @@
-import type { SecurityScheme } from '@scalar/oas-utils/entities/spec'
+import {
+  ADD_AUTH_OPTIONS,
+  type SecuritySchemeGroup,
+  type SecuritySchemeOption,
+} from '@/views/Request/consts'
+import type {
+  Collection,
+  Operation,
+  SecurityScheme,
+} from '@scalar/oas-utils/entities/spec'
+import { isDefined } from '@scalar/oas-utils/helpers'
+
+type DisplayScheme = {
+  type: SecurityScheme['type'] | 'complex'
+  nameKey: SecurityScheme['nameKey']
+  uid: SecurityScheme['uid']
+}
 
 /** Format a scheme object into a display object */
-export const displaySchemeFormatter = (s: SecurityScheme) => ({
+export const formatScheme = (s: DisplayScheme) => ({
   id: s.uid,
   label: s.type === 'openIdConnect' ? `${s.nameKey} (coming soon)` : s.nameKey,
 })
+
+/** Formats complex security schemes */
+export const formatComplexScheme = (
+  uids: string[],
+  securitySchemes: Record<string, DisplayScheme>,
+) =>
+  formatScheme(
+    uids.reduce(
+      (acc, uid, index) => {
+        const scheme = securitySchemes[uid]
+        if (scheme) {
+          acc.nameKey += `${index > 0 ? ' & ' : ''}${scheme.nameKey}`
+          acc.uid += `${index > 0 ? ',' : ''}${scheme.uid}`
+        }
+        return acc
+      },
+      { type: 'complex', nameKey: '', uid: '' },
+    ),
+  )
+
+/** Compute what the security requirements should be for a request */
+export const getSecurityRequirements = (
+  operation?: Operation,
+  collection?: Collection,
+) => {
+  // If the request security is optional, use the collection security and ensure it includes an optional object
+  if (
+    JSON.stringify(operation?.security) === '[{}]' &&
+    collection?.security?.length
+  ) {
+    const collectionHasOptional = Boolean(
+      collection?.security.find((s) => JSON.stringify(s) === '{}'),
+    )
+
+    return collectionHasOptional
+      ? collection.security
+      : [...collection.security, {}]
+  }
+
+  return operation?.security ?? collection?.security ?? []
+}
+
+/**
+ * Generates the options for the security scheme combobox
+ *
+ * contains either a flat list, or different groups of required, available, and add new
+ */
+export const getSchemeOptions = (
+  filteredRequirements: Collection['security'],
+  collectionSchemeUids: Collection['securitySchemes'],
+  securitySchemes: Record<string, DisplayScheme>,
+  isReadOnly: boolean = false,
+): SecuritySchemeOption[] | SecuritySchemeGroup[] => {
+  {
+    /** Creates a dictionary of security schemes by nameKey (not UID) */
+    const schemeDict = collectionSchemeUids.reduce(
+      (acc, uid) => {
+        const scheme = securitySchemes[uid]
+        if (scheme) acc[scheme.nameKey] = scheme
+        return acc
+      },
+      {} as Record<string, DisplayScheme>,
+    )
+
+    /** Builds the required schemes formatted as options */
+    const requiredFormatted = filteredRequirements.flatMap(
+      (r): SecuritySchemeOption | [] => {
+        const keys = Object.keys(r)
+
+        // Complex auth
+        if (keys.length > 1) {
+          const uids = keys.map((k) => schemeDict[k]?.uid).filter(isDefined)
+          return formatComplexScheme(uids, securitySchemes)
+        }
+        // Simple auth
+        else if (keys[0]) {
+          const scheme = schemeDict[keys[0]]
+          if (scheme) return formatScheme(scheme)
+        }
+
+        return []
+      },
+    )
+
+    /** Collection schemes minus the required ones */
+    const availableFormatted = collectionSchemeUids
+      .filter((uid) => !requiredFormatted.some((r) => r.id === uid))
+      .map((uid) => {
+        const scheme = securitySchemes[uid]
+        if (scheme) return formatScheme(scheme)
+        return null
+      })
+      .filter(isDefined)
+
+    const options = [
+      { label: 'Required authentication', options: requiredFormatted },
+      { label: 'Available authentication', options: availableFormatted },
+    ]
+
+    if (isReadOnly)
+      return requiredFormatted.length ? options : availableFormatted
+
+    options.push({
+      label: 'Add new authentication',
+      options: ADD_AUTH_OPTIONS,
+    })
+
+    return options
+  }
+}

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -26,7 +26,7 @@ const props = withDefaults(
 )
 
 const { hideModels } = useSidebar()
-const { activeCollection } = useActiveEntities()
+const { activeCollection, activeServer, activeWorkspace } = useActiveEntities()
 
 const introCardsSlot = computed(() =>
   props.layout === 'classic' ? 'after' : 'aside',
@@ -66,11 +66,15 @@ const introCardsSlot = computed(() =>
             </div>
             <div class="scalar-client introduction-card-item">
               <RequestAuth
+                v-if="activeCollection && activeWorkspace"
+                :collection="activeCollection"
                 layout="reference"
                 :selectedSecuritySchemeUids="
                   activeCollection?.selectedSecuritySchemeUids ?? []
                 "
-                title="Authentication" />
+                :server="activeServer"
+                title="Authentication"
+                :workspace="activeWorkspace" />
             </div>
             <ClientLibraries class="introduction-card-item" />
           </div>

--- a/packages/api-reference/src/features/Operation/hooks/useRequestExample.ts
+++ b/packages/api-reference/src/features/Operation/hooks/useRequestExample.ts
@@ -96,7 +96,7 @@ export const useRequestExample = ({
   /** Generates an array of secrets we want to hide in the code block */
   const secretCredentials = computed(
     () =>
-      selectedSecuritySchemeUids.value?.flatMap((uid) => {
+      selectedSecuritySchemeUids.value?.flat().flatMap((uid) => {
         const scheme = securitySchemes[uid]
         if (scheme?.type === 'apiKey') return scheme.value
         if (scheme?.type === 'http')

--- a/packages/oas-utils/src/entities/shared/index.ts
+++ b/packages/oas-utils/src/entities/shared/index.ts
@@ -1,1 +1,6 @@
-export * from './utility'
+export {
+  type Nanoid,
+  type SelectedSecuritySchemeUids,
+  nanoidSchema,
+  selectedSecuritySchemeUidSchema,
+} from './utility'

--- a/packages/oas-utils/src/entities/shared/utility.ts
+++ b/packages/oas-utils/src/entities/shared/utility.ts
@@ -10,3 +10,13 @@ export const nanoidSchema = z
 
 /** UID format for objects */
 export type Nanoid = z.infer<typeof nanoidSchema>
+
+/** Schema for selectedSecuritySchemeUids */
+export const selectedSecuritySchemeUidSchema = z
+  .union([nanoidSchema, nanoidSchema.array()])
+  .array()
+  .default([])
+
+export type SelectedSecuritySchemeUids = z.infer<
+  typeof selectedSecuritySchemeUidSchema
+>

--- a/packages/oas-utils/src/entities/spec/collection.ts
+++ b/packages/oas-utils/src/entities/spec/collection.ts
@@ -1,4 +1,7 @@
-import { nanoidSchema } from '@/entities/shared'
+import {
+  nanoidSchema,
+  selectedSecuritySchemeUidSchema,
+} from '@/entities/shared/utility'
 import { xScalarEnvironmentsSchema } from '@/entities/spec/x-scalar-environments'
 import { xScalarSecretsSchema } from '@/entities/spec/x-scalar-secrets'
 import { z } from 'zod'
@@ -55,7 +58,7 @@ export const extendedCollectionSchema = z.object({
   /** A list of security schemes UIDs associated with the collection */
   securitySchemes: z.string().array().default([]),
   /** List of currently selected security scheme UIDs, these can be overridden per request */
-  selectedSecuritySchemeUids: nanoidSchema.array().default([]),
+  selectedSecuritySchemeUids: selectedSecuritySchemeUidSchema,
   /** The currently selected server */
   selectedServerUid: z.string().default(''),
   /** UIDs which refer to servers on the workspace base */

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -1,7 +1,10 @@
+import {
+  nanoidSchema,
+  selectedSecuritySchemeUidSchema,
+} from '@/entities/shared/utility'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { type ZodSchema, z } from 'zod'
 
-import { nanoidSchema } from '../shared'
 import { oasParameterSchema } from './parameters'
 import { type RequestExample, xScalarExampleSchema } from './request-examples'
 import { oasSecurityRequirementSchema } from './security'
@@ -125,7 +128,7 @@ const extendedRequestSchema = z.object({
   /** List of example UIDs associated with the request */
   examples: nanoidSchema.array().default([]),
   /** List of security scheme UIDs associated with the request */
-  selectedSecuritySchemeUids: nanoidSchema.array().default([]),
+  selectedSecuritySchemeUids: selectedSecuritySchemeUidSchema,
 })
 
 /** Unified request schema for client usage */
@@ -135,3 +138,7 @@ export const requestSchema = oasRequestSchema
 
 export type Request = z.infer<typeof requestSchema>
 export type RequestPayload = z.input<typeof requestSchema>
+
+// Alias these types as request conflicts with built in
+export type Operation = Request
+export type OperationPayload = RequestPayload


### PR DESCRIPTION
Complex security, this was done a few times but kept breaking whenever we refactored or changed something. Have now added tests to ensure this does not happen again!

fixes #3359

currently needs
- [x] integration tests
- [x] switch to array instead of comma

Originally I did it the easy way with much less changes, but it was not quite correct. So I switched from comma separated to using a proper array! Also switched to prop drilling so we can add integration tests :). Now the integration tests are still a little basic as we have a lot of reliance on `useActiveEntities` but I will keep drilling 

**Problem**
Complex auth was broken

**Solution**
We add back in complex auth

**To test**
load up the client and import this spec to test
`https://gist.githubusercontent.com/amritk/f64887015e998bf81ff349d3ace64cd5/raw/4499a362e1f274ef7f2f61e7f572c34dfa67e4db/test.yml`
the key part is
```json
  "security": [
    {
      "bearerAuth": [],
      "apiKeyQuery": []
    },
  ],
```
which has two security schemes in a single requirement

![image](https://github.com/user-attachments/assets/4e775251-4c1d-44a8-ae79-d1fcb240f5ac)
@cameronrohani I just stacked em like this, feel like it makes sense?

![image](https://github.com/user-attachments/assets/6da40362-5947-43e6-a286-798aa9f3896d)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
