### PR TITLE
fix(api-client): parse security requirements per operation correctly

### DIFF
--- a/.changeset/few-maps-serve.md
+++ b/.changeset/few-maps-serve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: add security requirements for operations

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -445,6 +445,20 @@ describe('importSpecToWorkspace', () => {
       expect(res.requests[0].security).toEqual([{}])
     })
 
+    it('handles empty operation security requirements', async () => {
+      const res = await importSpecToWorkspace({
+        ...galaxy,
+        paths: {
+          '/test': {
+            get: { security: [] },
+          },
+        },
+      })
+
+      if (res.error) throw res.error
+      expect(res.requests[0].security).toEqual([])
+    })
+
     it('imports path-level parameters', async () => {
       const example = {
         paths: {

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -314,6 +314,8 @@ export async function importSpecToWorkspace(
         })
         .filter(isDefined)
 
+      console.log(securityRequirements)
+
       // Set the initially selected security scheme
       const selectedSecuritySchemeUids =
         securityRequirements.length && !setCollectionSecurity
@@ -328,6 +330,7 @@ export async function importSpecToWorkspace(
         ...operationWithoutSecurity,
         method,
         path: pathString,
+        security: operationSecurity,
         selectedSecuritySchemeUids,
         // Merge path and operation level parameters
         parameters: [


### PR DESCRIPTION
**Problem**
We aren't storing security requirements on an operation

**Solution**
We fix that and add a test

Fixes #4017

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
