### PR TITLE
chore(tooling): copy node tsconfig base file in base builder dockerfile

### DIFF
--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -13,6 +13,7 @@ COPY pnpm-lock.yaml .
 COPY pnpm-workspace.yaml .
 COPY package.json .
 COPY tsconfig.json .
+COPY tsconfig.node.json .
 COPY turbo.json .
 COPY packages ./packages
 COPY integrations ./integrations


### PR DESCRIPTION
**Problem**
Currently, the base-builder Docker file is failing to build. 

**Solution**
With this PR, the tsconfig.node.json is copied into the Dockerfile because it is needed by @scalar/types and others. 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
