### PR TITLE
feat(api-reference): add onLoaded event

### DIFF
--- a/.changeset/tough-mice-cover.md
+++ b/.changeset/tough-mice-cover.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: add onLoaded event

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -401,7 +401,7 @@ Customize how webhook URLs are generated. This function receives the webhook obj
 
 > Note: This must be passed through JavaScript, setting a data attribute will not work.
 
-````js
+```js
 // Default behavior - results in hash: #webhook/webhook-name
 {
   generateWebhookSlug: (webhook) => slug(webhook.name)
@@ -409,8 +409,24 @@ Customize how webhook URLs are generated. This function receives the webhook obj
 
 // Custom example - results in hash: #webhook/v1-post-user-created
 {
-  generateWebhookSlug: (webhook) => `v1-${webhook.method?.toLowerCase()}-${webhook.name}`
+  generateWebhookSlug: (webhook) =>
+    `v1-${webhook.method?.toLowerCase()}-${webhook.name}`
 }
+```
+
+#### onLoaded?: () => void
+
+Callback that triggers as soon as the references are lazy loaded.
+
+> Note: This must be passed through JavaScript, setting a data attribute will not work.
+
+```js
+{
+  onLoaded: () => {
+    console.log('References loaded')
+  }
+}
+```
 
 #### withDefaultFonts?: boolean
 
@@ -420,7 +436,7 @@ By default we’re using Inter and JetBrains Mono, served by Google Fonts. If yo
 {
   withDefaultFonts: false
 }
-````
+```
 
 #### defaultOpenAllTags?: boolean
 

--- a/packages/api-reference/playground/esm/index.html
+++ b/packages/api-reference/playground/esm/index.html
@@ -25,32 +25,35 @@
         spec: {
           url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         },
+        onLoaded: () => {
+          console.log('references loaded')
+        },
       })
 
       // Replace the OpenAPI document URL
-      let currentOpenApiDocument = 'scalar-galaxy'
+      // let currentOpenApiDocument = 'scalar-galaxy'
 
-      setInterval(() => {
-        currentOpenApiDocument =
-          currentOpenApiDocument === 'scalar-galaxy'
-            ? 'outline'
-            : 'scalar-galaxy'
+      // setInterval(() => {
+      //   currentOpenApiDocument =
+      //     currentOpenApiDocument === 'scalar-galaxy'
+      //       ? 'outline'
+      //       : 'scalar-galaxy'
 
-        reference.updateSpec({
-          url:
-            currentOpenApiDocument === 'scalar-galaxy'
-              ? 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json'
-              : 'https://raw.githubusercontent.com/outline/openapi/refs/heads/main/spec3.yml',
-        })
-      }, 4000)
+      //   reference.updateSpec({
+      //     url:
+      //       currentOpenApiDocument === 'scalar-galaxy'
+      //         ? 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json'
+      //         : 'https://raw.githubusercontent.com/outline/openapi/refs/heads/main/spec3.yml',
+      //   })
+      // }, 4000)
 
-      // Toggle dark mode
-      let isDark = false
+      // // Toggle dark mode
+      // let isDark = false
 
-      setInterval(() => {
-        isDark = !isDark
-        reference.updateConfig({ darkMode: isDark })
-      }, 2000)
+      // setInterval(() => {
+      //   isDark = !isDark
+      //   reference.updateConfig({ darkMode: isDark })
+      // }, 2000)
     </script>
   </body>
 </html>

--- a/packages/api-reference/playground/esm/vite.config.ts
+++ b/packages/api-reference/playground/esm/vite.config.ts
@@ -1,6 +1,13 @@
 import vue from '@vitejs/plugin-vue'
+import { fileURLToPath } from 'url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('../../src', import.meta.url)),
+    },
+    dedupe: ['vue'],
+  },
 })

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -275,7 +275,7 @@ provide(ACTIVE_ENTITIES_SYMBOL, activeEntitiesStore)
 provide(LAYOUT_SYMBOL, 'modal')
 
 // Provide the configuration
-provide(CONFIGURATION_SYMBOL, props.configuration)
+provide(CONFIGURATION_SYMBOL, props.configuration ?? {})
 
 // ---------------------------------------------------------------------------/
 // HANDLE MAPPING CONFIGURATION TO INTERNAL REFERENCE STATE

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { useConfig } from '@/hooks/useConfig'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Spec } from '@scalar/types/legacy'
 import GitHubSlugger from 'github-slugger'
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
 
 import DownloadLink from '../../../features/DownloadLink/DownloadLink.vue'
 import { Badge } from '../../Badge'
@@ -50,6 +51,10 @@ const version = computed(() => {
       ? `v${props.info.version}`
       : undefined
 })
+
+/** Trigger the onLoaded event when the component is mounted */
+const { onLoaded } = useConfig()
+onMounted(() => onLoaded?.())
 </script>
 <template>
   <SectionContainer>

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { Operation } from '@/features/Operation'
-import { useConfig } from '@/hooks/useConfig'
 import { useActiveEntities } from '@scalar/api-client/store'
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type {
@@ -52,7 +51,6 @@ const models = ref<string[]>([])
 const { activeCollection, activeServer } = useActiveEntities()
 const { getModelId, getSectionId, getTagId, hash, isIntersectionEnabled } =
   useNavState()
-const { onLoaded } = useConfig()
 
 const isLoading = ref(props.layout !== 'classic' && hash.value)
 
@@ -125,20 +123,10 @@ watch(
   { immediate: true },
 )
 
-const hasLoaded = ref(false)
-
 // Scroll to hash when component has rendered
 const unsubscribe = lazyBus.on(({ id }) => {
   const hashStr = hash.value
-
-  if (!hashStr || id !== hashStr) {
-    // Only call onLoaded once if we have no hash
-    if ((!hashStr || hashStr.startsWith('description')) && !hasLoaded.value) {
-      onLoaded?.()
-      hasLoaded.value = true
-    }
-    return
-  }
+  if (!hashStr || id !== hashStr) return
 
   // Unsubscribe once our element has loaded
   unsubscribe()
@@ -148,7 +136,6 @@ const unsubscribe = lazyBus.on(({ id }) => {
   setTimeout(() => {
     if (typeof window !== 'undefined') scrollToId(hashStr)
     isLoading.value = false
-    onLoaded?.()
     setTimeout(() => (isIntersectionEnabled.value = true), 1000)
   }, 300)
 })

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { Operation } from '@/features/Operation'
+import { useConfig } from '@/hooks/useConfig'
 import { useActiveEntities } from '@scalar/api-client/store'
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type {
@@ -51,6 +52,7 @@ const models = ref<string[]>([])
 const { activeCollection, activeServer } = useActiveEntities()
 const { getModelId, getSectionId, getTagId, hash, isIntersectionEnabled } =
   useNavState()
+const { onLoaded } = useConfig()
 
 const isLoading = ref(props.layout !== 'classic' && hash.value)
 
@@ -123,10 +125,20 @@ watch(
   { immediate: true },
 )
 
+const hasLoaded = ref(false)
+
 // Scroll to hash when component has rendered
 const unsubscribe = lazyBus.on(({ id }) => {
   const hashStr = hash.value
-  if (!hashStr || id !== hashStr) return
+
+  if (!hashStr || id !== hashStr) {
+    // Only call onLoaded once if we have no hash
+    if ((!hashStr || hashStr.startsWith('description')) && !hasLoaded.value) {
+      onLoaded?.()
+      hasLoaded.value = true
+    }
+    return
+  }
 
   // Unsubscribe once our element has loaded
   unsubscribe()
@@ -136,6 +148,7 @@ const unsubscribe = lazyBus.on(({ id }) => {
   setTimeout(() => {
     if (typeof window !== 'undefined') scrollToId(hashStr)
     isLoading.value = false
+    onLoaded?.()
     setTimeout(() => (isIntersectionEnabled.value = true), 1000)
   }, 300)
 })

--- a/packages/api-reference/src/hooks/useConfig.ts
+++ b/packages/api-reference/src/hooks/useConfig.ts
@@ -6,6 +6,6 @@ export const CONFIGURATION_SYMBOL =
 
 /** Hook for easy access to the reference configuration */
 export const useConfig = () => {
-  const config = inject(CONFIGURATION_SYMBOL, undefined)
+  const config = inject(CONFIGURATION_SYMBOL, {})
   return config
 }

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -258,6 +258,19 @@ export type ReferenceConfiguration = {
    * @default undefined
    * @example 'http://localhost:3000'
    */
+  /**
+   * Callback that triggers as soon as the references are lazy loaded.
+   *
+   * Note: you must pass this function through js, setting a data attribute will not work!
+   *
+   * @example
+   * ```ts
+   * onLoaded: () => {
+   *   console.log('references loaded')
+   * }
+   * ```
+   */
+  onLoaded?: () => void
   baseServerURL?: string
   /**
    * List of servers to override the servers in the given OpenAPI document


### PR DESCRIPTION
**Solution**
We add an onLoaded callback to the reference config. ~This gets triggered as soon as lazy loading occurs and the loading component is up.~ moved it to the intro so its a bit faster than lazy load but should still be pretty accurate.

For our friends at upload thing.

To test cd into `packages/api-reference` and run `pnpm playground:esm`

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
