### PR TITLE
refactor(api-reference): render example responses from store

### DIFF
--- a/.changeset/real-pots-shave.md
+++ b/.changeset/real-pots-shave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+refactor: use store to render example responses

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponses.test.ts
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponses.test.ts
@@ -1,0 +1,373 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import ExampleResponses from './ExampleResponses.vue'
+
+describe('ExampleResponses', () => {
+  it('renders a single example correctly', () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'Successful response',
+            content: {
+              'application/json': {
+                example: { message: 'Success' },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'CardTab' })
+    const codeBlock = wrapper.findAllComponents({ name: 'ScalarCodeBlock' })
+    const examplePicker = wrapper.findComponent({ name: 'ExamplePicker' })
+
+    expect(tabs.length).toBe(1)
+    expect(tabs[0].text()).toContain('200')
+    expect(codeBlock.length).toBe(1)
+    expect(wrapper.text()).toContain('Success')
+    expect(examplePicker.exists()).toBe(false)
+  })
+
+  it('multiple examples for the same status code', async () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'Successful response',
+            content: {
+              'application/json': {
+                examples: {
+                  example1: { value: { message: 'Example 1' } },
+                  example2: { value: { message: 'Example 2' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'CardTab' })
+    const codeBlock = wrapper.findAllComponents({ name: 'ScalarCodeBlock' })
+    const examplePicker = wrapper.findComponent({ name: 'ExamplePicker' })
+    const textSelectLabel = wrapper.find('.text-select-label')
+
+    expect(tabs.length).toBe(1)
+    expect(tabs[0].text()).toContain('200')
+
+    expect(codeBlock.length).toBe(1)
+    expect(textSelectLabel.text()).toContain('example1')
+    expect(codeBlock[0].text()).toContain('Example 1')
+    expect(codeBlock[0].text()).not.toContain('Example 2')
+
+    await examplePicker.vm.$emit('update:modelValue', 'example2')
+    expect(wrapper.text()).not.toContain('Example 1')
+    expect(wrapper.text()).toContain('Example 2')
+  })
+
+  it('handles xml example response', () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'XML response',
+            content: {
+              'application/xml': {
+                example: '<user><name>John</name><age>30</age></user>',
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'CardTab' })
+    const codeBlock = wrapper.findAllComponents({ name: 'ScalarCodeBlock' })
+    const examplePicker = wrapper.findComponent({ name: 'ExamplePicker' })
+
+    expect(tabs.length).toBe(1)
+    expect(tabs[0].text()).toContain('200')
+    expect(codeBlock.length).toBe(1)
+    expect(wrapper.text()).toContain('XML response')
+    expect(wrapper.text()).toContain(
+      '<user><name>John</name><age>30</age></user>',
+    )
+    expect(examplePicker.exists()).toBe(false)
+  })
+
+  it('handles plain text example response', () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'Plain text response',
+            content: {
+              'text/plain': {
+                example: 'Hello world',
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'CardTab' })
+    const codeBlock = wrapper.findAllComponents({ name: 'ScalarCodeBlock' })
+    const examplePicker = wrapper.findComponent({ name: 'ExamplePicker' })
+
+    expect(tabs.length).toBe(1)
+    expect(tabs[0].text()).toContain('200')
+    expect(codeBlock.length).toBe(1)
+    expect(wrapper.text()).toContain('Plain text response')
+    expect(wrapper.text()).toContain('Hello world')
+    expect(examplePicker.exists()).toBe(false)
+  })
+
+  it('handles HTML example response', () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'HTML response',
+            content: {
+              'text/html': {
+                example: '<div>Hello <strong>world</strong></div>',
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'CardTab' })
+    const codeBlock = wrapper.findAllComponents({ name: 'ScalarCodeBlock' })
+    const examplePicker = wrapper.findComponent({ name: 'ExamplePicker' })
+
+    expect(tabs.length).toBe(1)
+    expect(tabs[0].text()).toContain('200')
+    expect(codeBlock.length).toBe(1)
+    expect(wrapper.text()).toContain('HTML response')
+    expect(wrapper.text()).toContain('<div>Hello <strong>world</strong></div>')
+    expect(examplePicker.exists()).toBe(false)
+  })
+
+  it('handles multiple status codes', () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'Success response',
+            content: {
+              'application/json': {
+                example: { status: 'success' },
+              },
+            },
+          },
+          '400': {
+            description: 'Error response',
+            content: {
+              'application/json': {
+                example: { error: 'Bad request' },
+              },
+            },
+          },
+          '500': {
+            description: 'Server error',
+            content: {
+              'application/json': {
+                example: { error: 'Internal server error' },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'CardTab' })
+    expect(tabs.length).toBe(3)
+    expect(tabs[0].text()).toContain('200')
+    expect(tabs[1].text()).toContain('400')
+    expect(tabs[2].text()).toContain('500')
+
+    const codeBlock = wrapper.findComponent({ name: 'ScalarCodeBlock' })
+    expect(codeBlock.exists()).toBe(true)
+
+    // Verify initial content shows first status code
+    expect(wrapper.text()).toContain('Success response')
+    expect(wrapper.text()).toContain('status')
+    expect(wrapper.text()).toContain('success')
+  })
+
+  it('handles default status code along with numbered codes', () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'Success response',
+            content: {
+              'application/json': {
+                example: { status: 'success' },
+              },
+            },
+          },
+          'default': {
+            description: 'Default error response',
+            content: {
+              'application/json': {
+                example: { error: 'Unexpected error' },
+              },
+            },
+          },
+          '404': {
+            description: 'Not found error',
+            content: {
+              'application/json': {
+                example: { error: 'Resource not found' },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'CardTab' })
+    expect(tabs.length).toBe(3)
+    expect(tabs[0].text()).toContain('200')
+    expect(tabs[1].text()).toContain('404')
+    expect(tabs[2].text()).toContain('default')
+
+    const codeBlock = wrapper.findComponent({ name: 'ScalarCodeBlock' })
+    expect(codeBlock.exists()).toBe(true)
+
+    // Verify initial content shows first status code
+    expect(wrapper.text()).toContain('Success response')
+    expect(wrapper.text()).toContain('status')
+    expect(wrapper.text()).toContain('success')
+  })
+
+  it('handles multiple response codes without 200 or default', () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '404': {
+            description: 'Not found error',
+            content: {
+              'application/json': {
+                example: { error: 'Resource not found' },
+              },
+            },
+          },
+          '500': {
+            description: 'Server error',
+            content: {
+              'application/json': {
+                example: { error: 'Internal server error' },
+              },
+            },
+          },
+          '403': {
+            description: 'Forbidden error',
+            content: {
+              'application/json': {
+                example: { error: 'Access denied' },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'CardTab' })
+    expect(tabs.length).toBe(3)
+    expect(tabs[0].text()).toContain('403')
+    expect(tabs[1].text()).toContain('404')
+    expect(tabs[2].text()).toContain('500')
+
+    const codeBlock = wrapper.findComponent({ name: 'ScalarCodeBlock' })
+    expect(codeBlock.exists()).toBe(true)
+
+    // Verify initial content shows first status code (403)
+    expect(wrapper.text()).toContain('Forbidden error')
+    expect(wrapper.text()).toContain('error')
+    expect(wrapper.text()).toContain('Access denied')
+  })
+
+  it('copies example response when clicking copy button', async () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                example: { foo: 'bar' },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const copyButton = wrapper.find('.code-copy')
+    expect(copyButton.exists()).toBe(true)
+
+    await copyButton.trigger('click')
+
+    // Since we can’t test clipboard directly in jsdom, we can verify the click handler was called
+    expect(wrapper.emitted()).toBeDefined()
+  })
+
+  it('toggles between schema and example view', async () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    message: {
+                      type: 'string',
+                      example: 'Foobar',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    // Find the schema toggle checkbox
+    const schemaToggle = wrapper.find('.scalar-card-checkbox-input')
+    expect(schemaToggle.exists()).toBe(true)
+
+    // Initially should show example
+    expect(wrapper.text()).toContain('"message": "Foobar"')
+    expect(wrapper.text()).not.toContain('type')
+    expect(wrapper.text()).not.toContain('properties')
+
+    // Toggle schema view
+    await schemaToggle.setValue(true)
+
+    // Should now show schema
+    expect(wrapper.text()).toContain('type')
+    expect(wrapper.text()).toContain('object')
+    expect(wrapper.text()).toContain('properties')
+    expect(wrapper.text()).not.toContain('"message": "Foobar"')
+
+    // Toggle back to example view
+    await schemaToggle.setValue(false)
+
+    // Should show example again
+    expect(wrapper.text()).toContain('"message": "Foobar"')
+    expect(wrapper.text()).not.toContain('type')
+    expect(wrapper.text()).not.toContain('properties')
+  })
+})

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
@@ -1,17 +1,17 @@
 <script lang="ts" setup>
-import { ScalarCodeBlock, ScalarIcon, ScalarMarkdown } from '@scalar/components'
-import { normalizeMimeTypeObject } from '@scalar/oas-utils/helpers'
-import type { TransformedOperation } from '@scalar/types/legacy'
-import { useClipboard } from '@scalar/use-hooks/useClipboard'
-import { computed, ref, useId } from 'vue'
-
 import {
   Card,
   CardContent,
   CardFooter,
   CardTab,
   CardTabHeader,
-} from '../../components/Card'
+} from '@/components/Card'
+import { ScalarCodeBlock, ScalarIcon, ScalarMarkdown } from '@scalar/components'
+import type { Operation } from '@scalar/oas-utils/entities/spec'
+import { normalizeMimeTypeObject } from '@scalar/oas-utils/helpers'
+import { useClipboard } from '@scalar/use-hooks/useClipboard'
+import { computed, ref, useId } from 'vue'
+
 import { ExamplePicker } from '../ExampleRequest'
 import ExampleResponse from './ExampleResponse.vue'
 
@@ -19,7 +19,7 @@ import ExampleResponse from './ExampleResponse.vue'
  * TODO: copyToClipboard isn’t using the right content if there are multiple examples
  */
 
-const props = defineProps<{ operation: TransformedOperation }>()
+const { responses } = defineProps<{ responses: Operation['responses'] }>()
 
 const id = useId()
 
@@ -28,9 +28,7 @@ const { copyToClipboard } = useClipboard()
 const selectedExampleKey = ref<string>()
 
 // Bring the status codes in the right order.
-const orderedStatusCodes = computed(() =>
-  Object.keys(props?.operation?.information?.responses ?? {}).sort(),
-)
+const orderedStatusCodes = computed(() => Object.keys(responses ?? {}).sort())
 
 const hasMultipleExamples = computed<boolean>(
   () => !!currentJsonResponse.value.examples,
@@ -44,7 +42,7 @@ const currentResponse = computed(() => {
   const currentStatusCode =
     orderedStatusCodes.value[selectedResponseIndex.value]
 
-  return props.operation.information?.responses?.[currentStatusCode]
+  return responses?.[currentStatusCode]
 })
 
 const currentJsonResponse = computed(() => {
@@ -55,7 +53,9 @@ const currentJsonResponse = computed(() => {
   return (
     // OpenAPI 3.x
     normalizedContent?.['application/json'] ??
+    normalizedContent?.['application/xml'] ??
     normalizedContent?.['text/plain'] ??
+    normalizedContent?.['text/html'] ??
     // Swagger 2.0
     currentResponse.value
   )

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -110,7 +110,7 @@ const config = useConfig()
             :operation="transformedOperation" />
         </div>
       </div>
-      <ExampleResponses :operation="transformedOperation" />
+      <ExampleResponses :responses="operation.responses" />
       <ExampleRequest
         :collection="collection"
         :operation="operation"

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -90,7 +90,7 @@ defineProps<{
             </ScalarErrorBoundary>
             <ScalarErrorBoundary>
               <ExampleResponses
-                :operation="transformedOperation"
+                :responses="operation.responses"
                 style="margin-top: 12px" />
             </ScalarErrorBoundary>
           </div>


### PR DESCRIPTION
Splitting #4281 in smaller PRs:

**Problem**
Currently, we still use the deprecated transformed operation to render the example responses.

**Solution**
With this PR, we’re using the store to render example responses and add tests! Isn’t that cool?

For the example responses in the card on the right side only.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
