### PR TITLE
refactor(api-reference): use the store in `TestRequestButton`

### DIFF
--- a/.changeset/pretty-flies-beam.md
+++ b/.changeset/pretty-flies-beam.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+refactor: use request entity for TestRequestButton

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -324,13 +324,15 @@ export const createApiClient = ({
     /** Route to a method + path */
     route: (
       /** The first request you would like to display */
-      { requestUid, method, path, _source }: OpenClientPayload,
+      payload?: OpenClientPayload,
     ) => {
+      const { requestUid, method, path, _source } = payload ?? {}
+
       // Find the request from path + method
       const resolvedRequestUid =
         requestUid ||
         Object.values(requests).find((item) =>
-          item.path && item.method
+          path && method && item.path && item.method
             ? // The given operation
               item.path === path &&
               item.method.toUpperCase() === method.toUpperCase()
@@ -351,12 +353,14 @@ export const createApiClient = ({
     },
 
     /** Open the API client modal and optionally route to a request */
-    open: ({ path, method, requestUid, _source }: OpenClientPayload) => {
+    open: (payload?: OpenClientPayload) => {
+      const { path, method, requestUid, _source } = payload ?? {}
+
       // Find the request from path + method
       const resolvedRequestUid =
         requestUid ||
         Object.values(requests).find((item) =>
-          item.path && item.method
+          path && method && item.path && item.method
             ? // The given operation
               item.path === path &&
               item.method.toUpperCase() === method.toUpperCase()

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -61,7 +61,7 @@ const config = useConfig()
     <template #actions="{ active }">
       <TestRequestButton
         v-if="active"
-        :operation="operation" />
+        :operation="requestEntity" />
       <ScalarIcon
         v-else-if="!config?.hideTestRequestButton"
         class="endpoint-try-hint"

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -66,7 +66,7 @@ defineProps<{
                     :path="operation.path" />
                 </template>
                 <template #footer>
-                  <TestRequestButton :operation="operation" />
+                  <TestRequestButton :operation="requestEntity" />
                 </template>
               </ExampleRequest>
             </ScalarErrorBoundary>

--- a/packages/api-reference/src/features/TestRequestButton/TestRequestButton.test.ts
+++ b/packages/api-reference/src/features/TestRequestButton/TestRequestButton.test.ts
@@ -1,0 +1,96 @@
+import { CONFIGURATION_SYMBOL } from '@/hooks/useConfig'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import TestRequestButton from './TestRequestButton.vue'
+
+const mockClient = ref({
+  open: vi.fn(),
+})
+
+vi.mock('@/features/ApiClientModal', () => ({
+  useApiClient: () => ({
+    client: mockClient,
+  }),
+}))
+
+describe('TestRequestButton', () => {
+  it('renders nothing when operation prop is not provided', () => {
+    const wrapper = mount(TestRequestButton)
+    // Just whitespace
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('renders nothing when hideTestRequestButton config is true', () => {
+    const wrapper = mount(TestRequestButton, {
+      global: {
+        provide: {
+          [CONFIGURATION_SYMBOL]: {
+            hideTestRequestButton: true,
+          },
+        },
+      },
+      props: {
+        operation: {
+          method: 'get',
+          path: '/test',
+          uid: '123',
+        },
+      },
+    })
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('renders button with correct text and icon when operation is provided', () => {
+    const wrapper = mount(TestRequestButton, {
+      props: {
+        operation: {
+          method: 'get',
+          path: '/test',
+          uid: '123',
+        },
+      },
+    })
+
+    expect(wrapper.find('button').exists()).toBe(true)
+    expect(wrapper.find('.scalar-icon').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Test Request')
+    expect(wrapper.text()).toContain('(get /test)')
+  })
+
+  it('has correct button attributes', () => {
+    const wrapper = mount(TestRequestButton, {
+      props: {
+        operation: {
+          method: 'post',
+          path: '/users',
+          uid: '456',
+        },
+      },
+    })
+
+    const button = wrapper.find('button')
+    expect(button.attributes('type')).toBe('button')
+    // Some use this to style the button (e.g. nuxt-theme.css)
+    expect(button.classes()).toContain('show-api-client-button')
+  })
+
+  it('calls client.open with correct params when clicked', async () => {
+    const wrapper = mount(TestRequestButton, {
+      props: {
+        operation: {
+          method: 'delete',
+          path: '/users/1',
+          uid: 'my-random-uuid',
+        },
+      },
+    })
+
+    await wrapper.find('button').trigger('click')
+
+    expect(mockClient.value.open).toHaveBeenCalledWith({
+      requestUid: 'my-random-uuid',
+    })
+  })
+})

--- a/packages/api-reference/src/features/TestRequestButton/TestRequestButton.vue
+++ b/packages/api-reference/src/features/TestRequestButton/TestRequestButton.vue
@@ -7,7 +7,7 @@ import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 import { computed } from 'vue'
 
 const { operation } = defineProps<{
-  operation?: RequestEntity
+  operation?: Pick<RequestEntity, 'method' | 'path' | 'uid'>
 }>()
 
 const { client } = useApiClient()
@@ -16,6 +16,14 @@ const config = useConfig()
 const isButtonVisible = computed(() => {
   return config?.hideTestRequestButton !== true
 })
+
+const handleClick = () => {
+  if (operation && client?.value?.open) {
+    client.value.open({
+      requestUid: operation.uid,
+    })
+  }
+}
 </script>
 <template>
   <!-- Render the Test Request Button -->
@@ -24,11 +32,7 @@ const isButtonVisible = computed(() => {
     class="show-api-client-button"
     :method="operation.method"
     type="button"
-    @click.stop="
-      client?.open({
-        requestUid: operation.uid,
-      })
-    ">
+    @click.stop="handleClick">
     <ScalarIcon
       icon="Play"
       size="sm" />

--- a/packages/api-reference/src/features/TestRequestButton/TestRequestButton.vue
+++ b/packages/api-reference/src/features/TestRequestButton/TestRequestButton.vue
@@ -3,10 +3,10 @@ import ScreenReader from '@/components/ScreenReader.vue'
 import { useApiClient } from '@/features/ApiClientModal'
 import { useConfig } from '@/hooks/useConfig'
 import { ScalarIcon } from '@scalar/components'
-import type { TransformedOperation } from '@scalar/types/legacy'
+import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 
 defineProps<{
-  operation: TransformedOperation
+  operation?: RequestEntity
 }>()
 
 const { client } = useApiClient()
@@ -14,21 +14,20 @@ const config = useConfig()
 </script>
 <template>
   <button
-    v-if="config?.hideTestRequestButton !== true"
+    v-if="config?.hideTestRequestButton !== true && operation"
     class="show-api-client-button"
-    :method="operation.httpVerb"
+    :method="operation.method"
     type="button"
     @click.stop="
       client?.open({
-        path: operation.path,
-        method: operation.httpVerb,
+        requestUid: operation.uid,
       })
     ">
     <ScalarIcon
       icon="Play"
       size="sm" />
     <span>Test Request</span>
-    <ScreenReader>({{ operation.httpVerb }} {{ operation.path }})</ScreenReader>
+    <ScreenReader>({{ operation.method }} {{ operation.path }})</ScreenReader>
   </button>
   <template v-else>&nbsp;</template>
 </template>

--- a/packages/api-reference/src/features/TestRequestButton/TestRequestButton.vue
+++ b/packages/api-reference/src/features/TestRequestButton/TestRequestButton.vue
@@ -4,17 +4,23 @@ import { useApiClient } from '@/features/ApiClientModal'
 import { useConfig } from '@/hooks/useConfig'
 import { ScalarIcon } from '@scalar/components'
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
+import { computed } from 'vue'
 
-defineProps<{
+const { operation } = defineProps<{
   operation?: RequestEntity
 }>()
 
 const { client } = useApiClient()
 const config = useConfig()
+
+const isButtonVisible = computed(() => {
+  return config?.hideTestRequestButton !== true
+})
 </script>
 <template>
+  <!-- Render the Test Request Button -->
   <button
-    v-if="config?.hideTestRequestButton !== true && operation"
+    v-if="operation && isButtonVisible"
     class="show-api-client-button"
     :method="operation.method"
     type="button"
@@ -29,6 +35,7 @@ const config = useConfig()
     <span>Test Request</span>
     <ScreenReader>({{ operation.method }} {{ operation.path }})</ScreenReader>
   </button>
+  <!-- Render whitespace, so the container doesn’t collapse -->
   <template v-else>&nbsp;</template>
 </template>
 <style scoped>

--- a/packages/play-button/src/index.ts
+++ b/packages/play-button/src/index.ts
@@ -111,7 +111,10 @@ if (!specUrlElement && !specElement && !specScriptTag) {
         if (specifiedOperation) {
           open({
             path: specifiedOperation.path,
-            method: specifiedOperation.httpVerb,
+            method: specifiedOperation.httpVerb.toLowerCase() as Exclude<
+              Lowercase<typeof specifiedOperation.httpVerb>,
+              'connect' | 'trace'
+            >,
           })
         } else {
           const firstOperation = parsedSpec.tags?.[0]?.operations?.[0]
@@ -119,7 +122,10 @@ if (!specUrlElement && !specElement && !specScriptTag) {
           if (firstOperation) {
             open({
               path: firstOperation.path,
-              method: firstOperation.httpVerb,
+              method: firstOperation.httpVerb.toLowerCase() as Exclude<
+                Lowercase<typeof firstOperation.httpVerb>,
+                'connect' | 'trace'
+              >,
             })
           }
         }


### PR DESCRIPTION
Currently, we pass the (legacy) `TransformedOperation` to the `TestRequestButton`, pass the method and the path to the API client, and then resolve the request entity from the store.

With this PR, we’re just passing the RequestEntity to the button, and then only pass the request UID to the client.

Way easier, and also another component where we can get rid of the (legacy) `TransformedOperation`.