### PR TITLE
fix(api-client): virtualization issues causing tab to be unresponsive

### DIFF
--- a/.changeset/eleven-pillows-leave.md
+++ b/.changeset/eleven-pillows-leave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: virtualization issues causing tab to be unresponsive

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -37,7 +37,7 @@ const { mimeType, attachmentFilename, dataUrl } = useResponseBody({
       This response body is massive! Syntax highlighting won’t work here.
     </div>
     <ScalarVirtualText
-      containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1 max-h-[100vh]"
+      containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1 max-h-screen"
       contentClass="language-plaintext whitespace-pre font-code text-base"
       :lineHeight="20"
       :text="textContent" />

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -37,7 +37,7 @@ const { mimeType, attachmentFilename, dataUrl } = useResponseBody({
       This response body is massive! Syntax highlighting won’t work here.
     </div>
     <ScalarVirtualText
-      containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1"
+      containerClass="custom-scroll scalar-code-block border-1/2 rounded-b flex flex-1 max-h-[100vh]"
       contentClass="language-plaintext whitespace-pre font-code text-base"
       :lineHeight="20"
       :text="textContent" />


### PR DESCRIPTION
**Problem**
Currently, on small screens virtualization was not working since the container did not have a fixed height so it was taking up all the space. That was causing all the response body to be rendered which was making the tab unresponsive

See  #4757 

**Solution**
With this PR we set a max height on the container in order to make virtualization work on smaller screens.

**Checklist**

I’ve gone through the following:

- [X] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
