### PR TITLE
fix: `tsconfig.strict.json` missing in Docker

### DIFF
--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -14,6 +14,7 @@ COPY pnpm-workspace.yaml .
 COPY package.json .
 COPY tsconfig.json .
 COPY tsconfig.node.json .
+COPY tsconfig.strict.json .
 COPY turbo.json .
 COPY packages ./packages
 COPY integrations ./integrations


### PR DESCRIPTION
We forgot to copy the new tsconfig. 