### PR TITLE
fix(api-reference): example request footer

### DIFF
--- a/.changeset/breezy-tips-hide.md
+++ b/.changeset/breezy-tips-hide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates example request footer display logic

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -21,6 +21,7 @@ import {
 } from '../../components/Card'
 import { HttpMethod } from '../../components/HttpMethod'
 import ScreenReader from '../../components/ScreenReader.vue'
+import { useConfig } from '../../hooks/useConfig'
 import { type HttpClientState, useHttpClientStore } from '../../stores'
 import ExamplePicker from './ExamplePicker.vue'
 import TextSelect from './TextSelect.vue'
@@ -37,6 +38,7 @@ const { transformedOperation, operation, collection, server } = defineProps<{
 
 const { selectedExampleKey, operationId } = useExampleStore()
 const { requestExamples, securitySchemes } = useWorkspace()
+const config = useConfig()
 
 const {
   httpClient,
@@ -276,7 +278,9 @@ function updateHttpClient(value: string) {
       </div>
     </CardContent>
     <CardFooter
-      v-if="hasMultipleExamples || $slots.footer"
+      v-if="
+        (hasMultipleExamples || !config.hideTestRequestButton) && $slots.footer
+      "
       class="request-card-footer"
       contrast>
       <div


### PR DESCRIPTION
**Problem**
currently on `hideTestRequestButton` the example request still displays a footer which in some cases act as an extra padding [as seen on vercel](https://vercel.com/docs/rest-api/endpoints#tag/access-groups/create-an-access-group-project).

**Solution**
this pr updates the footer display logic to ensure that it gets used only in multiple example or test request button presence.

| before | after |
| -------|------|
| <img width="538" alt="image" src="https://github.com/user-attachments/assets/3c8a2376-2698-4551-aaa3-67c1af4d7daf" /> | <img width="538" alt="image" src="https://github.com/user-attachments/assets/ef74fb90-e0ae-4b25-bf1b-64650f0c7371" /> |
| footer remains even without multiple examples | footer is not displayed | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
