### PR TITLE
fix(themes): box shadow variable

### DIFF
--- a/.changeset/smart-bears-breathe.md
+++ b/.changeset/smart-bears-breathe.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix: removes inset from box shadow variable

--- a/packages/themes/src/variables.css
+++ b/packages/themes/src/variables.css
@@ -60,7 +60,7 @@
   --scalar-button-1-color: black;
 
   --scalar-shadow-1: 0 1px 3px 0 rgb(0, 0, 0, 0.1);
-  --scalar-shadow-2: inset 0 0 0 0.5px var(--scalar-border-color),
+  --scalar-shadow-2: 0 0 0 0.5px var(--scalar-border-color),
     rgba(15, 15, 15, 0.2) 0px 3px 6px, rgba(15, 15, 15, 0.4) 0px 9px 24px;
 
   --scalar-lifted-brightness: 1.45;


### PR DESCRIPTION
**Problem**
recent changes to box shadow in darkmode mistakenly set it as inset which breaks the ui.

**Solution**
this pr removes the inset from the box shadow variable.

| before | after |
| -------|------|
| <img width="839" alt="image" src="https://github.com/user-attachments/assets/9b488aac-2bf3-4cc7-840e-8c761ae2842c" /> | <img width="839" alt="image" src="https://github.com/user-attachments/assets/8665b25a-ba9d-4a0c-9cb6-0063655922f2" /> |
| missing top border | whole border back | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).