### PR TITLE
fix(api-client): content-type request 

### DIFF
--- a/.changeset/lucky-papayas-look.md
+++ b/.changeset/lucky-papayas-look.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sets content type from request

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -73,7 +73,12 @@ const activeExampleContentType = computed(() => {
     return activeExample.value.body.raw.encoding
   }
 
-  return 'none'
+  // Set content type from request if present
+  const contentType = Object.keys(
+    activeRequest.value?.requestBody?.content || {},
+  )[0]
+
+  return contentType || 'none'
 })
 /** Selected ref from options above */
 const selectedContentType = computed({


### PR DESCRIPTION
**Problem**
currently when using a custom content type it is not retrieved at the client modal level and also override the example once back to the reference.

**Solution**
this pr sets the request content-type if present and fixes #4562.

| before | after |
| -------|------|
| <img width="765" alt="image" src="https://github.com/user-attachments/assets/8f5b2947-9956-4939-b287-2926f8f7f3d6" /> | <img width="765" alt="image" src="https://github.com/user-attachments/assets/2c2db24b-771a-44c6-8602-1e31a17b9e5b" /> |
| content-type is using json | content-type is using custom | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
