### PR TITLE
feat(galaxy): XML support

### DIFF
--- a/.changeset/tidy-jobs-hunt.md
+++ b/.changeset/tidy-jobs-hunt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat: add xml support

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -266,22 +266,30 @@ paths:
             schema:
               $ref: '#/components/schemas/User'
             examples:
-              - name: Marc
-                email: marc@scalar.com
-                password: i-love-scalar
-              - name: Cam
-                email: cam@scalar.com
-                password: scalar-is-cool
+              Marc:
+                value:
+                  name: Marc
+                  email: marc@scalar.com
+                  password: i-love-scalar
+              Cam:
+                value:
+                  name: Cam
+                  email: cam@scalar.com
+                  password: scalar-is-cool
           application/xml:
             schema:
               $ref: '#/components/schemas/User'
             examples:
-              - name: Marc
-                email: marc@scalar.com
-                password: i-love-scalar
-              - name: Cam
-                email: cam@scalar.com
-                password: scalar-is-cool
+              Marc:
+                value:
+                  name: Marc
+                  email: marc@scalar.com
+                  password: i-love-scalar
+              Cam:
+                value:
+                  name: Cam
+                  email: cam@scalar.com
+                  password: scalar-is-cool
       responses:
         '201':
           description: Created

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -84,8 +84,8 @@ paths:
       security:
         - {}
       parameters:
-        - '$ref': '#/components/parameters/limit'
-        - '$ref': '#/components/parameters/offset'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         '200':
           description: OK
@@ -98,8 +98,20 @@ paths:
                       data:
                         type: array
                         items:
-                          '$ref': '#/components/schemas/Planet'
-                  - '$ref': '#/components/schemas/PaginatedResource'
+                          $ref: '#/components/schemas/Planet'
+                  - $ref: '#/components/schemas/PaginatedResource'
+            application/xml:
+              schema:
+                allOf:
+                  - type: object
+                    xml:
+                      name: planets
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Planet'
+                  - $ref: '#/components/schemas/PaginatedResource'
     post:
       tags:
         - Planets
@@ -111,18 +123,24 @@ paths:
         content:
           application/json:
             schema:
-              '$ref': '#/components/schemas/Planet'
+              $ref: '#/components/schemas/Planet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Planet'
       responses:
         '201':
           description: Created
           content:
             application/json:
               schema:
-                '$ref': '#/components/schemas/Planet'
+                $ref: '#/components/schemas/Planet'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Planet'
         '400':
-          '$ref': '#/components/responses/BadRequest'
+          $ref: '#/components/responses/BadRequest'
         '403':
-          '$ref': '#/components/responses/Forbidden'
+          $ref: '#/components/responses/Forbidden'
   '/planets/{planetId}':
     get:
       tags:
@@ -133,16 +151,19 @@ paths:
       security:
         - {}
       parameters:
-        - '$ref': '#/components/parameters/planetId'
+        - $ref: '#/components/parameters/planetId'
       responses:
         '200':
           description: Planet Found
           content:
             application/json:
               schema:
-                '$ref': '#/components/schemas/Planet'
+                $ref: '#/components/schemas/Planet'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Planet'
         '404':
-          '$ref': '#/components/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
     put:
       tags:
         - Planets
@@ -154,22 +175,28 @@ paths:
         content:
           application/json:
             schema:
-              '$ref': '#/components/schemas/Planet'
+              $ref: '#/components/schemas/Planet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Planet'
       parameters:
-        - '$ref': '#/components/parameters/planetId'
+        - $ref: '#/components/parameters/planetId'
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                '$ref': '#/components/schemas/Planet'
+                $ref: '#/components/schemas/Planet'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Planet'
         '400':
-          '$ref': '#/components/responses/BadRequest'
+          $ref: '#/components/responses/BadRequest'
         '403':
-          '$ref': '#/components/responses/Forbidden'
+          $ref: '#/components/responses/Forbidden'
         '404':
-          '$ref': '#/components/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
     delete:
       tags:
         - Planets
@@ -181,7 +208,7 @@ paths:
         and should not be used anymore.
       x-scalar-stability: experimental
       parameters:
-        - '$ref': '#/components/parameters/planetId'
+        - $ref: '#/components/parameters/planetId'
       responses:
         '204':
           description: No Content
@@ -195,7 +222,7 @@ paths:
       description: Got a crazy good photo of a planet? Share it with the world!
       operationId: uploadImage
       parameters:
-        - '$ref': '#/components/parameters/planetId'
+        - $ref: '#/components/parameters/planetId'
       requestBody:
         content:
           multipart/form-data:
@@ -211,22 +238,13 @@ paths:
                     jupiter: '@jupiter.png'
       responses:
         '200':
-          description: Image uploaded
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    examples:
-                      - Image uploaded successfully
+          $ref: '#/components/responses/ImageUploaded'
         '400':
-          '$ref': '#/components/responses/BadRequest'
+          $ref: '#/components/responses/BadRequest'
         '403':
-          '$ref': '#/components/responses/Forbidden'
+          $ref: '#/components/responses/Forbidden'
         '404':
-          '$ref': '#/components/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
   '/user/signup':
     post:
       tags:
@@ -240,7 +258,7 @@ paths:
         content:
           application/json:
             schema:
-              '$ref': '#/components/schemas/User'
+              $ref: '#/components/schemas/User'
             examples:
               Marc:
                 value:
@@ -252,15 +270,34 @@ paths:
                   name: Cam
                   email: cam@scalar.com
                   password: scalar-is-cool
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/User'
+            examples:
+              Marc:
+                value: <User>
+                  <name>Marc</name>
+                  <email>marc@scalar.com</email>
+                  <password>i-love-scalar</password>
+                  </User>
+              Cam:
+                value: <User>
+                  <name>Cam</name>
+                  <email>cam@scalar.com</email>
+                  <password>scalar-is-cool</password>
+                  </User>
       responses:
         '201':
           description: Created
           content:
             application/json:
               schema:
-                '$ref': '#/components/schemas/User'
+                $ref: '#/components/schemas/User'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
         '400':
-          '$ref': '#/components/responses/BadRequest'
+          $ref: '#/components/responses/BadRequest'
   '/auth/token':
     post:
       tags:
@@ -274,14 +311,20 @@ paths:
         content:
           application/json:
             schema:
-              '$ref': '#/components/schemas/Credentials'
+              $ref: '#/components/schemas/Credentials'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Credentials'
       responses:
         '201':
           description: Token Created
           content:
             application/json:
               schema:
-                '$ref': '#/components/schemas/Token'
+                $ref: '#/components/schemas/Token'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Token'
   '/me':
     get:
       tags:
@@ -302,11 +345,14 @@ paths:
           content:
             application/json:
               schema:
-                '$ref': '#/components/schemas/User'
+                $ref: '#/components/schemas/User'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
         '401':
-          '$ref': '#/components/responses/Unauthorized'
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          '$ref': '#/components/responses/Forbidden'
+          $ref: '#/components/responses/Forbidden'
 webhooks:
   newPlanet:
     post:
@@ -317,7 +363,10 @@ webhooks:
         content:
           application/json:
             schema:
-              '$ref': '#/components/schemas/Planet'
+              $ref: '#/components/schemas/Planet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Planet'
       responses:
         '200':
           description:
@@ -414,110 +463,57 @@ components:
         format: int64
         default: 0
   responses:
+    ImageUploaded:
+      description: Image uploaded
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ImageUploadedMessage'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/ImageUploadedMessage'
     BadRequest:
       description: Bad Request
       content:
         application/json:
           schema:
-            type: object
-            description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
-            properties:
-              type:
-                type: string
-                examples:
-                  - https://example.com/errors/bad-request
-              title:
-                type: string
-                examples:
-                  - Bad Request
-              status:
-                type: integer
-                format: int64
-                examples:
-                  - 400
-              detail:
-                type: string
-                examples:
-                  - The request was invalid.
+            $ref: '#/components/schemas/BadRequestError'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/BadRequestError'
     Forbidden:
       description: Forbidden
       content:
         application/json:
           schema:
-            type: object
-            description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
-            properties:
-              type:
-                type: string
-                examples:
-                  - https://example.com/errors/forbidden
-              title:
-                type: string
-                examples:
-                  - Forbidden
-              status:
-                type: integer
-                format: int64
-                examples:
-                  - 403
-              detail:
-                type: string
-                examples:
-                  - You are not authorized to access this resource.
+            $ref: '#/components/schemas/ForbiddenError'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/ForbiddenError'
     NotFound:
       description: NotFound
       content:
         application/json:
           schema:
-            type: object
-            description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
-            properties:
-              type:
-                type: string
-                examples:
-                  - https://example.com/errors/not-found
-              title:
-                type: string
-                examples:
-                  - Not Found
-              status:
-                type: integer
-                format: int64
-                examples:
-                  - 404
-              detail:
-                type: string
-                examples:
-                  - The resource you are trying to access does not exist.
+            $ref: '#/components/schemas/NotFoundError'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/NotFoundError'
     Unauthorized:
       description: Unauthorized
       content:
         application/json:
           schema:
-            type: object
-            description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
-            properties:
-              type:
-                type: string
-                examples:
-                  - https://example.com/errors/not-found
-              title:
-                type: string
-                examples:
-                  - Unauthorized
-              status:
-                type: integer
-                format: int64
-                examples:
-                  - 401
-              detail:
-                type: string
-                examples:
-                  - You are not authorized to access this resource.
+            $ref: '#/components/schemas/UnauthorizedError'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/UnauthorizedError'
   schemas:
     User:
       allOf:
         - type: object
+          xml:
+            name: user
           properties:
             id:
               type: integer
@@ -558,6 +554,8 @@ components:
       required:
         - id
         - name
+      xml:
+        name: planet
       properties:
         id:
           type: integer
@@ -582,7 +580,7 @@ components:
           examples:
             - https://cdn.scalar.com/photos/mars.jpg
         creator:
-          '$ref': '#/components/schemas/User'
+          $ref: '#/components/schemas/User'
     PaginatedResource:
       type: object
       properties:
@@ -610,3 +608,121 @@ components:
                 - 'null'
               examples:
                 - '/planets?limit=10&offset=10'
+    ImageUploadedMessage:
+      x-scalar-ignore: true
+      type: object
+      properties:
+        message:
+          type: string
+          examples:
+            - Image uploaded successfully
+        imageUrl:
+          type: string
+          description: The URL where the uploaded image can be accessed
+          examples:
+            - https://cdn.scalar.com/images/8f47c132-9d1f-4f83-b5a4-91db5ee757ab.jpg
+        uploadedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the image was uploaded
+          examples:
+            - '2024-01-15T14:30:00Z'
+        fileSize:
+          type: integer
+          description: Size of the uploaded image in bytes
+          examples:
+            - 1048576
+        mimeType:
+          type: string
+          description: The content type of the uploaded image
+          examples:
+            - image/jpeg
+            - image/png
+    BadRequestError:
+      x-scalar-ignore: true
+      type: object
+      description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
+      properties:
+        type:
+          type: string
+          examples:
+            - https://example.com/errors/bad-request
+        title:
+          type: string
+          examples:
+            - Bad Request
+        status:
+          type: integer
+          format: int64
+          examples:
+            - 400
+        detail:
+          type: string
+          examples:
+            - The request was invalid.
+    ForbiddenError:
+      x-scalar-ignore: true
+      type: object
+      description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
+      properties:
+        type:
+          type: string
+          examples:
+            - https://example.com/errors/forbidden
+        title:
+          type: string
+          examples:
+            - Forbidden
+        status:
+          type: integer
+          format: int64
+          examples:
+            - 403
+        detail:
+          type: string
+          examples:
+            - You are not authorized to access this resource.
+    NotFoundError:
+      x-scalar-ignore: true
+      type: object
+      description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
+      properties:
+        type:
+          type: string
+          examples:
+            - https://example.com/errors/not-found
+        title:
+          type: string
+          examples:
+            - Not Found
+        status:
+          type: integer
+          format: int64
+          examples:
+            - 404
+        detail:
+          type: string
+          examples:
+            - The resource you are trying to access does not exist.
+    UnauthorizedError:
+      x-scalar-ignore: true
+      type: object
+      description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
+      properties:
+        type:
+          type: string
+          examples:
+            - https://example.com/errors/not-found
+        title:
+          type: string
+          examples:
+            - Unauthorized
+        status:
+          type: integer
+          format: int64
+          examples:
+            - 401
+        detail:
+          type: string
+          examples:
+            - You are not authorized to access this resource.

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -48,6 +48,9 @@ info:
     name: Marc from Scalar
     url: https://scalar.com
     email: marc@scalar.com
+  license:
+    name: MIT
+    url: https://opensource.org/license/MIT
 servers:
   - url: https://galaxy.scalar.com
   - url: '{protocol}://void.scalar.com/{path}'
@@ -66,6 +69,7 @@ security:
   - apiKeyHeader: []
   - apiKeyCookie: []
   - oAuth2: []
+  - openIdConnect: []
 tags:
   - name: Authentication
     description:
@@ -224,6 +228,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/planetId'
       requestBody:
+        description: Image to upload
         content:
           multipart/form-data:
             schema:
@@ -255,37 +260,28 @@ paths:
       security:
         - {}
       requestBody:
+        description: User to create
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/User'
             examples:
-              Marc:
-                value:
-                  name: Marc
-                  email: marc@scalar.com
-                  password: i-love-scalar
-              Cam:
-                value:
-                  name: Cam
-                  email: cam@scalar.com
-                  password: scalar-is-cool
+              - name: Marc
+                email: marc@scalar.com
+                password: i-love-scalar
+              - name: Cam
+                email: cam@scalar.com
+                password: scalar-is-cool
           application/xml:
             schema:
               $ref: '#/components/schemas/User'
             examples:
-              Marc:
-                value: <User>
-                  <name>Marc</name>
-                  <email>marc@scalar.com</email>
-                  <password>i-love-scalar</password>
-                  </User>
-              Cam:
-                value: <User>
-                  <name>Cam</name>
-                  <email>cam@scalar.com</email>
-                  <password>scalar-is-cool</password>
-                  </User>
+              - name: Marc
+                email: marc@scalar.com
+                password: i-love-scalar
+              - name: Cam
+                email: cam@scalar.com
+                password: scalar-is-cool
       responses:
         '201':
           description: Created
@@ -308,6 +304,7 @@ paths:
       security:
         - {}
       requestBody:
+        description: Credentials to authenticate a user
         content:
           application/json:
             schema:
@@ -435,6 +432,7 @@ components:
   parameters:
     planetId:
       name: planetId
+      description: The ID of the planet to get
       in: path
       required: true
       schema:
@@ -444,8 +442,8 @@ components:
           - 1
     limit:
       name: limit
-      in: query
       description: The number of items to return
+      in: query
       required: false
       schema:
         type: integer
@@ -453,10 +451,10 @@ components:
         default: 10
     offset:
       name: offset
-      in: query
       description:
         The number of items to skip before starting to collect the result
         set
+      in: query
       required: false
       schema:
         type: integer
@@ -510,6 +508,7 @@ components:
             $ref: '#/components/schemas/UnauthorizedError'
   schemas:
     User:
+      description: A user
       allOf:
         - type: object
           xml:
@@ -527,6 +526,7 @@ components:
                 - Marc
         - $ref: '#/components/schemas/Credentials'
     Credentials:
+      description: Credentials to authenticate a user
       type: object
       required:
         - email
@@ -543,6 +543,7 @@ components:
           examples:
             - i-love-scalar
     Token:
+      description: A token to authenticate a user
       type: object
       properties:
         token:
@@ -550,6 +551,7 @@ components:
           examples:
             - eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
     Planet:
+      description: A planet
       type: object
       required:
         - id
@@ -582,6 +584,7 @@ components:
         creator:
           $ref: '#/components/schemas/User'
     PaginatedResource:
+      description: A paginated resource
       type: object
       properties:
         meta:
@@ -610,6 +613,7 @@ components:
                 - '/planets?limit=10&offset=10'
     ImageUploadedMessage:
       x-scalar-ignore: true
+      description: Message about an image upload
       type: object
       properties:
         message:
@@ -640,8 +644,8 @@ components:
             - image/png
     BadRequestError:
       x-scalar-ignore: true
-      type: object
       description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
+      type: object
       properties:
         type:
           type: string
@@ -662,8 +666,8 @@ components:
             - The request was invalid.
     ForbiddenError:
       x-scalar-ignore: true
-      type: object
       description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
+      type: object
       properties:
         type:
           type: string
@@ -684,8 +688,8 @@ components:
             - You are not authorized to access this resource.
     NotFoundError:
       x-scalar-ignore: true
-      type: object
       description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
+      type: object
       properties:
         type:
           type: string
@@ -706,8 +710,8 @@ components:
             - The resource you are trying to access does not exist.
     UnauthorizedError:
       x-scalar-ignore: true
-      type: object
       description: RFC 7807 (https://datatracker.ietf.org/doc/html/rfc7807)
+      type: object
       properties:
         type:
           type: string


### PR DESCRIPTION
**Problem**
I’m working on the code examples and the example responses and wanted to test multiple mime types. But you know what? The Scalar Galaxy example has JSON only!

**Solution**
With this PR we’re adding XML to the Scalar Galaxy example.

I’ve also asked the [OpenAPI doctor](https://pb33f.io/doctor/) to give feedback and addressed most points (e.g. missing descriptions).

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.