### PR TITLE
fix(Scalar.AspNetCore): allow anonymous for assets endpoint

### DIFF
--- a/.changeset/strong-shirts-juggle.md
+++ b/.changeset/strong-shirts-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+fix: anonymous assets endpoint

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -204,8 +204,8 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// </summary>
     private static void MapStaticAssetsEndpoint(this IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet(ScalarJavaScriptFile, static (HttpContext httpContext) => HandleStaticAsset(ScalarJavaScriptFile, httpContext));
-        endpoints.MapGet(ScalarJavaScriptHelperFile, static (HttpContext httpContext) => HandleStaticAsset(ScalarJavaScriptHelperFile, httpContext));
+        endpoints.MapGet(ScalarJavaScriptFile, static (HttpContext httpContext) => HandleStaticAsset(ScalarJavaScriptFile, httpContext)).AllowAnonymous();
+        endpoints.MapGet(ScalarJavaScriptHelperFile, static (HttpContext httpContext) => HandleStaticAsset(ScalarJavaScriptHelperFile, httpContext)).AllowAnonymous();
     }
 
     private static IResult HandleStaticAsset(string file, HttpContext httpContext)

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -201,6 +201,33 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
     }
     
     [Fact]
+    public async Task MapScalarApiReference_ShouldReturn401_WhenAuthenticationRequired()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/auth/scalar");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+    
+    [Fact]
+    public async Task MapScalarApiReference_ShouldReturn200_WhenAuthenticated()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Api-Key", "my-api-key");
+
+        // Act
+        var response = await client.GetAsync("/auth/scalar");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+    
+    [Fact]
     public async Task MapScalarApiReference_ShouldNotCauseOptionsConflict_WhenMultipleEndpointsAreDefined()
     {
         // Arrange

--- a/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/ApiKeyAuthenticationSchemeHandler.cs
+++ b/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/ApiKeyAuthenticationSchemeHandler.cs
@@ -1,0 +1,37 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Scalar.AspNetCore.Tests.Api;
+
+internal sealed class ApiKeyAuthenticationSchemeHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    [Obsolete("This constructor is obsolete.")]
+    public ApiKeyAuthenticationSchemeHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock) : base(options, logger, encoder, clock)
+    {
+    }
+
+    public ApiKeyAuthenticationSchemeHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder) : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Context.Request.Headers.TryGetValue("X-Api-Key", out var apiKey))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        if (apiKey != "my-api-key")
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Invalid API key"));
+        }
+
+        var identity = new ClaimsIdentity([new Claim(ClaimTypes.Name, "Api-Key-User")], Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        var result = AuthenticateResult.Success(ticket);
+        return Task.FromResult(result);
+    }
+}

--- a/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Program.cs
+++ b/packages/scalar.aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Program.cs
@@ -1,19 +1,26 @@
+using Microsoft.AspNetCore.Authentication;
 using Scalar.AspNetCore;
+using Scalar.AspNetCore.Tests.Api;
 
 var builder = WebApplication.CreateSlimBuilder(args);
 
 builder.Services.AddOpenApi();
+builder.Services.AddAuthentication("api-key")
+    .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationSchemeHandler>("api-key", null);
+builder.Services.AddAuthorizationBuilder().AddFallbackPolicy("fallback", policyBuilder => policyBuilder.RequireAuthenticatedUser());
 
 var app = builder.Build();
 
 app.MapOpenApi();
 
-app.MapScalarApiReference();
+app.MapScalarApiReference().AllowAnonymous();
 
-app.MapScalarApiReference("/api-reference");
+app.MapScalarApiReference("/api-reference").AllowAnonymous();
+
+app.MapScalarApiReference("/auth/scalar");
 
 #pragma warning disable CS0618 // Type or member is obsolete
-app.MapScalarApiReference(options => options.WithEndpointPrefix("/legacy/{documentName}"));
+app.MapScalarApiReference(options => options.WithEndpointPrefix("/legacy/{documentName}")).AllowAnonymous();
 #pragma warning restore CS0618 // Type or member is obsolete
 
 app.Run();


### PR DESCRIPTION
Closes #4529 

**Problem**
The recently introduced static assets endpoints may require authentication when a fallback authentication is configured. This results in `401 Unauthorized` responses when the browser attempts to load static assets.

**Solution**
I applied the `AllowAnonymous()` method to the static assets endpoints to ensure they bypass authentication. Additionally, I updated the test to cover this scenario.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] ~I’ve updated the documentation.~ 👀 