### PR TITLE
fix(snippetz): `findPlugin` undefined

### DIFF
--- a/.changeset/gold-buses-cheer.md
+++ b/.changeset/gold-buses-cheer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+feat: updates playground style

--- a/.changeset/tall-brooms-change.md
+++ b/.changeset/tall-brooms-change.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+fix: updates snippetz function

--- a/packages/snippetz/playground/src/App.vue
+++ b/packages/snippetz/playground/src/App.vue
@@ -130,6 +130,7 @@ h2 {
 }
 .badges {
   display: flex;
+  flex-wrap: wrap;
   gap: 4px;
 }
 .introduction {
@@ -147,7 +148,7 @@ h2 {
 .client {
   background: transparent;
   font-size: 1rem;
-  border: 2px solid #343a40;
+  border: 1px solid #2d2d2d;
   display: inline-block;
   padding: 6px 12px;
   border-radius: 6px;
@@ -155,6 +156,6 @@ h2 {
   cursor: pointer;
 }
 .client--selected {
-  background: #343a40;
+  background-color: #2d2d2d;
 }
 </style>

--- a/packages/snippetz/playground/src/components/CodeExample.vue
+++ b/packages/snippetz/playground/src/components/CodeExample.vue
@@ -27,33 +27,33 @@ async function renderExample() {
     ) ?? ''
   // Syntax highlighting for the code
   const shiki = await getHighlighter({
-    themes: ['vitesse-dark'],
+    themes: ['dark-plus'],
     langs: ['javascript', 'json'],
   })
-  const example =
-    `/* Snippetz */
-import { snippetz } from '@scalar/snippetz'
+
+  // Generate the example code
+  const example = `import { snippetz } from '@scalar/snippetz'
 
 const { print } = snippetz()
 
 const request = ${objectToString(props.request)}
 
-const snippet = print('${props.target}', '${props.client}', request)
+const snippet = print('${props.target}', '${props.client}', request)`
 
-/* Output */
+  // Generate the result snippet
+  const result = code.value.split(`\r`).join(``).split(`\n`).join(`\n`)
 
-// ` + code.value.split(`\r`).join(``).split(`\n`).join(`\n// `)
   highlightedConfiguration.value = shiki.codeToHtml(
     JSON.stringify(props.request, null, 2),
-    { lang: 'json', theme: 'vitesse-dark' },
+    { lang: 'json', theme: 'dark-plus' },
   )
-  highlightedResult.value = shiki.codeToHtml(code.value, {
+  highlightedResult.value = shiki.codeToHtml(result, {
     lang: 'javascript',
-    theme: 'vitesse-dark',
+    theme: 'dark-plus',
   })
   highlightedExample.value = shiki.codeToHtml(example, {
     lang: 'javascript',
-    theme: 'vitesse-dark',
+    theme: 'dark-plus',
   })
 }
 onMounted(async () => {
@@ -65,26 +65,41 @@ watch(props, renderExample)
 <template>
   <div class="code-block">
     <div class="code-block-content">
+      <h2>Example</h2>
       <div
         class="source"
         v-html="highlightedExample" />
+    </div>
+    <div class="code-block-content">
+      <h2>Output</h2>
+      <div
+        class="source"
+        v-html="highlightedResult" />
     </div>
   </div>
 </template>
 
 <style scoped>
-.code-block-content {
-  border: 2px solid #343a40;
-  border-radius: 6px;
-  overflow: hidden;
-  font-family: monospace;
-  width: 100%;
-  max-width: 600px;
+.code-block {
+  display: flex;
+  gap: 1em;
 }
-.title {
-  background: #343a40;
-  color: #868e96;
-  padding: 0.75em 1rem calc(0.75em + 2px);
+.code-block-content {
+  border: 1px solid #2d2d2d;
+  border-radius: 6px;
+  font-family: monospace;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-top: 1em;
+  overflow: hidden;
+}
+.code-block-content h2 {
+  border-bottom: 1px solid #2d2d2d;
+  font-size: 0.875rem;
+  font-weight: 400;
+  margin: 0;
+  padding: 0.75em 1rem;
 }
 .divider {
   color: #868e96;
@@ -92,35 +107,21 @@ watch(props, renderExample)
   padding: 0.75em 1rem calc(0.75em + 2px);
   border-bottom: 2px solid #343a40;
 }
+.source {
+  display: flex;
+  flex: 1;
+  overflow-x: scroll;
+}
 :deep(.source) pre {
+  display: flex;
+  flex: 1;
   margin: 0;
   padding: 0.75rem;
 }
-pre code {
-  color: #adb5bd;
-  display: block;
-  background: none;
-  white-space: pre;
-  -webkit-overflow-scrolling: touch;
-  overflow-x: auto;
-  max-width: 100%;
-  min-width: 100px;
-  padding: 0;
-}
-.tab {
-  background: none;
-  border: none;
-  background-color: #343a40;
-  padding: 5px 10px;
-  font-family: sans-serif;
-  font-size: 0.8rem;
-  border-radius: 6px 6px 0 0;
-  opacity: 0.6;
-  margin-right: 4px;
-  outline: none;
-}
-.tab--selected {
-  color: #fff;
-  opacity: 1;
+
+@media (max-width: 768px) {
+  .code-block {
+    flex-direction: column;
+  }
 }
 </style>

--- a/packages/snippetz/playground/src/style.css
+++ b/packages/snippetz/playground/src/style.css
@@ -16,6 +16,7 @@ a {
   font-weight: 500;
   color: #646cff;
   text-decoration: inherit;
+  word-break: break-word;
 }
 a:hover {
   color: #535bf2;

--- a/packages/snippetz/src/snippetz.ts
+++ b/packages/snippetz/src/snippetz.ts
@@ -5,13 +5,22 @@ import type { ClientId, HarRequest, TargetId } from '@/types'
  * Generate code examples for HAR requests
  */
 export function snippetz() {
+  function findPlugin<T extends TargetId>(
+    target: T | string,
+    client: ClientId<T> | string,
+  ) {
+    return clients
+      .find(({ key }) => key === target)
+      ?.clients.find((plugin) => plugin.client === client)
+  }
+
   return {
     print<T extends TargetId>(
       target: T,
       client: ClientId<T>,
       request: Partial<HarRequest>,
     ) {
-      return this.findPlugin(target, client)?.generate(request)
+      return findPlugin(target, client)?.generate(request)
     },
     clients() {
       return clients
@@ -24,19 +33,12 @@ export function snippetz() {
         })),
       )
     },
-    findPlugin<T extends TargetId>(
-      target: T | string,
-      client: ClientId<T> | string,
-    ) {
-      return clients
-        .find(({ key }) => key === target)
-        ?.clients.find((plugin) => plugin.client === client)
-    },
+    findPlugin,
     hasPlugin<T extends TargetId>(
       target: T | string,
       client: ClientId<T> | string,
     ) {
-      return Boolean(this.findPlugin(target, client))
+      return Boolean(findPlugin(target, client))
     },
   }
 }


### PR DESCRIPTION
**Problem**
playground snippetz usage is throwing an error. 

```console
Cannot read properties of undefined (reading 'findPlugin')
```

**Solution**
this pr returns object in the snippetz function + updates playground style.

| before | after |
| -------|------|
| <img width="888" alt="image" src="https://github.com/user-attachments/assets/a0a45ce5-db95-48d7-87aa-d81b9b962c84" /> | <img width="888" alt="image" src="https://github.com/user-attachments/assets/23668e10-d018-497a-a0f9-69a7ecb36180" /> |
| example and input in one code block | display example and output distinctly | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
