### PR TITLE
fix(Scalar.AspNetCore): update playground Dockerfile

### DIFF
--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Dockerfile
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Dockerfile
@@ -1,7 +1,7 @@
 ﻿FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY . .
-RUN dotnet publish "playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj" -c Release -o /app
+RUN dotnet publish "playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj" -c Release -o /app /p:PublishAot=false
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
 WORKDIR /app

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -216,7 +216,7 @@ public static class ScalarEndpointRouteBuilderExtensions
         var resourceFile = FileProvider.GetFileInfo(file);
         if (!resourceFile.Exists)
         {
-            // Return 404 if the file does not exist. This should not happen due to the regex.
+            // Return 404 if the file does not exist. This should not happen because the file is embedded.
             return Results.NotFound();
         }
 


### PR DESCRIPTION
**Problem**
The Dockerfile was not working as expected. It publishes the app as AOT, but this takes time and is not working in docker.

**Solution**
I disabled AOT publishing for Docker. We don't need this anyway, it's just enabled for the analyzers. 
I also updated one comment in the code.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] ~I’ve added a changeset (`pnpm changeset`).~
- [ ] ~I’ve added tests for the regression or new feature.~
- [ ] ~I’ve updated the documentation.~

