### PR TITLE
chore(tooling): setup proxy multi-region deployment

### DIFF
--- a/examples/proxy-server/cloudbuild.yaml
+++ b/examples/proxy-server/cloudbuild.yaml
@@ -17,11 +17,12 @@ steps:
     entrypoint: gcloud
     args:
       [
+        'beta',
         'run',
         'deploy',
         '$_SERVICE_GO_PROXY',
         '--image=gcr.io/${_PROJECT_ID}/${_SERVICE_GO_PROXY}',
-        '--region=$_REGION',
+        '--regions=$_REGIONS',
         '--platform=managed',
         '--allow-unauthenticated',
         '--execution-environment=gen2',


### PR DESCRIPTION
**Problem**
Request latency in Europe and Asia for proxy requests is fairly substantial (often reaching highs of 500-750ms+), compared to users in US regions.

**Solution**
After introducing multi-region deployments for the proxy, we can add an extra regional NEG which the external load balancer will point to. This should significantly decrease proxy latency in our most popular regions.

(Note that we are using beta cli here as this is a shortcut for having to define multiple separate deployment steps for each region, because Google).

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
