### PR TITLE
chore(Scalar.AspNetCore): migrate tests to xunit v3

### DIFF
--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="1.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -17,7 +17,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var client = factory.CreateClient();
 
         // Act
-        var response = await client.GetAsync("/scalar");
+        var response = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
 
         // Assert
         const string expected = $$"""
@@ -46,10 +46,10 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
                                   </html>
                                   """;
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         content.ReplaceLineEndings().Should().Match(expected);
     }
-    
+
     [Fact]
     public async Task MapScalarApiReference_ShouldRedirectToTrailingSlash_WhenRequestedWithoutTrailingSlash()
     {
@@ -60,7 +60,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         });
 
         // Act
-        var response = await client.GetAsync("/scalar");
+        var response = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Redirect);
@@ -79,17 +79,17 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var client = factory.CreateClient();
 
         // Act
-        var response = await client.GetAsync(assetUrl);
+        var response = await client.GetAsync(assetUrl, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.CacheControl.Should().NotBeNull();
         response.Headers.CacheControl!.NoCache.Should().BeTrue();
         response.Headers.ETag.Should().NotBeNull();
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         content.ReplaceLineEndings().Should().Contain(expectedContent);
     }
-    
+
     [Fact]
     public async Task MapScalarApiReference_ShouldReturn304_WhenETagIsEqual()
     {
@@ -98,17 +98,17 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var client = factory.CreateClient();
 
         // Act
-        var response = await client.GetAsync(assetUrl);
+        var response = await client.GetAsync(assetUrl, TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var etag = response.Headers.ETag;
         etag.Should().NotBeNull();
-        
+
         // Act
         client.DefaultRequestHeaders.IfNoneMatch.Add(etag!);
-        response = await client.GetAsync(assetUrl);
-        
+        response = await client.GetAsync(assetUrl, TestContext.Current.CancellationToken);
+
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotModified);
     }
@@ -121,11 +121,11 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var client = factory.CreateClient();
 
         // Act
-        var response = await client.GetAsync("/scalar");
+        var response = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         content.ReplaceLineEndings().Should().Contain("/openapi/v1.json");
     }
 
@@ -136,14 +136,14 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var client = factory.CreateClient();
 
         // Act
-        var response = await client.GetAsync("/scalar/v3");
+        var response = await client.GetAsync("/scalar/v3", TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         content.ReplaceLineEndings().Should().Contain("/openapi/v3.json").And.NotContain("/openapi/v1.json");
     }
-    
+
     [Fact]
     public async Task MapScalarApiReference_ShouldUseDocumentProvider_WhenSpecified()
     {
@@ -157,14 +157,14 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         }).CreateClient();
 
         // Act
-        var response = await client.GetAsync("/scalar/");
+        var response = await client.GetAsync("/scalar/", TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var content = await response.Content.ReadAsStringAsync();
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         content.ReplaceLineEndings().Should().Contain("/openapi/v2.json").And.NotContain("/openapi/v1.json");
     }
-    
+
     [Fact]
     public async Task MapScalarApiReference_ShouldUseCustomCdn_WhenRequested()
     {
@@ -179,11 +179,11 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         }).CreateClient();
 
         // Act
-        var index = await client.GetAsync($"/scalar");
+        var index = await client.GetAsync($"/scalar", TestContext.Current.CancellationToken);
 
         // Assert
         index.StatusCode.Should().Be(HttpStatusCode.OK);
-        var indexContent = await index.Content.ReadAsStringAsync();
+        var indexContent = await index.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         indexContent.ReplaceLineEndings().Should().Contain($"<script src=\"{cdnUrl}\"></script>");
     }
 
@@ -194,12 +194,12 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var client = factory.CreateClient();
 
         // Act
-        var response = await client.GetAsync("/api-reference");
+        var response = await client.GetAsync("/api-reference", TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
-    
+
     [Fact]
     public async Task MapScalarApiReference_ShouldNotCauseOptionsConflict_WhenMultipleEndpointsAreDefined()
     {
@@ -212,7 +212,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
                 options.UseRouting();
                 options.UseEndpoints(endpoints =>
                 {
-                    endpoints.MapScalarApiReference( (o, _) => o.WithTheme(ScalarTheme.Purple));
+                    endpoints.MapScalarApiReference((o, _) => o.WithTheme(ScalarTheme.Purple));
                     endpoints.MapScalarApiReference("/bar", o => o.WithTheme(ScalarTheme.Alternate));
                 });
             });
@@ -220,16 +220,16 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var client = localFactory.CreateClient();
 
         // Act
-        var scalarResponse = await client.GetAsync("/scalar");
-        var barResponse = await client.GetAsync("/bar");
+        var scalarResponse = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
+        var barResponse = await client.GetAsync("/bar", TestContext.Current.CancellationToken);
 
         // Assert
         scalarResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         barResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        
+
         localFactory.Services.GetRequiredService<IOptions<ScalarOptions>>().Value.Theme.Should().Be(ScalarTheme.Mars);
     }
-    
+
     [Fact]
     public async Task MapScalarApiReference_ShouldHandleLegacyEndpointPathPrefix_WhenSpecified()
     {
@@ -237,7 +237,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var client = factory.CreateClient();
 
         // Act
-        var response = await client.GetAsync("/legacy");
+        var response = await client.GetAsync("/legacy", TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);


### PR DESCRIPTION
This PR bumps the `xunit` dependency to version 3. I followed their [migration guide](https://xunit.net/docs/getting-started/v3/migration).
