### PR TITLE
fix(Scalar.AspNetCore): HiddenClients configuration behavior

### DIFF
--- a/.changeset/fluffy-insects-protect.md
+++ b/.changeset/fluffy-insects-protect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+fix: HiddenClients behavior and add missing clients and targets

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarClient.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarClient.cs
@@ -26,6 +26,12 @@ public enum ScalarClient
     /// </summary>
     [Description("httpclient")]
     HttpClient,
+    
+    /// <summary>
+    /// Http client.
+    /// </summary>
+    [Description("http")]
+    Http,
 
     /// <summary>
     /// RestSharp client.
@@ -181,5 +187,11 @@ public enum ScalarClient
     /// Wget client.
     /// </summary>
     [Description("wget")]
-    Wget
+    Wget,
+    
+    /// <summary>
+    /// OFetch client.
+    /// </summary>
+    [Description("ofetch")]
+    OFetch
 }

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTarget.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTarget.cs
@@ -28,6 +28,12 @@ public enum ScalarTarget
     CSharp,
 
     /// <summary>
+    /// Dart programming language.
+    /// </summary>
+    [Description("dart")]
+    Dart,
+    
+    /// <summary>
     /// Go programming language.
     /// </summary>
     [Description("go")]
@@ -74,7 +80,7 @@ public enum ScalarTarget
     /// </summary>
     [Description("ocaml")]
     OCaml,
-
+    
     /// <summary>
     /// PHP programming language.
     /// </summary>

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -165,7 +165,7 @@ public static class ScalarEndpointRouteBuilderExtensions
             }
 
             var configuration = options.ToScalarConfiguration();
-            var serializedConfiguration = JsonSerializer.Serialize(configuration, ScalarConfigurationSerializerContext.Default.ScalarConfiguration);
+            var serializedConfiguration = JsonSerializer.Serialize(configuration, typeof(ScalarConfiguration), ScalarConfigurationSerializerContext.Default);
 
             // Workaround. Once we support multiple OpenAPI documents, we must update this.
             var documentUrl = configuration.Documents.First();

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -52,7 +52,7 @@ internal static class ScalarOptionsMapper
             Authentication = options.Authentication,
             TagSorter = options.TagSorter?.ToStringFast(),
             OperationsSorter = options.OperationSorter?.ToStringFast(),
-            HiddenClients = options.HiddenClients ? true : GetHiddenClients(options),
+            HiddenClients = options.HiddenClients ? options.HiddenClients : GetHiddenClients(options),
             DefaultHttpClient = new DefaultHttpClient
             {
                 ClientKey = options.DefaultHttpClient.Value.ToStringFast(),

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -11,8 +11,8 @@ internal static class ScalarOptionsMapper
         { ScalarTarget.CSharp, [ScalarClient.HttpClient, ScalarClient.RestSharp] },
         { ScalarTarget.Http, [ScalarClient.Http11] },
         { ScalarTarget.Java, [ScalarClient.AsyncHttp, ScalarClient.NetHttp, ScalarClient.OkHttp, ScalarClient.Unirest] },
-        { ScalarTarget.JavaScript, [ScalarClient.Xhr, ScalarClient.Axios, ScalarClient.Fetch, ScalarClient.JQuery] },
-        { ScalarTarget.Node, [ScalarClient.Undici, ScalarClient.Native, ScalarClient.Request, ScalarClient.Unirest, ScalarClient.Axios, ScalarClient.Fetch] },
+        { ScalarTarget.JavaScript, [ScalarClient.Xhr, ScalarClient.Axios, ScalarClient.Fetch, ScalarClient.JQuery, ScalarClient.OFetch] },
+        { ScalarTarget.Node, [ScalarClient.Undici, ScalarClient.Native, ScalarClient.Request, ScalarClient.Unirest, ScalarClient.Axios, ScalarClient.Fetch, ScalarClient.OFetch] },
         { ScalarTarget.ObjC, [ScalarClient.Nsurlsession] },
         { ScalarTarget.OCaml, [ScalarClient.CoHttp] },
         { ScalarTarget.Php, [ScalarClient.Curl, ScalarClient.Guzzle, ScalarClient.Http1, ScalarClient.Http2] },
@@ -23,7 +23,8 @@ internal static class ScalarOptionsMapper
         { ScalarTarget.Shell, [ScalarClient.Curl, ScalarClient.Httpie, ScalarClient.Wget] },
         { ScalarTarget.Swift, [ScalarClient.Nsurlsession] },
         { ScalarTarget.Go, [ScalarClient.Native] },
-        { ScalarTarget.Kotlin, [ScalarClient.OkHttp] }
+        { ScalarTarget.Kotlin, [ScalarClient.OkHttp] },
+        { ScalarTarget.Dart , [ScalarClient.Http]}
     };
 
     internal static ScalarConfiguration ToScalarConfiguration(this ScalarOptions options)
@@ -51,7 +52,7 @@ internal static class ScalarOptionsMapper
             Authentication = options.Authentication,
             TagSorter = options.TagSorter?.ToStringFast(),
             OperationsSorter = options.OperationSorter?.ToStringFast(),
-            HiddenClients = GetHiddenClients(options),
+            HiddenClients = options.HiddenClients ? true : GetHiddenClients(options),
             DefaultHttpClient = new DefaultHttpClient
             {
                 ClientKey = options.DefaultHttpClient.Value.ToStringFast(),
@@ -75,11 +76,6 @@ internal static class ScalarOptionsMapper
 
     private static Dictionary<ScalarTarget, ScalarClient[]>? ProcessOptions(ScalarOptions options)
     {
-        if (options.HiddenClients)
-        {
-            return ClientOptions;
-        }
-
         if (options.EnabledTargets.Length == 0 && options.EnabledClients.Length == 0)
         {
             return null;

--- a/packages/scalar.aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
+++ b/packages/scalar.aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
@@ -34,7 +34,10 @@ internal sealed class ScalarConfiguration
 
     public required DefaultHttpClient? DefaultHttpClient { get; init; }
 
-    public required IDictionary<string, IEnumerable<string>>? HiddenClients { get; init; }
+    /// <remarks>
+    /// This could be a dictionary of <see cref="ScalarTarget"/> and <see cref="ScalarClient"/> arrays or a boolean if all clients are hidden.
+    /// </remarks>
+    public required object? HiddenClients { get; init; }
 
     public required ScalarAuthenticationOptions? Authentication { get; init; }
 
@@ -64,5 +67,6 @@ internal sealed class ScalarConfiguration
 }
 
 [JsonSerializable(typeof(ScalarConfiguration))]
+[JsonSerializable(typeof(Dictionary<string, IEnumerable<string>>))] // Type of hidden clients
 [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class ScalarConfigurationSerializerContext : JsonSerializerContext;

--- a/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/packages/scalar.aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -94,7 +94,7 @@ public class ScalarOptionsMapperTests
         configuration.MetaData.Should().ContainKey("key").WhoseValue.Should().Be("value");
         configuration.DefaultHttpClient!.TargetKey.Should().Be(ScalarTarget.CSharp.ToStringFast());
         configuration.DefaultHttpClient!.ClientKey.Should().Be(ScalarClient.HttpClient.ToStringFast());
-        configuration.HiddenClients.Should().ContainKeys(ScalarOptionsMapper.ClientOptions.Keys.Select(x => x.ToStringFast()));
+        ((bool) configuration.HiddenClients!).Should().BeTrue();
         configuration.Authentication.Should().NotBeNull();
         configuration.Authentication!.PreferredSecurityScheme.Should().Be("my-scheme");
         configuration.Authentication.ApiKey.Should().NotBeNull();
@@ -124,16 +124,16 @@ public class ScalarOptionsMapperTests
     }
 
     [Fact]
-    public void GetHiddenClients_ShouldReturnAllClients_WhenHiddenClientsIsTrue()
+    public void GetHiddenClients_ShouldReturnTrue_WhenHiddenClientsIsTrue()
     {
         // Arrange
         var options = new ScalarOptions { HiddenClients = true };
 
         // Act
-        var hiddenClients = options.ToScalarConfiguration().HiddenClients;
+        var hiddenClients = (bool) options.ToScalarConfiguration().HiddenClients!;
 
         // Assert
-        hiddenClients.Should().ContainKeys(ScalarOptionsMapper.ClientOptions.Keys.Select(x => x.ToStringFast()));
+        hiddenClients.Should().BeTrue();
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class ScalarOptionsMapperTests
         var options = new ScalarOptions { EnabledTargets = [ScalarTarget.CSharp] };
 
         // Act
-        var hiddenClients = options.ToScalarConfiguration().HiddenClients;
+        var hiddenClients = (IDictionary<string, IEnumerable<string>>) options.ToScalarConfiguration().HiddenClients!;
 
         // Assert
         hiddenClients.Should().HaveCount(ScalarOptionsMapper.ClientOptions.Count - 1);
@@ -157,7 +157,7 @@ public class ScalarOptionsMapperTests
         var options = new ScalarOptions { EnabledClients = [ScalarClient.HttpClient, ScalarClient.Python3] };
 
         // Act
-        var hiddenClients = options.ToScalarConfiguration().HiddenClients;
+        var hiddenClients = (IDictionary<string, IEnumerable<string>>) options.ToScalarConfiguration().HiddenClients!;
 
         // Assert
         hiddenClients.Should().HaveCount(ScalarOptionsMapper.ClientOptions.Count);
@@ -174,7 +174,7 @@ public class ScalarOptionsMapperTests
         var options = new ScalarOptions { EnabledClients = [ScalarClient.OkHttp] }; // All Kotlin clients are enabled
 
         // Act
-        var hiddenClients = options.ToScalarConfiguration().HiddenClients;
+        var hiddenClients = (IDictionary<string, IEnumerable<string>>) options.ToScalarConfiguration().HiddenClients!;
 
         // Assert
         hiddenClients.Should().HaveCount(ScalarOptionsMapper.ClientOptions.Count - 1);


### PR DESCRIPTION
Closes #4549

It looks like we added support for some more targets and clients, I added them to `ScalarTarget` and `ScalarClient` enums. I also updated the JSON serializer options to return `true` if `HiddenClients` is true.


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] ~I’ve updated the documentation.~