### PR TITLE
fix(components): improve ScalarMenu team picker a11y

### DIFF
--- a/.changeset/tame-pumpkins-approve.md
+++ b/.changeset/tame-pumpkins-approve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): improve ScalarMenu team picker a11y

--- a/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
@@ -56,7 +56,7 @@ defineOptions({ inheritAttrs: false })
         :sideOffset="3">
         <DropdownMenu.RadioGroup
           v-model="model"
-          as="template">
+          class="contents">
           <DropdownMenu.RadioItem
             v-for="t in teams"
             :key="t.id"

--- a/packages/components/src/components/ScalarMenu/ScalarMenuTeamProfile.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuTeamProfile.vue
@@ -14,9 +14,11 @@ const { cx } = useBindCx()
     <img
       v-if="src"
       class="size-5 rounded"
+      role="presentation"
       :src="src" />
     <div
       v-else
+      aria-hidden="true"
       class="flex items-center justify-center text-3xs font-medium text-c-3 size-5 bg-b-3 rounded">
       <template v-if="label && label.length > 0">
         {{ label[0] }}


### PR DESCRIPTION
This PR correctly sets the role for team picker items (before it was being overridden by the `DropdownMenu.RadioGroup`) and hides the team profile icon from screen readers.

### Before

![Google Chrome-2025-01-20-22-10-40@2x](https://github.com/user-attachments/assets/274277d3-8ada-4836-818a-8e885ccee89a)

### After

![Google Chrome-2025-01-20-22-10-10@2x](https://github.com/user-attachments/assets/3efb6d77-fa60-4053-af4d-4819e44a3e71)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
