### PR TITLE
fix(components): set z-index on ScalarMenu by default

### DIFF
--- a/.changeset/mean-experts-count.md
+++ b/.changeset/mean-experts-count.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): set z-index on ScalarMenu by default

--- a/packages/components/src/components/ScalarMenu/ScalarMenu.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenu.vue
@@ -61,7 +61,7 @@ function close() {
     <DropdownMenu.Content
       align="start"
       :as="ScalarDropdownMenu"
-      class="max-h-radix-popper"
+      class="max-h-radix-popper z-context"
       :sideOffset="5"
       v-bind="$attrs">
       <!-- Menu content -->


### PR DESCRIPTION
Because this doesn't use `ScalarFloating` we need to set a `z-index`

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
