### PR TITLE
fix(api-client): change OAuth State parameter to a length of 8

### DIFF
--- a/.changeset/shaggy-trees-sort.md
+++ b/.changeset/shaggy-trees-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Increase OAuth state parameter to 8 characters for increased entropy

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -41,7 +41,7 @@ const windowTarget = 'openAuth2Window'
 const windowFeatures = 'left=100,top=100,width=800,height=600'
 
 /** This state corresponds to Math.random() === 0.123456 */
-const state = '82mvz'
+const state = '4fzyo82m'
 const randomVal = 0.123456
 
 describe('oauth2', () => {

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -75,7 +75,7 @@ export const authorizeOauth2 = async (
 
     // OAuth2 flows with a login popup
     else {
-      const state = (Math.random() + 1).toString(36).substring(7)
+      const state = (Math.random() + 1).toString(36).substring(2, 10)
       const url = new URL(flow.authorizationUrl)
 
       /** Special PKCE state */

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -75,6 +75,7 @@ export const authorizeOauth2 = async (
 
     // OAuth2 flows with a login popup
     else {
+      // Generate a random state string with the length of 8 characters
       const state = (Math.random() + 1).toString(36).substring(2, 10)
       const url = new URL(flow.authorizationUrl)
 


### PR DESCRIPTION
Make state variable a length of 8 to support OAuth providers (Kinde) who need more entropy in the state parameter

**Problem**
Currently, I cannot use Scalar to authenticate with Kinde due to the state parameter not being at least 8 characters

**Solution**
With this PR I am changing the length of the state parameter from 5 to 8.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
