### PR TITLE
feat(api-client): query parameters array support

### DIFF
--- a/.changeset/clean-planets-fly.md
+++ b/.changeset/clean-planets-fly.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds query parameters array support

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -115,7 +115,7 @@ const initialValue = computed(() => {
           </ScalarDropdownItem>
 
           <template v-if="canAddCustomValue">
-            <ScalarDropdownDivider />
+            <ScalarDropdownDivider v-if="options.length" />
             <ScalarDropdownItem
               class="flex items-center gap-1.5"
               @click="addingCustomValue = true">

--- a/packages/api-client/src/libs/send-request/create-fetch-query-params.test.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-query-params.test.ts
@@ -58,4 +58,21 @@ describe('createFetchQueryParams', () => {
     expect(result).toBeInstanceOf(URLSearchParams)
     expect([...result.entries()]).toHaveLength(0)
   })
+
+  it('handles query parameters for array type value', () => {
+    const requestExample: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        headers: [],
+        path: [],
+        cookies: [],
+        query: [
+          { key: 'key', value: 'one, two', enabled: true, type: 'array' },
+        ],
+      },
+    }
+
+    const result = createFetchQueryParams(requestExample, {})
+
+    expect(result.toString()).toEqual('key=one&key=two')
+  })
 })

--- a/packages/api-client/src/libs/send-request/send-request.ts
+++ b/packages/api-client/src/libs/send-request/send-request.ts
@@ -70,8 +70,13 @@ export function createFetchQueryParams(
 ) {
   const params = new URLSearchParams()
   example.parameters.query.forEach((p) => {
-    if (p.enabled)
-      params.append(p.key, replaceTemplateVariables(p.value ?? '', env))
+    if (p.enabled) {
+      const values =
+        p.type === 'array'
+          ? replaceTemplateVariables(p.value ?? '', env).split(',')
+          : [replaceTemplateVariables(p.value ?? '', env)]
+      values.forEach((value) => params.append(p.key, value.trim()))
+    }
   })
 
   return params


### PR DESCRIPTION
**Problem**
currently we cannot send query parameter array value.

**Solution**
this pr is a first stepping stone to fix #4232  in order to support the query parameters array value for array typed using the following format `123,456
`. this will be then enhanced by more UI formatting + selector.

| before | after |
| -------|------|
| <img width="850" alt="image" src="https://github.com/user-attachments/assets/1a8ab44c-984e-43c5-835e-a404d598f18c" /> | <img width="850" alt="image" src="https://github.com/user-attachments/assets/babd7075-c44a-435f-aa8d-1328ca7a99b4" /> |
| comma separated value is sent as it is | comma separated value is handle as an array | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
