### PR TITLE
fix(tooling): build integrations in base builder

### DIFF
--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -15,9 +15,12 @@ COPY package.json .
 COPY tsconfig.json .
 COPY turbo.json .
 COPY packages ./packages
+COPY integrations ./integrations
 RUN pnpm install
 RUN pnpm turbo \
     run build \
     --filter='./packages/*' \
+    --filter='./integrations/*' \
     # … don’t build too many in parallel, we don’t want to hit a memory limit.
     --concurrency=2
+


### PR DESCRIPTION
**Problem**
Currently, the base builder is failing because integrations are not being built. 

**Solution**
With this PR, integrations are built in the base builder so they are available in later build and deploy steps. This may significantly increase the base builder time and further selectivity could help reduce unneccessary build time.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
