### PR TITLE
feat(api-client): favors layout hook over isReadOnly

### DIFF
--- a/.changeset/chatty-garlics-deny.md
+++ b/.changeset/chatty-garlics-deny.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: favors layout hook over isReadOnly

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
+import { useLayout } from '@/hooks'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 import { ScalarButton, ScalarIcon } from '@scalar/components'
@@ -19,7 +20,9 @@ const id = useId()
 
 const { activeRequest, activeExample, activeServer, activeCollection } =
   useActiveEntities()
-const { isReadOnly, requestMutators, events } = useWorkspace()
+const { requestMutators, events } = useWorkspace()
+
+const { layout } = useLayout()
 
 const addressBarRef = ref<typeof CodeInput | null>(null)
 
@@ -138,7 +141,7 @@ function updateRequestPath(url: string) {
         </div>
         <div class="flex gap-1 z-context-plus">
           <HttpMethod
-            :isEditable="!isReadOnly"
+            :isEditable="layout !== 'modal'"
             isSquare
             :method="activeRequest.method"
             teleport
@@ -159,7 +162,7 @@ function updateRequestPath(url: string) {
             aria-label="Path"
             class="outline-none"
             disableCloseBrackets
-            :disabled="isReadOnly"
+            :disabled="layout === 'modal'"
             disableEnter
             disableTabIndent
             :emitOnBlur="false"

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -20,7 +20,6 @@ defineProps<{
 
 const { activeRequest, activeCollection, activeServer } = useActiveEntities()
 const { servers, collectionMutators, events } = useWorkspace()
-
 const { layout } = useLayout()
 
 const requestServerOptions = computed(() =>

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -11,11 +11,11 @@ import { ref, toRef, useAttrs, watch, type Ref, computed } from 'vue'
 import DataTableInputSelect from '../DataTable/DataTableInputSelect.vue'
 import { pillPlugin, backspaceCommand } from './codeVariableWidget'
 import EnvironmentVariableDropdown from '@/views/Environment/EnvironmentVariableDropdown.vue'
-import { useWorkspace } from '@/store'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { ScalarIcon } from '@scalar/components'
 import { prettyPrintJson } from '@scalar/oas-utils/helpers'
 import { useActiveEntities } from '@/store/active-entities'
+import { useLayout } from '@/hooks'
 
 const props = withDefaults(
   defineProps<{
@@ -76,8 +76,7 @@ const dropdownRef = ref<InstanceType<
 
 const { activeEnvVariables, activeEnvironment, activeWorkspace } =
   useActiveEntities()
-const { isReadOnly } = useWorkspace()
-
+const { layout } = useLayout()
 const { copyToClipboard } = useClipboard()
 
 // ---------------------------------------------------------------------------
@@ -131,7 +130,7 @@ extensions.push(
     environment: activeEnvironment.value,
     envVariables: activeEnvVariables.value,
     workspace: activeWorkspace.value,
-    isReadOnly,
+    isReadOnly: layout === 'modal',
   }),
   backspaceCommand,
 )
@@ -281,7 +280,9 @@ export default {
     Required
   </div>
   <EnvironmentVariableDropdown
-    v-if="showDropdown && withVariables && !isReadOnly && activeEnvironment"
+    v-if="
+      showDropdown && withVariables && layout !== 'modal' && activeEnvironment
+    "
     ref="dropdownRef"
     :dropdownPosition="dropdownPosition"
     :envVariables="activeEnvVariables"

--- a/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
+++ b/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
@@ -1,7 +1,6 @@
 /* eslint-disable vue/one-component-per-file */
 import { parseEnvVariables } from '@/libs'
 import { type EnvVariables, getEnvColor } from '@/libs/env-helpers'
-import type { WorkspaceStore } from '@/store'
 import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
@@ -17,8 +16,6 @@ import {
 } from '@scalar/use-codemirror'
 import { createApp, defineComponent, h } from 'vue'
 
-type IsReadOnly = WorkspaceStore['isReadOnly']
-
 /**
  * Displays the value of a variable of the active environment in a pill
  */
@@ -27,14 +24,14 @@ class PillWidget extends WidgetType {
   environment?: Environment
   envVariables?: EnvVariables
   workspace?: Workspace
-  isReadOnly?: IsReadOnly
+  isReadOnly?: boolean
 
   constructor(
     private variableName: string,
     environment?: Environment,
     envVariables?: EnvVariables,
     workspace?: Workspace,
-    isReadOnly?: IsReadOnly,
+    isReadOnly?: boolean,
   ) {
     super()
     this.variableName = variableName
@@ -154,7 +151,7 @@ export const pillPlugin = (props: {
   environment?: Environment
   envVariables?: EnvVariables
   workspace?: Workspace
-  isReadOnly?: IsReadOnly
+  isReadOnly?: boolean
 }) =>
   ViewPlugin.fromClass(
     class {

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useLayout } from '@/hooks'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 import {
@@ -15,7 +16,8 @@ import { useRouter } from 'vue-router'
 
 const { activeCollection, activeWorkspace, activeEnvironment } =
   useActiveEntities()
-const { isReadOnly, collectionMutators } = useWorkspace()
+const { collectionMutators } = useWorkspace()
+const { layout } = useLayout()
 
 const router = useRouter()
 
@@ -125,7 +127,7 @@ onMounted(() => {
         <ScalarDropdownDivider />
         <!-- Manage environments -->
         <ScalarDropdownItem
-          v-if="!isReadOnly"
+          v-if="layout !== 'modal'"
           class="flex items-center gap-1.5"
           @click="createNewEnvironment">
           <div class="flex items-center justify-center h-4 w-4">

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useLayout } from '@/hooks'
 import { useWorkspace } from '@/store'
 import { useBreakpoints } from '@scalar/use-hooks/useBreakpoints'
 import { ref } from 'vue'
@@ -12,7 +13,8 @@ const props = withDefaults(
     isSidebarOpen: true,
   },
 )
-const { isReadOnly, sidebarWidth, setSidebarWidth } = useWorkspace()
+const { sidebarWidth, setSidebarWidth } = useWorkspace()
+const { layout } = useLayout()
 const isDragging = ref(false)
 
 const sidebarRef = ref<HTMLElement | null>(null)
@@ -68,7 +70,7 @@ const startDrag = (event: MouseEvent) => {
     :style="{ width: breakpoints.lg ? sidebarWidth : '100%' }">
     <slot name="header" />
     <div
-      v-if="!isReadOnly && title"
+      v-if="layout !== 'modal' && title"
       class="min-h-12 xl:min-h-client-header flex items-center justify-between px-3 py-1.5 md:px-[18px] md:py-2.5 text-sm">
       <h2 class="font-medium m-0 text-sm whitespace-nowrap">
         {{ title }}
@@ -80,7 +82,7 @@ const startDrag = (event: MouseEvent) => {
     <div
       class="custom-scroll sidebar-height pb-0 md:pb-[37px] w-[inherit]"
       :class="{
-        'sidebar-mask': !isReadOnly,
+        'sidebar-mask': layout !== 'modal',
       }">
       <slot name="content" />
     </div>

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -96,12 +96,7 @@ export type ApiClient = Omit<
    */
   store: Omit<
     WorkspaceStore,
-    | 'isReadOnly'
-    | 'router'
-    | 'events'
-    | 'sidebarWidth'
-    | 'proxyUrl'
-    | 'requestHistory'
+    'router' | 'events' | 'sidebarWidth' | 'proxyUrl' | 'requestHistory'
   >
 }
 
@@ -125,7 +120,6 @@ export const createApiClient = ({
   const store =
     _store ||
     createWorkspaceStore({
-      isReadOnly,
       proxyUrl: configuration.proxyUrl,
       themeId: configuration.themeId,
       showSidebar: configuration.showSidebar,

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -56,8 +56,6 @@ type CreateWorkspaceStoreOptions = {
    * @default true
    */
   useLocalStorage: boolean
-  /** Puts the client into read only mode, usually reservered for the modal */
-  isReadOnly: boolean
   /** Should be renamed to theme to match the references config */
   themeId: ReferenceConfiguration['theme']
   /** Specifies the integration being used. This is primarily for internal purposes and should not be manually set. */
@@ -76,7 +74,6 @@ type CreateWorkspaceStoreOptions = {
  */
 export const createWorkspaceStore = ({
   useLocalStorage = true,
-  isReadOnly = false,
   showSidebar = true,
   proxyUrl,
   themeId,
@@ -213,7 +210,6 @@ export const createWorkspaceStore = ({
     // ---------------------------------------------------------------------------
     // CONFIGURATION "PROPS"
     // TODO: move these to their own store
-    isReadOnly,
     hideClientButton,
     showSidebar,
     integration,

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -39,7 +39,6 @@ const {
 } = useActiveEntities()
 const {
   cookies,
-  isReadOnly,
   modalState,
   requestHistory,
   showSidebar,
@@ -55,7 +54,7 @@ type ExtendedRequestPayload = RequestPayload & {
   url?: string
 }
 
-const isSidebarOpen = ref(!isReadOnly)
+const isSidebarOpen = ref(layout !== 'modal')
 const requestAbortController = ref<AbortController>()
 const parsedCurl = ref<ExtendedRequestPayload>()
 const selectedServerUid = ref('')
@@ -80,7 +79,7 @@ watch(mediaQueries.xl, (isXL) => (isSidebarOpen.value = isXL), {
  */
 const selectedSecuritySchemeUids = computed(
   () =>
-    (isReadOnly
+    (layout === 'modal'
       ? activeCollection.value?.selectedSecuritySchemeUids
       : activeRequest.value?.selectedSecuritySchemeUids) ?? [],
 )
@@ -220,7 +219,7 @@ function handleCurlImport(curl: string) {
   <div
     class="flex flex-1 flex-col pt-0 h-full bg-b-1 relative z-0 overflow-hidden"
     :class="{
-      '!mr-0 !mb-0 !border-0': isReadOnly,
+      '!mr-0 !mb-0 !border-0': layout === 'modal',
     }">
     <div class="flex h-full">
       <RequestSidebar

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { DataTable } from '@/components/DataTable'
+import type { ClientLayout } from '@/hooks'
 import { useWorkspace } from '@/store'
 import { displaySchemeFormatter } from '@/views/Request/libs'
 import { useModal } from '@scalar/components'
@@ -10,11 +11,10 @@ import RequestExampleAuth from './RequestExampleAuth.vue'
 
 const { selectedSecuritySchemeUids, layout = 'client' } = defineProps<{
   selectedSecuritySchemeUids: string[]
-  layout?: 'client' | 'reference'
+  layout?: 'client' | 'reference' | ClientLayout
 }>()
 
 const { securitySchemes } = useWorkspace()
-
 const deleteSchemeModal = useModal()
 const selectedScheme = ref<{ id: string; label: string } | null>(null)
 
@@ -68,9 +68,7 @@ watch(
       class="flex-1"
       :class="layout === 'reference' && 'border-0'"
       :columns="['']">
-      <RequestExampleAuth
-        :layout="layout"
-        :selectedSecuritySchemeUids="[activeAuth]" />
+      <RequestExampleAuth :selectedSecuritySchemeUids="[activeAuth]" />
     </DataTable>
 
     <div

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestExampleAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestExampleAuth.vue
@@ -147,7 +147,7 @@ const updateScheme = <U extends string, P extends Path<SecurityScheme>>(
               class="floating-bg py-1 text-sm border-b-[1px] border-transparent relative cursor-pointer font-medium text-c-3"
               :class="{
                 '!text-c-1 !border-current border-b-[1px] !rounded-none':
-                  layout === 'client' &&
+                  layout !== 'reference' &&
                   (activeFlow === key || (ind === 0 && !activeFlow)),
                 '!text-c-1 !border-current border-b-[1px] !rounded-none opacity-100':
                   layout === 'reference' &&

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import ContextBar from '@/components/ContextBar.vue'
 import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import { useLayout } from '@/hooks'
 import { matchesDomain } from '@/libs/send-request/set-request-cookies'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
@@ -18,7 +19,8 @@ defineProps<{
 
 const { activeRequest, activeExample, activeWorkspace, activeServer } =
   useActiveEntities()
-const { isReadOnly, requestMutators, cookies } = useWorkspace()
+const { requestMutators, cookies } = useWorkspace()
+const { layout } = useLayout()
 
 const sections = computed(() => {
   const allSections = new Set([
@@ -42,7 +44,7 @@ const sections = computed(() => {
 
 // If security = [] or [{}] just hide it on readOnly mode
 const isAuthHidden = computed(
-  () => isReadOnly && activeRequest.value?.security?.length === 0,
+  () => layout === 'modal' && activeRequest.value?.security?.length === 0,
 )
 
 type ActiveSections = (typeof sections.value)[number]
@@ -99,11 +101,11 @@ const activeWorkspaceCookies = computed(() =>
       <div
         class="flex-1 flex gap-1 items-center lg:pr-24 pointer-events-none group">
         <label
-          v-if="!isReadOnly"
+          v-if="layout !== 'modal'"
           class="absolute w-full h-full top-0 left-0 pointer-events-auto opacity-0 cursor-text"
           for="requestname" />
         <input
-          v-if="!isReadOnly"
+          v-if="layout !== 'modal'"
           id="requestname"
           class="text-c-1 rounded pointer-events-auto relative w-full pl-1.25 -ml-0.5 md:-ml-1.25 h-8 group-hover-input has-[:focus-visible]:outline z-10"
           placeholder="Request Name"

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -60,7 +60,7 @@ const {
   activeWorkspaceRequests,
   activeWorkspace,
 } = useActiveEntities()
-const { findRequestParents, isReadOnly, events, requestMutators, requests } =
+const { findRequestParents, events, requestMutators, requests } =
   workspaceContext
 
 const { handleDragEnd, isDroppable } = dragHandlerFactory(
@@ -145,7 +145,7 @@ watch(
   (newWatchModes, oldWatchModes) => {
     newWatchModes.forEach((newWatchMode: boolean, index: number) => {
       if (
-        !isReadOnly &&
+        layout !== 'modal' &&
         newWatchMode !== oldWatchModes[index] &&
         activeWorkspaceCollections.value[index]?.info?.title !== 'Drafts' &&
         activeWorkspaceCollections.value[index]
@@ -226,7 +226,7 @@ const toggleSearch = () => {
     :isSidebarOpen="isSidebarOpen"
     @update:isSidebarOpen="$emit('update:isSidebarOpen', $event)">
     <template
-      v-if="!isReadOnly"
+      v-if="layout !== 'modal'"
       #header>
     </template>
     <template #content>
@@ -236,13 +236,13 @@ const toggleSearch = () => {
           :class="[{ '!flex': layout === 'modal' }]"
           :modelValue="isSidebarOpen"
           @update:modelValue="$emit('update:isSidebarOpen', $event)" />
-        <WorkspaceDropdown v-if="!isReadOnly" />
+        <WorkspaceDropdown v-if="layout !== 'modal'" />
         <span
-          v-if="!isReadOnly"
+          v-if="layout !== 'modal'"
           class="text-c-3">
           /
         </span>
-        <EnvironmentSelector v-if="!isReadOnly" />
+        <EnvironmentSelector v-if="layout !== 'modal'" />
         <button
           class="ml-auto"
           type="button"
@@ -270,7 +270,7 @@ const toggleSearch = () => {
       <div
         class="gap-1/2 flex flex-1 flex-col overflow-visible px-3 pb-3 pt-0"
         :class="{
-          'pb-14': !isReadOnly,
+          'pb-14': layout !== 'modal',
         }"
         @dragenter.prevent
         @dragover.prevent>
@@ -307,7 +307,9 @@ const toggleSearch = () => {
           <RequestSidebarItem
             v-for="collection in activeWorkspaceCollections"
             :key="collection.uid"
-            :isDraggable="!isReadOnly && collection.info?.title !== 'Drafts'"
+            :isDraggable="
+              layout !== 'modal' && collection.info?.title !== 'Drafts'
+            "
             :isDroppable="isDroppable"
             :menuItem="menuItem"
             :parentUids="[]"
@@ -363,7 +365,7 @@ const toggleSearch = () => {
           </div>
         </div>
         <ScalarButton
-          v-if="!isReadOnly"
+          v-if="layout !== 'modal'"
           class="mb-1.5 w-full h-fit hidden opacity-0 p-1.5"
           :class="{
             'flex opacity-100': activeWorkspaceRequests.length <= 1,
@@ -372,7 +374,7 @@ const toggleSearch = () => {
           Import Collection
         </ScalarButton>
         <SidebarButton
-          v-if="!isReadOnly"
+          v-if="layout !== 'modal'"
           :click="events.commandPalette.emit"
           hotkey="K">
           <template #title>Add Item</template>
@@ -383,7 +385,7 @@ const toggleSearch = () => {
 
   <!-- Menu -->
   <RequestSidebarItemMenu
-    v-if="!isReadOnly && menuItem"
+    v-if="layout !== 'modal' && menuItem"
     :menuItem="menuItem"
     @clearDrafts="handleClearDrafts"
     @closeMenu="menuItem.open = false"

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
@@ -44,6 +44,13 @@ const mockActiveEntities = {
   activeWorkspace: ref({}),
 }
 
+// Mock useLayout
+vi.mock('@/hooks', () => ({
+  useLayout: () => ({
+    layout: 'modal',
+  }),
+}))
+
 describe('RequestSubpageHeader', () => {
   const createWrapper = (options = {}) => {
     return mount(RequestSubpageHeader, {
@@ -78,10 +85,17 @@ describe('RequestSubpageHeader', () => {
     expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(false)
   })
 
-  it('shows OpenApiClientButton when in readonly mode with document URL', async () => {
+  it('shows OpenApiClientButton when layout is modal and document URL is present', async () => {
     mockUseWorkspace.mockReturnValue({
       ...mockWorkspace,
-      isReadOnly: true,
+      hideClientButton: false,
+    })
+    mockUseActiveEntities.mockReturnValue({
+      ...mockActiveEntities,
+      activeCollection: ref({
+        documentUrl: 'https://example.com',
+        integration: 'test',
+      }),
     })
     const wrapper = createWrapper()
 
@@ -98,7 +112,6 @@ describe('RequestSubpageHeader', () => {
   it('emits hideModal when close button is clicked', async () => {
     mockUseWorkspace.mockReturnValue({
       ...mockWorkspace,
-      isReadOnly: true,
     })
     const wrapper = createWrapper()
 

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -19,8 +19,7 @@ defineEmits<{
 }>()
 
 const { activeCollection } = useActiveEntities()
-const { isReadOnly, hideClientButton, showSidebar, integration } =
-  useWorkspace()
+const { hideClientButton, showSidebar, integration } = useWorkspace()
 
 const { layout } = useLayout()
 const { currentRoute } = useRouter()
@@ -46,7 +45,11 @@ const { currentRoute } = useRouter()
     <div
       class="flex flex-row items-center gap-1 lg:px-2.5 lg:mb-0 mb-2 lg:flex-1 justify-end w-1/2">
       <OpenApiClientButton
-        v-if="isReadOnly && activeCollection?.documentUrl && !hideClientButton"
+        v-if="
+          layout === 'modal' &&
+          activeCollection?.documentUrl &&
+          !hideClientButton
+        "
         buttonSource="modal"
         class="!w-fit lg:-mr-1"
         :integration="integration || activeCollection?.integration"
@@ -56,7 +59,7 @@ const { currentRoute } = useRouter()
         :url="activeCollection?.documentUrl" />
       <!-- TODO: There should be an `ìsModal` flag instead -->
       <button
-        v-if="isReadOnly"
+        v-if="layout === 'modal'"
         class="app-exit-button p-2 rounded-full fixed right-2 top-2 gitbook-hidden"
         type="button"
         @click="$emit('hideModal')">
@@ -68,7 +71,7 @@ const { currentRoute } = useRouter()
       </button>
       <!-- TODO: temporary solution: 2nd button (not fixed position) for our friends at GitBook -->
       <button
-        v-if="isReadOnly"
+        v-if="layout === 'modal'"
         class="text-c-1 hover:bg-b-2 active:text-c-1 p-2 rounded -mr-1.5 gitbook-show"
         type="button"
         @click="$emit('hideModal')">

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -11,7 +11,7 @@ import { onBeforeUnmount, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 
 const { activeWorkspaceRequests } = useActiveEntities()
-const { isReadOnly, events } = useWorkspace()
+const { events } = useWorkspace()
 const route = useRoute()
 const { layout } = useLayout()
 
@@ -39,7 +39,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
           activeWorkspaceRequests.length <= 1 && layout !== 'modal',
       }">
       <div
-        v-if="!isReadOnly"
+        v-if="layout !== 'modal'"
         class="scalar-version-number">
         Scalar App V{{ packageVersion }} Beta
         <div class="mt-2">

--- a/packages/api-client/src/views/Request/handle-drag.ts
+++ b/packages/api-client/src/views/Request/handle-drag.ts
@@ -1,3 +1,4 @@
+import { useLayout } from '@/hooks'
 import type { WorkspaceStore } from '@/store'
 import type { ActiveEntitiesStore } from '@/store/active-entities'
 import type { DraggingItem, HoveredItem } from '@scalar/draggable'
@@ -8,12 +9,13 @@ export function dragHandlerFactory(
   {
     collections,
     collectionMutators,
-    isReadOnly,
     tags,
     tagMutators,
     workspaceMutators,
   }: WorkspaceStore,
 ) {
+  const { layout } = useLayout()
+
   /** Mutate tag OR collection */
   function mutateTagOrCollection(uid: string, childUids: string[]) {
     if (collections[uid]) collectionMutators.edit(uid, 'children', childUids)
@@ -97,7 +99,7 @@ export function dragHandlerFactory(
     hoveredItem: HoveredItem,
   ) => {
     // Cannot drop in read only mode
-    if (isReadOnly) return false
+    if (layout === 'modal') return false
     // Cannot drop requests/folders into a workspace
     if (!collections[draggingItem.id] && hoveredItem.offset !== 2) return false
     // Collections cannot drop over Drafts

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -244,7 +244,6 @@ provideUseId(() => {
 
 // Create the workspace store and provide it
 const workspaceStore = createWorkspaceStore({
-  isReadOnly: true,
   proxyUrl: props.configuration.proxyUrl || props.configuration.proxy,
   themeId: props.configuration.theme,
   useLocalStorage: false,


### PR DESCRIPTION
**Problem**
we currently have two way to distinguish reference and client usages.

**Solution**
this pr favors the usage of the layout hook over the previously used isReadOnly. To be thoroughly tested to make sure no previously set behavior are now possible in client/reference and vice versa.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
