### PR TITLE
chore: add reviewers to snapshot update pr

### DIFF
--- a/.github/workflows/test-cdn-jsdelivr.yml
+++ b/.github/workflows/test-cdn-jsdelivr.yml
@@ -54,7 +54,6 @@ jobs:
         uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f
         with:
           commit-message: 'test: update CDN API Reference snapshots'
-          committer: Tom Mastromonaco <tom@scalar.com>
           body: |
             This PR was automatically created to update the snapshots for the CDN build hosted on jsdelivr.
 
@@ -63,6 +62,7 @@ jobs:
           branch: update-cdn-snapshots
           base: main
           delete-branch: true
+          reviewers: amritk, antlio, cameronrohani, geoffgscott, hanspagel, marclave
       - name: Comment on PR with report link
         uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6
         if: ${{ failure() && github.event_name == 'pull_request'}}


### PR DESCRIPTION
**Problem**
Currently, the automated PRs created to update the CDN api reference test snapshots are not notifying the correct people. 

**Solution**
With this PR, review is requested from relevant members of the team.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
