### PR TITLE
feat(aspnetcore): allow full url for `OpenApiRoutePattern`

### DIFF
--- a/.changeset/violet-chefs-poke.md
+++ b/.changeset/violet-chefs-poke.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': minor
+---
+
+feat(aspnetcore): allow full url for OpenApiRoutePattern

--- a/.changeset/violet-chefs-poke.md
+++ b/.changeset/violet-chefs-poke.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/aspnetcore': minor
+'@scalar/aspnetcore': patch
 ---
 
 feat(aspnetcore): allow full url for OpenApiRoutePattern

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -194,7 +194,7 @@ app.MapScalarApiReference(options =>
     // or
     options.OpenApiRoutePattern = "/swagger/{documentName}.json";
     // Can also point to an external URL:
-    options.OpenApiRoutePattern = "https://somewhere.else.com/swagger/{documentName}.json";
+    options.OpenApiRoutePattern = "https://example.com/swagger/{documentName}.json";
 });
 ```
 

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -185,7 +185,7 @@ app.MapScalarApiReference(options =>
 
 ### OpenAPI Document
 
-Scalar expects the OpenAPI document to be located at `/openapi/{documentName}.json`, matching the route of the built-in .NET OpenAPI generator in the `Microsoft.AspNetCore.OpenApi` package. If the document is located elsewhere (e.g., when using `Swashbuckle` or `NSwag`), specify the path using the `OpenApiRoutePattern` property:
+Scalar expects the OpenAPI document to be located at `/openapi/{documentName}.json`, matching the route of the built-in .NET OpenAPI generator in the `Microsoft.AspNetCore.OpenApi` package. If the document is located elsewhere (e.g., when using `Swashbuckle` or `NSwag`), specify the path or URL using the `OpenApiRoutePattern` property:
 
 ```csharp
 app.MapScalarApiReference(options =>
@@ -193,6 +193,8 @@ app.MapScalarApiReference(options =>
     options.WithOpenApiRoutePattern("/swagger/{documentName}.json");
     // or
     options.OpenApiRoutePattern = "/swagger/{documentName}.json";
+    // Can also point to an external URL:
+    options.OpenApiRoutePattern = "https://somewhere.else.com/swagger/{documentName}.json";
 });
 ```
 

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
@@ -52,6 +52,12 @@ app.MapScalarApiReference((options, context) =>
 
 app.MapScalarApiReference("/", configureOptions);
 
+app.MapScalarApiReference("/scalar-url-pattern", (options, context) =>
+{
+    configureOptions.Invoke(options);
+    options.OpenApiRoutePattern = $"{context.Request.Scheme}://{context.Request.Host}/openapi/v1.json";
+});
+
 app.MapBookEndpoints();
 
 app.Run();

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -189,8 +189,7 @@ public static class ScalarEndpointRouteBuilderExtensions
                       <script>
                           const basePath = getBasePath('{{httpContext.Request.Path}}');
                           console.log(basePath)
-                          const documentUrl = `{{documentUrl}}`;
-                          const openApiUrl = documentUrl.match('^[a-zA-Z]+://.*') ? documentUrl : `${window.location.origin}${basePath}/${documentUrl}`
+                          const openApiUrl = `{{(options.IsOpenApiRoutePatternUrl ? documentUrl : $"${{window.location.origin}}${{basePath}}/{documentUrl}")}}`
                           const reference = document.getElementById('api-reference')
                           reference.dataset.url = openApiUrl;
                           reference.dataset.configuration = JSON.stringify({{serializedConfiguration}})

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -189,7 +189,8 @@ public static class ScalarEndpointRouteBuilderExtensions
                       <script>
                           const basePath = getBasePath('{{httpContext.Request.Path}}');
                           console.log(basePath)
-                          const openApiUrl = `${window.location.origin}${basePath}/{{documentUrl}}`
+                          const documentUrl = `{{documentUrl}}`;
+                          const openApiUrl = documentUrl.match('^[a-zA-Z]+://.*') ? documentUrl : `${window.location.origin}${basePath}/${documentUrl}`
                           const reference = document.getElementById('api-reference')
                           reference.dataset.url = openApiUrl;
                           reference.dataset.configuration = JSON.stringify({{serializedConfiguration}})

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -43,6 +43,7 @@ public sealed class ScalarOptions
 
     /// <summary>
     /// Gets or sets the route pattern of the OpenAPI document.
+    /// Can also be a complete URL to a remote OpenAPI document, just be aware of CORS restrictions in this case.
     /// </summary>
     /// <value>The default value is <c>'/openapi/{documentName}.json'</c>.</value>
     [StringSyntax("Route")]

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -15,7 +15,7 @@ public sealed partial class ScalarOptions
     private static partial Regex OpenApiRoutePatternIsUrlRegex();
     
     /// <summary>
-    /// Retruns whether the <see cref="OpenApiRoutePattern"/> is set to a URL (true) or a route/path (false).
+    /// Returns whether the <see cref="OpenApiRoutePattern"/> is set to a URL (true) or a route/path (false).
     /// </summary>
     internal bool IsOpenApiRoutePatternUrl => OpenApiRoutePatternIsUrlRegex().IsMatch(OpenApiRoutePattern);
     

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 
 namespace Scalar.AspNetCore;
@@ -7,8 +8,17 @@ namespace Scalar.AspNetCore;
 /// Represents all available options for the Scalar API reference.
 /// Based on <a href="https://github.com/scalar/scalar/blob/main/documentation/configuration.md">Configuration</a>.
 /// </summary>
-public sealed class ScalarOptions
+public sealed partial class ScalarOptions
 {
+
+    [GeneratedRegex("^[a-zA-Z]+://.*", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex OpenApiRoutePatternIsUrlRegex();
+    
+    /// <summary>
+    /// Retruns whether the <see cref="OpenApiRoutePattern"/> is set to a URL (true) or a route/path (false).
+    /// </summary>
+    internal bool IsOpenApiRoutePatternUrl => OpenApiRoutePatternIsUrlRegex().IsMatch(OpenApiRoutePattern);
+    
     internal List<string> DocumentNames { get; } = [];
 
     /// <summary>
@@ -46,7 +56,6 @@ public sealed class ScalarOptions
     /// Can also be a complete URL to a remote OpenAPI document, just be aware of CORS restrictions in this case.
     /// </summary>
     /// <value>The default value is <c>'/openapi/{documentName}.json'</c>.</value>
-    [StringSyntax("Route")]
     public string OpenApiRoutePattern
     {
         get => field.TrimStart('/');

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -11,7 +11,7 @@ namespace Scalar.AspNetCore;
 public sealed partial class ScalarOptions
 {
 
-    [GeneratedRegex("^[a-zA-Z]+://.*", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    [GeneratedRegex("^[a-zA-Z]+://.*", RegexOptions.IgnoreCase)]
     private static partial Regex OpenApiRoutePatternIsUrlRegex();
     
     /// <summary>

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -36,7 +36,8 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
                                       <script>
                                           const basePath = getBasePath('/scalar/');
                                           console.log(basePath)
-                                          const openApiUrl = `${window.location.origin}${basePath}*`
+                                          const documentUrl = `*`;
+                                          const openApiUrl = documentUrl.match('^[a-zA-Z]+://.*') ? documentUrl : `${window.location.origin}${basePath}/${documentUrl}`
                                           const reference = document.getElementById('api-reference')
                                           reference.dataset.url = openApiUrl;
                                           reference.dataset.configuration = JSON.stringify(*)
@@ -126,7 +127,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("/openapi/v1.json");
+        content.ReplaceLineEndings().Should().Contain("openapi/v1.json");
     }
 
     [Fact]
@@ -141,7 +142,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("/openapi/v3.json").And.NotContain("/openapi/v1.json");
+        content.ReplaceLineEndings().Should().Contain("openapi/v3.json").And.NotContain("/openapi/v1.json");
     }
 
     [Fact]
@@ -162,7 +163,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("/openapi/v2.json").And.NotContain("/openapi/v1.json");
+        content.ReplaceLineEndings().Should().Contain("openapi/v2.json").And.NotContain("openapi/v1.json");
     }
 
     [Fact]

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -176,7 +176,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("/openapi/v2.json").And.NotContain("openapi/v1.json");
+        content.ReplaceLineEndings().Should().Contain("/openapi/v2.json").And.NotContain("/openapi/v1.json");
     }
 
     [Fact]

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -36,8 +36,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
                                       <script>
                                           const basePath = getBasePath('/scalar/');
                                           console.log(basePath)
-                                          const documentUrl = `*`;
-                                          const openApiUrl = documentUrl.match('^[a-zA-Z]+://.*') ? documentUrl : `${window.location.origin}${basePath}/${documentUrl}`
+                                          const openApiUrl = `${window.location.origin}${basePath}*`
                                           const reference = document.getElementById('api-reference')
                                           reference.dataset.url = openApiUrl;
                                           reference.dataset.configuration = JSON.stringify(*)
@@ -113,7 +112,21 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotModified);
     }
+    
+    [Fact]
+    public async Task MapScalarApiReference_ShouldNotPrefixOpenApiUrlWithOrigin_WhenRouteIsUrl()
+    {
+        // Arrange
+        var client = factory.CreateClient();
 
+        // Act
+        var response = await client.GetAsync("/external/document/scalar", TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        content.ReplaceLineEndings().Should().Contain("`https://example.com/openapi.json`");
+    }
 
     [Fact]
     public async Task MapScalarApiReference_ShouldAddDefaultOpenApiDocument_WhenNotSpecified()
@@ -127,7 +140,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("openapi/v1.json");
+        content.ReplaceLineEndings().Should().Contain("/openapi/v1.json");
     }
 
     [Fact]
@@ -142,7 +155,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("openapi/v3.json").And.NotContain("/openapi/v1.json");
+        content.ReplaceLineEndings().Should().Contain("/openapi/v3.json").And.NotContain("/openapi/v1.json");
     }
 
     [Fact]
@@ -163,7 +176,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("openapi/v2.json").And.NotContain("openapi/v1.json");
+        content.ReplaceLineEndings().Should().Contain("/openapi/v2.json").And.NotContain("openapi/v1.json");
     }
 
     [Fact]

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsTests.cs
@@ -1,0 +1,42 @@
+namespace Scalar.AspNetCore.Tests;
+
+public class ScalarOptionsTests
+{
+    [Theory]
+    [InlineData("https://some.url/openapi.json")]
+    [InlineData("http://some.url/openapi.json")]
+    public void IsOpenApiRoutePatternUrl_ShouldReturnTrueForAbsoluteUrls(string openApiRoute)
+    {
+        // Arrange
+        var options = new ScalarOptions
+        {
+            OpenApiRoutePattern = openApiRoute,
+        };
+
+        // Act
+        var result = options.IsOpenApiRoutePatternUrl;
+
+        // Assert
+        result.Should().BeTrue();
+    }
+    
+    [Theory]
+    [InlineData("relative/path/openapi.json")]
+    [InlineData("/absolute/path/openapi.json")]
+    [InlineData("//doubleslash//path/openapi.json")]
+    [InlineData("/placeholder/path/{documentName}.json")]
+    public void IsOpenApiRoutePatternUrl_ShouldReturnTrueForPathOnly(string openApiRoute)
+    {
+        // Arrange
+        var options = new ScalarOptions
+        {
+            OpenApiRoutePattern = openApiRoute,
+        };
+
+        // Act
+        var result = options.IsOpenApiRoutePatternUrl;
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/integrations/aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Program.cs
+++ b/integrations/aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Program.cs
@@ -19,6 +19,11 @@ app.MapScalarApiReference("/api-reference").AllowAnonymous();
 
 app.MapScalarApiReference("/auth/scalar");
 
+app.MapScalarApiReference("/external/document/scalar", options =>
+{
+    options.OpenApiRoutePattern = "https://example.com/openapi.json";
+}).AllowAnonymous();
+
 #pragma warning disable CS0618 // Type or member is obsolete
 app.MapScalarApiReference(options => options.WithEndpointPrefix("/legacy/{documentName}")).AllowAnonymous();
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
**Problem**
Currently, OpenApiRoutePattern only allows relative paths

**Solution**
With this PR OpenApiRoutePattern also allows full URLs to external openapi documents

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
