### PR TITLE
feat(build-tooling): only lint when vue files are there

### DIFF
--- a/packages/build-tooling/scripts/lint-check.sh
+++ b/packages/build-tooling/scripts/lint-check.sh
@@ -2,4 +2,6 @@
 set -e
 
 biome lint --diagnostic-level=error
-pnpm eslint '**/*.vue'
+if find . -name "*.vue" -type f | grep -q .; then
+    pnpm eslint '**/*.vue'
+fi

--- a/packages/build-tooling/scripts/lint-fix.sh
+++ b/packages/build-tooling/scripts/lint-fix.sh
@@ -2,5 +2,7 @@
 set -e
 
 biome lint --fix
-pnpm eslint '**/*.vue' --fix
+if find . -name "*.vue" -type f | grep -q .; then
+  pnpm eslint '**/*.vue' --fix
+fi
 


### PR DESCRIPTION
**Problem**
The new lint script uses ESLint to lint Vue files, but it tries it even in packages that don’t have Vue files.

**Solution**
Let’s just check whether we have Vue files before running ESLint.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
