### PR TITLE
fix(api-client): custom parameter disappearing

### DIFF
--- a/.changeset/lazy-clouds-look.md
+++ b/.changeset/lazy-clouds-look.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Allow custom value in parameters

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -41,15 +41,14 @@ const updateSelected = (value: string) => {
 const addCustomValue = () => {
   if (customValue.value.trim()) {
     updateSelected(customValue.value)
-    customValue.value = ''
   }
 }
 
 const handleBlur = () => {
   if (!customValue.value.trim()) {
     emit('update:modelValue', '')
-    addingCustomValue.value = false
   }
+  addingCustomValue.value = false
 }
 
 const isSelected = (value: string) => {


### PR DESCRIPTION
**Problem**
Currently, when you try to provide a custom value for a parameter that has examples, the value disappears as soon as you hit enter.

https://github.com/user-attachments/assets/49c49699-b289-4d68-902a-e5fa2426cf5c

I think I tracked it down to events being emitted too much and overwriting your custom value...

**Solution**
With this PR, I removed those (unneeded?) event emits and got 'working' behavior. Meaning, the custom value is not dissapearing. The value itself however is still not being added to the list of available entries. Unsure if that's desired behavior?


https://github.com/user-attachments/assets/4c699d8d-503d-4960-a285-750763d6bbae


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
