### PR TITLE
fix(import): can’t parse HTML attributes with HTML tags inside

### DIFF
--- a/.changeset/tender-ducks-hang.md
+++ b/.changeset/tender-ducks-hang.md
@@ -1,0 +1,5 @@
+---
+'@scalar/import': patch
+---
+
+fix: can’t parse HTML attributes with HTML tags inside

--- a/packages/import/src/get-configuration-attribute.test.ts
+++ b/packages/import/src/get-configuration-attribute.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { getConfigurationAttribute } from './resolve'
+
+describe('getConfigurationAttribute', () => {
+  it('returns the configuration attribute with double quotes', () => {
+    const html = `<script id="api-reference" data-configuration="{&quot;spec&quot;:{&quot;content&quot;:&quot;foo&quot;}}"></script>`
+    const result = getConfigurationAttribute(html)
+    expect(result).toBe(
+      '{&quot;spec&quot;:{&quot;content&quot;:&quot;foo&quot;}}',
+    )
+  })
+
+  it('returns the configuration attribute with single quotes', () => {
+    const html = `<script id='api-reference' data-configuration='{&quot;spec&quot;:{&quot;content&quot;:&quot;foo&quot;}}'></script>`
+    const result = getConfigurationAttribute(html)
+    expect(result).toBe(
+      '{&quot;spec&quot;:{&quot;content&quot;:&quot;foo&quot;}}',
+    )
+  })
+
+  it('returns undefined if no configuration attribute is present', () => {
+    const html = `<script id="api-reference"></script>`
+    const result = getConfigurationAttribute(html)
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined for non-matching script tags', () => {
+    const html = `<script data-other-attribute="value" data-configuration="{&quot;spec&quot;:{&quot;content&quot;:&quot;foo&quot;}}"></script>`
+    const result = getConfigurationAttribute(html)
+    expect(result).toBeUndefined()
+  })
+
+  it('handles multiple script tags and returns the first match', () => {
+    const html = `
+      <script id="api-reference" data-configuration="{&quot;spec&quot;:{&quot;content&quot;:&quot;first&quot;}}"></script>
+      <script id="api-reference" data-configuration="{&quot;spec&quot;:{&quot;content&quot;:&quot;second&quot;}}"></script>
+    `
+    const result = getConfigurationAttribute(html)
+    expect(result).toBe(
+      '{&quot;spec&quot;:{&quot;content&quot;:&quot;first&quot;}}',
+    )
+  })
+})

--- a/packages/import/src/get-content-of-script-tag.test.ts
+++ b/packages/import/src/get-content-of-script-tag.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { getContentOfScriptTag } from './resolve'
+
+describe('getContentOfScriptTag', () => {
+  it('returns the content of the script tag', () => {
+    const html =
+      '<script id="api-reference">console.log("Hello, world!");</script>'
+    expect(getContentOfScriptTag(html)).toBe('console.log("Hello, world!");')
+  })
+
+  it('works with single quotes', () => {
+    const html = `<script id='api-reference'>console.log("Hello, world!");</script>`
+    expect(getContentOfScriptTag(html)).toBe('console.log("Hello, world!");')
+  })
+
+  it('ignores HTML characters inside the attributes', () => {
+    // HTML tags inside the attributes
+    const html = `<!DOCTYPE html>
+    <html>
+      <head>
+        <title>Scalar API Reference</title>
+        <meta charset="utf-8" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1" />
+        <style>
+          null
+        </style>
+      </head>
+      <body>
+        <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+        <script id="api-reference" type="application/json" data-configuration="foo<br>bar">console.log("Hello, world!");</script>
+      </body>
+    </html>`
+
+    expect(getContentOfScriptTag(html)).toBe('console.log("Hello, world!");')
+  })
+})

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -379,11 +379,12 @@ describe('resolve', () => {
     const result = await resolve('https://example.com/reference')
 
     expect(result).toStrictEqual({
-      openapi: '3.1.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0',
-        description: 'Cats API<br>The cats API description',
+      openapi: '3.0.0',
+      paths: {
+        '/v1/projects/{ref}/sessions/tags': {
+          pattern: '/^\\s*([a-z0-9_-]+(\\s*,+\\s*)?)*\\s*$/i',
+          type: 'string',
+        },
       },
     })
   })

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -361,6 +361,33 @@ describe('resolve', () => {
     })
   })
 
+  it('finds embedded OpenAPI document in script tag, even if it contains HTML tags (JSON)', async () => {
+    const html = `<!DOCTYPE html>
+<html>
+  <head />
+  <body>
+    <script
+        id="api-reference"
+        type="application/json">{"openapi":"3.0.0","paths":{"/v1/projects/{ref}/sessions/tags":{"type":"string","pattern":"/^\\s*([a-z0-9_-]+(\\s*,+\\s*)?)*\\s*$/i"}}}</script>
+  </body>
+</html>
+    `
+
+    // @ts-expect-error Mocking types are missing
+    fetch.mockResolvedValue(createFetchResponse(html))
+
+    const result = await resolve('https://example.com/reference')
+
+    expect(result).toStrictEqual({
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0',
+        description: 'Cats API<br>The cats API description',
+      },
+    })
+  })
+
   it('finds embedded OpenAPI document in script tag (YAML)', async () => {
     const html = `<!DOCTYPE html>
 <html>

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -273,6 +273,48 @@ describe('resolve', () => {
     })
   })
 
+  it('finds embedded OpenAPI documents, even if they contain HTML tags', async () => {
+    const html = `<!DOCTYPE html>
+<html>
+  <head />
+  <body>
+    <script
+      id="api-reference"
+      type="application/json"
+      data-configuration="{&quot;spec&quot;:{&quot;content&quot;:{&quot;openapi&quot;:&quot;3.0.0&quot;,&quot;paths&quot;:{&quot;/&quot;:{&quot;get&quot;:{&quot;operationId&quot;:&quot;AppController_getHello&quot;,&quot;parameters&quot;:[],&quot;responses&quot;:{&quot;200&quot;:{&quot;description&quot;:&quot;&quot;}}}}},&quot;info&quot;:{&quot;title&quot;:&quot;Cats example&quot;,&quot;description&quot;:&quot;The cats<br>API description&quot;,&quot;version&quot;:&quot;1.0&quot;,&quot;contact&quot;:{}},&quot;tags&quot;:[{&quot;name&quot;:&quot;cats&quot;,&quot;description&quot;:&quot;&quot;}],&quot;servers&quot;:[],&quot;components&quot;:{&quot;schemas&quot;:{}}}}}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>
+    `
+
+    // @ts-expect-error Mocking types are missing
+    fetch.mockResolvedValue(createFetchResponse(html))
+
+    const result = await resolve('https://example.com/reference')
+
+    expect(result).toStrictEqual({
+      openapi: '3.0.0',
+      paths: {
+        '/': {
+          get: {
+            operationId: 'AppController_getHello',
+            parameters: [],
+            responses: { '200': { description: '' } },
+          },
+        },
+      },
+      info: {
+        title: 'Cats example',
+        description: 'The cats<br>API description',
+        version: '1.0',
+        contact: {},
+      },
+      tags: [{ name: 'cats', description: '' }],
+      servers: [],
+      components: { schemas: {} },
+    })
+  })
+
   it('finds embedded OpenAPI document URLs (JSON)', async () => {
     const html = `<!DOCTYPE html>
 <html>

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -229,9 +229,18 @@ function parseScriptContent(html: string): Record<string, any> | undefined {
 
     if (content) {
       try {
+        // JSON
         return JSON.parse(content)
       } catch {
-        return parse(content)
+        try {
+          // JSON with escaped whitespace
+          const sanitizedContent = content.replace(/\\s/g, '\\\\s')
+
+          return JSON.parse(sanitizedContent)
+        } catch {
+          // YAML
+          return parse(content)
+        }
       }
     }
   } catch (error) {

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -215,18 +215,34 @@ function parseHtml(html?: string) {
 }
 
 /**
+ * Get the content between the script tags
+ *
+ * @example <script id="api-reference">console.log("Hello, world!");</script>
+ */
+export function getContentOfScriptTag(html: string): string | undefined {
+  const patterns = [
+    // Double quotes
+    /<script[^>]*id="api-reference[\s\S]*?">([\s\S]*?)<\/script>/i,
+    // Single quotes
+    /<script[^>]*id='api-reference[\s\S]*?'>([\s\S]*?)<\/script>/i,
+  ]
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern)
+
+    if (match?.[1]) return match[1].trim()
+  }
+
+  return undefined
+}
+
+/**
  * Parse OpenAPI document directly from script tag content
  */
 function parseScriptContent(html: string): Record<string, any> | undefined {
-  const match = html.match(
-    /<script[^>]*id="api-reference"[^>]*>([\s\S]*?)<\/script>/,
-  )
-
-  if (!match?.[1]) return undefined
+  const content = getContentOfScriptTag(html)
 
   try {
-    const content = match[1].trim()
-
     if (content) {
       try {
         // JSON
@@ -251,19 +267,39 @@ function parseScriptContent(html: string): Record<string, any> | undefined {
 }
 
 /**
+ * Get the configuration attribute from the script tag
+ *
+ * @example <script id="api-reference" data-configuration="{&quot;spec&quot;:{&quot;content&quot;:&quot;foo&quot;}}"></script>
+ */
+export function getConfigurationAttribute(html: string): string | undefined {
+  const patterns = [
+    // Double quotes
+    /<script[^>]*id="api-reference"[^>]*data-configuration=["]([^"]+)["][^>]*>(.*?)<\/script>/s,
+    // Single quotes
+    /<script[^>]*id='api-reference'[^>]*data-configuration=[']([^']+)['][^>]*>(.*?)<\/script>/s,
+  ]
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern)
+
+    if (match?.[1]) {
+      return match[1]
+    }
+  }
+
+  return undefined
+}
+
+/**
  * Parse embedded OpenAPI document from HTML
  */
 function parseEmbeddedOpenApi(html: string): object | undefined {
-  const match = html.match(
-    /<script[^>]*data-configuration=['"]([^'"]+)['"][^>]*>(.*?)<\/script>/s,
-  )
+  const configString = getConfigurationAttribute(html)
 
-  if (!match?.[1]) return undefined
+  if (!configString) return undefined
 
   try {
-    const configString = decodeHtmlEntities(match[1])
-
-    const config = JSON.parse(configString)
+    const config = JSON.parse(decodeHtmlEntities(configString))
 
     // Handle both direct JSON content and YAML content
     if (config.spec?.content) {


### PR DESCRIPTION
**Problem**
Currently, the import breaks with HTML attributes that contain HTML tags (e.g. in the description of the OpenAPI document).

**Solution**
With this PR we’re doing a better job parsing HTML attributes and `<script>` tag contents.

And if something fails, we also try to sanitize the JSON to make it parse. That’s pretty specific for a case I’ve found, we might be able to remove this eventually again, but for now it helps.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
