### PR TITLE
fix(api-reference): only the first entry in a tag is hidden

### DIFF
--- a/.changeset/flat-laws-battle.md
+++ b/.changeset/flat-laws-battle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: only first entry in hidden tag is hidden from the reference

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -271,13 +271,13 @@ const transformResult = (originalSchema: OpenAPI.Document): Spec => {
           schema.tags[tagIndex].operations.push(newOperation)
         })
       }
-
-      // Remove tags with `x-internal` set to true
-      schema.tags = schema.tags?.filter(
-        (tag: UnknownObject) => !shouldIgnoreEntity(tag),
-      )
     })
   })
+
+  // Remove tags with `x-internal` set to true
+  schema.tags = schema.tags?.filter(
+    (tag: UnknownObject) => !shouldIgnoreEntity(tag),
+  )
 
   const returnedResult = {
     ...schema,

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -10,13 +10,8 @@ import {
 import { redirectToProxy, shouldIgnoreEntity } from '@scalar/oas-utils/helpers'
 import { dereference, load } from '@scalar/openapi-parser'
 import { fetchUrls } from '@scalar/openapi-parser/plugins/fetch-urls'
-import type {
-  OpenAPI,
-  OpenAPIV2,
-  OpenAPIV3,
-  OpenAPIV3_1,
-} from '@scalar/openapi-types'
-import type { Spec, Webhook } from '@scalar/types/legacy'
+import type { OpenAPI, OpenAPIV2, OpenAPIV3 } from '@scalar/openapi-types'
+import type { Spec } from '@scalar/types/legacy'
 import type { UnknownObject } from '@scalar/types/utils'
 
 import { createEmptySpecification } from '../helpers'


### PR DESCRIPTION
**Problem**
Turns out, I’ve deleted the hook in wrong loop (horrible legacy code) and only the first operation in a hidden tag was actually hidden.

**Solution**
This PR moves the code to the right loop, so *all* operations in a hidden tag are hidden.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
