### PR TITLE
fix(Scalar.AspNetCore): add missing parameter to tests

### DIFF
--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -27,10 +27,10 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
                                       <title>Scalar API Reference</title>
                                       <meta charset="utf-8" />
                                       <meta name="viewport" content="width=device-width, initial-scale=1" />
-                                      
+
                                   </head>
                                   <body>
-                                      
+
                                       <script id="api-reference"></script>
                                       <script src="scalar.aspnetcore.js"></script>
                                       <script>
@@ -212,7 +212,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
-    
+
     [Fact]
     public async Task MapScalarApiReference_ShouldReturn200_WhenAuthenticated()
     {
@@ -226,7 +226,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
-    
+
     [Fact]
     public async Task MapScalarApiReference_ShouldNotCauseOptionsConflict_WhenMultipleEndpointsAreDefined()
     {

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -207,7 +207,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var client = factory.CreateClient();
 
         // Act
-        var response = await client.GetAsync("/auth/scalar");
+        var response = await client.GetAsync("/auth/scalar", TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -221,7 +221,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         client.DefaultRequestHeaders.Add("X-Api-Key", "my-api-key");
 
         // Act
-        var response = await client.GetAsync("/auth/scalar");
+        var response = await client.GetAsync("/auth/scalar", TestContext.Current.CancellationToken);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -27,10 +27,10 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
                                       <title>Scalar API Reference</title>
                                       <meta charset="utf-8" />
                                       <meta name="viewport" content="width=device-width, initial-scale=1" />
-
+                                      
                                   </head>
                                   <body>
-
+                                      
                                       <script id="api-reference"></script>
                                       <script src="scalar.aspnetcore.js"></script>
                                       <script>


### PR DESCRIPTION
**Problem**
Currently, the Scalar.AspNetCore tests fail in main. I forgot to rebase before merging the recent PR.

**Solution**
With this PR it should pass again, because we added the recently introduced parameter to the also recently introduced tests.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
