### PR TITLE
feat(api-client): better server handling

### DIFF
--- a/.changeset/smart-rice-breathe.md
+++ b/.changeset/smart-rice-breathe.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+refactor: better handle servers

--- a/.changeset/three-nails-remember.md
+++ b/.changeset/three-nails-remember.md
@@ -1,0 +1,5 @@
+---
+'@scalar/types': patch
+---
+
+feat: rewmove custom Server type

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -166,19 +166,26 @@ Key used with CTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k)
 }
 ```
 
+#### baseServerURL?: string
+
+If you want to prefix all relative servers with a base URL, you can do so here.
+
+```js
+{
+  baseServerURL: 'https://scalar.com'
+}
+```
+
 #### servers?: Server[]
 
-List of servers to override the openapi spec servers
-
-@default undefined
-@example [{ url: 'https://api.scalar.com', description: 'Production server' }]
+Pass a list of servers to override the servers in your OpenAPI document.
 
 ```js
 {
   servers: [
     {
       url: 'https://api.scalar.com',
-      description: 'Production server',
+      description: 'Production',
     },
   ]
 }

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -33,7 +33,9 @@ export const createRequestPayload = (
   metaRequestPayload: MetaRequestPayload = {},
 ) => {
   const request = requestSchema.parse(metaRequestPayload.requestPayload ?? {})
-  const server = serverSchema.parse(metaRequestPayload.serverPayload ?? {})
+  const server = metaRequestPayload.serverPayload
+    ? serverSchema.parse(metaRequestPayload.serverPayload)
+    : undefined
   let example = createExampleFromRequest(request, 'example')
 
   // Overwrite any example properties

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -184,7 +184,7 @@ function createRequestFromCurl({
       selectedServerUid.value = existingServer.uid
     } else {
       selectedServerUid.value = serverMutators.add(
-        { url: parsedCurl.value.servers[0] },
+        { url: parsedCurl.value.servers[0] ?? '/' },
         collection.uid,
       ).uid
     }

--- a/packages/api-client/src/views/Request/hooks/useOpenApiWatcher.ts
+++ b/packages/api-client/src/views/Request/hooks/useOpenApiWatcher.ts
@@ -8,7 +8,7 @@ import {
   mutateSecuritySchemeDiff,
   mutateServerDiff,
   mutateTagDiff,
-} from '@/views/Request/libs/live-sync'
+} from '@/views/Request/libs/watch-mode'
 import { createHash, fetchSpecFromUrl } from '@scalar/oas-utils/helpers'
 import { parseSchema } from '@scalar/oas-utils/transforms'
 import { useToasts } from '@scalar/use-toasts'
@@ -16,11 +16,11 @@ import { useTimeoutPoll } from '@vueuse/core'
 import microdiff, { type Difference } from 'microdiff'
 import { watch } from 'vue'
 
-/** Live Sync polling timeout, every 5 seconds */
-const POLLING_INTERVAL = 5 * 1000
+/** Timeout for the watch mode polling */
+const POLLING_INTERVAL = 5 * 1000 // 5 seconds
 
 /** Pause for 60 seconds after an error */
-const ERROR_TIMEOUT = 60 * 1000
+const ERROR_TIMEOUT = 60 * 1000 // 60 seconds
 
 /**
  * Hook which handles polling the documentUrl for changes then attempts to merge what is new

--- a/packages/api-client/src/views/Request/libs/watch-mode.test.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.test.ts
@@ -24,7 +24,7 @@ import {
   narrowUnionSchema,
   parseDiff,
   traverseZodSchema,
-} from './live-sync'
+} from './watch-mode'
 
 const mockRequests: Record<`request${number}uid`, Request> = {
   request1uid: {

--- a/packages/api-client/src/views/Request/libs/watch-mode.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.ts
@@ -147,6 +147,7 @@ export const findResource = <T>(
 const unwrapSchema = (schema: ZodSchema): ZodSchema => {
   if (schema instanceof z.ZodOptional) return unwrapSchema(schema.unwrap())
   if (schema instanceof z.ZodDefault) return unwrapSchema(schema._def.innerType)
+  if (schema instanceof z.ZodEffects) return unwrapSchema(schema._def.schema)
   return schema
 }
 

--- a/packages/api-client/src/views/Request/libs/watch-mode.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.ts
@@ -13,7 +13,7 @@ import {
   serverSchema,
   tagSchema,
 } from '@scalar/oas-utils/entities/spec'
-import { isDefined, isHttpMethod, schemaModel } from '@scalar/oas-utils/helpers'
+import { isHttpMethod, schemaModel } from '@scalar/oas-utils/helpers'
 import {
   type Path,
   type PathValue,

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -43,7 +43,7 @@ watch(server, (newServer) => {
 })
 
 // Update the config on change
-// We temporarily just debounce this but we should switch to the diff from live sync for updates
+// We temporarily just debounce this but we should switch to the diff from watch mode for updates
 watchDebounced(
   () => configuration,
   (_config) => _config && client.value?.updateConfig(_config),

--- a/packages/oas-utils/src/entities/spec/collection.ts
+++ b/packages/oas-utils/src/entities/spec/collection.ts
@@ -66,7 +66,12 @@ export const extendedCollectionSchema = z.object({
   tags: nanoidSchema.array().default([]),
   /** List of requests without tags and top level tag "folders" */
   children: nanoidSchema.array().default([]),
-  /** A link to where this document is stored, useful for live sync and possibly git sync down the line */
+  /**
+   * A link to where this document is stored
+   *
+   * - Used for watch mode
+   * - Possibly useful for Git sync down the line
+   */
   documentUrl: z.string().optional(),
   /**
    * Enables polling of OpenAPI document urls

--- a/packages/oas-utils/src/entities/spec/server.test.ts
+++ b/packages/oas-utils/src/entities/spec/server.test.ts
@@ -43,6 +43,10 @@ describe('serverSchema', () => {
           default: 'demo',
           description: 'Username selection',
         },
+        version: {
+          enum: ['v1', 'v2'],
+          description: 'Version selection',
+        },
       },
     }
 
@@ -52,12 +56,20 @@ describe('serverSchema', () => {
       variables: {
         environment: {
           enum: ['dev', 'staging', 'prod'],
+          // kept
           default: 'dev',
           description: 'Environment selection',
         },
         username: {
+          // enum omitted
           default: 'demo',
           description: 'Username selection',
+        },
+        version: {
+          enum: ['v1', 'v2'],
+          // added
+          default: 'v1',
+          description: 'Version selection',
         },
       },
     })

--- a/packages/oas-utils/src/entities/spec/server.test.ts
+++ b/packages/oas-utils/src/entities/spec/server.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import { serverSchema } from './server'
+
+describe('serverSchema', () => {
+  it('validates valid server object', () => {
+    const server = { url: 'https://api.example.com' }
+    expect(serverSchema.parse(server)).toMatchObject(server)
+  })
+
+  it('validates server with description', () => {
+    const server = {
+      url: 'https://api.example.com',
+      description: 'Production API',
+    }
+    expect(serverSchema.parse(server)).toMatchObject(server)
+  })
+
+  it('validates server with variables', () => {
+    const server = {
+      url: 'https://{username}.example.com',
+      variables: {
+        username: {
+          default: 'demo',
+        },
+      },
+    }
+    expect(serverSchema.parse(server)).toMatchObject(server)
+  })
+
+  it('validates server with enum variables', () => {
+    const server = {
+      url: 'https://{environment}.example.com',
+      variables: {
+        environment: {
+          enum: ['dev', 'staging', 'prod'],
+          default: 'dev',
+          description: 'Environment selection',
+        },
+      },
+    }
+    expect(serverSchema.parse(server)).toMatchObject(server)
+  })
+
+  it('fails when URL is missing', () => {
+    const server = {}
+    expect(() => serverSchema.parse(server)).toThrow()
+  })
+
+  it('fails when variable default is not in enum', () => {
+    const server = {
+      url: 'https://{environment}.example.com',
+      variables: {
+        environment: {
+          enum: ['dev', 'staging', 'prod'],
+          default: 'invalid',
+          description: 'Environment selection',
+        },
+      },
+    }
+    expect(() => serverSchema.parse(server)).toThrow(
+      'Default value must be one of the enum values if enum is defined',
+    )
+  })
+
+  it('validates server with relative URL', () => {
+    const server = {
+      url: '/api/v1',
+      description: 'Relative URL',
+    }
+    expect(serverSchema.parse(server)).toMatchObject(server)
+  })
+
+  it('validates server with multiple variables', () => {
+    const server = {
+      url: 'https://{username}.{domain}.com',
+      variables: {
+        username: {
+          default: 'demo',
+        },
+        domain: {
+          enum: ['example', 'test'],
+          default: 'example',
+        },
+      },
+    }
+    expect(serverSchema.parse(server)).toMatchObject(server)
+  })
+})

--- a/packages/oas-utils/src/entities/spec/server.test.ts
+++ b/packages/oas-utils/src/entities/spec/server.test.ts
@@ -37,9 +37,30 @@ describe('serverSchema', () => {
           default: 'dev',
           description: 'Environment selection',
         },
+        username: {
+          // invalid enum
+          enum: [],
+          default: 'demo',
+          description: 'Username selection',
+        },
       },
     }
-    expect(serverSchema.parse(server)).toMatchObject(server)
+
+    expect(serverSchema.parse(server)).toStrictEqual({
+      uid: expect.any(String),
+      url: 'https://{environment}.example.com',
+      variables: {
+        environment: {
+          enum: ['dev', 'staging', 'prod'],
+          default: 'dev',
+          description: 'Environment selection',
+        },
+        username: {
+          default: 'demo',
+          description: 'Username selection',
+        },
+      },
+    })
   })
 
   it('fails when URL is missing', () => {
@@ -58,9 +79,17 @@ describe('serverSchema', () => {
         },
       },
     }
-    expect(() => serverSchema.parse(server)).toThrow(
-      'Default value must be one of the enum values if enum is defined',
-    )
+
+    expect(serverSchema.parse(server)).toMatchObject({
+      url: 'https://{environment}.example.com',
+      variables: {
+        environment: {
+          enum: ['dev', 'staging', 'prod'],
+          default: 'dev',
+          description: 'Environment selection',
+        },
+      },
+    })
   })
 
   it('validates server with relative URL', () => {

--- a/packages/oas-utils/src/entities/spec/server.ts
+++ b/packages/oas-utils/src/entities/spec/server.ts
@@ -21,8 +21,7 @@ export const oasServerVariableSchema = z.object({
    * Note this behavior is different than the Schema Object’s treatment of default values, because in those cases
    * parameter values are optional. If the enum is defined, the value MUST exist in the enum’s values.
    */
-  default: z.string().optional().default('default'),
-  /** An optional description for the server variable. CommonMark syntax MAY be used for rich text representation. */
+  default: z.string().optional(),
   description: z.string().optional(),
 }) as ZodSchema<
   Omit<OpenAPIV3_1.ServerVariableObject, 'enum'> & {

--- a/packages/oas-utils/src/entities/spec/server.ts
+++ b/packages/oas-utils/src/entities/spec/server.ts
@@ -1,7 +1,6 @@
+import { nanoidSchema } from '@/entities/shared'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { type ZodSchema, z } from 'zod'
-
-import { nanoidSchema } from '../shared'
 
 /**
  * Server variables

--- a/packages/oas-utils/src/entities/spec/server.ts
+++ b/packages/oas-utils/src/entities/spec/server.ts
@@ -1,49 +1,57 @@
 import { nanoidSchema } from '@/entities/shared'
-import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import { type ZodSchema, z } from 'zod'
+import { z } from 'zod'
 
 /**
- * Server variables
+ * Server Variable Object
+ *
  * An object representing a Server Variable for server URL template substitution.
  *
- * @see https://spec.openapis.org/oas/v3.1.0#server-variable-object
- *
- * NOTE: Typecase is required to handle enum string array type
+ * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#server-variable-object
  */
-export const oasServerVariableSchema = z.object({
-  /**
-   * An enumeration of string values to be used if the substitution options are from a limited set.
-   * The array MUST NOT be empty.
-   */
-  enum: z.string().array().min(1).optional(),
-  /**
-   * REQUIRED. The default value to use for substitution, which SHALL be sent if an alternate value is not supplied.
-   * Note this behavior is different than the Schema Object’s treatment of default values, because in those cases
-   * parameter values are optional. If the enum is defined, the value MUST exist in the enum’s values.
-   */
-  default: z.string().optional(),
-  description: z.string().optional(),
-}) as ZodSchema<
-  Omit<OpenAPIV3_1.ServerVariableObject, 'enum'> & {
-    enum?: [string, ...string[]]
-  }
->
+export const oasServerVariableSchema = z
+  .object({
+    /**
+     * An enumeration of string values to be used if the substitution options are from a limited set. The array MUST NOT be empty.
+     */
+    enum: z.array(z.string()).optional(),
+    /**
+     * REQUIRED. The default value to use for substitution, which SHALL be sent if an alternate value is not supplied.
+     * Note this behavior is different than the Schema Object’s treatment of default values, because in those cases
+     * parameter values are optional. If the enum is defined, the value MUST exist in the enum’s values.
+     */
+    default: z.string().optional(),
+    /**
+     * An optional description for the server variable. CommonMark syntax MAY be used for rich text representation.
+     */
+    description: z.string().optional(),
+  })
+  .refine((data) => !data.enum || data.enum.includes(data.default ?? ''), {
+    message: 'Default value must be one of the enum values if enum is defined',
+    path: ['default'],
+  })
 
+/**
+ * Server Object
+ *
+ * An object representing a Server.
+ *
+ * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#server-object
+ */
 export const oasServerSchema = z.object({
   /**
    * REQUIRED. A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that
    * the host location is relative to the location where the OpenAPI document is being served. Variable substitutions
    * will be made when a variable is named in {brackets}.
    */
-  url: z.string().optional().default(''),
+  url: z.string(),
   /**
    * An optional string describing the host designated by the URL. CommonMark syntax MAY be used for rich text
    * representation.
    */
   description: z.string().optional(),
   /** A map between a variable name and its value. The value is used for substitution in the server’s URL template. */
-  variables: z.record(z.string(), oasServerVariableSchema).optional(),
-}) satisfies ZodSchema<OpenAPIV3_1.ServerObject>
+  variables: z.record(z.string(), oasServerVariableSchema).optional().catch({}),
+})
 
 export const serverSchema = oasServerSchema.extend({
   uid: nanoidSchema,

--- a/packages/oas-utils/src/entities/spec/server.ts
+++ b/packages/oas-utils/src/entities/spec/server.ts
@@ -63,7 +63,7 @@ export const oasServerSchema = z.object({
    */
   description: z.string().optional(),
   /** A map between a variable name and its value. The value is used for substitution in the server's URL template. */
-  variables: z.record(z.string(), oasServerVariableSchema).optional().catch({}),
+  variables: z.record(z.string(), oasServerVariableSchema).optional(),
 })
 
 export const serverSchema = oasServerSchema.extend({

--- a/packages/oas-utils/src/entities/spec/server.ts
+++ b/packages/oas-utils/src/entities/spec/server.ts
@@ -25,9 +25,22 @@ export const oasServerVariableSchema = z
      */
     description: z.string().optional(),
   })
-  .refine((data) => !data.enum || data.enum.includes(data.default ?? ''), {
-    message: 'Default value must be one of the enum values if enum is defined',
-    path: ['default'],
+  .refine((data) => {
+    // Set default to the first enum value if invalid
+    if (
+      Array.isArray(data.enum) &&
+      !data.enum.includes(data.default ?? '') &&
+      data.enum.length > 0
+    ) {
+      data.default = data.enum[0]
+    }
+
+    if (Array.isArray(data.enum) && data.enum.length === 0) {
+      delete data.enum
+    }
+
+    // Always return true since we’ve modified the data to be valid
+    return true
   })
 
 /**
@@ -49,7 +62,7 @@ export const oasServerSchema = z.object({
    * representation.
    */
   description: z.string().optional(),
-  /** A map between a variable name and its value. The value is used for substitution in the server’s URL template. */
+  /** A map between a variable name and its value. The value is used for substitution in the server's URL template. */
   variables: z.record(z.string(), oasServerVariableSchema).optional().catch({}),
 })
 

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -471,7 +471,6 @@ export function getServersFromOpenApiDocument(
         // Validate the server against the schema
         const parsedSchema = serverSchema.parse(server)
 
-        console.log()
 
         // Prepend with the base server URL (if the given URL is relative)
         if (parsedSchema?.url?.startsWith('/')) {

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -471,7 +471,6 @@ export function getServersFromOpenApiDocument(
         // Validate the server against the schema
         const parsedSchema = serverSchema.parse(server)
 
-
         // Prepend with the base server URL (if the given URL is relative)
         if (parsedSchema?.url?.startsWith('/')) {
           // Use the base server URL (if provided)

--- a/packages/oas-utils/vite.config.ts
+++ b/packages/oas-utils/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   plugins: [],
   resolve: {
     alias: alias(import.meta.url),
-    dedupe: ['vue'],
   },
   server: {
     port: 9000,

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -26,6 +26,13 @@ export type ClientInfo = {
   description: string
 }
 
+/**
+ * Alias for the OpenAPI 3.1 ServerObject type
+ *
+ * @deprecated Use OpenAPIV3_1.ServerObject instead
+ */
+export type Server = OpenAPIV3_1.ServerObject
+
 export type TargetInfo = {
   key: TargetId
   title: string

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -258,7 +258,7 @@ export type ReferenceConfiguration = {
    * @default undefined
    * @example [{ url: 'https://api.scalar.com', description: 'Production server' }]
    */
-  servers?: Server[]
+  servers?: OpenAPIV3_1.ServerObject[]
   /**
    * We’re using Inter and JetBrains Mono as the default fonts. If you want to use your own fonts, set this to false.
    *
@@ -325,8 +325,6 @@ export type ReferenceConfiguration = {
   hideClientButton?: boolean
 }
 
-export type Server = OpenAPIV3.ServerObject | OpenAPIV3_1.ServerObject
-
 export type BaseParameter = {
   name: string
   description?: string | null
@@ -376,7 +374,7 @@ export type Information = {
   'summary'?: string
   'tags'?: string[]
   'deprecated'?: boolean
-  'servers'?: Server[]
+  'servers'?: OpenAPIV3_1.ServerObject[]
   /**
    * Scalar
    */
@@ -407,7 +405,7 @@ export type Operation = {
   name?: string
   description?: string
   information?: Information
-  servers?: Server[]
+  servers?: OpenAPIV3_1.ServerObject[]
 }
 
 /**


### PR DESCRIPTION
WIP

Need to fix tests

**Problem**

The server logic in the reference covered some edge cases that we didn't cover in the client.

**Solution**

This PR:
* moves the server logic to a separate function
* add tests
* covers some more edge cases
* adds baseServerURL to the documentation
* improves the Zod schema for the servers
  * closer to the specification
  * removes `'default'` as the default value for variables
  * if `enum` is defined: enforces `default` is a possible value
  * if a single server is invalid, it's omitted, but the others servers are still there
  * the data is validated against the schema first *and then* modified, this makes it more robust
  * updated the comments

<img width="766" alt="Screenshot 2025-01-21 at 17 02 16" src="https://github.com/user-attachments/assets/993872a3-f9aa-4a9c-9865-fef4cd1cc97b" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.
