### PR TITLE
fix(api-client): appearance settings button hover

### DIFF
--- a/.changeset/hungry-hornets-fix.md
+++ b/.changeset/hungry-hornets-fix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: adds setting apparence button hover

--- a/packages/api-client/src/views/Settings/components/SettingsAppearance.vue
+++ b/packages/api-client/src/views/Settings/components/SettingsAppearance.vue
@@ -9,7 +9,7 @@ const buttonStyles = cva({
   variants: {
     active: {
       true: 'bg-primary text-c-1 hover:bg-inherit',
-      false: 'bg-b-1',
+      false: 'bg-b-1 hover:bg-b-2',
     },
   },
 })


### PR DESCRIPTION
**Problem**
currently the appearance setting button are missing hover state background.

**Solution**
this pr adds the missing hover state background on appearance button hover.

| before | after |
| -------|------|
| <img width="727" alt="image" src="https://github.com/user-attachments/assets/fa614267-39ca-4299-bffa-86f9faf2c86f" /> | <img width="727" alt="image" src="https://github.com/user-attachments/assets/4ef5efcb-9b1f-4077-af5a-b191ed2ff100" /> |
| missing background on hover | background on hover | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).