### PR TITLE
fix(api-reference): inconsistent scroll position on page load when navigating to

### DIFF
--- a/.changeset/fuzzy-bottles-smell.md
+++ b/.changeset/fuzzy-bottles-smell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: jumping on initial load for big specs

--- a/examples/nextjs-api-reference/app/header/layout.tsx
+++ b/examples/nextjs-api-reference/app/header/layout.tsx
@@ -1,0 +1,17 @@
+import type { JSX } from 'react'
+
+import './style.css'
+
+export default function DocsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}): JSX.Element {
+  return (
+    <>
+      <div className="header">Header</div>
+      {children}
+      <div className="footer">Footer</div>
+    </>
+  )
+}

--- a/examples/nextjs-api-reference/app/header/style.css
+++ b/examples/nextjs-api-reference/app/header/style.css
@@ -1,0 +1,24 @@
+:root {
+  /* Adjust to your header height */
+  --scalar-custom-header-height: 64px;
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  background-color: blueviolet;
+  height: 64px;
+  z-index: 100;
+  text-align: center;
+  line-height: 64px;
+  color: white;
+  font-size: 24px;
+}
+.footer {
+  background-color: red;
+  padding: 16px;
+  text-align: center;
+  line-height: 64px;
+  color: white;
+  font-size: 24px;
+}

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import { Operation } from '@/features/Operation'
-import { getRequest } from '@/helpers/get-request'
-import { useActiveEntities, useWorkspace } from '@scalar/api-client/store'
+import { useWorkspace } from '@scalar/api-client/store'
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type {
   Spec,
@@ -213,11 +212,12 @@ onMounted(() => {
 .references-loading-top-spacer {
   top: -1px;
 }
-@media (min-width: 1001px) {
+/* This doesn't seem to work but leaving here in case we need it */
+/* @media (min-width: 1001px) {
   .references-loading-top-spacer {
-    top: calc(var(--refs-header-height) - 1px);
+    top: calc(var(--scalar-custom-header-height, --refs-header-height) - 1px);
   }
-}
+} */
 .references-loading-hidden-tag .section-container > .section:first-child {
   display: none;
 }

--- a/packages/api-reference/src/components/Content/Tag/TagList.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagList.vue
@@ -4,13 +4,13 @@ import { Operation } from '@/features/Operation'
 import { useNavState, useSidebar } from '@/hooks'
 import { useWorkspace } from '@scalar/api-client/store'
 import { ScalarErrorBoundary } from '@scalar/components'
-import type { Spec, Tag as tagType } from '@scalar/types/legacy'
+import type { Spec, Tag as TagType } from '@scalar/types/legacy'
 import { computed } from 'vue'
 
 import { Tag, TagAccordion } from './'
 
 const props = defineProps<{
-  tags: tagType[]
+  tags: TagType[]
   spec: Spec
   layout?: 'modern' | 'classic'
 }>()
@@ -19,19 +19,31 @@ const { getOperationId, getTagId, hash } = useNavState()
 const { collapsedSidebarItems } = useSidebar()
 const { requests, requestExamples, securitySchemes } = useWorkspace()
 
-const tagLayout = computed<typeof Tag>(() =>
+const tagLayout = computed(() =>
   props.layout === 'classic' ? TagAccordion : Tag,
 )
 
-// If the first load is models, we do not lazy load tags/operations
-const isLazy = props.layout !== 'classic' && !hash.value.startsWith('model')
+/**
+ * All tags on the list UNTIL the one afterfirst open tag should not be lazy loaded. However their operations should be.
+ * This so so we can get to the first open tag + operation as quick as possible and avoid any jumps
+ */
+const lazyIndex = computed(
+  () =>
+    props.tags.findIndex((tag) => !collapsedSidebarItems[getTagId(tag)]) + 1,
+)
+
+/** If the first load is models, we do not lazy load tags/operations */
+const isLazy = (index: number) =>
+  props.layout !== 'classic' &&
+  !hash.value.startsWith('model') &&
+  index > lazyIndex.value
 </script>
 <template>
   <Lazy
-    v-for="tag in tags"
+    v-for="(tag, index) in tags"
     :id="getTagId(tag)"
     :key="getTagId(tag)"
-    :isLazy="isLazy && !collapsedSidebarItems[getTagId(tag)]">
+    :isLazy="isLazy(index)">
     <Component
       :is="tagLayout"
       :id="getTagId(tag)"
@@ -41,7 +53,10 @@ const isLazy = props.layout !== 'classic' && !hash.value.startsWith('model')
         v-for="(operation, operationIndex) in tag.operations"
         :id="getOperationId(operation, tag)"
         :key="`${operation.httpVerb}-${operation.operationId}`"
-        :isLazy="operationIndex > 0">
+        :isLazy="
+          isLazy(index) ||
+          (collapsedSidebarItems[getTagId(tag)] && operationIndex > 0)
+        ">
         <ScalarErrorBoundary>
           <Operation
             :id="getOperationId(operation, tag)"


### PR DESCRIPTION
**Problem**
On bigger specs when we load the first operation of a tag, sometimes there is a jump and it scrolls to the wrong element.

**Solution**
We do NOT lazy load any tags until the open one, this should eliminate the jump!

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
