### PR TITLE
feat(themes): add scalar danger color

### DIFF
--- a/.changeset/moody-jeans-pull.md
+++ b/.changeset/moody-jeans-pull.md
@@ -1,0 +1,6 @@
+---
+'@scalar/components': patch
+'@scalar/themes': patch
+---
+
+feat(themes): add scalar danger color

--- a/packages/components/src/components/ScalarButton/ScalarButton.stories.ts
+++ b/packages/components/src/components/ScalarButton/ScalarButton.stories.ts
@@ -41,6 +41,18 @@ export const FullWidth: Story = { args: { fullWidth: true } }
 
 export const Ghost: Story = { args: { variant: 'ghost' } }
 
+export const Danger: Story = {
+  args: { variant: 'danger' },
+
+  render: (args) => ({
+    components: { ScalarButton },
+    setup() {
+      return { args }
+    },
+    template: `<ScalarButton v-bind="args">Delete</ScalarButton>`,
+  }),
+}
+
 export const Disabled: Story = { args: { disabled: true } }
 
 export const Loading: Story = {

--- a/packages/components/src/components/ScalarButton/variants.ts
+++ b/packages/components/src/components/ScalarButton/variants.ts
@@ -17,7 +17,7 @@ export const styles: Record<string, Record<string, any>> = {
   ],
   danger: [
     'scalar-button-danger',
-    'bg-red text-white active:brightness-90 hocus:brightness-90',
+    'bg-c-danger text-white active:brightness-90 hocus:brightness-90',
   ],
 }
 

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -56,6 +56,12 @@
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
   --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+
+  --scalar-danger-color: color-mix(
+    in srgb,
+    var(--scalar-color-red),
+    var(--scalar-color-1) 20%
+  );
 }
 .dark-mode {
   --scalar-color-green: #00b648;
@@ -68,4 +74,10 @@
   --scalar-button-1: rgba(255, 255, 255, 1);
   --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
   --scalar-button-1-color: black;
+
+  --scalar-danger-color: color-mix(
+    in srgb,
+    var(--scalar-color-red),
+    var(--scalar-background-1) 20%
+  );
 }

--- a/packages/themes/src/tailwind.ts
+++ b/packages/themes/src/tailwind.ts
@@ -74,6 +74,7 @@ export default {
         ghost: 'var(--scalar-color-ghost)',
         disabled: 'var(--scalar-color-disabled)',
         btn: 'var(--scalar-button-1-color)',
+        danger: 'var(--scalar-danger-color)',
       },
 
       // Hover Colors


### PR DESCRIPTION
Adds a `danger` theme color which is a little darker than theme `red` (which is used for syntax highlighting).

## Before / After

![Google Chrome-2025-01-22-21-42-15@2x](https://github.com/user-attachments/assets/98495489-e759-4afd-ab2e-f4a36c376e0d)![Google Chrome-2025-01-22-21-41-27@2x](https://github.com/user-attachments/assets/1976b44f-4d0f-4267-a1fd-62d74fc0ee2d)


![Google Chrome-2025-01-22-21-42-20@2x](https://github.com/user-attachments/assets/0e2255d6-4b21-4343-bb21-e6e87ebd4738)![Google Chrome-2025-01-22-21-41-37@2x](https://github.com/user-attachments/assets/959ab28a-ca5c-49e0-afd2-2305475fbb89)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
