### PR TITLE
fix(api-client): set modal z-index via scoped style

### DIFF
--- a/.changeset/fair-beds-film.md
+++ b/.changeset/fair-beds-film.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): set modal z-index via scoped style

--- a/packages/api-client/src/layouts/Modal/ApiClientModal.vue
+++ b/packages/api-client/src/layouts/Modal/ApiClientModal.vue
@@ -73,7 +73,7 @@ onBeforeUnmount(() => {
   <div
     v-show="modalState.open"
     class="scalar scalar-app">
-    <div class="scalar-container z-overlay">
+    <div class="scalar-container">
       <div
         :id="id"
         ref="client"
@@ -172,6 +172,7 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   justify-content: center;
+  @apply z-overlay;
 }
 
 .scalar .url-form-input {


### PR DESCRIPTION
Turns out this needs to be a scoped style instead of a tailwind class because all the tailwind classes are scoped to `.scalar-client`.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
