### PR TITLE
chore(oas-utils): remove console.log

### DIFF
--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -334,8 +334,6 @@ export async function importSpecToWorkspace(
         })
         .filter(isDefined)
 
-      console.log(securityRequirements)
-
       // Set the initially selected security scheme
       const selectedSecuritySchemeUids =
         securityRequirements.length && !setCollectionSecurity


### PR DESCRIPTION
Found this console.log, which produces a lot of noise.

Let’s remove this.

Doesn’t need a changeset, will be just part of the next release.

<img width="699" alt="Screenshot 2025-02-10 at 10 35 40" src="https://github.com/user-attachments/assets/8bbe8e9a-f7ea-4732-af2a-f536bccf30f4" />
