### PR TITLE
feat(proxy-server): always return wildcard (*) for `Access-Control-Allow-Origin`

### DIFF
--- a/examples/proxy-server/main.go
+++ b/examples/proxy-server/main.go
@@ -194,14 +194,8 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Add CORS headers here, after the response headers are copied
-	allowOrigin := "*"
-
-	if r.Header.Get("Origin") != "" {
-		allowOrigin = r.Header.Get("Origin")
-	}
-
 	w.Header().Set("Access-Control-Allow-Headers", "*")
-	w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH")
 	w.Header().Set("Access-Control-Expose-Headers", "*")
@@ -226,13 +220,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Headers", "*")
 
-		allowOrigin := "*"
-
-		if r.Header.Get("Origin") != "" {
-			allowOrigin = r.Header.Get("Origin")
-		}
-
-		w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, PATCH")
 		w.Header().Set("Access-Control-Expose-Headers", "*")

--- a/examples/proxy-server/main_test.go
+++ b/examples/proxy-server/main_test.go
@@ -138,8 +138,8 @@ func TestCORSHandling(t *testing.T) {
 
 		// Check CORS headers
 		headers := w.Header()
-		if headers.Get("Access-Control-Allow-Origin") != "http://example.com" {
-			t.Errorf("Expected Allow-Origin header to be 'http://example.com'")
+		if headers.Get("Access-Control-Allow-Origin") != "*" {
+			t.Errorf("Expected Allow-Origin header to be '*'")
 		}
 		if headers.Get("Access-Control-Allow-Credentials") != "true" {
 			t.Errorf("Expected Allow-Credentials header to be 'true'")
@@ -171,7 +171,7 @@ func TestCORSHandling(t *testing.T) {
 	t.Run("Preserves CORS headers from origin", func(t *testing.T) {
 		// Create a test server that sends CORS headers
 		targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", "https://original-allowed-origin.com")
+			w.Header().Set("Access-Control-Allow-Origin", "*")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 			w.Write([]byte("response with CORS"))
@@ -194,8 +194,8 @@ func TestCORSHandling(t *testing.T) {
 		// Verify that our proxy's CORS headers override the target's headers
 		headers := w.Header()
 
-		if headers.Get("Access-Control-Allow-Origin") != "http://example.com" {
-			t.Errorf("Expected Access-Control-Allow-Origin header to be 'http://example.com', got '%s'",
+		if headers.Get("Access-Control-Allow-Origin") != "*" {
+			t.Errorf("Expected Access-Control-Allow-Origin header to be '*', got '%s'",
 				headers.Get("Access-Control-Allow-Origin"))
 		}
 
@@ -275,14 +275,14 @@ func TestProxyBehavior(t *testing.T) {
 	t.Run("Overwrites CORS headers after redirects", func(t *testing.T) {
 		server := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/initial" {
-				w.Header().Set("Access-Control-Allow-Origin", "https://original-allowed-origin.com")
+				w.Header().Set("Access-Control-Allow-Origin", "*")
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 				http.Redirect(w, r, "/final", http.StatusTemporaryRedirect)
 				return
 			}
 
 			if r.URL.Path == "/final" {
-				w.Header().Set("Access-Control-Allow-Origin", "https://original-allowed-origin.com")
+				w.Header().Set("Access-Control-Allow-Origin", "*")
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 				w.Write([]byte("final destination"))
 			}


### PR DESCRIPTION
**Problem**
There’s an issue that should only affect us: When hitting the proxy with the same request from various origins (e.g. http://localhost:5137 and http://localhost:5065), there’s an error in the console:

<img width="839" alt="Screenshot 2025-02-13 at 10 41 43" src="https://github.com/user-attachments/assets/363f9e87-56a0-4a58-bb24-53a14ae07d39" />

Currently, the proxy adds the `Origin` header as the `Access-Control-Allow-Origin`, so in the example above it would for example be explicitly `http://localhost:5137`. And when we do a request from a different origin, the browser blocks it, because - according to the explicit header - the request won’t go through.

I’ve added this behaviour a while ago, because an explicit value (instead of `*` as a wildcard) was required to make cookies work in certain scenarios (cross subdomain requests).

BUT, we’ve built a custom solution to make the cookies work, so that’s not needed anymore. 

**Solution**

With this PR, the `Access-Control-Allow-Origin` is set to `*` - always. That’s what basically every other CORS middleware does, too, and that’s what we did until a few months ago.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

No changeset needed for the proxy, it’s not hooked up to our release process.
