### PR TITLE
fix(api-reference): code example authentication

### DIFF
--- a/.changeset/curly-flowers-act.md
+++ b/.changeset/curly-flowers-act.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: fix(api-reference): displays authorization header based on security presence

--- a/packages/api-client/src/libs/send-request/create-fetch-auth.test.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-auth.test.ts
@@ -244,4 +244,38 @@ describe('authentication', () => {
       authorization: 'Bearer oauth-token',
     })
   })
+
+  it('does not add Authorization header when security is not required in reference layout', async () => {
+    const [error, requestOperation] = createRequestOperation({
+      ...createRequestPayload({
+        serverPayload: { url: VOID_URL },
+      }),
+      isReadOnly: true,
+      securitySchemes: {
+        'bearer-auth': {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'Bearer',
+          username: '',
+          password: '',
+          uid: 'bearer-auth',
+          nameKey: 'Authorization',
+          token: 'xxxx',
+        },
+      },
+      selectedSecuritySchemeUids: ['bearer-auth'],
+      request: {
+        ...createRequestPayload({}).request,
+        security: undefined,
+      },
+    })
+    if (error) throw error
+
+    const [requestError, result] = await requestOperation.sendRequest()
+
+    expect(requestError).toBe(null)
+    expect(
+      JSON.parse(result?.response.data as string).headers,
+    ).not.toHaveProperty('authorization')
+  })
 })

--- a/packages/api-reference/src/features/Operation/hooks/useRequestExample.ts
+++ b/packages/api-reference/src/features/Operation/hooks/useRequestExample.ts
@@ -70,6 +70,7 @@ export const useRequestExample = ({
       environment: {},
       // TODO: cookies if we want em
       globalCookies: [],
+      isReadOnly: true,
     })
 
     if (error) {


### PR DESCRIPTION
**Problem**
currently when a security scheme is selected in an api reference, the security header gets added on every endpoint regardless of the endpoint security requirement.

**Solution**
this pr adds a check for reference to the request security presence in order to only add the header accordingly and fixes #4652.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.