### PR TITLE
feat(fastify-api-reference): pass `logLevel` to registered routes

### DIFF
--- a/.changeset/cyan-camels-exist.md
+++ b/.changeset/cyan-camels-exist.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+feat: pass logLevel to all registered routes

--- a/packages/fastify-api-reference/README.md
+++ b/packages/fastify-api-reference/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/npm/l/%40scalar%2Ffastify-api-reference)](https://www.npmjs.com/package/@scalar/fastify-api-reference)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-This plugin provides an easy way to render a beautiful API reference based on a OpenAPI/Swagger file with Fastify.
+The easiest way to render a beautiful API reference with Fastify. All based on your OpenAPI/Swagger document.
 
 [![Screenshot of an API Reference](https://github.com/scalar/scalar/assets/6201407/d8beb5e1-bf64-4589-8cb0-992ba79215a8)](https://docs.scalar.com/swagger-editor)
 
@@ -25,7 +25,7 @@ await fastify.register(require('@scalar/fastify-api-reference'), {
 
 ## Usage
 
-If you have a OpenAPI/Swagger file already, you can pass an URL to the plugin:
+If you have a OpenAPI/Swagger document already, you can pass an URL to the plugin:
 
 ```ts
 // Render an API reference for a given OpenAPI/Swagger spec URL
@@ -62,6 +62,17 @@ await fastify.register(require('@scalar/fastify-api-reference'), {
   configuration: {
     theme: 'purple',
   },
+})
+```
+
+## Logging
+
+The plugin is compatible with the Fastify logger. You can configure the log level for the routes registered by the plugin:
+
+```ts
+fastify.register(require('@scalar/fastify-api-reference'), {
+  routePrefix: '/reference',
+  logLevel: 'silent',
 })
 ```
 

--- a/packages/fastify-api-reference/src/fastifyApiReference.ts
+++ b/packages/fastify-api-reference/src/fastifyApiReference.ts
@@ -231,6 +231,7 @@ const fastifyApiReference = fp<
       // @ts-ignore We don’t know whether @fastify/swagger is loaded.
       schema: schemaToHideRoute,
       ...hooks,
+      ...(options.logLevel && { logLevel: options.logLevel }),
       async handler(_, reply) {
         const spec = getLoadedSpecIfAvailable()
         const filename: string = await getSpecFilenameSlug(spec)
@@ -251,6 +252,7 @@ const fastifyApiReference = fp<
       // @ts-ignore We don’t know whether @fastify/swagger is loaded.
       schema: schemaToHideRoute,
       ...hooks,
+      ...(options.logLevel && { logLevel: options.logLevel }),
       async handler(_, reply) {
         const spec = getLoadedSpecIfAvailable()
         const filename: string = await getSpecFilenameSlug(spec)
@@ -277,6 +279,7 @@ const fastifyApiReference = fp<
         // @ts-ignore We don't know whether @fastify/swagger is loaded.
         schema: schemaToHideRoute,
         ...hooks,
+        ...(options.logLevel && { logLevel: options.logLevel }),
         handler(_, reply) {
           return reply.redirect(getRoutePrefix(options.routePrefix) + '/', 302)
         },
@@ -291,6 +294,7 @@ const fastifyApiReference = fp<
       // @ts-ignore We don’t know whether @fastify/swagger is loaded.
       schema: schemaToHideRoute,
       ...hooks,
+      ...(options.logLevel && { logLevel: options.logLevel }),
       handler(_, reply) {
         // Redirect if it’s the route without a slash
         const currentUrl = new URL(_.url, `${_.protocol}://${_.hostname}`)
@@ -337,6 +341,7 @@ const fastifyApiReference = fp<
       // @ts-ignore We don’t know whether @fastify/swagger is loaded.
       schema: schemaToHideRoute,
       ...hooks,
+      ...(options.logLevel && { logLevel: options.logLevel }),
       handler(_, reply) {
         return reply.header('Content-Type', 'application/javascript; charset=utf-8').send(fileContent)
       },

--- a/packages/fastify-api-reference/src/types.ts
+++ b/packages/fastify-api-reference/src/types.ts
@@ -58,6 +58,11 @@ export type FastifyApiReferenceOptions = {
    * The hooks for the API Reference.
    */
   hooks?: FastifyApiReferenceHooksOptions
+  /**
+   * The log level for all routes registered by this plugin.
+   * Set to 'silent' to disable logging for these routes.
+   */
+  logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent'
 }
 
 export type FastifyApiReferenceHooksOptions = Partial<{


### PR DESCRIPTION
**Problem**
Currently, we just use the default logger settings. If you want to override the setting for the logLevel for our routes, there’s no way to do this.

**Solution**
With this PR we’re passing an (optional) `logLevel` to all registered routes.

Fixes #4783

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.