### PR TITLE
feat(components): create sidebar item components

### DIFF
--- a/.changeset/sweet-sloths-boil.md
+++ b/.changeset/sweet-sloths-boil.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+feat(components): create sidebar item components

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -89,9 +89,9 @@ const handleRename = (id: string) => {
         class="text-sidebar-c-2 size-3.5 stroke-[2.25]"
         :icon="variable.icon" />
       <span
-        class="empty-variable-name text-sm line-clamp-1 break-all group-hover:pr-5"
-        >{{ variable.name }}</span
-      >
+        class="empty-variable-name text-sm line-clamp-1 break-all group-hover:pr-5">
+        {{ variable.name }}
+      </span>
       <SidebarListElementActions
         :isCopyable="isCopyable"
         :isDeletable="isDeletable"

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -6,7 +6,12 @@ import { PathId } from '@/router'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 import type { SidebarItem, SidebarMenuItem } from '@/views/Request/types'
-import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
+import {
+  ScalarButton,
+  ScalarIcon,
+  ScalarSidebarGroupToggle,
+  ScalarTooltip,
+} from '@scalar/components'
 import {
   Draggable,
   type DraggableProps,
@@ -394,15 +399,9 @@ const shouldShowItem = computed(() => {
         @click="toggleSidebarFolder(item.entity.uid)">
         <span class="flex h-5 items-center justify-center max-w-[14px]">
           <slot name="leftIcon">
-            <div
-              :class="{
-                'rotate-90': collapsedSidebarFolders[item.entity.uid],
-              }">
-              <ScalarIcon
-                class="text-c-3 text-sm"
-                icon="ChevronRight"
-                size="md" />
-            </div>
+            <ScalarSidebarGroupToggle
+              class="text-c-3 shrink-0"
+              :open="collapsedSidebarFolders[item.entity.uid]" />
           </slot>
           &hairsp;
         </span>

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { type Icon, ScalarIcon, ScalarIconButton } from '@scalar/components'
+import {
+  type Icon,
+  ScalarIcon,
+  ScalarSidebarGroupToggle,
+} from '@scalar/components'
 
 import { joinWithSlash, scrollToId, sleep } from '../../helpers'
 import { useNavState } from '../../hooks'
@@ -94,14 +98,17 @@ const onAnchorClick = async (ev: Event) => {
       <p
         v-if="hasChildren"
         class="sidebar-heading-chevron">
-        <ScalarIconButton
+        <button
           :aria-expanded="open"
           class="toggle-nested-icon"
-          :icon="open ? 'ChevronDown' : 'ChevronRight'"
-          :label="`${open ? 'Collapse' : 'Expand'} ${item.title}`"
-          size="xs"
-          thickness="1.5"
-          @click.stop="handleClick" />
+          type="button"
+          @click.stop="handleClick">
+          <ScalarSidebarGroupToggle :open="open">
+            <template #label>
+              {{ open ? 'Collapse' : 'Expand' }} {{ item.title }}
+            </template>
+          </ScalarSidebarGroupToggle>
+        </button>
         &hairsp;
       </p>
       <a
@@ -272,10 +279,12 @@ const onAnchorClick = async (ev: Event) => {
   box-shadow: inset 0 0 0 1px var(--scalar-color-accent);
 }
 .toggle-nested-icon {
-  border: none;
-  color: currentColor;
-  padding: 2px;
-  color: var(--scalar-sidebar-color-2);
+  color: var(--scalar-color-3);
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .active_page .toggle-nested-icon {
   color: var(--scalar-sidebar-color-active, var(--scalar-color-accent));

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
 
 import ScalarSidebar from './ScalarSidebar.vue'
 import ScalarSidebarFooter from './ScalarSidebarFooter.vue'
+import ScalarSidebarGroup from './ScalarSidebarGroup.vue'
+import ScalarSidebarItem from './ScalarSidebarItem.vue'
+import ScalarSidebarItems from './ScalarSidebarItems.vue'
 
 const meta: Meta<typeof ScalarSidebar> = {
   component: ScalarSidebar,
@@ -30,6 +34,42 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Base: Story = {}
+
+export const WithNavItems: Story = {
+  render: (args) => ({
+    components: {
+      ScalarSidebar,
+      ScalarSidebarItem,
+      ScalarSidebarItems,
+      ScalarSidebarGroup,
+    },
+    setup() {
+      const open = ref(false)
+      return { args, open }
+    },
+    template: `
+<div class="flex h-screen">
+  <ScalarSidebar>
+    <ScalarSidebarItems>
+      <ScalarSidebarItem href="#" icon="Scribble" selected>Item 1 (Selected)</ScalarSidebarItem>
+      <ScalarSidebarItem href="#" icon="Scribble">Item 2 </ScalarSidebarItem>
+      <ScalarSidebarItem href="#" icon="Scribble">Item 3</ScalarSidebarItem>
+      <ScalarSidebarItem icon="Scribble" disabled>Item 4 (Disabled)</ScalarSidebarItem>
+      <ScalarSidebarGroup v-model="open">
+        Item Group ({{ open ? 'Open' : 'Closed' }})
+        <template #items>
+          <ScalarSidebarItem href="#" icon="Scribble">Subitem 1</ScalarSidebarItem>
+          <ScalarSidebarItem href="#" icon="Scribble">Subitem 2</ScalarSidebarItem>
+          <ScalarSidebarItem href="#" icon="Scribble">Subitem 3</ScalarSidebarItem>
+        </template>
+      </ScalarSidebarGroup>
+    </ScalarSidebarItems>
+  </ScalarSidebar>
+  <div class="placeholder flex-1">Main content</div>
+</div>
+`,
+  }),
+}
 
 export const WithFooter: Story = {
   render: (args) => ({

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -1,19 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import { ref } from 'vue'
 
+import { ICONS } from '..//ScalarIcon/icons'
 import ScalarSidebar from './ScalarSidebar.vue'
 import ScalarSidebarFooter from './ScalarSidebarFooter.vue'
 import ScalarSidebarGroup from './ScalarSidebarGroup.vue'
 import ScalarSidebarItem from './ScalarSidebarItem.vue'
 import ScalarSidebarItems from './ScalarSidebarItems.vue'
 
-const meta: Meta<typeof ScalarSidebar> = {
+const meta: Meta = {
   component: ScalarSidebar,
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',
   },
-  argTypes: { class: { control: 'text' } },
+  argTypes: {
+    class: { control: 'text' },
+    icon: { control: 'select', options: ICONS },
+  },
   render: (args) => ({
     components: { ScalarSidebar },
     setup() {
@@ -36,6 +40,9 @@ type Story = StoryObj<typeof meta>
 export const Base: Story = {}
 
 export const WithNavItems: Story = {
+  args: {
+    icon: 'Scribble',
+  },
   render: (args) => ({
     components: {
       ScalarSidebar,
@@ -51,16 +58,79 @@ export const WithNavItems: Story = {
 <div class="flex h-screen">
   <ScalarSidebar>
     <ScalarSidebarItems>
-      <ScalarSidebarItem href="#" icon="Scribble" selected>Item 1 (Selected)</ScalarSidebarItem>
-      <ScalarSidebarItem href="#" icon="Scribble">Item 2 </ScalarSidebarItem>
-      <ScalarSidebarItem href="#" icon="Scribble">Item 3</ScalarSidebarItem>
-      <ScalarSidebarItem icon="Scribble" disabled>Item 4 (Disabled)</ScalarSidebarItem>
+      <ScalarSidebarItem href="#" :icon="args.icon" selected>Item 1 (Selected)</ScalarSidebarItem>
+      <ScalarSidebarItem href="#" :icon="args.icon">Item 2 </ScalarSidebarItem>
+      <ScalarSidebarItem href="#" :icon="args.icon">Item 3</ScalarSidebarItem>
+      <ScalarSidebarItem :icon="args.icon" disabled>Item 4 (Disabled)</ScalarSidebarItem>
       <ScalarSidebarGroup v-model="open">
         Item Group ({{ open ? 'Open' : 'Closed' }})
         <template #items>
-          <ScalarSidebarItem href="#" icon="Scribble">Subitem 1</ScalarSidebarItem>
-          <ScalarSidebarItem href="#" icon="Scribble">Subitem 2</ScalarSidebarItem>
-          <ScalarSidebarItem href="#" icon="Scribble">Subitem 3</ScalarSidebarItem>
+          <ScalarSidebarItem href="#" :icon="args.icon">Subitem 1</ScalarSidebarItem>
+          <ScalarSidebarItem href="#" :icon="args.icon">Subitem 2</ScalarSidebarItem>
+          <ScalarSidebarItem href="#" :icon="args.icon">Subitem 3</ScalarSidebarItem>
+        </template>
+      </ScalarSidebarGroup>
+    </ScalarSidebarItems>
+  </ScalarSidebar>
+  <div class="placeholder flex-1">Main content</div>
+</div>
+`,
+  }),
+}
+
+export const WithNestedGroups: Story = {
+  render: (args) => ({
+    components: {
+      ScalarSidebar,
+      ScalarSidebarItem,
+      ScalarSidebarItems,
+      ScalarSidebarGroup,
+    },
+    setup() {
+      return { args }
+    },
+    template: `
+<div class="flex h-screen">
+  <ScalarSidebar>
+    <ScalarSidebarItems class="custom-scroll">
+      <ScalarSidebarGroup>
+        Item Group
+        <template #items>
+          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+            <ScalarSidebarGroup>
+              Item Group
+              <template #items>
+                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                  <ScalarSidebarGroup>
+                  Item Group
+                  <template #items>
+                    <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                    <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                      <ScalarSidebarGroup>
+                        Item Group
+                        <template #items>
+                          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                            <ScalarSidebarGroup>
+                              Item Group
+                              <template #items>
+                                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                              </template>
+                            </ScalarSidebarGroup>
+                          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                        </template>
+                      </ScalarSidebarGroup>
+                    <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                  </template>
+                </ScalarSidebarGroup>
+                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+              </template>
+            </ScalarSidebarGroup>
+          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
         </template>
       </ScalarSidebarGroup>
     </ScalarSidebarItems>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -29,20 +29,29 @@ import { useBindCx } from '../../hooks/useBindCx'
 import { ScalarIcon } from '../ScalarIcon'
 import type { ScalarSidebarItemProps, ScalarSidebarItemSlots } from './types'
 
-const { is = 'a' } = defineProps<ScalarSidebarItemProps>()
+const { is = 'a', indent = 0 } = defineProps<ScalarSidebarItemProps>()
 
 defineSlots<ScalarSidebarItemSlots>()
 
 const variants = cva({
-  base: 'rounded p-1.5 font-medium text-c-2 no-underline',
+  base: ['rounded p-1.5 font-medium text-c-2 no-underline'],
   variants: {
     selected: { true: 'cursor-auto bg-b-2 text-c-1' },
     disabled: { true: 'cursor-auto' },
+    indent: {
+      0: 'pl-[6px]',
+      1: 'pl-[24px]',
+      2: 'pl-[42px]',
+      3: 'pl-[60px]',
+      4: 'pl-[78px]',
+      5: 'pl-[96px]',
+      6: 'pl-[114px]',
+    },
   },
   compoundVariants: [
     { selected: false, disabled: false, class: 'hover:bg-b-2' },
   ],
-  defaultVariants: { selected: false, disabled: false },
+  defaultVariants: { selected: false, disabled: false, indent: 0 },
 })
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
@@ -50,14 +59,15 @@ const { cx } = useBindCx()
 <template>
   <component
     :is="is"
+    :aria-level="indent"
     :type="is === 'button' ? 'button' : undefined"
-    v-bind="cx(variants({ selected, disabled }))">
+    v-bind="cx(variants({ selected, disabled, indent }))">
     <div class="flex items-center gap-1 flex-1">
-      <div class="size-3.5">
+      <div
+        v-if="icon || $slots.icon"
+        class="size-3.5">
         <slot name="icon">
-          <ScalarIcon
-            v-if="icon"
-            :icon="icon" />
+          <ScalarIcon :icon="icon" />
         </slot>
       </div>
       <slot />

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -1,0 +1,69 @@
+<script lang="ts">
+/**
+ * Scalar Sidebar Button component
+ *
+ * Provide a styled link for the ScalarSidebar or similar, supports
+ * the same props and slots as ScalarSidebarItem
+ *
+ * This is used internally by the ScalarSidebarItem component
+ *
+ * If you're looking to create items in ScalarSidebarItems
+ * you probably want the ScalarSidebarItem component
+ *
+ * @example
+ *   <ScalarSidebarButton>
+ *     <template #icon>
+ *       <!-- Overrides the icon slot -->
+ *     </template>
+ *     <!-- Button text -->
+ *     <template #aside>
+ *       <!-- After the button text -->
+ *     </template>
+ *   </ScalarSidebarButton>
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import { cva } from '../../cva'
+import { useBindCx } from '../../hooks/useBindCx'
+import { ScalarIcon } from '../ScalarIcon'
+import type { ScalarSidebarItemProps, ScalarSidebarItemSlots } from './types'
+
+const { is = 'a' } = defineProps<ScalarSidebarItemProps>()
+
+defineSlots<ScalarSidebarItemSlots>()
+
+const variants = cva({
+  base: 'rounded p-1.5 font-medium text-c-2 no-underline',
+  variants: {
+    selected: { true: 'cursor-auto bg-b-2 text-c-1' },
+    disabled: { true: 'cursor-auto' },
+  },
+  compoundVariants: [
+    { selected: false, disabled: false, class: 'hover:bg-b-2' },
+  ],
+  defaultVariants: { selected: false, disabled: false },
+})
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+</script>
+<template>
+  <component
+    :is="is"
+    :type="is === 'button' ? 'button' : undefined"
+    v-bind="cx(variants({ selected, disabled }))">
+    <div class="flex items-center gap-1 flex-1">
+      <div class="size-3.5">
+        <slot name="icon">
+          <ScalarIcon
+            v-if="icon"
+            :icon="icon" />
+        </slot>
+      </div>
+      <slot />
+    </div>
+    <div v-if="$slots.aside">
+      <slot name="aside" />
+    </div>
+  </component>
+</template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.test.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.test.ts
@@ -1,0 +1,120 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import ScalarSidebarGroup from './ScalarSidebarGroup.vue'
+import ScalarSidebarItem from './ScalarSidebarItem.vue'
+
+describe('ScalarSidebarGroup', () => {
+  it('renders a single group with correct base level', async () => {
+    const wrapper = mount(ScalarSidebarGroup, {
+      slots: {
+        default: 'Group 1',
+        items: '<ScalarSidebarItem>Items</ScalarSidebarItem>',
+      },
+      global: {
+        components: {
+          ScalarSidebarItem,
+        },
+      },
+    })
+
+    const button = wrapper.find('button')
+    expect(button.attributes('aria-level')).toBe('0')
+
+    await button.trigger('click')
+
+    const item = wrapper.find('a')
+    expect(item.attributes('aria-level')).toBe('1')
+  })
+
+  it('supports nested groups with correct aria levels', async () => {
+    const wrapper = mount(ScalarSidebarGroup, {
+      slots: {
+        default: 'Parent Group',
+        items: {
+          template: `
+            <ScalarSidebarItem>Level 1 Item</ScalarSidebarItem>
+            <ScalarSidebarGroup>
+              Level 2 Group
+              <template #items>
+                <ScalarSidebarItem>Level 2 Item</ScalarSidebarItem>
+              </template>
+            </ScalarSidebarGroup>
+          `,
+        },
+      },
+      global: {
+        components: {
+          ScalarSidebarGroup,
+          ScalarSidebarItem,
+        },
+      },
+    })
+
+    // Open the parent group
+    await wrapper.find('button').trigger('click')
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons).toHaveLength(2) // Parent + 1 nested groups
+
+    // Verify aria-level for each group
+    expect(buttons[0].attributes('aria-level')).toBe('0') // Parent
+    expect(buttons[1].attributes('aria-level')).toBe('1') // First nested
+  })
+
+  it('handles deeply nested groups', async () => {
+    const wrapper = mount(ScalarSidebarGroup, {
+      slots: {
+        default: 'Level 1',
+        items: {
+          template: `
+            <ScalarSidebarItem>Level 1 Item</ScalarSidebarItem>
+            <ScalarSidebarGroup>
+              Level 2
+              <template #items>
+                <ScalarSidebarItem>Level 2 Item</ScalarSidebarItem>
+                <ScalarSidebarGroup>
+                  Level 3
+                  <template #items>
+                    <ScalarSidebarItem>Level 3 Item</ScalarSidebarItem>
+                    <ScalarSidebarGroup>
+                      Level 4
+                      <template #items>
+                        <ScalarSidebarItem>Level 4 Item</ScalarSidebarItem>
+                        <ScalarSidebarGroup>
+                          Level 5
+                          <template #items>
+                            <ScalarSidebarItem>Level 5 Item</ScalarSidebarItem>
+                          </template>
+                        </ScalarSidebarGroup>
+                      </template>
+                    </ScalarSidebarGroup>
+                  </template>
+                </ScalarSidebarGroup>
+              </template>
+            </ScalarSidebarGroup>
+          `,
+        },
+      },
+      global: {
+        components: {
+          ScalarSidebarGroup,
+          ScalarSidebarItem,
+        },
+      },
+    })
+
+    // Open all groups
+    while (wrapper.find('button[aria-expanded="false"]').exists())
+      await wrapper.find('button[aria-expanded="false"]').trigger('click')
+
+    const items = wrapper.findAll('a')
+
+    // Verify aria-level for each nested level
+    items.forEach((item, index) => {
+      expect(item.attributes('aria-level')).toBe((index + 1).toString())
+    })
+
+    expect(items).toHaveLength(5) // Should have 5 levels of nesting
+  })
+})

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -1,0 +1,68 @@
+<script lang="ts">
+/**
+ * Scalar Sidebar Group component
+ *
+ * A collapsible ScalarSidebarItem that can contain subitems
+ *
+ * @example
+ * <ScalarSidebarGroup v-model="open">
+ *   <!-- Group toggle text -->
+ *   <template #items>
+ *     <ScalarSidebarItem>...</ScalarSidebarItem>
+ *     <ScalarSidebarItem>...</ScalarSidebarItem>
+ *     <ScalarSidebarItem>...</ScalarSidebarItem>
+ *   </template>
+ * </ScalarSidebarGroup>
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import type { Component } from 'vue'
+
+import { useBindCx } from '../../hooks/useBindCx'
+import ScalarSidebarButton from './ScalarSidebarButton.vue'
+import ScalarSidebarGroupToggle from './ScalarSidebarGroupToggle.vue'
+
+const { is = 'ul' } = defineProps<{
+  is?: Component | string
+}>()
+
+const open = defineModel<boolean>()
+
+defineSlots<{
+  /** The text content of the toggle */
+  default?: () => any
+  /** Override the entire toggle button */
+  button?: () => any
+  /** The list of sidebar subitems */
+  items?: () => any
+}>()
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+</script>
+<template>
+  <li class="contents">
+    <slot
+      name="button"
+      :open="open">
+      <ScalarSidebarButton
+        is="button"
+        :aria-expanded="open"
+        @click="open = !open">
+        <template #icon>
+          <ScalarSidebarGroupToggle :open="open" />
+        </template>
+        <slot :open="open" />
+      </ScalarSidebarButton>
+    </slot>
+    <component
+      :is="is"
+      v-if="open"
+      v-bind="cx('flex flex-col pl-3')">
+      <slot
+        name="items"
+        :open="open" />
+    </component>
+  </li>
+</template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -22,6 +22,7 @@ import type { Component } from 'vue'
 import { useBindCx } from '../../hooks/useBindCx'
 import ScalarSidebarButton from './ScalarSidebarButton.vue'
 import ScalarSidebarGroupToggle from './ScalarSidebarGroupToggle.vue'
+import { useSidebarGroups } from './useSidebarGroups'
 
 const { is = 'ul' } = defineProps<{
   is?: Component | string
@@ -38,6 +39,8 @@ defineSlots<{
   items?: () => any
 }>()
 
+const { level } = useSidebarGroups({ increment: true })
+
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
 </script>
@@ -49,6 +52,7 @@ const { cx } = useBindCx()
       <ScalarSidebarButton
         is="button"
         :aria-expanded="open"
+        :indent="level"
         @click="open = !open">
         <template #icon>
           <ScalarSidebarGroupToggle :open="open" />
@@ -59,7 +63,7 @@ const { cx } = useBindCx()
     <component
       :is="is"
       v-if="open"
-      v-bind="cx('flex flex-col pl-3')">
+      v-bind="cx('flex flex-col')">
       <slot
         name="items"
         :open="open" />

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroupToggle.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroupToggle.vue
@@ -1,0 +1,63 @@
+<script lang="ts">
+/**
+ * Scalar Sidebar Group toggle component
+ *
+ * Provides the toggle icon for a ScalarSidebarGroup
+ *
+ * @example
+ * <ScalarSidebarGroupToggle :open="..." />
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import type { Component } from 'vue'
+
+import { cva } from '../../cva'
+import { useBindCx } from '../../hooks/useBindCx'
+import { type Icon, ScalarIcon } from '../ScalarIcon'
+
+const {
+  is = 'div',
+  open = false,
+  icon = 'ChevronRight',
+} = defineProps<{
+  /** Override the element tag */
+  is?: Component | string
+  /** Whether or not the toggle is open */
+  open?: boolean
+  /** Overrides the icon */
+  icon?: Icon
+}>()
+
+defineSlots<{
+  /** Override the toggle icon */
+  default?: (props: { open: boolean }) => any
+  /** Override the screen reader label */
+  label?: (props: { open: boolean }) => any
+}>()
+
+const variants = cva({
+  base: 'size-4 -m-px transition-transform duration-100',
+  variants: { open: { true: 'rotate-90' } },
+  defaultVariants: { open: false },
+})
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+</script>
+<template>
+  <component
+    :is="is"
+    :type="is === 'button' ? 'button' : undefined"
+    v-bind="cx(variants({ open }))">
+    <slot :open="open">
+      <ScalarIcon :icon="icon" />
+    </slot>
+    <span class="sr-only">
+      <slot
+        name="label"
+        :open="open">
+        {{ open ? 'Close' : 'Open' }} Group
+      </slot>
+    </span>
+  </component>
+</template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItem.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItem.vue
@@ -3,7 +3,8 @@
  * Scalar Sidebar Item component
  *
  * Provides a ScalarSidebarButton wrapped in an `<li>` to
- * meet accessibility requirements
+ * meet accessibility requirements and automatically indents
+ * the button based on the level of the sidebar group
  *
  * @example
  * <ScalarSidebarItem>
@@ -19,18 +20,23 @@
 export default {}
 </script>
 <script setup lang="ts">
+import { useSidebarGroups } from './useSidebarGroups'
 import ScalarSidebarButton from './ScalarSidebarButton.vue'
 import type { ScalarSidebarItemProps, ScalarSidebarItemSlots } from './types'
 
-defineProps<ScalarSidebarItemProps>()
+const { indent = undefined } = defineProps<ScalarSidebarItemProps>()
 // We need to expose the slots here or we get a type error :(
 const slots = defineSlots<ScalarSidebarItemSlots>()
+
+const { level } = useSidebarGroups()
 
 defineOptions({ inheritAttrs: false })
 </script>
 <template>
   <li class="contents">
-    <ScalarSidebarButton v-bind="{ ...$attrs, ...$props }">
+    <ScalarSidebarButton
+      v-bind="{ ...$attrs, ...$props }"
+      :indent="indent ?? level">
       <!-- Pass through all the slots -->
       <template
         v-for="(_, name) in slots"

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItem.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItem.vue
@@ -1,0 +1,41 @@
+<script lang="ts">
+/**
+ * Scalar Sidebar Item component
+ *
+ * Provides a ScalarSidebarButton wrapped in an `<li>` to
+ * meet accessibility requirements
+ *
+ * @example
+ * <ScalarSidebarItem>
+ *   <template #icon>
+ *     <!-- Overrides the icon slot -->
+ *   </template>
+ *   <!-- Button text -->
+ *   <template #aside>
+ *     <!-- After the button text -->
+ *   </template>
+ * </ScalarSidebarItem>
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import ScalarSidebarButton from './ScalarSidebarButton.vue'
+import type { ScalarSidebarItemProps, ScalarSidebarItemSlots } from './types'
+
+defineProps<ScalarSidebarItemProps>()
+defineSlots<ScalarSidebarItemSlots>()
+
+defineOptions({ inheritAttrs: false })
+</script>
+<template>
+  <li class="contents">
+    <ScalarSidebarButton v-bind="{ ...$attrs, ...$props }">
+      <!-- Pass through all the slots -->
+      <template
+        v-for="(_, name) in $slots"
+        #[name]>
+        <slot :name="name" />
+      </template>
+    </ScalarSidebarButton>
+  </li>
+</template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItem.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItem.vue
@@ -23,7 +23,8 @@ import ScalarSidebarButton from './ScalarSidebarButton.vue'
 import type { ScalarSidebarItemProps, ScalarSidebarItemSlots } from './types'
 
 defineProps<ScalarSidebarItemProps>()
-defineSlots<ScalarSidebarItemSlots>()
+// We need to expose the slots here or we get a type error :(
+const slots = defineSlots<ScalarSidebarItemSlots>()
 
 defineOptions({ inheritAttrs: false })
 </script>
@@ -32,7 +33,7 @@ defineOptions({ inheritAttrs: false })
     <ScalarSidebarButton v-bind="{ ...$attrs, ...$props }">
       <!-- Pass through all the slots -->
       <template
-        v-for="(_, name) in $slots"
+        v-for="(_, name) in slots"
         #[name]>
         <slot :name="name" />
       </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
@@ -1,0 +1,35 @@
+<script lang="ts">
+/**
+ * Scalar Sidebar Items component
+ *
+ * A base container for ScalarSidebarItem(s), renders as
+ * a  `<ul>` by default to meet accessibility requirements
+ *
+ * @example
+ * <ScalarSidebarItems>
+ *   <ScalarSidebarItem>...</ScalarSidebarItem>
+ *   <ScalarSidebarItem>...</ScalarSidebarItem>
+ *   <ScalarSidebarItem>...</ScalarSidebarItem>
+ * </ScalarSidebarItems>
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import type { Component } from 'vue'
+
+import { useBindCx } from '../../hooks/useBindCx'
+
+const { is = 'ul' } = defineProps<{
+  is?: Component | string
+}>()
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+</script>
+<template>
+  <component
+    :is="is"
+    v-bind="cx('flex flex-col p-3')">
+    <slot />
+  </component>
+</template>

--- a/packages/components/src/components/ScalarSidebar/index.ts
+++ b/packages/components/src/components/ScalarSidebar/index.ts
@@ -1,2 +1,7 @@
 export { default as ScalarSidebar } from './ScalarSidebar.vue'
 export { default as ScalarSidebarFooter } from './ScalarSidebarFooter.vue'
+export { default as ScalarSidebarButton } from './ScalarSidebarButton.vue'
+export { default as ScalarSidebarGroup } from './ScalarSidebarGroup.vue'
+export { default as ScalarSidebarGroupToggle } from './ScalarSidebarGroupToggle.vue'
+export { default as ScalarSidebarItem } from './ScalarSidebarItem.vue'
+export { default as ScalarSidebarItems } from './ScalarSidebarItems.vue'

--- a/packages/components/src/components/ScalarSidebar/types.ts
+++ b/packages/components/src/components/ScalarSidebar/types.ts
@@ -1,0 +1,24 @@
+import type { Component } from 'vue'
+
+import type { Icon } from '../ScalarIcon'
+
+/** Scalar Sidebar Item Props */
+export type ScalarSidebarItemProps = {
+  /** Overrides the rendered element */
+  is?: Component | string
+  /** Sets the icon for the item */
+  icon?: Icon
+  /** Wether or not the item is selected */
+  selected?: boolean
+  disabled?: boolean
+}
+
+/** Scalar Sidebar Item Slots */
+export type ScalarSidebarItemSlots = {
+  /** The main text content of the button */
+  default?: () => any
+  /** Override the icon */
+  icon?: () => any
+  /** The content to display to the right of the text content */
+  aside?: () => any
+}

--- a/packages/components/src/components/ScalarSidebar/types.ts
+++ b/packages/components/src/components/ScalarSidebar/types.ts
@@ -1,6 +1,7 @@
 import type { Component } from 'vue'
 
 import type { Icon } from '../ScalarIcon'
+import type { SidebarGroupLevel } from './useSidebarGroups'
 
 /** Scalar Sidebar Item Props */
 export type ScalarSidebarItemProps = {
@@ -11,6 +12,8 @@ export type ScalarSidebarItemProps = {
   /** Wether or not the item is selected */
   selected?: boolean
   disabled?: boolean
+  /** The level of the sidebar group */
+  indent?: SidebarGroupLevel
 }
 
 /** Scalar Sidebar Item Slots */

--- a/packages/components/src/components/ScalarSidebar/useSidebarGroups.test.ts
+++ b/packages/components/src/components/ScalarSidebar/useSidebarGroups.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { inject, provide } from 'vue'
+
+import { SIDEBAR_GROUPS_SYMBOL, useSidebarGroups } from './useSidebarGroups'
+
+// Mock vue's inject/provide
+vi.mock('vue', () => ({
+  inject: vi.fn(),
+  provide: vi.fn(),
+}))
+
+describe('useSidebarGroups', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return default level 0 when no level is injected', () => {
+    vi.mocked(inject).mockReturnValue(0)
+
+    const { level } = useSidebarGroups()
+
+    expect(level).toBe(0)
+    expect(provide).toHaveBeenCalledWith(SIDEBAR_GROUPS_SYMBOL, 0)
+  })
+
+  it('should return injected level without incrementing', () => {
+    vi.mocked(inject).mockReturnValue(2)
+
+    const { level } = useSidebarGroups()
+
+    expect(level).toBe(2)
+    expect(provide).toHaveBeenCalledWith(SIDEBAR_GROUPS_SYMBOL, 2)
+  })
+
+  it('should increment level when increment option is true', () => {
+    vi.mocked(inject).mockReturnValue(1)
+
+    const { level } = useSidebarGroups({ increment: true })
+
+    expect(level).toBe(1)
+    expect(provide).toHaveBeenCalledWith(SIDEBAR_GROUPS_SYMBOL, 2)
+  })
+
+  it('should not increment beyond level 6', () => {
+    vi.mocked(inject).mockReturnValue(6)
+
+    const { level } = useSidebarGroups({ increment: true })
+
+    expect(level).toBe(6)
+    expect(provide).toHaveBeenCalledWith(SIDEBAR_GROUPS_SYMBOL, 6)
+  })
+
+  it('should handle level 0 increment correctly', () => {
+    vi.mocked(inject).mockReturnValue(0)
+
+    const { level } = useSidebarGroups({ increment: true })
+
+    expect(level).toBe(0)
+    expect(provide).toHaveBeenCalledWith(SIDEBAR_GROUPS_SYMBOL, 1)
+  })
+})

--- a/packages/components/src/components/ScalarSidebar/useSidebarGroups.ts
+++ b/packages/components/src/components/ScalarSidebar/useSidebarGroups.ts
@@ -1,0 +1,35 @@
+import { type InjectionKey, inject, provide } from 'vue'
+
+/**
+ * The level of the sidebar groups
+ *
+ * We shouldn't go deeper than 6 levels
+ */
+export type SidebarGroupLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+/**
+ * Tracks the level of the sidebar groups
+ *
+ * @default 0
+ */
+export const SIDEBAR_GROUPS_SYMBOL = Symbol() as InjectionKey<SidebarGroupLevel>
+
+/**
+ * Get the current level of the sidebar groups
+ *
+ * Optionally increments the level of the sidebar groups
+ */
+export const useSidebarGroups = ({
+  increment = false,
+}: {
+  /** Whether to increment the level of the sidebar groups */
+  increment?: boolean
+} = {}) => {
+  const level = inject(SIDEBAR_GROUPS_SYMBOL, 0)
+
+  if (increment && level < 6)
+    provide(SIDEBAR_GROUPS_SYMBOL, (level + 1) as SidebarGroupLevel)
+  else provide(SIDEBAR_GROUPS_SYMBOL, level)
+
+  return { level }
+}


### PR DESCRIPTION
This creates a sidebar item component for use everywhere and align the sidebar group toggles in the API Client and references. There's more work to do on fully aligning how the sidebars work and look but I wanted to sync with Cam first because it will noticeably change how the references sidebar looks.

Also adds a (little) animation for the chevron but we can remove that if we prefer.

## References sidebar before / after

![Google Chrome-2025-02-02-22-53-37](https://github.com/user-attachments/assets/eb51c267-abbc-4ca3-bd2b-ad5372b9510a)

## API Client sidebar with animation

![Google Chrome-2025-02-02-22-56-31](https://github.com/user-attachments/assets/45c6a4c4-0ae5-45b7-a015-5366af2f9a1d)

## Video of new sidebar components

(Also check out the storybook preview)


https://github.com/user-attachments/assets/f2cdab79-6218-4201-8680-83e972a6061f

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
