### PR TITLE
docs(components): make introduction the first page of storybook

### DIFF
--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -9,7 +9,7 @@ function getAbsolutePath(value: string): any {
   return dirname(require.resolve(join(value, 'package.json')))
 }
 const config: StorybookConfig = {
-  stories: ['../src/**/*.stories.ts', '../src/**/*.mdx'],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.ts'],
   addons: [
     getAbsolutePath('storybook-dark-mode'),
     getAbsolutePath('@storybook/addon-links'),


### PR DESCRIPTION
Turns out the order of this array affects the order in which Storybook selects the first page. This updates it so the docs will be the first page loaded.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] ~I’ve added a changeset (`pnpm changeset`).~
- [x] ~I’ve added tests for the regression or new feature.~
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
