### PR TITLE
chore(openapi-parser): remove comments

### DIFF
--- a/packages/openapi-parser/src/utils/load/load.test.ts
+++ b/packages/openapi-parser/src/utils/load/load.test.ts
@@ -128,14 +128,6 @@ describe('load', async () => {
       './components/coordinates.yaml',
     ])
 
-    // dirs
-    // expect(filesystem.map((entry) => entry.dir)).toStrictEqual([
-    //   '/Users/hanspagel/Documents/Projects/openapi-parser/packages/openapi-parser/tests/filesystem/api',
-    //   '/Users/hanspagel/Documents/Projects/openapi-parser/packages/openapi-parser/tests/filesystem/api/schemas',
-    //   '/Users/hanspagel/Documents/Projects/openapi-parser/packages/openapi-parser/tests/filesystem/api/schemas',
-    //   '/Users/hanspagel/Documents/Projects/openapi-parser/packages/openapi-parser/tests/filesystem/api/schemas/components',
-    // ])
-
     // specification
     expect(filesystem[0].specification).toBeTypeOf('object')
 


### PR DESCRIPTION
**Problem**
Currently, we have some unnecessary comments in the openapi parser testing.

**Solution**
With this PR we can remove @hanspagel 's filesystem from the test comments 😄 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
