### PR TITLE
feat(api-reference): implement rendering of `patternProperties`

### DIFF
--- a/.changeset/tidy-zebras-poke.md
+++ b/.changeset/tidy-zebras-poke.md
@@ -1,6 +1,6 @@
 ---
-'@scalar/api-reference': minor
-'@scalar/openapi-types': minor
+'@scalar/api-reference': patch
+'@scalar/openapi-types': patch
 ---
 
 feat(api-reference): implement rendering of `patternProperties`

--- a/.changeset/tidy-zebras-poke.md
+++ b/.changeset/tidy-zebras-poke.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': minor
+'@scalar/openapi-types': minor
+---
+
+feat(api-reference): implement rendering of `patternProperties`

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -94,7 +94,12 @@ const handleClick = (e: MouseEvent) =>
           </template>
         </DisclosureButton>
         <DisclosurePanel :static="noncollapsible">
-          <template v-if="value.properties || value.additionalProperties">
+          <template
+            v-if="
+              value.properties ||
+              value.additionalProperties ||
+              value.patternProperties
+            ">
             <template v-if="value.properties">
               <SchemaProperty
                 v-for="property in Object.keys(value?.properties)"
@@ -107,6 +112,16 @@ const handleClick = (e: MouseEvent) =>
                   value.properties?.[property]?.required === true
                 "
                 :value="value.properties?.[property]" />
+            </template>
+            <template v-if="value.patternProperties">
+              <SchemaProperty
+                v-for="property in Object.keys(value?.patternProperties)"
+                :key="property"
+                :compact="compact"
+                :level="level"
+                :name="property"
+                pattern
+                :value="value.patternProperties?.[property]" />
             </template>
             <template v-if="value.additionalProperties">
               <!--

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -245,4 +245,23 @@ describe('SchemaProperty sub-schema', () => {
     const enumValues = wrapper.findAll('.property-enum-value')
     expect(enumValues).toHaveLength(1)
   })
+
+  it('shows pattern properties for type object', async () => {
+    const wrapper = mount(SchemaProperty, {
+      props: {
+        pattern: true,
+        value: {
+          type: 'object',
+          patternProperties: {
+            '^foo-': {
+              type: 'string',
+            },
+          },
+        },
+      },
+    })
+
+    const badge = wrapper.find('.property-pattern')
+    expect(badge.exists()).toBe(true)
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -20,6 +20,7 @@ const props = withDefaults(
     compact?: boolean
     description?: string
     additional?: boolean
+    pattern?: boolean
     withExamples?: boolean
   }>(),
   {
@@ -56,6 +57,10 @@ const displayDescription = function (
   }
 
   if (value?.additionalProperties) {
+    return null
+  }
+
+  if (value?.patternProperties) {
     return null
   }
 
@@ -107,6 +112,7 @@ const optimizedValue = computed(() => optimizeValueForDisplay(props.value))
     ]">
     <SchemaPropertyHeading
       :additional="additional"
+      :pattern="pattern"
       :enum="getEnumFromValue(value).length > 0"
       :required="required"
       :value="optimizedValue">

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -59,4 +59,15 @@ describe('SchemaPropertyHeading', () => {
     expect(constElement.text()).toContain('const:')
     expect(constElement.text()).toContain('example')
   })
+
+  it('renders pattern badge', async () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        pattern: true
+      },
+    })
+
+    const constElement = wrapper.find('.property-pattern')
+    expect(constElement.text()).toContain('pattern')
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -63,7 +63,7 @@ describe('SchemaPropertyHeading', () => {
   it('renders pattern badge', async () => {
     const wrapper = mount(SchemaPropertyHeading, {
       props: {
-        pattern: true
+        pattern: true,
       },
     })
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -27,11 +27,6 @@ const flattenDefaultValue = (value: Record<string, any>) => {
 <template>
   <div class="property-heading">
     <div
-      v-if="pattern"
-      class="property-pattern">
-      <Badge>pattern</Badge>
-    </div>
-    <div
       v-if="$slots.name"
       class="property-name">
       <slot
@@ -46,6 +41,11 @@ const flattenDefaultValue = (value: Record<string, any>) => {
         {{ value['x-additionalPropertiesName'] }}
       </template>
       <template v-else>additional properties</template>
+    </div>
+    <div
+      v-if="pattern"
+      class="property-pattern">
+      <Badge>pattern</Badge>
     </div>
     <div
       v-if="value?.deprecated"

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -8,6 +8,7 @@ withDefaults(
     enum?: boolean
     required?: boolean
     additional?: boolean
+    pattern?: boolean
   }>(),
   {
     level: 0,
@@ -26,9 +27,17 @@ const flattenDefaultValue = (value: Record<string, any>) => {
 <template>
   <div class="property-heading">
     <div
+      v-if="pattern"
+      class="property-pattern">
+      <Badge>pattern</Badge>
+    </div>
+    <div
       v-if="$slots.name"
       class="property-name">
-      <slot name="name" />
+      <slot
+        v-if="!pattern"
+        name="name" />
+      <template v-else>&sol;<slot name="name" />&sol;</template>
     </div>
     <div
       v-if="additional"

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -228,6 +228,9 @@ export namespace OpenAPIV3_1 {
       properties?: {
         [name: string]: ReferenceObject | SchemaObject
       }
+      patternProperties?: {
+        [name: string]: ReferenceObject | SchemaObject
+      }
       allOf?: (ReferenceObject | SchemaObject)[]
       oneOf?: (ReferenceObject | SchemaObject)[]
       anyOf?: (ReferenceObject | SchemaObject)[]
@@ -484,6 +487,9 @@ export namespace OpenAPIV3 {
     required?: string[]
     enum?: any[]
     properties?: {
+      [name: string]: ReferenceObject | SchemaObject
+    }
+    patternProperties?: {
       [name: string]: ReferenceObject | SchemaObject
     }
     allOf?: (ReferenceObject | SchemaObject)[]


### PR DESCRIPTION
**Problem**
Currently, Scalar's `api-reference` does not show a model's properties defined in [`patternProperties`](https://json-schema.org/understanding-json-schema/reference/object#patternProperties) at all (just like many other tools like Swagger's UI to my knowledge), making it hard to see that they exist *should they exist*.

**Solution**
With this PR I implemented rudimentary rendering for these properties.

**Checklist**
I’ve gone through the following:

- [X] I’ve added an explanation _why_ this change is needed.
- [X] I’ve added a changeset (`pnpm changeset`).
- [X] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation. *(see remarks below)*

**Preview**
A model with an exemplary schema as follows:
```json5
{
  "type": "object",
  "properties": {
    "foo": { "type": "integer" },
    "bar": { "type": "string" }
  },
  "additionalProperties": { "type": "string" },
  "patternProperties": {
    "^foo-\\d+": {
      "type": "object",
      "properties": {
        "bar": { "type": "boolean" }
      }
    },
    "^bar-\\w+": { "nullable": true }
  }
}
```

... will render `patternProperties` as follows:

![image](https://github.com/user-attachments/assets/b39d5088-1d8b-48a1-bb6f-bd20c4178259)

**Remarks**
My changes to the tests and rendering were inspired by how rendering for `additionalProperties` is implemented, although I chose not to define a [custom attribute](https://github.com/scalar/scalar/blob/main/documentation/openapi.md#x-additionalpropertiesname) as it didn't seem to make much sense for how I implemented this.

The `patternProperties` will render between `properties` and `additionalProperties`, since they're more specifically defined than `additionalProperties`, so this made the most sense to me.

Rendering of the property's actual pattern is manually prefixed and suffixed with a slash to denote that it's a pattern (so a `patternProperty` of `foo-\d` will show as `/foo-\d/`), using the HTML entity `&sol;` (= `/`) instead of an actual `/`, but I'm open to adding the slashes in another way, like using CSS or whatever.

I wasn't quite sure about updating the documentation in the root path of the repository. I hope you guys can guide me here.