### PR TITLE
feat(components): add sidebar nesting indicator lines

### DIFF
--- a/.changeset/giant-parents-live.md
+++ b/.changeset/giant-parents-live.md
@@ -1,0 +1,6 @@
+---
+'@scalar/components': patch
+'@scalar/themes': patch
+---
+
+feat(components): add sidebar nesting indicator lines

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -79,6 +79,12 @@ export const WithNavItems: Story = {
 }
 
 export const WithNestedGroups: Story = {
+  argTypes: {
+    indent: { control: 'number' },
+  },
+  args: {
+    indent: 18,
+  },
   render: (args) => ({
     components: {
       ScalarSidebar,
@@ -90,7 +96,7 @@ export const WithNestedGroups: Story = {
       return { args }
     },
     template: `
-<div class="flex h-screen">
+<div class="flex h-screen" :style="{ '--scalar-sidebar-indent': args.indent + 'px' }">
   <ScalarSidebar>
     <ScalarSidebarItems class="custom-scroll">
       <ScalarSidebarGroup>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -99,6 +99,8 @@ export const WithNestedGroups: Story = {
 <div class="flex h-screen" :style="{ '--scalar-sidebar-indent': args.indent + 'px' }">
   <ScalarSidebar>
     <ScalarSidebarItems class="custom-scroll">
+      <ScalarSidebarItem :icon="args.icon">Item</ScalarSidebarItem>
+      <ScalarSidebarItem :icon="args.icon">Item</ScalarSidebarItem>
       <ScalarSidebarGroup>
         Item Group
         <template #items>
@@ -139,6 +141,8 @@ export const WithNestedGroups: Story = {
           <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
         </template>
       </ScalarSidebarGroup>
+      <ScalarSidebarItem :icon="args.icon">Item</ScalarSidebarItem>
+      <ScalarSidebarItem :icon="args.icon">Item</ScalarSidebarItem>
     </ScalarSidebarItems>
   </ScalarSidebar>
   <div class="placeholder flex-1">Main content</div>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -93,59 +93,73 @@ export const WithNestedGroups: Story = {
       ScalarSidebarGroup,
     },
     setup() {
-      return { args }
+      const selected = ref('')
+      return { args, selected }
     },
     template: `
-<div class="flex h-screen" :style="{ '--scalar-sidebar-indent': args.indent + 'px' }">
+
+<div class="flex h-screen" 
+  :style="{ 
+    '--scalar-sidebar-indent': args.indent + 'px', 
+    '--scalar-sidebar-indent-border-hover': 'var(--scalar-color-3)',
+    '--scalar-sidebar-indent-border-active': 'var(--scalar-color-accent)'
+  }">
   <ScalarSidebar>
     <ScalarSidebarItems class="custom-scroll">
-      <ScalarSidebarItem :icon="args.icon">Item</ScalarSidebarItem>
-      <ScalarSidebarItem :icon="args.icon">Item</ScalarSidebarItem>
-      <ScalarSidebarGroup>
-        Item Group
+      <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 1'" @click="selected = 'Item 1'">Item 1</ScalarSidebarItem>
+      <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 2'" @click="selected = 'Item 2'">Item 2</ScalarSidebarItem>
+      <ScalarSidebarGroup>  
+        Level 1 Group 
         <template #items>
-          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
-          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 1'" @click="selected = 'Subitem 1'">Subitem 1</ScalarSidebarItem>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 2'" @click="selected = 'Subitem 2'">Subitem 2</ScalarSidebarItem>
             <ScalarSidebarGroup>
-              Item Group
+              Level 2 Group
               <template #items>
-                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
-                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 3'" @click="selected = 'Subitem 3'">Subitem 3</ScalarSidebarItem>
+                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 4'" @click="selected = 'Subitem 4'">Subitem 4</ScalarSidebarItem>
                   <ScalarSidebarGroup>
-                  Item Group
+                  Level 3 Group
                   <template #items>
-                    <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
-                    <ScalarSidebarItem :icon="args.icon" selected>Subitem</ScalarSidebarItem>
+                    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 5'" @click="selected = 'Subitem 5'">Subitem 5</ScalarSidebarItem>
+                    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 6'" @click="selected = 'Subitem 6'">Subitem 6</ScalarSidebarItem>
                       <ScalarSidebarGroup>
-                        Item Group
+                        Level 4 Group
                         <template #items>
-                          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
-                          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 7'" @click="selected = 'Subitem 7'">Subitem 7</ScalarSidebarItem>
+                          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 8'" @click="selected = 'Subitem 8'">Subitem 8</ScalarSidebarItem>
                             <ScalarSidebarGroup>
-                              Item Group
+                              Level 5 Group
                               <template #items>
-                                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
-                                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
-                                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 9'" @click="selected = 'Subitem 9'">Subitem 9</ScalarSidebarItem>
+                                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 10'" @click="selected = 'Subitem 10'">Subitem 10</ScalarSidebarItem>
+                                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 11'" @click="selected = 'Subitem 11'">Subitem 11</ScalarSidebarItem>
                               </template>
                             </ScalarSidebarGroup>
-                          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 12'" @click="selected = 'Subitem 12'">Subitem 12</ScalarSidebarItem>
                         </template>
                       </ScalarSidebarGroup>
-                    <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 13'" @click="selected = 'Subitem 13'">Subitem 13</ScalarSidebarItem>
                   </template>
                 </ScalarSidebarGroup>
-                <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 14'" @click="selected = 'Subitem 14'">Subitem 14</ScalarSidebarItem>
               </template>
             </ScalarSidebarGroup>
-          <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 15'" @click="selected = 'Subitem 15'">Subitem 15</ScalarSidebarItem>
         </template>
       </ScalarSidebarGroup>
-      <ScalarSidebarItem :icon="args.icon">Item</ScalarSidebarItem>
-      <ScalarSidebarItem :icon="args.icon">Item</ScalarSidebarItem>
+      <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 3'" @click="selected = 'Item 3'">Item 3</ScalarSidebarItem>
+      <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 4'" @click="selected = 'Item 4'">Item 4</ScalarSidebarItem>
     </ScalarSidebarItems>
   </ScalarSidebar>
-  <div class="placeholder flex-1">Main content</div>
+  <div class="flex items-center justify-center flex-1 text-c-2">
+    <template v-if="selected">
+      {{ selected }} Selected
+    </template>
+    <template v-else>
+      Select an item in the sidebar
+    </template>
+  </div>
 </div>
 `,
   }),

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -115,7 +115,7 @@ export const WithNestedGroups: Story = {
                   Item Group
                   <template #items>
                     <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
-                    <ScalarSidebarItem :icon="args.icon">Subitem</ScalarSidebarItem>
+                    <ScalarSidebarItem :icon="args.icon" selected>Subitem</ScalarSidebarItem>
                       <ScalarSidebarGroup>
                         Item Group
                         <template #items>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -35,7 +35,7 @@ const { is = 'a', indent = 0 } = defineProps<ScalarSidebarItemProps>()
 defineSlots<ScalarSidebarItemSlots>()
 
 const variants = cva({
-  base: ['group/item flex rounded px-1.5 font-medium text-c-2 no-underline'],
+  base: ['group/button flex rounded px-1.5 font-medium text-c-2 no-underline'],
   variants: {
     selected: { true: 'cursor-auto bg-b-2 text-c-1' },
     disabled: { true: 'cursor-auto' },

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -35,7 +35,7 @@ const { is = 'a', indent = 0 } = defineProps<ScalarSidebarItemProps>()
 defineSlots<ScalarSidebarItemSlots>()
 
 const variants = cva({
-  base: ['flex rounded px-1.5 font-medium text-c-2 no-underline'],
+  base: ['group/item flex rounded px-1.5 font-medium text-c-2 no-underline'],
   variants: {
     selected: { true: 'cursor-auto bg-b-2 text-c-1' },
     disabled: { true: 'cursor-auto' },
@@ -52,10 +52,13 @@ const { cx } = useBindCx()
   <component
     :is="is"
     :aria-level="indent"
+    :aria-selected="selected"
     :type="is === 'button' ? 'button' : undefined"
     v-bind="cx(variants({ selected, disabled }))">
     <slot name="indent">
-      <ScalarSidebarIndent :indent="indent" />
+      <ScalarSidebarIndent
+        :indent="indent"
+        :selected="selected" />
     </slot>
     <div class="flex items-center gap-1 flex-1 py-2 leading-5">
       <div

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -24,6 +24,7 @@
 export default {}
 </script>
 <script setup lang="ts">
+import ScalarSidebarIndent from './ScalarSidebarIndent.vue'
 import { cva } from '../../cva'
 import { useBindCx } from '../../hooks/useBindCx'
 import { ScalarIcon } from '../ScalarIcon'
@@ -34,7 +35,7 @@ const { is = 'a', indent = 0 } = defineProps<ScalarSidebarItemProps>()
 defineSlots<ScalarSidebarItemSlots>()
 
 const variants = cva({
-  base: ['rounded p-1.5 font-medium text-c-2 no-underline'],
+  base: ['flex rounded px-1.5 font-medium text-c-2 no-underline'],
   variants: {
     selected: { true: 'cursor-auto bg-b-2 text-c-1' },
     disabled: { true: 'cursor-auto' },
@@ -53,12 +54,10 @@ const { cx } = useBindCx()
     :aria-level="indent"
     :type="is === 'button' ? 'button' : undefined"
     v-bind="cx(variants({ selected, disabled }))">
-    <div
-      class="flex items-center gap-1 flex-1"
-      :style="{
-        'padding-left':
-          'calc(var(--scalar-sidebar-indent,18px) * var(--scalar-sidebar-level))',
-      }">
+    <slot name="indent">
+      <ScalarSidebarIndent :indent="indent" />
+    </slot>
+    <div class="flex items-center gap-1 flex-1 py-2 leading-5">
       <div
         v-if="icon || $slots.icon"
         class="size-3.5">

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -38,20 +38,11 @@ const variants = cva({
   variants: {
     selected: { true: 'cursor-auto bg-b-2 text-c-1' },
     disabled: { true: 'cursor-auto' },
-    indent: {
-      0: 'pl-[6px]',
-      1: 'pl-[24px]',
-      2: 'pl-[42px]',
-      3: 'pl-[60px]',
-      4: 'pl-[78px]',
-      5: 'pl-[96px]',
-      6: 'pl-[114px]',
-    },
   },
   compoundVariants: [
     { selected: false, disabled: false, class: 'hover:bg-b-2' },
   ],
-  defaultVariants: { selected: false, disabled: false, indent: 0 },
+  defaultVariants: { selected: false, disabled: false },
 })
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
@@ -61,8 +52,13 @@ const { cx } = useBindCx()
     :is="is"
     :aria-level="indent"
     :type="is === 'button' ? 'button' : undefined"
-    v-bind="cx(variants({ selected, disabled, indent }))">
-    <div class="flex items-center gap-1 flex-1">
+    v-bind="cx(variants({ selected, disabled }))">
+    <div
+      class="flex items-center gap-1 flex-1"
+      :style="{
+        'padding-left':
+          'calc(var(--scalar-sidebar-indent,18px) * var(--scalar-sidebar-level))',
+      }">
       <div
         v-if="icon || $slots.icon"
         class="size-3.5">

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -46,7 +46,7 @@ defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
 </script>
 <template>
-  <li class="contents">
+  <li class="group/item contents">
     <slot
       :level="level"
       name="button"
@@ -73,7 +73,7 @@ const { cx } = useBindCx()
     <component
       :is="is"
       v-if="open"
-      v-bind="cx('flex flex-col relative')">
+      v-bind="cx('flex flex-col gap-px')">
       <slot
         name="items"
         :open="open" />

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -47,6 +47,7 @@ const { cx } = useBindCx()
 <template>
   <li class="contents">
     <slot
+      :level="level"
       name="button"
       :open="open">
       <ScalarSidebarButton
@@ -56,7 +57,9 @@ const { cx } = useBindCx()
         :indent="level"
         @click="open = !open">
         <template #icon>
-          <ScalarSidebarGroupToggle :open="open" />
+          <ScalarSidebarGroupToggle
+            class="text-c-3"
+            :open="open" />
         </template>
         <slot :open="open" />
       </ScalarSidebarButton>
@@ -64,13 +67,16 @@ const { cx } = useBindCx()
     <component
       :is="is"
       v-if="open"
-      v-bind="cx('flex flex-col relative')">
+      v-bind="cx('flex flex-col relative')"
+      :style="{ '--scalar-sidebar-level': level + 1 }">
       <slot
         name="items"
         :open="open" />
       <div
-        class="absolute w-border bg-border h-full top-1/2 -translate-y-1/2"
-        :style="{ left: 13 + 18 * level + 'px' }" />
+        class="absolute w-border bg-border inset-y-0 ml-1.5"
+        :style="{
+          left: `calc(var(--scalar-sidebar-indent,18px) * ${level} + 7px)`,
+        }" />
     </component>
   </li>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -22,6 +22,7 @@ import type { Component } from 'vue'
 import { useBindCx } from '../../hooks/useBindCx'
 import ScalarSidebarButton from './ScalarSidebarButton.vue'
 import ScalarSidebarGroupToggle from './ScalarSidebarGroupToggle.vue'
+import ScalarSidebarIndent from './ScalarSidebarIndent.vue'
 import { useSidebarGroups } from './useSidebarGroups'
 
 const { is = 'ul' } = defineProps<{
@@ -53,9 +54,14 @@ const { cx } = useBindCx()
       <ScalarSidebarButton
         is="button"
         :aria-expanded="open"
-        class="text-c-1"
+        class="text-c-1 bg-b-1"
         :indent="level"
         @click="open = !open">
+        <template #indent>
+          <ScalarSidebarIndent
+            class="mr-0"
+            :indent="level" />
+        </template>
         <template #icon>
           <ScalarSidebarGroupToggle
             class="text-c-3"
@@ -67,16 +73,10 @@ const { cx } = useBindCx()
     <component
       :is="is"
       v-if="open"
-      v-bind="cx('flex flex-col relative')"
-      :style="{ '--scalar-sidebar-level': level + 1 }">
+      v-bind="cx('flex flex-col relative')">
       <slot
         name="items"
         :open="open" />
-      <div
-        class="absolute w-border bg-border inset-y-0 ml-1.5"
-        :style="{
-          left: `calc(var(--scalar-sidebar-indent,18px) * ${level} + 7px)`,
-        }" />
     </component>
   </li>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -23,9 +23,10 @@ import { useBindCx } from '../../hooks/useBindCx'
 import ScalarSidebarButton from './ScalarSidebarButton.vue'
 import ScalarSidebarGroupToggle from './ScalarSidebarGroupToggle.vue'
 import ScalarSidebarIndent from './ScalarSidebarIndent.vue'
-import { useSidebarGroups } from './useSidebarGroups'
+import { useSidebarGroups, type SidebarGroupLevel } from './useSidebarGroups'
 
 const { is = 'ul' } = defineProps<{
+  /** Override the element tag */
   is?: Component | string
 }>()
 
@@ -33,11 +34,11 @@ const open = defineModel<boolean>()
 
 defineSlots<{
   /** The text content of the toggle */
-  default?: () => any
+  default?: (props: { open: boolean }) => any
   /** Override the entire toggle button */
-  button?: () => any
+  button?: (props: { open: boolean; level: SidebarGroupLevel }) => any
   /** The list of sidebar subitems */
-  items?: () => any
+  items?: (props: { open: boolean }) => any
 }>()
 
 const { level } = useSidebarGroups({ increment: true })
@@ -50,7 +51,7 @@ const { cx } = useBindCx()
     <slot
       :level="level"
       name="button"
-      :open="open">
+      :open="!!open">
       <ScalarSidebarButton
         is="button"
         :aria-expanded="open"
@@ -67,7 +68,7 @@ const { cx } = useBindCx()
             class="text-c-3"
             :open="open" />
         </template>
-        <slot :open="open" />
+        <slot :open="!!open" />
       </ScalarSidebarButton>
     </slot>
     <component
@@ -76,7 +77,7 @@ const { cx } = useBindCx()
       v-bind="cx('flex flex-col gap-px')">
       <slot
         name="items"
-        :open="open" />
+        :open="!!open" />
     </component>
   </li>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -52,6 +52,7 @@ const { cx } = useBindCx()
       <ScalarSidebarButton
         is="button"
         :aria-expanded="open"
+        class="text-c-1"
         :indent="level"
         @click="open = !open">
         <template #icon>
@@ -63,10 +64,13 @@ const { cx } = useBindCx()
     <component
       :is="is"
       v-if="open"
-      v-bind="cx('flex flex-col')">
+      v-bind="cx('flex flex-col relative')">
       <slot
         name="items"
         :open="open" />
+      <div
+        class="absolute w-border bg-border h-full top-1/2 -translate-y-1/2"
+        :style="{ left: 13 + 18 * level + 'px' }" />
     </component>
   </li>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
@@ -1,0 +1,40 @@
+<script lang="ts">
+/**
+ * Scalar Sidebar Indent component
+ *
+ * @example
+ *   <ScalarSidebarIndent :indent="1" />
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import type { SidebarGroupLevel } from './useSidebarGroups'
+import { useBindCx } from '../../hooks/useBindCx'
+import { computed } from 'vue'
+
+const { indent = 0 } = defineProps<{
+  indent: SidebarGroupLevel
+}>()
+
+const indents = computed<number[]>(() => {
+  return Array.from({ length: indent }, (_, i) => i)
+})
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+</script>
+<template>
+  <div
+    v-bind="
+      cx('flex justify-center', {
+        'mr-[calc(18px-var(--scalar-sidebar-indent))]': indent > 0,
+      })
+    ">
+    <div
+      v-for="block in indents"
+      :key="block"
+      class="flex w-[var(--scalar-sidebar-indent)]">
+      <div class="ml-1.75 w-border bg-border shrink-0" />
+    </div>
+  </div>
+</template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
@@ -27,20 +27,47 @@ const { cx } = useBindCx()
 <template>
   <div
     v-bind="
-      cx('flex justify-center', {
+      cx('scalar-sidebar-indent flex justify-center', {
         'mr-[calc(18px-var(--scalar-sidebar-indent))]': indent > 0,
+        'scalar-sidebar-indent-selected': selected,
       })
     ">
     <div
-      v-for="block in indents"
+      v-for="(block, index) in indents"
       :key="block"
-      class="flex w-[var(--scalar-sidebar-indent)] text-sidebar-indent-border"
-      :class="
-        selected
-          ? 'last:text-sidebar-indent-active'
-          : 'group-hover/item:last:text-sidebar-indent-hover'
-      ">
-      <div class="ml-1.75 w-border bg-current shrink-0" />
+      class="relative w-[var(--scalar-sidebar-indent)]">
+      <!-- Indent Border -->
+      <div
+        class="scalar-sidebar-indent-border absolute left-1.75 inset-y-0 w-border bg-sidebar-indent-border" />
+      <!-- Indent Border Active or Hover -->
+      <div
+        v-if="index === indents.length - 1"
+        class="absolute left-1.75 inset-y-0 w-border"
+        :class="
+          selected
+            ? 'bg-sidebar-indent-active'
+            : 'group-hover/button:bg-sidebar-indent-hover'
+        " />
     </div>
   </div>
 </template>
+<style scoped lang="postcss">
+.group\/item
+  > .group\/button
+  > .scalar-sidebar-indent
+  .scalar-sidebar-indent-border {
+  @apply -inset-y-px;
+}
+.group\/item:first-child
+  > .group\/button
+  > .scalar-sidebar-indent
+  .scalar-sidebar-indent-border {
+  @apply top-0;
+}
+.group\/item:last-child
+  > .group\/button
+  > .scalar-sidebar-indent
+  .scalar-sidebar-indent-border {
+  @apply bottom-0;
+}
+</style>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
@@ -12,9 +12,11 @@ import type { SidebarGroupLevel } from './useSidebarGroups'
 import { useBindCx } from '../../hooks/useBindCx'
 import { computed } from 'vue'
 
-const { indent = 0 } = defineProps<{
+const { indent = 0, selected = false } = defineProps<{
+  /** The number of indents to render @default 0 */
+  indent?: SidebarGroupLevel
+  /** Whether the indent is selected @default false */
   selected?: boolean
-  indent: SidebarGroupLevel
 }>()
 
 const indents = computed<number[]>(() => {

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
@@ -13,6 +13,7 @@ import { useBindCx } from '../../hooks/useBindCx'
 import { computed } from 'vue'
 
 const { indent = 0 } = defineProps<{
+  selected?: boolean
   indent: SidebarGroupLevel
 }>()
 
@@ -33,8 +34,13 @@ const { cx } = useBindCx()
     <div
       v-for="block in indents"
       :key="block"
-      class="flex w-[var(--scalar-sidebar-indent)]">
-      <div class="ml-1.75 w-border bg-border shrink-0" />
+      class="flex w-[var(--scalar-sidebar-indent)] text-sidebar-indent-border"
+      :class="
+        selected
+          ? 'last:text-sidebar-indent-active'
+          : 'group-hover/item:last:text-sidebar-indent-hover'
+      ">
+      <div class="ml-1.75 w-border bg-current shrink-0" />
     </div>
   </div>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItem.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItem.vue
@@ -33,7 +33,7 @@ const { level } = useSidebarGroups()
 defineOptions({ inheritAttrs: false })
 </script>
 <template>
-  <li class="contents">
+  <li class="group/item contents">
     <ScalarSidebarButton
       v-bind="{ ...$attrs, ...$props }"
       :indent="indent ?? level">

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
@@ -29,7 +29,7 @@ const { cx } = useBindCx()
 <template>
   <component
     :is="is"
-    v-bind="cx('flex flex-col p-3')">
+    v-bind="cx('flex flex-col p-3 gap-px')">
     <slot />
   </component>
 </template>

--- a/packages/components/src/components/ScalarSidebar/types.ts
+++ b/packages/components/src/components/ScalarSidebar/types.ts
@@ -24,4 +24,6 @@ export type ScalarSidebarItemSlots = {
   icon?: () => any
   /** The content to display to the right of the text content */
   aside?: () => any
+  /** The indent to display before content */
+  indent?: () => any
 }

--- a/packages/components/tailwind.config.ts
+++ b/packages/components/tailwind.config.ts
@@ -19,6 +19,42 @@ export default {
   ],
   theme: {
     extend: {
+      colors: {
+        // Sidebar
+        sidebar: {
+          b: {
+            1: 'var(--scalar-sidebar-background-1, var(--scalar-background-1))',
+          },
+          c: {
+            1: 'var(--scalar-sidebar-color-1, var(--scalar-color-1))',
+            2: 'var(--scalar-sidebar-color-2, var(--scalar-color-2))',
+          },
+          h: {
+            b: 'var(--scalar-sidebar-item-hover-background, var(--scalar-background-2))',
+            c: 'var(--scalar-sidebar-item-hover-color, currentColor)',
+          },
+          active: {
+            b: 'var(--scalar-sidebar-item-active-background, var(--scalar-background-2))',
+            c: 'var(--scalar-sidebar-color-active, currentColor)',
+          },
+          border:
+            'var(--scalar-sidebar-border-color, var(--scalar-border-color))',
+          indent: {
+            border:
+              'var(--scalar-sidebar-indent-border, var(--scalar-border-color))',
+            hover:
+              'var(--scalar-sidebar-indent-border-hover, var(--scalar-border-color))',
+            active:
+              'var(--scalar-sidebar-indent-border-active, var(--scalar-color-accent))',
+          },
+          search: {
+            b: 'var(--scalar-sidebar-search-background, var(--scalar-background-2))',
+            c: 'var(--scalar-sidebar-search-color, var(--scalar-color-3))',
+            border:
+              'var(--scalar-sidebar-search-border-color, var(--scalar-border-color))',
+          },
+        },
+      },
       maxWidth: {
         'screen-xxs': '360px',
         'screen-xs': '480px',

--- a/packages/themes/src/presets/alternate.css
+++ b/packages/themes/src/presets/alternate.css
@@ -51,10 +51,6 @@
   --scalar-sidebar-search-background: transparent;
   --scalar-sidebar-search-color: var(--scalar-color-3);
   --scalar-sidebar-search-border-color: var(--scalar-border-color);
-
-  --scalar-sidebar-indent-border: var(--scalar-sidebar-border-color);
-  --scalar-sidebar-indent-border-hover: var(--scalar-sidebar-border-color);
-  --scalar-sidebar-indent-border-active: var(--scalar-sidebar-border-color);
 }
 /* advanced */
 .light-mode .dark-mode,

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -40,6 +40,10 @@
   --scalar-sidebar-item-active-background: var(--scalar-background-2);
   --scalar-sidebar-color-active: var(--scalar-color-1);
 
+  --scalar-sidebar-indent-border: var(--scalar-sidebar-border-color);
+  --scalar-sidebar-indent-border-hover: var(--scalar-sidebar-border-color);
+  --scalar-sidebar-indent-border-active: var(--scalar-color-accent);
+
   --scalar-sidebar-search-background: transparent;
   --scalar-sidebar-search-color: var(--scalar-color-3);
   --scalar-sidebar-search-border-color: var(--scalar-border-color);

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -42,8 +42,8 @@
 
   --scalar-sidebar-indent-border: var(--scalar-sidebar-border-color);
   --scalar-sidebar-indent-border-hover: var(--scalar-sidebar-border-color);
-  --scalar-sidebar-indent-border-active: var(--scalar-color-accent);
-
+  --scalar-sidebar-indent-border-active: var(--scalar-sidebar-border-color);
+  
   --scalar-sidebar-search-background: transparent;
   --scalar-sidebar-search-color: var(--scalar-color-3);
   --scalar-sidebar-search-border-color: var(--scalar-border-color);

--- a/packages/themes/src/variables.css
+++ b/packages/themes/src/variables.css
@@ -67,10 +67,6 @@
   --scalar-lifted-brightness: 1.45;
   --scalar-backdrop-brightness: 0.5;
 
-  --scalar-sidebar-indent-border: transparent;
-  --scalar-sidebar-indent-border-hover: transparent;
-  --scalar-sidebar-indent-border-active: transparent;
-
   --scalar-link-color: var(--scalar-color-accent);
   --scalar-link-color-hover: var(--scalar-color-accent);
   --scalar-text-decoration-color: currentColor;
@@ -89,10 +85,6 @@
 
   --scalar-lifted-brightness: 1;
   --scalar-backdrop-brightness: 1;
-
-  --scalar-sidebar-indent-border: transparent;
-  --scalar-sidebar-indent-border-hover: transparent;
-  --scalar-sidebar-indent-border-active: transparent;
 
   --scalar-link-color: var(--scalar-color-accent);
   --scalar-link-color-hover: var(--scalar-color-accent);

--- a/packages/themes/src/variables.css
+++ b/packages/themes/src/variables.css
@@ -51,6 +51,8 @@
   --scalar-text-decoration: none;
   --scalar-text-decoration-hover: underline;
   --scalar-link-font-weight: inherit;
+
+  --scalar-sidebar-indent: 18px;
 }
 .dark-mode {
   color-scheme: dark;


### PR DESCRIPTION
This PR adds theme-able nesting lines with a customizable offset / spacing.

https://github.com/user-attachments/assets/3e33c03b-6f26-4ed1-b1ca-cfdc504f154e

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
