### PR TITLE
fix(api-reference): add hash prefix to heading IDs

### DIFF
--- a/.changeset/tasty-onions-yell.md
+++ b/.changeset/tasty-onions-yell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: include has prefix in heading ids

--- a/packages/api-reference/src/components/Content/Introduction/Description.test.ts
+++ b/packages/api-reference/src/components/Content/Introduction/Description.test.ts
@@ -1,0 +1,42 @@
+import { ScalarMarkdown } from '@scalar/components'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import Description from './Description.vue'
+
+describe('Description', () => {
+  it('renders nothing when no value is provided', () => {
+    const wrapper = mount(Description)
+    expect(wrapper.find('.introduction-description').exists()).toBe(false)
+  })
+
+  it('renders markdown content when value is provided', () => {
+    const wrapper = mount(Description, {
+      props: {
+        value: '# Hello World',
+      },
+    })
+    expect(wrapper.findComponent(ScalarMarkdown).exists()).toBe(true)
+    expect(wrapper.find('.introduction-description').exists()).toBe(true)
+  })
+
+  it('splits content into sections', () => {
+    const wrapper = mount(Description, {
+      props: {
+        value: '# Heading 1\nContent 1\n# Heading 2\nContent 2',
+      },
+    })
+    const sections = wrapper.findAllComponents(ScalarMarkdown)
+    expect(sections).toHaveLength(4) // 2 headings + 2 content sections
+  })
+
+  it('prefixes the heading section id', () => {
+    const wrapper = mount(Description, {
+      props: {
+        value: '# Test Heading',
+      },
+    })
+    const observer = wrapper.findComponent({ name: 'IntersectionObserver' })
+    expect(observer.attributes('id')).toBe('description/test-heading')
+  })
+})

--- a/packages/api-reference/src/components/Content/Introduction/Description.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Description.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
+import IntersectionObserver from '@/components/IntersectionObserver.vue'
+import { useNavState } from '@/hooks/useNavState'
 import { getHeadings, splitContent } from '@scalar/code-highlight/markdown'
 import { ScalarMarkdown } from '@scalar/components'
-import GithubSlugger from 'github-slugger'
+import GitHubSlugger from 'github-slugger'
 import { computed } from 'vue'
-
-import { useNavState } from '../../../hooks'
-import IntersectionObserver from '../../IntersectionObserver.vue'
 
 const props = defineProps<{
   /** Markdown document */
@@ -21,7 +20,7 @@ const sections = computed(() => {
     return []
   }
 
-  const slugger = new GithubSlugger()
+  const slugger = new GitHubSlugger()
 
   const items = splitContent(props.value).map((markdown) => {
     // Get “first” (and only) heading, if available
@@ -53,7 +52,7 @@ function handleScroll(headingId = '') {
   replaceUrlState(headingId)
 }
 
-const slugger = new GithubSlugger()
+const slugger = new GitHubSlugger()
 
 /** Add ids to all headings */
 const transformHeading = (node: Record<string, any>) => {

--- a/packages/api-reference/src/components/Content/Introduction/Description.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Description.vue
@@ -4,7 +4,6 @@ import { ScalarMarkdown } from '@scalar/components'
 import GithubSlugger from 'github-slugger'
 import { computed } from 'vue'
 
-import { joinWithSlash } from '../../../helpers'
 import { useNavState } from '../../../hooks'
 import IntersectionObserver from '../../IntersectionObserver.vue'
 
@@ -45,7 +44,8 @@ const sections = computed(() => {
   return items
 })
 
-const { getHeadingId, isIntersectionEnabled, replaceUrlState } = useNavState()
+const { getHeadingId, getFullHash, isIntersectionEnabled, replaceUrlState } =
+  useNavState()
 
 function handleScroll(headingId = '') {
   if (!isIntersectionEnabled.value) return
@@ -81,7 +81,7 @@ const transformHeading = (node: Record<string, any>) => {
       <!-- headings -->
       <template v-if="section.id">
         <IntersectionObserver
-          :id="section.id"
+          :id="getFullHash(section.id)"
           class="introduction-description-heading"
           @intersecting="() => handleScroll(section.id)">
           <ScalarMarkdown

--- a/packages/api-reference/src/components/Content/Introduction/Description.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Description.vue
@@ -78,7 +78,7 @@ const transformHeading = (node: Record<string, any>) => {
     <template
       v-for="section in sections"
       :key="section.id">
-      <!-- headings -->
+      <!-- Headings -->
       <template v-if="section.id">
         <IntersectionObserver
           :id="getFullHash(section.id)"
@@ -90,7 +90,7 @@ const transformHeading = (node: Record<string, any>) => {
             :value="section.content" />
         </IntersectionObserver>
       </template>
-      <!-- everything else -->
+      <!-- Everything else -->
       <template v-else>
         <ScalarMarkdown
           :value="section.content"


### PR DESCRIPTION
**Problem**
The hash prefix was missing and not working on ORG

**Solution**
We ensure the hash prefix is added to the heading IDs

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
