### PR TITLE
fix(api-client): type mismatch for the server variable

### DIFF
--- a/.changeset/empty-sheep-relate.md
+++ b/.changeset/empty-sheep-relate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: server variable type mismatch

--- a/packages/api-client/src/components/Server/types.ts
+++ b/packages/api-client/src/components/Server/types.ts
@@ -8,4 +8,6 @@ export type ServerVariableValues = {
   [variable: string]: string
 }
 
-export type ServerVariable = OpenAPIV3_1.ServerVariableObject
+export type ServerVariable =
+  | OpenAPIV3.ServerVariableObject
+  | OpenAPIV3_1.ServerVariableObject


### PR DESCRIPTION
Types are broken in main, let’s fix this swiftly.