### PR TITLE
fix(ci): components dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,7 +492,7 @@ jobs:
         run: pnpm --filter components build:storybook
 
       - if: steps.changed-files.outputs.components_any_changed == 'true'
-        name: Deploy to Netlify
+        name: Deploy Storybook to Netlify (Preview)
         run: |
           netlify deploy --dir "./packages/components/storybook-static" \
             --message "Deployed from GitHub (${{ env.DEPLOY_ID }})" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,9 +486,13 @@ jobs:
       - if: steps.changed-files.outputs.components_any_changed == 'true'
         name: Install Netlify CLI
         run: pnpm install -g netlify
-      - name: Build storybook
+
+      - if: steps.changed-files.outputs.components_any_changed == 'true'
+        name: Build storybook
         run: pnpm --filter components build:storybook
-      - name: Deploy to Netlify
+
+      - if: steps.changed-files.outputs.components_any_changed == 'true'
+        name: Deploy to Netlify
         run: |
           netlify deploy --dir "./packages/components/storybook-static" \
             --message "Deployed from GitHub (${{ env.DEPLOY_ID }})" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,8 @@ jobs:
       - if: steps.changed-files.outputs.components_any_changed == 'true'
         name: Install Netlify CLI
         run: pnpm install -g netlify
+      - name: Build storybook
+        run: pnpm --filter components build:storybook
       - name: Deploy to Netlify
         run: |
           netlify deploy --dir "./packages/components/storybook-static" \

--- a/.github/workflows/deploy-components.yml
+++ b/.github/workflows/deploy-components.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Generate Run UUID
         run: echo "DEPLOY_ID=$(uuidgen)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Install dependencies
-        run: pnpm --filter components install
+        run: pnpm --filter components... install
       - name: Build
         run: cd packages/components && pnpm build:storybook
         env:

--- a/.github/workflows/deploy-components.yml
+++ b/.github/workflows/deploy-components.yml
@@ -1,4 +1,4 @@
-name: Deploy Scalar examples
+name: Deploy Scalar storybook
 
 on:
   push:

--- a/.github/workflows/deploy-components.yml
+++ b/.github/workflows/deploy-components.yml
@@ -1,4 +1,4 @@
-name: Deploy Scalar storybook
+name: Deploy Storybook
 
 on:
   push:

--- a/.github/workflows/deploy-components.yml
+++ b/.github/workflows/deploy-components.yml
@@ -30,8 +30,10 @@ jobs:
         run: echo "DEPLOY_ID=$(uuidgen)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Install dependencies
         run: pnpm --filter components... install
-      - name: Build
-        run: cd packages/components && pnpm build:storybook
+      - name: Build components and dependencies
+        run: pnpm --filter components... build
+      - name: Build storybook
+        run: pnpm --filter components build:storybook
         env:
           DEPLOY_ID: ${{ env.DEPLOY_ID }}
       - name: Deploy to netlify

--- a/.github/workflows/deploy-components.yml
+++ b/.github/workflows/deploy-components.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm --filter components build:storybook
         env:
           DEPLOY_ID: ${{ env.DEPLOY_ID }}
-      - name: Deploy to netlify
+      - name: Deploy Storybook to Netlify (Production)
         run: |
           netlify deploy --dir "./packages/components/storybook-static" \
             --message "Deployed from GitHub (${{ env.DEPLOY_ID }})" \


### PR DESCRIPTION
**Problem**
Currently, the components library is failing to build in CI. It is missing dependencies related to build-tooling. 

**Solution**
With this PR, 

`/workflows/deploy-components`
- Use [ellipsis](https://pnpm.io/filtering#--filter-package_name-1) to ensure that all direct and indirect dependencies are installed. 
* add a step to build the components library and related dependencies (build-tooling)
* Run all commands from root using `--filter` to ensure pathing is consistent. 

`/workflows/ci` 
* build storybook before deploying the preview

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
