### PR TITLE
chore(tooling): fine grained proxy deployment

### DIFF
--- a/examples/proxy-server/cloudbuild.yaml
+++ b/examples/proxy-server/cloudbuild.yaml
@@ -28,6 +28,8 @@ steps:
         '--execution-environment=gen2',
         '--cpu=$_CPU',
         '--memory=$_MEMORY',
+        '--concurrency=$_CONCURRENCY',
+        '--min-instances=$_MIN_INSTANCES',
         '--service-account=$_SERVICE_ACCOUNT',
       ]
 options:


### PR DESCRIPTION
**Problem**
Client proxy is now deployed cross-regionally, with a great improvement in response metrics (this is the pattern we will follow going forward for other services).

Now we just need some slight extra control over instance sizes and numbers.

**Solution**
Just adding two extra flags to increase the number of concurrent requests each proxy instance can handle, and the minimum number of instances - we will be updating both as needed based on metrics.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
