### PR TITLE
fix(api-client): topbar active page

### DIFF
--- a/.changeset/wild-poets-check.md
+++ b/.changeset/wild-poets-check.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates sidenav link active style for lightmode

--- a/packages/api-client/src/components/SideNav/SideNavLink.vue
+++ b/packages/api-client/src/components/SideNav/SideNavLink.vue
@@ -14,9 +14,10 @@ const { layout } = useLayout()
 <template>
   <component
     :is="is ?? 'a'"
-    class="hover:bg-b-2 no-underline min-w-[37px] max-w-[37px] flex items-center justify-center rounded-lg p-2"
+    class="hover:bg-b-3 dark:hover:bg-b-2 no-underline min-w-[37px] max-w-[37px] flex items-center justify-center rounded-lg p-2"
     :class="{
-      'bg-b-2 transition-none hover:cursor-auto text-c-1': active,
+      'bg-b-3 dark:bg-b-2 transition-none hover:cursor-default text-c-1':
+        active,
       'sm:min-w-max sm:max-w-max sm:rounded sm:py-1.5': layout === 'web',
     }">
     <slot name="icon">


### PR DESCRIPTION
**Problem**
currently in light mode the topbar active pages are not highlighted as they should.

**Solution**
this pr updates the sidenav topbar style to get active page highlighted.

| before | after |
| -------|------|
| <img width="378" alt="image" src="https://github.com/user-attachments/assets/4211ba38-50cf-4447-8b07-cfef3d174b89" /> | <img width="378" alt="image" src="https://github.com/user-attachments/assets/706adbf9-4a63-4629-ba2f-c3add07fe477" /> |
| active page not highlighted | active page highlighted | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).