### PR TITLE
feat(express-api-reference): render the content only once

### DIFF
--- a/.changeset/ninety-moose-switch.md
+++ b/.changeset/ninety-moose-switch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/express-api-reference': patch
+---
+
+feat: render embedded content only once

--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -22,7 +22,7 @@
     "docker:run": "docker run -p 5055:5055 express-api-reference",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
-    "test": "vitest run",
+    "test": "vitest",
     "types:build": "scalar-types-build",
     "types:check": "scalar-types-check"
   },

--- a/integrations/express/src/apiReference.test.ts
+++ b/integrations/express/src/apiReference.test.ts
@@ -91,4 +91,23 @@ describe('apiReference', () => {
     const titleCount = (text.match(/Test API/g) || []).length
     expect(titleCount).toBe(1)
   })
+
+  it('keeps the URL in the configuration', async () => {
+    const app = express()
+
+    app.use(
+      apiReference({
+        spec: {
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+        },
+      }),
+    )
+
+    const response = await request(app).get('/')
+
+    // Check the URL is present
+    expect(response.text).toContain(
+      'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+    )
+  })
 })

--- a/integrations/express/src/apiReference.test.ts
+++ b/integrations/express/src/apiReference.test.ts
@@ -73,4 +73,22 @@ describe('apiReference', () => {
       'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
     )
   })
+
+  it('doesn’t have the content twice', async () => {
+    const app = express()
+    app.use(
+      apiReference({ spec: { content: { info: { title: 'Test API' } } } }),
+    )
+
+    const response = await request(app).get('/')
+    expect(response.status).toBe(200)
+
+    // Check the title is present
+    expect(response.text).toContain('Test API')
+
+    // Check that the title is only present once
+    const text = response.text
+    const titleCount = (text.match(/Test API/g) || []).length
+    expect(titleCount).toBe(1)
+  })
 })

--- a/integrations/express/src/apiReference.ts
+++ b/integrations/express/src/apiReference.ts
@@ -1,14 +1,11 @@
-import type { ReferenceConfiguration } from '@scalar/types/legacy'
+import { getHtmlDocument } from '@/lib/static-rendering'
+import type { ApiReferenceOptions } from '@/types'
 import type { Request, Response } from 'express'
-
-export type ApiReferenceOptions = ReferenceConfiguration & {
-  cdn?: string
-}
 
 /**
  * The custom theme CSS for the Express theme.
  */
-export const customThemeCSS = `
+export const customTheme = `
 /* basic theme */
 .light-mode {
   --scalar-color-1: #353535;
@@ -105,55 +102,10 @@ export const customThemeCSS = `
 `
 
 /**
- * The script tags to load the @scalar/api-reference package from the CDN.
- */
-export const getScriptTags = (configuration: ApiReferenceOptions) => {
-  const defaultConfiguration: Partial<ReferenceConfiguration> = {
-    _integration: 'express',
-  }
-
-  return `
-    <script
-      id="api-reference"
-      type="application/json"
-      data-configuration="${JSON.stringify({
-        ...defaultConfiguration,
-        ...configuration,
-      })
-        .split('"')
-        .join('&quot;')}">${
-        configuration.spec?.content
-          ? typeof configuration.spec?.content === 'function'
-            ? JSON.stringify(configuration.spec?.content())
-            : JSON.stringify(configuration.spec?.content)
-          : ''
-      }</script>
-      <script src="${configuration.cdn || 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'}"></script>
-  `
-}
-
-/**
  * The route handler to render the API Reference.
  */
 export function apiReference(options: ApiReferenceOptions) {
-  return (req: Request, res: Response) => {
-    res.type('text/html').send(`
-  <!DOCTYPE html>
-  <html>
-    <head>
-      <title>Scalar API Reference</title>
-      <meta charset="utf-8" />
-      <meta
-        name="viewport"
-        content="width=device-width, initial-scale=1" />
-      <style>
-        ${options.theme ? null : customThemeCSS}
-      </style>
-    </head>
-    <body>
-      ${getScriptTags(options)}
-    </body>
-  </html>
-`)
+  return (_: Request, res: Response) => {
+    res.type('text/html').send(getHtmlDocument(options, customTheme))
   }
 }

--- a/integrations/express/src/lib/static-rendering.ts
+++ b/integrations/express/src/lib/static-rendering.ts
@@ -54,7 +54,11 @@ export function getConfiguration(givenConfiguration: ApiReferenceOptions) {
     ...givenConfiguration,
   }
 
-  delete configuration.spec
+  if (!configuration.spec?.url) {
+    delete configuration.spec
+  } else if (configuration.spec?.content) {
+    delete configuration.spec?.content
+  }
 
   return JSON.stringify(configuration).split('"').join('&quot;')
 }

--- a/integrations/express/src/lib/static-rendering.ts
+++ b/integrations/express/src/lib/static-rendering.ts
@@ -1,0 +1,80 @@
+import type { ApiReferenceOptions } from '@/types'
+import type { ReferenceConfiguration } from '@scalar/types'
+
+const DEFAULT_CONFIGURATION: Partial<ReferenceConfiguration> = {
+  _integration: 'express',
+}
+
+/**
+ * The HTML document to render the Scalar API reference.
+ */
+export function getHtmlDocument(
+  options: ApiReferenceOptions,
+  customTheme?: string,
+) {
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Scalar API Reference</title>
+        <meta charset="utf-8" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1" />
+        <style>
+          ${options.theme ? null : (customTheme ?? '')}
+        </style>
+      </head>
+      <body>
+        ${getScriptTags(options)}
+      </body>
+    </html>
+  `
+}
+
+/**
+ * The script tags to load the @scalar/api-reference package from the CDN.
+ */
+export function getScriptTags(configuration: ApiReferenceOptions) {
+  return `
+      <script
+        id="api-reference"
+        type="application/json"
+        data-configuration="${getConfiguration(configuration)}">${getScriptTagContent(configuration)}</script>
+        <script src="${getCdnUrl(configuration)}"></script>
+    `
+}
+
+/**
+ * The configuration to pass to the @scalar/api-reference package.
+ */
+export function getConfiguration(givenConfiguration: ApiReferenceOptions) {
+  const configuration = {
+    ...DEFAULT_CONFIGURATION,
+    ...givenConfiguration,
+  }
+
+  delete configuration.spec
+
+  return JSON.stringify(configuration).split('"').join('&quot;')
+}
+
+/**
+ * The content to pass to the @scalar/api-reference package as the <script> tag content.
+ */
+export function getScriptTagContent(configuration: ApiReferenceOptions) {
+  return configuration.spec?.content
+    ? typeof configuration.spec?.content === 'function'
+      ? JSON.stringify(configuration.spec?.content())
+      : JSON.stringify(configuration.spec?.content)
+    : ''
+}
+
+/**
+ * The CDN URL to load the @scalar/api-reference package from.
+ */
+export function getCdnUrl(configuration: ApiReferenceOptions) {
+  return (
+    configuration.cdn || 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+  )
+}

--- a/integrations/express/src/types.ts
+++ b/integrations/express/src/types.ts
@@ -1,0 +1,5 @@
+import type { ReferenceConfiguration } from '@scalar/types/legacy'
+
+export type ApiReferenceOptions = ReferenceConfiguration & {
+  cdn?: string
+}

--- a/integrations/express/tsconfig.json
+++ b/integrations/express/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["vitest/globals"]
+    "paths": {
+      "@/*": ["./src/*"],
+      "@test/*": ["./test/*"]
+    }
   },
   "include": ["src/**/*.ts", "rollup.config.ts"]
 }

--- a/integrations/express/vite.config.ts
+++ b/integrations/express/vite.config.ts
@@ -1,0 +1,9 @@
+import { alias } from '@scalar/build-tooling'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [],
+  resolve: {
+    alias: alias(import.meta.url),
+  },
+})


### PR DESCRIPTION
**Problem**

Currently, we’re rendering embedded content twice in the Express integration. First as part of the configuration object and then as the content of the script tag.

This makes the server response roughly twice as big as needed.

**Solution**

With this PR we’re rendering it only once! I’ve used the opportunity to extract a few of the functions into a lib.

As a next step, I’d like to move the lib to a global place and use the same lib in all JS-based integrations. 👀  

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
