### PR TITLE
fix(code-highlight): removes regex for highlight credentials

### DIFF
--- a/.changeset/itchy-tigers-float.md
+++ b/.changeset/itchy-tigers-float.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+fix: removes regex for highlight credentials

--- a/packages/code-highlight/src/code/highlight.test.ts
+++ b/packages/code-highlight/src/code/highlight.test.ts
@@ -1,0 +1,75 @@
+import type { LanguageFn } from 'highlight.js'
+import { describe, expect, it } from 'vitest'
+
+import { syntaxHighlight } from './highlight'
+
+describe('syntaxHighlight', () => {
+  const mockLanguages: Record<string, LanguageFn> = {
+    javascript: () => ({
+      name: 'javascript',
+      aliases: ['js'],
+      contains: [],
+    }),
+  }
+
+  const defaultOptions = {
+    lang: 'javascript',
+    languages: mockLanguages,
+  }
+
+  const codeExample = `
+    fetch('https://galaxy.scalar.com/planets', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+  `
+
+  it('should return highlighted HTML for a given code string', () => {
+    const result = syntaxHighlight(codeExample, defaultOptions)
+    expect(result).toContain('class="hljs language-javascript"')
+  })
+
+  it('should mask credentials in the code string', () => {
+    const codeWithCredentials = `
+      fetch('https://galaxy.scalar.com/planets', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer secret'
+        }
+      })
+    `
+    const options = {
+      ...defaultOptions,
+      maskCredentials: ['secret'],
+    }
+
+    const result = syntaxHighlight(codeWithCredentials, options)
+    expect(result).toContain('<span class="credentials">secret</span>')
+  })
+
+  it('should handle line numbers if option is enabled', () => {
+    const options = {
+      ...defaultOptions,
+      lineNumbers: true,
+    }
+
+    const result = syntaxHighlight(codeExample, options)
+    expect(result).toContain('class="line"')
+  })
+
+  it('should correctly work with special characters in credentials', () => {
+    const codeExampleWithSpecialChar = `
+      const secret = '(secret';
+    `
+    const options = {
+      ...defaultOptions,
+      maskCredentials: ['(secret'],
+    }
+
+    const result = syntaxHighlight(codeExampleWithSpecialChar, options)
+    expect(result).toContain('<span class="credentials">(secret</span>')
+  })
+})

--- a/packages/code-highlight/src/code/highlight.ts
+++ b/packages/code-highlight/src/code/highlight.ts
@@ -57,9 +57,12 @@ export function syntaxHighlight(
 
   // Replace any credentials with a wrapper element
   return credentials.length
-    ? htmlString.replace(
-        new RegExp(credentials.join('|'), 'g'),
-        (m) => `<span class="credentials">${m}</span>`,
+    ? credentials.reduce(
+        (acc, credential) =>
+          acc
+            .split(credential)
+            .join(`<span class="credentials">${credential}</span>`),
+        htmlString,
       )
     : htmlString
 }

--- a/packages/code-highlight/src/code/highlight.ts
+++ b/packages/code-highlight/src/code/highlight.ts
@@ -9,6 +9,9 @@ import { visit } from 'unist-util-visit'
 
 import { codeBlockLinesPlugin } from './line-numbers'
 
+/**
+ * Syntax highlights a code string using the `rehype-highlight` library.
+ */
 export function syntaxHighlight(
   codeString: string,
   options: {


### PR DESCRIPTION
**Problem**
currently when using `token(` in credentials value, the code example is not rendered.

**Solution**
this pr fixes #4498 by removing regex instance to highlight credentials.

| before | after |
| -------|------|
| <img width="546" alt="image" src="https://github.com/user-attachments/assets/6760878c-45ac-4f90-b3c4-11ec6b47835f" /> | <img width="546" alt="image" src="https://github.com/user-attachments/assets/2bbfd973-86d7-4bd3-a94f-8b7d5179804b" /> |
| code example is not rendered | code example get rendered |  

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.