### PR TITLE
fix(api-client): sidebar outline + markup

### DIFF
--- a/.changeset/green-laws-tease.md
+++ b/.changeset/green-laws-tease.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+feat: adds reset outline offset for button

--- a/.changeset/young-cooks-draw.md
+++ b/.changeset/young-cooks-draw.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates markup in unordered list

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -68,6 +68,7 @@ const handleRename = (id: string) => {
       class="h-8 text-c-2 hover:bg-b-2 group relative block flex items-center gap-1.5 rounded py-1 pr-1.5 font-medium no-underline"
       :class="[variable.color ? 'pl-1' : 'pl-1.5']"
       exactActiveClass="active-link"
+      role="button"
       :to="
         collectionId
           ? `/workspace/${activeWorkspace?.uid}/${type}/${collectionId}/${variable.uid}`

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -132,7 +132,7 @@ const hasCookies = computed(
       <template #content>
         <div class="flex-1">
           <SidebarList>
-            <div
+            <li
               v-for="cookie in Object.values(cookies)"
               :key="cookie.uid"
               class="flex flex-col gap-1/2">
@@ -147,7 +147,7 @@ const hasCookies = computed(
                   @click.prevent="handleNavigation($event, cookie.uid)"
                   @delete="removeCookie(cookie.uid)" />
               </div>
-            </div>
+            </li>
           </SidebarList>
         </div>
       </template>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -373,7 +373,7 @@ function handleRename(newName: string) {
                 icon: 'Globe',
                 isDefault: true,
               }" />
-            <div
+            <li
               v-for="collection in activeWorkspaceCollections"
               :key="collection.uid"
               class="flex flex-col gap-0.25">
@@ -445,7 +445,7 @@ function handleRename(newName: string) {
                   <span>Add Environment</span>
                 </ScalarButton>
               </div>
-            </div>
+            </li>
           </SidebarList>
         </div>
       </template>

--- a/packages/api-client/src/views/Servers/Servers.vue
+++ b/packages/api-client/src/views/Servers/Servers.vue
@@ -67,7 +67,7 @@ function handleDelete(uid: string) {
       <template #content>
         <div class="flex-1">
           <SidebarList>
-            <div
+            <li
               v-for="collection in collections"
               :key="collection.uid"
               class="flex flex-col gap-1/2">
@@ -140,7 +140,7 @@ function handleDelete(uid: string) {
                   <span>Add Server</span>
                 </ScalarButton>
               </div>
-            </div>
+            </li>
           </SidebarList>
         </div>
       </template>

--- a/packages/themes/src/reset.css
+++ b/packages/themes/src/reset.css
@@ -102,6 +102,12 @@
     border-radius: var(--scalar-radius);
   }
 
+  /** Set outline offset for buttons */
+  button:focus-visible,
+  [role='button']:focus-visible {
+    outline-offset: -1px;
+  }
+
   /** Set the default cursor for buttons. */
   button,
   [role='button'] {


### PR DESCRIPTION
**Problem**
currently api client sidebar are using wrong markup + outline focus is off.

**Solution**
this pr is a proposal to reset outline by offsetting it by default + update markups.

| before | after |
| -------|------|
| <img width="440" alt="image" src="https://github.com/user-attachments/assets/aaf422c8-a9d5-4880-9110-293d21a1a8e0" /> | <img width="440" alt="image" src="https://github.com/user-attachments/assets/36e3347f-399a-4a0a-b780-d683b6edda65" /> |
| top outline focus is cropped | top outline is now fully visible | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).