### PR TITLE
feat(oas-utils): alias request with operation

### DIFF
--- a/.changeset/poor-peaches-exist.md
+++ b/.changeset/poor-peaches-exist.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+chore: alias request to operation

--- a/packages/oas-utils/src/entities/spec/index.ts
+++ b/packages/oas-utils/src/entities/spec/index.ts
@@ -9,3 +9,9 @@ export * from './x-scalar-environments'
 
 type FetchRequest = Request
 export type { FetchRequest }
+
+export {
+  type Operation,
+  type OperationPayload,
+  operationSchema,
+} from './operation'

--- a/packages/oas-utils/src/entities/spec/operation.ts
+++ b/packages/oas-utils/src/entities/spec/operation.ts
@@ -1,0 +1,13 @@
+/**
+ * Aliases Request to Operation which is closer to the spec,
+ * also will not conflict with the builtin Request class
+ */
+import {
+  type RequestPayload,
+  type Request as RequestType,
+  requestSchema,
+} from './requests'
+
+export type Operation = RequestType
+export type OperationPayload = RequestPayload
+export const operationSchema = requestSchema

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -138,7 +138,3 @@ export const requestSchema = oasRequestSchema
 
 export type Request = z.infer<typeof requestSchema>
 export type RequestPayload = z.input<typeof requestSchema>
-
-// Alias these types as request conflicts with built in
-export type Operation = Request
-export type OperationPayload = RequestPayload


### PR DESCRIPTION
**Problem**
request was constantly bumping into the global request class causing typescript errors, also auto import didn't work. 

**Solution**
We alias request with operation which brings it more in line with our codebase + openapi spec.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
