### PR TITLE
chore: ignore some updates that are harder to apply

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       interval: 'weekly'
     # This will disable updates, but still create PRs for security updates.
     open-pull-requests-limit: 0
+    # Those mostly have a bigger impact:
+    ignore:
+      - dependency-name: 'vite'
+      - dependency-name: 'vitest'
+      - dependency-name: 'rollup'
   - package-ecosystem: 'nuget'
     directory: '/integrations/aspnetcore'
     schedule:


### PR DESCRIPTION
pls dependabot, stop creating PRs for those dependencies. I won’t update them weekly, but every few months if I feel like it. 

Otherwise it’s just causing some random type errors that I don't want to waste time on.