### PR TITLE
feat(api-client): request example array multiselect

### DIFF
--- a/.changeset/silent-dots-knock.md
+++ b/.changeset/silent-dots-knock.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: updates button base variant outline offset

--- a/.changeset/sweet-walls-brush.md
+++ b/.changeset/sweet-walls-brush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds request example array multiselect

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -222,6 +222,7 @@ export default {
     <DataTableInputSelect
       :default="props.default"
       :modelValue="modelValue"
+      :type="type"
       :value="props.enum"
       @update:modelValue="emit('update:modelValue', $event)" />
   </template>
@@ -237,7 +238,7 @@ export default {
       :id="uid"
       v-bind="$attrs"
       ref="codeMirrorRef"
-      class="peer font-code w-full whitespace-nowrap overflow-hidden text-xs leading-[1.44] relative has-[:focus-visible]:outline has-[:focus-visible]:rounded-[4px] -outline-offset-2"
+      class="peer font-code w-full whitespace-nowrap overflow-hidden text-xs leading-[1.44] relative has-[:focus-visible]:outline has-[:focus-visible]:rounded-[4px] -outline-offset-1"
       :class="{
         'flow-code-input--error': error,
       }"

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
   ScalarButton,
+  ScalarComboboxMultiselect,
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
@@ -14,6 +15,7 @@ const props = withDefaults(
     value?: string[]
     default?: string | number
     canAddCustomValue?: boolean
+    type?: string
   }>(),
   { canAddCustomValue: true },
 )
@@ -65,11 +67,51 @@ watch(addingCustomValue, (newValue) => {
 const initialValue = computed(() => {
   return props.modelValue !== undefined ? props.modelValue : props.default
 })
+
+/** Currently selected array example values */
+const selectedArrayOptions = computed(() => {
+  const selectedValues = new Set(props.modelValue.toString().split(', '))
+  return options.value
+    .filter((option) => selectedValues.has(option))
+    .map((option) => ({ id: option, label: option, value: option }))
+})
+
+/** Options for the array type */
+const arrayOptions = computed(() =>
+  options.value.map((option) => ({ id: option, label: option, value: option })),
+)
+
+/** Update the model value when the selected options change */
+const updateSelectedOptions = (selectedOptions: any) => {
+  const selectedValues = selectedOptions.map((option: any) => option.value)
+  emit('update:modelValue', selectedValues.join(', '))
+}
 </script>
 
 <template>
-  <div class="w-full">
-    <template v-if="addingCustomValue">
+  <div
+    class="pr-4 w-full has-[:focus-visible]:outline has-[:focus-visible]:rounded-[4px] -outline-offset-1">
+    <template v-if="type === 'array'">
+      <ScalarComboboxMultiselect
+        :modelValue="selectedArrayOptions"
+        :options="arrayOptions"
+        @update:modelValue="updateSelectedOptions">
+        <ScalarButton
+          class="gap-1.5 font-normal h-full justify-start px-2 py-1.5 custom-scroll pr-6 outline-none"
+          fullWidth
+          variant="ghost">
+          <span class="text-c-1 whitespace-nowrap">{{
+            selectedArrayOptions.length > 0
+              ? selectedArrayOptions.map((option) => option.label).join(', ')
+              : 'Select a value'
+          }}</span>
+          <ScalarIcon
+            icon="ChevronDown"
+            size="md" />
+        </ScalarButton>
+      </ScalarComboboxMultiselect>
+    </template>
+    <template v-else-if="addingCustomValue">
       <input
         ref="inputRef"
         v-model="customValue"
@@ -84,7 +126,7 @@ const initialValue = computed(() => {
         resize
         :value="initialValue">
         <ScalarButton
-          class="gap-1.5 font-normal h-full justify-start px-2 py-1.5"
+          class="gap-1.5 font-normal h-full justify-start px-2 py-1.5 outline-none"
           fullWidth
           variant="ghost">
           <span class="text-c-1">{{ initialValue || 'Select a value' }}</span>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -7,12 +7,12 @@ defineProps<{ item: RequestExampleParameter }>()
 <template>
   <ScalarTooltip
     align="start"
-    class="w-full"
+    class="w-full pr-px"
     :delay="0"
     side="left"
-    triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 before:min-h-[calc(100%-4px)] before:pointer-events-none before:right-[23px] before:top-0.5 before:w-3 absolute h-full right-0">
+    triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 before:min-h-[calc(100%-4px)] before:pointer-events-none before:right-[23px] before:top-0.5 before:w-3 absolute h-full right-0 -outline-offset-1">
     <template #trigger>
-      <div class="pl-1 pr-1.5 py-[9px]">
+      <div class="bg-b-1 pl-1 pr-1.5 mr-0.25">
         <ScalarIcon
           class="text-c-3 group-hover/info:text-c-1"
           icon="Info"

--- a/packages/components/src/components/ScalarButton/variants.ts
+++ b/packages/components/src/components/ScalarButton/variants.ts
@@ -22,7 +22,7 @@ export const styles: Record<string, Record<string, any>> = {
 }
 
 export const variants = cva({
-  base: 'scalar-button scalar-row cursor-pointer items-center justify-center rounded font-medium',
+  base: 'scalar-button scalar-row cursor-pointer items-center justify-center rounded font-medium -outline-offset-1',
   variants: {
     disabled: {
       true: 'bg-background-2 text-color-3 shadow-none',


### PR DESCRIPTION
**Problem**
currently user cannot select multiple value in the request example dropdown selector for array.

**Solution**
this pr adds multiselect support to request example array as seen below:

https://github.com/user-attachments/assets/482ea9ef-8012-44d8-a8a1-8757aa69cd6d

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).