### PR TITLE
fix(api-client): ensure we preserve lowercase authentication headers

### DIFF
--- a/.changeset/angry-rocks-rescue.md
+++ b/.changeset/angry-rocks-rescue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: preserve lowercase auth headers

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -905,5 +905,26 @@ describe('create-request-operation', () => {
         },
       )
     })
+
+    it('accepts a lowercase auth header', () => {
+      const [error, requestOperation] = createRequestOperation({
+        ...createRequestPayload({
+          serverPayload: { url: VOID_URL },
+        }),
+        securitySchemes: {
+          'api-key': {
+            type: 'apiKey',
+            name: 'x-api-key',
+            in: 'header',
+            value: 'test-key',
+            uid: 'api-key',
+            nameKey: 'api-key',
+          },
+        },
+        selectedSecuritySchemeUids: ['api-key'],
+      })
+      if (error) throw error
+      expect(requestOperation.request.headers.get('x-api-key')).toBe('test-key')
+    })
   })
 })

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -114,13 +114,15 @@ export const createRequestOperation = ({
     const security = buildRequestSecurity(selectedSecuritySchemes, env)
 
     // For securityheaders, we lowercase them so they can be uppercased later (in normalizeHeaders)
-    Object.keys(security.headers).forEach((key) => {
-      security.headers[key.toLowerCase()] = security.headers[key] ?? ''
-      delete security.headers[key]
-    })
+    const normalizedSecurityHeaders = Object.entries(security.headers).reduce<
+      Record<string, string>
+    >((acc, [key, value]) => {
+      acc[key.toLowerCase()] = value
+      return acc
+    }, {})
 
     // Populate all forms of auth to the request segments
-    const headers = { ...security.headers, ..._headers }
+    const headers = { ...normalizedSecurityHeaders, ..._headers }
     const cookieParams = [..._cookieParams, ...security.cookies]
     const urlParams = new URLSearchParams([
       ..._urlParams,


### PR DESCRIPTION
**Problem**
If you have a lowercase only auth header it will get deleted

**Solution**
Instead of adding and deleting we just lowercase them.

fixes #4763

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
