### PR TITLE
test(api-reference): testing SSR for a bunch of real-world examples

### DIFF
--- a/packages/api-reference/src/components/ApiReferenceLayout.test.ts
+++ b/packages/api-reference/src/components/ApiReferenceLayout.test.ts
@@ -121,6 +121,8 @@ describe('ApiReferenceLayout', () => {
         // Verify it renders the title in the HTML output
         expect(html).toContain(title)
       },
+      // Increase timeout to 10 seconds
+      10 * 1000,
     )
   })
 })

--- a/packages/api-reference/src/components/ApiReferenceLayout.test.ts
+++ b/packages/api-reference/src/components/ApiReferenceLayout.test.ts
@@ -77,48 +77,50 @@ describe('ApiReferenceLayout', () => {
     expect(html).toContain('Test API')
   })
 
-  test.each(EXAMPLE_API_DEFINITIONS)(
-    `$title ($url)`,
-    async ({ url, title }) => {
-      // Spy for console.error to avoid errors in the console
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
+  describe('real-world examples', () => {
+    test.each(EXAMPLE_API_DEFINITIONS)(
+      `$title ($url)`,
+      async ({ url, title }) => {
+        // Spy for console.error to avoid errors in the console
+        const consoleErrorSpy = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {})
 
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {})
+        const consoleWarnSpy = vi
+          .spyOn(console, 'warn')
+          .mockImplementation(() => {})
 
-      const definition = await fetch(url).then((res) => res.text())
+        const definition = await fetch(url).then((res) => res.text())
 
-      const result = await parse(definition)
+        const result = await parse(definition)
 
-      const app = createSSRApp({
-        render: () =>
-          h(ApiReferenceLayout, {
-            configuration: {},
-            parsedSpec: result,
-            rawSpec: definition,
-          }),
-      })
+        const app = createSSRApp({
+          render: () =>
+            h(ApiReferenceLayout, {
+              configuration: {},
+              parsedSpec: result,
+              rawSpec: definition,
+            }),
+        })
 
-      const html = await renderToString(app)
+        const html = await renderToString(app)
 
-      // Check if console.error was called
-      expect(consoleErrorSpy).not.toHaveBeenCalled()
+        // Check if console.error was called
+        expect(consoleErrorSpy).not.toHaveBeenCalled()
 
-      // Restore the original console.error
-      consoleErrorSpy.mockRestore()
+        // Restore the original console.error
+        consoleErrorSpy.mockRestore()
 
-      // Check if console.warn was called
-      // TODO: In the future, we should fix the warnings.
-      // expect(consoleWarnSpy).not.toHaveBeenCalled()
+        // Check if console.warn was called
+        // TODO: In the future, we should fix the warnings.
+        // expect(consoleWarnSpy).not.toHaveBeenCalled()
 
-      // Restore the original console.warn
-      consoleWarnSpy.mockRestore()
+        // Restore the original console.warn
+        consoleWarnSpy.mockRestore()
 
-      // Verify it renders the title in the HTML output
-      expect(html).toContain(title)
-    },
-  )
+        // Verify it renders the title in the HTML output
+        expect(html).toContain(title)
+      },
+    )
+  })
 })

--- a/packages/api-reference/src/components/ApiReferenceLayout.test.ts
+++ b/packages/api-reference/src/components/ApiReferenceLayout.test.ts
@@ -1,10 +1,57 @@
 // @vitest-environment node
 import { parse } from '@/helpers'
 import { renderToString } from '@vue/server-renderer'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, test, vi } from 'vitest'
 import { createSSRApp, h } from 'vue'
 
 import ApiReferenceLayout from './ApiReferenceLayout.vue'
+
+const EXAMPLE_API_DEFINITIONS = [
+  {
+    title: `GitHub's v3 REST API.`,
+    url: 'https://raw.githubusercontent.com/github/rest-api-description/refs/heads/main/descriptions/api.github.com/api.github.com.json',
+  },
+  {
+    title: 'Scalar Galaxy',
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+  },
+  {
+    title: 'Scalar Galaxy',
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+  },
+  {
+    title: 'Stripe',
+    url: 'https://raw.githubusercontent.com/stripe/openapi/refs/heads/master/openapi/spec3.yaml',
+  },
+  {
+    title: 'Swagger Petstore',
+    url: 'https://petstore.swagger.io/v2/swagger.json',
+  },
+  {
+    title: 'Swagger Petstore',
+    url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+  },
+  {
+    title: 'Swagger Petstore',
+    url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+  },
+  {
+    title: 'Val Town',
+    url: 'https://docs.val.town/openapi.documented.json',
+  },
+  {
+    title: 'Outline',
+    url: 'https://raw.githubusercontent.com/outline/openapi/refs/heads/main/spec3.yml',
+  },
+  {
+    title: 'Sentry',
+    url: 'https://raw.githubusercontent.com/getsentry/sentry/refs/heads/master/api-docs/openapi.json',
+  },
+  {
+    title: 'Vercel',
+    url: 'https://openapi.vercel.sh/',
+  },
+] as const
 
 describe('ApiReferenceLayout', () => {
   it('has the title in the HTML output', async () => {
@@ -30,47 +77,48 @@ describe('ApiReferenceLayout', () => {
     expect(html).toContain('Test API')
   })
 
-  it('can render the GitHub REST API reference', async () => {
-    // Spy for console.error to avoid errors in the console
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {})
+  test.each(EXAMPLE_API_DEFINITIONS)(
+    `$title ($url)`,
+    async ({ url, title }) => {
+      // Spy for console.error to avoid errors in the console
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
 
-    const consoleWarnSpy = vi
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {})
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {})
 
-    const definition = await fetch(
-      'https://raw.githubusercontent.com/github/rest-api-description/refs/heads/main/descriptions/api.github.com/api.github.com.json',
-    ).then((res) => res.json())
+      const definition = await fetch(url).then((res) => res.text())
 
-    const result = await parse(definition)
+      const result = await parse(definition)
 
-    const app = createSSRApp({
-      render: () =>
-        h(ApiReferenceLayout, {
-          configuration: {},
-          parsedSpec: result,
-          rawSpec: definition,
-        }),
-    })
+      const app = createSSRApp({
+        render: () =>
+          h(ApiReferenceLayout, {
+            configuration: {},
+            parsedSpec: result,
+            rawSpec: definition,
+          }),
+      })
 
-    const html = await renderToString(app)
+      const html = await renderToString(app)
 
-    // Check if console.error was called
-    expect(consoleErrorSpy).not.toHaveBeenCalled()
+      // Check if console.error was called
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
 
-    // Restore the original console.error
-    consoleErrorSpy.mockRestore()
+      // Restore the original console.error
+      consoleErrorSpy.mockRestore()
 
-    // Check if console.warn was called
-    // TODO: In the future, we should fix the warnings.
-    // expect(consoleWarnSpy).not.toHaveBeenCalled()
+      // Check if console.warn was called
+      // TODO: In the future, we should fix the warnings.
+      // expect(consoleWarnSpy).not.toHaveBeenCalled()
 
-    // Restore the original console.warn
-    consoleWarnSpy.mockRestore()
+      // Restore the original console.warn
+      consoleWarnSpy.mockRestore()
 
-    // Verify it renders the title in the HTML output
-    expect(html).toContain(`GitHub's v3 REST API.`)
-  })
+      // Verify it renders the title in the HTML output
+      expect(html).toContain(title)
+    },
+  )
 })


### PR DESCRIPTION
**Problem**
Currently, we only test a basic example and the GitHub REST API definition in an SSR environment. This is already good, but maybe not broad enough.

**Solution**
With this PR we’re testing a bunch of real-world examples.

**Preview**

<img width="861" alt="Screenshot 2025-01-24 at 13 24 34" src="https://github.com/user-attachments/assets/a2aa5e4e-d657-468c-88f8-3b541d04d43d" />


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`). (just a test, doesn’t need a changeset)
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.