### PR TITLE
fix(api-client): No request imported while collection successfully created

### DIFF
--- a/.changeset/big-tomatoes-invite.md
+++ b/.changeset/big-tomatoes-invite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Add requests to the children of collections, so they'll be shown in the client

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -56,10 +56,7 @@ export function importSpecFileFactory({
     // Add all basic entities to the store
     // WARNING: We expect all internal references to be set between entities at this point
     workspaceEntities.examples.forEach((e) => requestExampleMutators.add(e))
-    workspaceEntities.requests.forEach((r) => {
-      requestMutators.add(r)
-      workspaceEntities.collection.children.push(r.uid)
-    })
+    workspaceEntities.requests.forEach((r) => requestMutators.add(r))
     workspaceEntities.tags.forEach((t) => tagMutators.add(t))
     workspaceEntities.servers.forEach((s) => serverMutators.add(s))
     workspaceEntities.securitySchemes.forEach((s) =>

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -56,7 +56,10 @@ export function importSpecFileFactory({
     // Add all basic entities to the store
     // WARNING: We expect all internal references to be set between entities at this point
     workspaceEntities.examples.forEach((e) => requestExampleMutators.add(e))
-    workspaceEntities.requests.forEach((r) => requestMutators.add(r))
+    workspaceEntities.requests.forEach((r) => {
+      requestMutators.add(r)
+      workspaceEntities.collection.children.push(r.uid)
+    })
     workspaceEntities.tags.forEach((t) => tagMutators.add(t))
     workspaceEntities.servers.forEach((s) => serverMutators.add(s))
     workspaceEntities.securitySchemes.forEach((s) =>

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -382,7 +382,7 @@ export async function importSpecToWorkspace(
 
   // Add the request UIDs to the tag children (or collection root)
   requests.forEach((r) => {
-    if (r.tags) {
+    if (r.tags && r.tags.length > 0) {
       r.tags.forEach((t) => {
         tagMap[t].children.push(r.uid)
       })

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -382,7 +382,7 @@ export async function importSpecToWorkspace(
 
   // Add the request UIDs to the tag children (or collection root)
   requests.forEach((r) => {
-    if (r.tags && r.tags.length > 0) {
+    if (r.tags?.length) {
       r.tags.forEach((t) => {
         tagMap[t].children.push(r.uid)
       })


### PR DESCRIPTION
**Problem**
Currently, when importing a spec file, the collection is created, but no requests are shown

**Solution**
With this PR, I'm fixing the way requests are added to the children of the collection. In the example spec, `tags` was an empty list, so `if (r.tags)` evaluated to `true`, added an extra step to check list length.

solves #4596 (see this issue for example spec file)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.

---

Which references should be added as children? Is it fine that only requests are added to the children property? Should others also be added (like examples)?

I'm also not sure if this is the correct place to add the requests to the children, or if this needs to happen anywhere else?
