### PR TITLE
fix(api-client): sidebar search request

### DIFF
--- a/.changeset/odd-ducks-smoke.md
+++ b/.changeset/odd-ducks-smoke.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: adds back request in search

--- a/packages/api-client/src/components/Search/useSearch.test.ts
+++ b/packages/api-client/src/components/Search/useSearch.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { useSearch } from './useSearch'
+
+// Mocking the necessary modules and functions
+vi.mock('vue-router', () => ({
+  useRouter: vi.fn(),
+}))
+
+vi.mock('@/store', () => ({
+  useWorkspace: vi.fn(() => ({
+    requests: {
+      request1: {
+        'uid': 'request1',
+        'summary': 'Request 1',
+        'x-internal': false,
+      },
+      request2: {
+        'uid': 'request2',
+        'summary': 'Request 2',
+        'x-internal': true,
+      },
+    },
+    tags: {},
+  })),
+}))
+
+vi.mock('@/store/active-entities', () => ({
+  useActiveEntities: vi.fn(() => ({
+    activeWorkspace: ref({ uid: 'workspace1' }),
+    activeWorkspaceRequests: ref([]),
+    activeWorkspaceCollections: ref([]),
+  })),
+}))
+
+describe('useSearch', () => {
+  it('initializes with default values', () => {
+    const {
+      searchText,
+      searchResultsWithPlaceholderResults,
+      selectedSearchResult,
+      populateFuseDataArray,
+    } = useSearch()
+
+    console.log(populateFuseDataArray)
+    expect(searchText.value).toBe('')
+    expect(searchResultsWithPlaceholderResults.value).toEqual([])
+    expect(selectedSearchResult.value).toBe(0)
+  })
+
+  it('performs a search and updates results', () => {
+    const {
+      populateFuseDataArray,
+      searchText,
+      fuseSearch,
+      searchResultsWithPlaceholderResults,
+    } = useSearch()
+
+    populateFuseDataArray([
+      {
+        uid: 'request1',
+        summary: 'Request 1',
+        path: '/path1',
+        type: 'request',
+        method: 'get',
+        selectedSecuritySchemeUids: [],
+        selectedServerUid: '',
+        servers: [],
+        examples: [],
+      },
+    ])
+
+    searchText.value = 'test'
+    fuseSearch()
+
+    expect(searchResultsWithPlaceholderResults.value).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ item: expect.any(Object) }),
+      ]),
+    )
+  })
+
+  it('returns results for requests', () => {
+    const {
+      populateFuseDataArray,
+      searchText,
+      fuseSearch,
+      searchResultsWithPlaceholderResults,
+    } = useSearch()
+
+    populateFuseDataArray([
+      {
+        uid: 'request1',
+        summary: 'Request 1',
+        path: '/path1',
+        type: 'request',
+        method: 'get',
+        selectedSecuritySchemeUids: [],
+        selectedServerUid: '',
+        servers: [],
+        examples: [],
+      },
+    ])
+    searchText.value = 'Request 1'
+    fuseSearch()
+
+    expect(searchResultsWithPlaceholderResults.value).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          item: {
+            id: 'request1',
+            title: 'Request 1',
+            path: '/path1',
+            httpVerb: 'get',
+            description: '',
+            link: '/workspace/workspace1/request/request1',
+          },
+        }),
+      ]),
+    )
+  })
+
+  it('filters out requests with x-internal: true', () => {
+    const {
+      populateFuseDataArray,
+      searchText,
+      fuseSearch,
+      searchResultsWithPlaceholderResults,
+    } = useSearch()
+
+    populateFuseDataArray([
+      {
+        uid: 'request1',
+        summary: 'Request 1',
+        path: '/path1',
+        type: 'request',
+        method: 'get',
+        selectedSecuritySchemeUids: [],
+        selectedServerUid: '',
+        servers: [],
+        examples: [],
+      },
+      {
+        'uid': 'request2',
+        'summary': 'Request 2',
+        'path': '/path2',
+        'type': 'request',
+        'method': 'get',
+        'selectedSecuritySchemeUids': [],
+        'selectedServerUid': '',
+        'servers': [],
+        'examples': [],
+        'x-internal': true,
+      },
+    ])
+
+    searchText.value = 'Request'
+    fuseSearch()
+
+    expect(searchResultsWithPlaceholderResults.value).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          item: {
+            id: 'request1',
+            title: 'Request 1',
+            path: '/path1',
+            httpVerb: 'get',
+            description: '',
+            link: '/workspace/workspace1/request/request1',
+          },
+          refIndex: 0,
+        }),
+      ]),
+    )
+    expect(searchResultsWithPlaceholderResults.value).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          item: { id: 'request2' },
+        }),
+      ]),
+    )
+  })
+})

--- a/packages/api-client/src/components/Search/useSearch.ts
+++ b/packages/api-client/src/components/Search/useSearch.ts
@@ -52,7 +52,7 @@ export function useSearch() {
     fuseDataArray.value = items
       // TODO: We should probably filter in the store or somewhere else.
       // Check if the request is marked has hidden/internal
-      .filter((request) => shouldIgnoreEntity(request))
+      .filter((request) => !shouldIgnoreEntity(request))
       // Check if the request is in a tag that is marked has hidden/internal
       .filter((request) => {
         // Find the collection for the request
@@ -168,5 +168,6 @@ export function useSearch() {
     searchResultRefs,
     navigateSearchResults,
     selectSearchResult,
+    populateFuseDataArray,
   }
 }


### PR DESCRIPTION
**Problem**
currently the search is not returning any results.

**Solution**
this pr updates the filtering in order to return requests.

| before | after |
| -------|------|
| <img width="285" alt="image" src="https://github.com/user-attachments/assets/9333563c-74a6-40a7-ba9b-bd580c316238" /> | <img width="285" alt="image" src="https://github.com/user-attachments/assets/22c3bbbd-4cdf-4f82-8ffd-c5d98c2888cc" /> |
| no results | results back in | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.