### PR TITLE
feat(api-reference): render Markdown in the response list

### DIFF
--- a/.changeset/hungry-schools-doubt.md
+++ b/.changeset/hungry-schools-doubt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: markdown for the response description

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { SchemaProperty } from '@/components/Content/Schema'
-import ScreenReader from '@/components/ScreenReader.vue'
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 import type { ContentType } from '@scalar/types/legacy'
 import { computed, ref } from 'vue'
+
+import { SchemaProperty } from '@/components/Content/Schema'
+import ScreenReader from '@/components/ScreenReader.vue'
 
 import ContentTypeSelect from './ContentTypeSelect.vue'
 import ParameterHeaders from './ParameterHeaders.vue'
@@ -63,7 +64,7 @@ const shouldShowParameter = computed(() => {
     <Disclosure v-slot="{ open }">
       <DisclosureButton
         v-if="shouldCollapse"
-        class="flex parameter-item-trigger"
+        class="parameter-item-trigger flex"
         :class="{ 'parameter-item-trigger-open': open }">
         <ScalarIcon
           class="parameter-item-icon"
@@ -76,7 +77,10 @@ const shouldShowParameter = computed(() => {
           {{ parameter.name }}
         </span>
         <span class="parameter-item-type">
-          {{ parameter.description }}
+          <ScalarMarkdown
+            v-if="parameter.description"
+            class="markdown"
+            :value="parameter.description" />
         </span>
         <div class="absolute right-0">
           <ContentTypeSelect


### PR DESCRIPTION
**Problem**
Currently, we’re rendering Markdown in the response description on the right side, but not on the left side. That’s inconsistent.

**Solution**
With this PR we’re rendering Markdown on the left side, too.

Fixes #4747

**Before**

<img width="969" alt="Screenshot 2025-02-18 at 13 57 42" src="https://github.com/user-attachments/assets/9fae480f-faa9-4f15-bd8c-24bc89a394fb" />

**After**

<img width="980" alt="Screenshot 2025-02-18 at 13 57 26" src="https://github.com/user-attachments/assets/fb8923d2-3533-4b3f-aca7-ba3337db5aa9" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.