### PR TITLE
fix(components): listbox margin

### DIFF
--- a/.changeset/metal-phones-burn.md
+++ b/.changeset/metal-phones-burn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: removes listbox margin

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -80,7 +80,7 @@ const { cx } = useBindCx()
           <!-- Scroll container -->
           <div class="custom-scroll min-h-0 flex-1">
             <!-- Options list -->
-            <ListboxOptions class="flex flex-col p-0.75">
+            <ListboxOptions class="flex flex-col gap-0.75 p-0.75">
               <ScalarListboxOption
                 v-for="option in options"
                 :key="option.id"

--- a/packages/components/src/components/ScalarListbox/ScalarListboxItem.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListboxItem.vue
@@ -15,7 +15,6 @@ const variants = cva({
     // Layout
     'group/item',
     'flex min-w-0 items-center gap-1.5 rounded px-2 py-1.5 text-left',
-    'first-of-type:mt-0.75 last-of-type:mb-0.75',
     // Text / background style
     'truncate bg-transparent text-c-1',
     // Interaction


### PR DESCRIPTION
**Problem**
current margin usage in listbox is causing gap inconsistency on single list item.

**Solution**
this pr removes margin and uses gap instead.

| before | after |
| -------|------|
| <img width="331" alt="image" src="https://github.com/user-attachments/assets/92c3ec44-9857-4828-8720-4ae0d2fb0ffb" /> | <img width="331" alt="image" src="https://github.com/user-attachments/assets/231c1a0c-7964-49d5-b003-509e499f2434" /> |
| higher top and down spaces | consistent surrounding space | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).