### PR TITLE
fix(api-client): give headers priority over auth

### DIFF
--- a/.changeset/mighty-eyes-talk.md
+++ b/.changeset/mighty-eyes-talk.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: make headers take priority over auth

--- a/packages/api-client/src/libs/send-request/build-request-security.ts
+++ b/packages/api-client/src/libs/send-request/build-request-security.ts
@@ -40,11 +40,11 @@ export const buildRequestSecurity = (
         const password = replaceTemplateVariables(scheme.password, env)
         const value = `${username}:${password}`
 
-        headers['Authorization'] =
+        headers['authorization'] =
           `Basic ${value === ':' ? 'username:password' : btoa(value)}`
       } else {
         const value = replaceTemplateVariables(scheme.token, env)
-        headers['Authorization'] = `Bearer ${value || emptyTokenPlaceholder}`
+        headers['authorization'] = `Bearer ${value || emptyTokenPlaceholder}`
       }
     }
 
@@ -53,7 +53,7 @@ export const buildRequestSecurity = (
       const flows = Object.values(scheme.flows)
       const token = flows.find((f) => f.token)?.token
 
-      headers['Authorization'] = `Bearer ${token || emptyTokenPlaceholder}`
+      headers['authorization'] = `Bearer ${token || emptyTokenPlaceholder}`
     }
   })
 

--- a/packages/api-client/src/libs/send-request/build-request-security.ts
+++ b/packages/api-client/src/libs/send-request/build-request-security.ts
@@ -40,11 +40,11 @@ export const buildRequestSecurity = (
         const password = replaceTemplateVariables(scheme.password, env)
         const value = `${username}:${password}`
 
-        headers['authorization'] =
+        headers['Authorization'] =
           `Basic ${value === ':' ? 'username:password' : btoa(value)}`
       } else {
         const value = replaceTemplateVariables(scheme.token, env)
-        headers['authorization'] = `Bearer ${value || emptyTokenPlaceholder}`
+        headers['Authorization'] = `Bearer ${value || emptyTokenPlaceholder}`
       }
     }
 
@@ -53,7 +53,7 @@ export const buildRequestSecurity = (
       const flows = Object.values(scheme.flows)
       const token = flows.find((f) => f.token)?.token
 
-      headers['authorization'] = `Bearer ${token || emptyTokenPlaceholder}`
+      headers['Authorization'] = `Bearer ${token || emptyTokenPlaceholder}`
     }
   })
 

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -113,6 +113,12 @@ export const createRequestOperation = ({
     // Grab the security headers, cookies and url params
     const security = buildRequestSecurity(selectedSecuritySchemes, env)
 
+    // For securityheaders, we lowercase them so they can be uppercased later (in normalizeHeaders)
+    Object.keys(security.headers).forEach((key) => {
+      security.headers[key.toLowerCase()] = security.headers[key] ?? ''
+      delete security.headers[key]
+    })
+
     // Populate all forms of auth to the request segments
     const headers = { ...security.headers, ..._headers }
     const cookieParams = [..._cookieParams, ...security.cookies]

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -114,7 +114,7 @@ export const createRequestOperation = ({
     const security = buildRequestSecurity(selectedSecuritySchemes, env)
 
     // Populate all forms of auth to the request segments
-    const headers = { ..._headers, ...security.headers }
+    const headers = { ...security.headers, ..._headers }
     const cookieParams = [..._cookieParams, ...security.cookies]
     const urlParams = new URLSearchParams([
       ..._urlParams,


### PR DESCRIPTION
**Problem**
Currently if we have both an auth header and a regular header with the same key 'Authorization' we stack them up into an array.

**Solution**
With this PR the headers overrides the auth and there is no more array.

fixes #4131

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
