### PR TITLE
feat(api-client): parameter examples support

### DIFF
--- a/.changeset/chilly-rivers-march.md
+++ b/.changeset/chilly-rivers-march.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: adds parameter examples support

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -35,6 +35,7 @@ const props = withDefaults(
     disableEnter?: boolean
     disableCloseBrackets?: boolean
     enum?: string[]
+    examples?: string[]
     type?: string
     nullable?: boolean
     withVariables?: boolean
@@ -230,6 +231,13 @@ export default {
       :default="props.default"
       :modelValue="modelValue"
       :value="booleanOptions"
+      @update:modelValue="emit('update:modelValue', $event)" />
+  </template>
+  <template v-else-if="props.examples && props.examples.length">
+    <DataTableInputSelect
+      :default="props.default"
+      :modelValue="props.modelValue"
+      :value="props.examples"
       @update:modelValue="emit('update:modelValue', $event)" />
   </template>
   <template v-else>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -147,6 +147,7 @@ const flattenValue = (item: RequestExampleParameter) => {
           disableEnter
           disableTabIndent
           :enum="item.enum"
+          :examples="item.examples"
           :max="item.maximum"
           :min="item.minimum"
           :modelValue="item.value"

--- a/packages/oas-utils/src/entities/spec/request-example.test.ts
+++ b/packages/oas-utils/src/entities/spec/request-example.test.ts
@@ -102,4 +102,104 @@ describe('createParamInstance', () => {
       default: false,
     })
   })
+
+  it('works with schema examples type number', () => {
+    const result = createParamInstance({
+      in: 'path',
+      name: 'foo',
+      required: true,
+      deprecated: false,
+      schema: {
+        default: 1.2,
+        type: 'number',
+        examples: [1.2, 2.1, 3],
+      },
+    })
+
+    expect(result).toEqual({
+      key: 'foo',
+      value: '1.2',
+      enabled: true,
+      description: undefined,
+      required: true,
+      examples: ['1.2', '2.1', '3'],
+      type: 'number',
+      default: 1.2,
+    })
+  })
+
+  it('works with schema examples type string', () => {
+    const result = createParamInstance({
+      in: 'query',
+      name: 'foo',
+      required: true,
+      deprecated: false,
+      schema: {
+        default: false,
+        type: 'boolean',
+        examples: ['foo', 'bar'],
+      },
+    })
+
+    expect(result).toEqual({
+      key: 'foo',
+      value: 'false',
+      enabled: true,
+      description: undefined,
+      required: true,
+      type: 'boolean',
+      default: false,
+      examples: ['foo', 'bar'],
+    })
+  })
+
+  it('works with schema examples type integer', () => {
+    const result = createParamInstance({
+      in: 'query',
+      name: 'foo',
+      required: true,
+      deprecated: false,
+      schema: {
+        default: 1,
+        type: 'integer',
+        examples: [1, 2, 3],
+      },
+    })
+
+    expect(result).toEqual({
+      key: 'foo',
+      value: '1',
+      enabled: true,
+      description: undefined,
+      required: true,
+      examples: ['1', '2', '3'],
+      type: 'integer',
+      default: 1,
+    })
+  })
+
+  it('works with schema examples type boolean', () => {
+    const result = createParamInstance({
+      in: 'query',
+      name: 'foo',
+      required: true,
+      deprecated: false,
+      schema: {
+        default: false,
+        type: 'boolean',
+        examples: [true, false],
+      },
+    })
+
+    expect(result).toEqual({
+      key: 'foo',
+      value: 'false',
+      enabled: true,
+      description: undefined,
+      required: true,
+      examples: ['true', 'false'],
+      type: 'boolean',
+      default: false,
+    })
+  })
 })

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -28,6 +28,7 @@ export const requestExampleParametersSchema = z.object({
   description: z.string().optional(),
   required: z.boolean().optional(),
   enum: z.array(z.string()).optional(),
+  examples: z.array(z.string()).optional(),
   type: z.string().optional(),
   format: z.string().optional(),
   minimum: z.number().optional(),
@@ -315,6 +316,12 @@ export function createParamInstance(param: RequestParameter) {
         ? schema.items.enum.map(String)
         : schema?.enum
 
+  // Handle non-string examples
+  const parseExamples =
+    schema?.examples && schema?.type !== 'string'
+      ? schema.examples?.map(String)
+      : schema?.examples
+
   // safe parse the example
   const example = schemaModel(
     {
@@ -326,6 +333,7 @@ export function createParamInstance(param: RequestParameter) {
       /** Initialized all required properties to enabled */
       enabled: !!param.required,
       enum: parseEnum,
+      examples: parseExamples,
     },
     requestExampleParametersSchema,
     false,


### PR DESCRIPTION
**Problem**
setting examples in parameters is not currently retrieved in the client and displays only the first example value.

**Solution**
this pr fixes #4188 by displaying parameters examples in the client as a dropdown.

| before | after |
| -------|------|
| <img width="729" alt="image" src="https://github.com/user-attachments/assets/d1cabc74-1023-42e8-bf60-48aee2779e61" /> | <img width="729" alt="image" src="https://github.com/user-attachments/assets/5f032269-b6cc-4ba9-a6d3-ee183cf82ff1" /> |
| description of the issue in image | description of the change in image | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.