### PR TITLE
chore(Scalar.AspNetCore): update packages and test improvements

### DIFF
--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="APIWeaver.OpenApi" Version="2.7.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="Bogus" Version="35.6.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -33,8 +33,8 @@ internal static class ScalarOptionsMapper
         return new ScalarConfiguration
         {
             ProxyUrl = options.ProxyUrl,
-            Theme = options.Theme.ToStringFast(),
-            Layout = options.Layout.ToStringFast(),
+            Theme = options.Theme.ToStringFast(true),
+            Layout = options.Layout.ToStringFast(true),
             Favicon = options.Favicon,
             DarkMode = options.DarkMode,
             HideModels = options.HideModels,
@@ -42,7 +42,7 @@ internal static class ScalarOptionsMapper
             HideDownloadButton = options.HideDownloadButton,
             HideTestRequestButton = options.HideTestRequestButton,
             DefaultOpenAllTags = options.DefaultOpenAllTags,
-            ForceDarkModeState = options.ForceThemeMode?.ToStringFast(),
+            ForceDarkModeState = options.ForceThemeMode?.ToStringFast(true),
             ShowSidebar = options.ShowSidebar,
             WithDefaultFonts = options.DefaultFonts,
             CustomCss = options.CustomCss,
@@ -50,13 +50,13 @@ internal static class ScalarOptionsMapper
             Servers = options.Servers,
             MetaData = options.Metadata,
             Authentication = options.Authentication,
-            TagSorter = options.TagSorter?.ToStringFast(),
-            OperationsSorter = options.OperationSorter?.ToStringFast(),
+            TagSorter = options.TagSorter?.ToStringFast(true),
+            OperationsSorter = options.OperationSorter?.ToStringFast(true),
             HiddenClients = options.HiddenClients ? options.HiddenClients : GetHiddenClients(options),
             DefaultHttpClient = new DefaultHttpClient
             {
-                ClientKey = options.DefaultHttpClient.Value.ToStringFast(),
-                TargetKey = options.DefaultHttpClient.Key.ToStringFast()
+                ClientKey = options.DefaultHttpClient.Value.ToStringFast(true),
+                TargetKey = options.DefaultHttpClient.Key.ToStringFast(true)
             },
             Integration = options.DotNetFlag ? "dotnet" : null,
             HideClientButton = options.HideClientButton,
@@ -69,8 +69,8 @@ internal static class ScalarOptionsMapper
         var targets = ProcessOptions(options);
 
         return targets?.ToDictionary(k =>
-                k.Key.ToStringFast(),
-            k => k.Value.Select(v => v.ToStringFast())
+                k.Key.ToStringFast(true),
+            k => k.Value.Select(v => v.ToStringFast(true))
         );
     }
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta11" PrivateAssets="all" ExcludeAssets="runtime" NoWarn="NU5104" />
+    <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta12" PrivateAssets="all" ExcludeAssets="runtime" NoWarn="NU5104" />
   </ItemGroup>
 
   <ItemGroup>

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -11,16 +11,16 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" Version="8.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="7.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit.v3" Version="1.0.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -24,15 +24,15 @@ public class ScalarOptionsMapperTests
         configuration.SearchHotKey.Should().BeNull();
         configuration.Servers.Should().BeNull();
         configuration.MetaData.Should().BeNull();
-        configuration.DefaultHttpClient!.TargetKey.Should().Be(ScalarTarget.Shell.ToStringFast());
-        configuration.DefaultHttpClient!.ClientKey.Should().Be(ScalarClient.Curl.ToStringFast());
+        configuration.DefaultHttpClient!.TargetKey.Should().Be("shell");
+        configuration.DefaultHttpClient!.ClientKey.Should().Be("curl");
         configuration.HiddenClients.Should().BeNull();
         configuration.Authentication.Should().BeNull();
         configuration.WithDefaultFonts.Should().BeTrue();
         configuration.DefaultOpenAllTags.Should().BeFalse();
         configuration.TagSorter.Should().BeNull();
         configuration.OperationsSorter.Should().BeNull();
-        configuration.Theme.Should().Be(ScalarTheme.Purple.ToStringFast());
+        configuration.Theme.Should().Be("purple");
         configuration.Integration.Should().Be("dotnet");
         configuration.Documents.Should().BeEmpty();
     }
@@ -86,14 +86,14 @@ public class ScalarOptionsMapperTests
         configuration.HideDownloadButton.Should().BeTrue();
         configuration.HideTestRequestButton.Should().BeTrue();
         configuration.DarkMode.Should().BeFalse();
-        configuration.ForceDarkModeState.Should().Be(ThemeMode.Light.ToStringFast());
+        configuration.ForceDarkModeState.Should().Be("light");
         configuration.HideDarkModeToggle.Should().BeTrue();
         configuration.CustomCss.Should().Be("*{}");
         configuration.SearchHotKey.Should().Be("o");
         configuration.Servers.Should().ContainSingle().Which.Url.Should().Be("https://example.com");
         configuration.MetaData.Should().ContainKey("key").WhoseValue.Should().Be("value");
-        configuration.DefaultHttpClient!.TargetKey.Should().Be(ScalarTarget.CSharp.ToStringFast());
-        configuration.DefaultHttpClient!.ClientKey.Should().Be(ScalarClient.HttpClient.ToStringFast());
+        configuration.DefaultHttpClient!.TargetKey.Should().Be("csharp");
+        configuration.DefaultHttpClient!.ClientKey.Should().Be("httpclient");
         ((bool) configuration.HiddenClients!).Should().BeTrue();
         configuration.Authentication.Should().NotBeNull();
         configuration.Authentication!.PreferredSecurityScheme.Should().Be("my-scheme");
@@ -101,10 +101,10 @@ public class ScalarOptionsMapperTests
         configuration.Authentication.ApiKey!.Token.Should().Be("my-token");
         configuration.WithDefaultFonts.Should().BeFalse();
         configuration.DefaultOpenAllTags.Should().BeTrue();
-        configuration.TagSorter.Should().Be(TagSorter.Alpha.ToStringFast());
-        configuration.OperationsSorter.Should().Be(OperationSorter.Method.ToStringFast());
-        configuration.Theme.Should().Be(ScalarTheme.Saturn.ToStringFast());
-        configuration.Layout.Should().Be(ScalarLayout.Classic.ToStringFast());
+        configuration.TagSorter.Should().Be("alpha");
+        configuration.OperationsSorter.Should().Be("method");
+        configuration.Theme.Should().Be("saturn");
+        configuration.Layout.Should().Be("classic");
         configuration.Integration.Should().BeNull();
         configuration.HideClientButton.Should().BeTrue();
         configuration.Documents.Should().ContainSingle().Which.Should().Be("openapi/v2.json");
@@ -147,7 +147,7 @@ public class ScalarOptionsMapperTests
 
         // Assert
         hiddenClients.Should().HaveCount(ScalarOptionsMapper.ClientOptions.Count - 1);
-        hiddenClients.Should().NotContainKey(ScalarTarget.CSharp.ToStringFast());
+        hiddenClients.Should().NotContainKey("csharp");
     }
 
     [Fact]
@@ -161,10 +161,10 @@ public class ScalarOptionsMapperTests
 
         // Assert
         hiddenClients.Should().HaveCount(ScalarOptionsMapper.ClientOptions.Count);
-        hiddenClients.Should().ContainKey(ScalarTarget.CSharp.ToStringFast())
-            .WhoseValue.Should().ContainSingle().Which.Should().Be(ScalarClient.RestSharp.ToStringFast());
-        hiddenClients.Should().ContainKey(ScalarTarget.Python.ToStringFast())
-            .WhoseValue.Should().ContainSingle().Which.Should().Be(ScalarClient.Requests.ToStringFast());
+        hiddenClients.Should().ContainKey("csharp")
+            .WhoseValue.Should().ContainSingle().Which.Should().Be("restsharp");
+        hiddenClients.Should().ContainKey("python")
+            .WhoseValue.Should().ContainSingle().Which.Should().Be("requests");
     }
 
     [Fact]
@@ -178,6 +178,6 @@ public class ScalarOptionsMapperTests
 
         // Assert
         hiddenClients.Should().HaveCount(ScalarOptionsMapper.ClientOptions.Count - 1);
-        hiddenClients.Should().NotContainKey(ScalarTarget.Kotlin.ToStringFast());
+        hiddenClients.Should().NotContainKey("kotlin");
     }
 }

--- a/integrations/aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj
+++ b/integrations/aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1"/>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates some dependencies to the latest version. The `NetEscapades.EnumGenerators` package has a breaking change which I fixed. I also improved the tests to test the behavior of the `NetEscapades.EnumGenerators` generator.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.