### PR TITLE
fix(api-reference): renders arrays with discriminators four times instead of once

### DIFF
--- a/.changeset/perfect-news-love.md
+++ b/.changeset/perfect-news-love.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: renders arrays with discriminators four times instead of once

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -277,4 +277,27 @@ describe('SchemaProperty sub-schema', () => {
     const enumValues = wrapper.findAll('.property-enum-value')
     expect(enumValues).toHaveLength(3)
   })
+
+  it('renders discriminators for array items', () => {
+    const wrapper = mount(SchemaProperty, {
+      props: {
+        value: {
+          type: 'array',
+          items: {
+            oneOf: [
+              {
+                type: 'object',
+                description: 'foobar',
+                properties: { test: { type: 'string' } },
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    // Find 'foobar' only once
+    const foobar = wrapper.html().match(/foobar/g)
+    expect(foobar).toHaveLength(1)
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -1,12 +1,13 @@
 <script lang="ts" setup>
+import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
+import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
+import { computed } from 'vue'
+
 import { formatExample } from '@/components/Content/Schema/helpers/formatExample'
 import {
   discriminators,
   optimizeValueForDisplay,
 } from '@/components/Content/Schema/helpers/optimizeValueForDisplay'
-import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
-import { computed } from 'vue'
 
 import Schema from './Schema.vue'
 import SchemaPropertyHeading from './SchemaPropertyHeading.vue'
@@ -55,10 +56,10 @@ const descriptions: Record<string, Record<string, string>> = {
   },
 }
 
-const displayDescription = function (
+const displayDescription = (
   description: string | undefined,
   value?: Record<string, any>,
-) {
+) => {
   if (value?.properties) {
     return null
   }
@@ -74,7 +75,7 @@ const displayDescription = function (
   return description || value?.description || null
 }
 
-const generatePropertyDescription = function (property?: Record<string, any>) {
+const generatePropertyDescription = (property?: Record<string, any>) => {
   if (!property) {
     return null
   }
@@ -86,9 +87,8 @@ const generatePropertyDescription = function (property?: Record<string, any>) {
   return descriptions[property.type][property.format || '_default']
 }
 
-const getEnumFromValue = function (value?: Record<string, any>): any[] | [] {
-  return value?.enum || value?.items?.enum || []
-}
+const getEnumFromValue = (value?: Record<string, any>): any[] | [] =>
+  value?.enum || value?.items?.enum || []
 
 // These helpers manage how enum values are displayed:
 //
@@ -310,15 +310,15 @@ const discriminatorType = discriminators.find((r) => {
       <div
         v-if="
           optimizedValue?.items &&
-          typeof discriminatorType === 'string' &&
+          typeof discriminator === 'string' &&
           typeof optimizedValue.items === 'object' &&
-          discriminatorType in optimizedValue.items &&
-          Array.isArray(optimizedValue.items[discriminatorType]) &&
+          discriminator in optimizedValue.items &&
+          Array.isArray(optimizedValue.items[discriminator]) &&
           level < 3
         "
         class="property-rule">
         <Schema
-          v-for="schema in optimizedValue.items[discriminatorType]"
+          v-for="schema in optimizedValue.items[discriminator]"
           :key="schema.id"
           :compact="compact"
           :level="level + 1"


### PR DESCRIPTION
**Problem**
Currently, we’re rendering arrays with discriminators (oneOf, anyOf …) four times. The reason is a typo, where we loop through all four possible discriminators and output the schema every time.

**Solution**
With this PR we’re only rendering the specified discriminator, which

closes #4807

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.