### PR TITLE
fix(api-client): getting started sidebar state

### DIFF
--- a/.changeset/dirty-mails-stare.md
+++ b/.changeset/dirty-mails-stare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates request sidebar height responsiveness

--- a/.changeset/silly-parents-itch.md
+++ b/.changeset/silly-parents-itch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates getting started state logic in request sidebar

--- a/packages/api-client/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-client/src/components/Sidebar/Sidebar.vue
@@ -88,7 +88,7 @@ const startDrag = (event: MouseEvent) => {
     </div>
     <template v-if="breakpoints.lg">
       <div
-        class="relative z-10 pt-0 md:px-2.5 md:pb-2.5 sticky bottom-0 w-[inherit] has-[.empty-sidebar-item]:border-t-1/2">
+        class="bg-b-1 relative z-10 pt-0 md:px-2.5 md:pb-2.5 sticky bottom-0 w-[inherit] has-[.empty-sidebar-item]:border-t-1/2">
         <slot name="button" />
       </div>
       <div

--- a/packages/api-client/src/views/Request/RequestSection/helpers/getting-started.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/helpers/getting-started.test.ts
@@ -1,0 +1,80 @@
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+import { describe, expect, it } from 'vitest'
+
+import { isGettingStarted } from './getting-started'
+
+describe('gettingStarted', () => {
+  const mockRequests = {
+    request1: { summary: 'My First Request' },
+    request2: { summary: 'Another Request' },
+  }
+
+  const createCollection = (
+    uid: string,
+    title: string,
+    requests: string[],
+  ): Collection => ({
+    uid,
+    'info': { title, version: '1.0.0' },
+    requests,
+    'type': 'collection',
+    'children': [],
+    'openapi': '',
+    'security': [],
+    'x-scalar-icon': '',
+    'securitySchemes': [],
+    'selectedSecuritySchemeUids': [],
+    'selectedServerUid': '',
+    'servers': [],
+    'tags': [],
+    'watchMode': false,
+    'watchModeStatus': 'IDLE',
+  })
+
+  const draftCollection = createCollection('drafts', 'Drafts', ['request1'])
+  const anotherCollection = createCollection(
+    'anotherCollection',
+    'Another Collection',
+    ['request2'],
+  )
+
+  it('should return true for a single draft request that is not renamed', () => {
+    const result = isGettingStarted(
+      [draftCollection],
+      ['request1'],
+      mockRequests,
+    )
+    expect(result).toBe(true)
+  })
+
+  it('should return false for a single draft request that is renamed', () => {
+    const renamedRequests = {
+      ...mockRequests,
+      request1: { summary: 'Renamed Request' },
+    }
+    const result = isGettingStarted(
+      [draftCollection],
+      ['request1'],
+      renamedRequests,
+    )
+    expect(result).toBe(false)
+  })
+
+  it('should return false if there are multiple requests', () => {
+    const result = isGettingStarted(
+      [draftCollection],
+      ['request1', 'request2'],
+      mockRequests,
+    )
+    expect(result).toBe(false)
+  })
+
+  it('should return false if the request is not in the drafts collection', () => {
+    const result = isGettingStarted(
+      [anotherCollection],
+      ['request2'],
+      mockRequests,
+    )
+    expect(result).toBe(false)
+  })
+})

--- a/packages/api-client/src/views/Request/RequestSection/helpers/getting-started.ts
+++ b/packages/api-client/src/views/Request/RequestSection/helpers/getting-started.ts
@@ -1,0 +1,24 @@
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+
+/**
+ * Checks if the user gets the getting started state displayed
+ */
+export const isGettingStarted = (
+  activeWorkspaceCollections: Collection[],
+  activeWorkspaceRequests: string[],
+  requests: Record<string, any>,
+) => {
+  const draftCollection = activeWorkspaceCollections.find(
+    (collection) => collection.info?.title === 'Drafts',
+  )
+  const hasSingleRequest = activeWorkspaceRequests.length === 1
+  const isDraftsRequest = draftCollection?.requests.includes(
+    activeWorkspaceRequests[0] ?? '',
+  )
+
+  if (!isDraftsRequest) return false
+  const isRenamed =
+    requests[draftCollection?.requests[0] ?? '']?.summary !== 'My First Request'
+
+  return hasSingleRequest && isDraftsRequest && !isRenamed
+}

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -279,7 +279,7 @@ const toggleSearch = () => {
           @keydown.up.stop="navigateSearchResults('up')" />
       </div>
       <div
-        class="gap-1/2 flex flex-1 flex-col overflow-visible px-3 pb-3 pt-0"
+        class="gap-1/2 flex flex-1 flex-col overflow-visible overflow-y-auto px-3 pb-3 pt-0 h-[calc(100%-273.5px)]"
         :class="{
           'pb-14': layout !== 'modal',
         }"

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -39,6 +39,7 @@ import {
 } from 'vue'
 import { useRouter } from 'vue-router'
 
+import { isGettingStarted } from './RequestSection/helpers/getting-started'
 import RequestSidebarItem from './RequestSidebarItem.vue'
 import { WorkspaceDropdown } from './components'
 
@@ -229,6 +230,14 @@ const toggleSearch = () => {
   // Simply toggle the visibility
   isSearchVisible.value = !isSearchVisible.value
 }
+
+const showGettingStarted = computed(() => {
+  return isGettingStarted(
+    activeWorkspaceCollections.value,
+    activeWorkspaceRequests.value,
+    requests,
+  )
+})
 </script>
 <template>
   <Sidebar
@@ -279,10 +288,15 @@ const toggleSearch = () => {
           @keydown.up.stop="navigateSearchResults('up')" />
       </div>
       <div
-        class="gap-1/2 flex flex-1 flex-col overflow-visible overflow-y-auto px-3 pb-3 pt-0 h-[calc(100%-273.5px)]"
-        :class="{
-          'pb-14': layout !== 'modal',
-        }"
+        class="gap-1/2 flex flex-1 flex-col overflow-visible overflow-y-auto px-3 pb-3 pt-0"
+        :class="[
+          {
+            'pb-14': layout !== 'modal',
+          },
+          {
+            'h-[calc(100%-273.5px)]': showGettingStarted,
+          },
+        ]"
         @dragenter.prevent
         @dragover.prevent>
         <template v-if="searchText">
@@ -357,7 +371,7 @@ const toggleSearch = () => {
     <template #button>
       <div
         :class="{
-          'empty-sidebar-item': activeWorkspaceRequests.length <= 1,
+          'empty-sidebar-item': showGettingStarted,
         }">
         <div class="empty-sidebar-item-content px-2.5 py-2.5">
           <div class="w-[60px] h-[68px] m-auto rabbit-ascii mt-2 relative">
@@ -379,7 +393,7 @@ const toggleSearch = () => {
           v-if="layout !== 'modal'"
           class="mb-1.5 w-full h-fit hidden opacity-0 p-1.5"
           :class="{
-            'flex opacity-100': activeWorkspaceRequests.length <= 1,
+            'flex opacity-100': showGettingStarted,
           }"
           @click="openCommandPaletteImport">
           Import Collection

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -498,7 +498,7 @@ const shouldShowItem = computed(() => {
           @openMenu="(item) => $emit('openMenu', item)" />
         <ScalarButton
           v-if="item.children.length === 0"
-          class="mb-[.5px] flex gap-1.5 h-8 text-c-1 py-0 justify-start text-xs w-full hover:bg-b-2"
+          class="flex gap-1.5 h-8 text-c-1 py-0 justify-start text-xs w-full hover:bg-b-2"
           :class="parentUids.length ? 'pl-9' : ''"
           variant="ghost"
           @click="openCommandPaletteRequest()">


### PR DESCRIPTION
**Problem**
currently the getting started state is not optimally responsive + get displayed when a request exists out of a drafts collection.

**Solution**
this pr updates responsiveness + only extracts a function to only display the state when a single request from the draft collection is added.

| before | after |
| -------|------|
| <img width="506" alt="image" src="https://github.com/user-attachments/assets/6bf40129-9d5e-4a8d-a39c-1cd200f57d4d" /> | <img width="506" alt="image" src="https://github.com/user-attachments/assets/e9f14f5b-b2dd-42dd-aec9-df203c8961bc" /> |
| state is overflowing the requests | requests height according to state presence + scroll |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
