### PR TITLE
fix(api-client): request auth modal

### DIFF
--- a/.changeset/lazy-boxes-bake.md
+++ b/.changeset/lazy-boxes-bake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: displays request auth if security schemes only in modal

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -25,7 +25,7 @@ const {
   activeWorkspace,
   activeServer,
 } = useActiveEntities()
-const { requestMutators, cookies } = useWorkspace()
+const { requestMutators, cookies, securitySchemes } = useWorkspace()
 const { layout } = useLayout()
 
 const sections = computed(() => {
@@ -130,7 +130,11 @@ const activeWorkspaceCookies = computed(() =>
     </template>
     <div class="request-section-content custom-scroll flex flex-1 flex-col">
       <RequestAuth
-        v-if="activeCollection && activeWorkspace"
+        v-if="
+          activeCollection &&
+          activeWorkspace &&
+          (layout !== 'modal' || Object.keys(securitySchemes ?? {}).length)
+        "
         v-show="
           !isAuthHidden && (activeSection === 'All' || activeSection === 'Auth')
         "


### PR DESCRIPTION
**Solution**
this PR is following up with #4667 in order to only display auth in security schemes presence in reference client modal also.

| before | after |
| -------|------|
| <img width="725" alt="image" src="https://github.com/user-attachments/assets/bed03f48-1dd0-4697-b54d-1e48bdfd5530" /> | <img width="725" alt="image" src="https://github.com/user-attachments/assets/c1d7891b-ae84-4295-b0b7-466eb8c9cb9e" /> |
| auth section displayed without security presence | hidden auth section in no security presence | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).