### PR TITLE
fix(api-client): address bar UI

### DIFF
--- a/.changeset/witty-bats-double.md
+++ b/.changeset/witty-bats-double.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates address bar ui

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -128,7 +128,7 @@ function updateRequestPath(url: string) {
     <div class="m-auto flex flex-row items-center">
       <!-- Address Bar -->
       <div
-        class="addressbar-bg-states group text-xxs relative flex w-full xl:min-w-[720px] xl:max-w-[720px] lg:min-w-[580px] lg:max-w-[580px] order-last lg:order-none flex-1 flex-row items-stretch rounded-lg p-0.75">
+        class="addressbar-bg-states group text-xxs relative flex w-full xl:min-w-[720px] xl:max-w-[720px] lg:min-w-[580px] lg:max-w-[580px] order-last lg:order-none flex-1 flex-row items-stretch rounded-lg p-0.75 max-w-[calc(100dvw-24px)]">
         <div
           class="border rounded-lg pointer-events-none absolute left-0 top-0 block h-full w-full overflow-hidden">
           <div

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -124,7 +124,7 @@ function updateRequestPath(url: string) {
   <div
     v-if="activeRequest && activeExample"
     :id="id"
-    class="scalar-address-bar order-last lg:order-none lg:w-auto w-full [--scalar-address-bar-height:34px] h-[--scalar-address-bar-height]">
+    class="scalar-address-bar order-last lg:order-none lg:w-auto w-full [--scalar-address-bar-height:32px] h-[--scalar-address-bar-height]">
     <div class="m-auto flex flex-row items-center">
       <!-- Address Bar -->
       <div
@@ -145,19 +145,19 @@ function updateRequestPath(url: string) {
             @change="updateRequestMethod" />
         </div>
 
-        <!-- Servers -->
-        <AddressBarServers
-          v-if="activeCollection?.servers?.length"
-          :target="id" />
-
         <div
           class="codemirror-bg-switcher scroll-timeline-x scroll-timeline-x-hidden z-context-plus relative flex w-full">
+          <!-- Servers -->
+          <AddressBarServers
+            v-if="activeCollection?.servers?.length"
+            :target="id" />
+
           <div class="fade-left"></div>
           <!-- Path + URL + env vars -->
           <CodeInput
             ref="addressBarRef"
             aria-label="Path"
-            class="outline-none"
+            class="outline-none min-w-fit"
             disableCloseBrackets
             :disabled="isReadOnly"
             disableEnter
@@ -218,7 +218,7 @@ function updateRequestPath(url: string) {
   -ms-overflow-style: none; /* IE and Edge */
 }
 .scroll-timeline-x-hidden {
-  overflow: hidden;
+  overflow-x: auto;
 }
 .scroll-timeline-x-hidden :deep(.cm-scroller) {
   scrollbar-width: none;

--- a/packages/api-client/src/components/AddressBar/AddressBarServer.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarServer.vue
@@ -77,9 +77,10 @@ const serverUrlWithoutTrailingSlash = computed(() => {
   <ScalarPopover
     class="max-h-[inherit] p-0 text-sm"
     :offset="0"
-    placement="top-start"
+    placement="bottom-start"
     resize
-    :target="target">
+    :target="target"
+    :teleport="`#${target}`">
     <ScalarButton
       class="font-code z-context-plus lg:text-sm text-xs whitespace-nowrap border ml-0.75 rounded px-1.5 h-6.5 text-c-2 hover:bg-b-2"
       variant="ghost">

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -215,7 +215,7 @@ export default {
 </script>
 <template>
   <template v-if="disabled">
-    <div class="flex items-center justify-center p-2">
+    <div class="flex items-center justify-center px-1">
       <span class="text-c-2 text-sm">{{ modelValue }}</span>
     </div>
   </template>


### PR DESCRIPTION
**Problem**
recent updates from #4532 broke the address bar ui in the reference + doesn't allow scroll on long server content.

**Solution**
this pr fixes the ui on reference + enables scroll on long server content.

| before | after |
| -------|------|
| <img width="781" alt="image" src="https://github.com/user-attachments/assets/c2d103af-047d-4348-a0cd-a372f1b5e891" /> | <img width="781" alt="image" src="https://github.com/user-attachments/assets/e3425185-359b-4573-bf36-604309f47026" /> |
| description of the issue in image | description of the change in image | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).