### PR TITLE
fix(Scalar.AspNetCore): rename Proxy property to ProxyUrl

### DIFF
--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -32,7 +32,7 @@ internal static class ScalarOptionsMapper
         var documentUrls = options.DocumentNames.Select(name => options.OpenApiRoutePattern.Replace(DocumentName, name));
         return new ScalarConfiguration
         {
-            Proxy = options.ProxyUrl,
+            ProxyUrl = options.ProxyUrl,
             Theme = options.Theme.ToStringFast(),
             Layout = options.Layout.ToStringFast(),
             Favicon = options.Favicon,

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
@@ -8,7 +8,7 @@ namespace Scalar.AspNetCore;
 /// </summary>
 internal sealed class ScalarConfiguration
 {
-    public required string? Proxy { get; init; }
+    public required string? ProxyUrl { get; init; }
 
     public required bool? ShowSidebar { get; init; }
 

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -12,7 +12,7 @@ public class ScalarOptionsMapperTests
         var configuration = options.ToScalarConfiguration();
 
         // Assert
-        configuration.Proxy.Should().BeNull();
+        configuration.ProxyUrl.Should().BeNull();
         configuration.ShowSidebar.Should().BeTrue();
         configuration.HideModels.Should().BeFalse();
         configuration.HideDownloadButton.Should().BeFalse();
@@ -80,7 +80,7 @@ public class ScalarOptionsMapperTests
         var configuration = options.ToScalarConfiguration();
 
         // Assert
-        configuration.Proxy.Should().Be("http://localhost:8080");
+        configuration.ProxyUrl.Should().Be("http://localhost:8080");
         configuration.ShowSidebar.Should().BeFalse();
         configuration.HideModels.Should().BeTrue();
         configuration.HideDownloadButton.Should().BeTrue();


### PR DESCRIPTION
**Problem**
I noticed that the `Proxy` property is marked as deprecated.

**Solution**
I renamed it to `ProxyUrl`.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] ~I’ve added a changeset (`pnpm changeset`).~
- [ ] ~I’ve added tests for the regression or new feature.~
- [ ] ~I’ve updated the documentation.~
