### PR TITLE
fix(api-client): routing broken on environment and servers page

### DIFF
--- a/.changeset/hot-dolls-cover.md
+++ b/.changeset/hot-dolls-cover.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: routing broken on servers and environment page

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -263,7 +263,7 @@ const handleHotKey = (event?: HotKeyEvent) => {
 }
 
 watch(
-  () => [route.params.collectionId, route.params.environmentId],
+  () => [route.params[PathId.Collection], route.params[PathId.Environment]],
   ([newCollectionId, newEnvironmentId]) => {
     if (newCollectionId) {
       // Collection environment
@@ -277,9 +277,9 @@ watch(
 
 onMounted(() => {
   currentEnvironmentId.value =
-    (route.params.environmentId as string) || 'default'
+    (route.params[PathId.Environment] as string) || 'default'
   events.hotKeys.on(handleHotKey)
-  const { collectionId } = router.currentRoute.value.params
+  const collectionId = route.params[PathId.Collection]
   if (collectionId && !collapsedSidebarFolders[collectionId as string]) {
     toggleSidebarFolder(collectionId as string)
   }

--- a/packages/api-client/src/views/Servers/Servers.vue
+++ b/packages/api-client/src/views/Servers/Servers.vue
@@ -25,8 +25,10 @@ const { push, resolve } = useRouter()
 const route = useRoute()
 const { collapsedSidebarFolders, toggleSidebarFolder } = useSidebar()
 
-const collectionIdParam = computed(() => route.params.collectionId as string)
-const serverUidParam = computed(() => route.params.servers as string)
+const collectionUidParam = computed(
+  () => route.params[PathId.Collection] as string,
+)
+const serverUidParam = computed(() => route.params[PathId.Servers] as string)
 
 const showChildren = (key: string) => {
   return collapsedSidebarFolders[key]
@@ -68,7 +70,7 @@ const handleNavigation = (
 
 function handleDelete(uid: string) {
   if (!activeCollection?.value?.uid) return
-  serverMutators.delete(uid, collectionIdParam.value)
+  serverMutators.delete(uid, collectionUidParam.value)
 }
 
 const hasServers = computed(() => Object.keys(servers).length > 0)
@@ -165,7 +167,7 @@ const hasServers = computed(() => Object.keys(servers).length > 0)
     <ViewLayoutContent class="flex-1">
       <ServerForm
         v-if="hasServers"
-        :collectionId="collectionIdParam"
+        :collectionId="collectionUidParam"
         :serverUid="serverUidParam" />
       <EmptyState v-else />
     </ViewLayoutContent>


### PR DESCRIPTION
**Problem**
With #4716 I broke the routing on the servers and environment pages. We’ve used `:collectionId` before, but I refactored the code to use `PathId.Collection` (which is `collection` not `collectionId`), so we’ve had to update more places then I did in the initial PR.

**Solution**
With this PR you can click on environments and servers and see the content change again.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
