### PR TITLE
feat(api-reference): allow preferredSecurityScheme to bypass security requirements

### DIFF
--- a/.changeset/late-eels-crash.md
+++ b/.changeset/late-eels-crash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: allow preferredSecurityScheme to pre-select a scheme not in the requirements


### PR DESCRIPTION
**Problem**
We made a recent change that the preferred security scheme will only select from the collection requirements.

**Solution**
It no longer needs to be a requirement of the collection.

fixes #4781

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
