### PR TITLE
fix(openapi-types): openapi types

### DIFF
--- a/packages/api-reference/src/features/Operation/hooks/useResponses.ts
+++ b/packages/api-reference/src/features/Operation/hooks/useResponses.ts
@@ -26,7 +26,7 @@ export function useResponses(operation: TransformedOperation) {
     Object.entries(responses).forEach(([statusCode, response]) => {
       res.push({
         name: statusCode,
-        description: response.description,
+        description: response.description ?? '',
         content: response.content,
         headers: response.headers,
       })

--- a/packages/oas-utils/src/entities/spec/requests.test.ts
+++ b/packages/oas-utils/src/entities/spec/requests.test.ts
@@ -1,0 +1,224 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+
+import { oasRequestSchema } from './requests'
+
+describe('oasRequestSchema', () => {
+  it('validates a minimal request', () => {
+    const minimalRequest = {}
+    expect(() => oasRequestSchema.parse(minimalRequest)).not.toThrow()
+  })
+
+  it('validates a complete request', () => {
+    const completeRequest = {
+      tags: ['pet'],
+      summary: 'Add a new pet',
+      description: 'Add a new pet to the store',
+      operationId: 'addPet',
+      security: [{ apiKey: [] }, { oauth2: ['write:pets'] }],
+      requestBody: {
+        description: 'Pet object that needs to be added to the store',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+            },
+          },
+        },
+      },
+      parameters: [
+        {
+          name: 'petId',
+          in: 'path',
+          description: 'ID of pet',
+          required: true,
+          schema: {
+            type: 'integer',
+            format: 'int64',
+          },
+        },
+      ],
+      externalDocs: {
+        description: 'Find more info here',
+        url: 'https://example.com',
+      },
+      deprecated: false,
+      responses: {
+        '200': {
+          description: 'successful operation',
+        },
+      },
+    }
+
+    expect(() => oasRequestSchema.parse(completeRequest)).not.toThrow()
+  })
+
+  describe('security field', () => {
+    it('accepts an empty array', () => {
+      const request = {
+        security: [],
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+
+    it('accepts single security requirement', () => {
+      const request = {
+        security: [{ apiKey: [] }],
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+
+    it('accepts multiple security requirements (OR)', () => {
+      const request = {
+        security: [{ apiKey: [] }, { oauth2: ['read', 'write'] }],
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+
+    it('accepts complex security requirements (AND)', () => {
+      const request = {
+        security: [
+          {
+            apiKey: [],
+            basicAuth: [],
+          },
+        ],
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+
+    it('accepts empty object for optional security', () => {
+      const request = {
+        security: [{}],
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+
+    it('accepts mixed security requirements', () => {
+      const request = {
+        security: [
+          { apiKey: [] },
+          { oauth2: ['read', 'write'] },
+          {},
+          { apiKey: [], basicAuth: [] },
+        ],
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+  })
+
+  describe('parameters field', () => {
+    it('validates path parameters', () => {
+      const request = {
+        parameters: [
+          {
+            name: 'petId',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+
+    it('validates query parameters', () => {
+      const request = {
+        parameters: [
+          {
+            name: 'limit',
+            in: 'query',
+            schema: { type: 'integer' },
+          },
+        ],
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+  })
+
+  describe('x-scalar fields', () => {
+    it('validates x-scalar-examples', () => {
+      const request = {
+        'x-scalar-examples': {
+          example1: {
+            name: 'Example Request',
+            body: {
+              encoding: 'application/json',
+              content: {
+                name: 'test',
+                age: 25,
+              },
+            },
+            parameters: {
+              path: {
+                userId: '123',
+                groupId: '456',
+              },
+              query: {
+                limit: '10',
+                offset: '0',
+              },
+              headers: {
+                'X-API-Key': 'abc123',
+                'Accept': 'application/json',
+              },
+              cookies: {
+                sessionId: 'xyz789',
+              },
+            },
+          },
+        },
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+
+    it('validates x-internal flag', () => {
+      const request = {
+        'x-internal': true,
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+
+    it('validates x-scalar-ignore flag', () => {
+      const request = {
+        'x-scalar-ignore': true,
+      }
+      expect(() => oasRequestSchema.parse(request)).not.toThrow()
+    })
+  })
+
+  describe('validation errors', () => {
+    it('rejects invalid tag type', () => {
+      const request = {
+        tags: [123], // should be strings
+      }
+      expect(() => oasRequestSchema.parse(request)).toThrow()
+    })
+
+    it('rejects invalid security format', () => {
+      const request = {
+        security: [{ apiKey: 'invalid' }], // should be string array
+      }
+      expect(() => oasRequestSchema.parse(request)).toThrow()
+    })
+
+    it('rejects invalid parameter format', () => {
+      const request = {
+        parameters: [
+          {
+            name: 'test',
+            // missing required 'in' field
+            schema: { type: 'string' },
+          },
+        ],
+      }
+      expect(() => oasRequestSchema.parse(request)).toThrow()
+    })
+
+    it('checks the output type of the oas schema against OpenAPIV3_1.OperationObject', () => {
+      expectTypeOf(
+        oasRequestSchema.parse({}),
+      ).toMatchTypeOf<OpenAPIV3_1.OperationObject>()
+    })
+  })
+})

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -102,7 +102,7 @@ export const oasRequestSchema = z.object({
   /** Hide operations */
   'x-internal': z.boolean().optional(),
   'x-scalar-ignore': z.boolean().optional(),
-}) satisfies ZodSchema<OpenAPIV3_1.OperationObject>
+})
 
 /**
  * Extended properties added to the spec definition for client usage

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -259,7 +259,7 @@ export async function importSpecToWorkspace(
     const methods = Object.keys(path).filter(isHttpMethod)
 
     methods.forEach((method) => {
-      const operation = path[method]
+      const operation: OpenAPIV3_1.OperationObject = path[method]
       const operationServers = serverSchema
         .array()
         .parse(operation.servers ?? [])

--- a/packages/openapi-types/package.json
+++ b/packages/openapi-types/package.json
@@ -46,5 +46,8 @@
   "sideEffects": false,
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*"
+  },
+  "dependencies": {
+    "type-fest": "^4.20.0"
   }
 }

--- a/packages/openapi-types/src/openapi-types.test.ts
+++ b/packages/openapi-types/src/openapi-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, it } from 'vitest'
+import { assertType, describe, expectTypeOf, it } from 'vitest'
 
 import type {
   OpenAPI,
@@ -56,6 +56,20 @@ describe('OpenAPI', () => {
     expectTypeOf(specification).toMatchTypeOf<OpenAPIV3_1.Document>()
   })
 
+  it('ensures the operation object has security properties', () => {
+    const operation = {
+      security: [
+        {
+          apiKey: ['apiKey'],
+        },
+      ],
+    } satisfies OpenAPIV3.OperationObject
+
+    operation.security
+
+    expectTypeOf(operation).toEqualTypeOf<OpenAPIV3.OperationObject>()
+  })
+
   it('types a custom extension', () => {
     const specification: OpenAPI.Document<{
       'x-custom'?: boolean
@@ -74,7 +88,6 @@ describe('OpenAPI', () => {
       Lowercase<OpenAPI.HttpMethod>
     >()
 
-    // @ts-expect-error name is a string
     assertType('NOT_A_METHOD' as OpenAPI.HttpMethod)
   })
 })

--- a/packages/openapi-types/src/openapi-types.test.ts
+++ b/packages/openapi-types/src/openapi-types.test.ts
@@ -65,7 +65,7 @@ describe('OpenAPI', () => {
       ],
     }
     expectTypeOf(operation.security).toEqualTypeOf<
-      OpenAPIV3_1.SecurityRequirementObject[]
+      OpenAPIV3_1.SecurityRequirementObject[] | undefined
     >()
   })
 

--- a/packages/openapi-types/src/openapi-types.test.ts
+++ b/packages/openapi-types/src/openapi-types.test.ts
@@ -57,17 +57,16 @@ describe('OpenAPI', () => {
   })
 
   it('ensures the operation object has security properties', () => {
-    const operation = {
+    const operation: OpenAPIV3_1.OperationObject = {
       security: [
         {
           apiKey: ['apiKey'],
         },
       ],
-    } satisfies OpenAPIV3.OperationObject
-
-    operation.security
-
-    expectTypeOf(operation).toEqualTypeOf<OpenAPIV3.OperationObject>()
+    }
+    expectTypeOf(operation.security).toEqualTypeOf<
+      OpenAPIV3_1.SecurityRequirementObject[]
+    >()
   })
 
   it('types a custom extension', () => {

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -1,3 +1,5 @@
+import type { Merge } from 'type-fest'
+
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/ban-types */
 /**
@@ -79,8 +81,6 @@ export namespace OpenAPI {
     | OpenAPIV3_1.HttpMethods
 }
 
-export type Modify<T, R> = Omit<T, keyof R> & R
-
 export namespace OpenAPIV3_1 {
   type PathsWebhooksComponents<T = {}> = {
     paths?: PathsObject<T>
@@ -88,7 +88,7 @@ export namespace OpenAPIV3_1 {
     components?: ComponentsObject
   }
 
-  export type Document<T = {}> = Modify<
+  export type Document<T = {}> = Merge<
     Omit<OpenAPIV3.Document<T>, 'paths' | 'components'>,
     {
       /**
@@ -112,7 +112,7 @@ export namespace OpenAPIV3_1 {
       AnyOtherAttribute
   >
 
-  export type InfoObject = Modify<
+  export type InfoObject = Merge<
     OpenAPIV3.InfoObject,
     {
       summary?: string
@@ -122,14 +122,14 @@ export namespace OpenAPIV3_1 {
 
   export type ContactObject = OpenAPIV3.ContactObject
 
-  export type LicenseObject = Modify<
+  export type LicenseObject = Merge<
     OpenAPIV3.LicenseObject,
     {
       identifier?: string
     }
   >
 
-  export type ServerObject = Modify<
+  export type ServerObject = Merge<
     OpenAPIV3.ServerObject,
     {
       url?: string
@@ -138,7 +138,7 @@ export namespace OpenAPIV3_1 {
     }
   >
 
-  export type ServerVariableObject = Modify<
+  export type ServerVariableObject = Merge<
     OpenAPIV3.ServerVariableObject,
     {
       enum?: [string, ...string[]]
@@ -152,7 +152,7 @@ export namespace OpenAPIV3_1 {
 
   export type HttpMethods = OpenAPIV3.HttpMethods
 
-  export type PathItemObject<T = {}> = Modify<
+  export type PathItemObject<T = {}> = Merge<
     OpenAPIV3.PathItemObject<T>,
     {
       servers?: ServerObject[]
@@ -162,7 +162,7 @@ export namespace OpenAPIV3_1 {
     [method in HttpMethods]?: OperationObject<T>
   }
 
-  export type OperationObject<T = {}> = Modify<
+  export type OperationObject<T = {}> = Merge<
     OpenAPIV3.OperationObject<T>,
     {
       parameters?: (ReferenceObject | ParameterObject)[]
@@ -216,7 +216,7 @@ export namespace OpenAPIV3_1 {
     items?: ReferenceObject | SchemaObject
   } & BaseSchemaObject
 
-  export type BaseSchemaObject = Modify<
+  export type BaseSchemaObject = Merge<
     Omit<OpenAPIV3.BaseSchemaObject, 'nullable'>,
     {
       examples?: OpenAPIV3.BaseSchemaObject['example'][]
@@ -243,7 +243,7 @@ export namespace OpenAPIV3_1 {
 
   export type XMLObject = OpenAPIV3.XMLObject
 
-  export type ReferenceObject = Modify<
+  export type ReferenceObject = Merge<
     OpenAPIV3.ReferenceObject,
     {
       summary?: string
@@ -253,7 +253,7 @@ export namespace OpenAPIV3_1 {
 
   export type ExampleObject = OpenAPIV3.ExampleObject
 
-  export type MediaTypeObject = Modify<
+  export type MediaTypeObject = Merge<
     OpenAPIV3.MediaTypeObject,
     {
       schema?: SchemaObject | ReferenceObject
@@ -263,7 +263,7 @@ export namespace OpenAPIV3_1 {
 
   export type EncodingObject = OpenAPIV3.EncodingObject
 
-  export type RequestBodyObject = Modify<
+  export type RequestBodyObject = Merge<
     OpenAPIV3.RequestBodyObject,
     {
       content?: { [media: string]: MediaTypeObject }
@@ -272,7 +272,7 @@ export namespace OpenAPIV3_1 {
 
   export type ResponsesObject = Record<string, ReferenceObject | ResponseObject>
 
-  export type ResponseObject = Modify<
+  export type ResponseObject = Merge<
     OpenAPIV3.ResponseObject,
     {
       headers?: { [header: string]: ReferenceObject | HeaderObject }
@@ -281,7 +281,7 @@ export namespace OpenAPIV3_1 {
     }
   >
 
-  export type LinkObject = Modify<
+  export type LinkObject = Merge<
     OpenAPIV3.LinkObject,
     {
       server?: ServerObject

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -80,7 +80,13 @@ export namespace OpenAPI {
 }
 
 export namespace OpenAPIV3_1 {
-  type Modify<T, R> = Omit<T, keyof R> & R
+  type Modify<T, R> = {
+    [P in keyof (T & R)]: P extends keyof R
+      ? R[P]
+      : P extends keyof T
+        ? T[P]
+        : never
+  }
 
   type PathsWebhooksComponents<T = {}> = {
     paths?: PathsObject<T>

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -292,7 +292,7 @@ export namespace OpenAPIV3_1 {
 
   export type SecurityRequirementObject = OpenAPIV3.SecurityRequirementObject
 
-  export type ComponentsObject = Modify<
+  export type ComponentsObject = Merge<
     OpenAPIV3.ComponentsObject,
     {
       schemas?: Record<string, SchemaObject>

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -79,15 +79,9 @@ export namespace OpenAPI {
     | OpenAPIV3_1.HttpMethods
 }
 
-export namespace OpenAPIV3_1 {
-  type Modify<T, R> = {
-    [P in keyof (T & R)]: P extends keyof R
-      ? R[P]
-      : P extends keyof T
-        ? T[P]
-        : never
-  }
+export type Modify<T, R> = Omit<T, keyof R> & R
 
+export namespace OpenAPIV3_1 {
   type PathsWebhooksComponents<T = {}> = {
     paths?: PathsObject<T>
     webhooks?: Record<string, PathItemObject | ReferenceObject>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 12.4.0(typescript@5.6.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.5.29)(@types/node@20.17.10)(typescript@5.6.2)
+        version: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@20.17.10)(typescript@5.6.2)
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -1813,6 +1813,10 @@ importers:
         version: 2.8.0
 
   packages/openapi-types:
+    dependencies:
+      type-fest:
+        specifier: ^4.20.0
+        version: 4.26.1
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -32297,7 +32301,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.17.10
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.17.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@20.17.10)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -35121,7 +35125,7 @@ snapshots:
       yaml: 2.6.0
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.17.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@20.17.10)(typescript@5.6.2)
 
   postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.17.10)(typescript@5.6.2)):
     dependencies:
@@ -35129,7 +35133,7 @@ snapshots:
       yaml: 2.6.0
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.5.29)(@types/node@20.17.10)(typescript@5.6.2)
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@20.17.10)(typescript@5.6.2)
 
   postcss-load-config@5.1.0(jiti@2.4.0)(postcss@8.4.39)(tsx@4.19.1):
     dependencies:
@@ -37998,7 +38002,7 @@ snapshots:
       '@swc/core': 1.5.29(@swc/helpers@0.5.15)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.5.29)(@types/node@20.17.10)(typescript@5.6.2):
+  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@20.17.10)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11


### PR DESCRIPTION
HMMM MAYBE NOT?

**Problem**
Quite a few parameters are typed as any

**Solution**
We type the missing parameters by fixing the modify type helper

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
