### PR TITLE
feat(api-client): accept header

### DIFF
--- a/.changeset/fresh-shoes-push.md
+++ b/.changeset/fresh-shoes-push.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: adds accept header by default

--- a/.changeset/lazy-beans-sparkle.md
+++ b/.changeset/lazy-beans-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: adds v-2.5.0 accept header migration

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -319,12 +319,23 @@ const updateActiveBody = (type: Content) => {
     }
   }
   // Add header if doesn't have one
-  else if (header)
-    headers.push({
-      key: 'Content-Type',
-      value: header,
-      enabled: true,
-    })
+  else if (header) {
+    const lastHeader = headers[headers.length - 1]
+    // Add header before last if empty to prevent empty row duplication
+    if (lastHeader && lastHeader.key === '' && lastHeader.value === '') {
+      headers.splice(headers.length - 1, 0, {
+        key: 'Content-Type',
+        value: header,
+        enabled: true,
+      })
+    } else {
+      headers.push({
+        key: 'Content-Type',
+        value: header,
+        enabled: true,
+      })
+    }
+  }
 
   requestExampleMutators.edit(
     activeExample.value.uid,

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -50,6 +50,11 @@
       "types": "./dist/migrations/index.d.ts",
       "default": "./dist/migrations/index.js"
     },
+    "./migrations/v-2.5.0": {
+      "import": "./dist/migrations/v-2.5.0/index.js",
+      "types": "./dist/migrations/v-2.5.0/index.d.ts",
+      "default": "./dist/migrations/v-2.5.0/index.js"
+    },
     "./migrations/v-2.4.0": {
       "import": "./dist/migrations/v-2.4.0/index.js",
       "types": "./dist/migrations/v-2.4.0/index.d.ts",

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -184,7 +184,9 @@ export const requestExampleSchema = z.object({
     .object({
       path: requestExampleParametersSchema.array().default([]),
       query: requestExampleParametersSchema.array().default([]),
-      headers: requestExampleParametersSchema.array().default([]),
+      headers: requestExampleParametersSchema
+        .array()
+        .default([{ key: 'Accept', value: '*/*', enabled: true }]),
       cookies: requestExampleParametersSchema.array().default([]),
     })
     .optional()
@@ -365,7 +367,7 @@ export function createExampleFromRequest(
     cookie: [],
     // deprecated TODO: add zod transform to remove
     header: [],
-    headers: [],
+    headers: [{ key: 'Accept', value: '*/*', enabled: true }],
   }
 
   // Populated the separated params

--- a/packages/oas-utils/src/migrations/README.md
+++ b/packages/oas-utils/src/migrations/README.md
@@ -13,3 +13,4 @@ To generate a new migration:
 3. Rename the types to the new version number in `types.generated.ts` and `index.ts`.
 4. Update the data-version.ts file to the new version number.
 5. Add a test for the new migration in `migration.test.ts`.
+6. Update the migrator.ts file to include the new migration.

--- a/packages/oas-utils/src/migrations/data-version.ts
+++ b/packages/oas-utils/src/migrations/data-version.ts
@@ -8,8 +8,9 @@
  * - 2.2.0 - auth compliancy
  * - 2.3.0 - environments
  * - 2.4.0 - draft collection servers
+ * - 2.5.0 - accept header
  */
-export const DATA_VERSION = '2.4.0'
+export const DATA_VERSION = '2.5.0'
 
 /** The localStorage key under which the data version is stored */
 export const DATA_VERSION_LS_LEY = 'scalar_api_client_data_version'

--- a/packages/oas-utils/src/migrations/migrator.ts
+++ b/packages/oas-utils/src/migrations/migrator.ts
@@ -5,11 +5,12 @@ import {
 import { semverLessThan } from '@/migrations/semver'
 import { migrate_v_2_1_0 } from '@/migrations/v-2.1.0'
 import { migrate_v_2_2_0 } from '@/migrations/v-2.2.0'
-import { migrate_v_2_3_0, type v_2_3_0 } from '@/migrations/v-2.3.0'
-import { migrate_v_2_4_0, type v_2_4_0 } from '@/migrations/v-2.4.0'
+import { migrate_v_2_3_0 } from '@/migrations/v-2.3.0'
+import { migrate_v_2_4_0 } from '@/migrations/v-2.4.0'
+import { migrate_v_2_5_0, type v_2_5_0 } from '@/migrations/v-2.5.0'
 
 /** Handles all data migrations per entity */
-export const migrator = (): v_2_4_0.DataArray => {
+export const migrator = (): v_2_5_0.DataArray => {
   const dataVersion = getLocalStorageVersion()
   console.info('Data version: ' + dataVersion)
 
@@ -34,6 +35,8 @@ export const migrator = (): v_2_4_0.DataArray => {
   if (semverLessThan(dataVersion, '2.3.0')) data = migrate_v_2_3_0(data)
   // 2.3.0 -> 2.4.0 migration
   if (semverLessThan(dataVersion, '2.4.0')) data = migrate_v_2_4_0(data)
+  // 2.4.0 -> 2.5.0 migration
+  if (semverLessThan(dataVersion, '2.5.0')) data = migrate_v_2_5_0(data)
 
   // Convert to data array
   data = {
@@ -46,7 +49,7 @@ export const migrator = (): v_2_4_0.DataArray => {
     servers: Object.values(data.servers),
     tags: Object.values(data.tags),
     workspaces: Object.values(data.workspaces),
-  } satisfies v_2_4_0.DataArray
+  } satisfies v_2_5_0.DataArray
 
   return data
 }

--- a/packages/oas-utils/src/migrations/v-2.4.0/types.generated.ts
+++ b/packages/oas-utils/src/migrations/v-2.4.0/types.generated.ts
@@ -1,25 +1,488 @@
-import type { Cookie as Ck } from '@/entities/cookie'
-import type { Environment as E } from '@/entities/environment'
-import type {
-  Collection as Co,
-  Request as R,
-  RequestExample as RE,
-  Server as S,
-  SecurityScheme as SS,
-  Tag as T,
-} from '@/entities/spec'
-import type { Workspace as W } from '@/entities/workspace'
-
 export namespace v_2_4_0 {
-  export type Cookie = Ck
-  export type Environment = E
-  export type Collection = Co
-  export type Request = R
-  export type RequestExample = RE
-  export type SecurityScheme = SS
-  export type Server = S
-  export type Tag = T
-  export type Workspace = W
+  export type Collection = {
+    'type': 'collection'
+    'openapi': string | '3.0.0' | '3.1.0' | '4.0.0'
+    'jsonSchemaDialect'?: string | undefined
+    'info'?:
+      | {
+          title: string
+          summary?: string | undefined
+          description?: string | undefined
+          termsOfService?: string | undefined
+          contact?:
+            | {
+                name?: string | undefined
+                url?: string | undefined
+                email?: string | undefined
+              }
+            | undefined
+          license?:
+            | {
+                name: string
+                identifier?: string | undefined
+                url?: string | undefined
+              }
+            | undefined
+          version: string
+        }
+      | undefined
+    'security': {
+      [x: string]: string[]
+    }[]
+    'externalDocs'?:
+      | {
+          description?: string | undefined
+          url: string
+        }
+      | undefined
+    'components'?:
+      | {
+          [x: string]: unknown
+        }
+      | undefined
+    'webhooks'?:
+      | {
+          [x: string]: unknown
+        }
+      | undefined
+    'x-scalar-icon': string
+    'x-scalar-active-environment'?: string | undefined
+    'x-scalar-environments'?:
+      | {
+          [x: string]: {
+            description?: string | undefined
+            color?: string | undefined
+            variables: {
+              [x: string]:
+                | {
+                    description?: string | undefined
+                    default: string
+                  }
+                | string
+            }
+          }
+        }
+      | undefined
+    'x-scalar-secrets'?:
+      | {
+          [x: string]: {
+            description?: string | undefined
+            example?: string | undefined
+          }
+        }
+      | undefined
+    'uid': string
+    'securitySchemes': string[]
+    'selectedSecuritySchemeUids': string[]
+    'selectedServerUid': string
+    'servers': string[]
+    'requests': string[]
+    'tags': string[]
+    'children': string[]
+    'documentUrl'?: string | undefined
+    'watchMode': boolean
+    'integration'?: (string | null) | undefined
+    'watchModeStatus': 'IDLE' | 'WATCHING' | 'ERROR'
+  }
+
+  export type Cookie = {
+    uid: string
+    name: string
+    value: string
+    domain?: string | undefined
+    path?: string | undefined
+  }
+
+  export type Environment = {
+    uid: string
+    name: string
+    color: string
+    value: string
+    isDefault?: boolean | undefined
+  }
+
+  export type Tag = {
+    'type': 'tag'
+    'name': string
+    'description'?: string | undefined
+    'externalDocs'?:
+      | {
+          description?: string | undefined
+          url: string
+        }
+      | undefined
+    'x-scalar-children'?:
+      | {
+          tagName: string
+        }[]
+      | undefined
+    'x-internal'?: boolean | undefined
+    'x-scalar-ignore'?: boolean | undefined
+    'uid': string
+    'children': string[]
+  }
+
+  export type RequestExample = {
+    uid: string
+    type: 'requestExample'
+    requestUid: string
+    name: string
+    body: {
+      raw?:
+        | {
+            encoding:
+              | 'json'
+              | 'text'
+              | 'html'
+              | 'javascript'
+              | 'xml'
+              | 'yaml'
+              | 'edn'
+            value: string
+          }
+        | undefined
+      formData?:
+        | {
+            encoding: 'form-data' | 'urlencoded'
+            value: {
+              key: string
+              value: string
+              enabled: boolean
+              file?: any | undefined
+              description?: string | undefined
+              required?: boolean | undefined
+              enum?: string[] | undefined
+              examples?: string[] | undefined
+              type?: string | undefined
+              format?: string | undefined
+              minimum?: number | undefined
+              maximum?: number | undefined
+              default?: any | undefined
+              nullable?: boolean | undefined
+            }[]
+          }
+        | undefined
+      binary?: any | undefined
+      activeBody: 'raw' | 'formData' | 'binary'
+    }
+    parameters: {
+      path: {
+        key: string
+        value: string
+        enabled: boolean
+        file?: any | undefined
+        description?: string | undefined
+        required?: boolean | undefined
+        enum?: string[] | undefined
+        examples?: string[] | undefined
+        type?: string | undefined
+        format?: string | undefined
+        minimum?: number | undefined
+        maximum?: number | undefined
+        default?: any | undefined
+        nullable?: boolean | undefined
+      }[]
+      query: {
+        key: string
+        value: string
+        enabled: boolean
+        file?: any | undefined
+        description?: string | undefined
+        required?: boolean | undefined
+        enum?: string[] | undefined
+        examples?: string[] | undefined
+        type?: string | undefined
+        format?: string | undefined
+        minimum?: number | undefined
+        maximum?: number | undefined
+        default?: any | undefined
+        nullable?: boolean | undefined
+      }[]
+      headers: {
+        key: string
+        value: string
+        enabled: boolean
+        file?: any | undefined
+        description?: string | undefined
+        required?: boolean | undefined
+        enum?: string[] | undefined
+        examples?: string[] | undefined
+        type?: string | undefined
+        format?: string | undefined
+        minimum?: number | undefined
+        maximum?: number | undefined
+        default?: any | undefined
+        nullable?: boolean | undefined
+      }[]
+      cookies: {
+        key: string
+        value: string
+        enabled: boolean
+        file?: any | undefined
+        description?: string | undefined
+        required?: boolean | undefined
+        enum?: string[] | undefined
+        examples?: string[] | undefined
+        type?: string | undefined
+        format?: string | undefined
+        minimum?: number | undefined
+        maximum?: number | undefined
+        default?: any | undefined
+        nullable?: boolean | undefined
+      }[]
+    }
+    serverVariables?:
+      | {
+          [x: string]: string[]
+        }
+      | undefined
+  }
+
+  export type Request = {
+    'tags'?: string[] | undefined
+    'summary'?: string | undefined
+    'description'?: string | undefined
+    'operationId'?: string | undefined
+    'security'?:
+      | {
+          [x: string]: string[]
+        }[]
+      | undefined
+    'requestBody'?: any | undefined
+    'parameters'?:
+      | {
+          in: 'path' | 'query' | 'header' | 'cookie'
+          name: string
+          description?: string | undefined
+          required: boolean
+          deprecated: boolean
+          schema?: unknown | undefined
+          content?: unknown | undefined
+          style?:
+            | (
+                | 'matrix'
+                | 'simple'
+                | 'form'
+                | 'label'
+                | 'spaceDelimited'
+                | 'pipeDelimited'
+                | 'deepObject'
+              )
+            | undefined
+          example?: unknown | undefined
+          examples?:
+            | {
+                [x: string]: {
+                  value?: unknown
+                  summary?: string | undefined
+                }
+              }
+            | undefined
+        }[]
+      | undefined
+    'externalDocs'?:
+      | {
+          description?: string | undefined
+          url: string
+        }
+      | undefined
+    'deprecated'?: boolean | undefined
+    'responses'?:
+      | {
+          [x: string]: any
+        }
+      | undefined
+    'x-internal'?: boolean | undefined
+    'x-scalar-ignore'?: boolean | undefined
+    'type': 'request'
+    'uid': string
+    'path': string
+    'method':
+      | 'connect'
+      | 'delete'
+      | 'get'
+      | 'head'
+      | 'options'
+      | 'patch'
+      | 'post'
+      | 'put'
+      | 'trace'
+    'servers': string[]
+    'selectedServerUid': string
+    'examples': string[]
+    'selectedSecuritySchemeUids': string[]
+  }
+
+  export type SecurityScheme =
+    | {
+        description?: string | undefined
+        type: 'apiKey'
+        name: string
+        in: 'query' | 'header' | 'cookie'
+        uid: string
+        nameKey: string
+        value: string
+      }
+    | {
+        description?: string | undefined
+        type: 'http'
+        scheme: any
+        bearerFormat: 'JWT' | string
+        uid: string
+        nameKey: string
+        username: string
+        password: string
+        token: string
+      }
+    | {
+        description?: string | undefined
+        type: 'openIdConnect'
+        openIdConnectUrl: string
+        uid: string
+        nameKey: string
+      }
+    | {
+        description?: string | undefined
+        type: 'oauth2'
+        flows: {
+          implicit?:
+            | {
+                'refreshUrl': string
+                'scopes': {
+                  [x: string]: string
+                }
+                'selectedScopes': string[]
+                'x-scalar-client-id': string
+                'token': string
+                'type': 'implicit'
+                'authorizationUrl': string
+                'x-scalar-redirect-uri': string
+              }
+            | undefined
+          password?:
+            | {
+                'refreshUrl': string
+                'scopes': {
+                  [x: string]: string
+                }
+                'selectedScopes': string[]
+                'x-scalar-client-id': string
+                'token': string
+                'type': 'password'
+                'tokenUrl': string
+                'clientSecret': string
+                'username': string
+                'password': string
+              }
+            | undefined
+          clientCredentials?:
+            | {
+                'refreshUrl': string
+                'scopes': {
+                  [x: string]: string
+                }
+                'selectedScopes': string[]
+                'x-scalar-client-id': string
+                'token': string
+                'type': 'clientCredentials'
+                'tokenUrl': string
+                'clientSecret': string
+              }
+            | undefined
+          authorizationCode?:
+            | {
+                'refreshUrl': string
+                'scopes': {
+                  [x: string]: string
+                }
+                'selectedScopes': string[]
+                'x-scalar-client-id': string
+                'token': string
+                'type': 'authorizationCode'
+                'authorizationUrl': string
+                'x-usePkce': 'SHA-256' | 'plain' | 'no'
+                'x-scalar-redirect-uri': string
+                'tokenUrl': string
+                'clientSecret': string
+              }
+            | undefined
+        }
+        uid: string
+        nameKey: string
+      }
+
+  export type Server = {
+    url: string
+    description?: string | undefined
+    variables?:
+      | {
+          [x: string]: {
+            enum?: string[] | undefined
+            default?: string | undefined
+            description?: string | undefined
+          }
+        }
+      | undefined
+    uid: string
+  }
+
+  export type Workspace = {
+    uid: string
+    name: string
+    description: string
+    collections: string[]
+    environments: {
+      [x: string]: string
+    }
+    hotKeyConfig?:
+      | {
+          modifiers: ('Meta' | 'Control' | 'Shift' | 'Alt' | 'default')[]
+          hotKeys?:
+            | {
+                [x: string]: {
+                  modifiers?:
+                    | ('Meta' | 'Control' | 'Shift' | 'Alt' | 'default')[]
+                    | undefined
+                  event:
+                    | 'addTopNav'
+                    | 'closeModal'
+                    | 'closeTopNav'
+                    | 'createNew'
+                    | 'executeRequest'
+                    | 'focusAddressBar'
+                    | 'focusRequestSearch'
+                    | 'jumpToLastTab'
+                    | 'jumpToTab'
+                    | 'navigateSearchResultsDown'
+                    | 'navigateSearchResultsUp'
+                    | 'navigateTopNavLeft'
+                    | 'navigateTopNavRight'
+                    | 'openCommandPalette'
+                    | 'selectSearchResult'
+                    | 'toggleSidebar'
+                }
+              }
+            | undefined
+        }
+      | undefined
+    activeEnvironmentId: string
+    cookies: string[]
+    proxyUrl?: string | undefined
+    themeId:
+      | 'alternate'
+      | 'default'
+      | 'moon'
+      | 'purple'
+      | 'solarized'
+      | 'bluePlanet'
+      | 'deepSpace'
+      | 'saturn'
+      | 'kepler'
+      | 'elysiajs'
+      | 'fastify'
+      | 'mars'
+      | 'none'
+  }
 
   export type DataRecord = {
     collections: Record<string, Collection>
@@ -31,17 +494,5 @@ export namespace v_2_4_0 {
     servers: Record<string, Server>
     tags: Record<string, Tag>
     workspaces: Record<string, Workspace>
-  }
-
-  export type DataArray = {
-    collections: Collection[]
-    cookies: Cookie[]
-    environments: Environment[]
-    requestExamples: RequestExample[]
-    requests: Request[]
-    securitySchemes: SecurityScheme[]
-    servers: Server[]
-    tags: Tag[]
-    workspaces: Workspace[]
   }
 }

--- a/packages/oas-utils/src/migrations/v-2.5.0/index.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/index.ts
@@ -1,0 +1,2 @@
+export * from './migration'
+export * from './types.generated'

--- a/packages/oas-utils/src/migrations/v-2.5.0/migration.test.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/migration.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+
+import type { v_2_4_0 } from '../v-2.4.0'
+import { migrate_v_2_5_0 } from '../v-2.5.0/migration'
+import type { v_2_5_0 } from './types.generated'
+
+describe('migrate_v_2_5_0', () => {
+  it('should add default "Accept" header if it does not exist', () => {
+    // Setup test data
+    const mockRequestExample: v_2_4_0.RequestExample = {
+      type: 'requestExample',
+      uid: 'example1',
+      requestUid: 'request1',
+      name: 'Example with no Accept header',
+      body: {
+        activeBody: 'raw',
+      },
+      parameters: {
+        headers: [
+          { key: 'Content-Type', value: 'application/json', enabled: true },
+        ],
+        path: [],
+        query: [],
+        cookies: [],
+      },
+    }
+
+    // Perform migration
+    const mockData: v_2_4_0.DataRecord = {
+      requestExamples: { example1: mockRequestExample },
+      collections: {},
+      cookies: {},
+      environments: {},
+      requests: {},
+      securitySchemes: {},
+      servers: {},
+      tags: {},
+      workspaces: {},
+    }
+
+    // Perform migration
+    const result = migrate_v_2_5_0(mockData)
+
+    // Assertions
+    expectTypeOf(result).toMatchTypeOf<v_2_5_0.DataRecord>()
+    expect(result.requestExamples.example1.parameters.headers[0].key).toBe(
+      'Accept',
+    )
+    expect(result.requestExamples.example1.parameters.headers[0].value).toBe(
+      '*/*',
+    )
+  })
+
+  it('should not add "Accept" header if it already exists', () => {
+    // Setup test data
+    const mockRequestExample: v_2_4_0.RequestExample = {
+      type: 'requestExample',
+      uid: 'example2',
+      requestUid: 'request2',
+      name: 'Example with Accept header',
+      body: {
+        activeBody: 'raw',
+      },
+      parameters: {
+        headers: [
+          { key: 'Accept', value: 'application/json', enabled: true },
+          { key: 'Content-Type', value: 'application/json', enabled: true },
+        ],
+        path: [],
+        query: [],
+        cookies: [],
+      },
+    }
+
+    const mockData: v_2_4_0.DataRecord = {
+      requestExamples: { example2: mockRequestExample },
+      collections: {},
+      cookies: {},
+      environments: {},
+      requests: {},
+      securitySchemes: {},
+      servers: {},
+      tags: {},
+      workspaces: {},
+    }
+
+    // Perform migration
+    const result = migrate_v_2_5_0(mockData)
+
+    // Assertions
+    expectTypeOf(result).toMatchTypeOf<v_2_5_0.DataRecord>()
+    expect(result.requestExamples.example2.parameters.headers.length).toBe(2)
+    expect(result.requestExamples.example2.parameters.headers[0].key).toBe(
+      'Accept',
+    )
+    expect(result.requestExamples.example2.parameters.headers[0].value).toBe(
+      'application/json',
+    )
+  })
+})

--- a/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
@@ -1,0 +1,72 @@
+import type { v_2_4_0 } from '@/migrations/v-2.4.0/types.generated'
+
+import type { v_2_5_0 } from './types.generated'
+
+/** V-2.4.0 to V-2.5.0 migration */
+export const migrate_v_2_5_0 = (
+  data: v_2_4_0.DataRecord,
+): v_2_5_0.DataRecord => {
+  console.info('Performing data migration v-2.4.0 to v-2.5.0')
+
+  const requestExamples = Object.entries(data.requestExamples || {}).reduce<
+    Record<string, v_2_5_0.RequestExample>
+  >((acc, [key, example]) => {
+    const headers = example.parameters.headers
+
+    // Check if "Accept" header exists
+    const hasAcceptHeader = headers.some(
+      (header) => header.key.toLowerCase() === 'accept',
+    )
+
+    if (!hasAcceptHeader) {
+      // Add "Accept" header as the first entry
+      headers.unshift({ key: 'Accept', value: '*/*', enabled: true })
+    }
+
+    // Update the example with potentially modified headers
+    acc[key] = {
+      ...example,
+      parameters: {
+        ...example.parameters,
+        headers,
+      },
+    }
+    return acc
+  }, {})
+
+  const servers = Object.entries(data.servers || {}).reduce<
+    Record<string, v_2_5_0.Server>
+  >((acc, [key, server]) => {
+    acc[key] = {
+      ...server,
+      variables: Object.entries(server.variables || {}).reduce<
+        Record<
+          string,
+          {
+            enum?: [string, ...string[]]
+            default: string
+            description?: string
+          }
+        >
+      >((variablesAcc, [variableKey, variable]) => {
+        variablesAcc[variableKey] = {
+          ...variable,
+          enum:
+            variable.enum && variable.enum.length > 0
+              ? (variable.enum as [string, ...string[]])
+              : undefined,
+          default: variable.default ?? '',
+          description: variable.description,
+        }
+        return variablesAcc
+      }, {}),
+    }
+    return acc
+  }, {})
+
+  return {
+    ...data,
+    requestExamples,
+    servers,
+  } satisfies v_2_5_0.DataRecord
+}

--- a/packages/oas-utils/src/migrations/v-2.5.0/types.generated.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/types.generated.ts
@@ -1,0 +1,47 @@
+import type { Cookie as Ck } from '@/entities/cookie'
+import type { Environment as E } from '@/entities/environment'
+import type {
+  Collection as Co,
+  Request as R,
+  RequestExample as RE,
+  Server as S,
+  SecurityScheme as SS,
+  Tag as T,
+} from '@/entities/spec'
+import type { Workspace as W } from '@/entities/workspace'
+
+export namespace v_2_5_0 {
+  export type Cookie = Ck
+  export type Environment = E
+  export type Collection = Co
+  export type Request = R
+  export type RequestExample = RE
+  export type SecurityScheme = SS
+  export type Server = S
+  export type Tag = T
+  export type Workspace = W
+
+  export type DataRecord = {
+    collections: Record<string, Collection>
+    cookies: Record<string, Cookie>
+    environments: Record<string, Environment>
+    requestExamples: Record<string, RequestExample>
+    requests: Record<string, Request>
+    securitySchemes: Record<string, SecurityScheme>
+    servers: Record<string, Server>
+    tags: Record<string, Tag>
+    workspaces: Record<string, Workspace>
+  }
+
+  export type DataArray = {
+    collections: Collection[]
+    cookies: Cookie[]
+    environments: Environment[]
+    requestExamples: RequestExample[]
+    requests: Request[]
+    securitySchemes: SecurityScheme[]
+    servers: Server[]
+    tags: Tag[]
+    workspaces: Workspace[]
+  }
+}


### PR DESCRIPTION
**Problem**
currently we do not pre-fill the header with default ones as highlighted in #4534 

**Solution**
this pr adds `Accept` header by default and fixes #4534. we might want to adds other ones:
- Accep-Encoding
- User-Agent (in desktop app usage)
- Connection

| before | after |
| -------|------|
| <img width="632" alt="image" src="https://github.com/user-attachments/assets/6557a819-5a70-45dd-aa6d-026ee1b59ba7" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/69998143-2ce3-4e21-99fe-6cf23e3e6502" /> |
| content type header only | accept header prefilled | 

**Checklist**

- [x] Migration

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
