### PR TITLE
feat(api-client): remove reliance on `activeEntities` injection and switch to prop drilling

### DIFF
--- a/.changeset/violet-garlics-rhyme.md
+++ b/.changeset/violet-garlics-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+chore: remove active entities for prop drilling

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ScalarButton, ScalarIcon } from '@scalar/components'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type {
   Collection,
   Operation,
   RequestMethod,
   Server,
 } from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { REQUEST_METHODS } from '@scalar/oas-utils/helpers'
 import { ref, useId, watch } from 'vue'
 
@@ -13,15 +15,20 @@ import CodeInput from '@/components/CodeInput/CodeInput.vue'
 import { ServerDropdown } from '@/components/Server'
 import { useLayout } from '@/hooks'
 import { useWorkspace } from '@/store'
+import type { EnvVariable } from '@/store/active-entities'
 
 import HttpMethod from '../HttpMethod/HttpMethod.vue'
 import AddressBarHistory from './AddressBarHistory.vue'
 
-const { collection, operation, server } = defineProps<{
-  collection: Collection
-  operation: Operation
-  server: Server | undefined
-}>()
+const { collection, operation, server, environment, envVariables, workspace } =
+  defineProps<{
+    collection: Collection
+    operation: Operation
+    server: Server | undefined
+    environment: Environment
+    envVariables: EnvVariable[]
+    workspace: Workspace
+  }>()
 
 defineEmits<{
   (e: 'importCurl', value: string): void
@@ -173,6 +180,8 @@ function updateRequestPath(url: string) {
             disableEnter
             disableTabIndent
             :emitOnBlur="false"
+            :envVariables="envVariables"
+            :environment="environment"
             importCurl
             :modelValue="operation.path"
             :placeholder="
@@ -181,6 +190,7 @@ function updateRequestPath(url: string) {
                 : 'Enter a URL or cURL command'
             "
             server
+            :workspace="workspace"
             @curl="$emit('importCurl', $event)"
             @submit="handleExecuteRequest"
             @update:modelValue="updateRequestPath" />

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -2,7 +2,6 @@
 import { formatMs } from '@/libs/formatters'
 import { PathId } from '@/routes'
 import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import {
   Listbox,
   ListboxButton,
@@ -14,7 +13,7 @@ import {
   ScalarFloatingBackdrop,
   ScalarIcon,
 } from '@scalar/components'
-import type { RequestEvent } from '@scalar/oas-utils/entities/spec'
+import type { Operation, RequestEvent } from '@scalar/oas-utils/entities/spec'
 import { httpStatusCodes } from '@scalar/oas-utils/helpers'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
@@ -22,12 +21,12 @@ import { useRouter } from 'vue-router'
 import HttpMethod from '../HttpMethod/HttpMethod.vue'
 import { getStatusCodeColor } from './httpStatusCodeColors'
 
-defineProps<{
+const { operation, target } = defineProps<{
+  operation: Operation
   /** The id of the target to use for the popover (e.g. address bar) */
   target: string
 }>()
 
-const { activeRequest } = useActiveEntities()
 const { requestHistory, requestExampleMutators } = useWorkspace()
 
 const router = useRouter()
@@ -37,7 +36,7 @@ const selectedRequest = ref(requestHistory[0] ?? null)
 /** Use a local copy to prevent mutation of the reactive object */
 const history = computed(() =>
   requestHistory
-    .filter((entry) => entry.request.requestUid === activeRequest.value?.uid)
+    .filter((entry) => entry.request.requestUid === operation.uid)
     .slice()
     .reverse(),
 )
@@ -63,7 +62,7 @@ function handleHistoryClick(historicalRequest: RequestEvent) {
   // see if we need to update the topnav
   // todo potentially search and find a previous open request id of this maybe
   // or we can open it in a draft state if the request is already open :)
-  if (activeRequest.value?.uid !== historicalRequest.request.requestUid) {
+  if (operation.uid !== historicalRequest.request.requestUid) {
     // TODO: This is not working. We don't want to just redirect to the same request, but restore the state.
 
     router.push({

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components'
+import type { Workspace } from '@scalar/oas-utils/entities'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import { prettyPrintJson } from '@scalar/oas-utils/helpers'
 import {
   colorPicker as colorPickerExtension,
@@ -13,7 +15,7 @@ import { nanoid } from 'nanoid'
 import { computed, ref, toRef, useAttrs, watch, type Ref } from 'vue'
 
 import { useLayout } from '@/hooks'
-import { useActiveEntities } from '@/store/active-entities'
+import type { EnvVariable } from '@/store/active-entities'
 import EnvironmentVariableDropdown from '@/views/Environment/EnvironmentVariableDropdown.vue'
 
 import DataTableInputSelect from '../DataTable/DataTableInputSelect.vue'
@@ -44,6 +46,9 @@ const props = withDefaults(
     importCurl?: boolean
     isCopyable?: boolean
     default?: string | number
+    environment: Environment
+    envVariables: EnvVariable[]
+    workspace: Workspace
   }>(),
   {
     disableCloseBrackets: false,
@@ -76,8 +81,6 @@ const dropdownRef = ref<InstanceType<
   typeof EnvironmentVariableDropdown
 > | null>(null)
 
-const { activeEnvVariables, activeEnvironment, activeWorkspace } =
-  useActiveEntities()
 const { layout } = useLayout()
 const { copyToClipboard } = useClipboard()
 
@@ -129,9 +132,9 @@ const extensions: Extension[] = []
 if (props.colorPicker) extensions.push(colorPickerExtension)
 extensions.push(
   pillPlugin({
-    environment: activeEnvironment.value,
-    envVariables: activeEnvVariables.value,
-    workspace: activeWorkspace.value,
+    environment: props.environment,
+    envVariables: props.envVariables,
+    workspace: props.workspace,
     isReadOnly: layout === 'modal',
   }),
   backspaceCommand,
@@ -295,13 +298,11 @@ export default {
     Required
   </div>
   <EnvironmentVariableDropdown
-    v-if="
-      showDropdown && withVariables && layout !== 'modal' && activeEnvironment
-    "
+    v-if="showDropdown && withVariables && layout !== 'modal' && environment"
     ref="dropdownRef"
     :dropdownPosition="dropdownPosition"
-    :envVariables="activeEnvVariables"
-    :environment="activeEnvironment"
+    :envVariables="envVariables"
+    :environment="environment"
     :query="dropdownQuery"
     @select="handleDropdownSelect" />
 </template>

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
+import type { EnvVariable } from '@/store/active-entities'
 import type { VueClassProp } from '@/types/vue'
 import { ScalarIconButton } from '@scalar/components'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { computed, ref } from 'vue'
 
 import DataTableCell from './DataTableCell.vue'
@@ -21,6 +24,9 @@ const props = withDefaults(
     enum?: string[]
     min?: number
     max?: number
+    environment: Environment
+    envVariables: EnvVariable[]
+    workspace: Workspace
   }>(),
   { canAddCustomEnumValue: true, required: false, readOnly: false },
 )
@@ -92,6 +98,8 @@ const inputType = computed(() =>
           class="border-none text-c-1 disabled:text-c-2 min-w-0 w-full peer"
           disableCloseBrackets
           disableTabIndent
+          :envVariables="envVariables"
+          :environment="environment"
           :max="max"
           :min="min"
           :modelValue="modelValue ?? ''"
@@ -99,6 +107,7 @@ const inputType = computed(() =>
           :required="Boolean(required)"
           spellcheck="false"
           :type="inputType"
+          :workspace="workspace"
           @blur="handleBlur"
           @focus="emit('inputFocus')"
           @update:modelValue="emit('update:modelValue', $event)" />

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -6,6 +6,7 @@ import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableInput from '@/components/DataTable/DataTableInput.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import { useActiveEntities } from '@/store/active-entities'
 
 defineProps<{
   title?: string
@@ -20,6 +21,9 @@ defineProps<{
     value: NonNullable<PathValue<Cookie, P>>,
   ) => void
 }>()
+
+const { activeEnvVariables, activeEnvironment, activeWorkspace } =
+  useActiveEntities()
 </script>
 <template>
   <ViewLayoutSection>
@@ -31,15 +35,18 @@ defineProps<{
     </template>
     <div class="custom-scroll flex flex-1 flex-col gap-1.5">
       <DataTable
-        v-if="Object.keys(data).length > 0"
+        v-if="Object.keys(data).length > 0 && activeWorkspace"
         :columns="['']">
         <DataTableRow
           v-for="(option, index) in options"
           :key="index"
           :class="{ 'border-t': index === 0 }">
           <DataTableInput
+            :envVariables="activeEnvVariables"
+            :environment="activeEnvironment"
             :modelValue="data[option.key] ?? ''"
             :placeholder="option.placeholder"
+            :workspace="activeWorkspace"
             @update:modelValue="onUpdate(option.key as Path<Cookie>, $event)">
             {{ option.label }}
           </DataTableInput>

--- a/packages/api-client/src/components/ImportCollection/ImportNowButton.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportNowButton.vue
@@ -27,7 +27,7 @@ async function importCollection() {
   try {
     if (props.source) {
       if (isUrl(props.source)) {
-        const [error, collection] = await importSpecFromUrl(
+        const [error, entities] = await importSpecFromUrl(
           props.source,
           activeWorkspace.value?.uid ?? '',
           {
@@ -35,13 +35,13 @@ async function importCollection() {
             watchMode: props.watchMode,
           },
         )
-        if (!error) redirectToFirstRequestInCollection(collection)
+        if (!error) redirectToFirstRequestInCollection(entities?.collection)
       } else {
-        const collection = await importSpecFile(
+        const entities = await importSpecFile(
           props.source,
           activeWorkspace.value?.uid ?? '',
         )
-        redirectToFirstRequestInCollection(collection)
+        redirectToFirstRequestInCollection(entities?.collection)
       }
 
       toast('Import successful', 'info')

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -20,7 +20,7 @@ type CreateActiveEntitiesStoreParams = {
   router?: Router
 }
 
-type EnvVariable = {
+export type EnvVariable = {
   key: string
   value: any
   source: 'global' | 'collection'

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -62,7 +62,7 @@ export function importSpecFileFactory({
       workspaceEntities.collection.uid,
     ])
 
-    return workspaceEntities.collection
+    return workspaceEntities
   }
 
   /**

--- a/packages/api-client/src/views/Collection/Collection.vue
+++ b/packages/api-client/src/views/Collection/Collection.vue
@@ -9,6 +9,7 @@ import Sidebar from '@/components/Sidebar/Sidebar.vue'
 import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
 import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import { useActiveEntities } from '@/store/active-entities'
 import { reactive } from 'vue'
 
 const data = reactive<{ key: string; value: string; enabled: boolean }[]>([
@@ -16,12 +17,15 @@ const data = reactive<{ key: string; value: string; enabled: boolean }[]>([
   { key: 'key 2', value: 'value 2', enabled: false },
   { key: '', value: '', enabled: false },
 ])
+
+const { activeEnvironment, activeEnvVariables, activeWorkspace } =
+  useActiveEntities()
 </script>
 <template>
   <ViewLayout>
     <Sidebar title="Collection" />
     <ViewLayoutContent class="flex-1">
-      <ViewLayoutSection>
+      <ViewLayoutSection v-if="activeWorkspace">
         <template #title>Section 1</template>
         <div class="flex flex-col p-2">
           <DataTable :columns="['', '', 'auto']">
@@ -40,10 +44,16 @@ const data = reactive<{ key: string; value: string; enabled: boolean }[]>([
               <DataTableCheckbox v-model="item.enabled" />
               <DataTableInput
                 v-model="item.key"
-                placeholder="Key" />
+                :envVariables="activeEnvVariables"
+                :environment="activeEnvironment"
+                placeholder="Key"
+                :workspace="activeWorkspace" />
               <DataTableInput
                 v-model="item.value"
-                placeholder="Value" />
+                :envVariables="activeEnvVariables"
+                :environment="activeEnvironment"
+                placeholder="Value"
+                :workspace="activeWorkspace" />
             </DataTableRow>
             <DataTableRow>
               <DataTableCell>Static Text</DataTableCell>

--- a/packages/api-client/src/views/Cookies/CookieRaw.vue
+++ b/packages/api-client/src/views/Cookies/CookieRaw.vue
@@ -4,7 +4,12 @@ import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 
-const { activeCookieId } = useActiveEntities()
+const {
+  activeCookieId,
+  activeEnvVariables,
+  activeEnvironment,
+  activeWorkspace,
+} = useActiveEntities()
 const { cookies } = useWorkspace()
 </script>
 <template>
@@ -12,11 +17,15 @@ const { cookies } = useWorkspace()
     <template #title>
       <span>Raw Cookie String</span>
     </template>
-    <template v-if="activeCookieId && cookies[activeCookieId]">
+    <template
+      v-if="activeCookieId && cookies[activeCookieId] && activeWorkspace">
       <CodeInput
         class="pl-px pr-2 md:px-2 py-2.5"
+        :envVariables="activeEnvVariables"
+        :environment="activeEnvironment"
         lineNumbers
-        modelValue="" />
+        modelValue=""
+        :workspace="activeWorkspace" />
     </template>
   </ViewLayoutSection>
 </template>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -31,8 +31,12 @@ import EnvironmentModal from './EnvironmentModal.vue'
 
 const router = useRouter()
 const route = useRoute()
-const { activeWorkspace, activeEnvironment, activeWorkspaceCollections } =
-  useActiveEntities()
+const {
+  activeWorkspace,
+  activeEnvironment,
+  activeWorkspaceCollections,
+  activeEnvVariables,
+} = useActiveEntities()
 const { events, workspaceMutators, collectionMutators } = useWorkspace()
 const { collapsedSidebarFolders, toggleSidebarFolder } = useSidebar()
 const colorModal = useModal()
@@ -482,13 +486,16 @@ function handleRename(newName: string) {
           </span>
         </template>
         <CodeInput
-          v-if="currentEnvironmentId"
+          v-if="currentEnvironmentId && activeWorkspace"
           class="border-t py-2 pl-px pr-2 md:px-4"
+          :envVariables="activeEnvVariables"
+          :environment="activeEnvironment"
           isCopyable
           language="json"
           lineNumbers
           lint
           :modelValue="getEnvironmentValue()"
+          :workspace="activeWorkspace"
           @update:modelValue="handleEnvironmentUpdate" />
       </ViewLayoutSection>
     </ViewLayoutContent>

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -36,6 +36,7 @@ const {
   activeRequest,
   activeWorkspace,
   activeServer,
+  activeEnvVariables,
   activeWorkspaceCollections,
   activeWorkspaceRequests,
 } = useActiveEntities()
@@ -239,8 +240,11 @@ function handleCurlImport(curl: string) {
         <RequestSubpageHeader
           v-model="isSidebarOpen"
           :collection="activeCollection"
+          :envVariables="activeEnvVariables"
+          :environment="activeEnvironment"
           :operation="activeRequest"
           :server="activeServer"
+          :workspace="activeWorkspace"
           @hideModal="() => modalState.hide()"
           @importCurl="handleCurlImport" />
         <ViewLayout>
@@ -251,6 +255,8 @@ function handleCurlImport(curl: string) {
             :class="[isSidebarOpen ? 'sidebar-active-hide-layout' : '']">
             <RequestSection
               :collection="activeCollection"
+              :envVariables="activeEnvVariables"
+              :environment="activeEnvironment"
               :example="activeExample"
               :operation="activeRequest"
               :selectedSecuritySchemeUids="selectedSecuritySchemeUids"

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -37,6 +37,7 @@ const {
   activeWorkspace,
   activeServer,
   activeWorkspaceCollections,
+  activeWorkspaceRequests,
 } = useActiveEntities()
 const {
   cookies,
@@ -223,6 +224,7 @@ function handleCurlImport(curl: string) {
 </script>
 <template>
   <div
+    v-if="activeCollection && activeRequest && activeWorkspace"
     class="flex flex-1 flex-col pt-0 h-full bg-b-1 relative z-0 overflow-hidden"
     :class="{
       '!mr-0 !mb-0 !border-0': layout === 'modal',
@@ -236,6 +238,9 @@ function handleCurlImport(curl: string) {
       <div class="flex flex-1 flex-col h-full">
         <RequestSubpageHeader
           v-model="isSidebarOpen"
+          :collection="activeCollection"
+          :operation="activeRequest"
+          :server="activeServer"
           @hideModal="() => modalState.hide()"
           @importCurl="handleCurlImport" />
         <ViewLayout>
@@ -245,8 +250,15 @@ function handleCurlImport(curl: string) {
             class="flex-1"
             :class="[isSidebarOpen ? 'sidebar-active-hide-layout' : '']">
             <RequestSection
-              :selectedSecuritySchemeUids="selectedSecuritySchemeUids" />
-            <ResponseSection :response="activeHistoryEntry?.response" />
+              :collection="activeCollection"
+              :example="activeExample"
+              :operation="activeRequest"
+              :selectedSecuritySchemeUids="selectedSecuritySchemeUids"
+              :server="activeServer"
+              :workspace="activeWorkspace" />
+            <ResponseSection
+              :numWorkspaceRequests="activeWorkspaceRequests.length"
+              :response="activeHistoryEntry?.response" />
           </ViewLayoutContent>
         </ViewLayout>
       </div>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { DataTableRow } from '@/components/DataTable'
+import type { EnvVariable } from '@/store/active-entities'
 import { type UpdateScheme, useWorkspace } from '@/store/store'
 import { authorizeOauth2 } from '@/views/Request/libs'
 import { ScalarButton, useLoadingState } from '@scalar/components'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import {
   type Collection,
   type Oauth2Flow,
@@ -16,10 +18,20 @@ import { useToasts } from '@scalar/use-toasts'
 import OAuthScopesInput from './OAuthScopesInput.vue'
 import RequestAuthDataTableInput from './RequestAuthDataTableInput.vue'
 
-const { scheme, flow, collection, server, workspace } = defineProps<{
-  scheme: SecuritySchemeOauth2
-  flow: Oauth2Flow
+const {
+  collection,
+  environment,
+  envVariables,
+  flow,
+  scheme,
+  server,
+  workspace,
+} = defineProps<{
   collection: Collection
+  environment: Environment
+  envVariables: EnvVariable[]
+  flow: Oauth2Flow
+  scheme: SecuritySchemeOauth2
   server: Server | undefined
   workspace: Workspace
 }>()
@@ -54,6 +66,13 @@ const handleAuthorize = async () => {
     toast(error?.message ?? 'Failed to authorize', 'error')
   }
 }
+
+/** To make prop drilling a little easier */
+const dataTableInputProps = {
+  environment,
+  envVariables,
+  workspace,
+}
 </script>
 
 <template>
@@ -61,6 +80,7 @@ const handleAuthorize = async () => {
   <template v-if="flow.token">
     <DataTableRow>
       <RequestAuthDataTableInput
+        v-bind="dataTableInputProps"
         class="border-r-transparent"
         :modelValue="flow.token"
         placeholder="QUxMIFlPVVIgQkFTRSBBUkUgQkVMT05HIFRPIFVT"
@@ -88,6 +108,7 @@ const handleAuthorize = async () => {
       <!-- Auth URL -->
       <RequestAuthDataTableInput
         v-if="'authorizationUrl' in flow"
+        v-bind="dataTableInputProps"
         :modelValue="flow.authorizationUrl"
         placeholder="https://galaxy.scalar.com/authorize"
         @update:modelValue="
@@ -99,6 +120,7 @@ const handleAuthorize = async () => {
       <!-- Token URL -->
       <RequestAuthDataTableInput
         v-if="'tokenUrl' in flow"
+        v-bind="dataTableInputProps"
         :modelValue="flow.tokenUrl"
         placeholder="https://galaxy.scalar.com/token"
         @update:modelValue="
@@ -111,6 +133,7 @@ const handleAuthorize = async () => {
     <DataTableRow v-if="'x-scalar-redirect-uri' in flow">
       <!-- Redirect URI -->
       <RequestAuthDataTableInput
+        v-bind="dataTableInputProps"
         :modelValue="flow['x-scalar-redirect-uri']"
         placeholder="https://galaxy.scalar.com/callback"
         @update:modelValue="
@@ -124,6 +147,7 @@ const handleAuthorize = async () => {
     <template v-if="flow.type === 'password'">
       <DataTableRow>
         <RequestAuthDataTableInput
+          v-bind="dataTableInputProps"
           class="text-c-2"
           :modelValue="flow.username"
           placeholder="janedoe"
@@ -135,6 +159,7 @@ const handleAuthorize = async () => {
       </DataTableRow>
       <DataTableRow>
         <RequestAuthDataTableInput
+          v-bind="dataTableInputProps"
           :modelValue="flow.password"
           placeholder="********"
           type="password"
@@ -149,6 +174,7 @@ const handleAuthorize = async () => {
     <!-- Client ID -->
     <DataTableRow>
       <RequestAuthDataTableInput
+        v-bind="dataTableInputProps"
         :modelValue="flow['x-scalar-client-id']"
         placeholder="12345"
         @update:modelValue="
@@ -161,6 +187,7 @@ const handleAuthorize = async () => {
     <!-- Client Secret (Authorization Code / Client Credentials / Password (optional)) -->
     <DataTableRow v-if="'clientSecret' in flow">
       <RequestAuthDataTableInput
+        v-bind="dataTableInputProps"
         :modelValue="flow.clientSecret"
         placeholder="XYZ123"
         type="password"
@@ -174,6 +201,7 @@ const handleAuthorize = async () => {
     <!-- PKCE -->
     <DataTableRow v-if="'x-usePkce' in flow">
       <RequestAuthDataTableInput
+        v-bind="dataTableInputProps"
         :enum="pkceOptions"
         :modelValue="flow['x-usePkce']"
         readOnly

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.test.ts
@@ -1,3 +1,5 @@
+import type { EnvVariable } from '@/store/active-entities'
+import { environmentSchema } from '@scalar/oas-utils/entities/environment'
 import { type Collection, collectionSchema, requestSchema, serverSchema } from '@scalar/oas-utils/entities/spec'
 import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { mount } from '@vue/test-utils'
@@ -70,6 +72,10 @@ describe('RequestAuth.vue', () => {
       server: serverSchema.parse({
         url: 'https://api.example.com',
       }),
+      environment: environmentSchema.parse({
+        uid: 'test-environment',
+      }),
+      envVariables: [] as EnvVariable[],
       title: 'Authentication',
       layout: 'client',
       workspace: workspaceSchema.parse({

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -7,6 +7,7 @@ import {
   type Icon,
   type ScalarButton as ScalarButtonType,
 } from '@scalar/components'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
 import type {
   Collection,
@@ -20,6 +21,7 @@ import { computed, ref } from 'vue'
 
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useLayout } from '@/hooks/useLayout'
+import type { EnvVariable } from '@/store/active-entities'
 import { useWorkspace } from '@/store/store'
 import type { SecuritySchemeOption } from '@/views/Request/consts'
 import {
@@ -34,6 +36,8 @@ import RequestAuthDataTable from './RequestAuthDataTable.vue'
 
 const {
   collection,
+  environment,
+  envVariables,
   layout,
   operation,
   selectedSecuritySchemeUids,
@@ -42,6 +46,8 @@ const {
   workspace,
 } = defineProps<{
   collection: Collection
+  environment: Environment
+  envVariables: EnvVariable[]
   layout: 'client' | 'reference'
   operation?: Operation | undefined
   selectedSecuritySchemeUids: SelectedSecuritySchemeUids
@@ -228,6 +234,8 @@ const schemeOptions = computed(() =>
     </template>
     <RequestAuthDataTable
       :collection="collection"
+      :envVariables="envVariables"
+      :environment="environment"
       :layout="layout"
       :selectedSchemeOptions="selectedSchemeOptions"
       :server="server"

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useModal } from '@scalar/components'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type {
   Collection,
   SecurityScheme,
@@ -9,18 +10,23 @@ import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { computed, ref, watch } from 'vue'
 
 import { DataTable } from '@/components/DataTable'
+import type { EnvVariable } from '@/store/active-entities'
 
 import DeleteRequestAuthModal from './DeleteRequestAuthModal.vue'
 import RequestAuthTab from './RequestAuthTab.vue'
 
 const {
   collection,
+  environment,
+  envVariables,
   layout = 'client',
   selectedSchemeOptions = [],
   server,
   workspace,
 } = defineProps<{
   collection: Collection
+  environment: Environment
+  envVariables: EnvVariable[]
   layout: 'client' | 'reference'
   selectedSchemeOptions: { id: string; label: string }[]
   server: Server | undefined
@@ -85,6 +91,8 @@ watch(
       :columns="['']">
       <RequestAuthTab
         :collection="collection"
+        :envVariables="envVariables"
+        :environment="environment"
         :layout="layout"
         :securitySchemeUids="activeScheme"
         :server="server"

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTableInput.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTableInput.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import DataTableInput from '@/components/DataTable/DataTableInput.vue'
+import type { EnvVariable } from '@/store/active-entities'
 import type { VueClassProp } from '@/types/vue'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { useId } from 'vue'
 
 const props = withDefaults(
@@ -10,6 +13,9 @@ const props = withDefaults(
     required?: boolean
     modelValue: string | number
     readOnly?: boolean
+    environment: Environment
+    envVariables: EnvVariable[]
+    workspace: Workspace
   }>(),
   { required: false, readOnly: false },
 )
@@ -28,11 +34,14 @@ const id = useId()
     :id="id"
     :canAddCustomEnumValue="!props.readOnly"
     :containerClass="props.containerClass"
+    v-bind="$attrs"
+    :envVariables="props.envVariables"
+    :environment="props.environment"
     :modelValue="props.modelValue"
     :readOnly="props.readOnly"
     :required="props.required"
     :type="props.type"
-    v-bind="$attrs"
+    :workspace="props.workspace"
     @inputBlur="emit('inputBlur')"
     @inputFocus="emit('inputFocus')"
     @selectVariable="emit('selectVariable', $event)"

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
@@ -1,10 +1,12 @@
 import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
-import { requestExampleSchema } from '@scalar/oas-utils/entities/spec'
+import { operationSchema, requestExampleSchema } from '@scalar/oas-utils/entities/spec'
+import { createStoreEvents } from '@/store/events'
 import { mount } from '@vue/test-utils'
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import RequestBody from './RequestBody.vue'
+import { environmentSchema } from '@scalar/oas-utils/entities/environment'
+import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 
 // Mock the useWorkspace hook
 vi.mock('@/store', () => ({
@@ -16,34 +18,42 @@ vi.mock('@/store/active-entities', () => ({
 }))
 
 describe('RequestBody.vue', () => {
-  const props = { props: { title: 'Body' } }
-  const mockActiveRequest = { value: { uid: 'mockRequestUid' } }
-  const mockActiveExample = {
-    value: requestExampleSchema.parse({
-      uid: 'mockExampleUid',
-      body: {
-        activeBody: 'raw',
-      },
-    }),
-  }
-
-  const mockActiveEnvironment = { value: { uid: 'mockEnvironmentUid' } }
-  const mockActiveEnvVariables = { value: [] }
-  const mockActiveWorkspace = { value: {} }
+  const mockOperation = operationSchema.parse({ uid: 'mockRequestUid' })
+  const mockActiveExample = requestExampleSchema.parse({
+    uid: 'mockExampleUid',
+    body: {
+      activeBody: 'raw',
+    },
+  })
+  const mockActiveEnvironment = environmentSchema.parse({
+    uid: 'mockEnvironmentUid',
+  })
+  const mockActiveWorkspace = workspaceSchema.parse({
+    uid: 'mockWorkspaceUid',
+  })
   const mockRequestExampleMutators = {
     edit: vi.fn(),
+  }
+  const props = {
+    props: {
+      title: 'Body',
+      example: mockActiveExample,
+      operation: mockOperation,
+      environment: mockActiveEnvironment,
+      envVariables: [],
+      workspace: mockActiveWorkspace,
+    },
+    global: {
+      stubs: {
+        RouterLink: true,
+      },
+    },
   }
 
   // Mock our request + example
   beforeEach(() => {
-    ;(useActiveEntities as Mock).mockReturnValue({
-      activeRequest: mockActiveRequest,
-      activeExample: mockActiveExample,
-      activeEnvironment: mockActiveEnvironment,
-      activeEnvVariables: mockActiveEnvVariables,
-      activeWorkspace: mockActiveWorkspace,
-    })
     ;(useWorkspace as Mock).mockReturnValue({
+      events: createStoreEvents(),
       requestExampleMutators: mockRequestExampleMutators,
     })
   })
@@ -59,7 +69,7 @@ describe('RequestBody.vue', () => {
   })
 
   it('renders with multipart form', async () => {
-    mockActiveExample.value.body = {
+    mockActiveExample.body = {
       activeBody: 'formData',
       formData: {
         encoding: 'form-data',
@@ -73,8 +83,7 @@ describe('RequestBody.vue', () => {
   })
 
   it('renders with url encoded form', async () => {
-    // @ts-expect-error TODO: figure out how vue utils handles unwrapping refs
-    mockActiveExample.body = mockActiveExample.value.body = {
+    mockActiveExample.body = mockActiveExample.body = {
       activeBody: 'formData',
       formData: {
         encoding: 'urlencoded',
@@ -88,7 +97,7 @@ describe('RequestBody.vue', () => {
   })
 
   it('renders with binary file', async () => {
-    mockActiveExample.value.body = {
+    mockActiveExample.body = {
       activeBody: 'binary',
     }
     const wrapper = mount(RequestBody, props)
@@ -98,7 +107,7 @@ describe('RequestBody.vue', () => {
   })
 
   it('renders with json', async () => {
-    mockActiveExample.value.body = {
+    mockActiveExample.body = {
       activeBody: 'raw',
       raw: {
         encoding: 'json',
@@ -112,7 +121,7 @@ describe('RequestBody.vue', () => {
   })
 
   it('renders with xml', async () => {
-    mockActiveExample.value.body = {
+    mockActiveExample.body = {
       activeBody: 'raw',
       raw: {
         encoding: 'xml',
@@ -126,7 +135,7 @@ describe('RequestBody.vue', () => {
   })
 
   it('renders with yaml', async () => {
-    mockActiveExample.value.body = {
+    mockActiveExample.body = {
       activeBody: 'raw',
       raw: {
         encoding: 'yaml',
@@ -140,7 +149,7 @@ describe('RequestBody.vue', () => {
   })
 
   it('renders with edn', async () => {
-    mockActiveExample.value.body = {
+    mockActiveExample.body = {
       activeBody: 'raw',
       raw: {
         encoding: 'edn',
@@ -154,7 +163,7 @@ describe('RequestBody.vue', () => {
   })
 
   it('renders with other', async () => {
-    mockActiveExample.value.body = {
+    mockActiveExample.body = {
       activeBody: 'raw',
       raw: {
         encoding: 'html',

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -6,7 +6,10 @@ import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useFileDialog } from '@/hooks'
 import { useWorkspace } from '@/store'
+import type { EnvVariable } from '@/store/active-entities'
 import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import type { Workspace } from '@scalar/oas-utils/entities'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import {
   type Operation,
   type RequestExample,
@@ -19,11 +22,15 @@ import { computed, nextTick, ref, watch } from 'vue'
 
 import RequestTable from './RequestTable.vue'
 
-const { example, operation, title } = defineProps<{
-  example: RequestExample
-  operation: Operation
-  title: string
-}>()
+const { example, operation, environment, envVariables, workspace, title } =
+  defineProps<{
+    example: RequestExample
+    operation: Operation
+    environment: Environment
+    envVariables: EnvVariable[]
+    workspace: Workspace
+    title: string
+  }>()
 
 const { requestExampleMutators } = useWorkspace()
 
@@ -526,8 +533,11 @@ const selectedExample = computed({
             ref="tableWrapperRef"
             class="!m-0 rounded-t-none shadow-none border-l-0 border-r-0 border-t-0 border-b-0"
             :columns="['32px', '', '', '61px']"
+            :envVariables="envVariables"
+            :environment="environment"
             :items="formParams"
             showUploadButton
+            :workspace="workspace"
             @deleteRow="deleteRow"
             @removeFile="handleRemoveFileFormData"
             @toggleRow="toggleRow"
@@ -539,8 +549,11 @@ const selectedExample = computed({
             ref="tableWrapperRef"
             class="!m-0 rounded-t-none shadow-none border-l-0 border-r-0 border-t-0 border-b-0"
             :columns="['32px', '', '', '61px']"
+            :envVariables="envVariables"
+            :environment="environment"
             :items="formParams"
             showUploadButton
+            :workspace="workspace"
             @deleteRow="deleteRow"
             @removeFile="handleRemoveFileFormData"
             @toggleRow="toggleRow"
@@ -552,10 +565,13 @@ const selectedExample = computed({
           <CodeInput
             class="border-t-1/2 px-1"
             content=""
+            :envVariables="envVariables"
+            :environment="environment"
             :language="codeInputLanguage as CodeMirrorLanguage"
             lineNumbers
             lint
             :modelValue="example.body?.raw?.value ?? ''"
+            :workspace="workspace"
             @update:modelValue="updateRequestBody" />
         </template>
       </DataTableRow>

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -114,7 +114,7 @@ const selectClient = ({ id }: ScalarComboboxOption) => {
 <template>
   <div class="w-full">
     <ViewLayoutCollapse
-      class="group/preview -mt-0.25 w-full"
+      class="group/preview -mt-0.25 w-full border-b-0"
       :defaultOpen="false"
       :hasIcon="false">
       <template #title>Code Snippet</template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -3,7 +3,6 @@ import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import { CodeSnippet } from '@/views/Components/CodeSnippet'
 import {
   ScalarButton,
@@ -11,19 +10,26 @@ import {
   type ScalarComboboxOption,
   ScalarIcon,
 } from '@scalar/components'
+import type { Workspace } from '@scalar/oas-utils/entities'
+import type {
+  Collection,
+  Operation,
+  RequestExample,
+  Server,
+} from '@scalar/oas-utils/entities/spec'
 import { type ClientId, type TargetId, snippetz } from '@scalar/snippetz'
 import { computed } from 'vue'
 
 import { filterSecurityRequirements } from './helpers/filter-security-requirements'
 
-// Get the entities from the store
-const {
-  activeRequest,
-  activeExample,
-  activeServer,
-  activeCollection,
-  activeWorkspace,
-} = useActiveEntities()
+const { collection, example, operation, server, workspace } = defineProps<{
+  collection: Collection
+  example: RequestExample
+  operation: Operation
+  server: Server | undefined
+  workspace: Workspace
+}>()
+
 const { securitySchemes, workspaceMutators } = useWorkspace()
 
 /**
@@ -31,8 +37,8 @@ const { securitySchemes, workspaceMutators } = useWorkspace()
  */
 const selectedSecuritySchemes = computed(() =>
   filterSecurityRequirements(
-    activeRequest.value?.security || activeCollection.value?.security || [],
-    activeCollection.value?.selectedSecuritySchemeUids,
+    operation.security || collection.security || [],
+    collection.selectedSecuritySchemeUids,
     securitySchemes,
   ),
 )
@@ -64,7 +70,7 @@ const snippets = computed(() => {
 
 /** The currently selected plugin */
 const selectedPlugin = computed(() => {
-  const selectedClient = activeWorkspace.value?.selectedHttpClient
+  const selectedClient = workspace.selectedHttpClient
 
   // Backups on backups
   if (!selectedClient)
@@ -84,23 +90,21 @@ const selectedPlugin = computed(() => {
 
 /** The currently selected target, unsafely typecast until we can extract validation fron snippetz */
 const selectedTarget = computed(
-  () =>
-    (activeWorkspace.value?.selectedHttpClient?.targetKey ?? 'js') as TargetId,
+  () => (workspace.selectedHttpClient?.targetKey ?? 'js') as TargetId,
 )
 
 /** The currently selected client, unsafely typecast until we can extract validation fron snippetz */
 const selectedClient = computed(
   () =>
-    (activeWorkspace.value?.selectedHttpClient?.clientKey ??
-      'fetch') as ClientId<TargetId>,
+    (workspace.selectedHttpClient?.clientKey ?? 'fetch') as ClientId<TargetId>,
 )
 
 /** Update the store with the newly selected client */
 const selectClient = ({ id }: ScalarComboboxOption) => {
   const [target, client] = id.split(',')
-  if (!activeWorkspace.value || !target || !client) return
+  if (!target || !client) return
 
-  workspaceMutators.edit(activeWorkspace.value.uid, 'selectedHttpClient', {
+  workspaceMutators.edit(workspace.uid, 'selectedHttpClient', {
     targetKey: target,
     clientKey: client,
   })
@@ -140,10 +144,10 @@ const selectClient = ({ id }: ScalarComboboxOption) => {
             <CodeSnippet
               class="px-3 py-1.5"
               :client="selectedClient"
-              :example="activeExample"
-              :operation="activeRequest"
+              :example="example"
+              :operation="operation"
               :securitySchemes="selectedSecuritySchemes"
-              :server="activeServer"
+              :server="server"
               :target="selectedTarget" />
           </div>
         </DataTableRow>

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -1,25 +1,34 @@
 <script setup lang="ts">
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useWorkspace } from '@/store'
+import type { EnvVariable } from '@/store/active-entities'
 import RequestTable from '@/views/Request/RequestSection/RequestTable.vue'
 import { ScalarButton, ScalarTooltip } from '@scalar/components'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import {
   type Operation,
   type RequestExample,
   requestExampleParametersSchema,
 } from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
 
 const {
   example,
   operation,
+  environment,
+  envVariables,
+  workspace,
   title,
   paramKey,
   readOnlyEntries = [],
 } = defineProps<{
   example: RequestExample
   operation: Operation
+  environment: Environment
+  envVariables: EnvVariable[]
+  workspace: Workspace
   title: string
   paramKey: keyof RequestExample['parameters']
   readOnlyEntries?: {
@@ -34,9 +43,7 @@ const { requestExampleMutators } = useWorkspace()
 
 const params = computed(() => example.parameters[paramKey] ?? [])
 
-onMounted(() => {
-  defaultRow()
-})
+onMounted(() => defaultRow())
 
 /** Add a new row to a given parameter list */
 const addRow = () => {
@@ -201,14 +208,20 @@ const hasReadOnlyEntries = computed(() => (readOnlyEntries ?? []).length > 0)
           'bg-mix-transparent bg-mix-amount-95 bg-c-3': hasReadOnlyEntries,
         }"
         :columns="['32px', '', '']"
+        :envVariables="envVariables"
+        :environment="environment"
         isGlobal
         isReadOnly
-        :items="readOnlyEntries" />
+        :items="readOnlyEntries"
+        :workspace="workspace" />
       <!-- Dynamic entries -->
       <RequestTable
         class="flex-1"
         :columns="['32px', '', '']"
+        :envVariables="envVariables"
+        :environment="environment"
         :items="params"
+        :workspace="workspace"
         @toggleRow="toggleRow"
         @updateRow="updateRow" />
     </div>

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -6,7 +6,6 @@ import RequestTable from '@/views/Request/RequestSection/RequestTable.vue'
 import { ScalarButton, ScalarTooltip } from '@scalar/components'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import {
-  type Operation,
   type RequestExample,
   requestExampleParametersSchema,
 } from '@scalar/oas-utils/entities/spec'
@@ -16,7 +15,6 @@ import type { RouteLocationRaw } from 'vue-router'
 
 const {
   example,
-  operation,
   environment,
   envVariables,
   workspace,
@@ -25,7 +23,6 @@ const {
   readOnlyEntries = [],
 } = defineProps<{
   example: RequestExample
-  operation: Operation
   environment: Environment
   envVariables: EnvVariable[]
   workspace: Workspace
@@ -83,18 +80,14 @@ const updateRow = (rowIdx: number, field: 'key' | 'value', value: string) => {
     }
 
     requestExampleMutators.edit(
-      operation.uid,
+      example.uid,
       `parameters.${paramKey}`,
       updatedParams,
     )
   } else {
     /** if there is no row at the index, add a new one */
     const payload = [requestExampleParametersSchema.parse({ [field]: value })]
-    requestExampleMutators.edit(
-      operation.uid,
-      `parameters.${paramKey}`,
-      payload,
-    )
+    requestExampleMutators.edit(example.uid, `parameters.${paramKey}`, payload)
 
     /** focus the new row */
     nextTick(() => {
@@ -114,7 +107,7 @@ const updateRow = (rowIdx: number, field: 'key' | 'value', value: string) => {
 /** Toggle a parameter row on or off */
 const toggleRow = (rowIdx: number, enabled: boolean) =>
   requestExampleMutators.edit(
-    operation.uid,
+    example.uid,
     `parameters.${paramKey}.${rowIdx}.enabled`,
     enabled,
   )
@@ -124,7 +117,7 @@ const deleteAllRows = () => {
   const exampleParams = params.value.filter((param) => param.required)
 
   requestExampleMutators.edit(
-    operation.uid,
+    example.uid,
     `parameters.${paramKey}`,
     exampleParams,
   )

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -39,6 +39,14 @@ const {
   }[]
 }>()
 
+console.log({
+  example,
+  operation,
+  environment,
+  envVariables,
+  workspace,
+})
+
 const { requestExampleMutators } = useWorkspace()
 
 const params = computed(() => example.parameters[paramKey] ?? [])
@@ -51,11 +59,7 @@ const addRow = () => {
   const newParam = requestExampleParametersSchema.parse({ enabled: false })
   const newParams = [...params.value, newParam]
 
-  requestExampleMutators.edit(
-    operation.uid,
-    `parameters.${paramKey}`,
-    newParams,
-  )
+  requestExampleMutators.edit(example.uid, `parameters.${paramKey}`, newParams)
 }
 
 const tableWrapperRef = ref<HTMLInputElement | null>(null)

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -39,14 +39,6 @@ const {
   }[]
 }>()
 
-console.log({
-  example,
-  operation,
-  environment,
-  envVariables,
-  workspace,
-})
-
 const { requestExampleMutators } = useWorkspace()
 
 const params = computed(() => example.parameters[paramKey] ?? [])

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -1,16 +1,30 @@
 <script setup lang="ts">
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useWorkspace } from '@/store'
+import type { EnvVariable } from '@/store/active-entities'
 import RequestTable from '@/views/Request/RequestSection/RequestTable.vue'
+import type { Workspace } from '@scalar/oas-utils/entities'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { Operation, RequestExample } from '@scalar/oas-utils/entities/spec'
 import { REGEX } from '@scalar/oas-utils/helpers'
 import { computed, watch } from 'vue'
 
-const { example, operation, paramKey, title } = defineProps<{
+const {
+  example,
+  operation,
+  paramKey,
+  title,
+  environment,
+  envVariables,
+  workspace,
+} = defineProps<{
   example: RequestExample
   operation: Operation
   paramKey: keyof RequestExample['parameters']
   title: string
+  environment: Environment
+  envVariables: EnvVariable[]
+  workspace: Workspace
 }>()
 
 const { requestMutators, requestExampleMutators } = useWorkspace()
@@ -105,8 +119,10 @@ watch(
       v-if="params.length"
       class="flex-1"
       :columns="['32px', '', '']"
-      hasCheckboxDisabled
+      :envVariables="envVariables"
+      :environment="environment"
       :items="params"
+      :workspace="workspace"
       @updateRow="updateRow" />
   </ViewLayoutCollapse>
 </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -1,35 +1,30 @@
 <script setup lang="ts">
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import RequestTable from '@/views/Request/RequestSection/RequestTable.vue'
-import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import type { Operation, RequestExample } from '@scalar/oas-utils/entities/spec'
 import { REGEX } from '@scalar/oas-utils/helpers'
 import { computed, watch } from 'vue'
 
-const props = defineProps<{
-  title: string
+const { example, operation, paramKey, title } = defineProps<{
+  example: RequestExample
+  operation: Operation
   paramKey: keyof RequestExample['parameters']
+  title: string
 }>()
 
-const { activeRequest, activeExample } = useActiveEntities()
 const { requestMutators, requestExampleMutators } = useWorkspace()
 
-const params = computed(() => {
-  const example = activeExample.value
-  if (!example) return []
-
-  return example.parameters[props.paramKey].map((param) => ({
+const params = computed(() =>
+  example.parameters[paramKey].map((param) => ({
     ...param,
     enum: param.enum,
-  }))
-})
+  })),
+)
 
 /** Update a field in a parameter row */
 const updateRow = (rowIdx: number, field: 'key' | 'value', value: string) => {
-  if (!activeRequest.value || !activeExample.value) return
-
-  const parameters = activeExample.value.parameters[props.paramKey]
+  const parameters = example.parameters[paramKey]
   const oldKey = parameters[rowIdx]?.key
   if (!oldKey) return
 
@@ -43,34 +38,29 @@ const updateRow = (rowIdx: number, field: 'key' | 'value', value: string) => {
       /** Remove parameter if path params table key is empty */
       parameters.splice(rowIdx, 1)
       const regx = new RegExp(`/:${encodeURIComponent(oldKey)}(?=[/?#]|$)`, 'g')
-      const newPath = activeRequest.value.path.replace(regx, '')
+      const newPath = operation.path.replace(regx, '')
 
-      requestMutators.edit(activeRequest.value.uid, 'path', newPath)
+      requestMutators.edit(operation.uid, 'path', newPath)
     } else {
       /** Update URL with path params table key */
       const encodedOldKey = encodeURIComponent(oldKey)
       const encodedNewKey = encodeURIComponent(value)
       const regx = new RegExp(`(?<=/):${encodedOldKey}(?=[/?#]|$)`, 'g')
-      const newPath = activeRequest.value.path.replace(
-        regx,
-        `:${encodedNewKey}`,
-      )
-      requestMutators.edit(activeRequest.value.uid, 'path', newPath)
+      const newPath = operation.path.replace(regx, `:${encodedNewKey}`)
+      requestMutators.edit(operation.uid, 'path', newPath)
     }
   }
 
   requestExampleMutators.edit(
-    activeExample.value.uid,
-    `parameters.${props.paramKey}.${rowIdx}.${field}`,
+    operation.uid,
+    `parameters.${paramKey}.${rowIdx}.${field}`,
     value,
   )
 }
 
 const setPathVariable = (url: string) => {
-  if (!activeExample.value) return
-
   const pathVariables = url.match(REGEX.PATH)?.map((v) => v.slice(1, -1)) || []
-  const parameters = activeExample.value.parameters[props.paramKey]
+  const parameters = example.parameters[paramKey]
 
   const paramMap = new Map(parameters.map((param) => [param.key, param]))
   const updatedParameters = pathVariables.map(
@@ -83,16 +73,11 @@ const setPathVariable = (url: string) => {
       updatedParameters.push(param)
     }
   })
-
   parameters.splice(0, parameters.length, ...updatedParameters)
 
-  // if (pathVariables.length === 0) {
-  //   parameters.splice(0, parameters.length)
-  // }
-
   requestExampleMutators.edit(
-    activeExample.value.uid,
-    `parameters.${props.paramKey}`,
+    operation.uid,
+    `parameters.${paramKey}`,
     parameters,
   )
 }
@@ -104,11 +89,9 @@ const handlePathVariableUpdate = (url: string) => {
 }
 
 watch(
-  () => activeRequest.value?.path,
+  () => operation.path,
   (newURL) => {
-    if (newURL) {
-      handlePathVariableUpdate(newURL)
-    }
+    if (newURL) handlePathVariableUpdate(newURL)
   },
 )
 </script>

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -66,7 +66,7 @@ const updateRow = (rowIdx: number, field: 'key' | 'value', value: string) => {
   }
 
   requestExampleMutators.edit(
-    operation.uid,
+    example.uid,
     `parameters.${paramKey}.${rowIdx}.${field}`,
     value,
   )

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -89,11 +89,7 @@ const setPathVariable = (url: string) => {
   })
   parameters.splice(0, parameters.length, ...updatedParameters)
 
-  requestExampleMutators.edit(
-    operation.uid,
-    `parameters.${paramKey}`,
-    parameters,
-  )
+  requestExampleMutators.edit(example.uid, `parameters.${paramKey}`, parameters)
 }
 
 const handlePathVariableUpdate = (url: string) => {

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -4,29 +4,40 @@ import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
 import { useLayout } from '@/hooks'
 import { matchesDomain } from '@/libs/send-request/set-request-cookies'
 import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import RequestBody from '@/views/Request/RequestSection/RequestBody.vue'
 import RequestParams from '@/views/Request/RequestSection/RequestParams.vue'
 import RequestPathParams from '@/views/Request/RequestSection/RequestPathParams.vue'
 import { ScalarErrorBoundary } from '@scalar/components'
+import type { Workspace } from '@scalar/oas-utils/entities'
 import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
+import type {
+  Collection,
+  Operation,
+  RequestExample,
+  Server,
+} from '@scalar/oas-utils/entities/spec'
 import { canMethodHaveBody, isDefined } from '@scalar/oas-utils/helpers'
 import { computed, ref, watch } from 'vue'
 
 import RequestAuth from './RequestAuth/RequestAuth.vue'
 import RequestCodeExample from './RequestCodeExample.vue'
 
-defineProps<{
+const {
+  selectedSecuritySchemeUids,
+  collection,
+  example,
+  operation,
+  server,
+  workspace,
+} = defineProps<{
   selectedSecuritySchemeUids: SelectedSecuritySchemeUids
+  collection: Collection
+  example: RequestExample
+  operation: Operation
+  server: Server | undefined
+  workspace: Workspace
 }>()
 
-const {
-  activeRequest,
-  activeCollection,
-  activeExample,
-  activeWorkspace,
-  activeServer,
-} = useActiveEntities()
 const { requestMutators, cookies, securitySchemes } = useWorkspace()
 const { layout } = useLayout()
 
@@ -41,10 +52,8 @@ const sections = computed(() => {
     'Body',
   ])
 
-  if (!activeExample.value?.parameters.path.length)
-    allSections.delete('Variables')
-  if (!canMethodHaveBody(activeRequest.value?.method ?? 'get'))
-    allSections.delete('Body')
+  if (!example.parameters.path.length) allSections.delete('Variables')
+  if (!canMethodHaveBody(operation.method ?? 'get')) allSections.delete('Body')
   if (isAuthHidden.value) allSections.delete('Auth')
 
   return [...allSections]
@@ -52,43 +61,41 @@ const sections = computed(() => {
 
 // If security = [] or [{}] just hide it on readOnly mode
 const isAuthHidden = computed(
-  () => layout === 'modal' && activeRequest.value?.security?.length === 0,
+  () => layout === 'modal' && operation.security?.length === 0,
 )
 
 type ActiveSections = (typeof sections.value)[number]
 
 const activeSection = ref<ActiveSections>('All')
 
-watch(activeRequest, (newRequest) => {
-  if (
-    activeSection.value === 'Body' &&
-    newRequest &&
-    !canMethodHaveBody(newRequest.method)
-  ) {
-    activeSection.value = 'All'
-  }
-})
+watch(
+  () => operation,
+  (newOperation) => {
+    if (
+      activeSection.value === 'Body' &&
+      newOperation &&
+      !canMethodHaveBody(newOperation.method)
+    ) {
+      activeSection.value = 'All'
+    }
+  },
+)
 
 const updateRequestNameHandler = (event: Event) => {
-  if (!activeRequest.value) return
-
   const target = event.target as HTMLInputElement
-  requestMutators.edit(activeRequest.value.uid, 'summary', target.value)
+  requestMutators.edit(operation.uid, 'summary', target.value)
 }
 
 /**
  * Add the global cookies as static entries to the cookies section
  */
 const activeWorkspaceCookies = computed(() =>
-  (activeWorkspace.value?.cookies ?? [])
+  (workspace.cookies ?? [])
     .map((uid) => cookies[uid])
     .filter(isDefined)
     .filter((cookie) => cookie.name)
     .filter((cookie) =>
-      matchesDomain(
-        activeServer?.value?.url || activeRequest.value?.path,
-        cookie.domain,
-      ),
+      matchesDomain(server?.url || operation.path, cookie.domain),
     )
     .map((cookie) => ({
       key: cookie.name,
@@ -104,7 +111,7 @@ const activeWorkspaceCookies = computed(() =>
 )
 </script>
 <template>
-  <ViewLayoutSection :aria-label="`Request: ${activeRequest?.summary}`">
+  <ViewLayoutSection :aria-label="`Request: ${operation.summary}`">
     <template #title>
       <div
         class="flex-1 flex gap-1 items-center lg:pr-24 pointer-events-none group">
@@ -117,12 +124,12 @@ const activeWorkspaceCookies = computed(() =>
           id="requestname"
           class="text-c-1 rounded pointer-events-auto relative w-full pl-1.25 -ml-0.5 md:-ml-1.25 h-8 group-hover-input has-[:focus-visible]:outline z-10"
           placeholder="Request Name"
-          :value="activeRequest?.summary"
+          :value="operation.summary"
           @input="updateRequestNameHandler" />
         <span
           v-else
           class="flex items-center text-c-1 h-8">
-          {{ activeRequest?.summary }}
+          {{ operation.summary }}
         </span>
       </div>
       <ContextBar
@@ -134,24 +141,24 @@ const activeWorkspaceCookies = computed(() =>
       class="request-section-content custom-scroll flex flex-1 flex-col relative">
       <RequestAuth
         v-if="
-          activeCollection &&
-          activeWorkspace &&
+          collection &&
+          workspace &&
           (layout !== 'modal' || Object.keys(securitySchemes ?? {}).length)
         "
         v-show="
           !isAuthHidden && (activeSection === 'All' || activeSection === 'Auth')
         "
-        :collection="activeCollection"
+        :collection="collection"
         layout="client"
-        :operation="activeRequest"
+        :operation="operation"
         :selectedSecuritySchemeUids="selectedSecuritySchemeUids"
-        :server="activeServer"
+        :server="server"
         title="Authentication"
-        :workspace="activeWorkspace" />
+        :workspace="workspace" />
       <RequestPathParams
         v-show="
           (activeSection === 'All' || activeSection === 'Variables') &&
-          activeExample?.parameters?.path?.length
+          example.parameters.path.length
         "
         paramKey="path"
         title="Variables" />
@@ -171,9 +178,9 @@ const activeWorkspaceCookies = computed(() =>
         title="Query Parameters" />
       <RequestBody
         v-show="
-          activeRequest?.method &&
+          operation.method &&
           (activeSection === 'All' || activeSection === 'Body') &&
-          canMethodHaveBody(activeRequest.method)
+          canMethodHaveBody(operation.method)
         "
         title="Body" />
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -4,11 +4,13 @@ import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
 import { useLayout } from '@/hooks'
 import { matchesDomain } from '@/libs/send-request/set-request-cookies'
 import { useWorkspace } from '@/store'
+import type { EnvVariable } from '@/store/active-entities'
 import RequestBody from '@/views/Request/RequestSection/RequestBody.vue'
 import RequestParams from '@/views/Request/RequestSection/RequestParams.vue'
 import RequestPathParams from '@/views/Request/RequestSection/RequestPathParams.vue'
 import { ScalarErrorBoundary } from '@scalar/components'
 import type { Workspace } from '@scalar/oas-utils/entities'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
 import type {
   Collection,
@@ -23,17 +25,21 @@ import RequestAuth from './RequestAuth/RequestAuth.vue'
 import RequestCodeExample from './RequestCodeExample.vue'
 
 const {
-  selectedSecuritySchemeUids,
   collection,
+  environment,
+  envVariables,
   example,
   operation,
+  selectedSecuritySchemeUids,
   server,
   workspace,
 } = defineProps<{
-  selectedSecuritySchemeUids: SelectedSecuritySchemeUids
   collection: Collection
+  environment: Environment
+  envVariables: EnvVariable[]
   example: RequestExample
   operation: Operation
+  selectedSecuritySchemeUids: SelectedSecuritySchemeUids
   server: Server | undefined
   workspace: Workspace
 }>()
@@ -149,6 +155,8 @@ const activeWorkspaceCookies = computed(() =>
           !isAuthHidden && (activeSection === 'All' || activeSection === 'Auth')
         "
         :collection="collection"
+        :envVariables="envVariables"
+        :environment="environment"
         layout="client"
         :operation="operation"
         :selectedSecuritySchemeUids="selectedSecuritySchemeUids"
@@ -160,36 +168,66 @@ const activeWorkspaceCookies = computed(() =>
           (activeSection === 'All' || activeSection === 'Variables') &&
           example.parameters.path.length
         "
+        :envVariables="envVariables"
+        :environment="environment"
+        :example="example"
+        :operation="operation"
         paramKey="path"
-        title="Variables" />
+        title="Variables"
+        :workspace="workspace" />
       <RequestParams
         v-show="activeSection === 'All' || activeSection === 'Cookies'"
+        :envVariables="envVariables"
+        :environment="environment"
+        :example="example"
+        :operation="operation"
         paramKey="cookies"
         :readOnlyEntries="activeWorkspaceCookies"
         title="Cookies"
+        :workspace="workspace"
         workspaceParamKey="cookies" />
       <RequestParams
         v-show="activeSection === 'All' || activeSection === 'Headers'"
+        :envVariables="envVariables"
+        :environment="environment"
+        :example="example"
+        :operation="operation"
         paramKey="headers"
-        title="Headers" />
+        title="Headers"
+        :workspace="workspace" />
       <RequestParams
         v-show="activeSection === 'All' || activeSection === 'Query'"
+        :envVariables="envVariables"
+        :environment="environment"
+        :example="example"
+        :operation="operation"
         paramKey="query"
-        title="Query Parameters" />
+        title="Query Parameters"
+        :workspace="workspace" />
       <RequestBody
         v-show="
           operation.method &&
           (activeSection === 'All' || activeSection === 'Body') &&
           canMethodHaveBody(operation.method)
         "
-        title="Body" />
+        :envVariables="envVariables"
+        :environment="environment"
+        :example="example"
+        :operation="operation"
+        title="Body"
+        :workspace="workspace" />
 
       <!-- Spacer -->
       <div class="flex flex-grow" />
 
       <!-- Code Snippet -->
       <ScalarErrorBoundary>
-        <RequestCodeExample />
+        <RequestCodeExample
+          :collection="collection"
+          :example="example"
+          :operation="operation"
+          :server="server"
+          :workspace="workspace" />
       </ScalarErrorBoundary>
     </div>
   </ViewLayoutSection>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import type { RouteLocationRaw } from 'vue-router'
 
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
@@ -8,6 +10,7 @@ import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableCell from '@/components/DataTable/DataTableCell.vue'
 import DataTableCheckbox from '@/components/DataTable/DataTableCheckbox.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
+import type { EnvVariable } from '@/store/active-entities'
 
 import { hasItemProperties, parameterIsInvalid } from '../libs/request'
 import RequestTableTooltip from './RequestTableTooltip.vue'
@@ -20,6 +23,9 @@ const props = withDefaults(
     showUploadButton?: boolean
     isGlobal?: boolean
     isReadOnly?: boolean
+    environment: Environment
+    envVariables: EnvVariable[]
+    workspace: Workspace
   }>(),
   {
     hasCheckboxDisabled: false,
@@ -115,9 +121,12 @@ const flattenValue = (item: RequestExampleParameter) => {
           :disabled="props.isReadOnly"
           disableEnter
           disableTabIndent
+          :envVariables="envVariables"
+          :environment="environment"
           :modelValue="item.key"
           placeholder="Key"
           :required="Boolean(item.required)"
+          :workspace="workspace"
           @blur="emit('inputBlur')"
           @focus="emit('inputFocus')"
           @selectVariable="(v: string) => handleSelectVariable(idx, 'key', v)"
@@ -136,6 +145,8 @@ const flattenValue = (item: RequestExampleParameter) => {
           disableEnter
           disableTabIndent
           :enum="item.enum ?? []"
+          :envVariables="envVariables"
+          :environment="environment"
           :examples="item.examples ?? []"
           :max="item.maximum"
           :min="item.minimum"
@@ -143,6 +154,7 @@ const flattenValue = (item: RequestExampleParameter) => {
           :nullable="Boolean(item.nullable)"
           placeholder="Value"
           :type="item.type"
+          :workspace="workspace"
           @blur="emit('inputBlur')"
           @focus="emit('inputFocus')"
           @selectVariable="(v: string) => handleSelectVariable(idx, 'value', v)"

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
@@ -1,12 +1,13 @@
 import { useWorkspace } from '@/store'
 import { createStoreEvents } from '@/store/events'
+import { environmentSchema } from '@scalar/oas-utils/entities/environment'
 import {
   collectionSchema,
   operationSchema,
 } from '@scalar/oas-utils/entities/spec'
+import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { mount } from '@vue/test-utils'
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
 
 import RequestSubpageHeader from './RequestSubpageHeader.vue'
 
@@ -36,7 +37,7 @@ const mockWorkspace = {
   events: createStoreEvents(),
   hideClientButton: false,
   showSidebar: true,
-  requestHistory: ref([]),
+  requestHistory: [],
 }
 
 const mockCollection = collectionSchema.parse({
@@ -46,14 +47,24 @@ const mockCollection = collectionSchema.parse({
 const mockOperation = operationSchema.parse({
   uid: 'mockRequestUid',
 })
+const mockEnvironment = environmentSchema.parse({
+  uid: 'mockEnvironmentUid',
+  name: 'Mock Environment',
+  description: 'Mock Environment Description',
+})
 
 describe('RequestSubpageHeader', () => {
   const createWrapper = (options = {}) =>
     mount(RequestSubpageHeader, {
       props: {
         collection: mockCollection,
+        environment: mockEnvironment,
+        envVariables: [],
+        layout: 'modal',
         operation: mockOperation,
         server: undefined,
+        selectedSchemeOptions: [],
+        workspace: workspaceSchema.parse(mockWorkspace),
         modelValue: false,
       },
       ...options,

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
@@ -1,6 +1,9 @@
 import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import { createStoreEvents } from '@/store/events'
+import {
+  collectionSchema,
+  operationSchema,
+} from '@scalar/oas-utils/entities/spec'
 import { mount } from '@vue/test-utils'
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
@@ -13,6 +16,13 @@ vi.mock('vue-router', () => ({
     currentRoute: {
       query: {},
     },
+  }),
+}))
+
+// Mock useLayout
+vi.mock('@/hooks', () => ({
+  useLayout: () => ({
+    layout: 'modal',
   }),
 }))
 
@@ -29,41 +39,28 @@ const mockWorkspace = {
   requestHistory: ref([]),
 }
 
-// Mock useActiveEntities
-vi.mock('@/store/active-entities', () => ({
-  useActiveEntities: vi.fn(),
-}))
-const mockUseActiveEntities = useActiveEntities as Mock
-const mockActiveEntities = {
-  activeCollection: ref({
-    documentUrl: 'https://example.com',
-    integration: 'test',
-  }),
-  activeEnvironment: ref({}),
-  activeRequest: ref({ uid: 'mockRequestUid' }),
-  activeWorkspace: ref({}),
-}
-
-// Mock useLayout
-vi.mock('@/hooks', () => ({
-  useLayout: () => ({
-    layout: 'modal',
-  }),
-}))
+const mockCollection = collectionSchema.parse({
+  documentUrl: 'https://example.com',
+  integration: 'test',
+})
+const mockOperation = operationSchema.parse({
+  uid: 'mockRequestUid',
+})
 
 describe('RequestSubpageHeader', () => {
-  const createWrapper = (options = {}) => {
-    return mount(RequestSubpageHeader, {
+  const createWrapper = (options = {}) =>
+    mount(RequestSubpageHeader, {
       props: {
+        collection: mockCollection,
+        operation: mockOperation,
+        server: undefined,
         modelValue: false,
       },
       ...options,
     })
-  }
 
   // Mock our request + example
   beforeEach(() => {
-    mockUseActiveEntities.mockReturnValue(mockActiveEntities)
     mockUseWorkspace.mockReturnValue(mockWorkspace)
   })
 
@@ -89,13 +86,6 @@ describe('RequestSubpageHeader', () => {
     mockUseWorkspace.mockReturnValue({
       ...mockWorkspace,
       hideClientButton: false,
-    })
-    mockUseActiveEntities.mockReturnValue({
-      ...mockActiveEntities,
-      activeCollection: ref({
-        documentUrl: 'https://example.com',
-        integration: 'test',
-      }),
     })
     const wrapper = createWrapper()
 

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -4,18 +4,32 @@ import AddressBar from '@/components/AddressBar/AddressBar.vue'
 import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
 import { useLayout } from '@/hooks'
 import { useWorkspace } from '@/store'
+import type { EnvVariable } from '@/store/active-entities'
 import { ScalarIcon } from '@scalar/components'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type {
   Collection,
   Operation,
   Server,
 } from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { useRouter } from 'vue-router'
 
-const { collection, operation, server, modelValue } = defineProps<{
+const {
+  collection,
+  operation,
+  server,
+  modelValue,
+  environment,
+  envVariables,
+  workspace,
+} = defineProps<{
   collection: Collection
   operation: Operation
   server: Server | undefined
+  environment: Environment
+  envVariables: EnvVariable[]
+  workspace: Workspace
   modelValue: boolean
 }>()
 
@@ -50,8 +64,11 @@ const { currentRoute } = useRouter()
     <!-- Address Bar - we should always have a collection and operation -->
     <AddressBar
       :collection="collection"
+      :envVariables="envVariables"
+      :environment="environment"
       :operation="operation"
       :server="server"
+      :workspace="workspace"
       @importCurl="$emit('importCurl', $event)" />
     <div
       class="flex flex-row items-center gap-1 lg:px-2.5 lg:mb-0 mb-2 lg:flex-1 justify-end w-1/2">

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -4,11 +4,18 @@ import AddressBar from '@/components/AddressBar/AddressBar.vue'
 import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
 import { useLayout } from '@/hooks'
 import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import { ScalarIcon } from '@scalar/components'
+import type {
+  Collection,
+  Operation,
+  Server,
+} from '@scalar/oas-utils/entities/spec'
 import { useRouter } from 'vue-router'
 
-defineProps<{
+const { collection, operation, server, modelValue } = defineProps<{
+  collection: Collection
+  operation: Operation
+  server: Server | undefined
   modelValue: boolean
 }>()
 
@@ -18,7 +25,6 @@ defineEmits<{
   (e: 'importCurl', value: string): void
 }>()
 
-const { activeCollection } = useActiveEntities()
 const { hideClientButton, showSidebar, integration } = useWorkspace()
 
 const { layout } = useLayout()
@@ -41,22 +47,23 @@ const { currentRoute } = useRouter()
         :modelValue="modelValue"
         @update:modelValue="$emit('update:modelValue', $event)" />
     </div>
-    <AddressBar @importCurl="$emit('importCurl', $event)" />
+    <!-- Address Bar - we should always have a collection and operation -->
+    <AddressBar
+      :collection="collection"
+      :operation="operation"
+      :server="server"
+      @importCurl="$emit('importCurl', $event)" />
     <div
       class="flex flex-row items-center gap-1 lg:px-2.5 lg:mb-0 mb-2 lg:flex-1 justify-end w-1/2">
       <OpenApiClientButton
-        v-if="
-          layout === 'modal' &&
-          activeCollection?.documentUrl &&
-          !hideClientButton
-        "
+        v-if="layout === 'modal' && collection.documentUrl && !hideClientButton"
         buttonSource="modal"
         class="!w-fit lg:-mr-1"
-        :integration="integration ?? activeCollection?.integration ?? null"
+        :integration="integration ?? collection.integration ?? null"
         :source="
           currentRoute.query.source === 'gitbook' ? 'gitbook' : 'api-reference'
         "
-        :url="activeCollection?.documentUrl" />
+        :url="collection.documentUrl" />
       <!-- TODO: There should be an `ìsModal` flag instead -->
       <button
         v-if="layout === 'modal'"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -6,11 +6,13 @@ import ScalarHotkey from '@/components/ScalarHotkey.vue'
 import { useLayout } from '@/hooks'
 import type { HotKeyEvent } from '@/libs'
 import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import { onBeforeUnmount, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 
-const { activeWorkspaceRequests } = useActiveEntities()
+const { numWorkspaceRequests } = defineProps<{
+  numWorkspaceRequests: number
+}>()
+
 const { events } = useWorkspace()
 const route = useRoute()
 const { layout } = useLayout()
@@ -35,8 +37,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
     <div
       class="flex h-[calc(100%_-_50px)] flex-col items-center justify-center"
       :class="{
-        'hidden opacity-0':
-          activeWorkspaceRequests.length <= 1 && layout !== 'modal',
+        'hidden opacity-0': numWorkspaceRequests <= 1 && layout !== 'modal',
       }">
       <div
         v-if="layout !== 'modal'"
@@ -64,7 +65,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
       v-if="layout !== 'modal'"
       class="h-[calc(100%_-_50px)] items-center justify-center hidden pb-5"
       :class="{
-        '!flex opacity-100': activeWorkspaceRequests.length == 1,
+        '!flex opacity-100': numWorkspaceRequests == 1,
       }">
       <EmptyState />
     </div>

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -27,7 +27,13 @@ const props = withDefaults(
 
 const { hideModels } = useSidebar()
 const { securitySchemes } = useWorkspace()
-const { activeCollection, activeServer, activeWorkspace } = useActiveEntities()
+const {
+  activeCollection,
+  activeEnvVariables,
+  activeEnvironment,
+  activeServer,
+  activeWorkspace,
+} = useActiveEntities()
 
 const introCardsSlot = computed(() =>
   props.layout === 'classic' ? 'after' : 'aside',
@@ -74,6 +80,8 @@ const introCardsSlot = computed(() =>
               class="scalar-client introduction-card-item">
               <RequestAuth
                 :collection="activeCollection"
+                :envVariables="activeEnvVariables"
+                :environment="activeEnvironment"
                 layout="reference"
                 :selectedSecuritySchemeUids="
                   activeCollection?.selectedSecuritySchemeUids ?? []


### PR DESCRIPTION
**Problem**
We inject active entities, but when we want to consume these components elsewhere with different values for these entities it doesnt work.


**Solution**
With this PR we prop drill all the active entities around 🥵. not the best solution but it works and is easy to understand.

One alternate strategy would be to allow injection of any entity at any level which would clean up the code alot. The downside is you would never know which entities are currently inject + plus it would be harder to test.

This needs a fine tooth review! + testing!


I put this in draft so we can get this in first for extra protection

https://github.com/scalar/scalar/issues/4773

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
