### PR TITLE
fix(api-reference): warnings for `type: ['string', 'null']`

### DIFF
--- a/.changeset/clever-books-carry.md
+++ b/.changeset/clever-books-carry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+feat: make 'null' the second type in an array when upgrading

--- a/.changeset/healthy-steaks-compare.md
+++ b/.changeset/healthy-steaks-compare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: improve parameter zod schema

--- a/.changeset/thirty-wolves-try.md
+++ b/.changeset/thirty-wolves-try.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: can’t import type array e.g. `['string', 'null']`

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -36,7 +36,7 @@ const props = withDefaults(
     disableCloseBrackets?: boolean
     enum?: string[]
     examples?: string[]
-    type?: string
+    type?: string | string[]
     nullable?: boolean
     withVariables?: boolean
     importCurl?: boolean
@@ -205,6 +205,14 @@ const handleKeyDown = (key: string, event: KeyboardEvent) => {
     }
   }
 }
+
+const defaultType = computed(() => {
+  return Array.isArray(props.type)
+    ? // Find the first type, that’s not 'null'
+      (props.type.find((type) => type !== 'null') ?? 'string')
+    : // If it’s not an array, just return the type
+      props.type
+})
 </script>
 <script lang="ts">
 // use normal <script> to declare options
@@ -222,7 +230,7 @@ export default {
     <DataTableInputSelect
       :default="props.default"
       :modelValue="modelValue"
-      :type="type"
+      :type="defaultType"
       :value="props.enum"
       @update:modelValue="emit('update:modelValue', $event)" />
   </template>

--- a/packages/oas-utils/src/entities/spec/request-example.test.ts
+++ b/packages/oas-utils/src/entities/spec/request-example.test.ts
@@ -209,6 +209,30 @@ describe('createParamInstance', () => {
       default: false,
     })
   })
+
+  it('works with array of types', () => {
+    const result = createParamInstance({
+      in: 'path',
+      name: 'foo',
+      required: true,
+      deprecated: false,
+      schema: {
+        type: ['string', 'null'],
+      },
+    })
+
+    expect(result).toEqual({
+      key: 'foo',
+      enabled: true,
+      enum: undefined,
+      examples: undefined,
+      description: undefined,
+      required: true,
+      type: 'string',
+      nullable: true,
+      value: '',
+    })
+  })
 })
 
 describe('parameterArrayToObject', () => {

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
@@ -124,7 +124,7 @@ describe('upgradeFromThreeToThreeOne', () => {
         result.paths['/test'].get.responses['200'].content['application/json']
           .schema,
       ).toEqual({
-        type: ['null', 'string'],
+        type: ['string', 'null'],
       })
     })
   })

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -28,7 +28,7 @@ export function upgradeFromThreeToThreeOne(
   // Nullable types
   specification = traverse(specification, (schema) => {
     if (schema.type !== 'undefined' && schema.nullable === true) {
-      schema.type = ['null', schema.type]
+      schema.type = [schema.type, 'null']
       delete schema.nullable
     }
 


### PR DESCRIPTION
**Problem**

Currently, you receive a warning when importing an OpenAPI document containing `type: ['string', 'null']` or a Swagger 2.0, OpenAPI 3.0 document containing `nullable: true` (which will be transformed to the array syntax during upgrade), that’s the case for the [GitHub RestAPI OpenAPI document](https://raw.githubusercontent.com/github/rest-api-description/refs/heads/main/descriptions/api.github.com/api.github.com.yaml) for example.

Fixes #3812

**Solution**

With this PR, we’re extending the schema to allow an array as the type, normalize it to use a single string and `nullable: true` instead, but still deal with other arrays if someone goes wild.

**Example**

```diff
{
  "openapi": "3.0.0",
  "info": {
    "title": "Hello World",
    "version": "1.0.0"
  },
  "paths": {
    "/": {
      "get": {
        "parameters": [
          {
            "name": "Foo",
            "in": "query",
            "schema": {
+              "type": ["string", "null"]
            }
          },
          {
            "name": "Bar",
            "in": "query",
            "schema": {
+              "type": "string",
+              "nullable": true
            }
          }
        ]
      }
    }
  }
}
```

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
