### PR TITLE
fix(api-reference): setting initial security when there are no requirements

### DIFF
--- a/.changeset/happy-seahorses-warn.md
+++ b/.changeset/happy-seahorses-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: setting initial security with no requirements

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -542,6 +542,16 @@ describe('importSpecToWorkspace', () => {
       if (res.error) throw res.error
       expect(res.requests[0].selectedSecuritySchemeUids).toEqual([])
     })
+
+    it('sets the correct selectedSecuritySchemeUids when theres no collection security requirement', async () => {
+      const { security, ...noSecurity } = galaxy
+      const res = await importSpecToWorkspace(noSecurity, {
+        setCollectionSecurity: true,
+      })
+      if (res.error) throw res.error
+
+      expect(res.collection.selectedSecuritySchemeUids).toEqual([])
+    })
   })
 
   describe('complex security', () => {

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -427,8 +427,7 @@ export async function importSpecToWorkspace(
 
   // Grab the security requirements for this operation
   const securityRequirements: SelectedSecuritySchemeUids = (
-    (schema.security as OpenAPIV3_1.SecurityRequirementObject[]) ??
-    Object.keys(security ?? {})
+    schema.security ?? []
   ).map((s: OpenAPIV3_1.SecurityRequirementObject) => {
     const keys = Object.keys(s)
     return keys.length > 1 ? keys : keys[0]


### PR DESCRIPTION
**Problem**
It was incorrectly selecting security scheme uids when there was no security requirements on the collection

**Solution**
We add a test and only select security requirements from the collection

**To Test**
You can use this spec
https://socksproxyapi.darrenmc.dev/docs/openapi.json

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
