### PR TITLE
chore: add storybook build folder to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -26,5 +26,6 @@ examples/docusaurus/**/*.mdx
 packages/nuxt/src/runtime/plugins/hydrateClient.d.mts
 packages/openapi-parser/tests/**/*.yaml
 packages/snippetz/src/httpsnippet-lite/**/*
+packages/components/storybook-static/**/*
 
 cloudbuild.json


### PR DESCRIPTION
Looks like we’ve added a build folder which is not called dist, but didn’t add it to the .prettierignore yet.

That’ll change with this PR.