### PR TITLE
chore(tooling): use node slim base image

### DIFF
--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bullseye AS base
+FROM node:20-slim AS base
 
 # process init system
 RUN apt-get update && apt-get install -y --no-install-recommends dumb-init


### PR DESCRIPTION
**Problem**
Currently, we use a non-slim base image for the scalar base docker image. 

The image `node:20-bullseye` is built on `buildpack-deps` which includes a lot of tooling that is unnecessary for our use case. This image contains a full python installation and `gcc` toolchain for building node modules from C++. This massive package bloat leads to a large image and also opens the door to many more vulnerabilities. 

More info available [here](https://labs.iximiuz.com/tutorials/how-to-choose-nodejs-container-image) 

NOTE: we should be aware of this and if our Dockerfiles are having issues with the npm install step then this is the likely culprit. 

**Solution**
With this PR, we change the base image from `node:20-bullseye` to `node:20-slim` and save almost 1GB in image size.  These are still official, debian based node docker images with lots of standard compiled binaries.`slim` is debian bookworm (current stable release) whereas `bullseye` is "old stable" release

### Before (3.39GB)
![Screenshot 2025-02-18 at 12 20 47 PM](https://github.com/user-attachments/assets/a2595305-476a-4ce8-a407-77e68d459375)
### After (2.56GB)
![Screenshot 2025-02-18 at 12 28 40 PM](https://github.com/user-attachments/assets/622e0435-2bd8-4048-a02b-11abafe1a468)


**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
