### PR TITLE
fix(api-client): remove scopes from authCode auth call

### DIFF
--- a/.changeset/afraid-bags-dance.md
+++ b/.changeset/afraid-bags-dance.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: only send scopes during certain oauth2 auth calls

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -132,7 +132,6 @@ describe('oauth2', () => {
         method: 'POST',
         body: new URLSearchParams({
           client_id: flow['x-scalar-client-id'],
-          scope: scope.join(' '),
           client_secret: flow.clientSecret,
           redirect_uri: flow['x-scalar-redirect-uri'],
           code: 'auth_code_123',
@@ -216,7 +215,6 @@ describe('oauth2', () => {
           },
           body: new URLSearchParams({
             client_id: _flow['x-scalar-client-id'],
-            scope: scope.join(' '),
             client_secret: _flow.clientSecret,
             redirect_uri: _flow['x-scalar-redirect-uri'],
             code,
@@ -327,7 +325,6 @@ describe('oauth2', () => {
           method: 'POST',
           body: new URLSearchParams({
             client_id: flow['x-scalar-client-id'],
-            scope: scope.join(' '),
             client_secret: flow.clientSecret,
             redirect_uri: flow['x-scalar-redirect-uri'],
             code: 'auth_code_123',

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -234,7 +234,14 @@ export const authorizeServers = async (
 
   const formData = new URLSearchParams()
   formData.set('client_id', flow['x-scalar-client-id'])
-  if (scopes) formData.set('scope', scopes)
+
+  // Only client credentials and password flows support scopes in the token request
+  if (
+    scopes &&
+    (flow.type == 'clientCredentials' || flow.type === 'password')
+  ) {
+    formData.set('scope', scopes)
+  }
 
   if (flow.clientSecret) formData.set('client_secret', flow.clientSecret)
   if ('x-scalar-redirect-uri' in flow && flow['x-scalar-redirect-uri'])


### PR DESCRIPTION
**Problem**
Currently we send the scopes in the initial login as well as the authorization calls for auth code

**Solution**
Turns out it was breaking some security by sending the scopes a second time, this removes that bit.

Closes #4287

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
