### PR TITLE
fix(api-client): request body default

### DIFF
--- a/.changeset/orange-dogs-lick.md
+++ b/.changeset/orange-dogs-lick.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+fix: removes application/json content type as default

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -378,7 +378,7 @@ export const createApiClient = ({
       if (!request) return
 
       const contentType =
-        Object.keys(request.requestBody?.content || {})[0] || 'application/json'
+        Object.keys(request.requestBody?.content || {})[0] || ''
       const example =
         request.requestBody?.content?.[contentType]?.examples[exampleKey]
       if (!example) return

--- a/packages/api-client/src/libs/importers/curl.ts
+++ b/packages/api-client/src/libs/importers/curl.ts
@@ -58,7 +58,7 @@ export function importCurlCommand(curlCommand: string): CurlCommandResult {
   const contentType =
     body?.includes('=') && !body.startsWith('{')
       ? 'application/x-www-form-urlencoded'
-      : headers['Content-Type'] || 'application/json'
+      : headers['Content-Type'] || ''
   const requestBody = body ? parseData(body) : {}
 
   // Create parameters following request schema

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -135,7 +135,7 @@ const contentMapping: Record<BodyEncoding, BodyMime> = {
 export const exampleRequestBodySchema = z.object({
   raw: z
     .object({
-      encoding: z.enum(exampleRequestBodyEncoding).default('json'),
+      encoding: z.enum(exampleRequestBodyEncoding),
       value: z.string().default(''),
     })
     .optional(),
@@ -157,7 +157,7 @@ export type ExampleRequestBody = z.infer<typeof exampleRequestBodySchema>
 
 /** Schema for the OAS serialization of request example bodies */
 export const xScalarExampleBodySchema = z.object({
-  encoding: z.enum(exampleBodyMime).default('application/json'),
+  encoding: z.enum(exampleBodyMime),
   /**
    * Body content as an object with a separately specified encoding or a simple pre-encoded string value
    *
@@ -375,10 +375,6 @@ export function createExampleFromRequest(
   // Handle request body defaulting for various content type encodings
   const body: ExampleRequestBody = {
     activeBody: 'raw',
-    raw: {
-      encoding: 'json',
-      value: '',
-    },
   }
 
   if (request.requestBody) {


### PR DESCRIPTION
**Problem**
currently `application/json` is set by default on request example creation which can cause error in some use case as seen in #4542 

**Solution**
this pr removes the default content type.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
