### PR TITLE
feat(oas-utils): add brand to all zod uids

### DIFF
--- a/packages/api-client/src/components/ImportCollection/OperationBadge.vue
+++ b/packages/api-client/src/components/ImportCollection/OperationBadge.vue
@@ -14,8 +14,11 @@ const requestMethod = computed(() => {
 
 <template>
   <div
-    :class="`inline-flex items-center gap-2 py-1.5 px-2.5 text-sm font-medium font-code rounded whitespace-nowrap ${requestMethod.color} ${requestMethod.backgroundColor} bg-mix-transparent bg-mix-amount-90`">
-    <div class="text-xs">{{ requestMethod.short }}</div>
+    v-if="requestMethod"
+    :class="`font-code inline-flex items-center gap-2 whitespace-nowrap rounded px-2.5 py-1.5 text-sm font-medium ${requestMethod.color} ${requestMethod.backgroundColor} bg-mix-transparent bg-mix-amount-90`">
+    <div class="text-xs">
+      {{ requestMethod.short }}
+    </div>
     <div>{{ name }}</div>
   </div>
 </template>

--- a/packages/oas-utils/src/entities/cookie/cookie.ts
+++ b/packages/oas-utils/src/entities/cookie/cookie.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { nanoidSchema } from '../shared'
 
 export const cookieSchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand('cookie'),
   /**  Defines the cookie name and its value. A cookie definition begins with a name-value pair.  */
   name: z.string().default(''),
   value: z.string().default(''),

--- a/packages/oas-utils/src/entities/environment/environment.ts
+++ b/packages/oas-utils/src/entities/environment/environment.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { nanoidSchema } from '../shared'
 
 export const environmentSchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand('environment'),
   name: z.string().optional().default('Default Environment'),
   color: z.string().optional().default('#0082D0'),
   value: z.string().default(''),

--- a/packages/oas-utils/src/entities/shared/utility.ts
+++ b/packages/oas-utils/src/entities/shared/utility.ts
@@ -13,10 +13,8 @@ export type Nanoid = z.infer<typeof nanoidSchema>
 
 /** Schema for selectedSecuritySchemeUids */
 export const selectedSecuritySchemeUidSchema = z
-  .union([nanoidSchema, nanoidSchema.array()])
+  .union([nanoidSchema.brand('securityScheme'), nanoidSchema.brand('securityScheme').array()])
   .array()
   .default([])
 
-export type SelectedSecuritySchemeUids = z.infer<
-  typeof selectedSecuritySchemeUidSchema
->
+export type SelectedSecuritySchemeUids = z.infer<typeof selectedSecuritySchemeUidSchema>

--- a/packages/oas-utils/src/entities/spec/collection.ts
+++ b/packages/oas-utils/src/entities/spec/collection.ts
@@ -56,7 +56,7 @@ export const extendedCollectionSchema = z.object({
   /** UIDs which refer to servers on the workspace base */
   servers: nanoidSchema.brand('server').array().default([]),
   /** Request UIDs associated with a collection */
-  requests: nanoidSchema.brand('request').array().default([]),
+  requests: nanoidSchema.brand('operation').array().default([]),
   /** Tag UIDs associated with the collection */
   tags: nanoidSchema.brand('tag').array().default([]),
   /** List of requests without tags and top level tag "folders" */

--- a/packages/oas-utils/src/entities/spec/collection.ts
+++ b/packages/oas-utils/src/entities/spec/collection.ts
@@ -1,7 +1,4 @@
-import {
-  nanoidSchema,
-  selectedSecuritySchemeUidSchema,
-} from '@/entities/shared/utility'
+import { nanoidSchema, selectedSecuritySchemeUidSchema } from '@/entities/shared/utility'
 import { xScalarEnvironmentsSchema } from '@/entities/spec/x-scalar-environments'
 import { xScalarSecretsSchema } from '@/entities/spec/x-scalar-secrets'
 import { z } from 'zod'
@@ -17,12 +14,7 @@ export const oasCollectionSchema = z.object({
    */
   'type': z.literal('collection').optional().default('collection'),
   'openapi': z
-    .union([
-      z.string(),
-      z.literal('3.0.0'),
-      z.literal('3.1.0'),
-      z.literal('4.0.0'),
-    ])
+    .union([z.string(), z.literal('3.0.0'), z.literal('3.1.0'), z.literal('4.0.0')])
     .optional()
     .default('3.1.0'),
   'jsonSchemaDialect': z.string().optional(),
@@ -54,7 +46,7 @@ export const oasCollectionSchema = z.object({
 })
 
 export const extendedCollectionSchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand('collection'),
   /** A list of security schemes UIDs associated with the collection */
   securitySchemes: z.string().array().default([]),
   /** List of currently selected security scheme UIDs, these can be overridden per request */
@@ -62,13 +54,13 @@ export const extendedCollectionSchema = z.object({
   /** The currently selected server */
   selectedServerUid: z.string().default(''),
   /** UIDs which refer to servers on the workspace base */
-  servers: nanoidSchema.array().default([]),
+  servers: nanoidSchema.brand('server').array().default([]),
   /** Request UIDs associated with a collection */
-  requests: nanoidSchema.array().default([]),
+  requests: nanoidSchema.brand('request').array().default([]),
   /** Tag UIDs associated with the collection */
-  tags: nanoidSchema.array().default([]),
+  tags: nanoidSchema.brand('tag').array().default([]),
   /** List of requests without tags and top level tag "folders" */
-  children: nanoidSchema.array().default([]),
+  children: nanoidSchema.brand('collection').array().default([]),
   /**
    * A link to where this document is stored
    *
@@ -89,14 +81,9 @@ export const extendedCollectionSchema = z.object({
    *
    * @defaults to idle for all collections, doesn't mean that it can watch for changes
    */
-  watchModeStatus: z
-    .enum(['IDLE', 'WATCHING', 'ERROR'])
-    .optional()
-    .default('IDLE'),
+  watchModeStatus: z.enum(['IDLE', 'WATCHING', 'ERROR']).optional().default('IDLE'),
 })
 
-export const collectionSchema = oasCollectionSchema.merge(
-  extendedCollectionSchema,
-)
+export const collectionSchema = oasCollectionSchema.merge(extendedCollectionSchema)
 export type Collection = z.infer<typeof collectionSchema>
 export type CollectionPayload = z.input<typeof collectionSchema>

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -1,9 +1,6 @@
 import { nanoidSchema } from '@/entities/shared'
 import { schemaModel } from '@/helpers'
-import {
-  getRequestBodyFromOperation,
-  getServerVariableExamples,
-} from '@/spec-getters'
+import { getRequestBodyFromOperation, getServerVariableExamples } from '@/spec-getters'
 import { keysOf } from '@scalar/object-utils/arrays'
 import { z } from 'zod'
 
@@ -52,11 +49,7 @@ export const requestExampleParametersSchema = z
     }
 
     // Hey, if it’s just one value and 'null', we can make it a string and ditch the 'null'.
-    if (
-      Array.isArray(data.type) &&
-      data.type.length === 2 &&
-      data.type.includes('null')
-    ) {
+    if (Array.isArray(data.type) && data.type.length === 2 && data.type.includes('null')) {
       data = { ...data, type: data.type.find((item) => item !== 'null') }
     }
 
@@ -72,9 +65,7 @@ export function parameterArrayToObject(params: RequestExampleParameter[]) {
 }
 
 /** Request examples - formerly known as instances - are "children" of requests */
-export type RequestExampleParameter = z.infer<
-  typeof requestExampleParametersSchema
->
+export type RequestExampleParameter = z.infer<typeof requestExampleParametersSchema>
 
 export const xScalarFileValueSchema = z
   .object({
@@ -115,15 +106,7 @@ export type XScalarFormDataValue = z.infer<typeof xScalarFormDataValue>
  *
  * TODO: This list may not be comprehensive enough
  */
-export const exampleRequestBodyEncoding = [
-  'json',
-  'text',
-  'html',
-  'javascript',
-  'xml',
-  'yaml',
-  'edn',
-] as const
+export const exampleRequestBodyEncoding = ['json', 'text', 'html', 'javascript', 'xml', 'yaml', 'edn'] as const
 
 export type BodyEncoding = (typeof exampleRequestBodyEncoding)[number]
 
@@ -168,16 +151,12 @@ export const exampleRequestBodySchema = z.object({
     .optional(),
   formData: z
     .object({
-      encoding: z
-        .union([z.literal('form-data'), z.literal('urlencoded')])
-        .default('form-data'),
+      encoding: z.union([z.literal('form-data'), z.literal('urlencoded')]).default('form-data'),
       value: requestExampleParametersSchema.array().default([]),
     })
     .optional(),
   binary: z.instanceof(Blob).optional(),
-  activeBody: z
-    .union([z.literal('raw'), z.literal('formData'), z.literal('binary')])
-    .default('raw'),
+  activeBody: z.union([z.literal('raw'), z.literal('formData'), z.literal('binary')]).default('raw'),
 })
 
 export type ExampleRequestBody = z.infer<typeof exampleRequestBodySchema>
@@ -201,18 +180,16 @@ export type XScalarExampleBody = z.infer<typeof xScalarExampleBodySchema>
 // Example Schema
 
 export const requestExampleSchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand('requestExample'),
   type: z.literal('requestExample').optional().default('requestExample'),
-  requestUid: nanoidSchema,
+  requestUid: nanoidSchema.brand('request'),
   name: z.string().optional().default('Name'),
   body: exampleRequestBodySchema.optional().default({}),
   parameters: z
     .object({
       path: requestExampleParametersSchema.array().default([]),
       query: requestExampleParametersSchema.array().default([]),
-      headers: requestExampleParametersSchema
-        .array()
-        .default([{ key: 'Accept', value: '*/*', enabled: true }]),
+      headers: requestExampleParametersSchema.array().default([{ key: 'Accept', value: '*/*', enabled: true }]),
       cookies: requestExampleParametersSchema.array().default([]),
     })
     .optional()
@@ -224,9 +201,7 @@ export const requestExampleSchema = z.object({
 export type RequestExample = z.infer<typeof requestExampleSchema>
 
 /** For OAS serialization we just store the simple key/value pairs */
-const xScalarExampleParameterSchema = z
-  .record(z.string(), z.string())
-  .optional()
+const xScalarExampleParameterSchema = z.record(z.string(), z.string()).optional()
 
 /** Schema for the OAS serialization of request examples */
 export const xScalarExampleSchema = z.object({
@@ -264,15 +239,10 @@ export function convertExampleToXScalar(example: RequestExample) {
 
   if (active === 'formData' && example.body?.[active]) {
     const body = example.body[active]
-    xScalarBody.encoding =
-      body.encoding === 'form-data'
-        ? 'multipart/form-data'
-        : 'application/x-www-form-urlencoded'
+    xScalarBody.encoding = body.encoding === 'form-data' ? 'multipart/form-data' : 'application/x-www-form-urlencoded'
 
     // TODO: Need to allow users to set these properties
-    xScalarBody.content = body.value.reduce<
-      Record<string, XScalarFormDataValue>
-    >((map, param) => {
+    xScalarBody.content = body.value.reduce<Record<string, XScalarFormDataValue>>((map, param) => {
       /** TODO: We need to ensure only file or value is set */
       map[param.key] = param.file
         ? {
@@ -288,8 +258,7 @@ export function convertExampleToXScalar(example: RequestExample) {
   }
 
   if (example.body?.activeBody === 'raw') {
-    xScalarBody.encoding =
-      contentMapping[example.body.raw?.encoding ?? 'text'] ?? 'text/plain'
+    xScalarBody.encoding = contentMapping[example.body.raw?.encoding ?? 'text'] ?? 'text/plain'
 
     xScalarBody.content = example.body.raw?.value ?? ''
   }
@@ -304,10 +273,7 @@ export function convertExampleToXScalar(example: RequestExample) {
 
   return xScalarExampleSchema.parse({
     /** Only add the body if we have content or the body should be a file */
-    body:
-      xScalarBody.content || xScalarBody.encoding === 'binary'
-        ? xScalarBody
-        : undefined,
+    body: xScalarBody.content || xScalarBody.encoding === 'binary' ? xScalarBody : undefined,
     parameters,
   })
 }
@@ -328,12 +294,7 @@ export function createParamInstance(param: RequestParameter) {
    * - Need to handle unions/array values for schema
    */
   const value = String(
-    schema?.default ??
-      schema?.examples?.[0] ??
-      schema?.example ??
-      firstExample?.value ??
-      param.example ??
-      '',
+    schema?.default ?? schema?.examples?.[0] ?? schema?.example ?? firstExample?.value ?? param.example ?? '',
   )
 
   // Handle non-string enums and enums within items for array types
@@ -345,10 +306,7 @@ export function createParamInstance(param: RequestParameter) {
         : schema?.enum
 
   // Handle non-string examples
-  const parseExamples =
-    schema?.examples && schema?.type !== 'string'
-      ? schema.examples?.map(String)
-      : schema?.examples
+  const parseExamples = schema?.examples && schema?.type !== 'string' ? schema.examples?.map(String) : schema?.examples
 
   // safe parse the example
   const example = schemaModel(
@@ -377,17 +335,10 @@ export function createParamInstance(param: RequestParameter) {
  * Create new request example from a request
  * Iterates the name of the example if provided
  */
-export function createExampleFromRequest(
-  request: Request,
-  name: string,
-  server?: Server,
-): RequestExample {
+export function createExampleFromRequest(request: Request, name: string, server?: Server): RequestExample {
   // ---------------------------------------------------------------------------
   // Populate all parameters with an example value
-  const parameters: Record<
-    'path' | 'cookie' | 'header' | 'query' | 'headers',
-    RequestExampleParameter[]
-  > = {
+  const parameters: Record<'path' | 'cookie' | 'header' | 'query' | 'headers', RequestExampleParameter[]> = {
     path: [],
     query: [],
     cookie: [],
@@ -397,9 +348,7 @@ export function createExampleFromRequest(
   }
 
   // Populated the separated params
-  request.parameters?.forEach((p) =>
-    parameters[p.in].push(createParamInstance(p)),
-  )
+  request.parameters?.forEach((p) => parameters[p.in].push(createParamInstance(p)))
 
   // TODO: add zod transform to remove header and only support headers
   if (parameters.header.length > 0) {
@@ -452,10 +401,7 @@ export function createExampleFromRequest(
     ) {
       body.activeBody = 'formData'
       body.formData = {
-        encoding:
-          requestBody.mimeType === 'application/x-www-form-urlencoded'
-            ? 'urlencoded'
-            : 'form-data',
+        encoding: requestBody.mimeType === 'application/x-www-form-urlencoded' ? 'urlencoded' : 'form-data',
         value: (requestBody.params || []).map((param) => ({
           key: param.name,
           value: param.value || '',
@@ -465,10 +411,7 @@ export function createExampleFromRequest(
     }
 
     // Add the content-type header if it doesn't exist
-    if (
-      requestBody?.mimeType &&
-      !parameters.headers.find((h) => h.key.toLowerCase() === 'content-type')
-    ) {
+    if (requestBody?.mimeType && !parameters.headers.find((h) => h.key.toLowerCase() === 'content-type')) {
       parameters.headers.push({
         key: 'Content-Type',
         value: requestBody.mimeType,

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -182,7 +182,7 @@ export type XScalarExampleBody = z.infer<typeof xScalarExampleBodySchema>
 export const requestExampleSchema = z.object({
   uid: nanoidSchema.brand('requestExample'),
   type: z.literal('requestExample').optional().default('requestExample'),
-  requestUid: nanoidSchema.brand('request'),
+  requestUid: nanoidSchema.brand('operation'),
   name: z.string().optional().default('Name'),
   body: exampleRequestBodySchema.optional().default({}),
   parameters: z

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -103,7 +103,7 @@ export const oasRequestSchema = z.object({
  */
 const extendedRequestSchema = z.object({
   type: z.literal('request').optional().default('request'),
-  uid: nanoidSchema.brand('request'),
+  uid: nanoidSchema.brand('operation'),
   /** Path Key */
   path: z.string().optional().default(''),
   /** Request Method */

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -1,7 +1,4 @@
-import {
-  nanoidSchema,
-  selectedSecuritySchemeUidSchema,
-} from '@/entities/shared/utility'
+import { nanoidSchema, selectedSecuritySchemeUidSchema } from '@/entities/shared/utility'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { type ZodSchema, z } from 'zod'
 
@@ -10,17 +7,7 @@ import { type RequestExample, xScalarExampleSchema } from './request-examples'
 import { oasSecurityRequirementSchema } from './security'
 import { oasExternalDocumentationSchema } from './spec-objects'
 
-export const requestMethods = [
-  'connect',
-  'delete',
-  'get',
-  'head',
-  'options',
-  'patch',
-  'post',
-  'put',
-  'trace',
-] as const
+export const requestMethods = ['connect', 'delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'trace'] as const
 
 export type RequestMethod = (typeof requestMethods)[number]
 
@@ -116,25 +103,23 @@ export const oasRequestSchema = z.object({
  */
 const extendedRequestSchema = z.object({
   type: z.literal('request').optional().default('request'),
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand('request'),
   /** Path Key */
   path: z.string().optional().default(''),
   /** Request Method */
   method: z.enum(requestMethods).default('get'),
   /** List of server UIDs specific to the request */
-  servers: nanoidSchema.array().default([]),
+  servers: nanoidSchema.brand('server').array().default([]),
   /** The currently selected server */
   selectedServerUid: z.string().default(''),
   /** List of example UIDs associated with the request */
-  examples: nanoidSchema.array().default([]),
+  examples: nanoidSchema.brand('requestExample').array().default([]),
   /** List of security scheme UIDs associated with the request */
   selectedSecuritySchemeUids: selectedSecuritySchemeUidSchema,
 })
 
 /** Unified request schema for client usage */
-export const requestSchema = oasRequestSchema
-  .omit({ 'x-scalar-examples': true })
-  .merge(extendedRequestSchema)
+export const requestSchema = oasRequestSchema.omit({ 'x-scalar-examples': true }).merge(extendedRequestSchema)
 
 export type Request = z.infer<typeof requestSchema>
 export type RequestPayload = z.input<typeof requestSchema>

--- a/packages/oas-utils/src/entities/spec/security.ts
+++ b/packages/oas-utils/src/entities/spec/security.ts
@@ -12,7 +12,7 @@ const commonProps = z.object({
 })
 
 const extendedSecuritySchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand('securityScheme'),
   /** The name key that links a security requirement to a security object */
   nameKey: z.string().optional().default(''),
 })
@@ -34,9 +34,7 @@ const apiKeyValueSchema = z.object({
   value: z.string().default(''),
 })
 
-export const securityApiKeySchema = oasSecuritySchemeApiKey
-  .merge(extendedSecuritySchema)
-  .merge(apiKeyValueSchema)
+export const securityApiKeySchema = oasSecuritySchemeApiKey.merge(extendedSecuritySchema).merge(apiKeyValueSchema)
 export type SecuritySchemeApiKey = z.infer<typeof securityApiKeySchema>
 
 // ---------------------------------------------------------------------------
@@ -71,9 +69,7 @@ const httpValueSchema = z.object({
   token: z.string().default(''),
 })
 
-export const securityHttpSchema = oasSecuritySchemeHttp
-  .merge(extendedSecuritySchema)
-  .merge(httpValueSchema)
+export const securityHttpSchema = oasSecuritySchemeHttp.merge(extendedSecuritySchema).merge(httpValueSchema)
 export type SecuritySchemaHttp = z.infer<typeof securityHttpSchema>
 
 // ---------------------------------------------------------------------------
@@ -87,9 +83,7 @@ const oasSecuritySchemeOpenId = commonProps.extend({
   openIdConnectUrl: z.string().optional().default(''),
 })
 
-export const securityOpenIdSchema = oasSecuritySchemeOpenId.merge(
-  extendedSecuritySchema,
-)
+export const securityOpenIdSchema = oasSecuritySchemeOpenId.merge(extendedSecuritySchema)
 export type SecuritySchemaOpenId = z.infer<typeof securityOpenIdSchema>
 
 // ---------------------------------------------------------------------------
@@ -117,10 +111,7 @@ const flowsCommon = z.object({
    * REQUIRED. The available scopes for the OAuth2 security scheme. A map
    * between the scope name and a short description for it. The map MAY be empty.
    */
-  'scopes': z
-    .record(z.string(), z.string().optional().default(''))
-    .optional()
-    .default({}),
+  'scopes': z.record(z.string(), z.string().optional().default('')).optional().default({}),
   'selectedScopes': z.array(z.string()).optional().default([]),
   /** Extension to save the client Id associated with an oauth flow */
   'x-scalar-client-id': z.string().optional().default(''),
@@ -129,10 +120,7 @@ const flowsCommon = z.object({
 })
 
 /** Setup a default redirect uri if we can */
-const defaultRedirectUri =
-  typeof window !== 'undefined'
-    ? window.location.origin + window.location.pathname
-    : ''
+const defaultRedirectUri = typeof window !== 'undefined' ? window.location.origin + window.location.pathname : ''
 
 /** Options for the x-usePkce extension */
 export const pkceOptions = ['SHA-256', 'plain', 'no'] as const
@@ -147,10 +135,7 @@ const oasSecuritySchemeOauth2 = commonProps.extend({
       implicit: flowsCommon.extend({
         'type': z.literal('implicit'),
         authorizationUrl,
-        'x-scalar-redirect-uri': z
-          .string()
-          .optional()
-          .default(defaultRedirectUri),
+        'x-scalar-redirect-uri': z.string().optional().default(defaultRedirectUri),
       }),
       /** Configuration for the OAuth Resource Owner Password flow */
       password: flowsCommon.extend({
@@ -176,10 +161,7 @@ const oasSecuritySchemeOauth2 = commonProps.extend({
          * TODO: add docs
          */
         'x-usePkce': z.enum(pkceOptions).optional().default('no'),
-        'x-scalar-redirect-uri': z
-          .string()
-          .optional()
-          .default(defaultRedirectUri),
+        'x-scalar-redirect-uri': z.string().optional().default(defaultRedirectUri),
         tokenUrl,
         'clientSecret': z.string().default(''),
       }),
@@ -190,23 +172,19 @@ const oasSecuritySchemeOauth2 = commonProps.extend({
     }),
 })
 
-export const securityOauthSchema = oasSecuritySchemeOauth2.merge(
-  extendedSecuritySchema,
-)
+export const securityOauthSchema = oasSecuritySchemeOauth2.merge(extendedSecuritySchema)
 
 export type SecuritySchemeOauth2 = z.infer<typeof securityOauthSchema>
 export type SecuritySchemeOauth2Payload = z.input<typeof securityOauthSchema>
 export type Oauth2Flow = NonNullable<
-  SecuritySchemeOauth2['flows'][
-    | 'authorizationCode'
-    | 'clientCredentials'
-    | 'implicit'
-    | 'password']
+  SecuritySchemeOauth2['flows']['authorizationCode' | 'clientCredentials' | 'implicit' | 'password']
 >
 /** Payload for the oauth 2 flows + extensions */
-export type Oauth2FlowPayload = NonNullable<
-  SecuritySchemeOauth2Payload['flows']
->['authorizationCode' | 'clientCredentials' | 'implicit' | 'password'] &
+export type Oauth2FlowPayload = NonNullable<SecuritySchemeOauth2Payload['flows']>[
+  | 'authorizationCode'
+  | 'clientCredentials'
+  | 'implicit'
+  | 'password'] &
   Record<`x-${string}`, string>
 
 // ---------------------------------------------------------------------------
@@ -222,10 +200,7 @@ export type Oauth2FlowPayload = NonNullable<
  *
  * @see https://spec.openapis.org/oas/latest.html#security-requirement-object
  */
-export const oasSecurityRequirementSchema = z.record(
-  z.string(),
-  z.array(z.string()).optional().default([]),
-)
+export const oasSecurityRequirementSchema = z.record(z.string(), z.array(z.string()).optional().default([]))
 
 /** OAS Compliant security schemes */
 export const oasSecuritySchemeSchema = z.union([

--- a/packages/oas-utils/src/entities/spec/server.ts
+++ b/packages/oas-utils/src/entities/spec/server.ts
@@ -34,11 +34,7 @@ const extendedServerVariableSchema = oasServerVariableSchema
   })
   .refine((data) => {
     // Set default to the first enum value if invalid
-    if (
-      Array.isArray(data.enum) &&
-      !data.enum.includes(data.default ?? '') &&
-      data.enum.length > 0
-    ) {
+    if (Array.isArray(data.enum) && !data.enum.includes(data.default ?? '') && data.enum.length > 0) {
       data.default = data.enum[0]
     }
 
@@ -79,7 +75,7 @@ export const oasServerSchema = z.object({
 }) satisfies ZodSchema<OpenAPIV3_1.ServerObject>
 
 export const serverSchema = oasServerSchema.extend({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand('server'),
 })
 
 export type Server = z.infer<typeof serverSchema>

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -72,9 +72,7 @@ export const oasExternalDocumentationSchema = z.object({
   /** REQUIRED. The URL for the target documentation. This MUST be in the form of a URL. */
   url: z.string().default(''),
 })
-export type ExternalDocumentation = z.infer<
-  typeof oasExternalDocumentationSchema
->
+export type ExternalDocumentation = z.infer<typeof oasExternalDocumentationSchema>
 
 export const xScalarNestedSchema = z
   .object({
@@ -109,8 +107,8 @@ export const oasTagSchema = z.object({
 })
 
 export const tagSchema = oasTagSchema.extend({
-  uid: nanoidSchema,
-  children: nanoidSchema.array().default([]),
+  uid: nanoidSchema.brand('tag'),
+  children: nanoidSchema.brand('tag').array().default([]),
 })
 
 export type Tag = z.infer<typeof tagSchema>

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -109,7 +109,7 @@ export const oasTagSchema = z.object({
 export const tagSchema = oasTagSchema.extend({
   uid: nanoidSchema.brand('tag'),
   children: z
-    .union([nanoidSchema.brand('tag'), nanoidSchema.brand('request')])
+    .union([nanoidSchema.brand('tag'), nanoidSchema.brand('operation')])
     .array()
     .default([]),
 })

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -108,7 +108,10 @@ export const oasTagSchema = z.object({
 
 export const tagSchema = oasTagSchema.extend({
   uid: nanoidSchema.brand('tag'),
-  children: nanoidSchema.brand('tag').array().default([]),
+  children: z
+    .union([nanoidSchema.brand('tag'), nanoidSchema.brand('request')])
+    .array()
+    .default([]),
 })
 
 export type Tag = z.infer<typeof tagSchema>

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -29,7 +29,7 @@ const hotKeyConfigSchema = z
   .optional()
 
 export const workspaceSchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand('workspace'),
   name: z.string().default('Default Workspace'),
   /** Workspace description */
   description: z.string().default('Basic Scalar Workspace'),

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -24,22 +24,14 @@ import { combineUrlAndPath, isDefined } from '@/helpers'
 import { isHttpMethod } from '@/helpers/httpMethods'
 import { schemaModel } from '@/helpers/schema-model'
 import { keysOf } from '@scalar/object-utils/arrays'
-import {
-  type LoadResult,
-  dereference,
-  load,
-  upgrade,
-} from '@scalar/openapi-parser'
+import { type LoadResult, dereference, load, upgrade } from '@scalar/openapi-parser'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import type { UnknownObject } from '@scalar/types/utils'
 import type { Entries } from 'type-fest'
 
 /** Takes a string or object and parses it into an openapi spec compliant schema */
-export const parseSchema = async (
-  spec: string | UnknownObject,
-  { shouldLoad = true } = {},
-) => {
+export const parseSchema = async (spec: string | UnknownObject, { shouldLoad = true } = {}) => {
   if (spec === null || (typeof spec === 'string' && spec.trim() === '')) {
     console.warn('[@scalar/oas-utils] Empty OpenAPI document provided.')
 
@@ -71,10 +63,7 @@ export const parseSchema = async (
   const { specification } = upgrade(filesystem)
   const { schema, errors: derefErrors = [] } = await dereference(specification)
 
-  if (!schema)
-    console.warn(
-      '[@scalar/oas-utils] OpenAPI Parser Warning: Schema is undefined',
-    )
+  if (!schema) console.warn('[@scalar/oas-utils] OpenAPI Parser Warning: Schema is undefined')
   return {
     /**
      * Temporary fix for the parser returning an empty array
@@ -93,28 +82,18 @@ export const getSelectedSecuritySchemeUids = (
 ): SelectedSecuritySchemeUids => {
   // Set the first security requirement if no preferred security schemes are set
   const names =
-    securityRequirements[0] && !preferredSecurityNames.length
-      ? [securityRequirements[0]]
-      : preferredSecurityNames
+    securityRequirements[0] && !preferredSecurityNames.length ? [securityRequirements[0]] : preferredSecurityNames
 
   // Map names to uids
   const uids = names.map((name) =>
-    Array.isArray(name)
-      ? name.map((k) => securitySchemeMap[k])
-      : securitySchemeMap[name],
+    Array.isArray(name) ? name.map((k) => securitySchemeMap[k]) : securitySchemeMap[name],
   )
 
   return uids
 }
 
-export type ImportSpecToWorkspaceArgs = Pick<
-  CollectionPayload,
-  'documentUrl' | 'watchMode'
-> &
-  Pick<
-    ReferenceConfiguration,
-    'authentication' | 'baseServerURL' | 'servers'
-  > & {
+export type ImportSpecToWorkspaceArgs = Pick<CollectionPayload, 'documentUrl' | 'watchMode'> &
+  Pick<ReferenceConfiguration, 'authentication' | 'baseServerURL' | 'servers'> & {
     /** Sets the preferred security scheme on the collection instead of the requests */
     setCollectionSecurity?: boolean
     /** Call the load step from the parser */
@@ -168,12 +147,9 @@ export async function importSpecToWorkspace(
   const requests: Request[] = []
 
   // Add the base server url to any relative servers
-  const servers: Server[] = getServersFromOpenApiDocument(
-    configuredServers || schema.servers,
-    {
-      baseServerURL,
-    },
-  )
+  const servers: Server[] = getServersFromOpenApiDocument(configuredServers || schema.servers, {
+    baseServerURL,
+  })
 
   // Fallback to the current window.location.origin if no servers are provided
   if (!servers.length) {
@@ -193,14 +169,9 @@ export async function importSpecToWorkspace(
   // ---------------------------------------------------------------------------
   // SECURITY HANDLING
 
-  const security =
-    schema.components?.securitySchemes ?? schema?.securityDefinitions ?? {}
+  const security = schema.components?.securitySchemes ?? schema?.securityDefinitions ?? {}
 
-  const securitySchemes = (
-    Object.entries(security) as Entries<
-      Record<string, OpenAPIV3_1.SecuritySchemeObject>
-    >
-  )
+  const securitySchemes = (Object.entries(security) as Entries<Record<string, OpenAPIV3_1.SecuritySchemeObject>>)
     .map?.(([nameKey, _scheme]) => {
       // Apply any transforms we need before parsing
       const payload = {
@@ -210,9 +181,7 @@ export async function importSpecToWorkspace(
 
       // For oauth2 we need to add the type to the flows + prefill from authentication
       if (payload.type === 'oauth2' && payload.flows) {
-        const flowKeys = Object.keys(payload.flows) as Array<
-          keyof typeof payload.flows
-        >
+        const flowKeys = Object.keys(payload.flows) as Array<keyof typeof payload.flows>
 
         flowKeys.forEach((key) => {
           if (!payload.flows?.[key]) return
@@ -223,8 +192,7 @@ export async function importSpecToWorkspace(
 
           // Prefill values from authorization config
           if (authentication?.oAuth2) {
-            if (authentication.oAuth2.accessToken)
-              flow.token = authentication.oAuth2.accessToken
+            if (authentication.oAuth2.accessToken) flow.token = authentication.oAuth2.accessToken
 
             if (flow.type === 'password') {
               flow.username = authentication.oAuth2.username
@@ -237,22 +205,16 @@ export async function importSpecToWorkspace(
           }
 
           // Convert scopes to an object
-          if (Array.isArray(flow.scopes))
-            flow.scopes = flow.scopes.reduce(
-              (prev, s) => ({ ...prev, [s]: '' }),
-              {},
-            )
+          if (Array.isArray(flow.scopes)) flow.scopes = flow.scopes.reduce((prev, s) => ({ ...prev, [s]: '' }), {})
 
           // Handle x-defaultClientId
-          if (flow['x-defaultClientId'])
-            flow['x-scalar-client-id'] = flow['x-defaultClientId']
+          if (flow['x-defaultClientId']) flow['x-scalar-client-id'] = flow['x-defaultClientId']
         })
       }
       // Otherwise we just prefill
       else if (authentication) {
         // ApiKey
-        if (payload.type === 'apiKey' && authentication.apiKey?.token)
-          payload.value = authentication.apiKey.token
+        if (payload.type === 'apiKey' && authentication.apiKey?.token) payload.value = authentication.apiKey.token
         // HTTP
         else if (payload.type === 'http') {
           if (payload.scheme === 'basic' && authentication.http?.basic) {
@@ -292,9 +254,7 @@ export async function importSpecToWorkspace(
 
     methods.forEach((method) => {
       const operation: OpenAPIV3_1.OperationObject = path[method]
-      const operationServers = serverSchema
-        .array()
-        .parse(operation.servers ?? [])
+      const operationServers = serverSchema.array().parse(operation.servers ?? [])
 
       servers.push(...operationServers)
 
@@ -303,14 +263,9 @@ export async function importSpecToWorkspace(
       operation.tags?.forEach((t: string) => tagNames.add(t))
 
       // Remove security here and add it correctly below
-      const { security: operationSecurity, ...operationWithoutSecurity } =
-        operation
+      const { security: operationSecurity, ...operationWithoutSecurity } = operation
 
-      const securityRequirements: SelectedSecuritySchemeUids = (
-        operationSecurity ??
-        schema.security ??
-        []
-      )
+      const securityRequirements: SelectedSecuritySchemeUids = (operationSecurity ?? schema.security ?? [])
         .map((s: OpenAPIV3_1.SecurityRequirementObject) => {
           const keys = Object.keys(s)
           return keys.length > 1 ? keys : keys[0]
@@ -318,31 +273,24 @@ export async function importSpecToWorkspace(
         .filter(isDefined)
 
       // Filter the preferred security schemes to only include the ones that are in the security requirements
-      const preferredSecurityNames: SelectedSecuritySchemeUids = [
-        authentication?.preferredSecurityScheme ?? [],
-      ]
+      const preferredSecurityNames: SelectedSecuritySchemeUids = [authentication?.preferredSecurityScheme ?? []]
         .flat()
         .filter((name) => {
           // Match up complex security requirements, array to array
           if (Array.isArray(name)) {
             // We match every element in the array
             return securityRequirements.some(
-              (r) =>
-                Array.isArray(r) &&
-                r.length === name.length &&
-                r.every((v, i) => v === name[i]),
+              (r) => Array.isArray(r) && r.length === name.length && r.every((v, i) => v === name[i]),
             )
-          } else return securityRequirements.includes(name)
+          }
+
+          return securityRequirements.includes(name)
         })
 
       // Set the initially selected security scheme
       const selectedSecuritySchemeUids =
         securityRequirements.length && !setCollectionSecurity
-          ? getSelectedSecuritySchemeUids(
-              securityRequirements,
-              preferredSecurityNames,
-              securitySchemeMap,
-            )
+          ? getSelectedSecuritySchemeUids(securityRequirements, preferredSecurityNames, securitySchemeMap)
           : []
 
       const requestPayload: RequestPayload = {
@@ -352,43 +300,37 @@ export async function importSpecToWorkspace(
         security: operationSecurity,
         selectedSecuritySchemeUids,
         // Merge path and operation level parameters
-        parameters: [
-          ...(path?.parameters ?? []),
-          ...(operation.parameters ?? []),
-        ] as RequestParameterPayload[],
+        parameters: [...(path?.parameters ?? []), ...(operation.parameters ?? [])] as RequestParameterPayload[],
         servers: [...pathServers, ...operationServers].map((s) => s.uid),
       }
 
       // Remove any examples from the request payload as they conflict with our examples property and are not valid
       if (requestPayload.examples) {
-        console.warn(
-          '[@scalar/api-client] operation.examples is not a valid openapi property',
-        )
+        console.warn('[@scalar/api-client] operation.examples is not a valid openapi property')
         delete requestPayload.examples
       }
 
       // Add list of UIDs to associate security schemes
       // As per the spec if there is operation level security we ignore the top level requirements
       if (operationSecurity?.length)
-        requestPayload.security = operationSecurity.map(
-          (s: OpenAPIV3_1.SecurityRequirementObject) => {
-            const keys = Object.keys(s)
+        requestPayload.security = operationSecurity.map((s: OpenAPIV3_1.SecurityRequirementObject) => {
+          const keys = Object.keys(s)
 
-            // Handle the case of {} for optional
-            if (keys.length) {
-              const [key] = Object.keys(s)
-              return {
-                [key]: s[key],
-              }
-            } else return s
-          },
-        )
+          // Handle the case of {} for optional
+          if (keys.length) {
+            const [key] = Object.keys(s)
+            return {
+              [key]: s[key],
+            }
+          }
+
+          return s
+        })
 
       // Save parse the request
       const request = schemaModel(requestPayload, requestSchema, false)
 
-      if (!request)
-        importWarnings.push(`${method} Request at ${path} is invalid.`)
+      if (!request) importWarnings.push(`${method} Request at ${path} is invalid.`)
       else requests.push(request)
     })
   })
@@ -457,9 +399,7 @@ export async function importSpecToWorkspace(
   // Generate Collection
 
   // Grab the security requirements for this operation
-  const securityRequirements: SelectedSecuritySchemeUids = (
-    schema.security ?? []
-  )
+  const securityRequirements: SelectedSecuritySchemeUids = (schema.security ?? [])
     .map((s: OpenAPIV3_1.SecurityRequirementObject) => {
       const keys = Object.keys(s)
       return keys.length > 1 ? keys : keys[0]
@@ -467,19 +407,12 @@ export async function importSpecToWorkspace(
     .filter(isDefined)
 
   // Here we do not filter these as we let the preferredSecurityScheme override the requirements
-  const preferredSecurityNames: SelectedSecuritySchemeUids = [
-    authentication?.preferredSecurityScheme ?? [],
-  ].flat()
+  const preferredSecurityNames: SelectedSecuritySchemeUids = [authentication?.preferredSecurityScheme ?? []].flat()
 
   // Set the initially selected security scheme
   const selectedSecuritySchemeUids =
-    (securityRequirements.length || preferredSecurityNames?.length) &&
-    setCollectionSecurity
-      ? getSelectedSecuritySchemeUids(
-          securityRequirements,
-          preferredSecurityNames,
-          securitySchemeMap,
-        )
+    (securityRequirements.length || preferredSecurityNames?.length) && setCollectionSecurity
+      ? getSelectedSecuritySchemeUids(securityRequirements, preferredSecurityNames, securitySchemeMap)
       : []
 
   const collection = collectionSchema.parse({
@@ -537,10 +470,7 @@ export function getServersFromOpenApiDocument(
         if (parsedSchema?.url?.startsWith('/')) {
           // Use the base server URL (if provided)
           if (baseServerURL) {
-            parsedSchema.url = combineUrlAndPath(
-              baseServerURL,
-              parsedSchema.url,
-            )
+            parsedSchema.url = combineUrlAndPath(baseServerURL, parsedSchema.url)
 
             return parsedSchema
           }
@@ -549,10 +479,7 @@ export function getServersFromOpenApiDocument(
           const fallbackUrl = getFallbackUrl()
 
           if (fallbackUrl) {
-            parsedSchema.url = combineUrlAndPath(
-              fallbackUrl,
-              parsedSchema.url.replace(/^\//, ''),
-            )
+            parsedSchema.url = combineUrlAndPath(fallbackUrl, parsedSchema.url.replace(/^\//, ''))
 
             return parsedSchema
           }

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -78,7 +78,7 @@ export const parseSchema = async (spec: string | UnknownObject, { shouldLoad = t
 export const getSelectedSecuritySchemeUids = (
   securityRequirements: SelectedSecuritySchemeUids,
   preferredSecurityNames: SelectedSecuritySchemeUids = [],
-  securitySchemeMap: Record<string, string>,
+  securitySchemeMap: Record<string, SecurityScheme['uid']>,
 ): SelectedSecuritySchemeUids => {
   // Set the first security requirement if no preferred security schemes are set
   const names =
@@ -233,7 +233,7 @@ export async function importSpecToWorkspace(
     .filter((v) => !!v)
 
   // Map of security scheme names to UIDs
-  const securitySchemeMap: Record<string, string> = {}
+  const securitySchemeMap: Record<string, SecurityScheme['uid']> = {}
   securitySchemes.forEach((s) => {
     securitySchemeMap[s.nameKey] = s.uid
   })
@@ -273,7 +273,9 @@ export async function importSpecToWorkspace(
         .filter(isDefined)
 
       // Filter the preferred security schemes to only include the ones that are in the security requirements
-      const preferredSecurityNames: SelectedSecuritySchemeUids = [authentication?.preferredSecurityScheme ?? []]
+      const preferredSecurityNames: SelectedSecuritySchemeUids = [
+        (authentication?.preferredSecurityScheme ?? []) as SelectedSecuritySchemeUids,
+      ]
         .flat()
         .filter((name) => {
           // Match up complex security requirements, array to array
@@ -354,7 +356,7 @@ export async function importSpecToWorkspace(
   })
 
   // Add all tags by default. We will remove nested ones
-  const collectionChildren = new Set(tags.map((t) => t.uid))
+  const collectionChildren: Set<Tag['uid'] | Request['uid']> = new Set(tags.map((t) => t.uid))
 
   // Nested folders go before any requests
   tags.forEach((t) => {
@@ -369,13 +371,13 @@ export async function importSpecToWorkspace(
   })
 
   // Add the request UIDs to the tag children (or collection root)
-  requests.forEach((r) => {
-    if (r.tags?.length) {
-      r.tags.forEach((t) => {
-        tagMap[t].children.push(r.uid)
+  requests.forEach((request) => {
+    if (request.tags?.length) {
+      request.tags.forEach((tag) => {
+        tagMap[tag].children.push(request.uid)
       })
     } else {
-      collectionChildren.add(r.uid)
+      collectionChildren.add(request.uid)
     }
   })
 
@@ -407,7 +409,9 @@ export async function importSpecToWorkspace(
     .filter(isDefined)
 
   // Here we do not filter these as we let the preferredSecurityScheme override the requirements
-  const preferredSecurityNames: SelectedSecuritySchemeUids = [authentication?.preferredSecurityScheme ?? []].flat()
+  const preferredSecurityNames: SelectedSecuritySchemeUids = [
+    (authentication?.preferredSecurityScheme ?? []) as SelectedSecuritySchemeUids,
+  ].flat()
 
   // Set the initially selected security scheme
   const selectedSecuritySchemeUids =


### PR DESCRIPTION
WIP

**Problem**
Currently, you can pass any string to any `uid` field. For example, a collection uid when attempting to update a workspace.

**Solution**
With this PR we‘re using the Zod `.brand` feature to identify UIDs.

Fixes #4773

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
