### PR TITLE
fix(api-client):  duplicated css selector

### DIFF
--- a/packages/api-client/src/components/ContextBar.vue
+++ b/packages/api-client/src/components/ContextBar.vue
@@ -114,9 +114,6 @@ const model = computed<string>({
 .filter-hover:hover .filter-hover-item:nth-last-of-type(7) {
   transition-delay: 0.35s;
 }
-.filter-hover:hover .filter-hover-item:nth-last-of-type(8) {
-  transition-delay: 0.4s;
-}
 .filter-hover:hover .filter-hover-item,
 .filter-hover:has(:focus-visible) .filter-hover-item {
   opacity: 1;

--- a/packages/api-client/src/components/ContextBar.vue
+++ b/packages/api-client/src/components/ContextBar.vue
@@ -114,7 +114,7 @@ const model = computed<string>({
 .filter-hover:hover .filter-hover-item:nth-last-of-type(7) {
   transition-delay: 0.35s;
 }
-.filter-hover:hover .filter-hover-item:nth-last-of-type(7) {
+.filter-hover:hover .filter-hover-item:nth-last-of-type(8) {
   transition-delay: 0.4s;
 }
 .filter-hover:hover .filter-hover-item,


### PR DESCRIPTION
**Problem**
SonarQube [found an issue](https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&issueStatuses=OPEN%2CCONFIRMED&id=xC0dex_scalar&open=AZR-cmd64ZKv-nhPxGj0) in this CSS file. As a .NET developer, I felt brave enough to fix it. 😎

**Solution**
~I bumped the number to 8 because that seems like what was intended.~ I removed the duplicated code.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] ~I’ve added a changeset (`pnpm changeset`).~
- [ ] ~I’ve added tests for the regression or new feature.~
- [ ] ~I’ve updated the documentation.~


**Off-Topic**
BTW, I’m planning to open a discussion about SonarQube soon – I think it’s a valuable tool and worth diving deeper into.

