### PR TITLE
fix(api-client): sidebar icon state

### DIFF
--- a/.changeset/sweet-news-swim.md
+++ b/.changeset/sweet-news-swim.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates sidebar icon hover state style

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -390,7 +390,7 @@ function handleRename(newName: string) {
             <li
               v-for="collection in activeWorkspaceCollections"
               :key="collection.uid"
-              class="flex flex-col gap-0.25">
+              class="flex flex-col gap-1/2">
               <button
                 class="flex font-medium gap-1.5 group items-center p-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
                 type="button"
@@ -406,7 +406,7 @@ function handleRename(newName: string) {
                       'rotate-90': collapsedSidebarFolders[collection.uid],
                     }">
                     <ScalarIcon
-                      class="text-c-3 hidden text-sm group-hover:block"
+                      class="text-c-3 hidden text-sm group-hover:block hover:text-c-1"
                       icon="ChevronRight"
                       size="md" />
                   </div>
@@ -449,13 +449,12 @@ function handleRename(newName: string) {
                     Object.keys(collection['x-scalar-environments'] || {})
                       .length === 0
                   "
-                  class="mb-[.5px] flex gap-1.5 h-8 text-c-1 pl-6 py-0 justify-start text-xs w-full hover:bg-b-2"
+                  class="flex gap-1.5 h-8 text-c-1 pl-6 py-0 justify-start text-xs w-full hover:bg-b-2"
                   variant="ghost"
                   @click="openEnvironmentModal(collection.uid)">
                   <ScalarIcon
-                    class="ml-0.5 h-2.5 w-2.5"
                     icon="Add"
-                    thickness="3" />
+                    size="sm" />
                   <span>Add Environment</span>
                 </ScalarButton>
               </div>

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -359,7 +359,7 @@ const showGettingStarted = computed(() => {
                   'rotate-90': collapsedSidebarFolders[collection.uid],
                 }">
                 <ScalarIcon
-                  class="text-c-3 hidden text-sm group-hover:block"
+                  class="text-c-3 hidden text-sm group-hover:block hover:text-c-1"
                   icon="ChevronRight"
                   size="md" />
               </div>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -403,7 +403,7 @@ const shouldShowItem = computed(() => {
         <span class="flex h-5 items-center justify-center max-w-[14px]">
           <slot name="leftIcon">
             <ScalarSidebarGroupToggle
-              class="text-c-3 shrink-0"
+              class="text-c-3 shrink-0 hover:text-c-1"
               :open="Boolean(collapsedSidebarFolders[item.entity.uid])" />
           </slot>
           &hairsp;
@@ -503,9 +503,8 @@ const shouldShowItem = computed(() => {
           variant="ghost"
           @click="openCommandPaletteRequest()">
           <ScalarIcon
-            class="mx-0.5 h-2.5 w-2.5"
             icon="Add"
-            thickness="3" />
+            size="sm" />
           <span>Add Request</span>
         </ScalarButton>
       </ul>

--- a/packages/api-client/src/views/Servers/Servers.vue
+++ b/packages/api-client/src/views/Servers/Servers.vue
@@ -101,7 +101,7 @@ const hasServers = computed(() => Object.keys(servers).length > 0)
                       'rotate-90': collapsedSidebarFolders[collection.uid],
                     }">
                     <ScalarIcon
-                      class="text-c-3 hidden text-sm group-hover:block"
+                      class="text-c-3 hidden text-sm group-hover:block hover:text-c-1"
                       icon="ChevronRight"
                       size="md" />
                   </div>
@@ -148,9 +148,8 @@ const hasServers = computed(() => Object.keys(servers).length > 0)
                   variant="ghost"
                   @click="openCommandPaletteServer(collection.uid)">
                   <ScalarIcon
-                    class="ml-0.5 h-2.5 w-2.5"
                     icon="Add"
-                    thickness="3" />
+                    size="sm" />
                   <span>Add Server</span>
                 </ScalarButton>
               </div>


### PR DESCRIPTION
**Problem**
currently sidebar icon state are not being styled properly on hover.

**Solution**
this pr updates sidebar icon state style.

| before | after |
| -------|------|
| <img width="348" alt="image" src="https://github.com/user-attachments/assets/12f83caa-06fd-4bc7-a432-3c0ce3501579" /> | <img width="348" alt="image" src="https://github.com/user-attachments/assets/b16baec2-c2de-467a-8340-bb46ca6ce8ef" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).