### PR TITLE
feat(Scalar.AspNetCore): add placeholder support for the title

### DIFF
--- a/.changeset/sweet-donuts-reply.md
+++ b/.changeset/sweet-donuts-reply.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feature: Support {documentName} placeholder in title

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -167,6 +167,8 @@ public static class ScalarEndpointRouteBuilderExtensions
             var configuration = options.ToScalarConfiguration();
             var serializedConfiguration = JsonSerializer.Serialize(configuration, typeof(ScalarConfiguration), ScalarConfigurationSerializerContext.Default);
 
+            var title = options.DocumentNames.Count == 1 ? options.Title?.Replace(DocumentName, options.DocumentNames[0]) : options.Title;
+            
             // Workaround. Once we support multiple OpenAPI documents, we must update this.
             var documentUrl = configuration.Documents.First();
 
@@ -175,7 +177,7 @@ public static class ScalarEndpointRouteBuilderExtensions
                   <!doctype html>
                   <html>
                   <head>
-                      <title>{{options.Title}}</title>
+                      <title>{{title}}</title>
                       <meta charset="utf-8" />
                       <meta name="viewport" content="width=device-width, initial-scale=1" />
                       {{options.HeadContent}}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -19,9 +19,10 @@ public sealed class ScalarOptions
     internal Func<HttpContext, CancellationToken, Task<IEnumerable<string>>>? DocumentNamesProvider { get; set; }
 
     /// <summary>
-    /// Metadata title.
+    /// Gets or sets the title of the HTML document.
     /// </summary>
     /// <value>The default value is <c>'Scalar API Reference'</c>.</value>
+    /// <remarks>Use the <c>{documentName}</c> placeholder to include the document name in the title.</remarks>
     public string? Title { get; set; } = "Scalar API Reference";
 
     /// <summary>

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -256,6 +256,30 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
 
         localFactory.Services.GetRequiredService<IOptions<ScalarOptions>>().Value.Theme.Should().Be(ScalarTheme.Mars);
     }
+    
+    [Fact]
+    public async Task MapScalarApiReference_ShouldReplaceDocumentNamePlaceholder_WhenOnlyOneDocumentWasAdded()
+    {
+        // Arrange
+        var localFactory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.Configure(options =>
+            {
+                options.UseRouting();
+                options.UseEndpoints(endpoints => endpoints.MapScalarApiReference(o => o.Title = "Scalar API Reference | {documentName}")
+                );
+            });
+        });
+        var client = localFactory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        content.ReplaceLineEndings().Should().Contain("<title>Scalar API Reference | v1</title>");
+    }
 
     [Fact]
     public async Task MapScalarApiReference_ShouldHandleLegacyEndpointPathPrefix_WhenSpecified()


### PR DESCRIPTION
**Problem**
With version 2.0.0 we removed the option to set the document name in the HTML title due to the support of the multiple OpenAPI documents. However, if only one document was added to the configuration (which is currently the case because we postponed the multi docs support) we could technically show the document name again.

**Solution**
This PR brings back the support for showing the OpenAPI document name in the title. 

```c#
app.MapScalarApiReference(options =>
{
    options.Title = "Scalar API Reference | {documentName}";
});
```

results in `Scalar API Reference | v1`.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation (XML comments).