### PR TITLE
fix(api-reference): hide auth section in references when there's no securitySchemes

### DIFF
--- a/.changeset/nervous-rules-grin.md
+++ b/.changeset/nervous-rules-grin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: hide auth in references when there's no schemes in the spec

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { BaseUrl } from '@/features/BaseUrl'
-import { useActiveEntities } from '@scalar/api-client/store'
+import { useActiveEntities, useWorkspace } from '@scalar/api-client/store'
 import { RequestAuth } from '@scalar/api-client/views/Request/RequestSection/RequestAuth'
 import { ScalarErrorBoundary } from '@scalar/components'
 import type { Spec } from '@scalar/types/legacy'
@@ -26,6 +26,7 @@ const props = withDefaults(
 )
 
 const { hideModels } = useSidebar()
+const { securitySchemes } = useWorkspace()
 const { activeCollection, activeServer, activeWorkspace } = useActiveEntities()
 
 const introCardsSlot = computed(() =>
@@ -64,9 +65,12 @@ const introCardsSlot = computed(() =>
               class="scalar-client introduction-card-item [--scalar-address-bar-height:0px] divide-y text-sm">
               <BaseUrl />
             </div>
-            <div class="scalar-client introduction-card-item">
+            <div
+              v-if="
+                activeCollection && activeWorkspace && securitySchemes.length
+              "
+              class="scalar-client introduction-card-item">
               <RequestAuth
-                v-if="activeCollection && activeWorkspace"
                 :collection="activeCollection"
                 layout="reference"
                 :selectedSecuritySchemeUids="

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -67,7 +67,9 @@ const introCardsSlot = computed(() =>
             </div>
             <div
               v-if="
-                activeCollection && activeWorkspace && securitySchemes.length
+                activeCollection &&
+                activeWorkspace &&
+                Object.keys(securitySchemes ?? {}).length
               "
               class="scalar-client introduction-card-item">
               <RequestAuth


### PR DESCRIPTION
**Problem**
We show an optional auth when there's no auth defined in the schema

**Solution**
We hide the auth section
 
before: 
![image](https://github.com/user-attachments/assets/3eecb4da-91b8-41fb-9603-39f69663deeb)
after:
![image](https://github.com/user-attachments/assets/98db8691-dbda-4a5c-b3de-9bbf2d90e2ab)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
