### PR TITLE
fix(api-reference): example format

### DIFF
--- a/.changeset/fuzzy-teachers-push.md
+++ b/.changeset/fuzzy-teachers-push.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates format example helper

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.test.ts
@@ -27,9 +27,9 @@ describe('formatExample', () => {
   })
 
   it('handles array with number values', () => {
-    const input = ['123', '456.789']
+    const input = [123, 456.789]
     const result = formatExample(input)
-    expect(result).toBe('["123", "456.789"]')
+    expect(result).toBe('[123, 456.789]')
   })
 
   it('handles array with object values', () => {
@@ -72,5 +72,11 @@ describe('formatExample', () => {
     const input = null
     const result = formatExample(input)
     expect(result).toBe('null')
+  })
+
+  it('handles number input', () => {
+    const input = 123.456
+    const result = formatExample(input)
+    expect(result).toBe('123.456')
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
@@ -5,7 +5,7 @@ export function formatExample(example: unknown): string | number {
   if (Array.isArray(example)) {
     return `[${example
       .map((item) => {
-        if (typeof item === 'string' || typeof item === 'number') {
+        if (typeof item === 'string') {
           return `"${item.toString().trim()}"`
         }
 


### PR DESCRIPTION
**Problem**
currently number parameter example are being displayed as string in the reference and fixed #4678.

**Solution**
this PR updates the type formatting to maintain de type displayed.

| before | after |
| -------|------|
| <img width="580" alt="image" src="https://github.com/user-attachments/assets/24c13422-2334-467b-9f06-d730c2e92ff6" /> | <img width="580" alt="image" src="https://github.com/user-attachments/assets/15412885-000f-4a8f-a09d-6947183148a0" /> |
| example value as string | example value as number | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.