### PR TITLE
ci: reset github actions cache commit hash

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: pnpm install
     - name: Restore Turborepo cache
-      uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8
+      uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
       with:
         path: .turbo
         key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}-${{ github.sha }}


### PR DESCRIPTION
**Problem**
Currently, CI is failing claiming we use an old version of actions/cache.

**Solution**
With this PR all uses of actions/cache are pinned to the same hash.

If CI passes here, we can merge.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
