### PR TITLE
fix(api-reference):  add `.introduction-section` class to Introduction

### DIFF
--- a/.changeset/spotty-meals-report.md
+++ b/.changeset/spotty-meals-report.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): add .introduction-section class to Introduction

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.test.ts
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.test.ts
@@ -53,6 +53,35 @@ describe('Introduction', () => {
     expect(wrapper.find('.loading').exists()).toBe(true)
   })
 
+  /**
+   * We use the .introduction-section class for theming widely
+   * so we need to make sure it's there
+   */
+  it('exposes the .introduction-section class for theming', () => {
+    const example = {
+      openapi: '3.1.1',
+      info: {
+        title: 'Hello World',
+        description: 'Example description',
+        version: '1.0.0',
+      },
+    } satisfies Spec
+
+    const wrapper = mount(Introduction, {
+      props: {
+        parsedSpec: example,
+        info: example.info,
+      },
+    })
+
+    const section = wrapper.get('.introduction-section')
+
+    expect(section.html()).toContain('Hello World')
+    expect(section.html()).toContain('Example description')
+    expect(section.html()).toContain('v1.0.0')
+    expect(section.html()).toContain('OAS 3.1.1')
+  })
+
   it('generates filename from title', () => {
     const example = {
       openapi: '3.1.1',

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -54,7 +54,7 @@ const version = computed(() => {
 <template>
   <SectionContainer>
     <!-- If the #after slot is used, we need to add a gap to the section. -->
-    <Section class="gap-12">
+    <Section class="introduction-section gap-12">
       <SectionContent :loading="!info?.description && !info?.title">
         <div class="badges">
           <Badge v-if="version">{{ version }}</Badge>


### PR DESCRIPTION
Brings back the `.introduction-section` class which is used in a bunch of themes. Also adds a test so we (hopefully) don't accidentally delete the class again.