### PR TITLE
fix(api-client): modal address bar

### DIFF
--- a/.changeset/witty-garlics-thank.md
+++ b/.changeset/witty-garlics-thank.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates disabled style based on layout

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -222,7 +222,9 @@ export default {
 </script>
 <template>
   <template v-if="disabled">
-    <div class="cursor-default flex items-center justify-center px-2 text-c-2">
+    <div
+      class="cursor-default flex items-center justify-center text-c-2"
+      :class="layout === 'modal' ? 'font-code pl-1 pr-2 text-sm' : 'px-2'">
       <span>{{ modelValue }}</span>
     </div>
   </template>


### PR DESCRIPTION
**Problem**
currently address bar in modal is not using the right font style.

**Solution**
this pr updates code input style according to layout.

| before | after |
| -------|------|
| <img width="538" alt="image" src="https://github.com/user-attachments/assets/a8c344f9-ace6-40b5-b4d9-5ee18cdef886" /> | <img width="538" alt="image" src="https://github.com/user-attachments/assets/dcce4111-b659-482e-a810-6352de706a6d" /> |
| font family and size is off | consistent font family and size | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
