### PR TITLE
fix(api-client): request body file upload

### DIFF
--- a/.changeset/shaggy-beans-peel.md
+++ b/.changeset/shaggy-beans-peel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates file upload row content and logic

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -371,6 +371,8 @@ const handleFileUploadFormData = async (rowIdx: number) => {
           'body.formData.value',
           updatedParams,
         )
+
+        defaultRow()
       }
     },
     multiple: false,
@@ -388,13 +390,14 @@ function handleRemoveFileFormData(rowIdx: number) {
   if (!activeRequest.value || !activeExample.value) return
   const currentParams = formParams.value
   const updatedParams = [...currentParams]
-  updatedParams[rowIdx] = {
-    ...updatedParams[rowIdx],
-    file: undefined,
-    value: '',
-    key: '',
-    enabled: false,
+
+  if (currentParams.length > 1) {
+    // Removes the row if not the last one
+    updatedParams.splice(rowIdx, 1)
+  } else {
+    defaultRow()
   }
+
   requestExampleMutators.edit(
     activeExample.value.uid,
     'body.formData.value',

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -1,4 +1,11 @@
 <script setup lang="ts">
+import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import { requestExampleParametersSchema } from '@scalar/oas-utils/entities/spec'
+import { canMethodHaveBody } from '@scalar/oas-utils/helpers'
+import type { CodeMirrorLanguage } from '@scalar/use-codemirror'
+import type { Entries } from 'type-fest'
+import { computed, nextTick, ref, watch } from 'vue'
+
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
 import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableHeader from '@/components/DataTable/DataTableHeader.vue'
@@ -7,12 +14,6 @@ import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useFileDialog } from '@/hooks'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
-import { requestExampleParametersSchema } from '@scalar/oas-utils/entities/spec'
-import { canMethodHaveBody } from '@scalar/oas-utils/helpers'
-import type { CodeMirrorLanguage } from '@scalar/use-codemirror'
-import type { Entries } from 'type-fest'
-import { computed, nextTick, ref, watch } from 'vue'
 
 import RequestTable from './RequestTable.vue'
 
@@ -498,7 +499,7 @@ const selectedExample = computed({
             :options="contentTypeOptions"
             teleport>
             <ScalarButton
-              class="flex gap-1.5 h-full px-3 text-c-2 font-normal hover:text-c-1 w-fit"
+              class="text-c-2 hover:text-c-1 flex h-full w-fit gap-1.5 px-3 font-normal"
               fullWidth
               variant="ghost">
               <span>{{ selectedContentType?.label }}</span>
@@ -514,7 +515,7 @@ const selectedExample = computed({
             side="left"
             teleport>
             <ScalarButton
-              class="flex gap-1.5 h-full px-2 text-c-2 font-normal hover:text-c-1 w-fit"
+              class="text-c-2 hover:text-c-1 flex h-full w-fit gap-1.5 px-2 font-normal"
               fullWidth
               variant="ghost">
               <span>{{ selectedExample?.label }}</span>
@@ -534,14 +535,14 @@ const selectedExample = computed({
         </template>
         <template v-else-if="selectedContentType?.id === 'binaryFile'">
           <div
-            class="border-t flex items-center justify-center p-1.5 overflow-hidden">
+            class="flex items-center justify-center overflow-hidden border-t p-1.5">
             <template v-if="activeExample?.body.binary">
               <span
-                class="text-c-2 text-xs w-full border rounded py-1 px-1.5 max-w-full overflow-hidden whitespace-nowrap">
+                class="text-c-2 w-full max-w-full overflow-hidden whitespace-nowrap rounded border px-1.5 py-1 text-xs">
                 {{ (activeExample?.body.binary as File).name }}
               </span>
               <ScalarButton
-                class="bg-b-2 hover:bg-b-3 border-0 text-c-2 ml-1 shadow-none"
+                class="bg-b-2 hover:bg-b-3 text-c-2 ml-1 border-0 shadow-none"
                 size="sm"
                 variant="outlined"
                 @click="removeBinaryFile">
@@ -550,7 +551,7 @@ const selectedExample = computed({
             </template>
             <template v-else>
               <ScalarButton
-                class="bg-b-2 hover:bg-b-3 border-0 text-c-2 shadow-none"
+                class="bg-b-2 hover:bg-b-3 text-c-2 border-0 shadow-none"
                 size="sm"
                 variant="outlined"
                 @click="handleFileUpload">
@@ -567,8 +568,8 @@ const selectedExample = computed({
         <template v-else-if="selectedContentType?.id == 'multipartForm'">
           <RequestTable
             ref="tableWrapperRef"
-            class="!m-0 rounded-t-none shadow-none border-l-0 border-r-0 border-t-0 border-b-0"
-            :columns="['32px', '', '', '61px']"
+            class="!m-0 rounded-t-none border-b-0 border-l-0 border-r-0 border-t-0 shadow-none"
+            :columns="['32px', '', '', '104px']"
             :items="formParams"
             showUploadButton
             @deleteRow="deleteRow"
@@ -580,8 +581,8 @@ const selectedExample = computed({
         <template v-else-if="selectedContentType?.id == 'formUrlEncoded'">
           <RequestTable
             ref="tableWrapperRef"
-            class="!m-0 rounded-t-none border-t-0 shadow-none border-l-0 border-r-0 border-t-0 border-b-0"
-            :columns="['32px', '', '', '61px']"
+            class="!m-0 rounded-t-none border-b-0 border-l-0 border-r-0 border-t-0 shadow-none"
+            :columns="['32px', '', '', '104px']"
             :items="formParams"
             showUploadButton
             @deleteRow="deleteRow"

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
+import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
+import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
+import { computed } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
+
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
 import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableCell from '@/components/DataTable/DataTableCell.vue'
 import DataTableCheckbox from '@/components/DataTable/DataTableCheckbox.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
-import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
-import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
-import { computed } from 'vue'
-import type { RouteLocationRaw } from 'vue-router'
 
 import { hasItemProperties } from '../libs/request'
 import RequestTableTooltip from './RequestTableTooltip.vue'
@@ -85,7 +86,7 @@ const flattenValue = (item: RequestExampleParameter) => {
       <label class="contents">
         <template v-if="isGlobal">
           <RouterLink
-            class="!border-r-1/2 border-t-1/2 text-c-2 flex justify-center items-center"
+            class="!border-r-1/2 border-t-1/2 text-c-2 flex items-center justify-center"
             :to="item.route ?? {}">
             <span class="sr-only">Global</span>
             <ScalarTooltip
@@ -99,8 +100,8 @@ const flattenValue = (item: RequestExampleParameter) => {
               </template>
               <template #content>
                 <div
-                  class="grid gap-1.5 pointer-events-none max-w-[320px] w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
-                  <div class="flex items-center text-c-1">
+                  class="w-content bg-b-1 z-100 text-xxs text-c-1 pointer-events-none z-10 grid max-w-[320px] gap-1.5 rounded p-2 leading-5 shadow-lg">
+                  <div class="text-c-1 flex items-center">
                     <span class="text-pretty">
                       Global cookies are shared across the whole workspace.
                     </span>
@@ -175,14 +176,14 @@ const flattenValue = (item: RequestExampleParameter) => {
       </DataTableCell>
       <DataTableCell
         v-if="showUploadButton"
-        class="group/upload p-1 overflow-hidden relative text-ellipsis whitespace-nowrap">
+        class="group/upload relative overflow-hidden text-ellipsis whitespace-nowrap p-1">
         <template v-if="item.file">
           <div
-            class="text-c-2 max-w-[100%] overflow-hidden filemask flex items-end justify-end">
+            class="text-c-2 filemask flex max-w-[100%] items-end justify-end overflow-hidden">
             <span>{{ item.file?.name }}</span>
           </div>
           <button
-            class="absolute bg-b-2 font-medium centered-x centered-y hidden rounded text-center p-0.5 w-[calc(100%_-_8px)] group-hover/upload:block text-xs"
+            class="bg-b-2 centered-x centered-y absolute hidden w-[calc(100%_-_8px)] rounded p-0.5 text-center text-xs font-medium group-hover/upload:block"
             type="button"
             @click="emit('removeFile', idx)">
             Delete
@@ -190,11 +191,11 @@ const flattenValue = (item: RequestExampleParameter) => {
         </template>
         <template v-else>
           <ScalarButton
-            class="bg-b-2 hover:bg-b-3 border-0 py-px text-c-2 shadow-none"
+            class="bg-b-2 hover:bg-b-3 text-c-2 border-0 py-px shadow-none"
             size="sm"
             variant="outlined"
             @click="handleFileUpload(idx)">
-            <span>File</span>
+            <span>Upload File</span>
             <ScalarIcon
               class="ml-1"
               icon="UploadSimple"


### PR DESCRIPTION
**Problem**
currently the request body file cta might not seen very understandable only displaying `File` and no default empty row is added on upload.

**Solution**
this pr is a proposal to use `Upload File` as already used for binary file + fix the row management.

| before | after |
| -------|------|
| <img width="608" alt="image" src="https://github.com/user-attachments/assets/a71f7bdb-f30a-4382-8eab-435acd735f25" /> | <img width="608" alt="image" src="https://github.com/user-attachments/assets/d563c341-5fa0-4333-ba4f-ed36e6b3be1d" /> |
| default row not added on upload | default row added on upload + cta updated | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).