### PR TITLE
fix(api-client): add back index to template loop

### DIFF
--- a/.changeset/brave-boxes-jog.md
+++ b/.changeset/brave-boxes-jog.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: add back in using index as a key in a couple places

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -29,7 +29,7 @@ defineProps<{
         :columns="['']">
         <DataTableRow
           v-for="(option, index) in options"
-          :key="option.key"
+          :key="index"
           :class="{ 'border-t': index === 0 }">
           <DataTableInput
             :modelValue="data[option.key]"

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -318,9 +318,9 @@ const updateActiveBody = (type: Content) => {
       headers.splice(contentTypeIdx, 1)
     }
   }
-  // Add header if doesn't
+  // Add header if doesn't have one
   else if (header)
-    headers.unshift({
+    headers.push({
       key: 'Content-Type',
       value: header,
       enabled: true,

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -81,7 +81,7 @@ const flattenValue = (item: RequestExampleParameter) => {
     :columns="columns">
     <DataTableRow
       v-for="(item, idx) in items"
-      :key="item.key">
+      :key="idx">
       <label class="contents">
         <template v-if="isGlobal">
           <RouterLink


### PR DESCRIPTION
**Problem**
While using index as a key is often a bit no no, using the name caused a new one to be created every time you typed a letter.
![image](https://github.com/user-attachments/assets/2869bd32-b2fb-421f-b4c8-f44c5a36a593)


**Solution**
We bring back the index key and remove the unshift, we will need to be careful of array modification

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
