### PR TITLE
feat(openapi-parser): don’t load URLs/files passed as OpenAPI document

### DIFF
--- a/packages/openapi-parser/src/utils/load/load.ts
+++ b/packages/openapi-parser/src/utils/load/load.ts
@@ -1,7 +1,6 @@
 import { ERRORS } from '../../configuration'
 import type {
   AnyApiDefinitionFormat,
-  AnyObject,
   ErrorObject,
   Filesystem,
   LoadResult,
@@ -50,38 +49,7 @@ export async function load(
     }
   }
 
-  // Check whether the value is an URL or file path
-  const plugin = options?.plugins?.find((thisPlugin) => thisPlugin.check(value))
-
-  let content: AnyObject
-
-  if (plugin) {
-    try {
-      content = normalize(await plugin.get(value))
-    } catch (error) {
-      if (options?.throwOnError) {
-        throw new Error(
-          ERRORS.EXTERNAL_REFERENCE_NOT_FOUND.replace('%s', value as string),
-        )
-      }
-
-      errors.push({
-        code: 'EXTERNAL_REFERENCE_NOT_FOUND',
-        message: ERRORS.EXTERNAL_REFERENCE_NOT_FOUND.replace(
-          '%s',
-          value as string,
-        ),
-      })
-
-      return {
-        specification: null,
-        filesystem: [],
-        errors,
-      }
-    }
-  } else {
-    content = normalize(value)
-  }
+  const content = normalize(value)
 
   // No content
   if (content === undefined) {

--- a/packages/openapi-parser/tests/migration-layer.test.ts
+++ b/packages/openapi-parser/tests/migration-layer.test.ts
@@ -84,7 +84,8 @@ describe('validate', async () => {
     })
   })
 
-  it('throws an error for invalid documents', async () => {
+  // TODO: Doesn’t throw since we disabled fetching URLs/files passed as an OpenAPI document.
+  it.skip('throws an error for invalid documents', async () => {
     return new Promise((resolve, reject) => {
       SwaggerParser.validate('invalid', (err) => {
         if (err) {
@@ -112,7 +113,8 @@ describe('dereference', () => {
     expect(api?.paths?.['/foobar']?.post?.requestBody?.content).toEqual({})
   })
 
-  it('dereferences URLs', async () => {
+  // TODO: We don’t want this behaviour in the new parser.
+  it.skip('dereferences URLs', async () => {
     // @ts-expect-error
     fetch.mockImplementation(async (url: string) => ({
       text: async () => {
@@ -133,7 +135,8 @@ describe('dereference', () => {
     expect(api?.paths?.['/foobar']?.post?.requestBody?.content).toEqual({})
   })
 
-  it('dereferences files', async () => {
+  // TODO: We don’t want this behaviour in the new parser.
+  it.skip('dereferences files', async () => {
     const EXAMPLE_FILE = path.join(
       new URL(import.meta.url).pathname,
       '../../tests/migration-layer.json',

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/externalPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/externalPathItemRef.test.ts
@@ -10,7 +10,8 @@ const EXAMPLE_FILE = path.join(
 )
 
 describe('externalPathItemRef', () => {
-  it('passes', async () => {
+  // TODO: We don’t want this behaviour in the new parser.
+  it.skip('passes', async () => {
     const { filesystem } = await load(EXAMPLE_FILE, {
       plugins: [readFiles()],
     })


### PR DESCRIPTION
WIP

Needs more work than I thought initially.

**Problem**
Currently, the parser will try to resolves URLs and files passed directly (instead of a YAML/JSON OpenAPI document). This is confusing to some users.

**Solution**
With this PR we remove this feature.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
