### PR TITLE
feat(api-reference): allow pre-selecting multiple and complex auth

### DIFF
--- a/.changeset/funny-meals-smash.md
+++ b/.changeset/funny-meals-smash.md
@@ -1,0 +1,6 @@
+---
+'@scalar/oas-utils': patch
+'@scalar/types': patch
+---
+
+feat: allow pre-selecting multiple and complex auth

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -292,6 +292,10 @@ To make authentication easier you can prefill the credentials for your users:
     // The OpenAPI file has keys for all security schemes:
     // Which one should be used by default?
     preferredSecurityScheme: 'my_custom_security_scheme',
+    // Can also be an array of preferred security schemes to select multiple:
+    preferredSecuritySchemes: ['my_custom_security_scheme', 'another_security_scheme'],
+    // Or an array of arrays for complex security requirements:
+    preferredSecuritySchemes: [['my_custom_security_scheme', 'another_security_scheme'], 'yet_another_security_scheme'],
     // The `my_custom_security_scheme` security scheme is of type `apiKey`, so prefill the token:
     apiKey: {
       token: 'super-secret-token',

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -53,6 +53,39 @@ describe('getSelectedSecuritySchemeUids', () => {
     expect(result).toEqual(['basic-uid'])
   })
 
+  it('should select multiple security schemes when preferred scheme is an array', () => {
+    const securityRequirements = ['basic-auth', 'api-key']
+    const authentication = {
+      preferredSecurityScheme: ['basic-auth', 'api-key'],
+    }
+    const result = getSelectedSecuritySchemeUids(
+      securityRequirements,
+      authentication,
+      securitySchemeMap,
+    )
+    expect(result).toEqual(['basic-uid', 'apikey-uid'])
+  })
+
+  it('should select multiple security schemes when preferred scheme is an array including complex', () => {
+    const securityRequirements = [
+      'basic-auth',
+      'api-key',
+      ['basic-auth', 'api-key', 'oauth2'],
+    ]
+    const authentication = {
+      preferredSecurityScheme: [['basic-auth', 'api-key', 'oauth2'], 'api-key'],
+    }
+    const result = getSelectedSecuritySchemeUids(
+      securityRequirements,
+      authentication,
+      securitySchemeMap,
+    )
+    expect(result).toEqual([
+      ['basic-uid', 'apikey-uid', 'oauth-uid'],
+      'apikey-uid',
+    ])
+  })
+
   it('should handle array-type security requirements', () => {
     const securityRequirements = [['basic-auth', 'api-key']]
     const result = getSelectedSecuritySchemeUids(
@@ -70,7 +103,7 @@ describe('getSelectedSecuritySchemeUids', () => {
       undefined,
       securitySchemeMap,
     )
-    expect(result).toEqual([undefined])
+    expect(result).toEqual([])
   })
 
   it('should handle undefined preferred scheme', () => {

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -504,7 +504,8 @@ export type CollapsedSidebarItems = Record<string, boolean>
 
 export type AuthenticationState = {
   customSecurity: boolean
-  preferredSecurityScheme: string | null
+  /** You can pre-select a single security scheme, multiple, or complex security using an array of arrays */
+  preferredSecurityScheme: string | (string | string[])[] | null
   securitySchemes?:
     | OpenAPIV2.SecurityDefinitionsObject
     | OpenAPIV3.ComponentsObject['securitySchemes']


### PR DESCRIPTION
**Problem**
We can only pre-select a single auth type

**Solution**
With this PR we can pre-select both multiple auth, and complex auth as an added bonus

closes #3890

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
