### PR TITLE
refactor(api-reference): use store for search

### DIFF
--- a/packages/api-reference/src/components/Layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ClassicLayout.vue
@@ -32,13 +32,12 @@ const config = computed(() => ({ ...props.configuration, showSidebar: false }))
         :name="name"
         v-bind="slotProps || {}"></slot>
     </template>
-    <template #content-start="{ spec }">
+    <template #content-start>
       <ClassicHeader>
         <SearchButton
           v-if="!props.configuration.hideSearch"
           class="t-doc__sidebar"
-          :searchHotKey="config.searchHotKey"
-          :spec="spec" />
+          :searchHotKey="config.searchHotKey" />
         <template #dark-mode-toggle>
           <ScalarColorModeToggleIcon
             v-if="!props.configuration.hideDarkModeToggle"

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -58,13 +58,11 @@ watch(hash, (newHash, oldHash) => {
         v-if="props.configuration.showSidebar"
         v-model:open="isSidebarOpen" />
     </template>
-    <template #sidebar-start="{ spec }">
+    <template #sidebar-start>
       <div
         v-if="!props.configuration.hideSearch"
         class="scalar-api-references-standalone-search">
-        <SearchButton
-          :searchHotKey="props.configuration?.searchHotKey"
-          :spec="spec" />
+        <SearchButton :searchHotKey="props.configuration?.searchHotKey" />
       </div>
     </template>
     <template #sidebar-end>

--- a/packages/api-reference/src/features/Search/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/SearchButton.vue
@@ -1,15 +1,14 @@
 <script setup lang="ts">
+import { useApiClient } from '@/features/ApiClientModal'
+import { isMacOs } from '@/helpers/isMacOs'
+import { useWorkspace } from '@scalar/api-client/store'
 import { ScalarIcon, useModal } from '@scalar/components'
-import type { Spec } from '@scalar/types/legacy'
 import { onBeforeUnmount, onMounted } from 'vue'
 
-import { isMacOs } from '../../helpers'
-import { useApiClient } from '../ApiClientModal'
 import SearchModal from './SearchModal.vue'
 
 const props = withDefaults(
   defineProps<{
-    spec: Spec
     searchHotKey?: string
   }>(),
   {
@@ -31,6 +30,8 @@ const handleHotKey = (e: KeyboardEvent) => {
     modalState.open ? modalState.hide() : modalState.show()
   }
 }
+
+const store = useWorkspace()
 
 // Handle keyboard shortcuts
 // TODO: we can move this to the hotkey event bus but we would need to set up a custom key from the searchHotKey config
@@ -62,7 +63,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', handleHotKey))
   </button>
   <SearchModal
     :modalState="modalState"
-    :parsedSpec="spec" />
+    :store="store" />
 </template>
 <style scoped>
 .sidebar-search {

--- a/packages/api-reference/src/features/Search/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/SearchModal.vue
@@ -1,4 +1,9 @@
 <script setup lang="ts">
+import { lazyBus } from '@/components/Content/Lazy/lazyBus'
+import SidebarHttpBadge from '@/components/Sidebar/SidebarHttpBadge.vue'
+import { scrollToId } from '@/helpers'
+import { useSidebar } from '@/hooks'
+import type { WorkspaceStore } from '@scalar/api-client/store'
 import {
   type Icon,
   type ModalState,
@@ -7,23 +12,16 @@ import {
   ScalarSearchResultItem,
   ScalarSearchResultList,
 } from '@scalar/components'
-import type { Spec } from '@scalar/types/legacy'
 import type { FuseResult } from 'fuse.js'
 import { nanoid } from 'nanoid'
-import { computed, ref, toRef, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
-import { lazyBus } from '../../components/Content/Lazy/lazyBus'
-import SidebarHttpBadge from '../../components/Sidebar/SidebarHttpBadge.vue'
-import { scrollToId } from '../../helpers'
-import { useSidebar } from '../../hooks'
 import { type EntryType, type FuseData, useSearchIndex } from './useSearchIndex'
 
-const props = defineProps<{
-  parsedSpec: Spec
+const { store, modalState } = defineProps<{
+  store: WorkspaceStore
   modalState: ModalState
 }>()
-
-const specification = toRef(props, 'parsedSpec')
 
 /** Base id for the search form */
 const id = nanoid()
@@ -41,7 +39,7 @@ const {
   searchResultsWithPlaceholderResults,
   searchText,
 } = useSearchIndex({
-  specification,
+  store,
 })
 
 const ENTRY_ICONS: { [x in EntryType]: Icon } = {
@@ -63,7 +61,7 @@ const ENTRY_LABELS: { [x in EntryType]: string } = {
 const searchModalRef = ref<HTMLElement | null>(null)
 
 watch(
-  () => props.modalState.open,
+  () => modalState.open,
   (open) => {
     if (open) {
       resetSearch()
@@ -95,12 +93,12 @@ function onSearchResultClick(entry: FuseResult<FuseData>) {
       if (ev.id === targetId) {
         scrollToId(targetId)
         unsubscribe()
-        props.modalState.hide()
+        modalState.hide()
       }
     })
   } else {
     scrollToId(targetId)
-    props.modalState.hide()
+    modalState.hide()
   }
 }
 

--- a/packages/api-reference/src/features/Search/useSearchIndex.test.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.test.ts
@@ -1,27 +1,35 @@
+import { createWorkspaceStore } from '@scalar/api-client/store'
+import type { OpenAPI } from '@scalar/openapi-types'
 import { describe, expect, it } from 'vitest'
-import { toRef } from 'vue'
 
-import { createEmptySpecification, parse } from '../../helpers'
 import { useSearchIndex } from './useSearchIndex'
 
 describe('useSearchIndex', () => {
   it('should create the search index from an OpenAPI document', async () => {
-    const specification = await parse(
-      createEmptySpecification({
-        paths: {
-          '/foobar': {
-            get: {
-              summary: 'Get request',
-              description: 'Get request description',
-            },
+    const store = await createStore({
+      info: {
+        title: 'Test API',
+        description: 'Test API description',
+      },
+      tags: [
+        {
+          name: 'test',
+          description: 'test description',
+        },
+      ],
+      paths: {
+        '/foobar': {
+          get: {
+            summary: 'Get request',
+            description: 'Get request description',
           },
         },
-      }),
-    )
+      },
+    })
 
     const { searchText, fuseSearch, searchResultsWithPlaceholderResults } =
       useSearchIndex({
-        specification: toRef(specification),
+        store,
       })
 
     searchText.value = 'request'
@@ -41,3 +49,22 @@ describe('useSearchIndex', () => {
     ])
   })
 })
+
+/**
+ * Utility to quickly create a store with a given definition
+ */
+async function createStore(definition: OpenAPI.Document) {
+  const store = createWorkspaceStore({
+    themeId: 'default',
+    useLocalStorage: false,
+    hideClientButton: false,
+    integration: 'html',
+  })
+
+  await store.importSpecFile(definition, 'default', {
+    shouldLoad: false,
+    setCollectionSecurity: true,
+  })
+
+  return store
+}


### PR DESCRIPTION
WIP

**Problem**
Currently, we’re still not using the store for the API reference search.

**Solution**
With this PR we’re switching to the store. :)

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
