### PR TITLE
fix(api-client): read-only cookies visualisation

### DIFF
--- a/.changeset/weak-boxes-film.md
+++ b/.changeset/weak-boxes-film.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates request params global cookies style

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -214,8 +214,8 @@ export default {
 </script>
 <template>
   <template v-if="disabled">
-    <div class="flex items-center justify-center px-1">
-      <span class="text-c-1 text-sm font-code">{{ modelValue }}</span>
+    <div class="cursor-default flex items-center justify-center px-2 text-c-2">
+      <span>{{ modelValue }}</span>
     </div>
   </template>
   <template v-else-if="props.enum && props.enum.length">

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -206,6 +206,9 @@ const hasReadOnlyEntries = computed(
       <RequestTable
         v-if="hasReadOnlyEntries"
         class="flex-1"
+        :class="{
+          'bg-mix-transparent bg-mix-amount-95 bg-c-3': hasReadOnlyEntries,
+        }"
         :columns="['32px', '', '']"
         isGlobal
         isReadOnly

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -93,13 +93,14 @@ const flattenValue = (item: RequestExampleParameter) => {
               side="top">
               <template #trigger>
                 <ScalarIcon
+                  class="text-c-1"
                   icon="Globe"
                   size="xs" />
               </template>
               <template #content>
                 <div
                   class="grid gap-1.5 pointer-events-none max-w-[320px] w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
-                  <div class="flex items-center text-c-2">
+                  <div class="flex items-center text-c-1">
                     <span class="text-pretty">
                       Global cookies are shared across the whole workspace.
                     </span>


### PR DESCRIPTION
**Solution**
this pr fixes global cookies ui as caught by @hanspagel and highlight their readonly state.

| before | after |
| -------|------|
| <img width="632" alt="image" src="https://github.com/user-attachments/assets/f600b413-0a5e-40d3-a1ff-54ab222a743f" /> | <img width="632" alt="image" src="https://github.com/user-attachments/assets/29860f48-0401-48eb-ad8e-79141957a7db" /> |
| inconsistent padding | consistent padding + readonly style | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).