### PR TITLE
fix(express-api-reference): package.json points to CJS build

### DIFF
--- a/.changeset/big-cherries-worry.md
+++ b/.changeset/big-cherries-worry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/express-api-reference': patch
+---
+
+fix: package.json points to cjs file

--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -29,8 +29,8 @@
     "types:check": "scalar-types-check"
   },
   "type": "module",
-  "main": "dist/index.cjs",
-  "types": "dist/index.d.cts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -39,7 +39,8 @@
     }
   },
   "files": [
-    "dist"
+    "./dist",
+    "CHANGELOG.md"
   ],
   "module": "dist/index.js",
   "dependencies": {


### PR DESCRIPTION
**Problem**

Currently, the package.json of the Express integration points to the old CJS build that we don’t have anymore

**Solution**

This PR removes it. ✨ 

Fixes #4800

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
