### PR TITLE
fix(api-client): enum long value

### DIFF
--- a/.changeset/sixty-berries-sin.md
+++ b/.changeset/sixty-berries-sin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sets overflow on input enum value

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -125,7 +125,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
         resize
         :value="initialValue">
         <ScalarButton
-          class="gap-1.5 font-normal h-full justify-start px-2 py-1.5 outline-none"
+          class="gap-1.5 font-normal h-full justify-start px-2 py-1.5 outline-none overflow-auto whitespace-nowrap"
           fullWidth
           variant="ghost">
           <span class="text-c-1">{{ initialValue || 'Select a value' }}</span>
@@ -154,7 +154,6 @@ const updateSelectedOptions = (selectedOptions: any) => {
             </div>
             {{ option }}
           </ScalarDropdownItem>
-
           <template v-if="canAddCustomValue">
             <ScalarDropdownDivider v-if="options.length" />
             <ScalarDropdownItem


### PR DESCRIPTION
**Problem**
currently enum with long value breaks the layout.

**Solution**
this pr sets overflow on enum value.

| before | after |
| -------|------|
| <img width="348" alt="image" src="https://github.com/user-attachments/assets/73f687e1-b6a2-43a6-bf4b-d6bca1fcb641" /> | <img width="348" alt="image" src="https://github.com/user-attachments/assets/5a8edd22-a62c-4e01-a4cf-babac51c780d" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).