### PR TITLE
feat(api-client): add brands to entity UIDs

### DIFF
--- a/.changeset/tough-shoes-tan.md
+++ b/.changeset/tough-shoes-tan.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+chore: add brand to uids

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -143,7 +143,8 @@ const { codeMirror } = useCodeMirror({
     props.modelValue !== undefined ? String(props.modelValue) : '',
   ),
   onChange: (value) => {
-    handleChange(value), updateDropdownVisibility()
+    handleChange(value)
+    updateDropdownVisibility()
   },
   onFocus: () => (isFocused.value = true),
   onBlur: (val) => handleBlur(val),
@@ -285,7 +286,7 @@ export default {
     class="centered-y text-orange absolute right-7 text-xs">
     <slot name="warning" />
   </div>
-  <slot name="icon"></slot>
+  <slot name="icon" />
   <div
     v-if="required"
     class="required centered-y text-xxs text-c-3 bg-b-1 pointer-events-none absolute right-0 pr-2 pt-px opacity-100 shadow-[-8px_0_4px_var(--scalar-background-1)] transition-opacity duration-150 peer-has-[.cm-focused]:opacity-0">

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteCollection.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteCollection.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import IconSelector from '@/components/IconSelector.vue'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import { ScalarButton } from '@scalar/components'
 import { LibraryIcon } from '@scalar/icons'
 import { useToasts } from '@scalar/use-toasts'
 import { ref } from 'vue'
+
+import IconSelector from '@/components/IconSelector.vue'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -26,6 +27,10 @@ const handleSubmit = () => {
     toast('Please enter a name before creating a collection.', 'error')
     return
   }
+  if (!activeWorkspace.value?.uid) {
+    toast('No active workspace found.', 'error')
+    return
+  }
 
   collectionMutators.add(
     {
@@ -36,7 +41,7 @@ const handleSubmit = () => {
       },
       'x-scalar-icon': collectionIcon.value,
     },
-    activeWorkspace.value?.uid ?? '',
+    activeWorkspace.value?.uid,
   )
   emits('close')
 }
@@ -55,14 +60,14 @@ const handleSubmit = () => {
         v-model="collectionIcon"
         placement="bottom-start">
         <ScalarButton
-          class="aspect-square px-0 h-auto"
+          class="aspect-square h-auto px-0"
           variant="outlined">
           <LibraryIcon
-            class="size-4 text-c-2 stroke-[1.75]"
+            class="text-c-2 size-4 stroke-[1.75]"
             :src="collectionIcon" />
         </ScalarButton>
       </IconSelector>
     </template>
-    <template #submit>Create Collection</template>
+    <template #submit> Create Collection </template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
@@ -1,4 +1,14 @@
 <script setup lang="ts">
+import {
+  ScalarButton,
+  ScalarCodeBlock,
+  ScalarIcon,
+  ScalarTooltip,
+  useLoadingState,
+} from '@scalar/components'
+import { useToasts } from '@scalar/use-toasts'
+import { computed, ref, watch } from 'vue'
+
 import { useFileDialog } from '@/hooks'
 import {
   convertPostmanToOpenApi,
@@ -9,15 +19,6 @@ import {
 } from '@/libs'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import {
-  ScalarButton,
-  ScalarCodeBlock,
-  ScalarIcon,
-  ScalarTooltip,
-  useLoadingState,
-} from '@scalar/components'
-import { useToasts } from '@scalar/use-toasts'
-import { computed, ref, watch } from 'vue'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -39,9 +40,8 @@ const watchMode = ref(true)
 const documentDetails = computed(() => {
   if (isPostmanCollection(inputContent.value)) {
     return getPostmanDocumentDetails(inputContent.value)
-  } else {
-    return getOpenApiDocumentDetails(inputContent.value)
   }
+  return getOpenApiDocumentDetails(inputContent.value)
 })
 
 const documentType = computed(() =>
@@ -161,9 +161,9 @@ async function importCollection() {
     <template v-else>
       <!-- OpenAPI document preview -->
       <div class="flex justify-between">
-        <div class="pl-8 text-xs min-h-8 py-2 text-c-2">Preview</div>
+        <div class="text-c-2 min-h-8 py-2 pl-8 text-xs">Preview</div>
         <ScalarButton
-          class="ml-auto p-2 max-h-8 gap-1.5 text-xs hover:bg-b-2 relative"
+          class="hover:bg-b-2 relative ml-auto max-h-8 gap-1.5 p-2 text-xs"
           variant="ghost"
           @click="inputContent = ''">
           Clear
@@ -171,16 +171,16 @@ async function importCollection() {
       </div>
       <ScalarCodeBlock
         v-if="documentDetails && !isUrl(inputContent)"
-        class="border max-h-[40dvh] mt-1 bg-b-2 rounded [--scalar-small:--scalar-font-size-4]"
+        class="bg-b-2 mt-1 max-h-[40dvh] rounded border [--scalar-small:--scalar-font-size-4]"
         :content="inputContent"
         :copy="false"
         :lang="documentType" />
     </template>
     <template #options>
-      <div class="flex flex-row items-center justify-between gap-3 w-full">
+      <div class="flex w-full flex-row items-center justify-between gap-3">
         <!-- Upload -->
         <ScalarButton
-          class="p-2 max-h-8 gap-1.5 text-xs hover:bg-b-2 relative"
+          class="hover:bg-b-2 relative max-h-8 gap-1.5 p-2 text-xs"
           variant="outlined"
           @click="openSpecFileDialog">
           JSON, or YAML File
@@ -203,8 +203,8 @@ async function importCollection() {
           </template>
           <template #content>
             <div
-              class="grid gap-1.5 pointer-events-none max-w-[320px] w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
-              <div class="flex items-center text-c-2">
+              class="w-content bg-b-1 z-100 text-xxs text-c-1 pointer-events-none z-10 grid max-w-[320px] gap-1.5 rounded p-2 leading-5 shadow-lg">
+              <div class="text-c-2 flex items-center">
                 <span
                   v-if="isInputUrl"
                   class="text-pretty">
@@ -230,9 +230,11 @@ async function importCollection() {
         <template v-if="documentDetails.title">
           "{{ documentDetails.title }}"
         </template>
-        <template v-else>{{ documentDetails.version }}</template>
+        <template v-else>
+          {{ documentDetails.version }}
+        </template>
       </template>
-      <template v-else>Collection</template>
+      <template v-else> Collection </template>
     </template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
-import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import {
   ScalarButton,
-  type ScalarComboboxOption,
   ScalarIcon,
   ScalarListbox,
+  type ScalarComboboxOption,
 } from '@scalar/components'
 import { isHttpMethod } from '@scalar/oas-utils/helpers'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
+
+import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -70,7 +71,7 @@ const tags = computed(() =>
 )
 
 /** Currently selected collection with a reasonable default */
-const selectedCollection = ref<ScalarComboboxOption | undefined>(
+const selectedCollection = ref(
   props.metaData
     ? collections.value.find(
         (collection) =>
@@ -143,7 +144,7 @@ const handleSubmit = () => {
           v-model="selectedCollection"
           :options="collections">
           <ScalarButton
-            class="justify-between p-2 ml-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+            class="hover:bg-b-2 ml-2 max-h-8 w-full justify-between gap-1 p-2 text-xs"
             variant="outlined">
             <span
               class="whitespace-nowrap"
@@ -165,7 +166,7 @@ const handleSubmit = () => {
           v-model="selectedTag"
           :options="tags">
           <ScalarButton
-            class="justify-between p-2 ml-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+            class="hover:bg-b-2 ml-2 max-h-8 w-full justify-between gap-1 p-2 text-xs"
             variant="outlined">
             <span :class="selectedTag ? 'text-c-1' : 'text-c-3'">
               {{ selectedTag ? selectedTag.label : 'Select Tag' }}
@@ -178,6 +179,6 @@ const handleSubmit = () => {
         </ScalarListbox>
       </div>
     </template>
-    <template #submit>Create Request</template>
+    <template #submit> Create Request </template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
-import {
-  ScalarButton,
-  type ScalarComboboxOption,
-  ScalarIcon,
-  ScalarListbox,
-} from '@scalar/components'
+import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
+
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -28,7 +24,12 @@ const emits = defineEmits<{
 const { toast } = useToasts()
 
 const { activeCollection, activeWorkspaceCollections } = useActiveEntities()
-const { collectionMutators, serverMutators, events } = useWorkspace()
+const {
+  collectionMutators,
+  serverMutators,
+  events,
+  collections: _collections,
+} = useWorkspace()
 
 const url = ref('')
 
@@ -44,7 +45,7 @@ const collections = computed(() =>
 )
 
 /** Currently selected collection with a reasonable default */
-const selectedCollection = ref<ScalarComboboxOption | undefined>(
+const selectedCollection = ref(
   props.metaData
     ? collections.value.find(
         (collection) =>
@@ -61,16 +62,16 @@ const handleSubmit = () => {
     toast('Please enter a valid url before creating a server.', 'error')
     return
   }
-  const collectionUid = selectedCollection.value?.id
-  if (!collectionUid) {
+  const collection = _collections[selectedCollection.value?.id ?? '']
+  if (!collection) {
     toast('Please select a collection before creating a server.', 'error')
     return
   }
 
-  const server = serverMutators.add({ url: url.value }, collectionUid)
+  const server = serverMutators.add({ url: url.value }, collection.uid)
 
   // Select the server
-  collectionMutators.edit(collectionUid, 'selectedServerUid', server.uid)
+  collectionMutators.edit(collection.uid, 'selectedServerUid', server.uid)
 
   emits('close')
 }
@@ -94,7 +95,7 @@ const redirectToCreateCollection = () => {
         :options="collections">
         <ScalarButton
           v-if="collections.length > 0"
-          class="justify-between p-2 max-h-8 w-fit gap-1 text-xs hover:bg-b-2"
+          class="hover:bg-b-2 max-h-8 w-fit justify-between gap-1 p-2 text-xs"
           variant="outlined">
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
             selectedCollection ? selectedCollection.label : 'Select Collection'
@@ -106,13 +107,13 @@ const redirectToCreateCollection = () => {
         </ScalarButton>
         <ScalarButton
           v-else
-          class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2 w-fit"
+          class="hover:bg-b-2 max-h-8 w-fit justify-between gap-1 p-2 text-xs"
           variant="outlined"
           @click="redirectToCreateCollection">
           <span class="text-c-1">Create Collection</span>
         </ScalarButton>
       </ScalarListbox>
     </template>
-    <template #submit>Create Server</template>
+    <template #submit> Create Server </template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
-import {
-  ScalarButton,
-  type ScalarComboboxOption,
-  ScalarIcon,
-  ScalarListbox,
-} from '@scalar/components'
+import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
+
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -30,7 +26,7 @@ const availableCollections = computed(() =>
 )
 
 const name = ref('')
-const selectedCollection = ref<ScalarComboboxOption | undefined>(
+const selectedCollection = ref(
   availableCollections.value.find(
     (option) => option.id === activeCollection.value?.uid,
   ),
@@ -66,7 +62,7 @@ const handleSubmit = () => {
         v-model="selectedCollection"
         :options="availableCollections">
         <ScalarButton
-          class="justify-between p-2 max-h-8 w-fit gap-1 text-xs hover:bg-b-2"
+          class="hover:bg-b-2 max-h-8 w-fit justify-between gap-1 p-2 text-xs"
           variant="outlined">
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
             selectedCollection ? selectedCollection.label : 'Select Collection'
@@ -78,6 +74,6 @@ const handleSubmit = () => {
         </ScalarButton>
       </ScalarListbox>
     </template>
-    <template #submit>Create Tag</template>
+    <template #submit> Create Tag </template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import type { Cookie } from '@scalar/oas-utils/entities/cookie'
+import type { Path, PathValue } from '@scalar/object-utils/nested'
+
 import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableInput from '@/components/DataTable/DataTableInput.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
@@ -12,7 +15,10 @@ defineProps<{
     placeholder: string
   }[]
   data: Record<string, any>
-  onUpdate: (key: string, value: any) => void
+  onUpdate: <P extends Path<Cookie>>(
+    key: P,
+    value: NonNullable<PathValue<Cookie, P>>,
+  ) => void
 }>()
 </script>
 <template>
@@ -34,7 +40,7 @@ defineProps<{
           <DataTableInput
             :modelValue="data[option.key] ?? ''"
             :placeholder="option.placeholder"
-            @update:modelValue="onUpdate(option.key, $event)">
+            @update:modelValue="onUpdate(option.key as Path<Cookie>, $event)">
             {{ option.label }}
           </DataTableInput>
         </DataTableRow>

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
@@ -1,27 +1,28 @@
 <script setup lang="ts">
-import WatchModeToggle from '@/components/CommandPalette/WatchModeToggle.vue'
-import ImportNowButton from '@/components/ImportCollection/ImportNowButton.vue'
-import IntegrationLogo from '@/components/ImportCollection/IntegrationLogo.vue'
-import PrefetchError from '@/components/ImportCollection/PrefetchError.vue'
-import WorkspaceSelector from '@/components/ImportCollection/WorkspaceSelector.vue'
-import { useUrlPrefetcher } from '@/components/ImportCollection/hooks/useUrlPrefetcher'
-import { getOpenApiDocumentVersion } from '@/components/ImportCollection/utils/getOpenApiDocumentVersion'
-import { isDocument } from '@/components/ImportCollection/utils/isDocument'
-import { isUrl } from '@/components/ImportCollection/utils/isUrl'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import { ScalarIcon, ScalarModal, useModal } from '@scalar/components'
 import { isLocalUrl } from '@scalar/oas-utils/helpers'
 import { normalize } from '@scalar/openapi-parser'
 import type { OpenAPI } from '@scalar/openapi-types'
 import {
-  type IntegrationThemeId,
   getThemeStyles,
   themeIds,
+  type IntegrationThemeId,
 } from '@scalar/themes'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
+
+import WatchModeToggle from '@/components/CommandPalette/WatchModeToggle.vue'
+import { useUrlPrefetcher } from '@/components/ImportCollection/hooks/useUrlPrefetcher'
+import ImportNowButton from '@/components/ImportCollection/ImportNowButton.vue'
+import IntegrationLogo from '@/components/ImportCollection/IntegrationLogo.vue'
+import PrefetchError from '@/components/ImportCollection/PrefetchError.vue'
+import { getOpenApiDocumentVersion } from '@/components/ImportCollection/utils/getOpenApiDocumentVersion'
+import { isDocument } from '@/components/ImportCollection/utils/isDocument'
+import { isUrl } from '@/components/ImportCollection/utils/isUrl'
+import WorkspaceSelector from '@/components/ImportCollection/WorkspaceSelector.vue'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 const props = defineProps<{
   source: string | null
@@ -202,7 +203,7 @@ function handleImportFinished() {
 
   if (shouldShowIntegrationIcon.value) {
     workspaceMutators.edit(
-      activeWorkspace.value?.uid ?? '',
+      activeWorkspace.value?.uid,
       'themeId',
       integrationThemeId,
     )
@@ -217,22 +218,22 @@ function handleImportFinished() {
     :state="modalState">
     <div
       v-if="themeStyleTag"
-      v-html="themeStyleTag"></div>
+      v-html="themeStyleTag" />
     <div
-      class="flex flex-col h-screen justify-center px-6 overflow-hidden relative md:px-0">
+      class="relative flex h-screen flex-col justify-center overflow-hidden px-6 md:px-0">
       <div class="section-flare">
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
       </div>
       <!-- Wait until the URL is fetched -->
       <div
-        class="flex items-center flex-col m-auto px-8 py-8 rounded-xl border-1/2 max-w-[380px] w-full transition-opacity"
+        class="border-1/2 m-auto flex w-full max-w-[380px] flex-col items-center rounded-xl px-8 py-8 transition-opacity"
         :class="{ 'opacity-0': prefetchResult.state === 'loading' }">
         <!-- Prefetch error -->
         <!-- Or: Document doesn’t even have an OpenAPI/Swagger version, something is probably wrong -->
@@ -241,7 +242,7 @@ function handleImportFinished() {
             prefetchResult.error && prefetchResult.state === 'idle' && !version
           ">
           <!-- Heading -->
-          <div class="text-center text-md font-bold mb-2 line-clamp-1">
+          <div class="text-md mb-2 line-clamp-1 text-center font-bold">
             No OpenAPI document found
           </div>
           <PrefetchError :url="prefetchResult?.input || props.source" />
@@ -251,8 +252,8 @@ function handleImportFinished() {
           <!-- Integration Logo -->
           <div
             v-if="shouldShowIntegrationIcon"
-            class="flex justify-center items-center mb-2 p-1">
-            <div class="rounded-xl size-10">
+            class="mb-2 flex items-center justify-center p-1">
+            <div class="size-10 rounded-xl">
               <IntegrationLogo :integration="integration" />
             </div>
           </div>
@@ -261,24 +262,24 @@ function handleImportFinished() {
           <img
             v-else-if="companyLogo"
             alt="Logo"
-            class="w-full object-contain mb-2"
+            class="mb-2 w-full object-contain"
             :src="companyLogo" />
 
           <!-- Title -->
           <div
             v-if="!companyLogo"
-            class="text-center text-md font-bold mb-2 line-clamp-1">
+            class="text-md mb-2 line-clamp-1 text-center font-bold">
             {{ title || 'Untitled Collection' }}
           </div>
 
-          <div class="text-c-1 text-sm font-medium text-center text-balance">
+          <div class="text-c-1 text-balance text-center text-sm font-medium">
             Import the OpenAPI document to instantly send API requests. No
             signup required.
           </div>
 
           <!-- Actions -->
           <template v-if="version">
-            <div class="inline-flex flex-col gap-2 items-center z-10 w-full">
+            <div class="z-10 inline-flex w-full flex-col items-center gap-2">
               <ImportNowButton
                 :source="
                   prefetchResult?.url ?? prefetchResult?.content ?? source
@@ -290,20 +291,20 @@ function handleImportFinished() {
             <!-- Select the workspace -->
             <div class="flex justify-center">
               <div
-                class="inline-flex py-1 px-4 items-center text-xs font-medium text-c-3">
+                class="text-c-3 inline-flex items-center px-4 py-1 text-xs font-medium">
                 Import to: <WorkspaceSelector />
               </div>
             </div>
             <!-- Watch Mode -->
             <template v-if="prefetchResult?.url">
-              <div class="text-sm overflow-hidden mt-5 pt-4 border-t-1/2">
+              <div class="border-t-1/2 mt-5 overflow-hidden pt-4 text-sm">
                 <div class="flex items-center justify-center">
                   <WatchModeToggle
                     v-model="watchMode"
                     :disableToolTip="true" />
                 </div>
                 <div
-                  class="pt-0 text-center text-balance font-medium text-xs text-c-3">
+                  class="text-c-3 text-balance pt-0 text-center text-xs font-medium">
                   Automatically update your API client when the OpenAPI document
                   content changes.
                 </div>
@@ -313,10 +314,10 @@ function handleImportFinished() {
         </template>
       </div>
       <!-- Download Link -->
-      <div class="flex flex-col justify-center items-center pb-8">
-        <div class="text-center flex items-center flex-col">
+      <div class="flex flex-col items-center justify-center pb-8">
+        <div class="flex flex-col items-center text-center">
           <div
-            class="mb-2 w-10 h-10 border rounded-[10px] flex items-center justify-center">
+            class="mb-2 flex h-10 w-10 items-center justify-center rounded-[10px] border">
             <a
               href="https://scalar.com/download"
               target="_blank">
@@ -325,9 +326,9 @@ function handleImportFinished() {
                 size="xl" />
             </a>
           </div>
-          <span class="text-c-2 leading-snug text-sm font-medium">
+          <span class="text-c-2 text-sm font-medium leading-snug">
             <a
-              class="hover:text-c-1 underline-offset-2 mb-1 inline-block"
+              class="hover:text-c-1 mb-1 inline-block underline-offset-2"
               href="https://scalar.com/download"
               target="_blank">
               Download Desktop App

--- a/packages/api-client/src/components/Search/useSearch.test.ts
+++ b/packages/api-client/src/components/Search/useSearch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import { useSearch } from './useSearch'
+import { operationSchema } from '@scalar/oas-utils/entities/spec'
 
 // Mocking the necessary modules and functions
 vi.mock('vue-router', () => ({
@@ -36,12 +37,7 @@ vi.mock('@/store/active-entities', () => ({
 
 describe('useSearch', () => {
   it('initializes with default values', () => {
-    const {
-      searchText,
-      searchResultsWithPlaceholderResults,
-      selectedSearchResult,
-      populateFuseDataArray,
-    } = useSearch()
+    const { searchText, searchResultsWithPlaceholderResults, selectedSearchResult, populateFuseDataArray } = useSearch()
 
     console.log(populateFuseDataArray)
     expect(searchText.value).toBe('')
@@ -50,57 +46,35 @@ describe('useSearch', () => {
   })
 
   it('performs a search and updates results', () => {
-    const {
-      populateFuseDataArray,
-      searchText,
-      fuseSearch,
-      searchResultsWithPlaceholderResults,
-    } = useSearch()
+    const { populateFuseDataArray, searchText, fuseSearch, searchResultsWithPlaceholderResults } = useSearch()
 
     populateFuseDataArray([
-      {
+      operationSchema.parse({
         uid: 'request1',
         summary: 'Request 1',
         path: '/path1',
-        type: 'request',
         method: 'get',
-        selectedSecuritySchemeUids: [],
-        selectedServerUid: '',
-        servers: [],
-        examples: [],
-      },
+      }),
     ])
 
     searchText.value = 'test'
     fuseSearch()
 
     expect(searchResultsWithPlaceholderResults.value).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ item: expect.any(Object) }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ item: expect.any(Object) })]),
     )
   })
 
   it('returns results for requests', () => {
-    const {
-      populateFuseDataArray,
-      searchText,
-      fuseSearch,
-      searchResultsWithPlaceholderResults,
-    } = useSearch()
+    const { populateFuseDataArray, searchText, fuseSearch, searchResultsWithPlaceholderResults } = useSearch()
 
     populateFuseDataArray([
-      {
+      operationSchema.parse({
         uid: 'request1',
         summary: 'Request 1',
         path: '/path1',
-        type: 'request',
         method: 'get',
-        selectedSecuritySchemeUids: [],
-        selectedServerUid: '',
-        servers: [],
-        examples: [],
-      },
+      }),
     ])
     searchText.value = 'Request 1'
     fuseSearch()
@@ -124,37 +98,22 @@ describe('useSearch', () => {
   })
 
   it('filters out requests with x-internal: true', () => {
-    const {
-      populateFuseDataArray,
-      searchText,
-      fuseSearch,
-      searchResultsWithPlaceholderResults,
-    } = useSearch()
+    const { populateFuseDataArray, searchText, fuseSearch, searchResultsWithPlaceholderResults } = useSearch()
 
     populateFuseDataArray([
-      {
+      operationSchema.parse({
         uid: 'request1',
         summary: 'Request 1',
         path: '/path1',
-        type: 'request',
         method: 'get',
-        selectedSecuritySchemeUids: [],
-        selectedServerUid: '',
-        servers: [],
-        examples: [],
-      },
-      {
+      }),
+      operationSchema.parse({
         'uid': 'request2',
         'summary': 'Request 2',
         'path': '/path2',
-        'type': 'request',
         'method': 'get',
-        'selectedSecuritySchemeUids': [],
-        'selectedServerUid': '',
-        'servers': [],
-        'examples': [],
         'x-internal': true,
-      },
+      }),
     ])
 
     searchText.value = 'Request'

--- a/packages/api-client/src/components/Server/ServerDropdown.test.ts
+++ b/packages/api-client/src/components/Server/ServerDropdown.test.ts
@@ -1,21 +1,9 @@
 import { useLayout } from '@/hooks/useLayout'
 import { useWorkspace } from '@/store/store'
 import { PopoverPanel } from '@headlessui/vue'
-import {
-  collectionSchema,
-  requestSchema,
-  serverSchema,
-} from '@scalar/oas-utils/entities/spec'
+import { collectionSchema, requestSchema, serverSchema } from '@scalar/oas-utils/entities/spec'
 import { mount } from '@vue/test-utils'
-import {
-  type Mock,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ServerDropdown from './ServerDropdown.vue'
 import ServerDropdownItem from './ServerDropdownItem.vue'
@@ -100,10 +88,10 @@ describe('ServerDropdown', () => {
     const wrapper = mount(ServerDropdown, {
       props: {
         ...defaultProps,
-        server: {
+        server: serverSchema.parse({
           uid: 'server-1',
           url: 'https://scalar.com/',
-        },
+        }),
       },
     })
 
@@ -231,11 +219,7 @@ describe('ServerDropdown', () => {
       ?.trigger('click')
 
     const workspace = useWorkspace()
-    expect(workspace.collectionMutators.edit).toHaveBeenCalledWith(
-      'collection-1',
-      'selectedServerUid',
-      'server-2',
-    )
+    expect(workspace.collectionMutators.edit).toHaveBeenCalledWith('collection-1', 'selectedServerUid', 'server-2')
   })
 
   it('updates server variables correctly', async () => {
@@ -243,13 +227,13 @@ describe('ServerDropdown', () => {
       props: {
         ...defaultProps,
         layout: 'client',
-        server: {
+        server: serverSchema.parse({
           uid: 'server-1',
           url: 'https://scalar.com',
           variables: {
             version: { default: 'v1' },
           },
-        },
+        }),
       },
     })
 
@@ -259,19 +243,11 @@ describe('ServerDropdown', () => {
       .at(0)
     await dropdownButton?.trigger('click')
 
-    wrapper
-      .findAllComponents(ServerDropdownItem)
-      .at(0)
-      ?.find('input')
-      ?.setValue('v2')
+    wrapper.findAllComponents(ServerDropdownItem).at(0)?.find('input')?.setValue('v2')
 
     const workspace = useWorkspace()
-    expect(workspace.serverMutators.edit).toHaveBeenCalledWith(
-      'server-1',
-      'variables',
-      {
-        version: { default: 'v2' },
-      },
-    )
+    expect(workspace.serverMutators.edit).toHaveBeenCalledWith('server-1', 'variables', {
+      version: { default: 'v2' },
+    })
   })
 })

--- a/packages/api-client/src/components/Server/ServerDropdown.vue
+++ b/packages/api-client/src/components/Server/ServerDropdown.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
-import { useLayout } from '@/hooks/useLayout'
-import { useWorkspace } from '@/store/store'
 import {
+  cva,
+  cx,
   ScalarButton,
   ScalarDropdownDivider,
   ScalarFloatingBackdrop,
   ScalarIcon,
   ScalarPopover,
-  cva,
-  cx,
 } from '@scalar/components'
 import type {
   Collection,
@@ -16,6 +14,9 @@ import type {
   Server,
 } from '@scalar/oas-utils/entities/spec'
 import { computed, watch } from 'vue'
+
+import { useLayout } from '@/hooks/useLayout'
+import { useWorkspace } from '@/store/store'
 
 import ServerDropdownItem from './ServerDropdownItem.vue'
 
@@ -32,7 +33,7 @@ const { layout: clientLayout } = useLayout()
 const { servers, collectionMutators, events, serverMutators } = useWorkspace()
 
 const requestServerOptions = computed(() =>
-  operation?.servers?.map((serverUid: string) => ({
+  operation?.servers?.map((serverUid) => ({
     id: serverUid,
     label: servers[serverUid]?.url ?? 'Unknown server',
   })),
@@ -41,8 +42,8 @@ const requestServerOptions = computed(() =>
 const collectionServerOptions = computed(() =>
   // Filters out servers already present in the request
   collection?.servers
-    ?.filter((serverUid: string) => !operation?.servers?.includes(serverUid))
-    .map((serverUid: string) => ({
+    ?.filter((serverUid) => !operation?.servers?.includes(serverUid))
+    .map((serverUid) => ({
       id: serverUid,
       label: servers[serverUid]?.url ?? 'Unknown server',
     })),
@@ -125,7 +126,7 @@ const buttonVariants = cva({
     </ScalarButton>
     <template #popover="{ close }">
       <div
-        class="custom-scroll flex p-1 flex-col gap-1 max-h-[inherit]"
+        class="custom-scroll flex max-h-[inherit] flex-col gap-1 p-1"
         :class="layout !== 'reference' && 'border-t'"
         @click="close">
         <!-- Request -->
@@ -157,10 +158,10 @@ const buttonVariants = cva({
         <!-- Add Server -->
         <template v-if="clientLayout !== 'modal'">
           <button
-            class="rounded text-xxs flex items-center gap-1.5 p-1.75 hover:bg-b-2 cursor-pointer"
+            class="text-xxs p-1.75 hover:bg-b-2 flex cursor-pointer items-center gap-1.5 rounded"
             type="button"
             @click="handleAddServer">
-            <div class="flex items-center justify-center h-4 w-4">
+            <div class="flex h-4 w-4 items-center justify-center">
               <ScalarIcon
                 icon="Add"
                 size="sm" />

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -246,7 +246,7 @@ export const createApiClient = ({
         store.serverMutators.reset()
         store.tagMutators.reset()
 
-        workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'collections', [])
+        workspaceMutators.edit(activeWorkspace.value?.uid, 'collections', [])
 
         updateSpec(newConfig.spec)
       }
@@ -363,7 +363,7 @@ export const createApiClient = ({
       const example = request.requestBody?.content?.[contentType]?.examples[exampleKey]
       if (!example) return
 
-      requestExampleMutators.edit(request.examples[0] ?? '', 'body.raw.value', prettyPrintJson(example.value))
+      requestExampleMutators.edit(request.examples[0], 'body.raw.value', prettyPrintJson(example.value))
     },
   }
 }

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -1,28 +1,13 @@
 import { type ClientLayout, LAYOUT_SYMBOL } from '@/hooks/useLayout'
 import { loadAllResources } from '@/libs/local-storage'
-import {
-  ACTIVE_ENTITIES_SYMBOL,
-  createActiveEntitiesStore,
-} from '@/store/active-entities'
-import {
-  WORKSPACE_SYMBOL,
-  type WorkspaceStore,
-  createWorkspaceStore,
-} from '@/store/store'
+import { ACTIVE_ENTITIES_SYMBOL, createActiveEntitiesStore } from '@/store/active-entities'
+import { WORKSPACE_SYMBOL, type WorkspaceStore, createWorkspaceStore } from '@/store/store'
 import type { SecurityScheme } from '@scalar/oas-utils/entities/spec'
-import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
-import {
-  LS_KEYS,
-  objectMerge,
-  prettyPrintJson,
-} from '@scalar/oas-utils/helpers'
+import { workspaceSchema, type Workspace } from '@scalar/oas-utils/entities/workspace'
+import { LS_KEYS, objectMerge, prettyPrintJson } from '@scalar/oas-utils/helpers'
 import { DATA_VERSION, DATA_VERSION_LS_LEY } from '@scalar/oas-utils/migrations'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
-import type {
-  OpenAPI,
-  ReferenceConfiguration,
-  SpecConfiguration,
-} from '@scalar/types/legacy'
+import type { OpenAPI, ReferenceConfiguration, SpecConfiguration } from '@scalar/types/legacy'
 import { type Component, createApp, watch } from 'vue'
 import type { Router } from 'vue-router'
 
@@ -90,20 +75,14 @@ export type CreateApiClientParams = {
  * We need to do this due to some typescript type propogation errors
  * This is pretty much add properties as they are needed
  */
-export type ApiClient = Omit<
-  Awaited<ReturnType<typeof createApiClient>>,
-  'app' | 'store'
-> & {
+export type ApiClient = Omit<Awaited<ReturnType<typeof createApiClient>>, 'app' | 'store'> & {
   /** Add properties as they are needed, see above */
   app: { unmount: () => void }
   /**
    * The main workspace store from the client
    * These refs don't wanna play nice with typescript, if we need them we can de-reference them
    */
-  store: Omit<
-    WorkspaceStore,
-    'router' | 'events' | 'sidebarWidth' | 'proxyUrl' | 'requestHistory'
-  >
+  store: Omit<WorkspaceStore, 'router' | 'events' | 'sidebarWidth' | 'proxyUrl' | 'requestHistory'>
 }
 
 /**
@@ -162,7 +141,7 @@ export const createApiClient = ({
   else if (!isReadOnly || !configuration.spec) {
     // Create default workspace
     store.workspaceMutators.add({
-      uid: 'default',
+      uid: 'default' as Workspace['uid'],
       name: 'Workspace',
       proxyUrl: configuration.proxyUrl,
     })
@@ -267,11 +246,7 @@ export const createApiClient = ({
         store.serverMutators.reset()
         store.tagMutators.reset()
 
-        workspaceMutators.edit(
-          activeWorkspace.value?.uid ?? '',
-          'collections',
-          [],
-        )
+        workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'collections', [])
 
         updateSpec(newConfig.spec)
       }
@@ -281,11 +256,7 @@ export const createApiClient = ({
       const server = Object.values(servers).find((s) => s.url === serverUrl)
 
       if (server && activeCollection.value)
-        collectionMutators.edit(
-          activeCollection.value?.uid,
-          'selectedServerUid',
-          server.uid,
-        )
+        collectionMutators.edit(activeCollection.value?.uid, 'selectedServerUid', server.uid)
     },
     /** Update the currently selected server via URL */
     onUpdateServer: (callback: (url: string) => void) => {
@@ -327,8 +298,7 @@ export const createApiClient = ({
         Object.values(requests).find((item) =>
           path && method && item.path && item.method
             ? // The given operation
-              item.path === path &&
-              item.method.toUpperCase() === method.toUpperCase()
+              item.path === path && item.method.toUpperCase() === method.toUpperCase()
             : // Or the first request
               true,
         )?.uid
@@ -355,8 +325,7 @@ export const createApiClient = ({
         Object.values(requests).find((item) =>
           path && method && item.path && item.method
             ? // The given operation
-              item.path === path &&
-              item.method.toUpperCase() === method.toUpperCase()
+              item.path === path && item.method.toUpperCase() === method.toUpperCase()
             : // Or the first request
               true,
         )?.uid
@@ -386,22 +355,15 @@ export const createApiClient = ({
       if (!exampleKey || !operationId) return
 
       const request = Object.values(requests).find(
-        ({ operationId: reqOperationId, path }) =>
-          reqOperationId === operationId || path === operationId,
+        ({ operationId: reqOperationId, path }) => reqOperationId === operationId || path === operationId,
       )
       if (!request) return
 
-      const contentType =
-        Object.keys(request.requestBody?.content || {})[0] || ''
-      const example =
-        request.requestBody?.content?.[contentType]?.examples[exampleKey]
+      const contentType = Object.keys(request.requestBody?.content || {})[0] || ''
+      const example = request.requestBody?.content?.[contentType]?.examples[exampleKey]
       if (!example) return
 
-      requestExampleMutators.edit(
-        request.examples[0] ?? '',
-        'body.raw.value',
-        prettyPrintJson(example.value),
-      )
+      requestExampleMutators.edit(request.examples[0] ?? '', 'body.raw.value', prettyPrintJson(example.value))
     },
   }
 }

--- a/packages/api-client/src/libs/env-helpers.test.ts
+++ b/packages/api-client/src/libs/env-helpers.test.ts
@@ -1,16 +1,15 @@
-import type { Environment } from '@scalar/oas-utils/entities/environment'
+import { environmentSchema } from '@scalar/oas-utils/entities/environment'
 import { describe, expect, it } from 'vitest'
 
 import { getEnvColor } from './env-helpers'
 
 describe('getEnvColor', () => {
   it('returns the environment color when provided', () => {
-    const env: Environment = {
+    const env = environmentSchema.parse({
       color: '#FF0000',
       name: 'Production',
       value: 'production',
-      uid: '123',
-    }
+    })
 
     expect(getEnvColor(env)).toBe('#FF0000')
   })

--- a/packages/api-client/src/libs/env-helpers.ts
+++ b/packages/api-client/src/libs/env-helpers.ts
@@ -3,5 +3,4 @@ import type { Environment } from '@scalar/oas-utils/entities/environment'
 export type EnvVariables = { key: string; value: string; source: string }[]
 
 /** Gets the color of an environment with default fallback */
-export const getEnvColor = (environment: Environment) =>
-  environment ? environment.color : '#8E8E8E'
+export const getEnvColor = (environment: Environment) => (environment ? environment.color : '#8E8E8E')

--- a/packages/api-client/src/libs/find-request.test.ts
+++ b/packages/api-client/src/libs/find-request.test.ts
@@ -1,5 +1,5 @@
 import { parseCurlCommand } from '@/libs/parse-curl'
-import type { Request } from '@scalar/oas-utils/entities/spec'
+import { operationSchema } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
 import { findRequestByPathMethod, pathToRegex } from './find-request'
@@ -42,17 +42,11 @@ describe('pathToRegex', () => {
 })
 
 describe('findRequestByPathMethod', () => {
-  const mockRequest = {
+  const mockRequest = operationSchema.parse({
     method: 'get',
     path: '/planets/{planetId}',
-    type: 'request',
-    uid: '1',
-    selectedSecuritySchemeUids: [],
-    selectedServerUid: '',
-    servers: [],
-    examples: [],
-    responses: {},
-  } satisfies Request
+    uid: 'request-1-uid',
+  })
 
   it('should match a request with the path params before replacement', () => {
     const curlCommand = 'curl https://galaxy.scalar.com/planets/{planetId}'
@@ -70,9 +64,7 @@ describe('findRequestByPathMethod', () => {
     const encodedPath = new URL(url).pathname
     const path = decodeURIComponent(encodedPath)
 
-    const { request, pathParams } = findRequestByPathMethod(path, method, [
-      mockRequest,
-    ])
+    const { request, pathParams } = findRequestByPathMethod(path, method, [mockRequest])
     expect(request).toEqual(mockRequest)
     expect(pathParams).toEqual([{ key: 'planetId', value: '1' }])
   })
@@ -82,15 +74,12 @@ describe('findRequestByPathMethod', () => {
       ...mockRequest,
       path: '/planets/{planetId}/galaxies/{galaxyId}',
     }
-    const curlCommand =
-      'curl https://galaxy.scalar.com/planets/earth/galaxies/milky-way'
+    const curlCommand = 'curl https://galaxy.scalar.com/planets/earth/galaxies/milky-way'
     const { method = 'get', url } = parseCurlCommand(curlCommand)
     const encodedPath = new URL(url).pathname
     const path = decodeURIComponent(encodedPath)
 
-    const { request, pathParams } = findRequestByPathMethod(path, method, [
-      _mockRequest,
-    ])
+    const { request, pathParams } = findRequestByPathMethod(path, method, [_mockRequest])
     expect(request).toEqual(_mockRequest)
     expect(pathParams).toEqual([
       { key: 'planetId', value: 'earth' },

--- a/packages/api-client/src/libs/send-request/build-request-security.test.ts
+++ b/packages/api-client/src/libs/send-request/build-request-security.test.ts
@@ -1,7 +1,4 @@
-import {
-  type SecurityScheme,
-  securitySchemeSchema,
-} from '@scalar/oas-utils/entities/spec'
+import { type SecurityScheme, securitySchemeSchema } from '@scalar/oas-utils/entities/spec'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { buildRequestSecurity } from './build-request-security'
@@ -65,7 +62,7 @@ describe('buildRequestSecurity', () => {
         name: 'x-api-key',
         value: 'test-key',
         path: '/',
-        uid: 'x-api-key',
+        uid: 'apiKeyUid',
       })
     })
   })
@@ -74,9 +71,7 @@ describe('buildRequestSecurity', () => {
     it('should handle basic auth', () => {
       basic.scheme = 'basic'
       const result = buildRequestSecurity([basic])
-      expect(result.headers['Authorization']).toBe(
-        `Basic ${btoa('scalar:user')}`,
-      )
+      expect(result.headers['Authorization']).toBe(`Basic ${btoa('scalar:user')}`)
     })
 
     it('should handle basic auth with empty credentials', () => {

--- a/packages/api-client/src/libs/send-request/build-request-security.ts
+++ b/packages/api-client/src/libs/send-request/build-request-security.ts
@@ -27,6 +27,7 @@ export const buildRequestSecurity = (
       if (scheme.in === 'cookie') {
         cookies.push(
           cookieSchema.parse({
+            uid: scheme.uid,
             name: scheme.name,
             value,
             path: '/',

--- a/packages/api-client/src/libs/send-request/build-request-security.ts
+++ b/packages/api-client/src/libs/send-request/build-request-security.ts
@@ -1,5 +1,5 @@
 import { replaceTemplateVariables } from '@/libs/string-template'
-import type { Cookie } from '@scalar/oas-utils/entities/cookie'
+import { cookieSchema, type Cookie } from '@scalar/oas-utils/entities/cookie'
 import type { SecurityScheme } from '@scalar/oas-utils/entities/spec'
 import { isDefined } from '@scalar/oas-utils/helpers'
 
@@ -20,18 +20,18 @@ export const buildRequestSecurity = (
   securitySchemes.forEach((scheme) => {
     // Scheme type and example value type should always match
     if (scheme.type === 'apiKey') {
-      const value =
-        replaceTemplateVariables(scheme.value, env) || emptyTokenPlaceholder
+      const value = replaceTemplateVariables(scheme.value, env) || emptyTokenPlaceholder
 
       if (scheme.in === 'header') headers[scheme.name] = value
       if (scheme.in === 'query') urlParams.append(scheme.name, value)
       if (scheme.in === 'cookie') {
-        cookies.push({
-          name: scheme.name,
-          value,
-          path: '/',
-          uid: scheme.name,
-        })
+        cookies.push(
+          cookieSchema.parse({
+            name: scheme.name,
+            value,
+            path: '/',
+          }),
+        )
       }
     }
 
@@ -41,8 +41,7 @@ export const buildRequestSecurity = (
         const password = replaceTemplateVariables(scheme.password, env)
         const value = `${username}:${password}`
 
-        headers['Authorization'] =
-          `Basic ${value === ':' ? 'username:password' : btoa(value)}`
+        headers['Authorization'] = `Basic ${value === ':' ? 'username:password' : btoa(value)}`
       } else {
         const value = replaceTemplateVariables(scheme.token, env)
         headers['Authorization'] = `Bearer ${value || emptyTokenPlaceholder}`

--- a/packages/api-client/src/libs/send-request/create-fetch-auth.test.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-auth.test.ts
@@ -1,11 +1,9 @@
-import {
-  requestExampleSchema,
-  securitySchemeSchema,
-} from '@scalar/oas-utils/entities/spec'
+import { requestExampleSchema, securitySchemeSchema } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
 import { createRequestOperation } from './create-request-operation'
 import { VOID_URL, createRequestPayload } from './create-request-operation.test'
+import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
 
 describe('authentication', () => {
   it('adds apiKey auth in header', async () => {
@@ -14,16 +12,16 @@ describe('authentication', () => {
         serverPayload: { url: VOID_URL },
       }),
       securitySchemes: {
-        'api-key': {
+        'api-key': securitySchemeSchema.parse({
           type: 'apiKey',
           name: 'X-API-KEY',
           in: 'header',
           value: 'test-key',
           uid: 'api-key',
           nameKey: 'X-API-KEY',
-        },
+        }),
       },
-      selectedSecuritySchemeUids: ['api-key'],
+      selectedSecuritySchemeUids: ['api-key'] as SelectedSecuritySchemeUids,
     })
     if (error) throw error
 
@@ -41,16 +39,16 @@ describe('authentication', () => {
         serverPayload: { url: VOID_URL },
       }),
       securitySchemes: {
-        'api-key': {
+        'api-key': securitySchemeSchema.parse({
           type: 'apiKey',
           name: 'api_key',
           in: 'query',
           value: 'test-key',
           uid: 'api-key',
           nameKey: 'api_key',
-        },
+        }),
       },
-      selectedSecuritySchemeUids: ['api-key'],
+      selectedSecuritySchemeUids: ['api-key'] as SelectedSecuritySchemeUids,
     })
     if (error) throw error
 
@@ -68,25 +66,23 @@ describe('authentication', () => {
         serverPayload: { url: VOID_URL },
       }),
       securitySchemes: {
-        'api-key': {
+        'api-key': securitySchemeSchema.parse({
           type: 'apiKey',
           name: 'api_key',
           in: 'query',
           value: 'test-key',
           uid: 'api-key',
           nameKey: 'api_key',
-        },
+        }),
       },
-      selectedSecuritySchemeUids: ['api-key'],
+      selectedSecuritySchemeUids: ['api-key'] as SelectedSecuritySchemeUids,
     })
     if (error) throw error
 
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
-    expect(JSON.parse(result?.response.data as string).query.api_key).toEqual(
-      'test-key',
-    )
+    expect(JSON.parse(result?.response.data as string).query.api_key).toEqual('test-key')
   })
 
   it('adds basic auth header', async () => {
@@ -95,7 +91,7 @@ describe('authentication', () => {
         serverPayload: { url: VOID_URL },
       }),
       securitySchemes: {
-        'basic-auth': {
+        'basic-auth': securitySchemeSchema.parse({
           type: 'http',
           scheme: 'basic',
           bearerFormat: 'Basic',
@@ -104,9 +100,9 @@ describe('authentication', () => {
           password: 'pass',
           uid: 'basic-auth',
           nameKey: 'Authorization',
-        },
+        }),
       },
-      selectedSecuritySchemeUids: ['basic-auth'],
+      selectedSecuritySchemeUids: ['basic-auth'] as SelectedSecuritySchemeUids,
     })
     if (error) throw error
 
@@ -124,7 +120,7 @@ describe('authentication', () => {
         serverPayload: { url: VOID_URL },
       }),
       securitySchemes: {
-        'bearer-auth': {
+        'bearer-auth': securitySchemeSchema.parse({
           type: 'http',
           scheme: 'bearer',
           bearerFormat: 'Bearer',
@@ -133,9 +129,9 @@ describe('authentication', () => {
           uid: 'bearer-auth',
           nameKey: 'Authorization',
           token: 'xxxx',
-        },
+        }),
       },
-      selectedSecuritySchemeUids: ['bearer-auth'],
+      selectedSecuritySchemeUids: ['bearer-auth'] as SelectedSecuritySchemeUids,
     })
     if (error) throw error
 
@@ -153,15 +149,15 @@ describe('authentication', () => {
         serverPayload: { url: VOID_URL },
       }),
       securitySchemes: {
-        'api-key': {
+        'api-key': securitySchemeSchema.parse({
           type: 'apiKey',
           name: 'api_key',
           in: 'query',
           value: 'xxxx',
           uid: 'api-key',
           nameKey: 'api_key',
-        },
-        'bearer-auth': {
+        }),
+        'bearer-auth': securitySchemeSchema.parse({
           type: 'http',
           scheme: 'bearer',
           bearerFormat: 'Bearer',
@@ -170,9 +166,9 @@ describe('authentication', () => {
           uid: 'bearer-auth',
           nameKey: 'Authorization',
           token: 'xxxx',
-        },
+        }),
       },
-      selectedSecuritySchemeUids: [['bearer-auth', 'api-key']],
+      selectedSecuritySchemeUids: [['bearer-auth', 'api-key']] as SelectedSecuritySchemeUids,
     })
     if (error) throw error
 
@@ -190,7 +186,7 @@ describe('authentication', () => {
         serverPayload: { url: VOID_URL },
       }),
       securitySchemes: {
-        'oauth2-auth': {
+        'oauth2-auth': securitySchemeSchema.parse({
           type: 'oauth2',
           uid: 'oauth2-auth',
           nameKey: 'Authorization',
@@ -206,9 +202,9 @@ describe('authentication', () => {
               'x-scalar-redirect-uri': 'https://example.com/callback',
             },
           },
-        },
+        }),
       },
-      selectedSecuritySchemeUids: ['oauth2-auth'],
+      selectedSecuritySchemeUids: ['oauth2-auth'] as SelectedSecuritySchemeUids,
     })
     if (error) throw error
 
@@ -247,12 +243,10 @@ describe('authentication', () => {
           },
         }),
       },
-      selectedSecuritySchemeUids: ['oauth2-auth'],
+      selectedSecuritySchemeUids: ['oauth2-auth'] as SelectedSecuritySchemeUids,
     })
     if (error) throw error
 
-    expect(requestOperation.request.headers.get('Authorization')).toEqual(
-      'Bearer header-token',
-    )
+    expect(requestOperation.request.headers.get('Authorization')).toEqual('Bearer header-token')
   })
 })

--- a/packages/api-client/src/libs/send-request/create-fetch-body.test.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-body.test.ts
@@ -1,15 +1,11 @@
-import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import { requestExampleSchema } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
 import { createFetchBody } from './create-fetch-body'
 
 describe('createFetchBody', () => {
   it('should handle request method in lowercase', () => {
-    const example: RequestExample = {
-      uid: 'random-uid',
-      name: 'foo',
-      requestUid: 'other-random-uid',
-      type: 'requestExample',
+    const example = requestExampleSchema.parse({
       body: {
         activeBody: 'raw',
         raw: {
@@ -17,13 +13,7 @@ describe('createFetchBody', () => {
           encoding: 'text',
         },
       },
-      parameters: {
-        headers: [],
-        query: [],
-        path: [],
-        cookies: [],
-      },
-    }
+    })
 
     const result = createFetchBody('post', example, {})
 

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -14,6 +14,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest'
 import type { z } from 'zod'
 
 import { createRequestOperation } from './create-request-operation'
+import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
 
 const PROXY_PORT = 5051
 const VOID_PORT = 5052
@@ -30,13 +31,9 @@ type MetaRequestPayload = {
 }
 
 /** Creates the payload for createRequestOperation */
-export const createRequestPayload = (
-  metaRequestPayload: MetaRequestPayload = {},
-) => {
+export const createRequestPayload = (metaRequestPayload: MetaRequestPayload = {}) => {
   const request = requestSchema.parse(metaRequestPayload.requestPayload ?? {})
-  const server = metaRequestPayload.serverPayload
-    ? serverSchema.parse(metaRequestPayload.serverPayload)
-    : undefined
+  const server = metaRequestPayload.serverPayload ? serverSchema.parse(metaRequestPayload.serverPayload) : undefined
   let example = createExampleFromRequest(request, 'example')
 
   // Overwrite any example properties
@@ -697,7 +694,7 @@ describe('create-request-operation', () => {
           description: 'API key',
         }),
       },
-      selectedSecuritySchemeUids: ['api-key'],
+      selectedSecuritySchemeUids: ['api-key'] as SelectedSecuritySchemeUids,
     })
 
     if (error) throw error
@@ -719,27 +716,25 @@ describe('create-request-operation', () => {
           serverPayload: { url: VOID_URL },
         }),
         securitySchemes: {
-          'api-key': {
+          'api-key': securitySchemeSchema.parse({
             type: 'apiKey',
             name: 'X-API-KEY',
             in: 'header',
             value: 'test-key',
             uid: 'api-key',
             nameKey: 'X-API-KEY',
-          },
+          }),
         },
-        selectedSecuritySchemeUids: ['api-key'],
+        selectedSecuritySchemeUids: ['api-key'] as SelectedSecuritySchemeUids,
       })
       if (error) throw error
 
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
-      expect(JSON.parse(result?.response.data as string).headers).toMatchObject(
-        {
-          'x-api-key': 'test-key',
-        },
-      )
+      expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
+        'x-api-key': 'test-key',
+      })
     })
 
     it('adds apiKey auth in query', async () => {
@@ -748,16 +743,16 @@ describe('create-request-operation', () => {
           serverPayload: { url: VOID_URL },
         }),
         securitySchemes: {
-          'api-key': {
+          'api-key': securitySchemeSchema.parse({
             type: 'apiKey',
             name: 'api_key',
             in: 'query',
             value: 'test-key',
             uid: 'api-key',
             nameKey: 'api_key',
-          },
+          }),
         },
-        selectedSecuritySchemeUids: ['api-key'],
+        selectedSecuritySchemeUids: ['api-key'] as SelectedSecuritySchemeUids,
       })
       if (error) throw error
 
@@ -775,7 +770,7 @@ describe('create-request-operation', () => {
           serverPayload: { url: VOID_URL },
         }),
         securitySchemes: {
-          'basic-auth': {
+          'basic-auth': securitySchemeSchema.parse({
             type: 'http',
             scheme: 'basic',
             bearerFormat: 'Basic',
@@ -784,20 +779,18 @@ describe('create-request-operation', () => {
             password: 'pass',
             uid: 'basic-auth',
             nameKey: 'Authorization',
-          },
+          }),
         },
-        selectedSecuritySchemeUids: ['basic-auth'],
+        selectedSecuritySchemeUids: ['basic-auth'] as SelectedSecuritySchemeUids,
       })
       if (error) throw error
 
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
-      expect(JSON.parse(result?.response.data as string).headers).toMatchObject(
-        {
-          authorization: `Basic ${btoa('user:pass')}`,
-        },
-      )
+      expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
+        authorization: `Basic ${btoa('user:pass')}`,
+      })
     })
 
     it('adds bearer token header', async () => {
@@ -806,29 +799,25 @@ describe('create-request-operation', () => {
           serverPayload: { url: VOID_URL },
         }),
         securitySchemes: {
-          'bearer-auth': {
+          'bearer-auth': securitySchemeSchema.parse({
             type: 'http',
             scheme: 'bearer',
             bearerFormat: 'Bearer',
-            username: '',
-            password: '',
             uid: 'bearer-auth',
             nameKey: 'Authorization',
             token: 'xxxx',
-          },
+          }),
         },
-        selectedSecuritySchemeUids: ['bearer-auth'],
+        selectedSecuritySchemeUids: ['bearer-auth'] as SelectedSecuritySchemeUids,
       })
       if (error) throw error
 
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
-      expect(JSON.parse(result?.response.data as string).headers).toMatchObject(
-        {
-          authorization: 'Bearer xxxx',
-        },
-      )
+      expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
+        authorization: 'Bearer xxxx',
+      })
     })
 
     it('handles complex auth', async () => {
@@ -837,15 +826,15 @@ describe('create-request-operation', () => {
           serverPayload: { url: VOID_URL },
         }),
         securitySchemes: {
-          'api-key': {
+          'api-key': securitySchemeSchema.parse({
             type: 'apiKey',
             name: 'api_key',
             in: 'query',
             value: 'xxxx',
             uid: 'api-key',
             nameKey: 'api_key',
-          },
-          'bearer-auth': {
+          }),
+          'bearer-auth': securitySchemeSchema.parse({
             type: 'http',
             scheme: 'bearer',
             bearerFormat: 'Bearer',
@@ -854,9 +843,9 @@ describe('create-request-operation', () => {
             uid: 'bearer-auth',
             nameKey: 'Authorization',
             token: 'xxxx',
-          },
+          }),
         },
-        selectedSecuritySchemeUids: [['bearer-auth', 'api-key']],
+        selectedSecuritySchemeUids: [['bearer-auth', 'api-key']] as SelectedSecuritySchemeUids,
       })
       if (error) throw error
 
@@ -874,7 +863,7 @@ describe('create-request-operation', () => {
           serverPayload: { url: VOID_URL },
         }),
         securitySchemes: {
-          'oauth2-auth': {
+          'oauth2-auth': securitySchemeSchema.parse({
             type: 'oauth2',
             uid: 'oauth2-auth',
             nameKey: 'Authorization',
@@ -890,20 +879,18 @@ describe('create-request-operation', () => {
                 'x-scalar-redirect-uri': 'https://example.com/callback',
               },
             },
-          },
+          }),
         },
-        selectedSecuritySchemeUids: ['oauth2-auth'],
+        selectedSecuritySchemeUids: ['oauth2-auth'] as SelectedSecuritySchemeUids,
       })
       if (error) throw error
 
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
-      expect(JSON.parse(result?.response.data as string).headers).toMatchObject(
-        {
-          authorization: 'Bearer oauth-token',
-        },
-      )
+      expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
+        authorization: 'Bearer oauth-token',
+      })
     })
 
     it('accepts a lowercase auth header', () => {
@@ -912,16 +899,16 @@ describe('create-request-operation', () => {
           serverPayload: { url: VOID_URL },
         }),
         securitySchemes: {
-          'api-key': {
+          'api-key': securitySchemeSchema.parse({
             type: 'apiKey',
             name: 'x-api-key',
             in: 'header',
             value: 'test-key',
             uid: 'api-key',
             nameKey: 'api-key',
-          },
+          }),
         },
-        selectedSecuritySchemeUids: ['api-key'],
+        selectedSecuritySchemeUids: ['api-key'] as SelectedSecuritySchemeUids,
       })
       if (error) throw error
       expect(requestOperation.request.headers.get('x-api-key')).toBe('test-key')

--- a/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
+++ b/packages/api-client/src/libs/send-request/set-request-cookies.test.ts
@@ -1,12 +1,8 @@
-import type { Cookie } from '@scalar/oas-utils/entities/cookie'
-import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import { cookieSchema, type Cookie } from '@scalar/oas-utils/entities/cookie'
 import { describe, expect, it } from 'vitest'
 
-import {
-  getCookieHeader,
-  matchesDomain,
-  setRequestCookies,
-} from './set-request-cookies'
+import { getCookieHeader, matchesDomain, setRequestCookies } from './set-request-cookies'
+import { requestExampleSchema } from '@scalar/oas-utils/entities/spec'
 
 describe('setRequestCookies', () => {
   it('should set local and global cookies', () => {
@@ -17,7 +13,7 @@ describe('setRequestCookies', () => {
       enabled: true,
     }
 
-    const example: RequestExample = createRequestExample({
+    const example = requestExampleSchema.parse({
       parameters: {
         cookies: [localCookieParameter],
         path: [],
@@ -85,10 +81,7 @@ describe('getCookieHeader', () => {
   })
 
   it('generates a cookie header with multiple cookies', () => {
-    const cookieParams: Cookie[] = [
-      createCookie('foo', 'bar'),
-      createCookie('baz', 'qux'),
-    ]
+    const cookieParams: Cookie[] = [createCookie('foo', 'bar'), createCookie('baz', 'qux')]
     expect(getCookieHeader(cookieParams)).toBe('foo=bar; baz=qux')
   })
 
@@ -97,16 +90,11 @@ describe('getCookieHeader', () => {
       createCookie('test', 'hello world!@#$%^&*()'),
       createCookie('complex', '{"key": "value"}'),
     ]
-    expect(getCookieHeader(cookieParams)).toBe(
-      'test=hello world!@#$%^&*(); complex={"key": "value"}',
-    )
+    expect(getCookieHeader(cookieParams)).toBe('test=hello world!@#$%^&*(); complex={"key": "value"}')
   })
 
   it('handles cookies with empty values', () => {
-    const cookieParams: Cookie[] = [
-      createCookie('empty', ''),
-      createCookie('normal', 'value'),
-    ]
+    const cookieParams: Cookie[] = [createCookie('empty', ''), createCookie('normal', 'value')]
     expect(getCookieHeader(cookieParams)).toBe('empty=; normal=value')
   })
 
@@ -116,85 +104,39 @@ describe('getCookieHeader', () => {
   })
 
   it('handles cookies with unicode values', () => {
-    const cookieParams: Cookie[] = [
-      createCookie('greeting', '你好'),
-      createCookie('emoji', '👋'),
-    ]
+    const cookieParams: Cookie[] = [createCookie('greeting', '你好'), createCookie('emoji', '👋')]
     expect(getCookieHeader(cookieParams)).toBe('greeting=你好; emoji=👋')
   })
 
   it('merges with original cookie header', () => {
     const cookieParams: Cookie[] = [createCookie('foo', 'bar')]
-    expect(getCookieHeader(cookieParams, 'existing=value')).toBe(
-      'existing=value; foo=bar',
-    )
+    expect(getCookieHeader(cookieParams, 'existing=value')).toBe('existing=value; foo=bar')
   })
 
   it('merges multiple cookies with original cookie header', () => {
-    const cookieParams: Cookie[] = [
-      createCookie('foo', 'bar'),
-      createCookie('baz', 'qux'),
-    ]
-    expect(getCookieHeader(cookieParams, 'existing=value')).toBe(
-      'existing=value; foo=bar; baz=qux',
-    )
+    const cookieParams: Cookie[] = [createCookie('foo', 'bar'), createCookie('baz', 'qux')]
+    expect(getCookieHeader(cookieParams, 'existing=value')).toBe('existing=value; foo=bar; baz=qux')
   })
 
   it('handles empty cookie params with original cookie header', () => {
     const cookieParams: Cookie[] = []
-    expect(getCookieHeader(cookieParams, 'existing=value')).toBe(
-      'existing=value;',
-    )
+    expect(getCookieHeader(cookieParams, 'existing=value')).toBe('existing=value;')
   })
 
   it('handles original cookie header with multiple cookies', () => {
     const cookieParams: Cookie[] = [createCookie('foo', 'bar')]
-    expect(getCookieHeader(cookieParams, 'first=one; second=two')).toBe(
-      'first=one; second=two; foo=bar',
-    )
+    expect(getCookieHeader(cookieParams, 'first=one; second=two')).toBe('first=one; second=two; foo=bar')
   })
 })
 
 /**
  * Create a cookie with default values and optional overrides
  */
-function createCookie(
-  name: string,
-  value: string,
-  options: Partial<Exclude<Cookie, 'name' | 'value'>> = {},
-): Cookie {
-  return {
+const createCookie = (name: string, value: string, options: Partial<Exclude<Cookie, 'name' | 'value'>> = {}): Cookie =>
+  cookieSchema.parse({
     name,
     value,
     domain: 'example.com',
     path: '/',
-    uid: 'globalCookie',
-    // overwrite (optional)
     ...options,
-  }
-}
-
-function createRequestExample(
-  example: Partial<RequestExample> = {},
-): RequestExample {
-  return {
-    type: 'requestExample' as const,
-    uid: 'example',
-    name: 'Example',
-    requestUid: 'request',
-    parameters: {
-      cookies: [],
-      path: [],
-      query: [],
-      headers: [],
-    },
-    body: {
-      activeBody: 'raw' as const,
-      raw: {
-        encoding: 'json',
-        value: '',
-      },
-    },
-    ...example,
-  }
-}
+  })

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -83,7 +83,7 @@ export const createActiveEntitiesStore = ({
   const activeEnvironment = computed(() => {
     if (!activeWorkspace.value?.activeEnvironmentId) {
       return environmentSchema.parse({
-        uid: '',
+        uid: 'default',
         color: '#0082D0',
         name: 'No Environment',
         value: JSON.stringify(activeWorkspace.value?.environments, null, 2),
@@ -111,7 +111,7 @@ export const createActiveEntitiesStore = ({
     }
 
     return environmentSchema.parse({
-      uid: '',
+      uid: 'default',
       color: '#0082D0',
       name: 'No Environment',
       value: JSON.stringify(activeWorkspace.value.environments, null, 2),

--- a/packages/api-client/src/store/collections.test.ts
+++ b/packages/api-client/src/store/collections.test.ts
@@ -1,13 +1,10 @@
-import type { Collection } from '@scalar/oas-utils/entities/spec'
-import type { Workspace } from '@scalar/oas-utils/entities/workspace'
+import { collectionSchema, serverSchema } from '@scalar/oas-utils/entities/spec'
+import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { describe, expect, it, vi } from 'vitest'
 import { reactive } from 'vue'
 
-import {
-  createStoreCollections,
-  extendedCollectionDataFactory,
-} from './collections'
+import { createStoreCollections, extendedCollectionDataFactory } from './collections'
 import { createStoreServers } from './servers'
 
 // Mock data
@@ -15,56 +12,21 @@ vi.mock('@/store', () => ({
   useWorkspace: vi.fn(),
 }))
 
-const mockDraftsCollection: Collection = {
-  'uid': 'drafts',
-  'type': 'collection',
-  'children': [],
-  'openapi': '3.1.0',
-  'security': [],
-  'x-scalar-icon': 'interface-content-folder',
-  'securitySchemes': [],
-  'selectedSecuritySchemeUids': [],
-  'servers': [],
-  'requests': [],
-  'tags': [],
-  'selectedServerUid': '',
-  'watchMode': false,
-  'watchModeStatus': 'IDLE',
-}
+const mockDraftsCollection = collectionSchema.parse({})
 
-const mockWorkspace: Workspace = {
-  uid: 'workspace1',
+const mockWorkspace = workspaceSchema.parse({
   name: 'Mock Workspace',
   description: 'A mock workspace for testing',
-  collections: [] as string[],
-  environments: {},
-  activeEnvironmentId: '',
-  cookies: [],
-  themeId: 'default' as const,
   selectedHttpClient: {
     targetKey: 'node',
     clientKey: 'undici',
   },
-}
+})
 
-const mockCollection: Collection = {
-  'uid': 'collection1',
-  'info': { title: 'Test Collection', version: '1.0.0' },
-  'tags': [],
-  'requests': [],
-  'servers': [],
-  'x-scalar-environments': {},
-  'type': 'collection',
-  'children': [],
-  'openapi': '3.1.0',
-  'security': [],
-  'x-scalar-icon': 'interface-content-folder',
-  'securitySchemes': [],
-  'selectedSecuritySchemeUids': [],
-  'selectedServerUid': '',
-  'watchMode': false,
-  'watchModeStatus': 'IDLE',
-}
+const mockCollection = collectionSchema.parse({
+  uid: 'collection1',
+  info: { title: 'Test Collection', version: '1.0.0' },
+})
 
 const createStoreContext = () => {
   const { collections, collectionMutators } = createStoreCollections(false)
@@ -103,15 +65,12 @@ describe('Collections Store', () => {
     const collection = addCollection(mockCollection, mockWorkspace.uid)
 
     expect(storeContext.collections[collection.uid]).toBeDefined()
-    expect(storeContext.collections[collection.uid]?.info?.title).toEqual(
-      'Test Collection',
-    )
+    expect(storeContext.collections[collection.uid]?.info?.title).toEqual('Test Collection')
   })
 
   describe('should delete a collection', () => {
     const storeContext = createStoreContext()
-    const { addCollection, deleteCollection } =
-      extendedCollectionDataFactory(storeContext)
+    const { addCollection, deleteCollection } = extendedCollectionDataFactory(storeContext)
 
     const collectionPayload = {
       ...mockCollection,
@@ -132,21 +91,18 @@ describe('Collections Store', () => {
     const collection = addCollection(collectionPayload, mockWorkspace.uid)
 
     // Add the second collection
-    const anotherCollection = addCollection(
-      anotherCollectionPayload,
-      mockWorkspace.uid,
-    )
+    const anotherCollection = addCollection(anotherCollectionPayload, mockWorkspace.uid)
 
-    const collectionServer = {
+    const collectionServer = serverSchema.parse({
       uid: 'collection-server',
       url: 'https://api.example.com',
       description: 'A collection server',
-    }
+    })
 
-    const anotherCollectionServer = {
+    const anotherCollectionServer = serverSchema.parse({
       uid: 'collection-server-2',
       url: 'https://api.example.com/2',
-    }
+    })
 
     storeContext.serverMutators.add(collectionServer)
     storeContext.serverMutators.add(anotherCollectionServer)
@@ -163,9 +119,7 @@ describe('Collections Store', () => {
     })
 
     it('should delete its servers', () => {
-      expect(Object.keys(storeContext.servers)).not.toContain(
-        'collection-server',
-      )
+      expect(Object.keys(storeContext.servers)).not.toContain('collection-server')
       expect(Object.keys(storeContext.servers)).toContain('collection-server-2')
     })
 

--- a/packages/api-client/src/store/collections.ts
+++ b/packages/api-client/src/store/collections.ts
@@ -13,11 +13,7 @@ import { reactive } from 'vue'
 /** Initiate the workspace collections */
 export function createStoreCollections(useLocalStorage: boolean) {
   const collections = reactive<Record<string, Collection>>({})
-  const collectionMutators = mutationFactory(
-    collections,
-    reactive({}),
-    useLocalStorage && LS_KEYS.COLLECTION,
-  )
+  const collectionMutators = mutationFactory(collections, reactive({}), useLocalStorage && LS_KEYS.COLLECTION)
 
   return {
     collections,
@@ -38,14 +34,11 @@ export function extendedCollectionDataFactory({
   tagMutators,
   serverMutators,
 }: StoreContext) {
-  const addCollection = (payload: CollectionPayload, workspaceUid: string) => {
+  const addCollection = (payload: CollectionPayload, workspaceUid: Workspace['uid']) => {
     const collection = collectionSchema.parse(payload)
     const workspace = workspaces[workspaceUid]
     if (workspace) {
-      workspaceMutators.edit(workspaceUid, 'collections', [
-        ...workspace.collections,
-        collection.uid,
-      ])
+      workspaceMutators.edit(workspaceUid, 'collections', [...workspace.collections, collection.uid])
     }
 
     collectionMutators.add(collection)
@@ -78,9 +71,7 @@ export function extendedCollectionDataFactory({
       if (!request) return
 
       requestMutators.delete(uid)
-      request.examples.forEach(
-        (e) => requestExamples[e] && requestExampleMutators.delete(e),
-      )
+      request.examples.forEach((e) => requestExamples[e] && requestExampleMutators.delete(e))
     })
 
     // Remove servers
@@ -103,7 +94,7 @@ export function extendedCollectionDataFactory({
   const addCollectionEnvironment = (
     environmentName: string,
     environment: XScalarEnvironment,
-    collectionUid: string,
+    collectionUid: Collection['uid'],
   ) => {
     const collection = collections[collectionUid]
     if (collection) {
@@ -115,20 +106,13 @@ export function extendedCollectionDataFactory({
     }
   }
 
-  const removeCollectionEnvironment = (
-    environmentName: string,
-    collectionUid: string,
-  ) => {
+  const removeCollectionEnvironment = (environmentName: string, collectionUid: Collection['uid']) => {
     const collection = collections[collectionUid]
     if (collection) {
       const currentEnvironments = collection['x-scalar-environments'] || {}
       if (environmentName in currentEnvironments) {
         delete currentEnvironments[environmentName]
-        collectionMutators.edit(
-          collectionUid,
-          'x-scalar-environments',
-          currentEnvironments,
-        )
+        collectionMutators.edit(collectionUid, 'x-scalar-environments', currentEnvironments)
       }
     }
   }

--- a/packages/api-client/src/store/environment.ts
+++ b/packages/api-client/src/store/environment.ts
@@ -1,8 +1,5 @@
 import type { StoreContext } from '@/store/store-context'
-import {
-  type Environment,
-  environmentSchema,
-} from '@scalar/oas-utils/entities/environment'
+import { type Environment, environmentSchema } from '@scalar/oas-utils/entities/environment'
 import { LS_KEYS } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { reactive } from 'vue'
@@ -11,11 +8,7 @@ import { reactive } from 'vue'
 export function createStoreEnvironments(useLocalStorage: boolean) {
   /** Initialize default environment */
   const environments = reactive<Record<string, Environment>>({})
-  const environmentMutators = mutationFactory(
-    environments,
-    reactive({}),
-    useLocalStorage && LS_KEYS.ENVIRONMENT,
-  )
+  const environmentMutators = mutationFactory(environments, reactive({}), useLocalStorage && LS_KEYS.ENVIRONMENT)
 
   // Add default environment
   environmentMutators.add(
@@ -35,11 +28,9 @@ export function createStoreEnvironments(useLocalStorage: boolean) {
 }
 
 /** Extended environment data factory where workspace access is needed */
-export function extendedEnvironmentDataFactory({
-  environmentMutators,
-}: StoreContext) {
+export function extendedEnvironmentDataFactory({ environmentMutators }: StoreContext) {
   /** prevent deletion of the default environment */
-  const deleteEnvironment = (uid: string) => {
+  const deleteEnvironment = (uid: Environment['uid']) => {
     if (uid === 'default') {
       console.warn('Default environment cannot be deleted.')
       return

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -1,22 +1,16 @@
 import { type ErrorResponse, normalizeError } from '@/libs'
 import type { StoreContext } from '@/store/store-context'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { createHash, fetchSpecFromUrl } from '@scalar/oas-utils/helpers'
-import {
-  type ImportSpecToWorkspaceArgs,
-  importSpecToWorkspace,
-} from '@scalar/oas-utils/transforms'
+import { type ImportSpecToWorkspaceArgs, importSpecToWorkspace } from '@scalar/oas-utils/transforms'
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import { toRaw } from 'vue'
 
 /** Maps the specs by URL */
-export const specDictionary: Record<
-  string,
-  { hash: number; schema: OpenAPIV3.Document | OpenAPIV3_1.Document }
-> = {}
+export const specDictionary: Record<string, { hash: number; schema: OpenAPIV3.Document | OpenAPIV3_1.Document }> = {}
 
-type ImportSpecFileArgs = ImportSpecToWorkspaceArgs &
-  Pick<ReferenceConfiguration, 'servers'>
+type ImportSpecFileArgs = ImportSpecToWorkspaceArgs & Pick<ReferenceConfiguration, 'servers'>
 
 /** Generate the import functions from a store context */
 export function importSpecFileFactory({
@@ -59,13 +53,11 @@ export function importSpecFileFactory({
     workspaceEntities.requests.forEach((r) => requestMutators.add(r))
     workspaceEntities.tags.forEach((t) => tagMutators.add(t))
     workspaceEntities.servers.forEach((s) => serverMutators.add(s))
-    workspaceEntities.securitySchemes.forEach((s) =>
-      securitySchemeMutators.add(s),
-    )
+    workspaceEntities.securitySchemes.forEach((s) => securitySchemeMutators.add(s))
     collectionMutators.add(workspaceEntities.collection)
 
     // Add the collection UID to the workspace
-    workspaceMutators.edit(workspaceUid, 'collections', [
+    workspaceMutators.edit(workspaceUid as Workspace['uid'], 'collections', [
       ...(workspaces[workspaceUid]?.collections ?? []),
       workspaceEntities.collection.uid,
     ])
@@ -81,11 +73,7 @@ export function importSpecFileFactory({
   async function importSpecFromUrl(
     url: string,
     workspaceUid: string,
-    {
-      proxyUrl,
-      ...options
-    }: Omit<ImportSpecFileArgs, 'documentUrl'> &
-      Pick<ReferenceConfiguration, 'proxyUrl'> = {},
+    { proxyUrl, ...options }: Omit<ImportSpecFileArgs, 'documentUrl'> & Pick<ReferenceConfiguration, 'proxyUrl'> = {},
   ): Promise<ErrorResponse<Awaited<ReturnType<typeof importSpecFile>>>> {
     try {
       const spec = await fetchSpecFromUrl(url, proxyUrl)

--- a/packages/api-client/src/store/request-example.ts
+++ b/packages/api-client/src/store/request-example.ts
@@ -1,9 +1,5 @@
 import type { StoreContext } from '@/store/store-context'
-import {
-  type Request,
-  type RequestExample,
-  createExampleFromRequest,
-} from '@scalar/oas-utils/entities/spec'
+import { type Request, type RequestExample, createExampleFromRequest } from '@scalar/oas-utils/entities/spec'
 import { LS_KEYS, iterateTitle } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { reactive } from 'vue'
@@ -49,23 +45,20 @@ export function extendedExampleDataFactory({
     requestExampleMutators.add(example)
 
     // Add the uid to the request
-    requestMutators.edit(request.uid, 'examples', [
-      ...request.examples,
-      example.uid,
-    ])
+    requestMutators.edit(request.uid, 'examples', [...request.examples, example.uid])
 
     return example
   }
 
   /** Ensure we remove from the base as well as from the request it is in */
   const deleteRequestExample = (requestExample: RequestExample) => {
+    if (!requestExample.requestUid) return
+
     // Remove from request
     requestMutators.edit(
       requestExample.requestUid,
       'examples',
-      requests[requestExample.requestUid]?.examples.filter(
-        (uid) => uid !== requestExample.uid,
-      ) || [],
+      requests[requestExample.requestUid]?.examples.filter((uid) => uid !== requestExample.uid) || [],
     )
 
     // Remove from base

--- a/packages/api-client/src/store/router-params.ts
+++ b/packages/api-client/src/store/router-params.ts
@@ -1,30 +1,31 @@
 import { PathId } from '@/router'
+import type { Cookie } from '@scalar/oas-utils/entities/cookie'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
+import type { Collection, Request, RequestExample, Server } from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import type { Router } from 'vue-router'
-
-export type RouterPathParams = Record<PathId, string>
 
 /** Getter function for router parameters */
 export function getRouterParams(router?: Router) {
   return () => {
     const pathParams = {
-      [PathId.Collection]: 'default',
-      [PathId.Environment]: 'default',
-      [PathId.Request]: 'default',
-      [PathId.Examples]: 'default',
-      [PathId.Schema]: 'default',
-      [PathId.Cookies]: 'default',
-      [PathId.Servers]: 'default',
-      [PathId.Workspace]: 'default',
-      [PathId.Settings]: 'default',
-    } satisfies RouterPathParams
+      [PathId.Collection]: 'default' as Collection['uid'],
+      [PathId.Environment]: 'default' as Environment['uid'],
+      [PathId.Request]: 'default' as Request['uid'],
+      [PathId.Examples]: 'default' as RequestExample['uid'],
+      [PathId.Schema]: 'default' as string,
+      [PathId.Cookies]: 'default' as Cookie['uid'],
+      [PathId.Servers]: 'default' as Server['uid'],
+      [PathId.Workspace]: 'default' as Workspace['uid'],
+      [PathId.Settings]: 'default' as string,
+    } as const
 
     const currentRoute = router?.currentRoute.value
 
     if (currentRoute) {
-      Object.values(PathId).forEach((k) => {
-        if (currentRoute.params[k]) {
-          pathParams[k] = currentRoute.params[k] as string
-        }
+      ;(Object.keys(pathParams) as (keyof typeof pathParams)[]).forEach((k) => {
+        // @ts-expect-error this gives us good types without redoing PathId :)
+        if (currentRoute.params[k]) pathParams[k] = currentRoute.params[k]
       })
     }
 

--- a/packages/api-client/src/store/security-schemes.ts
+++ b/packages/api-client/src/store/security-schemes.ts
@@ -1,9 +1,5 @@
 import type { StoreContext } from '@/store/store-context'
-import {
-  type SecurityScheme,
-  type SecuritySchemePayload,
-  securitySchemeSchema,
-} from '@scalar/oas-utils/entities/spec'
+import { type SecurityScheme, type SecuritySchemePayload, securitySchemeSchema } from '@scalar/oas-utils/entities/spec'
 import { LS_KEYS } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { reactive } from 'vue'
@@ -52,7 +48,7 @@ export function extendedSecurityDataFactory({
   }
 
   /** Delete a security scheme and remove the key from its corresponding parent */
-  const deleteSecurityScheme = (schemeUid: string) => {
+  const deleteSecurityScheme = (schemeUid: SecurityScheme['uid']) => {
     Object.values(collections).forEach((c) => {
       // Remove the scheme from any collections that reference it (should only be 1 collection)
       if (c.securitySchemes.includes(schemeUid)) {
@@ -70,9 +66,7 @@ export function extendedSecurityDataFactory({
         requestMutators.edit(
           r.uid,
           'security',
-          requests[r.uid]?.security?.filter(
-            (s) => !Object.keys(s).includes(schemeUid),
-          ),
+          requests[r.uid]?.security?.filter((s) => !Object.keys(s).includes(schemeUid)),
         )
       }
       // Remove from any requests that have it selected

--- a/packages/api-client/src/store/security-schemes.ts
+++ b/packages/api-client/src/store/security-schemes.ts
@@ -1,5 +1,10 @@
 import type { StoreContext } from '@/store/store-context'
-import { type SecurityScheme, type SecuritySchemePayload, securitySchemeSchema } from '@scalar/oas-utils/entities/spec'
+import {
+  type Collection,
+  type SecurityScheme,
+  type SecuritySchemePayload,
+  securitySchemeSchema,
+} from '@scalar/oas-utils/entities/spec'
 import { LS_KEYS } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { reactive } from 'vue'
@@ -31,7 +36,7 @@ export function extendedSecurityDataFactory({
   const addSecurityScheme = (
     payload: SecuritySchemePayload,
     /** Schemes will always live at the collection level */
-    collectionUid: string,
+    collectionUid: Collection['uid'],
   ) => {
     const scheme = securitySchemeSchema.parse(payload)
     securitySchemeMutators.add(scheme)

--- a/packages/api-client/src/store/servers.ts
+++ b/packages/api-client/src/store/servers.ts
@@ -1,5 +1,7 @@
 import type { StoreContext } from '@/store/store-context'
 import {
+  type Collection,
+  type Request,
   type Server,
   type ServerPayload,
   serverSchema,
@@ -12,11 +14,7 @@ import { reactive } from 'vue'
 export function createStoreServers(useLocalStorage: boolean) {
   const servers = reactive<Record<string, Server>>({})
 
-  const serverMutators = mutationFactory(
-    servers,
-    reactive({}),
-    useLocalStorage && LS_KEYS.SERVER,
-  )
+  const serverMutators = mutationFactory(servers, reactive({}), useLocalStorage && LS_KEYS.SERVER)
 
   return {
     servers,
@@ -41,17 +39,14 @@ export function extendedServerDataFactory({
 
     // Add to collection
     if (collections[parentUid]) {
-      collectionMutators.edit(parentUid, 'servers', [
+      collectionMutators.edit(parentUid as Collection['uid'], 'servers', [
         ...collections[parentUid].servers,
         server.uid,
       ])
     }
     // Add to request
     else if (requests[parentUid]) {
-      requestMutators.edit(parentUid, 'servers', [
-        ...requests[parentUid].servers,
-        server.uid,
-      ])
+      requestMutators.edit(parentUid as Request['uid'], 'servers', [...requests[parentUid].servers, server.uid])
     }
 
     // Add to servers
@@ -61,7 +56,7 @@ export function extendedServerDataFactory({
   }
 
   /** Delete a server */
-  const deleteServer = (serverUid: string, collectionUid: string) => {
+  const deleteServer = (serverUid: Server['uid'], collectionUid: Collection['uid']) => {
     if (!collections[collectionUid]) return
 
     // Remove from parent collection

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -1,38 +1,17 @@
-import {
-  createStoreCollections,
-  extendedCollectionDataFactory,
-} from '@/store/collections'
+import { createStoreCollections, extendedCollectionDataFactory } from '@/store/collections'
 import { createStoreCookies } from '@/store/cookies'
-import {
-  createStoreEnvironments,
-  extendedEnvironmentDataFactory,
-} from '@/store/environment'
+import { createStoreEnvironments, extendedEnvironmentDataFactory } from '@/store/environment'
 import { createStoreEvents } from '@/store/events'
 import { importSpecFileFactory } from '@/store/import-spec'
-import {
-  createStoreRequestExamples,
-  extendedExampleDataFactory,
-} from '@/store/request-example'
-import {
-  createStoreRequests,
-  extendedRequestDataFactory,
-} from '@/store/requests'
-import {
-  createStoreSecuritySchemes,
-  extendedSecurityDataFactory,
-} from '@/store/security-schemes'
+import { createStoreRequestExamples, extendedExampleDataFactory } from '@/store/request-example'
+import { createStoreRequests, extendedRequestDataFactory } from '@/store/requests'
+import { createStoreSecuritySchemes, extendedSecurityDataFactory } from '@/store/security-schemes'
 import { createStoreServers, extendedServerDataFactory } from '@/store/servers'
 import type { StoreContext } from '@/store/store-context'
 import { createStoreTags, extendedTagDataFactory } from '@/store/tags'
-import {
-  createStoreWorkspaces,
-  extendedWorkspaceDataFactory,
-} from '@/store/workspace'
+import { createStoreWorkspaces, extendedWorkspaceDataFactory } from '@/store/workspace'
 import { useModal } from '@scalar/components'
-import type {
-  RequestEvent,
-  SecurityScheme,
-} from '@scalar/oas-utils/entities/spec'
+import type { RequestEvent, SecurityScheme } from '@scalar/oas-utils/entities/spec'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import { type InjectionKey, inject, reactive, ref, toRaw } from 'vue'
@@ -60,10 +39,7 @@ type CreateWorkspaceStoreOptions = {
   themeId: ReferenceConfiguration['theme']
   /** Specifies the integration being used. This is primarily for internal purposes and should not be manually set. */
   integration: ReferenceConfiguration['_integration']
-} & Pick<
-  ReferenceConfiguration,
-  'proxyUrl' | 'showSidebar' | 'hideClientButton'
->
+} & Pick<ReferenceConfiguration, 'proxyUrl' | 'showSidebar' | 'hideClientButton'>
 
 /**
  /**
@@ -83,20 +59,15 @@ export const createWorkspaceStore = ({
   // ---------------------------------------------------------------------------
   // Initialize all storage objects
 
-  const { collections, collectionMutators } =
-    createStoreCollections(useLocalStorage)
+  const { collections, collectionMutators } = createStoreCollections(useLocalStorage)
   const { tags, tagMutators } = createStoreTags(useLocalStorage)
   const { requests, requestMutators } = createStoreRequests(useLocalStorage)
-  const { requestExamples, requestExampleMutators } =
-    createStoreRequestExamples(useLocalStorage)
+  const { requestExamples, requestExampleMutators } = createStoreRequestExamples(useLocalStorage)
   const { cookies, cookieMutators } = createStoreCookies(useLocalStorage)
-  const { environments, environmentMutators } =
-    createStoreEnvironments(useLocalStorage)
+  const { environments, environmentMutators } = createStoreEnvironments(useLocalStorage)
   const { servers, serverMutators } = createStoreServers(useLocalStorage)
-  const { securitySchemes, securitySchemeMutators } =
-    createStoreSecuritySchemes(useLocalStorage)
-  const { workspaces, workspaceMutators } =
-    createStoreWorkspaces(useLocalStorage)
+  const { securitySchemes, securitySchemeMutators } = createStoreSecuritySchemes(useLocalStorage)
+  const { workspaces, workspaceMutators } = createStoreWorkspaces(useLocalStorage)
 
   // ---------------------------------------------------------------------------
   // Extended Mutators - Adds side effects as needed
@@ -123,34 +94,24 @@ export const createWorkspaceStore = ({
     workspaceMutators,
   }
   const { addTag, deleteTag } = extendedTagDataFactory(storeContext)
-  const { addRequest, deleteRequest, findRequestParents } =
-    extendedRequestDataFactory(storeContext, addTag)
+  const { addRequest, deleteRequest, findRequestParents } = extendedRequestDataFactory(storeContext, addTag)
   const { deleteEnvironment } = extendedEnvironmentDataFactory(storeContext)
   const { addServer, deleteServer } = extendedServerDataFactory(storeContext)
-  const { addCollection, deleteCollection } =
-    extendedCollectionDataFactory(storeContext)
-  const { addRequestExample, deleteRequestExample } =
-    extendedExampleDataFactory(storeContext)
-  const { addWorkspace, deleteWorkspace } =
-    extendedWorkspaceDataFactory(storeContext)
-  const { addSecurityScheme, deleteSecurityScheme } =
-    extendedSecurityDataFactory(storeContext)
-  const { addCollectionEnvironment, removeCollectionEnvironment } =
-    extendedCollectionDataFactory(storeContext)
+  const { addCollection, deleteCollection } = extendedCollectionDataFactory(storeContext)
+  const { addRequestExample, deleteRequestExample } = extendedExampleDataFactory(storeContext)
+  const { addWorkspace, deleteWorkspace } = extendedWorkspaceDataFactory(storeContext)
+  const { addSecurityScheme, deleteSecurityScheme } = extendedSecurityDataFactory(storeContext)
+  const { addCollectionEnvironment, removeCollectionEnvironment } = extendedCollectionDataFactory(storeContext)
 
   // ---------------------------------------------------------------------------
   // OTHER HELPER DATA
   /** Running request history list */
   const requestHistory = reactive<RequestEvent[]>([])
 
-  const { importSpecFile, importSpecFromUrl } =
-    importSpecFileFactory(storeContext)
+  const { importSpecFile, importSpecFromUrl } = importSpecFileFactory(storeContext)
 
   /** Helper function to manage the sidebar width */
-  const sidebarWidth = ref(
-    (useLocalStorage ? localStorage?.getItem('sidebarWidth') : undefined) ||
-      '280px',
-  )
+  const sidebarWidth = ref((useLocalStorage ? localStorage?.getItem('sidebarWidth') : undefined) || '280px')
 
   // Set the sidebar width
   const setSidebarWidth = (width: string) => {
@@ -164,7 +125,7 @@ export const createWorkspaceStore = ({
   const modalState = useModal()
 
   // Set some defaults on all workspaces
-  Object.keys(workspaces).forEach((uid) => {
+  Object.values(workspaces).forEach(({ uid }) => {
     if (proxyUrl) workspaceMutators.edit(uid, 'proxyUrl', proxyUrl)
     if (themeId) workspaceMutators.edit(uid, 'themeId', themeId)
   })

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -1,12 +1,6 @@
 import type { StoreContext } from '@/store/store-context'
-import {
-  collectionSchema,
-  requestExampleSchema,
-} from '@scalar/oas-utils/entities/spec'
-import {
-  type Workspace,
-  workspaceSchema,
-} from '@scalar/oas-utils/entities/workspace'
+import { collectionSchema, requestExampleSchema } from '@scalar/oas-utils/entities/spec'
+import { type Workspace, workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { LS_KEYS } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { reactive } from 'vue'
@@ -17,11 +11,7 @@ import { createInitialRequest } from './requests'
 export function createStoreWorkspaces(useLocalStorage: boolean) {
   /** Active workspace object (will be associated with an entry in the workspace collection) */
   const workspaces = reactive<Record<string, Workspace>>({})
-  const workspaceMutators = mutationFactory(
-    workspaces,
-    reactive({}),
-    useLocalStorage && LS_KEYS.WORKSPACE,
-  )
+  const workspaceMutators = mutationFactory(workspaces, reactive({}), useLocalStorage && LS_KEYS.WORKSPACE)
 
   return {
     workspaces,
@@ -71,7 +61,7 @@ export function extendedWorkspaceDataFactory({
   }
 
   /** Prevent deletion of the default workspace */
-  const deleteWorkspace = (uid: string) => {
+  const deleteWorkspace = (uid: Workspace['uid']) => {
     if (Object.keys(workspaces).length <= 1) {
       console.warn('The last workspace cannot be deleted.')
       return

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -21,7 +21,6 @@ const activeCookie = computed<Cookie>(
   () =>
     cookies[activeCookieId.value as string] ||
     cookieSchema.parse({
-      uid: '',
       name: '',
       value: '',
       domain: '',

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { cookieSchema, type Cookie } from '@scalar/oas-utils/entities/cookie'
+import type { Path, PathValue } from '@scalar/object-utils/nested'
 import { computed } from 'vue'
 
 import Form from '@/components/Form/Form.vue'
@@ -19,7 +20,7 @@ const fields = [
 
 const activeCookie = computed<Cookie>(
   () =>
-    cookies[activeCookieId.value as string] ||
+    cookies[activeCookieId.value] ||
     cookieSchema.parse({
       name: '',
       value: '',
@@ -27,10 +28,11 @@ const activeCookie = computed<Cookie>(
       path: '',
     }),
 )
-const updateCookie = (key: any, value: any) => {
-  if (activeCookieId.value) {
-    cookieMutators.edit(activeCookieId.value, key, value)
-  }
+const updateCookie = <P extends Path<Cookie>>(
+  key: P,
+  value: NonNullable<PathValue<Cookie, P>>,
+) => {
+  cookieMutators.edit(activeCookieId.value, key, value)
 }
 </script>
 <template>

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import { cookieSchema, type Cookie } from '@scalar/oas-utils/entities/cookie'
+import { computed } from 'vue'
+
 import Form from '@/components/Form/Form.vue'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import type { Cookie } from '@scalar/oas-utils/entities/cookie'
-import { computed } from 'vue'
 
 const { activeCookieId } = useActiveEntities()
 const { cookies, cookieMutators } = useWorkspace()
@@ -18,13 +19,14 @@ const fields = [
 
 const activeCookie = computed<Cookie>(
   () =>
-    cookies[activeCookieId.value as string] || {
+    cookies[activeCookieId.value as string] ||
+    cookieSchema.parse({
       uid: '',
       name: '',
       value: '',
       domain: '',
       path: '',
-    },
+    }),
 )
 const updateCookie = (key: any, value: any) => {
   if (activeCookieId.value) {

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -1,4 +1,9 @@
 <script setup lang="ts">
+import { useModal } from '@scalar/components'
+import { cookieSchema, type Cookie } from '@scalar/oas-utils/entities/cookie'
+import { computed, onBeforeUnmount, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
 import { Sidebar } from '@/components'
 import EmptyState from '@/components/EmptyState.vue'
 import SidebarButton from '@/components/Sidebar/SidebarButton.vue'
@@ -9,10 +14,6 @@ import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import type { HotKeyEvent } from '@/libs'
 import { PathId } from '@/routes'
 import { useActiveEntities, useWorkspace } from '@/store'
-import { useModal } from '@scalar/components'
-import { type Cookie, cookieSchema } from '@scalar/oas-utils/entities/cookie'
-import { computed, onBeforeUnmount, onMounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
 
 import CookieForm from './CookieForm.vue'
 import CookieModal from './CookieModal.vue'
@@ -41,7 +42,7 @@ const addCookieHandler = (cookieData: {
   cookieMutators.add(cookie)
 
   // Attach cookie to workspace
-  workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'cookies', [
+  workspaceMutators.edit(activeWorkspace.value?.uid, 'cookies', [
     ...(activeWorkspace.value?.cookies ?? []),
     cookie.uid,
   ])
@@ -55,11 +56,11 @@ const addCookieHandler = (cookieData: {
   })
 }
 
-const removeCookie = (uid: string) => {
+const removeCookie = (uid: Cookie['uid']) => {
   cookieMutators.delete(uid)
 
   // Delete cookie from workspace
-  workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'cookies', [
+  workspaceMutators.edit(activeWorkspace.value?.uid, 'cookies', [
     ...(activeWorkspace.value?.cookies ?? []).filter((c) => c !== uid),
   ])
 
@@ -140,8 +141,8 @@ const hasCookies = computed(
             <li
               v-for="cookie in Object.values(cookies)"
               :key="cookie.uid"
-              class="flex flex-col gap-1/2">
-              <div class="mb-[.5px] last:mb-0 relative">
+              class="gap-1/2 flex flex-col">
+              <div class="relative mb-[.5px] last:mb-0">
                 <SidebarListElement
                   :key="cookie.uid"
                   class="text-xs"
@@ -160,7 +161,7 @@ const hasCookies = computed(
         <SidebarButton
           :click="openCookieModal"
           hotkey="N">
-          <template #title>Add Cookie</template>
+          <template #title> Add Cookie </template>
         </SidebarButton>
       </template>
     </Sidebar>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -1,4 +1,16 @@
 <script setup lang="ts">
+import {
+  ScalarButton,
+  ScalarIcon,
+  ScalarModal,
+  useModal,
+} from '@scalar/components'
+import { LibraryIcon } from '@scalar/icons'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+import { useToasts } from '@scalar/use-toasts'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
 import EditSidebarListElement from '@/components/Sidebar/Actions/EditSidebarListElement.vue'
 import Sidebar from '@/components/Sidebar/Sidebar.vue'
@@ -13,16 +25,6 @@ import type { HotKeyEvent } from '@/libs'
 import { PathId } from '@/routes'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import {
-  ScalarButton,
-  ScalarIcon,
-  ScalarModal,
-  useModal,
-} from '@scalar/components'
-import { LibraryIcon } from '@scalar/icons'
-import { useToasts } from '@scalar/use-toasts'
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
 
 import EnvironmentColorModal from './EnvironmentColorModal.vue'
 import EnvironmentModal from './EnvironmentModal.vue'
@@ -70,7 +72,7 @@ function environmentNameToast(
 function addEnvironment(environment: {
   name: string
   color: string
-  collectionId: string | undefined
+  collectionId: Collection['uid'] | undefined
 }) {
   const environmentNameUsed = activeWorkspaceCollections.value.some(
     (collection) => {
@@ -114,7 +116,7 @@ function handleEnvironmentUpdate(raw: string) {
 
     if (currentEnvironmentId.value === 'default') {
       workspaceMutators.edit(
-        activeWorkspace.value?.uid ?? '',
+        activeWorkspace.value?.uid,
         'environments',
         updatedValue,
       )
@@ -390,14 +392,14 @@ function handleRename(newName: string) {
             <li
               v-for="collection in activeWorkspaceCollections"
               :key="collection.uid"
-              class="flex flex-col gap-1/2">
+              class="gap-1/2 flex flex-col">
               <button
-                class="flex font-medium gap-1.5 group items-center p-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
+                class="hover:bg-b-2 group flex w-full items-center gap-1.5 break-words rounded p-1.5 text-left text-sm font-medium"
                 type="button"
                 @click="toggleSidebarFolder(collection.uid)">
-                <span class="flex h-5 items-center justify-center max-w-[14px]">
+                <span class="flex h-5 max-w-[14px] items-center justify-center">
                   <LibraryIcon
-                    class="min-w-3.5 text-sidebar-c-2 size-3.5 stroke-2 group-hover:hidden"
+                    class="text-sidebar-c-2 size-3.5 min-w-3.5 stroke-2 group-hover:hidden"
                     :src="
                       collection['x-scalar-icon'] || 'interface-content-folder'
                     " />
@@ -406,7 +408,7 @@ function handleRename(newName: string) {
                       'rotate-90': collapsedSidebarFolders[collection.uid],
                     }">
                     <ScalarIcon
-                      class="text-c-3 hidden text-sm group-hover:block hover:text-c-1"
+                      class="text-c-3 hover:text-c-1 hidden text-sm group-hover:block"
                       icon="ChevronRight"
                       size="md" />
                   </div>
@@ -416,7 +418,7 @@ function handleRename(newName: string) {
               <div
                 v-show="showChildren(collection.uid)"
                 :class="{
-                  'before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-3 before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative':
+                  'before:bg-border before:z-1 relative mb-[.5px] before:pointer-events-none before:absolute before:left-3 before:top-0 before:h-[calc(100%_+_.5px)] before:w-[.5px] last:mb-0 last:before:h-full':
                     Object.keys(collection['x-scalar-environments'] || {})
                       .length > 0,
                 }">
@@ -449,7 +451,7 @@ function handleRename(newName: string) {
                     Object.keys(collection['x-scalar-environments'] || {})
                       .length === 0
                   "
-                  class="flex gap-1.5 h-8 text-c-1 pl-6 py-0 justify-start text-xs w-full hover:bg-b-2"
+                  class="text-c-1 hover:bg-b-2 flex h-8 w-full justify-start gap-1.5 py-0 pl-6 text-xs"
                   variant="ghost"
                   @click="openEnvironmentModal(collection.uid)">
                   <ScalarIcon
@@ -466,7 +468,7 @@ function handleRename(newName: string) {
         <SidebarButton
           :click="openEnvironmentModal"
           hotkey="N">
-          <template #title>Add Environment</template>
+          <template #title> Add Environment </template>
         </SidebarButton>
       </template>
     </Sidebar>
@@ -481,7 +483,7 @@ function handleRename(newName: string) {
         </template>
         <CodeInput
           v-if="currentEnvironmentId"
-          class="border-t pl-px pr-2 md:px-4 py-2"
+          class="border-t py-2 pl-px pr-2 md:px-4"
           isCopyable
           language="json"
           lineNumbers

--- a/packages/api-client/src/views/Environment/EnvironmentModal.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentModal.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import CommandActionForm from '@/components/CommandPalette/CommandActionForm.vue'
-import CommandActionInput from '@/components/CommandPalette/CommandActionInput.vue'
-import { useWorkspace } from '@/store'
 import {
-  type ModalState,
   ScalarButton,
-  type ScalarComboboxOption,
   ScalarIcon,
   ScalarListbox,
   ScalarModal,
+  type ModalState,
 } from '@scalar/components'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref, watch } from 'vue'
+
+import CommandActionForm from '@/components/CommandPalette/CommandActionForm.vue'
+import CommandActionInput from '@/components/CommandPalette/CommandActionInput.vue'
+import { useWorkspace } from '@/store'
 
 import EnvironmentColors from './EnvironmentColors.vue'
 
@@ -30,7 +30,7 @@ const emit = defineEmits<{
       name: string
       color: string
       type: string
-      collectionId: string | undefined
+      collectionId: Collection['uid'] | undefined
     },
   ): void
 }>()
@@ -49,7 +49,7 @@ const collections = computed(() => [
     })),
 ])
 
-const selectedEnvironment = ref<ScalarComboboxOption | undefined>(
+const selectedEnvironment = ref(
   collections.value.find((collection) => collection.id === props.collectionId),
 )
 
@@ -108,7 +108,7 @@ const redirectToCreateCollection = () => {
       :disabled="!selectedEnvironment"
       @cancel="emit('cancel')"
       @submit="handleSubmit">
-      <div class="flex gap-2 items-start">
+      <div class="flex items-start gap-2">
         <EnvironmentColors
           :activeColor="selectedColor"
           class="peer"
@@ -116,7 +116,7 @@ const redirectToCreateCollection = () => {
           @select="handleColorSelect" />
         <CommandActionInput
           v-model="environmentName"
-          class="!p-0 peer-has-[.color-selector]:hidden -mt-[.5px]"
+          class="-mt-[.5px] !p-0 peer-has-[.color-selector]:hidden"
           placeholder="Environment name" />
       </div>
       <template #options>
@@ -126,7 +126,7 @@ const redirectToCreateCollection = () => {
           placeholder="Select Type">
           <ScalarButton
             v-if="collections.length > 0"
-            class="justify-between p-2 max-h-8 gap-1 text-xs hover:bg-b-2 w-fit"
+            class="hover:bg-b-2 max-h-8 w-fit justify-between gap-1 p-2 text-xs"
             variant="outlined">
             <span :class="selectedEnvironment ? 'text-c-1' : 'text-c-3'">{{
               selectedEnvironment
@@ -140,14 +140,14 @@ const redirectToCreateCollection = () => {
           </ScalarButton>
           <ScalarButton
             v-else
-            class="justify-between p-2 max-h-8 gap-1 text-xs hover:bg-b-2"
+            class="hover:bg-b-2 max-h-8 justify-between gap-1 p-2 text-xs"
             variant="outlined"
             @click="redirectToCreateCollection">
             <span class="text-c-1">Create Collection</span>
           </ScalarButton>
         </ScalarListbox>
       </template>
-      <template #submit>Add Environment</template>
+      <template #submit> Add Environment </template>
     </CommandActionForm>
   </ScalarModal>
 </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/DeleteRequestAuthModal.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/DeleteRequestAuthModal.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { useWorkspace } from '@/store/store'
 import { ScalarButton, ScalarModal } from '@scalar/components'
+import type { SecurityScheme } from '@scalar/oas-utils/entities/spec'
+
+import { useWorkspace } from '@/store/store'
 
 const props = defineProps<{
   state: { open: boolean; show: () => void; hide: () => void }
-  scheme: { id: string; label: string } | null
+  scheme: { id: SecurityScheme['uid']; label: string } | null
 }>()
 
 const emit = defineEmits<{
@@ -24,20 +26,20 @@ const deleteScheme = () => {
     size="xxs"
     :state="state"
     title="Delete Security Scheme">
-    <p class="mb-4 leading-normal text-c-2 text-sm">
+    <p class="text-c-2 mb-4 text-sm leading-normal">
       This cannot be undone. You’re about to delete the
       {{ scheme?.label }} security scheme from the collection.
     </p>
     <div class="flex justify-between gap-2">
       <ScalarButton
-        class="gap-1.5 px-3 h-8 shadow-none focus:outline-none flex items-center cursor-pointer"
+        class="flex h-8 cursor-pointer items-center gap-1.5 px-3 shadow-none focus:outline-none"
         type="button"
         variant="outlined"
         @click="emit('close')">
         Cancel
       </ScalarButton>
       <ScalarButton
-        class="gap-1.5 px-3 h-8 shadow-none focus:outline-none flex items-center cursor-pointer"
+        class="flex h-8 cursor-pointer items-center gap-1.5 px-3 shadow-none focus:outline-none"
         type="submit"
         @click="deleteScheme">
         Delete {{ scheme?.label }}

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.test.ts
@@ -1,9 +1,4 @@
-import {
-  type Collection,
-  collectionSchema,
-  requestSchema,
-  serverSchema,
-} from '@scalar/oas-utils/entities/spec'
+import { type Collection, collectionSchema, requestSchema, serverSchema } from '@scalar/oas-utils/entities/spec'
 import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
@@ -71,7 +66,7 @@ describe('RequestAuth.vue', () => {
         uid: 'test-operation',
         security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
       }),
-      selectedSecuritySchemeUids: [] as Collection['securitySchemes'],
+      selectedSecuritySchemeUids: [] as Collection['selectedSecuritySchemeUids'],
       server: serverSchema.parse({
         url: 'https://api.example.com',
       }),
@@ -116,11 +111,7 @@ describe('RequestAuth.vue', () => {
     await option?.trigger('click')
 
     // Verify mutation
-    expect(requestMutators.edit).toHaveBeenCalledWith(
-      'test-operation',
-      'selectedSecuritySchemeUids',
-      ['bearer-auth'],
-    )
+    expect(requestMutators.edit).toHaveBeenCalledWith('test-operation', 'selectedSecuritySchemeUids', ['bearer-auth'])
   })
 
   it('shows optional status when security is optional', async () => {
@@ -137,7 +128,7 @@ describe('RequestAuth.vue', () => {
   it('displays multiple when multiple schemes are selected', async () => {
     const props = {
       ...createBaseProps(),
-      selectedSecuritySchemeUids: ['bearer-auth', 'api-key'],
+      selectedSecuritySchemeUids: ['bearer-auth', 'api-key'] as Collection['selectedSecuritySchemeUids'],
     }
 
     const wrapper = mount(RequestAuth, {

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -1,4 +1,23 @@
 <script setup lang="ts">
+import {
+  ScalarButton,
+  ScalarComboboxMultiselect,
+  ScalarIcon,
+  useModal,
+  type Icon,
+  type ScalarButton as ScalarButtonType,
+} from '@scalar/components'
+import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
+import type {
+  Collection,
+  Operation,
+  SecurityScheme,
+  Server,
+} from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
+import { isDefined } from '@scalar/oas-utils/helpers'
+import { computed, ref } from 'vue'
+
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useLayout } from '@/hooks/useLayout'
 import { useWorkspace } from '@/store/store'
@@ -9,23 +28,6 @@ import {
   getSchemeOptions,
   getSecurityRequirements,
 } from '@/views/Request/libs'
-import {
-  type Icon,
-  ScalarButton,
-  type ScalarButton as ScalarButtonType,
-  ScalarComboboxMultiselect,
-  ScalarIcon,
-  useModal,
-} from '@scalar/components'
-import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
-import type {
-  Collection,
-  Operation,
-  Server,
-} from '@scalar/oas-utils/entities/spec'
-import type { Workspace } from '@scalar/oas-utils/entities/workspace'
-import { isDefined } from '@scalar/oas-utils/helpers'
-import { computed, ref } from 'vue'
 
 import DeleteRequestAuthModal from './DeleteRequestAuthModal.vue'
 import RequestAuthDataTable from './RequestAuthDataTable.vue'
@@ -112,7 +114,9 @@ function updateSelectedAuth(entries: SecuritySchemeOption[]) {
     .filter((e) => !e.payload)
     .map(({ id }) => {
       const arr = id.split(',')
-      return arr.length > 1 ? arr : id
+      return arr.length > 1
+        ? (arr as SecurityScheme['uid'][])
+        : (id as SecurityScheme['uid'])
     })
 
   // Adding new auth
@@ -176,7 +180,7 @@ const schemeOptions = computed(() =>
     :itemCount="selectedSchemeOptions.length"
     :layout="layout">
     <template #title>
-      <div class="inline-flex gap-1 items-center">
+      <div class="inline-flex items-center gap-1">
         <span>{{ title }}</span>
         <!-- Authentication indicator -->
         <span
@@ -188,9 +192,9 @@ const schemeOptions = computed(() =>
       </div>
     </template>
     <template #actions>
-      <div class="flex flex-1 -mx-1">
+      <div class="-mx-1 flex flex-1">
         <ScalarComboboxMultiselect
-          class="text-xs w-72"
+          class="w-72 text-xs"
           :isDeletable="clientLayout !== 'modal' && layout !== 'reference'"
           :modelValue="selectedSchemeOptions"
           multiple
@@ -199,7 +203,7 @@ const schemeOptions = computed(() =>
           @update:modelValue="updateSelectedAuth">
           <ScalarButton
             ref="comboboxButtonRef"
-            class="h-auto px-1.5 py-0.75 hover:bg-b-3 text-c-1 hover:text-c-1 font-normal"
+            class="py-0.75 hover:bg-b-3 text-c-1 hover:text-c-1 h-auto px-1.5 font-normal"
             fullWidth
             variant="ghost">
             <div class="text-c-1">

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -145,11 +145,9 @@ const editSelectedSchemeUids = (uids: SelectedSecuritySchemeUids) => {
   }
 }
 
-function handleDeleteScheme(option: {
-  id: SecurityScheme['uid']
-  label: string
-}) {
-  selectedScheme.value = option
+function handleDeleteScheme({ id, label }: { id: string; label: string }) {
+  // We cast the type here just to make the combobox happy, TODO: we should make ID be string-like and accept brands
+  selectedScheme.value = { id: id as SecurityScheme['uid'], label }
   deleteSchemeModal.show()
 }
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -60,7 +60,9 @@ const {
 
 const comboboxButtonRef = ref<typeof ScalarButtonType | null>(null)
 const deleteSchemeModal = useModal()
-const selectedScheme = ref<{ id: string; label: string } | null>(null)
+const selectedScheme = ref<{ id: SecurityScheme['uid']; label: string } | null>(
+  null,
+)
 
 /** Security requirements for the request */
 const securityRequirements = computed(() => {
@@ -143,7 +145,10 @@ const editSelectedSchemeUids = (uids: SelectedSecuritySchemeUids) => {
   }
 }
 
-function handleDeleteScheme(option: { id: string; label: string }) {
+function handleDeleteScheme(option: {
+  id: SecurityScheme['uid']
+  label: string
+}) {
   selectedScheme.value = option
   deleteSchemeModal.show()
 }

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
-import { DataTable } from '@/components/DataTable'
 import { useModal } from '@scalar/components'
-import type { Collection, Server } from '@scalar/oas-utils/entities/spec'
+import type {
+  Collection,
+  SecurityScheme,
+  Server,
+} from '@scalar/oas-utils/entities/spec'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { computed, ref, watch } from 'vue'
+
+import { DataTable } from '@/components/DataTable'
 
 import DeleteRequestAuthModal from './DeleteRequestAuthModal.vue'
 import RequestAuthTab from './RequestAuthTab.vue'
@@ -23,7 +28,9 @@ const {
 }>()
 
 const deleteSchemeModal = useModal()
-const selectedScheme = ref<{ id: string; label: string } | null>(null)
+const selectedScheme = ref<{ id: SecurityScheme['uid']; label: string } | null>(
+  null,
+)
 
 /** Add new ref for active tab */
 const activeAuthIndex = ref(0)
@@ -49,25 +56,25 @@ watch(
   <form @submit.prevent>
     <div
       v-if="selectedSchemeOptions.length > 1"
-      class="border-t flex px-3 flex-wrap gap-x-2.5 overflow-hidden">
+      class="flex flex-wrap gap-x-2.5 overflow-hidden border-t px-3">
       <div
         v-for="(option, index) in selectedSchemeOptions"
         :key="option.id"
-        class="flex relative h-8 z-1 cursor-pointer -mb-[var(--scalar-border-width)]"
+        class="z-1 relative -mb-[var(--scalar-border-width)] flex h-8 cursor-pointer"
         :class="[activeAuthIndex === index ? 'text-c-1' : 'text-c-3']">
         <button
-          class="floating-bg py-1 text-sm border-b-[1px] border-transparent relative cursor-pointer font-medium"
+          class="floating-bg relative cursor-pointer border-b-[1px] border-transparent py-1 text-sm font-medium"
           type="button"
           @click="activeAuthIndex = index">
-          <span class="whitespace-nowrap font-medium z-10 relative">{{
+          <span class="relative z-10 whitespace-nowrap font-medium">{{
             option.label
           }}</span>
         </button>
         <div
-          class="absolute bottom-0 z-0 -inset-x-96 h-[var(--scalar-border-width)] bg-border" />
+          class="bg-border absolute -inset-x-96 bottom-0 z-0 h-[var(--scalar-border-width)]" />
         <div
           v-if="activeAuthIndex === index"
-          class="absolute bottom-[var(--scalar-border-width)] z-1 inset-x-1 h-px bg-current left-1/2 -translate-x-1/2 w-full" />
+          class="z-1 absolute inset-x-1 bottom-[var(--scalar-border-width)] left-1/2 h-px w-full -translate-x-1/2 bg-current" />
       </div>
     </div>
 
@@ -86,7 +93,7 @@ watch(
 
     <div
       v-else
-      class="text-c-3 px-4 text-sm border-t min-h-16 justify-center flex items-center bg-b-1">
+      class="text-c-3 bg-b-1 flex min-h-16 items-center justify-center border-t px-4 text-sm">
       No authentication selected
     </div>
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { DataTableCell, DataTableRow } from '@/components/DataTable'
-import { useWorkspace } from '@/store/store'
 import type { Workspace } from '@scalar/oas-utils/entities'
 import type {
   Collection,
@@ -9,6 +7,9 @@ import type {
 } from '@scalar/oas-utils/entities/spec'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import { capitalize, computed, ref } from 'vue'
+
+import { DataTableCell, DataTableRow } from '@/components/DataTable'
+import { useWorkspace } from '@/store/store'
 
 import OAuth2 from './OAuth2.vue'
 import RequestAuthDataTableInput from './RequestAuthDataTableInput.vue'
@@ -57,7 +58,10 @@ const generateLabel = (scheme: SecurityScheme) => {
 }
 
 /** Update the scheme */
-const updateScheme = <U extends string, P extends Path<SecurityScheme>>(
+const updateScheme = <
+  U extends SecurityScheme['uid'],
+  P extends Path<SecurityScheme>,
+>(
   uid: U,
   path: P,
   value: NonNullable<PathValue<SecurityScheme, P>>,
@@ -75,7 +79,7 @@ const updateScheme = <U extends string, P extends Path<SecurityScheme>>(
         'request-example-references-header': layout === 'reference',
       }">
       <DataTableCell
-        class="text-c-3 pl-2 font-medium flex items-center"
+        class="text-c-3 flex items-center pl-2 font-medium"
         :class="
           layout === 'reference' && `border-t ${index !== 0 ? 'mt-2' : ''}`
         ">
@@ -150,23 +154,23 @@ const updateScheme = <U extends string, P extends Path<SecurityScheme>>(
       <DataTableRow>
         <div
           v-if="Object.keys(scheme.flows).length > 1"
-          class="border-t min-h-8 flex text-sm">
-          <div class="flex h-8 gap-2.5 px-3 max-w-full overflow-x-auto">
+          class="flex min-h-8 border-t text-sm">
+          <div class="flex h-8 max-w-full gap-2.5 overflow-x-auto px-3">
             <button
               v-for="(_, key, ind) in scheme?.flows"
               :key="key"
-              class="floating-bg py-1 text-sm border-b-[1px] border-transparent relative cursor-pointer font-medium text-c-3"
+              class="floating-bg text-c-3 relative cursor-pointer border-b-[1px] border-transparent py-1 text-sm font-medium"
               :class="{
-                '!text-c-1 !border-current border-b-[1px] !rounded-none':
+                '!text-c-1 !rounded-none border-b-[1px] !border-current':
                   layout !== 'reference' &&
                   (activeFlow === key || (ind === 0 && !activeFlow)),
-                '!text-c-1 !border-current border-b-[1px] !rounded-none opacity-100':
+                '!text-c-1 !rounded-none border-b-[1px] !border-current opacity-100':
                   layout === 'reference' &&
                   (activeFlow === key || (ind === 0 && !activeFlow)),
               }"
               type="button"
               @click="activeFlow = key">
-              <span class="z-10 relative">{{ key }}</span>
+              <span class="relative z-10">{{ key }}</span>
             </button>
           </div>
         </div>
@@ -187,7 +191,7 @@ const updateScheme = <U extends string, P extends Path<SecurityScheme>>(
     <!-- Open ID Connect -->
     <template v-else-if="scheme?.type === 'openIdConnect'">
       <div
-        class="border-t text-c-3 px-4 text-sm min-h-16 justify-center flex items-center bg-b-1">
+        class="text-c-3 bg-b-1 flex min-h-16 items-center justify-center border-t px-4 text-sm">
         Coming soon
       </div>
     </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
@@ -1,16 +1,8 @@
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import { requestExampleSchema } from '@scalar/oas-utils/entities/spec'
 import { mount } from '@vue/test-utils'
-import {
-  type Mock,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import RequestBody from './RequestBody.vue'
 
@@ -26,14 +18,15 @@ vi.mock('@/store/active-entities', () => ({
 describe('RequestBody.vue', () => {
   const props = { props: { title: 'Body' } }
   const mockActiveRequest = { value: { uid: 'mockRequestUid' } }
-  const mockActiveExample: { value: Partial<RequestExample> } = {
-    value: {
+  const mockActiveExample = {
+    value: requestExampleSchema.parse({
       uid: 'mockExampleUid',
       body: {
         activeBody: 'raw',
       },
-    },
+    }),
   }
+
   const mockActiveEnvironment = { value: { uid: 'mockEnvironmentUid' } }
   const mockActiveEnvVariables = { value: [] }
   const mockActiveWorkspace = { value: {} }

--- a/packages/api-client/src/views/Request/RequestSection/helpers/filter-security-requirements.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/helpers/filter-security-requirements.test.ts
@@ -1,4 +1,4 @@
-import { securitySchemeSchema } from '@scalar/oas-utils/entities/spec'
+import { securitySchemeSchema, type Collection } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
 import { filterSecurityRequirements } from './filter-security-requirements'
@@ -37,36 +37,24 @@ describe('filterSecurityRequirements', () => {
   } as const
 
   it('should return empty array when no security requirements exist', () => {
-    const result = filterSecurityRequirements(
-      [],
-      ['bearerAuthUid'],
-      mockSecuritySchemes,
-    )
+    const result = filterSecurityRequirements([], [mockSecuritySchemes.bearerAuthUid.uid], mockSecuritySchemes)
     expect(result).toEqual([])
   })
 
   it('should return empty array when there is only an optional security requirement', () => {
-    const result = filterSecurityRequirements(
-      [{}],
-      ['bearerAuthUid'],
-      mockSecuritySchemes,
-    )
+    const result = filterSecurityRequirements([{}], [mockSecuritySchemes.bearerAuthUid.uid], mockSecuritySchemes)
     expect(result).toEqual([])
   })
 
   it('should return empty array when no security schemes are selected', () => {
-    const result = filterSecurityRequirements(
-      [{ bearerAuth: [] }],
-      [],
-      mockSecuritySchemes,
-    )
+    const result = filterSecurityRequirements([{ bearerAuth: [] }], [], mockSecuritySchemes)
     expect(result).toEqual([])
   })
 
   it('should filter single security requirement correctly', () => {
     const result = filterSecurityRequirements(
       [{ bearerAuth: [] }],
-      ['bearerAuthUid'],
+      [mockSecuritySchemes.bearerAuthUid.uid],
       mockSecuritySchemes,
     )
     expect(result).toEqual([mockSecuritySchemes.bearerAuthUid])
@@ -75,44 +63,35 @@ describe('filterSecurityRequirements', () => {
   it('should filter multiple security requirements correctly', () => {
     const result = filterSecurityRequirements(
       [{ bearerAuth: [] }, { apiKey: [] }, { oauth: [] }],
-      ['apiKeyUid', 'bearerAuthUid'],
+      [mockSecuritySchemes.apiKeyUid.uid, mockSecuritySchemes.bearerAuthUid.uid],
       mockSecuritySchemes,
     )
-    expect(result).toEqual([
-      mockSecuritySchemes.apiKeyUid,
-      mockSecuritySchemes.bearerAuthUid,
-    ])
+    expect(result).toEqual([mockSecuritySchemes.apiKeyUid, mockSecuritySchemes.bearerAuthUid])
   })
 
   it('should filter multiple security requirements correctly (reversed)', () => {
     const result = filterSecurityRequirements(
       [{ bearerAuth: [] }, { apiKey: [] }],
-      ['apiKeyUid', 'bearerAuthUid', 'oauthUid'],
+      [mockSecuritySchemes.apiKeyUid.uid, mockSecuritySchemes.bearerAuthUid.uid, mockSecuritySchemes.oauthUid.uid],
       mockSecuritySchemes,
     )
-    expect(result).toEqual([
-      mockSecuritySchemes.apiKeyUid,
-      mockSecuritySchemes.bearerAuthUid,
-    ])
+    expect(result).toEqual([mockSecuritySchemes.apiKeyUid, mockSecuritySchemes.bearerAuthUid])
   })
 
   it('should handle complex security requirements', () => {
     const result = filterSecurityRequirements(
       [{ bearerAuth: [], apiKey: [] }],
-      [['bearerAuthUid', 'apiKeyUid']],
+      [[mockSecuritySchemes.bearerAuthUid.uid, mockSecuritySchemes.apiKeyUid.uid]],
       mockSecuritySchemes,
     )
 
-    expect(result).toEqual([
-      mockSecuritySchemes.bearerAuthUid,
-      mockSecuritySchemes.apiKeyUid,
-    ])
+    expect(result).toEqual([mockSecuritySchemes.bearerAuthUid, mockSecuritySchemes.apiKeyUid])
   })
 
   it('should return empty array for non-matching security schemes', () => {
     const result = filterSecurityRequirements(
       [{ differentAuth: [] }],
-      ['auth1'],
+      ['auth1'] as Collection['selectedSecuritySchemeUids'],
       mockSecuritySchemes,
     )
     expect(result).toEqual([])

--- a/packages/api-client/src/views/Request/RequestSection/helpers/getting-started.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/helpers/getting-started.test.ts
@@ -1,4 +1,4 @@
-import type { Collection } from '@scalar/oas-utils/entities/spec'
+import { collectionSchema, type Operation } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
 import { isGettingStarted } from './getting-started'
@@ -9,41 +9,24 @@ describe('gettingStarted', () => {
     request2: { summary: 'Another Request' },
   }
 
-  const createCollection = (
-    uid: string,
-    title: string,
-    requests: string[],
-  ): Collection => ({
-    uid,
-    'info': { title, version: '1.0.0' },
-    requests,
-    'type': 'collection',
-    'children': [],
-    'openapi': '',
-    'security': [],
-    'x-scalar-icon': '',
-    'securitySchemes': [],
-    'selectedSecuritySchemeUids': [],
-    'selectedServerUid': '',
-    'servers': [],
-    'tags': [],
-    'watchMode': false,
-    'watchModeStatus': 'IDLE',
-  })
+  const createCollection = (uid: string, title: string, requests: string[]) =>
+    collectionSchema.parse({
+      uid,
+      'info': { title, version: '1.0.0' },
+      requests,
+      'type': 'collection',
+      'watchMode': false,
+      'watchModeStatus': 'IDLE',
+    })
 
-  const draftCollection = createCollection('drafts', 'Drafts', ['request1'])
-  const anotherCollection = createCollection(
-    'anotherCollection',
-    'Another Collection',
-    ['request2'],
-  )
+  const draftCollection = createCollection('drafts-uid', 'Drafts', ['request1'])
+  const anotherCollection = createCollection('anotherCollection', 'Another Collection', ['request2'])
+
+  const request1Uid = 'request1' as Operation['uid']
+  const request2Uid = 'request2' as Operation['uid']
 
   it('should return true for a single draft request that is not renamed', () => {
-    const result = isGettingStarted(
-      [draftCollection],
-      ['request1'],
-      mockRequests,
-    )
+    const result = isGettingStarted([draftCollection], [request1Uid], mockRequests)
     expect(result).toBe(true)
   })
 
@@ -52,29 +35,17 @@ describe('gettingStarted', () => {
       ...mockRequests,
       request1: { summary: 'Renamed Request' },
     }
-    const result = isGettingStarted(
-      [draftCollection],
-      ['request1'],
-      renamedRequests,
-    )
+    const result = isGettingStarted([draftCollection], [request1Uid], renamedRequests)
     expect(result).toBe(false)
   })
 
   it('should return false if there are multiple requests', () => {
-    const result = isGettingStarted(
-      [draftCollection],
-      ['request1', 'request2'],
-      mockRequests,
-    )
+    const result = isGettingStarted([draftCollection], [request1Uid, request2Uid], mockRequests)
     expect(result).toBe(false)
   })
 
   it('should return false if the request is not in the drafts collection', () => {
-    const result = isGettingStarted(
-      [anotherCollection],
-      ['request2'],
-      mockRequests,
-    )
+    const result = isGettingStarted([anotherCollection], [request2Uid], mockRequests)
     expect(result).toBe(false)
   })
 })

--- a/packages/api-client/src/views/Request/RequestSection/helpers/getting-started.ts
+++ b/packages/api-client/src/views/Request/RequestSection/helpers/getting-started.ts
@@ -1,24 +1,21 @@
-import type { Collection } from '@scalar/oas-utils/entities/spec'
+import type { Collection, Operation } from '@scalar/oas-utils/entities/spec'
 
 /**
  * Checks if the user gets the getting started state displayed
  */
 export const isGettingStarted = (
   activeWorkspaceCollections: Collection[],
-  activeWorkspaceRequests: string[],
+  activeWorkspaceRequests: Operation['uid'][],
   requests: Record<string, any>,
 ) => {
-  const draftCollection = activeWorkspaceCollections.find(
-    (collection) => collection.info?.title === 'Drafts',
-  )
+  const draftCollection = activeWorkspaceCollections.find((collection) => collection.info?.title === 'Drafts')
   const hasSingleRequest = activeWorkspaceRequests.length === 1
-  const isDraftsRequest = draftCollection?.requests.includes(
-    activeWorkspaceRequests[0] ?? '',
-  )
+
+  if (!activeWorkspaceRequests[0]) return false
+  const isDraftsRequest = draftCollection?.requests.includes(activeWorkspaceRequests[0])
 
   if (!isDraftsRequest) return false
-  const isRenamed =
-    requests[draftCollection?.requests[0] ?? '']?.summary !== 'My First Request'
+  const isRenamed = requests[draftCollection?.requests[0] ?? '']?.summary !== 'My First Request'
 
   return hasSingleRequest && isDraftsRequest && !isRenamed
 }

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -1,22 +1,4 @@
 <script setup lang="ts">
-import Rabbit from '@/assets/rabbit.ascii?raw'
-import RabbitJump from '@/assets/rabbitjump.ascii?raw'
-import { Sidebar } from '@/components'
-import EnvironmentSelector from '@/components/EnvironmentSelector/EnvironmentSelector.vue'
-import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
-import ScalarAsciiArt from '@/components/ScalarAsciiArt.vue'
-import { useSearch } from '@/components/Search/useSearch'
-import SidebarButton from '@/components/Sidebar/SidebarButton.vue'
-import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
-import { useLayout, useSidebar } from '@/hooks'
-import type { HotKeyEvent } from '@/libs'
-import { PathId } from '@/routes'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
-import { createInitialRequest } from '@/store/requests'
-import RequestSidebarItemMenu from '@/views/Request/RequestSidebarItemMenu.vue'
-import { dragHandlerFactory } from '@/views/Request/handle-drag'
-import type { SidebarItem, SidebarMenuItem } from '@/views/Request/types'
 import {
   ScalarButton,
   ScalarIcon,
@@ -39,9 +21,28 @@ import {
 } from 'vue'
 import { useRouter } from 'vue-router'
 
+import Rabbit from '@/assets/rabbit.ascii?raw'
+import RabbitJump from '@/assets/rabbitjump.ascii?raw'
+import { Sidebar } from '@/components'
+import EnvironmentSelector from '@/components/EnvironmentSelector/EnvironmentSelector.vue'
+import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
+import ScalarAsciiArt from '@/components/ScalarAsciiArt.vue'
+import { useSearch } from '@/components/Search/useSearch'
+import SidebarButton from '@/components/Sidebar/SidebarButton.vue'
+import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
+import { useLayout, useSidebar } from '@/hooks'
+import type { HotKeyEvent } from '@/libs'
+import { PathId } from '@/routes'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
+import { createInitialRequest } from '@/store/requests'
+import { dragHandlerFactory } from '@/views/Request/handle-drag'
+import RequestSidebarItemMenu from '@/views/Request/RequestSidebarItemMenu.vue'
+import type { SidebarItem, SidebarMenuItem } from '@/views/Request/types'
+
+import { WorkspaceDropdown } from './components'
 import { isGettingStarted } from './RequestSection/helpers/getting-started'
 import RequestSidebarItem from './RequestSidebarItem.vue'
-import { WorkspaceDropdown } from './components'
 
 const props = defineProps<{
   isSidebarOpen: boolean
@@ -231,13 +232,13 @@ const toggleSearch = () => {
   isSearchVisible.value = !isSearchVisible.value
 }
 
-const showGettingStarted = computed(() => {
-  return isGettingStarted(
+const showGettingStarted = computed(() =>
+  isGettingStarted(
     activeWorkspaceCollections.value,
     activeWorkspaceRequests.value,
     requests,
-  )
-})
+  ),
+)
 </script>
 <template>
   <Sidebar
@@ -247,10 +248,9 @@ const showGettingStarted = computed(() => {
     @update:isSidebarOpen="$emit('update:isSidebarOpen', $event)">
     <template
       v-if="layout !== 'modal'"
-      #header>
-    </template>
+      #header />
     <template #content>
-      <div class="flex items-center h-12 px-3 top-0 bg-b-1 sticky z-20">
+      <div class="bg-b-1 sticky top-0 z-20 flex h-12 items-center px-3">
         <SidebarToggle
           class="xl:hidden"
           :class="[{ '!flex': layout === 'modal' }]"
@@ -268,13 +268,13 @@ const showGettingStarted = computed(() => {
           type="button"
           @click="toggleSearch">
           <ScalarIcon
-            class="text-c-3 text-sm hover:bg-b-2 p-1.75 rounded-lg max-w-8 max-h-8"
+            class="text-c-3 hover:bg-b-2 p-1.75 max-h-8 max-w-8 rounded-lg text-sm"
             icon="Search" />
         </button>
       </div>
       <div
         v-show="isSearchVisible"
-        class="search-button-fade sticky px-3 py-2.5 z-10 pt-0 top-12 focus-within:z-20"
+        class="search-button-fade sticky top-12 z-10 px-3 py-2.5 pt-0 focus-within:z-20"
         role="search">
         <ScalarSearchInput
           ref="searchInputRef"
@@ -350,7 +350,7 @@ const showGettingStarted = computed(() => {
                 thickness="2.25" />
               <LibraryIcon
                 v-else
-                class="min-w-3.5 text-sidebar-c-2 size-3.5 stroke-2 group-hover:hidden"
+                class="text-sidebar-c-2 size-3.5 min-w-3.5 stroke-2 group-hover:hidden"
                 :src="
                   collection['x-scalar-icon'] || 'interface-content-folder'
                 " />
@@ -359,7 +359,7 @@ const showGettingStarted = computed(() => {
                   'rotate-90': collapsedSidebarFolders[collection.uid],
                 }">
                 <ScalarIcon
-                  class="text-c-3 hidden text-sm group-hover:block hover:text-c-1"
+                  class="text-c-3 hover:text-c-1 hidden text-sm group-hover:block"
                   icon="ChevronRight"
                   size="md" />
               </div>
@@ -374,15 +374,15 @@ const showGettingStarted = computed(() => {
           'empty-sidebar-item': showGettingStarted,
         }">
         <div class="empty-sidebar-item-content px-2.5 py-2.5">
-          <div class="w-[60px] h-[68px] m-auto rabbit-ascii mt-2 relative">
+          <div class="rabbit-ascii relative m-auto mt-2 h-[68px] w-[60px]">
             <ScalarAsciiArt
               :art="Rabbit"
-              class="font-bold rabbitsit" />
+              class="rabbitsit font-bold" />
             <ScalarAsciiArt
               :art="RabbitJump"
-              class="font-bold absolute top-0 left-0 rabbitjump" />
+              class="rabbitjump absolute left-0 top-0 font-bold" />
           </div>
-          <div class="text-center text-balance text-sm mb-2 mt-2">
+          <div class="mb-2 mt-2 text-balance text-center text-sm">
             <b class="font-medium">Let's Get Started</b>
             <p class="mt-2">
               Create request, folder, collection or import from OpenAPI/Postman
@@ -391,7 +391,7 @@ const showGettingStarted = computed(() => {
         </div>
         <ScalarButton
           v-if="layout !== 'modal'"
-          class="mb-1.5 w-full h-fit hidden opacity-0 p-1.5"
+          class="mb-1.5 hidden h-fit w-full p-1.5 opacity-0"
           :class="{
             'flex opacity-100': showGettingStarted,
           }"
@@ -402,7 +402,7 @@ const showGettingStarted = computed(() => {
           v-if="layout !== 'modal'"
           :click="events.commandPalette.emit"
           hotkey="K">
-          <template #title>Add Item</template>
+          <template #title> Add Item </template>
         </SidebarButton>
       </div>
     </template>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -11,7 +11,7 @@ import {
   type DraggingItem,
   type HoveredItem,
 } from '@scalar/draggable'
-import type { Request } from '@scalar/oas-utils/entities/spec'
+import type { Collection, Request } from '@scalar/oas-utils/entities/spec'
 import { shouldIgnoreEntity } from '@scalar/oas-utils/helpers'
 import { computed, ref } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
@@ -115,9 +115,9 @@ const item = computed<SidebarItem>(() => {
       warning:
         'This cannot be undone. You’re about to delete the tag and all requests inside it',
       edit: (name: string) => tagMutators.edit(tag.uid, 'name', name),
-      delete: () => {
-        if (parentUids[0]) tagMutators.delete(tag, parentUids[0])
-      },
+      delete: () =>
+        parentUids[0] &&
+        tagMutators.delete(tag, parentUids[0] as Collection['uid']),
     }
 
   if (request)
@@ -137,11 +137,9 @@ const item = computed<SidebarItem>(() => {
       children: request.examples.slice(1),
       edit: (name: string) =>
         requestMutators.edit(request.uid, 'summary', name),
-      delete: () => {
-        if (parentUids[0]) {
-          requestMutators.delete(request, parentUids[0])
-        }
-      },
+      delete: () =>
+        parentUids[0] &&
+        requestMutators.delete(request, parentUids[0] as Collection['uid']),
     }
 
   if (requestExample?.requestUid)

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -1,11 +1,4 @@
 <script setup lang="ts">
-import { HttpMethod } from '@/components/HttpMethod'
-import { useLayout, useSidebar } from '@/hooks'
-import { getModifiers } from '@/libs'
-import { PathId } from '@/router'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
-import type { SidebarItem, SidebarMenuItem } from '@/views/Request/types'
 import {
   ScalarButton,
   ScalarIcon,
@@ -22,6 +15,14 @@ import type { Request } from '@scalar/oas-utils/entities/spec'
 import { shouldIgnoreEntity } from '@scalar/oas-utils/helpers'
 import { computed, ref } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
+
+import { HttpMethod } from '@/components/HttpMethod'
+import { useLayout, useSidebar } from '@/hooks'
+import { getModifiers } from '@/libs'
+import { PathId } from '@/router'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
+import type { SidebarItem, SidebarMenuItem } from '@/views/Request/types'
 
 const {
   isDraggable = false,
@@ -143,7 +144,7 @@ const item = computed<SidebarItem>(() => {
       },
     }
 
-  if (requestExample)
+  if (requestExample?.requestUid)
     return {
       title: requestExample.name,
       link: {
@@ -174,8 +175,8 @@ const item = computed<SidebarItem>(() => {
     },
     resourceTitle: 'Unknown',
     children: [],
-    edit: () => {},
-    delete: () => {},
+    edit: () => null,
+    delete: () => null,
   } satisfies SidebarItem
 })
 
@@ -319,14 +320,14 @@ const shouldShowItem = computed(() => {
     :class="[
       (layout === 'modal' && parentUids.length > 1) ||
       (layout !== 'modal' && parentUids.length)
-        ? 'before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-[calc(.75rem_+_.5px)] before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 indent-border-line-offset'
+        ? 'before:bg-border before:z-1 indent-border-line-offset mb-[.5px] before:pointer-events-none before:absolute before:left-[calc(.75rem_+_.5px)] before:top-0 before:h-[calc(100%_+_.5px)] before:w-[.5px] last:mb-0 last:before:h-full'
         : '',
     ]">
     <Draggable
       :id="item.entity.uid"
       ref="draggableRef"
       :ceiling="getDraggableOffsets.ceiling"
-      class="flex flex-1 flex-col gap-1/2 text-sm"
+      class="gap-1/2 flex flex-1 flex-col text-sm"
       :floor="getDraggableOffsets.floor"
       :isDraggable="isDraggable"
       :isDroppable="isDroppable"
@@ -342,22 +343,22 @@ const shouldShowItem = computed(() => {
           (event: KeyboardEvent) => handleNavigation(event, item)
         ">
         <div
-          class="relative flex min-h-8 cursor-pointer flex-row items-start justify-between gap-0.5 py-1.5 pr-2 rounded w-full"
+          class="relative flex min-h-8 w-full cursor-pointer flex-row items-start justify-between gap-0.5 rounded py-1.5 pr-2"
           :class="[
             highlightClasses,
             isExactActive || isDefaultActive
               ? 'bg-sidebar-active-b text-sidebar-active-c transition-none'
               : 'text-sidebar-c-2',
           ]">
-          <span class="break-all line-clamp-1 font-medium w-full pl-2">
+          <span class="line-clamp-1 w-full break-all pl-2 font-medium">
             {{ item.title }}
           </span>
-          <div class="flex flex-row gap-1 items-center">
+          <div class="flex flex-row items-center gap-1">
             <!-- Menu -->
             <div class="relative">
               <ScalarButton
                 v-if="layout !== 'modal'"
-                class="hidden px-0.5 py-0 hover:bg-b-3 opacity-0 group-hover:opacity-100 group-hover:flex group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 aspect-square h-fit"
+                class="hover:bg-b-3 hidden aspect-square h-fit px-0.5 py-0 opacity-0 group-hover:flex group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100"
                 :class="{
                   flex:
                     menuItem?.item?.entity.uid === item.entity.uid &&
@@ -400,21 +401,21 @@ const shouldShowItem = computed(() => {
         :class="[highlightClasses]"
         type="button"
         @click="toggleSidebarFolder(item.entity.uid)">
-        <span class="flex h-5 items-center justify-center max-w-[14px]">
+        <span class="flex h-5 max-w-[14px] items-center justify-center">
           <slot name="leftIcon">
             <ScalarSidebarGroupToggle
-              class="text-c-3 shrink-0 hover:text-c-1"
+              class="text-c-3 hover:text-c-1 shrink-0"
               :open="Boolean(collapsedSidebarFolders[item.entity.uid])" />
           </slot>
           &hairsp;
         </span>
         <div class="flex flex-1 flex-row justify-between">
-          <span class="break-all line-clamp-1 font-medium text-left w-full">
+          <span class="line-clamp-1 w-full break-all text-left font-medium">
             {{ item.title }}
           </span>
-          <div class="relative flex justify-end h-fit">
+          <div class="relative flex h-fit justify-end">
             <div
-              class="items-center opacity-0 gap-px group-hover:opacity-100 group-hover:flex group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100"
+              class="items-center gap-px opacity-0 group-hover:flex group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100"
               :class="{
                 flex: menuItem.open,
                 hidden:
@@ -426,7 +427,7 @@ const shouldShowItem = computed(() => {
                   (layout !== 'modal' && !isDraftCollection) ||
                   (isDraftCollection && hasDraftRequests)
                 "
-                class="px-0.5 py-0 hover:bg-b-3 hover:text-c-1 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 aspect-square h-fit"
+                class="hover:bg-b-3 hover:text-c-1 aspect-square h-fit px-0.5 py-0 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100"
                 size="sm"
                 variant="ghost"
                 @click.stop.prevent="
@@ -444,7 +445,7 @@ const shouldShowItem = computed(() => {
               </ScalarButton>
               <ScalarButton
                 v-if="layout !== 'modal'"
-                class="px-0.5 py-0 hover:bg-b-3 hover:text-c-1 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 aspect-square h-fit"
+                class="hover:bg-b-3 hover:text-c-1 aspect-square h-fit px-0.5 py-0 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100"
                 size="sm"
                 variant="ghost"
                 @click.stop.prevent="openCommandPaletteRequest()">
@@ -468,8 +469,8 @@ const shouldShowItem = computed(() => {
               </template>
               <template #content>
                 <div
-                  class="grid gap-1.5 pointer-events-none max-w-10 w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
-                  <div class="flex items-center text-c-2">
+                  class="w-content bg-b-1 z-100 text-xxs text-c-1 pointer-events-none z-10 grid max-w-10 gap-1.5 rounded p-2 leading-5 shadow-lg">
+                  <div class="text-c-2 flex items-center">
                     <p class="text-pretty break-all">
                       Watching: {{ item.documentUrl }}
                     </p>
@@ -498,7 +499,7 @@ const shouldShowItem = computed(() => {
           @openMenu="(item) => $emit('openMenu', item)" />
         <ScalarButton
           v-if="item.children.length === 0"
-          class="flex gap-1.5 h-8 text-c-1 py-0 justify-start text-xs w-full hover:bg-b-2"
+          class="text-c-1 hover:bg-b-2 flex h-8 w-full justify-start gap-1.5 py-0 text-xs"
           :class="parentUids.length ? 'pl-9' : ''"
           variant="ghost"
           @click="openCommandPaletteRequest()">

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
-import EditSidebarListElement from '@/components/Sidebar/Actions/EditSidebarListElement.vue'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import {
   ScalarButton,
   ScalarDropdown,
@@ -14,14 +10,20 @@ import {
   ScalarTooltip,
   useModal,
 } from '@scalar/components'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
+
+import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
+import EditSidebarListElement from '@/components/Sidebar/Actions/EditSidebarListElement.vue'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 const { activeWorkspace } = useActiveEntities()
 const { workspaces, workspaceMutators, events } = useWorkspace()
 const { push } = useRouter()
 
-const updateSelected = (uid: string) => {
+const updateSelected = (uid: Workspace['uid']) => {
   if (uid === activeWorkspace.value?.uid) return
 
   push({
@@ -38,11 +40,11 @@ const createNewWorkspace = () =>
   events.commandPalette.emit({ commandName: 'Create Workspace' })
 
 const tempName = ref('')
-const tempUid = ref('')
+const tempUid = ref('' as Workspace['uid'])
 const editModal = useModal()
 const deleteModal = useModal()
 
-const openRenameModal = (uid: string) => {
+const openRenameModal = (uid: Workspace['uid']) => {
   const workspace = workspaces[uid]
   if (!workspace) return
 
@@ -60,7 +62,7 @@ const handleWorkspaceEdit = (name: string) => {
   editModal.hide()
 }
 
-const openDeleteModal = (uid: string) => {
+const openDeleteModal = (uid: Workspace['uid']) => {
   const workspace = workspaces[uid]
   if (!workspace) return
 
@@ -96,13 +98,13 @@ const deleteWorkspace = async () => {
 
 <template>
   <div>
-    <div class="flex items-center text-sm w-[inherit]">
+    <div class="flex w-[inherit] items-center text-sm">
       <ScalarDropdown>
         <ScalarButton
-          class="font-normal h-full justify-start line-clamp-1 py-1.5 px-1.5 text-c-1 hover:bg-b-2 w-fit"
+          class="text-c-1 hover:bg-b-2 line-clamp-1 h-full w-fit justify-start px-1.5 py-1.5 font-normal"
           fullWidth
           variant="ghost">
-          <div class="font-bold m-0 flex gap-1.5 items-center">
+          <div class="m-0 flex items-center gap-1.5 font-bold">
             <h2 class="line-clamp-1 text-left">
               {{ activeWorkspace?.name }}
             </h2>
@@ -114,17 +116,17 @@ const deleteWorkspace = async () => {
           <ScalarDropdownItem
             v-for="(workspace, uid) in workspaces"
             :key="uid"
-            class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden w-full"
-            @click.stop="updateSelected(uid)">
+            class="group/item flex w-full items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap"
+            @click.stop="updateSelected(workspace.uid)">
             <ScalarListboxCheckbox :selected="activeWorkspace?.uid === uid" />
-            <span class="text-ellipsis overflow-hidden">{{
+            <span class="overflow-hidden text-ellipsis">{{
               workspace.name
             }}</span>
             <ScalarDropdown
               placement="right-start"
               teleport>
               <ScalarButton
-                class="px-0.5 py-0 hover:bg-b-3 group-hover/item:flex aspect-square ml-auto -mr-1 h-fit"
+                class="hover:bg-b-3 -mr-1 ml-auto aspect-square h-fit px-0.5 py-0 group-hover/item:flex"
                 size="sm"
                 type="button"
                 variant="ghost">
@@ -135,8 +137,8 @@ const deleteWorkspace = async () => {
               <template #items>
                 <ScalarDropdownItem
                   class="flex gap-2"
-                  @mousedown="openRenameModal(uid)"
-                  @touchend.prevent="openRenameModal(uid)">
+                  @mousedown="openRenameModal(workspace.uid)"
+                  @touchend.prevent="openRenameModal(workspace.uid)">
                   <ScalarIcon
                     class="inline-flex"
                     icon="Edit"
@@ -150,7 +152,7 @@ const deleteWorkspace = async () => {
                   side="bottom">
                   <template #trigger>
                     <ScalarDropdownItem
-                      class="flex gap-2 w-full"
+                      class="flex w-full gap-2"
                       disabled
                       @mousedown.prevent
                       @touchend.prevent>
@@ -164,8 +166,8 @@ const deleteWorkspace = async () => {
                   </template>
                   <template #content>
                     <div
-                      class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 z-context p-2 text-xxs leading-5 z-10 text-c-1">
-                      <div class="flex items-center text-c-2">
+                      class="w-content bg-b-1 text-xxs text-c-1 pointer-events-none z-10 grid min-w-48 gap-1.5 rounded p-2 leading-5 shadow-lg">
+                      <div class="text-c-2 flex items-center">
                         <span>Only workspace cannot be deleted.</span>
                       </div>
                     </div>
@@ -174,8 +176,8 @@ const deleteWorkspace = async () => {
                 <ScalarDropdownItem
                   v-else
                   class="flex !gap-2"
-                  @mousedown.prevent="openDeleteModal(uid)"
-                  @touchend.prevent="openDeleteModal(uid)">
+                  @mousedown.prevent="openDeleteModal(workspace.uid)"
+                  @touchend.prevent="openDeleteModal(workspace.uid)">
                   <ScalarIcon
                     class="inline-flex"
                     icon="Delete"
@@ -192,7 +194,7 @@ const deleteWorkspace = async () => {
           <ScalarDropdownItem
             class="flex items-center gap-1.5"
             @click="createNewWorkspace">
-            <div class="flex items-center justify-center h-4 w-4">
+            <div class="flex h-4 w-4 items-center justify-center">
               <ScalarIcon
                 icon="Add"
                 size="sm" />

--- a/packages/api-client/src/views/Request/consts/new-auth-options.ts
+++ b/packages/api-client/src/views/Request/consts/new-auth-options.ts
@@ -1,8 +1,8 @@
-import type { SecuritySchemePayload } from '@scalar/oas-utils/entities/spec'
+import type { SecurityScheme, SecuritySchemePayload } from '@scalar/oas-utils/entities/spec'
 import type { Entries } from 'type-fest'
 
 export type SecuritySchemeOption = {
-  id: string
+  id: SecurityScheme['uid']
   label: string
   isDeletable?: boolean
   payload?: SecuritySchemePayload
@@ -115,7 +115,7 @@ const entries = Object.entries(ADD_AUTH_DICT) as Entries<typeof ADD_AUTH_DICT>
 export const ADD_AUTH_OPTIONS: SecuritySchemeOption[] = entries.map(
   ([id, value]) =>
     ({
-      id,
+      id: id as SecurityScheme['uid'],
       isDeletable: false,
       ...value,
     }) as const,

--- a/packages/api-client/src/views/Request/consts/new-auth-options.ts
+++ b/packages/api-client/src/views/Request/consts/new-auth-options.ts
@@ -2,7 +2,7 @@ import type { SecurityScheme, SecuritySchemePayload } from '@scalar/oas-utils/en
 import type { Entries } from 'type-fest'
 
 export type SecuritySchemeOption = {
-  id: SecurityScheme['uid']
+  id: string
   label: string
   isDeletable?: boolean
   payload?: SecuritySchemePayload

--- a/packages/api-client/src/views/Request/handle-drag.ts
+++ b/packages/api-client/src/views/Request/handle-drag.ts
@@ -30,7 +30,7 @@ export function dragHandlerFactory(
     // Parent is the workspace
     if (!draggingParentUid) {
       workspaceMutators.edit(
-        activeWorkspace.value?.uid ?? '',
+        activeWorkspace.value?.uid,
         'collections',
         activeWorkspace.value?.collections.filter((uid) => uid !== draggingUid) ?? [],
       )
@@ -39,7 +39,7 @@ export function dragHandlerFactory(
     // Parent is collection
     else if (collections[draggingParentUid]) {
       collectionMutators.edit(
-        draggingParentUid,
+        draggingParentUid as Collection['uid'],
         'children',
         collections[draggingParentUid].children.filter((uid) => uid !== draggingUid),
       )
@@ -47,7 +47,7 @@ export function dragHandlerFactory(
     // Parent is a tag
     else if (tags[draggingParentUid]) {
       tagMutators.edit(
-        draggingParentUid,
+        draggingParentUid as Tag['uid'],
         'children',
         tags[draggingParentUid].children.filter((uid) => uid !== draggingUid),
       )
@@ -64,7 +64,7 @@ export function dragHandlerFactory(
       const hoveredIndex = newChildUids.findIndex((uid) => hoveredUid === uid) ?? 0
       newChildUids.splice(hoveredIndex + offset, 0, draggingUid as Collection['uid'])
 
-      workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'collections', newChildUids)
+      workspaceMutators.edit(activeWorkspace.value?.uid, 'collections', newChildUids)
     }
     // Place it into the list at an index
     else {

--- a/packages/api-client/src/views/Request/libs/auth.test.ts
+++ b/packages/api-client/src/views/Request/libs/auth.test.ts
@@ -1,59 +1,51 @@
-import {
-  ADD_AUTH_OPTIONS,
-  type SecuritySchemeGroup,
-} from '@/views/Request/consts'
-import type { Collection, Request } from '@scalar/oas-utils/entities/spec'
+import { ADD_AUTH_OPTIONS, type SecuritySchemeGroup } from '@/views/Request/consts'
+import { securitySchemeSchema, type Collection, type Request } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
-import {
-  formatComplexScheme,
-  formatScheme,
-  getSchemeOptions,
-  getSecurityRequirements,
-} from './auth'
+import { formatComplexScheme, formatScheme, getSchemeOptions, getSecurityRequirements } from './auth'
 
 const securitySchemes = {
-  apiKeyUid: {
+  apiKeyUid: securitySchemeSchema.parse({
     type: 'apiKey',
     nameKey: 'apiKey',
     uid: 'apiKeyUid',
-  },
-  basicUid: {
+  }),
+  basicUid: securitySchemeSchema.parse({
     type: 'http',
     nameKey: 'basic',
     uid: 'basicUid',
-  },
-  oauth2Uid: {
+  }),
+  oauth2Uid: securitySchemeSchema.parse({
     type: 'oauth2',
     nameKey: 'oauth2',
     uid: 'oauth2Uid',
-  },
-} as const
+  }),
+}
 
 describe('auth utilities', () => {
   describe('formatScheme', () => {
     it('formats regular security scheme', () => {
-      const scheme = {
-        uid: 'auth1',
+      const scheme = securitySchemeSchema.parse({
+        uid: 'auth1-uid',
         type: 'http',
         nameKey: 'Basic Auth',
-      } as const
+      })
 
       expect(formatScheme(scheme)).toEqual({
-        id: 'auth1',
+        id: 'auth1-uid',
         label: 'Basic Auth',
       })
     })
 
     it('adds "coming soon" to openIdConnect schemes', () => {
-      const scheme = {
-        uid: 'auth2',
+      const scheme = securitySchemeSchema.parse({
+        uid: 'auth2-uid',
         type: 'openIdConnect',
         nameKey: 'OAuth',
-      } as const
+      })
 
       expect(formatScheme(scheme)).toEqual({
-        id: 'auth2',
+        id: 'auth2-uid',
         label: 'OAuth (coming soon)',
       })
     })
@@ -61,18 +53,14 @@ describe('auth utilities', () => {
 
   describe('formatComplexScheme', () => {
     it('combines multiple schemes into a single complex scheme', () => {
-      expect(
-        formatComplexScheme(['apiKeyUid', 'oauth2Uid'], securitySchemes),
-      ).toEqual({
+      expect(formatComplexScheme(['apiKeyUid', 'oauth2Uid'], securitySchemes)).toEqual({
         id: 'apiKeyUid,oauth2Uid',
         label: 'apiKey & oauth2',
       })
     })
 
     it('handles missing schemes gracefully', () => {
-      expect(
-        formatComplexScheme(['apiKeyUid', 'missing'], securitySchemes),
-      ).toEqual({
+      expect(formatComplexScheme(['apiKeyUid', 'missing'], securitySchemes)).toEqual({
         id: 'apiKeyUid',
         label: 'apiKey',
       })
@@ -103,9 +91,7 @@ describe('auth utilities', () => {
         security: [{ basic: [] }],
       } as unknown as Collection
 
-      expect(getSecurityRequirements(request, collection)).toEqual([
-        { apiKey: [] },
-      ])
+      expect(getSecurityRequirements(request, collection)).toEqual([{ apiKey: [] }])
     })
 
     it('falls back to collection security when request security is not defined', () => {
@@ -114,10 +100,7 @@ describe('auth utilities', () => {
         security: [{ basic: [] }, { apiKey: [] }],
       } as unknown as Collection
 
-      expect(getSecurityRequirements(request, collection)).toEqual([
-        { basic: [] },
-        { apiKey: [] },
-      ])
+      expect(getSecurityRequirements(request, collection)).toEqual([{ basic: [] }, { apiKey: [] }])
     })
 
     it('handles optional security in request', () => {
@@ -128,11 +111,7 @@ describe('auth utilities', () => {
         security: [{ basic: [] }, { apiKey: [] }],
       } as unknown as Collection
 
-      expect(getSecurityRequirements(request, collection)).toEqual([
-        { basic: [] },
-        { apiKey: [] },
-        {},
-      ])
+      expect(getSecurityRequirements(request, collection)).toEqual([{ basic: [] }, { apiKey: [] }, {}])
     })
 
     it('preserves existing optional security in collection', () => {
@@ -143,10 +122,7 @@ describe('auth utilities', () => {
         security: [{ basic: [] }, {}],
       } as unknown as Collection
 
-      expect(getSecurityRequirements(request, collection)).toEqual([
-        { basic: [] },
-        {},
-      ])
+      expect(getSecurityRequirements(request, collection)).toEqual([{ basic: [] }, {}])
     })
 
     it('handles complex security requirements', () => {
@@ -155,9 +131,7 @@ describe('auth utilities', () => {
       } as unknown as Request
       const collection = {} as unknown as Collection
 
-      expect(getSecurityRequirements(request, collection)).toEqual([
-        { basic: [], apiKey: [] },
-      ])
+      expect(getSecurityRequirements(request, collection)).toEqual([{ basic: [], apiKey: [] }])
     })
   })
 })
@@ -167,12 +141,7 @@ describe('getSchemeOptions', () => {
 
   it('returns flat list when readonly and theres no required schemes', () => {
     const filteredRequirements: Record<string, string[]>[] = []
-    const result = getSchemeOptions(
-      filteredRequirements,
-      collectionSchemeUids,
-      securitySchemes,
-      true,
-    )
+    const result = getSchemeOptions(filteredRequirements, collectionSchemeUids, securitySchemes, true)
 
     expect(Array.isArray(result)).toBe(true)
     expect(result).toHaveLength(3)
@@ -184,12 +153,7 @@ describe('getSchemeOptions', () => {
 
   it('returns 2 grouped options when there are required + available and readonly', () => {
     const filteredRequirements = [{ apiKey: [] }]
-    const result = getSchemeOptions(
-      filteredRequirements,
-      collectionSchemeUids,
-      securitySchemes,
-      true,
-    )
+    const result = getSchemeOptions(filteredRequirements, collectionSchemeUids, securitySchemes, true)
 
     expect(Array.isArray(result)).toBe(true)
     expect(result).toHaveLength(2)
@@ -208,11 +172,7 @@ describe('getSchemeOptions', () => {
 
   it('returns 3 grouped options when there are required + available + add new', () => {
     const filteredRequirements = [{ apiKey: [] }]
-    const result = getSchemeOptions(
-      filteredRequirements,
-      collectionSchemeUids,
-      securitySchemes,
-    )
+    const result = getSchemeOptions(filteredRequirements, collectionSchemeUids, securitySchemes)
 
     expect(Array.isArray(result)).toBe(true)
     expect(result).toHaveLength(3)
@@ -236,18 +196,8 @@ describe('getSchemeOptions', () => {
   it('includes "Add new authentication" group only when not readonly', () => {
     const filteredRequirements: Record<string, string[]>[] = []
 
-    const readonlyResult = getSchemeOptions(
-      filteredRequirements,
-      collectionSchemeUids,
-      securitySchemes,
-      true,
-    )
-    const editableResult = getSchemeOptions(
-      filteredRequirements,
-      collectionSchemeUids,
-      securitySchemes,
-      false,
-    )
+    const readonlyResult = getSchemeOptions(filteredRequirements, collectionSchemeUids, securitySchemes, true)
+    const editableResult = getSchemeOptions(filteredRequirements, collectionSchemeUids, securitySchemes, false)
 
     expect(readonlyResult).not.toContainEqual(
       expect.objectContaining({
@@ -263,11 +213,7 @@ describe('getSchemeOptions', () => {
 
   it('handles empty filtered requirements when not readonly', () => {
     const filteredRequirements: Record<string, string[]>[] = []
-    const result = getSchemeOptions(
-      filteredRequirements,
-      collectionSchemeUids,
-      securitySchemes,
-    )
+    const result = getSchemeOptions(filteredRequirements, collectionSchemeUids, securitySchemes)
 
     expect(result).toHaveLength(3)
     expect((result[0] as SecuritySchemeGroup).options).toHaveLength(0)
@@ -279,12 +225,7 @@ describe('getSchemeOptions', () => {
 
   it('handles complex security requirements', () => {
     const filteredRequirements = [{ apiKey: [], basic: [] }]
-    const result = getSchemeOptions(
-      filteredRequirements,
-      collectionSchemeUids,
-      securitySchemes,
-      false,
-    )
+    const result = getSchemeOptions(filteredRequirements, collectionSchemeUids, securitySchemes, false)
 
     expect(result[0]).toMatchObject({
       label: 'Required authentication',

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -141,7 +141,7 @@ export const authorizeOauth2 = async (
             const hashParams = new URLSearchParams(authWindow.location.href.split('#')[1])
             accessToken ||= hashParams.get('access_token')
             code ||= hashParams.get('code')
-          } catch (e) {
+          } catch (_e) {
             // Ignore CORS error from popup
           }
 
@@ -214,7 +214,7 @@ export const authorizeServers = async (
   formData.set('client_id', flow['x-scalar-client-id'])
 
   // Only client credentials and password flows support scopes in the token request
-  if (scopes && (flow.type == 'clientCredentials' || flow.type === 'password')) {
+  if (scopes && (flow.type === 'clientCredentials' || flow.type === 'password')) {
     formData.set('scope', scopes)
   }
 

--- a/packages/api-client/src/views/Request/libs/watch-mode.test.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.test.ts
@@ -4,10 +4,13 @@ import json from '@scalar/galaxy/3.1.json'
 import {
   type Request,
   type SecurityScheme,
-  type SecuritySchemePayload,
   type Server,
   type Tag,
   collectionSchema,
+  operationSchema,
+  securitySchemeSchema,
+  serverSchema,
+  tagSchema,
 } from '@scalar/oas-utils/entities/spec'
 import { parseSchema } from '@scalar/oas-utils/transforms'
 import microdiff, { type Difference } from 'microdiff'
@@ -27,15 +30,10 @@ import {
 } from './watch-mode'
 
 const mockRequests: Record<`request${number}uid`, Request> = {
-  request1uid: {
-    type: 'request',
+  request1uid: operationSchema.parse({
     uid: 'request1uid',
     method: 'get',
     path: '/planets',
-    examples: [],
-    selectedSecuritySchemeUids: [],
-    selectedServerUid: '',
-    servers: [],
     parameters: [
       {
         name: 'limit',
@@ -61,13 +59,11 @@ const mockRequests: Record<`request${number}uid`, Request> = {
     ] as const,
     summary: 'Get all planets',
     description: 'Retrieve all planets',
-  },
-  request2uid: {
-    type: 'request',
+  }),
+  request2uid: operationSchema.parse({
     uid: 'request2uid',
     method: 'post',
     path: '/planets',
-    examples: [],
     requestBody: {
       description: 'Planet',
       content: {
@@ -126,20 +122,14 @@ const mockRequests: Record<`request${number}uid`, Request> = {
     parameters: [],
     summary: 'Create a new planet',
     description: 'Add a new planet to the database',
-  },
-  request3uid: {
-    type: 'request',
+  }),
+  request3uid: operationSchema.parse({
     uid: 'request3uid',
     method: 'get',
     path: '/planets/{planetId}',
-    examples: [],
-    selectedSecuritySchemeUids: [],
-    selectedServerUid: '',
-    servers: [],
-    parameters: [],
     summary: 'Get a planet by ID',
     description: 'Retrieve a single planet by its ID',
-  },
+  }),
 }
 
 const mockCollection = Object.freeze(
@@ -153,24 +143,21 @@ const mockCollection = Object.freeze(
     },
     requests: Object.keys(mockRequests),
     servers: ['server1', 'server2', 'server3'],
-    security: [
-      { bearerAuth: ['read:users', 'read:events'] },
-      { apiKeyQuery: [] },
-    ],
+    security: [{ bearerAuth: ['read:users', 'read:events'] }, { apiKeyQuery: [] }],
     tags: ['tag1uid', 'tag2uid', 'tag3uid'],
   }),
 )
 const mockSecuritySchemes: Record<string, SecurityScheme> = {
-  apiKeyUid: {
+  apiKeyUid: securitySchemeSchema.parse({
     uid: 'apiKeyUid',
     nameKey: 'apiKeyHeader',
     type: 'apiKey',
     name: 'api_key',
     in: 'header',
     value: 'test-api-key',
-  },
-  oauth2: {
-    uid: 'oauth2',
+  }),
+  oauth2: securitySchemeSchema.parse({
+    uid: 'oauth2-uid',
     type: 'oauth2',
     nameKey: 'oauth2',
     flows: {
@@ -188,7 +175,7 @@ const mockSecuritySchemes: Record<string, SecurityScheme> = {
         },
       },
     },
-  },
+  }),
 }
 
 const mockActiveEntities = {
@@ -391,8 +378,7 @@ describe('combineRenameDiffs', () => {
         type: 'REMOVE',
         path: ['paths', '/planets', 'get', 'parameters', 1],
         oldValue: {
-          description:
-            'The number of items to skip before starting to collect the result set',
+          description: 'The number of items to skip before starting to collect the result set',
           name: 'offset',
           in: 'query',
           required: false,
@@ -420,9 +406,7 @@ describe('combineRenameDiffs', () => {
 
   // This one just tests microdiff but we use the value in another test
   it('creates a change diff for changing an oauth2 flow scope', () => {
-    const mutatedSecuritySchemes = JSON.parse(
-      JSON.stringify(mockSecuritySchemes),
-    )
+    const mutatedSecuritySchemes = JSON.parse(JSON.stringify(mockSecuritySchemes))
     mutatedSecuritySchemes.oauth2.flows.implicit.scopes = {
       'write:api': 'modify api',
     }
@@ -441,9 +425,8 @@ describe('combineRenameDiffs', () => {
 
   it('handles deep changes in the schema', () => {
     // Modify a deep property in the schema
-    mutated.paths['/planets'].get.responses['200'].content[
-      'application/json'
-    ].schema.allOf[0].properties.data.type = 'number'
+    mutated.paths['/planets'].get.responses['200'].content['application/json'].schema.allOf[0].properties.data.type =
+      'number'
 
     const diff = microdiff(original, mutated)
     const combinedDiff = combineRenameDiffs(diff)
@@ -489,11 +472,7 @@ describe('mutateCollectionDiff', () => {
 
     const result = mutateCollectionDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith(
-      'collection1',
-      'info.title',
-      'Updated Test API',
-    )
+    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith('collection1', 'info.title', 'Updated Test API')
   })
 
   it('generates a payload for updating the version', () => {
@@ -506,11 +485,7 @@ describe('mutateCollectionDiff', () => {
 
     const result = mutateCollectionDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith(
-      'collection1',
-      'info.version',
-      '2.0.0',
-    )
+    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith('collection1', 'info.version', '2.0.0')
   })
 
   it('generates a payload for updating the description', () => {
@@ -554,11 +529,7 @@ describe('mutateCollectionDiff', () => {
 
     const result = mutateCollectionDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith(
-      'collection1',
-      'info.termsOfService',
-      undefined,
-    )
+    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith('collection1', 'info.termsOfService', undefined)
   })
 
   it('generates a payload for adding a new security requirement', () => {
@@ -570,11 +541,10 @@ describe('mutateCollectionDiff', () => {
 
     const result = mutateCollectionDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith(
-      'collection1',
-      'security',
-      [...mockCollection.security, { oauth2: ['read:api', 'write:api'] }],
-    )
+    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith('collection1', 'security', [
+      ...mockCollection.security,
+      { oauth2: ['read:api', 'write:api'] },
+    ])
   })
 
   it('generates a payload for removing a security requirement', () => {
@@ -586,11 +556,9 @@ describe('mutateCollectionDiff', () => {
 
     const result = mutateCollectionDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith(
-      'collection1',
-      'security',
-      [mockCollection.security[0]],
-    )
+    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith('collection1', 'security', [
+      mockCollection.security[0],
+    ])
   })
 
   it('generates a payload for adding a security scope to oauth2', () => {
@@ -602,11 +570,11 @@ describe('mutateCollectionDiff', () => {
 
     const result = mutateCollectionDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith(
-      'collection1',
-      'security.0.bearerAuth',
-      ['read:users', 'read:events', 'write:events'],
-    )
+    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith('collection1', 'security.0.bearerAuth', [
+      'read:users',
+      'read:events',
+      'write:events',
+    ])
   })
 
   it('generates a payload for removing a security scope from oauth2', () => {
@@ -618,27 +586,25 @@ describe('mutateCollectionDiff', () => {
 
     const result = mutateCollectionDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith(
-      'collection1',
-      'security.0.bearerAuth',
-      ['read:users'],
-    )
+    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith('collection1', 'security.0.bearerAuth', [
+      'read:users',
+    ])
   })
 })
 
 describe('mutateServerDiff', () => {
   const mockServers: Record<string, Server> = {
-    server1: {
+    server1: serverSchema.parse({
       uid: 'server1',
       url: 'https://api.example.com',
       description: 'Production server',
-    },
-    server2: {
+    }),
+    server2: serverSchema.parse({
       uid: 'server2',
       url: 'https://staging.example.com',
       description: 'Staging server',
-    },
-    server3: {
+    }),
+    server3: serverSchema.parse({
       uid: 'server3',
       url: 'https://{environment}.example.com/{version}/',
       description: 'Development server',
@@ -649,7 +615,7 @@ describe('mutateServerDiff', () => {
           enum: ['production', 'staging'],
         },
       },
-    },
+    }),
   }
   const mockStore = {
     servers: mockServers,
@@ -670,11 +636,7 @@ describe('mutateServerDiff', () => {
 
     const result = mutateServerDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith(
-      'server1',
-      'url',
-      'https://new-api.example.com',
-    )
+    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith('server1', 'url', 'https://new-api.example.com')
   })
 
   it('generates a delete payload for removing a server', () => {
@@ -686,18 +648,15 @@ describe('mutateServerDiff', () => {
 
     const result = mutateServerDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.serverMutators.delete).toHaveBeenCalledWith(
-      'server2',
-      'collection1',
-    )
+    expect(mockStore.serverMutators.delete).toHaveBeenCalledWith('server2', 'collection1')
   })
 
   it('generates an add payload for creating a new server', () => {
-    const newServer: Server = {
+    const newServer = serverSchema.parse({
       uid: 'server4',
       url: 'https://test.example.com',
       description: 'Test server',
-    }
+    })
     const diff: Difference = {
       type: 'CREATE',
       path: ['servers', 3],
@@ -706,10 +665,7 @@ describe('mutateServerDiff', () => {
 
     const result = mutateServerDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.serverMutators.add).toHaveBeenCalledWith(
-      newServer,
-      'collection1',
-    )
+    expect(mockStore.serverMutators.add).toHaveBeenCalledWith(newServer, 'collection1')
   })
 
   it('generates an edit payload for adding a server variable', () => {
@@ -721,11 +677,10 @@ describe('mutateServerDiff', () => {
 
     const result = mutateServerDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith(
-      'server1',
-      'variables.newVar',
-      { default: 'default', enum: ['default', 'other'] },
-    )
+    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith('server1', 'variables.newVar', {
+      default: 'default',
+      enum: ['default', 'other'],
+    })
   })
 
   it('generates an edit payload for updating a server variable', () => {
@@ -738,11 +693,7 @@ describe('mutateServerDiff', () => {
 
     const result = mutateServerDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith(
-      'server3',
-      'variables.version.default',
-      'v2',
-    )
+    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith('server3', 'variables.version.default', 'v2')
   })
 
   it('generates an edit payload for removing a server variable', () => {
@@ -754,11 +705,7 @@ describe('mutateServerDiff', () => {
 
     const result = mutateServerDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith(
-      'server3',
-      'variables.version',
-      undefined,
-    )
+    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith('server3', 'variables.version', undefined)
   })
 
   it('generates an edit payload for adding all variables to a server', () => {
@@ -773,14 +720,10 @@ describe('mutateServerDiff', () => {
 
     const result = mutateServerDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith(
-      'server2',
-      'variables',
-      {
-        version: { default: 'v1', enum: ['v1', 'v2'] },
-        environment: { default: 'staging', enum: ['production', 'staging'] },
-      },
-    )
+    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith('server2', 'variables', {
+      version: { default: 'v1', enum: ['v1', 'v2'] },
+      environment: { default: 'staging', enum: ['production', 'staging'] },
+    })
   })
 
   it('generates an edit payload for removing all variables from a server', () => {
@@ -792,11 +735,7 @@ describe('mutateServerDiff', () => {
 
     const result = mutateServerDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith(
-      'server3',
-      'variables',
-      {},
-    )
+    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith('server3', 'variables', {})
   })
 
   it('generates an edit payload for updating a server variable enum', () => {
@@ -809,11 +748,7 @@ describe('mutateServerDiff', () => {
 
     const result = mutateServerDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith(
-      'server3',
-      'variables.version.enum',
-      ['v1', 'v2', 'v3'],
-    )
+    expect(mockStore.serverMutators.edit).toHaveBeenCalledWith('server3', 'variables.version.enum', ['v1', 'v2', 'v3'])
   })
 
   it('returns false when trying to edit a non-existent server', () => {
@@ -855,30 +790,22 @@ describe('mutateServerDiff', () => {
 
 describe('mutateTagDiff', () => {
   const mockTags: Record<string, Tag> = {
-    tag1uid: {
-      'type': 'tag',
-      'uid': 'tag1uid',
-      'name': 'Tag 1',
-      'description': 'First tag',
-      'children': [],
+    tag1uid: tagSchema.parse({
+      uid: 'tag1uid',
+      name: 'Tag 1',
+      description: 'First tag',
+    }),
+    tag2uid: tagSchema.parse({
+      uid: 'tag2uid',
+      name: 'Tag 2',
+      description: 'Second tag',
       'x-scalar-children': [],
-    },
-    tag2uid: {
-      'type': 'tag',
-      'uid': 'tag2uid',
-      'name': 'Tag 2',
-      'description': 'Second tag',
-      'children': [],
-      'x-scalar-children': [],
-    },
-    tag3uid: {
-      'type': 'tag',
-      'uid': 'tag3uid',
-      'name': 'Tag 3',
-      'description': 'Third tag',
-      'children': [],
-      'x-scalar-children': [],
-    },
+    }),
+    tag3uid: tagSchema.parse({
+      uid: 'tag3uid',
+      name: 'Tag 3',
+      description: 'Third tag',
+    }),
   }
 
   const mockStore = {
@@ -891,14 +818,11 @@ describe('mutateTagDiff', () => {
   } as unknown as WorkspaceStore
 
   it('generates an add payload for creating a new tag', () => {
-    const newTag: Tag = {
-      'type': 'tag',
+    const newTag = tagSchema.parse({
       'uid': 'tag4uid',
       'name': 'New Tag',
       'description': 'New tag description',
-      'children': [],
-      'x-scalar-children': [],
-    }
+    })
     const diff: Difference = {
       type: 'CREATE',
       path: ['tags', 3],
@@ -907,10 +831,7 @@ describe('mutateTagDiff', () => {
 
     const result = mutateTagDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.tagMutators.add).toHaveBeenCalledWith(
-      newTag,
-      'collection1',
-    )
+    expect(mockStore.tagMutators.add).toHaveBeenCalledWith(newTag, 'collection1')
   })
 
   it('generates a remove payload for deleting a tag', () => {
@@ -945,11 +866,7 @@ describe('mutateTagDiff', () => {
 
     const result = mutateTagDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.tagMutators.edit).toHaveBeenCalledWith(
-      'tag1uid',
-      'name',
-      'Updated Tag 1',
-    )
+    expect(mockStore.tagMutators.edit).toHaveBeenCalledWith('tag1uid', 'name', 'Updated Tag 1')
   })
 
   it('generates an edit payload for updating a tag description', () => {
@@ -962,11 +879,7 @@ describe('mutateTagDiff', () => {
 
     const result = mutateTagDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.tagMutators.edit).toHaveBeenCalledWith(
-      'tag2uid',
-      'description',
-      'Updated second tag',
-    )
+    expect(mockStore.tagMutators.edit).toHaveBeenCalledWith('tag2uid', 'description', 'Updated second tag')
   })
 
   it('generates an edit payload for adding a new property to a tag', () => {
@@ -978,11 +891,9 @@ describe('mutateTagDiff', () => {
 
     const result = mutateTagDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.tagMutators.edit).toHaveBeenCalledWith(
-      'tag3uid',
-      'externalDocs',
-      { url: 'https://example.com/docs' },
-    )
+    expect(mockStore.tagMutators.edit).toHaveBeenCalledWith('tag3uid', 'externalDocs', {
+      url: 'https://example.com/docs',
+    })
   })
 
   it('generates an edit payload for removing a property from a tag', () => {
@@ -994,11 +905,7 @@ describe('mutateTagDiff', () => {
 
     const result = mutateTagDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.tagMutators.edit).toHaveBeenCalledWith(
-      'tag1uid',
-      'description',
-      undefined,
-    )
+    expect(mockStore.tagMutators.edit).toHaveBeenCalledWith('tag1uid', 'description', undefined)
   })
 
   it('returns false when trying to edit a non-existent tag', () => {
@@ -1037,7 +944,7 @@ describe('mutateSecuritySchemeDiff', () => {
   } as unknown as WorkspaceStore
 
   it('generates an add payload for creating a new security scheme', () => {
-    const newScheme: SecuritySchemePayload = {
+    const newScheme = securitySchemeSchema.parse({
       type: 'http',
       scheme: 'bearer',
       bearerFormat: 'jwt',
@@ -1046,7 +953,7 @@ describe('mutateSecuritySchemeDiff', () => {
       username: '',
       password: '',
       token: '',
-    }
+    })
     const diff: Difference = {
       type: 'CREATE',
       path: ['components', 'securitySchemes', 'bearerAuth'],
@@ -1055,10 +962,7 @@ describe('mutateSecuritySchemeDiff', () => {
 
     const result = mutateSecuritySchemeDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.securitySchemeMutators.add).toHaveBeenCalledWith(
-      newScheme,
-      'collection1',
-    )
+    expect(mockStore.securitySchemeMutators.add).toHaveBeenCalledWith(newScheme, 'collection1')
   })
 
   it('generates a remove payload for deleting a security scheme', () => {
@@ -1070,9 +974,7 @@ describe('mutateSecuritySchemeDiff', () => {
 
     const result = mutateSecuritySchemeDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.securitySchemeMutators.delete).toHaveBeenCalledWith(
-      'apiKeyUid',
-    )
+    expect(mockStore.securitySchemeMutators.delete).toHaveBeenCalledWith('apiKeyUid')
   })
 
   it('generates an edit payload for updating a security scheme property', () => {
@@ -1085,24 +987,13 @@ describe('mutateSecuritySchemeDiff', () => {
 
     const result = mutateSecuritySchemeDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.securitySchemeMutators.edit).toHaveBeenCalledWith(
-      'apiKeyUid',
-      'name',
-      'new_api_key',
-    )
+    expect(mockStore.securitySchemeMutators.edit).toHaveBeenCalledWith('apiKeyUid', 'name', 'new_api_key')
   })
 
   it('generates an edit payload for updating an oauth2 flow property', () => {
     const diff: Difference = {
       type: 'CHANGE',
-      path: [
-        'components',
-        'securitySchemes',
-        'oauth2',
-        'flows',
-        'implicit',
-        'authorizationUrl',
-      ],
+      path: ['components', 'securitySchemes', 'oauth2', 'flows', 'implicit', 'authorizationUrl'],
       oldValue: 'https://example.com/oauth/authorize',
       value: 'https://example.com/oauth/authorize-admin',
     }
@@ -1110,7 +1001,7 @@ describe('mutateSecuritySchemeDiff', () => {
     const result = mutateSecuritySchemeDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
     expect(mockStore.securitySchemeMutators.edit).toHaveBeenCalledWith(
-      'oauth2',
+      'oauth2-uid',
       'flows.implicit.authorizationUrl',
       'https://example.com/oauth/authorize-admin',
     )
@@ -1135,22 +1026,14 @@ describe('mutateSecuritySchemeDiff', () => {
   it('generates an edit payload for removing a scope from an oauth2 flow', () => {
     const diff: Difference = {
       type: 'REMOVE',
-      path: [
-        'components',
-        'securitySchemes',
-        'oauth2',
-        'flows',
-        'implicit',
-        'scopes',
-        'read:api',
-      ],
+      path: ['components', 'securitySchemes', 'oauth2', 'flows', 'implicit', 'scopes', 'read:api'],
       oldValue: 'read api',
     }
 
     const result = mutateSecuritySchemeDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
     expect(mockStore.securitySchemeMutators.edit).toHaveBeenCalledWith(
-      'oauth2',
+      'oauth2-uid',
       'flows.implicit.scopes.read:api',
       undefined,
     )
@@ -1159,15 +1042,7 @@ describe('mutateSecuritySchemeDiff', () => {
   it('generates an edit payload for adding a scope to an oauth2 flow', () => {
     const diff: Difference = {
       type: 'CHANGE',
-      path: [
-        'components',
-        'securitySchemes',
-        'oauth2',
-        'flows',
-        'implicit',
-        'scopes',
-        'write:users',
-      ],
+      path: ['components', 'securitySchemes', 'oauth2', 'flows', 'implicit', 'scopes', 'write:users'],
       oldValue: '',
       value: 'write users',
     }
@@ -1175,7 +1050,7 @@ describe('mutateSecuritySchemeDiff', () => {
     const result = mutateSecuritySchemeDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
     expect(mockStore.securitySchemeMutators.edit).toHaveBeenCalledWith(
-      'oauth2',
+      'oauth2-uid',
       'flows.implicit.scopes.write:users',
       'write users',
     )
@@ -1184,15 +1059,7 @@ describe('mutateSecuritySchemeDiff', () => {
   it('generates an edit payload for updating a scope from an oauth2 flow', () => {
     const diff: Difference = {
       type: 'CHANGE',
-      path: [
-        'components',
-        'securitySchemes',
-        'oauth2',
-        'flows',
-        'implicit',
-        'scopes',
-        'write:api',
-      ],
+      path: ['components', 'securitySchemes', 'oauth2', 'flows', 'implicit', 'scopes', 'write:api'],
       oldValue: 'modify api',
       value: 'write the api',
     }
@@ -1200,7 +1067,7 @@ describe('mutateSecuritySchemeDiff', () => {
     const result = mutateSecuritySchemeDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
     expect(mockStore.securitySchemeMutators.edit).toHaveBeenCalledWith(
-      'oauth2',
+      'oauth2-uid',
       'flows.implicit.scopes.write:api',
       'write the api',
     )
@@ -1233,14 +1100,7 @@ describe('mutateSecuritySchemeDiff', () => {
   it('handles nested changes in oauth2 flows', () => {
     const diff: Difference = {
       type: 'CHANGE',
-      path: [
-        'components',
-        'securitySchemes',
-        'oauth2',
-        'flows',
-        'implicit',
-        'authorizationUrl',
-      ],
+      path: ['components', 'securitySchemes', 'oauth2', 'flows', 'implicit', 'authorizationUrl'],
       oldValue: 'https://example.com/oauth/authorize',
       value: 'https://api.example.com/oauth2/authorize',
     }
@@ -1248,7 +1108,7 @@ describe('mutateSecuritySchemeDiff', () => {
     const result = mutateSecuritySchemeDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
     expect(mockStore.securitySchemeMutators.edit).toHaveBeenCalledWith(
-      'oauth2',
+      'oauth2-uid',
       'flows.implicit.authorizationUrl',
       'https://api.example.com/oauth2/authorize',
     )
@@ -1271,19 +1131,14 @@ describe('mutateRequestDiff', () => {
   } as unknown as WorkspaceStore
 
   it('generates an add payload for creating a new request', () => {
-    const newRequest: Request = {
-      type: 'request',
+    const newRequest = operationSchema.parse({
       uid: 'request4uid',
       method: 'delete',
       path: '/planets/{planetId}',
       summary: 'Delete a planet',
-      description: 'Remove a planet by its ID',
       parameters: [],
-      examples: [],
-      selectedSecuritySchemeUids: [],
-      selectedServerUid: '',
-      servers: [],
-    }
+      description: 'Remove a planet by its ID',
+    })
     const diff: Difference = {
       type: 'CREATE',
       path: ['paths', '/planets/{planetId}', 'delete'],
@@ -1292,10 +1147,7 @@ describe('mutateRequestDiff', () => {
 
     const result = mutateRequestDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.requestMutators.add).toHaveBeenCalledWith(
-      newRequest,
-      mockCollection.uid,
-    )
+    expect(mockStore.requestMutators.add).toHaveBeenCalledWith(newRequest, mockCollection.uid)
   })
 
   it('generates a delete payload for removing a request', () => {
@@ -1307,10 +1159,7 @@ describe('mutateRequestDiff', () => {
 
     const result = mutateRequestDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.requestMutators.delete).toHaveBeenCalledWith(
-      mockRequests.request2uid,
-      mockCollection.uid,
-    )
+    expect(mockStore.requestMutators.delete).toHaveBeenCalledWith(mockRequests.request2uid, mockCollection.uid)
   })
 
   it('generates an edit payload for updating a request summary', () => {
@@ -1323,11 +1172,7 @@ describe('mutateRequestDiff', () => {
 
     const result = mutateRequestDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.requestMutators.edit).toHaveBeenCalledWith(
-      'request3uid',
-      'summary',
-      'Retrieve planet details',
-    )
+    expect(mockStore.requestMutators.edit).toHaveBeenCalledWith('request3uid', 'summary', 'Retrieve planet details')
   })
 
   it('generates an edit payload for adding a parameter to a request', () => {
@@ -1345,20 +1190,16 @@ describe('mutateRequestDiff', () => {
 
     const result = mutateRequestDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.requestMutators.edit).toHaveBeenCalledWith(
-      'request1uid',
-      'parameters',
-      [
-        ...(mockRequests.request1uid?.parameters ?? []),
-        {
-          name: 'highroller',
-          in: 'query',
-          required: false,
-          deprecated: false,
-          schema: { type: 'integer', format: 'int32' },
-        },
-      ],
-    )
+    expect(mockStore.requestMutators.edit).toHaveBeenCalledWith('request1uid', 'parameters', [
+      ...(mockRequests.request1uid?.parameters ?? []),
+      {
+        name: 'highroller',
+        in: 'query',
+        required: false,
+        deprecated: false,
+        schema: { type: 'integer', format: 'int32' },
+      },
+    ])
   })
 
   it('generates an edit payload for removing a parameter from a request', () => {
@@ -1366,8 +1207,7 @@ describe('mutateRequestDiff', () => {
       type: 'REMOVE',
       path: ['paths', '/planets', 'get', 'parameters', 1],
       oldValue: {
-        description:
-          'The number of items to skip before starting to collect the result set',
+        description: 'The number of items to skip before starting to collect the result set',
         name: 'offset',
         in: 'query',
         required: false,
@@ -1425,16 +1265,8 @@ describe('mutateRequestDiff', () => {
 
     const result = mutateRequestDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.requestMutators.edit).toHaveBeenCalledWith(
-      'request1uid',
-      'path',
-      '/planets/list',
-    )
-    expect(mockStore.requestMutators.edit).toHaveBeenCalledWith(
-      'request2uid',
-      'path',
-      '/planets/list',
-    )
+    expect(mockStore.requestMutators.edit).toHaveBeenCalledWith('request1uid', 'path', '/planets/list')
+    expect(mockStore.requestMutators.edit).toHaveBeenCalledWith('request2uid', 'path', '/planets/list')
   })
 
   it('handles changing the method of a request', () => {
@@ -1447,11 +1279,7 @@ describe('mutateRequestDiff', () => {
 
     const result = mutateRequestDiff(diff, mockActiveEntities, mockStore)
     expect(result).toBe(true)
-    expect(mockStore.requestMutators.edit).toHaveBeenCalledWith(
-      'request1uid',
-      'method',
-      'post',
-    )
+    expect(mockStore.requestMutators.edit).toHaveBeenCalledWith('request1uid', 'method', 'post')
   })
 
   it('handles invalid diff paths', () => {
@@ -1521,10 +1349,7 @@ describe('narrowUnionSchema', () => {
 })
 
 describe('traverseZodSchema', () => {
-  const smallSchema = z.record(
-    z.string(),
-    z.array(z.string()).optional().default([]),
-  )
+  const smallSchema = z.record(z.string(), z.array(z.string()).optional().default([]))
   const testSchema = z.object({
     name: z.string(),
     age: z.number().optional(),

--- a/packages/api-client/src/views/Request/libs/watch-mode.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.ts
@@ -14,11 +14,7 @@ import {
   tagSchema,
 } from '@scalar/oas-utils/entities/spec'
 import { isHttpMethod, schemaModel } from '@scalar/oas-utils/helpers'
-import {
-  type Path,
-  type PathValue,
-  getNestedValue,
-} from '@scalar/object-utils/nested'
+import { type Path, type PathValue, getNestedValue } from '@scalar/object-utils/nested'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import microdiff, { type Difference } from 'microdiff'
 import { type ZodSchema, type ZodTypeDef, z } from 'zod'
@@ -31,10 +27,7 @@ import { type ZodSchema, type ZodTypeDef, z } from 'zod'
  * - first we check if the payloads are the same then it was just a simple rename
  * - next we will add the rename and also handle any changes in the diff
  */
-export const combineRenameDiffs = (
-  diff: Difference[],
-  pathPrefix: string[] = [],
-): Difference[] => {
+export const combineRenameDiffs = (diff: Difference[], pathPrefix: string[] = []): Difference[] => {
   const combined: Difference[] = []
   let skipNext = false
 
@@ -63,9 +56,7 @@ export const combineRenameDiffs = (
     if (current.type === 'REMOVE' && next?.type === 'CREATE') {
       const [, currPath, currMethod] = current.path
       const [, nextPath, nextMethod] = next.path
-      const nestedPrefix = ['paths', nextPath].filter(
-        (p) => typeof p === 'string',
-      )
+      const nestedPrefix = ['paths', nextPath].filter((p) => typeof p === 'string')
 
       // Handle path rename
       if (currPath !== nextPath) {
@@ -78,12 +69,7 @@ export const combineRenameDiffs = (
       }
 
       // Handle method rename
-      if (
-        currMethod &&
-        typeof nextMethod === 'string' &&
-        currMethod !== nextMethod &&
-        nextPath
-      ) {
+      if (currMethod && typeof nextMethod === 'string' && currMethod !== nextMethod && nextPath) {
         combined.push({
           type: 'CHANGE',
           path: ['paths', nextPath, 'method'],
@@ -106,19 +92,11 @@ export const combineRenameDiffs = (
       skipNext = true
     }
     // If adding anthing other than a path, method, or array we can just change instead
-    else if (
-      current.type === 'CREATE' &&
-      current.path.length > 3 &&
-      typeof current.path.at(-1) !== 'number'
-    ) {
+    else if (current.type === 'CREATE' && current.path.length > 3 && typeof current.path.at(-1) !== 'number') {
       combined.push({ ...current, type: 'CHANGE', oldValue: undefined })
     }
     // If deleting anthing other than a path, method, or array we can also do a change
-    else if (
-      current.type === 'REMOVE' &&
-      current.path.length > 3 &&
-      typeof current.path.at(-1) !== 'number'
-    ) {
+    else if (current.type === 'REMOVE' && current.path.length > 3 && typeof current.path.at(-1) !== 'number') {
       combined.push({ ...current, type: 'CHANGE', value: undefined })
     }
     // Just regular things
@@ -155,10 +133,7 @@ const unwrapSchema = (schema: ZodSchema): ZodSchema => {
  * Traverses a zod schema based on the path and returns the schema at the end of the path
  * or null if the path doesn't exist. Handles optional unwrapping, records, and arrays
  */
-export const traverseZodSchema = (
-  schema: ZodSchema,
-  path: (string | number)[],
-): ZodSchema | null => {
+export const traverseZodSchema = (schema: ZodSchema, path: (string | number)[]): ZodSchema | null => {
   let currentSchema: ZodSchema = schema
 
   for (const key of path) {
@@ -171,11 +146,7 @@ export const traverseZodSchema = (
     }
 
     // Traverse an object
-    if (
-      currentSchema instanceof z.ZodObject &&
-      typeof key === 'string' &&
-      key in currentSchema.shape
-    ) {
+    if (currentSchema instanceof z.ZodObject && typeof key === 'string' && key in currentSchema.shape) {
       currentSchema = currentSchema.shape[key]
     }
     // Traverse into an array
@@ -186,10 +157,7 @@ export const traverseZodSchema = (
       } else if (typeof key === 'string') {
         // If the key is a string, we're accessing a property of the array elements
         currentSchema = currentSchema.element
-        if (
-          currentSchema instanceof z.ZodObject &&
-          key in currentSchema.shape
-        ) {
+        if (currentSchema instanceof z.ZodObject && key in currentSchema.shape) {
           currentSchema = currentSchema.shape[key]
         } else {
           return null
@@ -269,40 +237,27 @@ export const mutateCollectionDiff = (
 
   // We need to handle a special case for arrays, it only adds or removes the last element,
   // the rest are a series of changes
-  if (
-    typeof diff.path[diff.path.length - 1] === 'number' &&
-    (diff.type === 'CREATE' || diff.type === 'REMOVE')
-  ) {
+  if (typeof diff.path[diff.path.length - 1] === 'number' && (diff.type === 'CREATE' || diff.type === 'REMOVE')) {
     const parsed = parseDiff(collectionSchema, {
       ...diff,
       path: diff.path,
     })
     if (!parsed) return false
 
-    const oldValue = [
-      ...getNestedValue(activeCollection.value, parsed.pathMinusOne),
-    ]
+    const oldValue = [...getNestedValue(activeCollection.value, parsed.pathMinusOne)]
     if (diff.type === 'CREATE') {
       oldValue.push(parsed.value)
     } else if (diff.type === 'REMOVE') {
       oldValue.pop()
     }
-    collectionMutators.edit(
-      activeCollection.value.uid,
-      parsed.pathMinusOne,
-      oldValue,
-    )
+    collectionMutators.edit(activeCollection.value.uid, parsed.pathMinusOne, oldValue)
   }
   // Non array + array change
   else {
     const parsed = parseDiff(collectionSchema, diff)
     if (!parsed) return false
 
-    collectionMutators.edit(
-      activeCollection.value.uid,
-      parsed.path,
-      parsed.value,
-    )
+    collectionMutators.edit(activeCollection.value.uid, parsed.path, parsed.value)
   }
 
   return true
@@ -318,10 +273,7 @@ const updateRequestExamples = (requestUid: string, store: WorkspaceStore) => {
   const request = requests[requestUid]
 
   request?.examples.forEach((exampleUid) => {
-    const newExample = createExampleFromRequest(
-      request,
-      requestExamples[exampleUid]?.name ?? 'Default',
-    )
+    const newExample = createExampleFromRequest(request, requestExamples[exampleUid]?.name ?? 'Default')
     if (newExample)
       requestExampleMutators.set({
         ...newExample,
@@ -359,10 +311,7 @@ export const mutateRequestDiff = (
   // Method has changed
   else if (method === 'method' && diff.type === 'CHANGE') {
     activeCollection.value.requests.forEach((uid) => {
-      if (
-        requests[uid]?.method === diff.oldValue &&
-        requests[uid]?.path === path
-      ) {
+      if (requests[uid]?.method === diff.oldValue && requests[uid]?.path === path) {
         requestMutators.edit(uid, 'method', diff.value)
       }
     })
@@ -392,8 +341,7 @@ export const mutateRequestDiff = (
     requestMutators.edit(request.uid, parsed.pathMinusOne, oldValue)
 
     // Generate new examples
-    if (diff.path[3] === 'parameters' || diff.path[3] === 'requestBody')
-      updateRequestExamples(request.uid, store)
+    if (diff.path[3] === 'parameters' || diff.path[3] === 'requestBody') updateRequestExamples(request.uid, store)
   }
 
   // Add
@@ -412,8 +360,7 @@ export const mutateRequestDiff = (
     const operationServers = serverSchema.array().parse(operation.servers ?? [])
 
     // Remove security here and add it correctly below
-    const { security: operationSecurity, ...operationWithoutSecurity } =
-      operation
+    const { security: operationSecurity, ...operationWithoutSecurity } = operation
 
     const requestPayload: RequestPayload = {
       ...operationWithoutSecurity,
@@ -437,7 +384,8 @@ export const mutateRequestDiff = (
           return {
             [key]: s[key],
           }
-        } else return s
+        }
+        return s
       })
 
     // Save parse the request
@@ -471,8 +419,7 @@ export const mutateRequestDiff = (
     requestMutators.edit(request.uid, parsed.path, parsed.value)
 
     // Update the examples
-    if (diff.path[3] === 'parameters' || diff.path[3] === 'requestBody')
-      updateRequestExamples(request.uid, store)
+    if (diff.path[3] === 'parameters' || diff.path[3] === 'requestBody') updateRequestExamples(request.uid, store)
   }
 
   return true
@@ -498,8 +445,7 @@ export const mutateServerDiff = (
 
     if (!server || !parsed) return false
 
-    const removeVariables =
-      diff.type === 'REMOVE' && keys[keys.length - 1] === 'variables'
+    const removeVariables = diff.type === 'REMOVE' && keys[keys.length - 1] === 'variables'
     const value = removeVariables ? {} : parsed.value
 
     serverMutators.edit(serverUid, parsed.path, value)
@@ -508,10 +454,7 @@ export const mutateServerDiff = (
   else if (diff.type === 'REMOVE') {
     if (!activeCollection.value.servers[index]) return false
 
-    serverMutators.delete(
-      activeCollection.value.servers[index],
-      activeCollection.value.uid,
-    )
+    serverMutators.delete(activeCollection.value.servers[index], activeCollection.value.uid)
   }
   // Add whole object
   else if (diff.type === 'CREATE') {
@@ -566,17 +509,10 @@ export const mutateTagDiff = (
 }
 
 /** Narrows down a zod union schema */
-export const narrowUnionSchema = (
-  schema: ZodSchema,
-  key: string,
-  value: string,
-): ZodSchema | null => {
+export const narrowUnionSchema = (schema: ZodSchema, key: string, value: string): ZodSchema | null => {
   const _schema = unwrapSchema(schema)
 
-  if (
-    _schema instanceof z.ZodUnion ||
-    _schema instanceof z.ZodDiscriminatedUnion
-  ) {
+  if (_schema instanceof z.ZodUnion || _schema instanceof z.ZodDiscriminatedUnion) {
     for (const option of _schema.options) {
       if (
         option instanceof z.ZodObject &&
@@ -605,12 +541,7 @@ export const mutateSecuritySchemeDiff = (
 ): boolean => {
   if (!activeCollection.value) return false
 
-  const [, , schemeName, ...keys] = diff.path as [
-    'components',
-    'securitySchemes',
-    string,
-    ...string[],
-  ]
+  const [, , schemeName, ...keys] = diff.path as ['components', 'securitySchemes', string, ...string[]]
 
   const scheme =
     securitySchemes[schemeName] ??
@@ -623,11 +554,7 @@ export const mutateSecuritySchemeDiff = (
   // Edit update properties
   if (keys?.length) {
     // Narrows the schema and path based on type of security scheme
-    const schema = narrowUnionSchema(
-      securitySchemeSchema,
-      'type',
-      scheme?.type ?? '',
-    )
+    const schema = narrowUnionSchema(securitySchemeSchema, 'type', scheme?.type ?? '')
     if (!schema || !scheme) return false
     const parsed = parseDiff(schema, { ...diff, path: keys })
     if (!parsed) return false
@@ -642,10 +569,7 @@ export const mutateSecuritySchemeDiff = (
   }
   // Add whole object
   else if (diff.type === 'CREATE')
-    securitySchemeMutators.add(
-      securitySchemeSchema.parse(diff.value),
-      activeCollection.value.uid,
-    )
+    securitySchemeMutators.add(securitySchemeSchema.parse(diff.value), activeCollection.value.uid)
 
   return true
 }

--- a/packages/api-client/src/views/Settings/SettingsGeneral.vue
+++ b/packages/api-client/src/views/Settings/SettingsGeneral.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
+import { cva, cx, ScalarButton, ScalarIcon } from '@scalar/components'
+import {
+  themeLabels,
+  type IntegrationThemeId,
+  type ThemeId,
+} from '@scalar/themes'
+
 import IntegrationLogo from '@/components/ImportCollection/IntegrationLogo.vue'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import { ScalarButton, ScalarIcon, cva, cx } from '@scalar/components'
-import {
-  type IntegrationThemeId,
-  type ThemeId,
-  themeLabels,
-} from '@scalar/themes'
 
 import SettingsGeneralAppearance from './components/SettingsAppearance.vue'
 import SettingsSection from './components/SettingsSection.vue'
@@ -56,9 +57,8 @@ const getThemeColors = (
   )
 }
 
-const changeTheme = (themeId: ThemeId) => {
-  workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'themeId', themeId)
-}
+const changeTheme = (themeId: ThemeId) =>
+  workspaceMutators.edit(activeWorkspace.value?.uid, 'themeId', themeId)
 
 const buttonStyles = cva({
   base: 'w-full shadow-none text-c-1 justify-start pl-2 gap-2 border-1/2',
@@ -69,19 +69,22 @@ const buttonStyles = cva({
     },
   },
 })
+
+const setProxy = (newProxy: string | undefined) =>
+  workspaceMutators.edit(activeWorkspace.value?.uid, 'proxyUrl', newProxy)
 </script>
 <template>
-  <div class="bg-b-1 w-full h-full overflow-auto">
-    <div class="px-5 py-5 max-w-[720px] ml-auto mr-auto w-full">
+  <div class="bg-b-1 h-full w-full overflow-auto">
+    <div class="ml-auto mr-auto w-full max-w-[720px] px-5 py-5">
       <div class="flex flex-col gap-8">
         <!-- Heading -->
         <div>
-          <h2 class="font-bold text-xl mt-10">Settings</h2>
+          <h2 class="mt-10 text-xl font-bold">Settings</h2>
         </div>
 
         <!-- Proxy -->
         <SettingsSection>
-          <template #title>CORS Proxy</template>
+          <template #title> CORS Proxy </template>
           <template #description>
             Browsers block cross-origin requests for security. We provide a
             public proxy to
@@ -111,21 +114,16 @@ const buttonStyles = cva({
                   }),
                 )
               "
-              @click="
-                workspaceMutators.edit(
-                  activeWorkspace?.uid ?? '',
-                  'proxyUrl',
-                  DEFAULT_PROXY_URL,
-                )
+              @click="setProxy(DEFAULT_PROXY_URL)">
               ">
               <div
-                class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1"
+                class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                 :class="{
-                  'bg-c-accent border-transparent text-b-1':
+                  'bg-c-accent text-b-1 border-transparent':
                     activeWorkspace?.proxyUrl === DEFAULT_PROXY_URL,
                 }">
                 <ScalarIcon
-                  v-if="activeWorkspace.proxyUrl === DEFAULT_PROXY_URL"
+                  v-if="activeWorkspace?.proxyUrl === DEFAULT_PROXY_URL"
                   icon="Checkmark"
                   size="xs"
                   thickness="3.5" />
@@ -143,21 +141,16 @@ const buttonStyles = cva({
                   }),
                 )
               "
-              @click="
-                workspaceMutators.edit(
-                  activeWorkspace?.uid ?? '',
-                  'proxyUrl',
-                  proxyUrl,
-                )
+              @click="setProxy(proxyUrl)">
               ">
               <div
-                class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1"
+                class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                 :class="{
-                  'bg-c-accent border-transparent text-b-1':
+                  'bg-c-accent text-b-1 border-transparent':
                     activeWorkspace?.proxyUrl === proxyUrl,
                 }">
                 <ScalarIcon
-                  v-if="activeWorkspace.proxyUrl === proxyUrl"
+                  v-if="activeWorkspace?.proxyUrl === proxyUrl"
                   icon="Checkmark"
                   size="xs"
                   thickness="3.5" />
@@ -168,18 +161,12 @@ const buttonStyles = cva({
             <!-- No proxy -->
             <ScalarButton
               :class="cx(buttonStyles({ active: !activeWorkspace?.proxyUrl }))"
-              @click="
-                workspaceMutators.edit(
-                  activeWorkspace?.uid ?? '',
-                  'proxyUrl',
-                  '',
-                )
-              ">
+              @click="setProxy(undefined)">
               <div
-                class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1"
+                class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                 :class="
                   !activeWorkspace?.proxyUrl &&
-                  'bg-c-accent border-transparent text-b-1'
+                  'bg-c-accent text-b-1 border-transparent'
                 ">
                 <ScalarIcon
                   v-if="!activeWorkspace?.proxyUrl"
@@ -194,7 +181,7 @@ const buttonStyles = cva({
 
         <!-- Themes -->
         <SettingsSection>
-          <template #title>Themes</template>
+          <template #title> Themes </template>
           <template #description>
             We’ve got a whole rainbow of themes for you to play with:
           </template>
@@ -214,9 +201,9 @@ const buttonStyles = cva({
                 @click="changeTheme(themeId)">
                 <div class="flex items-center gap-2">
                   <div
-                    class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1"
+                    class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                     :class="{
-                      'bg-c-accent border-transparent text-b-1':
+                      'bg-c-accent text-b-1 border-transparent':
                         activeWorkspace?.themeId === themeId,
                     }">
                     <ScalarIcon
@@ -229,23 +216,20 @@ const buttonStyles = cva({
                 </div>
                 <div class="flex items-center gap-1">
                   <span
-                    class="inline-block w-5 h-5 rounded-full border-c-3 -mr-3"
+                    class="border-c-3 -mr-3 inline-block h-5 w-5 rounded-full"
                     :style="{
                       backgroundColor: getThemeColors(themeId).light,
-                    }">
-                  </span>
+                    }" />
                   <span
-                    class="inline-block w-5 h-5 rounded-full border-c-3 -mr-3"
+                    class="border-c-3 -mr-3 inline-block h-5 w-5 rounded-full"
                     :style="{
                       backgroundColor: getThemeColors(themeId).dark,
-                    }">
-                  </span>
+                    }" />
                   <span
-                    class="inline-block w-5 h-5 rounded-full border-c-3"
+                    class="border-c-3 inline-block h-5 w-5 rounded-full"
                     :style="{
                       backgroundColor: getThemeColors(themeId).accent,
-                    }">
-                  </span>
+                    }" />
                 </div>
               </ScalarButton>
             </div>
@@ -254,7 +238,7 @@ const buttonStyles = cva({
 
         <!-- Frameworks -->
         <SettingsSection>
-          <template #title>Framework Themes</template>
+          <template #title> Framework Themes </template>
           <template #description>
             Are you a real fan? Show your support by using your favorite
             framework’s theme!
@@ -274,9 +258,9 @@ const buttonStyles = cva({
               @click="changeTheme(themeId)">
               <div class="flex items-center gap-2">
                 <div
-                  class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1"
+                  class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                   :class="{
-                    'bg-c-accent border-transparent text-b-1':
+                    'bg-c-accent text-b-1 border-transparent':
                       activeWorkspace?.themeId === themeId,
                   }">
                   <ScalarIcon
@@ -288,7 +272,7 @@ const buttonStyles = cva({
                 {{ themeLabels[themeId] }}
               </div>
               <div class="flex items-center gap-1">
-                <div class="rounded-xl size-7">
+                <div class="size-7 rounded-xl">
                   <IntegrationLogo :integration="themeId" />
                 </div>
               </div>
@@ -298,7 +282,7 @@ const buttonStyles = cva({
 
         <!-- Appearance -->
         <SettingsSection>
-          <template #title>Appearance</template>
+          <template #title> Appearance </template>
           <template #description>
             Choose between light, dark, or system-based appearance for your
             workspace.

--- a/packages/api-reference/src/features/Operation/Operation.test.ts
+++ b/packages/api-reference/src/features/Operation/Operation.test.ts
@@ -1,4 +1,4 @@
-import { collectionSchema } from '@scalar/oas-utils/entities/spec'
+import { collectionSchema, serverSchema } from '@scalar/oas-utils/entities/spec'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { TransformedOperation } from '@scalar/types'
 import { renderToString } from '@vue/server-renderer'
@@ -39,19 +39,16 @@ const mockProps = {
     },
     requests: [],
     servers: ['server1', 'server2', 'server3'],
-    security: [
-      { bearerAuth: ['read:users', 'read:events'] },
-      { apiKeyQuery: [] },
-    ],
+    security: [{ bearerAuth: ['read:users', 'read:events'] }, { apiKeyQuery: [] }],
     tags: ['tag1uid', 'tag2uid', 'tag3uid'],
   }),
   requests: {},
   requestExamples: {},
   securitySchemes: {},
-  server: {
+  server: serverSchema.parse({
     uid: 'server1',
     url: 'https://example.com',
-  },
+  }),
 }
 
 // We temporarily mock this before we move it to a hook
@@ -64,10 +61,7 @@ vi.mock('@scalar/api-client/store', () => ({
         selectedSecuritySchemeUids: [],
         requests: [],
         servers: ['server1', 'server2', 'server3'],
-        security: [
-          { bearerAuth: ['read:users', 'read:events'] },
-          { apiKeyQuery: [] },
-        ],
+        security: [{ bearerAuth: ['read:users', 'read:events'] }, { apiKeyQuery: [] }],
         tags: ['tag1uid', 'tag2uid', 'tag3uid'],
       },
     },
@@ -99,12 +93,8 @@ describe.skip('Operation', () => {
       },
     })
 
-    expect(
-      operationComponent.findComponent({ name: 'ModernLayout' }).exists(),
-    ).toBe(true)
-    expect(
-      operationComponent.findComponent({ name: 'ClassicLayout' }).exists(),
-    ).toBe(false)
+    expect(operationComponent.findComponent({ name: 'ModernLayout' }).exists()).toBe(true)
+    expect(operationComponent.findComponent({ name: 'ClassicLayout' }).exists()).toBe(false)
   })
 
   it('switches to classic layout', async () => {
@@ -119,12 +109,8 @@ describe.skip('Operation', () => {
     })
 
     await operationComponent.setProps({ layout: 'classic' })
-    expect(
-      operationComponent.findComponent({ name: 'ClassicLayout' }).exists(),
-    ).toBe(true)
-    expect(
-      operationComponent.findComponent({ name: 'ModernLayout' }).exists(),
-    ).toBe(false)
+    expect(operationComponent.findComponent({ name: 'ClassicLayout' }).exists()).toBe(true)
+    expect(operationComponent.findComponent({ name: 'ModernLayout' }).exists()).toBe(false)
   })
 
   it('passes props correctly', async () => {

--- a/packages/api-reference/src/features/TestRequestButton/TestRequestButton.test.ts
+++ b/packages/api-reference/src/features/TestRequestButton/TestRequestButton.test.ts
@@ -36,7 +36,6 @@ describe('TestRequestButton', () => {
         operation: operationSchema.parse({
           method: 'get',
           path: '/test',
-          uid: '123',
         }),
       },
     })
@@ -49,7 +48,6 @@ describe('TestRequestButton', () => {
         operation: operationSchema.parse({
           method: 'get',
           path: '/test',
-          uid: '123',
         }),
       },
     })
@@ -66,7 +64,6 @@ describe('TestRequestButton', () => {
         operation: operationSchema.parse({
           method: 'post',
           path: '/users',
-          uid: '456',
         }),
       },
     })

--- a/packages/api-reference/src/features/TestRequestButton/TestRequestButton.test.ts
+++ b/packages/api-reference/src/features/TestRequestButton/TestRequestButton.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import TestRequestButton from './TestRequestButton.vue'
+import { operationSchema } from '@scalar/oas-utils/entities/spec'
 
 const mockClient = ref({
   open: vi.fn(),
@@ -32,11 +33,11 @@ describe('TestRequestButton', () => {
         },
       },
       props: {
-        operation: {
+        operation: operationSchema.parse({
           method: 'get',
           path: '/test',
           uid: '123',
-        },
+        }),
       },
     })
     expect(wrapper.text()).toBe('')
@@ -45,11 +46,11 @@ describe('TestRequestButton', () => {
   it('renders button with correct text and icon when operation is provided', () => {
     const wrapper = mount(TestRequestButton, {
       props: {
-        operation: {
+        operation: operationSchema.parse({
           method: 'get',
           path: '/test',
           uid: '123',
-        },
+        }),
       },
     })
 
@@ -62,11 +63,11 @@ describe('TestRequestButton', () => {
   it('has correct button attributes', () => {
     const wrapper = mount(TestRequestButton, {
       props: {
-        operation: {
+        operation: operationSchema.parse({
           method: 'post',
           path: '/users',
           uid: '456',
-        },
+        }),
       },
     })
 
@@ -79,11 +80,11 @@ describe('TestRequestButton', () => {
   it('calls client.open with correct params when clicked', async () => {
     const wrapper = mount(TestRequestButton, {
       props: {
-        operation: {
+        operation: operationSchema.parse({
           method: 'delete',
           path: '/users/1',
           uid: 'my-random-uuid',
-        },
+        }),
       },
     })
 

--- a/packages/oas-utils/src/entities/cookie/cookie.ts
+++ b/packages/oas-utils/src/entities/cookie/cookie.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod'
 
-import { nanoidSchema } from '../shared'
+import { type ENTITY_BRANDS, nanoidSchema } from '@/entities/shared/utility'
 
 export const cookieSchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand<ENTITY_BRANDS['COOKIE']>(),
   /**  Defines the cookie name and its value. A cookie definition begins with a name-value pair.  */
   name: z.string().default(''),
   value: z.string().default(''),

--- a/packages/oas-utils/src/entities/environment/environment.ts
+++ b/packages/oas-utils/src/entities/environment/environment.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod'
 
-import { nanoidSchema } from '../shared'
+import { type ENTITY_BRANDS, nanoidSchema } from '@/entities/shared/utility'
 
 export const environmentSchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand<ENTITY_BRANDS['ENVIRONMENT']>(),
   name: z.string().optional().default('Default Environment'),
   color: z.string().optional().default('#0082D0'),
   value: z.string().default(''),

--- a/packages/oas-utils/src/entities/shared/utility.ts
+++ b/packages/oas-utils/src/entities/shared/utility.ts
@@ -11,13 +11,13 @@ export const nanoidSchema = z
 /** UID format for objects */
 export type Nanoid = z.infer<typeof nanoidSchema>
 
-/** All of our zod brands for entities, used to brand nanoidSchemas */
+/** All of our Zod brands for entities, used to brand nanoidSchemas. */
 export type ENTITY_BRANDS = {
   COLLECTION: 'collection'
   COOKIE: 'cookie'
   ENVIRONMENT: 'environment'
   EXAMPLE: 'example'
-  REQUEST: 'request'
+  OPERATION: 'operation'
   SECURITY_SCHEME: 'securityScheme'
   SERVER: 'server'
   TAG: 'tag'

--- a/packages/oas-utils/src/entities/shared/utility.ts
+++ b/packages/oas-utils/src/entities/shared/utility.ts
@@ -11,12 +11,26 @@ export const nanoidSchema = z
 /** UID format for objects */
 export type Nanoid = z.infer<typeof nanoidSchema>
 
+/** All of our zod brands for entities, used to brand nanoidSchemas */
+export type ENTITY_BRANDS = {
+  COLLECTION: 'collection'
+  COOKIE: 'cookie'
+  ENVIRONMENT: 'environment'
+  EXAMPLE: 'example'
+  REQUEST: 'request'
+  SECURITY_SCHEME: 'securityScheme'
+  SERVER: 'server'
+  TAG: 'tag'
+  WORKSPACE: 'workspace'
+}
+
 /** Schema for selectedSecuritySchemeUids */
 export const selectedSecuritySchemeUidSchema = z
-  .union([nanoidSchema, nanoidSchema.array()])
+  .union([
+    nanoidSchema.brand<ENTITY_BRANDS['SECURITY_SCHEME']>(),
+    nanoidSchema.brand<ENTITY_BRANDS['SECURITY_SCHEME']>().array(),
+  ])
   .array()
   .default([])
 
-export type SelectedSecuritySchemeUids = z.infer<
-  typeof selectedSecuritySchemeUidSchema
->
+export type SelectedSecuritySchemeUids = z.infer<typeof selectedSecuritySchemeUidSchema>

--- a/packages/oas-utils/src/entities/shared/utility.ts
+++ b/packages/oas-utils/src/entities/shared/utility.ts
@@ -27,8 +27,8 @@ export type ENTITY_BRANDS = {
 /** Schema for selectedSecuritySchemeUids */
 export const selectedSecuritySchemeUidSchema = z
   .union([
-    nanoidSchema.brand<ENTITY_BRANDS['SECURITY_SCHEME']>(),
-    nanoidSchema.brand<ENTITY_BRANDS['SECURITY_SCHEME']>().array(),
+    z.string().brand<ENTITY_BRANDS['SECURITY_SCHEME']>(),
+    z.string().brand<ENTITY_BRANDS['SECURITY_SCHEME']>().array(),
   ])
   .array()
   .default([])

--- a/packages/oas-utils/src/entities/spec/collection.ts
+++ b/packages/oas-utils/src/entities/spec/collection.ts
@@ -1,7 +1,4 @@
-import {
-  nanoidSchema,
-  selectedSecuritySchemeUidSchema,
-} from '@/entities/shared/utility'
+import { nanoidSchema, selectedSecuritySchemeUidSchema, type ENTITY_BRANDS } from '@/entities/shared/utility'
 import { xScalarEnvironmentsSchema } from '@/entities/spec/x-scalar-environments'
 import { xScalarSecretsSchema } from '@/entities/spec/x-scalar-secrets'
 import { z } from 'zod'
@@ -17,12 +14,7 @@ export const oasCollectionSchema = z.object({
    */
   'type': z.literal('collection').optional().default('collection'),
   'openapi': z
-    .union([
-      z.string(),
-      z.literal('3.0.0'),
-      z.literal('3.1.0'),
-      z.literal('4.0.0'),
-    ])
+    .union([z.string(), z.literal('3.0.0'), z.literal('3.1.0'), z.literal('4.0.0')])
     .optional()
     .default('3.1.0'),
   'jsonSchemaDialect': z.string().optional(),
@@ -54,7 +46,7 @@ export const oasCollectionSchema = z.object({
 })
 
 export const extendedCollectionSchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand<ENTITY_BRANDS['COLLECTION']>(),
   /** A list of security schemes UIDs associated with the collection */
   securitySchemes: z.string().array().default([]),
   /** List of currently selected security scheme UIDs, these can be overridden per request */
@@ -62,13 +54,16 @@ export const extendedCollectionSchema = z.object({
   /** The currently selected server */
   selectedServerUid: z.string().default(''),
   /** UIDs which refer to servers on the workspace base */
-  servers: nanoidSchema.array().default([]),
+  servers: nanoidSchema.brand<ENTITY_BRANDS['SERVER']>().array().default([]),
   /** Request UIDs associated with a collection */
-  requests: nanoidSchema.array().default([]),
+  requests: nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>().array().default([]),
   /** Tag UIDs associated with the collection */
-  tags: nanoidSchema.array().default([]),
+  tags: nanoidSchema.brand<ENTITY_BRANDS['TAG']>().array().default([]),
   /** List of requests without tags and top level tag "folders" */
-  children: nanoidSchema.array().default([]),
+  children: z
+    .union([nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>(), nanoidSchema.brand<ENTITY_BRANDS['TAG']>()])
+    .array()
+    .default([]),
   /**
    * A link to where this document is stored
    *
@@ -89,14 +84,9 @@ export const extendedCollectionSchema = z.object({
    *
    * @defaults to idle for all collections, doesn't mean that it can watch for changes
    */
-  watchModeStatus: z
-    .enum(['IDLE', 'WATCHING', 'ERROR'])
-    .optional()
-    .default('IDLE'),
+  watchModeStatus: z.enum(['IDLE', 'WATCHING', 'ERROR']).optional().default('IDLE'),
 })
 
-export const collectionSchema = oasCollectionSchema.merge(
-  extendedCollectionSchema,
-)
+export const collectionSchema = oasCollectionSchema.merge(extendedCollectionSchema)
 export type Collection = z.infer<typeof collectionSchema>
 export type CollectionPayload = z.input<typeof collectionSchema>

--- a/packages/oas-utils/src/entities/spec/collection.ts
+++ b/packages/oas-utils/src/entities/spec/collection.ts
@@ -1,4 +1,4 @@
-import { nanoidSchema, selectedSecuritySchemeUidSchema, type ENTITY_BRANDS } from '@/entities/shared/utility'
+import { type ENTITY_BRANDS, nanoidSchema, selectedSecuritySchemeUidSchema } from '@/entities/shared/utility'
 import { xScalarEnvironmentsSchema } from '@/entities/spec/x-scalar-environments'
 import { xScalarSecretsSchema } from '@/entities/spec/x-scalar-secrets'
 import { z } from 'zod'
@@ -56,12 +56,12 @@ export const extendedCollectionSchema = z.object({
   /** UIDs which refer to servers on the workspace base */
   servers: z.string().brand<ENTITY_BRANDS['SERVER']>().array().default([]),
   /** Request UIDs associated with a collection */
-  requests: z.string().brand<ENTITY_BRANDS['REQUEST']>().array().default([]),
+  requests: z.string().brand<ENTITY_BRANDS['OPERATION']>().array().default([]),
   /** Tag UIDs associated with the collection */
   tags: z.string().brand<ENTITY_BRANDS['TAG']>().array().default([]),
   /** List of requests without tags and top level tag "folders" */
   children: z
-    .union([z.string().brand<ENTITY_BRANDS['REQUEST']>(), z.string().brand<ENTITY_BRANDS['TAG']>()])
+    .union([z.string().brand<ENTITY_BRANDS['OPERATION']>(), z.string().brand<ENTITY_BRANDS['TAG']>()])
     .array()
     .default([]),
   /**

--- a/packages/oas-utils/src/entities/spec/collection.ts
+++ b/packages/oas-utils/src/entities/spec/collection.ts
@@ -52,16 +52,16 @@ export const extendedCollectionSchema = z.object({
   /** List of currently selected security scheme UIDs, these can be overridden per request */
   selectedSecuritySchemeUids: selectedSecuritySchemeUidSchema,
   /** The currently selected server */
-  selectedServerUid: z.string().default(''),
+  selectedServerUid: z.string().brand<ENTITY_BRANDS['SERVER']>().optional(),
   /** UIDs which refer to servers on the workspace base */
-  servers: nanoidSchema.brand<ENTITY_BRANDS['SERVER']>().array().default([]),
+  servers: z.string().brand<ENTITY_BRANDS['SERVER']>().array().default([]),
   /** Request UIDs associated with a collection */
-  requests: nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>().array().default([]),
+  requests: z.string().brand<ENTITY_BRANDS['REQUEST']>().array().default([]),
   /** Tag UIDs associated with the collection */
-  tags: nanoidSchema.brand<ENTITY_BRANDS['TAG']>().array().default([]),
+  tags: z.string().brand<ENTITY_BRANDS['TAG']>().array().default([]),
   /** List of requests without tags and top level tag "folders" */
   children: z
-    .union([nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>(), nanoidSchema.brand<ENTITY_BRANDS['TAG']>()])
+    .union([z.string().brand<ENTITY_BRANDS['REQUEST']>(), z.string().brand<ENTITY_BRANDS['TAG']>()])
     .array()
     .default([]),
   /**

--- a/packages/oas-utils/src/entities/spec/request-example.test.ts
+++ b/packages/oas-utils/src/entities/spec/request-example.test.ts
@@ -460,9 +460,7 @@ describe('createExampleFromRequest', () => {
             required: true,
           },
         ],
-        headers: [
-          { key: 'Content-Type', value: 'application/testing', enabled: true },
-        ],
+        headers: [{ key: 'Content-Type', value: 'application/testing', enabled: true }],
         query: [],
         cookies: [],
       },

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -4,10 +4,10 @@ import { getRequestBodyFromOperation, getServerVariableExamples } from '@/spec-g
 import { keysOf } from '@scalar/object-utils/arrays'
 import { z } from 'zod'
 
+import type { ENTITY_BRANDS } from '@/entities/shared/utility'
 import type { RequestParameter } from './parameters'
 import type { Request } from './requests'
 import type { Server } from './server'
-import type { ENTITY_BRANDS } from '@/entities/shared/utility'
 
 // ---------------------------------------------------------------------------
 // Example Parameters
@@ -184,7 +184,7 @@ export type XScalarExampleBody = z.infer<typeof xScalarExampleBodySchema>
 export const requestExampleSchema = z.object({
   uid: nanoidSchema.brand<ENTITY_BRANDS['EXAMPLE']>(),
   type: z.literal('requestExample').optional().default('requestExample'),
-  requestUid: z.string().brand<ENTITY_BRANDS['REQUEST']>().optional(),
+  requestUid: z.string().brand<ENTITY_BRANDS['OPERATION']>().optional(),
   name: z.string().optional().default('Name'),
   body: exampleRequestBodySchema.optional().default({}),
   parameters: z

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -184,7 +184,7 @@ export type XScalarExampleBody = z.infer<typeof xScalarExampleBodySchema>
 export const requestExampleSchema = z.object({
   uid: nanoidSchema.brand<ENTITY_BRANDS['EXAMPLE']>(),
   type: z.literal('requestExample').optional().default('requestExample'),
-  requestUid: nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>(),
+  requestUid: z.string().brand<ENTITY_BRANDS['REQUEST']>().optional(),
   name: z.string().optional().default('Name'),
   body: exampleRequestBodySchema.optional().default({}),
   parameters: z
@@ -442,5 +442,6 @@ export function createExampleFromRequest(request: Request, name: string, server?
   if (!example) {
     console.warn(`Example at ${request.uid} is invalid.`)
     return requestExampleSchema.parse({})
-  } else return example
+  }
+  return example
 }

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -1,7 +1,4 @@
-import {
-  nanoidSchema,
-  selectedSecuritySchemeUidSchema,
-} from '@/entities/shared/utility'
+import { nanoidSchema, selectedSecuritySchemeUidSchema, type ENTITY_BRANDS } from '@/entities/shared/utility'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { type ZodSchema, z } from 'zod'
 
@@ -10,17 +7,7 @@ import { type RequestExample, xScalarExampleSchema } from './request-examples'
 import { oasSecurityRequirementSchema } from './security'
 import { oasExternalDocumentationSchema } from './spec-objects'
 
-export const requestMethods = [
-  'connect',
-  'delete',
-  'get',
-  'head',
-  'options',
-  'patch',
-  'post',
-  'put',
-  'trace',
-] as const
+export const requestMethods = ['connect', 'delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'trace'] as const
 
 export type RequestMethod = (typeof requestMethods)[number]
 
@@ -116,25 +103,23 @@ export const oasRequestSchema = z.object({
  */
 const extendedRequestSchema = z.object({
   type: z.literal('request').optional().default('request'),
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>(),
   /** Path Key */
   path: z.string().optional().default(''),
   /** Request Method */
   method: z.enum(requestMethods).default('get'),
   /** List of server UIDs specific to the request */
-  servers: nanoidSchema.array().default([]),
+  servers: nanoidSchema.brand<ENTITY_BRANDS['SERVER']>().array().default([]),
   /** The currently selected server */
-  selectedServerUid: z.string().default(''),
+  selectedServerUid: nanoidSchema.brand<ENTITY_BRANDS['SERVER']>().default(''),
   /** List of example UIDs associated with the request */
-  examples: nanoidSchema.array().default([]),
+  examples: nanoidSchema.brand<ENTITY_BRANDS['EXAMPLE']>().array().default([]),
   /** List of security scheme UIDs associated with the request */
   selectedSecuritySchemeUids: selectedSecuritySchemeUidSchema,
 })
 
 /** Unified request schema for client usage */
-export const requestSchema = oasRequestSchema
-  .omit({ 'x-scalar-examples': true })
-  .merge(extendedRequestSchema)
+export const requestSchema = oasRequestSchema.omit({ 'x-scalar-examples': true }).merge(extendedRequestSchema)
 
 export type Request = z.infer<typeof requestSchema>
 export type RequestPayload = z.input<typeof requestSchema>

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -109,11 +109,11 @@ const extendedRequestSchema = z.object({
   /** Request Method */
   method: z.enum(requestMethods).default('get'),
   /** List of server UIDs specific to the request */
-  servers: nanoidSchema.brand<ENTITY_BRANDS['SERVER']>().array().default([]),
+  servers: z.string().brand<ENTITY_BRANDS['SERVER']>().array().default([]),
   /** The currently selected server */
-  selectedServerUid: nanoidSchema.brand<ENTITY_BRANDS['SERVER']>().default(''),
+  selectedServerUid: z.string().brand<ENTITY_BRANDS['SERVER']>().optional(),
   /** List of example UIDs associated with the request */
-  examples: nanoidSchema.brand<ENTITY_BRANDS['EXAMPLE']>().array().default([]),
+  examples: z.string().brand<ENTITY_BRANDS['EXAMPLE']>().array().default([]),
   /** List of security scheme UIDs associated with the request */
   selectedSecuritySchemeUids: selectedSecuritySchemeUidSchema,
 })

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -111,7 +111,7 @@ const extendedRequestSchema = z.object({
   /** List of server UIDs specific to the request */
   servers: z.string().brand<ENTITY_BRANDS['SERVER']>().array().default([]),
   /** The currently selected server */
-  selectedServerUid: z.string().brand<ENTITY_BRANDS['SERVER']>().optional(),
+  selectedServerUid: z.string().brand<ENTITY_BRANDS['SERVER']>().optional().nullable().default(null),
   /** List of example UIDs associated with the request */
   examples: z.string().brand<ENTITY_BRANDS['EXAMPLE']>().array().default([]),
   /** List of security scheme UIDs associated with the request */

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -1,4 +1,4 @@
-import { nanoidSchema, selectedSecuritySchemeUidSchema, type ENTITY_BRANDS } from '@/entities/shared/utility'
+import { type ENTITY_BRANDS, nanoidSchema, selectedSecuritySchemeUidSchema } from '@/entities/shared/utility'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { type ZodSchema, z } from 'zod'
 
@@ -103,7 +103,7 @@ export const oasRequestSchema = z.object({
  */
 const extendedRequestSchema = z.object({
   type: z.literal('request').optional().default('request'),
-  uid: nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>(),
+  uid: nanoidSchema.brand<ENTITY_BRANDS['OPERATION']>(),
   /** Path Key */
   path: z.string().optional().default(''),
   /** Request Method */

--- a/packages/oas-utils/src/entities/spec/security.ts
+++ b/packages/oas-utils/src/entities/spec/security.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { nanoidSchema } from '../shared'
+import type { ENTITY_BRANDS } from '@/entities/shared/utility'
 
 // ---------------------------------------------------------------------------
 // COMMON PROPS FOR ALL SECURITY SCHEMES
@@ -12,7 +13,7 @@ const commonProps = z.object({
 })
 
 const extendedSecuritySchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand<ENTITY_BRANDS['SECURITY_SCHEME']>(),
   /** The name key that links a security requirement to a security object */
   nameKey: z.string().optional().default(''),
 })
@@ -34,9 +35,7 @@ const apiKeyValueSchema = z.object({
   value: z.string().default(''),
 })
 
-export const securityApiKeySchema = oasSecuritySchemeApiKey
-  .merge(extendedSecuritySchema)
-  .merge(apiKeyValueSchema)
+export const securityApiKeySchema = oasSecuritySchemeApiKey.merge(extendedSecuritySchema).merge(apiKeyValueSchema)
 export type SecuritySchemeApiKey = z.infer<typeof securityApiKeySchema>
 
 // ---------------------------------------------------------------------------
@@ -71,9 +70,7 @@ const httpValueSchema = z.object({
   token: z.string().default(''),
 })
 
-export const securityHttpSchema = oasSecuritySchemeHttp
-  .merge(extendedSecuritySchema)
-  .merge(httpValueSchema)
+export const securityHttpSchema = oasSecuritySchemeHttp.merge(extendedSecuritySchema).merge(httpValueSchema)
 export type SecuritySchemaHttp = z.infer<typeof securityHttpSchema>
 
 // ---------------------------------------------------------------------------
@@ -87,9 +84,7 @@ const oasSecuritySchemeOpenId = commonProps.extend({
   openIdConnectUrl: z.string().optional().default(''),
 })
 
-export const securityOpenIdSchema = oasSecuritySchemeOpenId.merge(
-  extendedSecuritySchema,
-)
+export const securityOpenIdSchema = oasSecuritySchemeOpenId.merge(extendedSecuritySchema)
 export type SecuritySchemaOpenId = z.infer<typeof securityOpenIdSchema>
 
 // ---------------------------------------------------------------------------
@@ -117,10 +112,7 @@ const flowsCommon = z.object({
    * REQUIRED. The available scopes for the OAuth2 security scheme. A map
    * between the scope name and a short description for it. The map MAY be empty.
    */
-  'scopes': z
-    .record(z.string(), z.string().optional().default(''))
-    .optional()
-    .default({}),
+  'scopes': z.record(z.string(), z.string().optional().default('')).optional().default({}),
   'selectedScopes': z.array(z.string()).optional().default([]),
   /** Extension to save the client Id associated with an oauth flow */
   'x-scalar-client-id': z.string().optional().default(''),
@@ -129,10 +121,7 @@ const flowsCommon = z.object({
 })
 
 /** Setup a default redirect uri if we can */
-const defaultRedirectUri =
-  typeof window !== 'undefined'
-    ? window.location.origin + window.location.pathname
-    : ''
+const defaultRedirectUri = typeof window !== 'undefined' ? window.location.origin + window.location.pathname : ''
 
 /** Options for the x-usePkce extension */
 export const pkceOptions = ['SHA-256', 'plain', 'no'] as const
@@ -147,10 +136,7 @@ const oasSecuritySchemeOauth2 = commonProps.extend({
       implicit: flowsCommon.extend({
         'type': z.literal('implicit'),
         authorizationUrl,
-        'x-scalar-redirect-uri': z
-          .string()
-          .optional()
-          .default(defaultRedirectUri),
+        'x-scalar-redirect-uri': z.string().optional().default(defaultRedirectUri),
       }),
       /** Configuration for the OAuth Resource Owner Password flow */
       password: flowsCommon.extend({
@@ -176,10 +162,7 @@ const oasSecuritySchemeOauth2 = commonProps.extend({
          * TODO: add docs
          */
         'x-usePkce': z.enum(pkceOptions).optional().default('no'),
-        'x-scalar-redirect-uri': z
-          .string()
-          .optional()
-          .default(defaultRedirectUri),
+        'x-scalar-redirect-uri': z.string().optional().default(defaultRedirectUri),
         tokenUrl,
         'clientSecret': z.string().default(''),
       }),
@@ -190,23 +173,19 @@ const oasSecuritySchemeOauth2 = commonProps.extend({
     }),
 })
 
-export const securityOauthSchema = oasSecuritySchemeOauth2.merge(
-  extendedSecuritySchema,
-)
+export const securityOauthSchema = oasSecuritySchemeOauth2.merge(extendedSecuritySchema)
 
 export type SecuritySchemeOauth2 = z.infer<typeof securityOauthSchema>
 export type SecuritySchemeOauth2Payload = z.input<typeof securityOauthSchema>
 export type Oauth2Flow = NonNullable<
-  SecuritySchemeOauth2['flows'][
-    | 'authorizationCode'
-    | 'clientCredentials'
-    | 'implicit'
-    | 'password']
+  SecuritySchemeOauth2['flows']['authorizationCode' | 'clientCredentials' | 'implicit' | 'password']
 >
 /** Payload for the oauth 2 flows + extensions */
-export type Oauth2FlowPayload = NonNullable<
-  SecuritySchemeOauth2Payload['flows']
->['authorizationCode' | 'clientCredentials' | 'implicit' | 'password'] &
+export type Oauth2FlowPayload = NonNullable<SecuritySchemeOauth2Payload['flows']>[
+  | 'authorizationCode'
+  | 'clientCredentials'
+  | 'implicit'
+  | 'password'] &
   Record<`x-${string}`, string>
 
 // ---------------------------------------------------------------------------
@@ -222,10 +201,7 @@ export type Oauth2FlowPayload = NonNullable<
  *
  * @see https://spec.openapis.org/oas/latest.html#security-requirement-object
  */
-export const oasSecurityRequirementSchema = z.record(
-  z.string(),
-  z.array(z.string()).optional().default([]),
-)
+export const oasSecurityRequirementSchema = z.record(z.string(), z.array(z.string()).optional().default([]))
 
 /** OAS Compliant security schemes */
 export const oasSecuritySchemeSchema = z.union([

--- a/packages/oas-utils/src/entities/spec/server.ts
+++ b/packages/oas-utils/src/entities/spec/server.ts
@@ -1,4 +1,4 @@
-import { nanoidSchema } from '@/entities/shared'
+import { type ENTITY_BRANDS, nanoidSchema } from '@/entities/shared/utility'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { type ZodSchema, z } from 'zod'
 
@@ -34,11 +34,7 @@ const extendedServerVariableSchema = oasServerVariableSchema
   })
   .refine((data) => {
     // Set default to the first enum value if invalid
-    if (
-      Array.isArray(data.enum) &&
-      !data.enum.includes(data.default ?? '') &&
-      data.enum.length > 0
-    ) {
+    if (Array.isArray(data.enum) && !data.enum.includes(data.default ?? '') && data.enum.length > 0) {
       data.default = data.enum[0]
     }
 
@@ -79,7 +75,7 @@ export const oasServerSchema = z.object({
 }) satisfies ZodSchema<OpenAPIV3_1.ServerObject>
 
 export const serverSchema = oasServerSchema.extend({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand<ENTITY_BRANDS['SERVER']>(),
 })
 
 export type Server = z.infer<typeof serverSchema>

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -1,4 +1,4 @@
-import { nanoidSchema } from '@/entities/shared'
+import { nanoidSchema, type ENTITY_BRANDS } from '@/entities/shared/utility'
 import { z } from 'zod'
 
 /**
@@ -72,9 +72,7 @@ export const oasExternalDocumentationSchema = z.object({
   /** REQUIRED. The URL for the target documentation. This MUST be in the form of a URL. */
   url: z.string().default(''),
 })
-export type ExternalDocumentation = z.infer<
-  typeof oasExternalDocumentationSchema
->
+export type ExternalDocumentation = z.infer<typeof oasExternalDocumentationSchema>
 
 export const xScalarNestedSchema = z
   .object({
@@ -109,8 +107,11 @@ export const oasTagSchema = z.object({
 })
 
 export const tagSchema = oasTagSchema.extend({
-  uid: nanoidSchema,
-  children: nanoidSchema.array().default([]),
+  uid: nanoidSchema.brand<ENTITY_BRANDS['TAG']>(),
+  children: z
+    .union([nanoidSchema.brand<ENTITY_BRANDS['TAG']>(), nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>().array()])
+    .array()
+    .default([]),
 })
 
 export type Tag = z.infer<typeof tagSchema>

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -109,7 +109,7 @@ export const oasTagSchema = z.object({
 export const tagSchema = oasTagSchema.extend({
   uid: nanoidSchema.brand<ENTITY_BRANDS['TAG']>(),
   children: z
-    .union([nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>(), nanoidSchema.brand<ENTITY_BRANDS['TAG']>()])
+    .union([z.string().brand<ENTITY_BRANDS['REQUEST']>(), z.string().brand<ENTITY_BRANDS['TAG']>()])
     .array()
     .default([]),
 })

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -109,7 +109,7 @@ export const oasTagSchema = z.object({
 export const tagSchema = oasTagSchema.extend({
   uid: nanoidSchema.brand<ENTITY_BRANDS['TAG']>(),
   children: z
-    .union([nanoidSchema.brand<ENTITY_BRANDS['TAG']>(), nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>().array()])
+    .union([nanoidSchema.brand<ENTITY_BRANDS['REQUEST']>(), nanoidSchema.brand<ENTITY_BRANDS['TAG']>()])
     .array()
     .default([]),
 })

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -1,4 +1,4 @@
-import { nanoidSchema, type ENTITY_BRANDS } from '@/entities/shared/utility'
+import { type ENTITY_BRANDS, nanoidSchema } from '@/entities/shared/utility'
 import { z } from 'zod'
 
 /**
@@ -109,7 +109,7 @@ export const oasTagSchema = z.object({
 export const tagSchema = oasTagSchema.extend({
   uid: nanoidSchema.brand<ENTITY_BRANDS['TAG']>(),
   children: z
-    .union([z.string().brand<ENTITY_BRANDS['REQUEST']>(), z.string().brand<ENTITY_BRANDS['TAG']>()])
+    .union([z.string().brand<ENTITY_BRANDS['OPERATION']>(), z.string().brand<ENTITY_BRANDS['TAG']>()])
     .array()
     .default([]),
 })

--- a/packages/oas-utils/src/entities/spec/x-scalar-secrets.ts
+++ b/packages/oas-utils/src/entities/spec/x-scalar-secrets.ts
@@ -6,5 +6,4 @@ export const xScalarSecretVarSchema = z.object({
 })
 
 export const xScalarSecretsSchema = z.record(z.string(), xScalarSecretVarSchema)
-
 export type XScalarSecrets = z.infer<typeof xScalarSecretsSchema>

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -2,7 +2,7 @@ import { themeIds } from '@scalar/themes'
 import { z } from 'zod'
 
 import { HOTKEY_EVENT_NAMES, KEYDOWN_KEYS } from '../hotkeys'
-import { nanoidSchema } from '../shared'
+import { type ENTITY_BRANDS, nanoidSchema } from '@/entities/shared/utility'
 
 const modifier = z
   .enum(['Meta', 'Control', 'Shift', 'Alt', 'default'] as const)
@@ -29,20 +29,20 @@ const hotKeyConfigSchema = z
   .optional()
 
 export const workspaceSchema = z.object({
-  uid: nanoidSchema,
+  uid: nanoidSchema.brand<ENTITY_BRANDS['WORKSPACE']>(),
   name: z.string().default('Default Workspace'),
   /** Workspace description */
   description: z.string().default('Basic Scalar Workspace'),
   /** List of all collection uids in a given workspace */
-  collections: z.array(z.string()).default([]),
-  /** List of all environment uids in a given workspace */
+  collections: z.array(nanoidSchema.brand<ENTITY_BRANDS['COLLECTION']>()).default([]),
+  /** List of all environment uids in a given workspace, TODO: why is this a record? */
   environments: z.record(z.string()).default({}),
   /** Customize hotkeys */
   hotKeyConfig: hotKeyConfigSchema,
   /** Active Environment ID to use for requests  */
   activeEnvironmentId: z.string().optional().default('default'),
   /** List of all cookie uids in a given workspace */
-  cookies: z.array(z.string()).default([]),
+  cookies: z.array(nanoidSchema.brand<ENTITY_BRANDS['COOKIE']>()).default([]),
   /** Workspace level proxy for all requests to be sent through */
   proxyUrl: z.string().optional(),
   /** Workspace level theme, we might move this to user level later */

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -34,7 +34,7 @@ export const workspaceSchema = z.object({
   /** Workspace description */
   description: z.string().default('Basic Scalar Workspace'),
   /** List of all collection uids in a given workspace */
-  collections: z.array(nanoidSchema.brand<ENTITY_BRANDS['COLLECTION']>()).default([]),
+  collections: z.array(z.string().brand<ENTITY_BRANDS['COLLECTION']>()).default([]),
   /** List of all environment uids in a given workspace, TODO: why is this a record? */
   environments: z.record(z.string()).default({}),
   /** Customize hotkeys */
@@ -42,7 +42,7 @@ export const workspaceSchema = z.object({
   /** Active Environment ID to use for requests  */
   activeEnvironmentId: z.string().optional().default('default'),
   /** List of all cookie uids in a given workspace */
-  cookies: z.array(nanoidSchema.brand<ENTITY_BRANDS['COOKIE']>()).default([]),
+  cookies: z.array(z.string().brand<ENTITY_BRANDS['COOKIE']>()).default([]),
   /** Workspace level proxy for all requests to be sent through */
   proxyUrl: z.string().optional(),
   /** Workspace level theme, we might move this to user level later */

--- a/packages/oas-utils/src/migrations/migrator.ts
+++ b/packages/oas-utils/src/migrations/migrator.ts
@@ -1,7 +1,4 @@
-import {
-  getLocalStorageVersion,
-  parseLocalStorage,
-} from '@/migrations/local-storage'
+import { getLocalStorageVersion, parseLocalStorage } from '@/migrations/local-storage'
 import { semverLessThan } from '@/migrations/semver'
 import { migrate_v_2_1_0 } from '@/migrations/v-2.1.0'
 import { migrate_v_2_2_0 } from '@/migrations/v-2.2.0'
@@ -10,7 +7,7 @@ import { migrate_v_2_4_0 } from '@/migrations/v-2.4.0'
 import { migrate_v_2_5_0, type v_2_5_0 } from '@/migrations/v-2.5.0'
 
 /** Handles all data migrations per entity */
-export const migrator = (): v_2_5_0.DataArray => {
+export const migrator = (): v_2_5_0['DataArray'] => {
   const dataVersion = getLocalStorageVersion()
   console.info('Data version: ' + dataVersion)
 
@@ -49,7 +46,7 @@ export const migrator = (): v_2_5_0.DataArray => {
     servers: Object.values(data.servers),
     tags: Object.values(data.tags),
     workspaces: Object.values(data.workspaces),
-  } satisfies v_2_5_0.DataArray
+  } satisfies v_2_5_0['DataArray']
 
   return data
 }

--- a/packages/oas-utils/src/migrations/v-2.5.0/migration.test.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/migration.test.ts
@@ -16,9 +16,7 @@ describe('migrate_v_2_5_0', () => {
         activeBody: 'raw',
       },
       parameters: {
-        headers: [
-          { key: 'Content-Type', value: 'application/json', enabled: true },
-        ],
+        headers: [{ key: 'Content-Type', value: 'application/json', enabled: true }],
         path: [],
         query: [],
         cookies: [],
@@ -42,13 +40,9 @@ describe('migrate_v_2_5_0', () => {
     const result = migrate_v_2_5_0(mockData)
 
     // Assertions
-    expectTypeOf(result).toMatchTypeOf<v_2_5_0.DataRecord>()
-    expect(result.requestExamples.example1.parameters.headers[0].key).toBe(
-      'Accept',
-    )
-    expect(result.requestExamples.example1.parameters.headers[0].value).toBe(
-      '*/*',
-    )
+    expectTypeOf(result).toMatchTypeOf<v_2_5_0['DataRecord']>()
+    expect(result.requestExamples.example1.parameters.headers[0].key).toBe('Accept')
+    expect(result.requestExamples.example1.parameters.headers[0].value).toBe('*/*')
   })
 
   it('should not add "Accept" header if it already exists', () => {
@@ -88,14 +82,10 @@ describe('migrate_v_2_5_0', () => {
     const result = migrate_v_2_5_0(mockData)
 
     // Assertions
-    expectTypeOf(result).toMatchTypeOf<v_2_5_0.DataRecord>()
+    expectTypeOf(result).toMatchTypeOf<v_2_5_0['DataRecord']>()
     expect(result.requestExamples.example2.parameters.headers.length).toBe(2)
-    expect(result.requestExamples.example2.parameters.headers[0].key).toBe(
-      'Accept',
-    )
-    expect(result.requestExamples.example2.parameters.headers[0].value).toBe(
-      'application/json',
-    )
+    expect(result.requestExamples.example2.parameters.headers[0].key).toBe('Accept')
+    expect(result.requestExamples.example2.parameters.headers[0].value).toBe('application/json')
   })
 
   it('should add default selectedHttpClient to workspaces', () => {
@@ -131,7 +121,7 @@ describe('migrate_v_2_5_0', () => {
     const result = migrate_v_2_5_0(mockData)
 
     // Assertions
-    expectTypeOf(result).toMatchTypeOf<v_2_5_0.DataRecord>()
+    expectTypeOf(result).toMatchTypeOf<v_2_5_0['DataRecord']>()
     expect(result.workspaces.default.selectedHttpClient).toEqual({
       targetKey: 'shell',
       clientKey: 'curl',

--- a/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
@@ -28,6 +28,7 @@ export const migrate_v_2_5_0 = (data: v_2_4_0.DataRecord): v_2_5_0['DataRecord']
         tags: collection.tags.map((uid) => uid as Tag['uid']),
         requests: collection.requests.map((uid) => uid as Operation['uid']),
         children: collection.children.map((uid) => uid as Operation['uid'] | Tag['uid']),
+        selectedServerUid: collection.selectedServerUid as Server['uid'],
       } satisfies v_2_5_0['Collection']
       return acc
     },

--- a/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
@@ -1,44 +1,107 @@
 import type { v_2_4_0 } from '@/migrations/v-2.4.0/types.generated'
 
 import type { v_2_5_0 } from './types.generated'
+import type { Collection, Operation, RequestExample, SecurityScheme, Server, Tag } from '@/entities/spec'
+import type { Workspace } from '@/entities/workspace'
+import type { Cookie } from '@/entities/cookie/cookie'
+import type { Environment } from '@/entities/environment/environment'
 
 /** V-2.4.0 to V-2.5.0 migration */
-export const migrate_v_2_5_0 = (
-  data: v_2_4_0.DataRecord,
-): v_2_5_0.DataRecord => {
+export const migrate_v_2_5_0 = (data: v_2_4_0.DataRecord): v_2_5_0['DataRecord'] => {
   console.info('Performing data migration v-2.4.0 to v-2.5.0')
 
-  const requestExamples = Object.entries(data.requestExamples || {}).reduce<
-    Record<string, v_2_5_0.RequestExample>
-  >((acc, [key, example]) => {
-    const headers = example.parameters.headers
-
-    // Check if "Accept" header exists
-    const hasAcceptHeader = headers.some(
-      (header) => header.key.toLowerCase() === 'accept',
-    )
-
-    if (!hasAcceptHeader) {
-      // Add "Accept" header as the first entry
-      headers.unshift({ key: 'Accept', value: '*/*', enabled: true })
-    }
-
-    // Update the example with potentially modified headers
+  const cookies = Object.entries(data.cookies || {}).reduce<Record<string, v_2_5_0['Cookie']>>((acc, [key, cookie]) => {
     acc[key] = {
-      ...example,
-      parameters: {
-        ...example.parameters,
-        headers,
-      },
-    }
+      ...cookie,
+      uid: cookie.uid as Cookie['uid'],
+    } satisfies v_2_5_0['Cookie']
     return acc
   }, {})
 
-  const servers = Object.entries(data.servers || {}).reduce<
-    Record<string, v_2_5_0.Server>
-  >((acc, [key, server]) => {
+  const collections = Object.entries(data.collections || {}).reduce<Record<string, v_2_5_0['Collection']>>(
+    (acc, [key, collection]) => {
+      acc[key] = {
+        ...collection,
+        uid: collection.uid as Collection['uid'],
+        selectedSecuritySchemeUids: collection.selectedSecuritySchemeUids as Collection['selectedSecuritySchemeUids'],
+        servers: collection.servers.map((uid) => uid as Server['uid']),
+        tags: collection.tags.map((uid) => uid as Tag['uid']),
+        requests: collection.requests.map((uid) => uid as Operation['uid']),
+        children: collection.children.map((uid) => uid as Operation['uid'] | Tag['uid']),
+      } satisfies v_2_5_0['Collection']
+      return acc
+    },
+    {},
+  )
+
+  const environments = Object.entries(data.environments || {}).reduce<Record<string, v_2_5_0['Environment']>>(
+    (acc, [key, environment]) => {
+      acc[key] = {
+        ...environment,
+        uid: environment.uid as Environment['uid'],
+      } satisfies v_2_5_0['Environment']
+      return acc
+    },
+    {},
+  )
+
+  const requests = Object.entries(data.requests || {}).reduce<Record<string, v_2_5_0['Request']>>(
+    (acc, [key, request]) => {
+      acc[key] = {
+        ...request,
+        uid: request.uid as Operation['uid'],
+        servers: request.servers as Operation['servers'],
+        selectedServerUid: request.selectedServerUid as Operation['selectedServerUid'],
+        examples: request.examples as Operation['examples'],
+        selectedSecuritySchemeUids: request.selectedSecuritySchemeUids as Operation['selectedSecuritySchemeUids'],
+      } satisfies v_2_5_0['Request']
+      return acc
+    },
+    {},
+  )
+
+  const requestExamples = Object.entries(data.requestExamples || {}).reduce<Record<string, v_2_5_0['RequestExample']>>(
+    (acc, [key, example]) => {
+      const headers = example.parameters.headers
+
+      // Check if "Accept" header exists
+      const hasAcceptHeader = headers.some((header) => header.key.toLowerCase() === 'accept')
+
+      if (!hasAcceptHeader) {
+        // Add "Accept" header as the first entry
+        headers.unshift({ key: 'Accept', value: '*/*', enabled: true })
+      }
+
+      // Update the example with potentially modified headers
+      acc[key] = {
+        ...example,
+        uid: example.uid as RequestExample['uid'],
+        requestUid: example.requestUid as RequestExample['requestUid'],
+        parameters: {
+          ...example.parameters,
+          headers,
+        },
+      }
+      return acc
+    },
+    {},
+  )
+
+  const securitySchemes = Object.entries(data.securitySchemes || {}).reduce<Record<string, v_2_5_0['SecurityScheme']>>(
+    (acc, [key, securityScheme]) => {
+      acc[key] = {
+        ...securityScheme,
+        uid: securityScheme.uid as SecurityScheme['uid'],
+      } satisfies v_2_5_0['SecurityScheme']
+      return acc
+    },
+    {},
+  )
+
+  const servers = Object.entries(data.servers || {}).reduce<Record<string, v_2_5_0['Server']>>((acc, [key, server]) => {
     acc[key] = {
       ...server,
+      uid: server.uid as Server['uid'],
       variables: Object.entries(server.variables || {}).reduce<
         Record<
           string,
@@ -51,10 +114,7 @@ export const migrate_v_2_5_0 = (
       >((variablesAcc, [variableKey, variable]) => {
         variablesAcc[variableKey] = {
           ...variable,
-          enum:
-            variable.enum && variable.enum.length > 0
-              ? (variable.enum as [string, ...string[]])
-              : undefined,
+          enum: variable.enum && variable.enum.length > 0 ? (variable.enum as [string, ...string[]]) : undefined,
           default: variable.default ?? '',
           description: variable.description,
         }
@@ -64,23 +124,42 @@ export const migrate_v_2_5_0 = (
     return acc
   }, {})
 
-  const workspaces = Object.entries(data.workspaces || {}).reduce<
-    Record<string, v_2_5_0.Workspace>
-  >((acc, [key, workspace]) => {
+  const tags = Object.entries(data.tags || {}).reduce<Record<string, v_2_5_0['Tag']>>((acc, [key, tag]) => {
     acc[key] = {
-      ...workspace,
-      selectedHttpClient: {
-        targetKey: 'shell',
-        clientKey: 'curl',
-      },
-    }
+      ...tag,
+      uid: tag.uid as Tag['uid'],
+      children: tag.children as Tag['children'],
+    } satisfies v_2_5_0['Tag']
     return acc
   }, {})
 
+  const workspaces = Object.entries(data.workspaces || {}).reduce<Record<string, v_2_5_0['Workspace']>>(
+    (acc, [key, workspace]) => {
+      acc[key] = {
+        ...workspace,
+        uid: workspace.uid as Workspace['uid'],
+        collections: workspace.collections.map((uid) => uid as Collection['uid']),
+        cookies: workspace.cookies.map((uid) => uid as Cookie['uid']),
+        selectedHttpClient: {
+          targetKey: 'shell',
+          clientKey: 'curl',
+        },
+      }
+      return acc
+    },
+    {},
+  )
+
   return {
     ...data,
+    collections,
+    cookies,
+    environments,
+    requests,
     requestExamples,
+    securitySchemes,
     servers,
+    tags,
     workspaces,
-  } satisfies v_2_5_0.DataRecord
+  } satisfies v_2_5_0['DataRecord']
 }

--- a/packages/oas-utils/src/migrations/v-2.5.0/types.generated.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/types.generated.ts
@@ -10,38 +10,38 @@ import type {
 } from '@/entities/spec'
 import type { Workspace as W } from '@/entities/workspace'
 
-export namespace v_2_5_0 {
-  export type Cookie = Ck
-  export type Environment = E
-  export type Collection = Co
-  export type Request = R
-  export type RequestExample = RE
-  export type SecurityScheme = SS
-  export type Server = S
-  export type Tag = T
-  export type Workspace = W
+export type v_2_5_0 = {
+  Cookie: Ck
+  Environment: E
+  Collection: Co
+  Request: R
+  RequestExample: RE
+  SecurityScheme: SS
+  Server: S
+  Tag: T
+  Workspace: W
 
-  export type DataRecord = {
-    collections: Record<string, Collection>
-    cookies: Record<string, Cookie>
-    environments: Record<string, Environment>
-    requestExamples: Record<string, RequestExample>
-    requests: Record<string, Request>
-    securitySchemes: Record<string, SecurityScheme>
-    servers: Record<string, Server>
-    tags: Record<string, Tag>
-    workspaces: Record<string, Workspace>
+  DataRecord: {
+    collections: Record<string, Co>
+    cookies: Record<string, Ck>
+    environments: Record<string, E>
+    requestExamples: Record<string, RE>
+    requests: Record<string, R>
+    securitySchemes: Record<string, SS>
+    servers: Record<string, S>
+    tags: Record<string, T>
+    workspaces: Record<string, W>
   }
 
-  export type DataArray = {
-    collections: Collection[]
-    cookies: Cookie[]
-    environments: Environment[]
-    requestExamples: RequestExample[]
-    requests: Request[]
-    securitySchemes: SecurityScheme[]
-    servers: Server[]
-    tags: Tag[]
-    workspaces: Workspace[]
+  DataArray: {
+    collections: Co[]
+    cookies: Ck[]
+    environments: E[]
+    requestExamples: RE[]
+    requests: R[]
+    securitySchemes: SS[]
+    servers: S[]
+    tags: T[]
+    workspaces: W[]
   }
 }

--- a/packages/oas-utils/src/migrations/v-2.5.0/types.generated.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/types.generated.ts
@@ -1,47 +1,40 @@
-import type { Cookie as Ck } from '@/entities/cookie'
-import type { Environment as E } from '@/entities/environment'
-import type {
-  Collection as Co,
-  Request as R,
-  RequestExample as RE,
-  Server as S,
-  SecurityScheme as SS,
-  Tag as T,
-} from '@/entities/spec'
-import type { Workspace as W } from '@/entities/workspace'
+import type { Cookie } from '@/entities/cookie'
+import type { Environment } from '@/entities/environment'
+import type { Collection, Request, RequestExample, Server, SecurityScheme, Tag } from '@/entities/spec'
+import type { Workspace } from '@/entities/workspace'
 
 export type v_2_5_0 = {
-  Cookie: Ck
-  Environment: E
-  Collection: Co
-  Request: R
-  RequestExample: RE
-  SecurityScheme: SS
-  Server: S
-  Tag: T
-  Workspace: W
+  Cookie: Cookie
+  Environment: Environment
+  Collection: Collection
+  Request: Request
+  RequestExample: RequestExample
+  SecurityScheme: SecurityScheme
+  Server: Server
+  Tag: Tag
+  Workspace: Workspace
 
   DataRecord: {
-    collections: Record<string, Co>
-    cookies: Record<string, Ck>
-    environments: Record<string, E>
-    requestExamples: Record<string, RE>
-    requests: Record<string, R>
-    securitySchemes: Record<string, SS>
-    servers: Record<string, S>
-    tags: Record<string, T>
-    workspaces: Record<string, W>
+    collections: Record<string, Collection>
+    cookies: Record<string, Cookie>
+    environments: Record<string, Environment>
+    requestExamples: Record<string, RequestExample>
+    requests: Record<string, Request>
+    securitySchemes: Record<string, SecurityScheme>
+    servers: Record<string, Server>
+    tags: Record<string, Tag>
+    workspaces: Record<string, Workspace>
   }
 
   DataArray: {
-    collections: Co[]
-    cookies: Ck[]
-    environments: E[]
-    requestExamples: RE[]
-    requests: R[]
-    securitySchemes: SS[]
-    servers: S[]
-    tags: T[]
-    workspaces: W[]
+    collections: Collection[]
+    cookies: Cookie[]
+    environments: Environment[]
+    requestExamples: RequestExample[]
+    requests: Request[]
+    securitySchemes: SecurityScheme[]
+    servers: Server[]
+    tags: Tag[]
+    workspaces: Workspace[]
   }
 }

--- a/packages/oas-utils/src/transforms/export-spec.test.ts
+++ b/packages/oas-utils/src/transforms/export-spec.test.ts
@@ -1,9 +1,4 @@
-import type {
-  Request,
-  RequestExample,
-  SecurityScheme,
-  Tag,
-} from '@/entities/spec'
+import type { Request, RequestExample, SecurityScheme, Tag } from '@/entities/spec'
 import { exportSpecFromWorkspace, importSpecToWorkspace } from '@/transforms'
 import { describe, expect, it } from 'vitest'
 
@@ -65,9 +60,7 @@ const testSpec = {
   },
 }
 
-const galaxy = await fetch(
-  'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-).then((r) => r.json())
+const galaxy = await fetch('https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json').then((r) => r.json())
 
 describe('Converts a collection into a spec', () => {
   it('Handles basic spec', async () => {
@@ -99,9 +92,7 @@ describe('Workspace output matches input when round-tripped', async () => {
     requests: arrayToUidMap<Request>(baseWorkspace.requests),
     collection: baseWorkspace.collection,
     requestExamples: arrayToUidMap<RequestExample>(baseWorkspace.examples),
-    securitySchemes: arrayToUidMap<SecurityScheme>(
-      baseWorkspace.securitySchemes,
-    ),
+    securitySchemes: arrayToUidMap<SecurityScheme>(baseWorkspace.securitySchemes),
     tags: arrayToUidMap<Tag>(baseWorkspace.tags),
   })
 
@@ -113,29 +104,21 @@ describe('Workspace output matches input when round-tripped', async () => {
   const baseExamples = arrayToUidMap<RequestExample>(baseWorkspace.examples)
   const nextExamples = arrayToUidMap<RequestExample>(nextWorkspace.examples)
 
-  const baseSecuritySchemes = arrayToUidMap<SecurityScheme>(
-    baseWorkspace.securitySchemes,
-  )
-  const nextSecuritySchemes = arrayToUidMap<SecurityScheme>(
-    nextWorkspace.securitySchemes,
-  )
+  const baseSecuritySchemes = arrayToUidMap<SecurityScheme>(baseWorkspace.securitySchemes)
+  const nextSecuritySchemes = arrayToUidMap<SecurityScheme>(nextWorkspace.securitySchemes)
 
   function getMatchingRequest(uid: string) {
     if (nextWorkspace.error) throw Error('Bad round-tripped workspace')
 
     const base = baseRequests[uid]
-    const next = nextWorkspace.requests.find(
-      (r) => r.path === base.path && r.method === base.method,
-    )
+    const next = nextWorkspace.requests.find((r) => r.path === base.path && r.method === base.method)
 
     if (!next) throw Error('Request not found')
     return { base, next }
   }
 
   it('Collections have the same number of requests', () => {
-    expect(baseWorkspace.collection.requests.length).toEqual(
-      nextWorkspace.collection.requests.length,
-    )
+    expect(baseWorkspace.collection.requests.length).toEqual(nextWorkspace.collection.requests.length)
   })
 
   it('Requests have the same examples', async () => {
@@ -148,60 +131,53 @@ describe('Workspace output matches input when round-tripped', async () => {
     // expect(roundTripped.requests).toEqual(workspace.requests)
   })
 
-  it.each(
-    baseWorkspace.requests.map((r) => [r.path, r.method.toUpperCase(), r.uid]),
-  )('Request %s:%s are functionally equivalent', (path, method, uid) => {
-    const { base, next } = getMatchingRequest(uid)
+  it.each(baseWorkspace.requests.map((r) => [r.path, r.method.toUpperCase(), r.uid]))(
+    'Request %s:%s are functionally equivalent',
+    (_path, _method, uid) => {
+      const { base, next } = getMatchingRequest(uid)
 
-    expect({
-      ...base,
-      uid: 'ignore',
-      selectedSecuritySchemeUids: 'ignore',
-      examples: 'ignore',
-    }).toEqual({
-      ...next,
-      uid: 'ignore',
-      selectedSecuritySchemeUids: 'ignore',
-      examples: 'ignore',
-    })
-
-    /** Check that the examples all match */
-    const baseRequestExamples = base.examples.map(
-      (exampleUid) => baseExamples[exampleUid],
-    )
-    const nextRequestExamples = next.examples.map(
-      (exampleUid) => nextExamples[exampleUid],
-    )
-
-    baseRequestExamples.forEach((example, idx) => {
       expect({
-        ...example,
+        ...base,
         uid: 'ignore',
-        requestUid: 'ignore',
+        selectedSecuritySchemeUids: 'ignore',
+        examples: 'ignore',
       }).toEqual({
-        ...nextRequestExamples[idx],
+        ...next,
         uid: 'ignore',
-        requestUid: 'ignore',
+        selectedSecuritySchemeUids: 'ignore',
+        examples: 'ignore',
       })
-    })
 
-    const baseSchemes = base.selectedSecuritySchemeUids.map(
-      (schemeUid) => baseSecuritySchemes[schemeUid],
-    )
-    const nextSchemes = next.selectedSecuritySchemeUids.map(
-      (schemeUid) => nextSecuritySchemes[schemeUid],
-    )
+      /** Check that the examples all match */
+      const baseRequestExamples = base.examples.map((exampleUid) => baseExamples[exampleUid])
+      const nextRequestExamples = next.examples.map((exampleUid) => nextExamples[exampleUid])
 
-    expect(
-      baseSchemes.map((s) => ({
-        ...s,
-        uid: 'ignore',
-      })),
-    ).toEqual(
-      nextSchemes.map((s) => ({
-        ...s,
-        uid: 'ignore',
-      })),
-    )
-  })
+      baseRequestExamples.forEach((example, idx) => {
+        expect({
+          ...example,
+          uid: 'ignore',
+          requestUid: 'ignore',
+        }).toEqual({
+          ...nextRequestExamples[idx],
+          uid: 'ignore',
+          requestUid: 'ignore',
+        })
+      })
+
+      const baseSchemes = base.selectedSecuritySchemeUids.map((schemeUid) => baseSecuritySchemes[schemeUid])
+      const nextSchemes = next.selectedSecuritySchemeUids.map((schemeUid) => nextSecuritySchemes[schemeUid])
+
+      expect(
+        baseSchemes.map((s) => ({
+          ...s,
+          uid: 'ignore',
+        })),
+      ).toEqual(
+        nextSchemes.map((s) => ({
+          ...s,
+          uid: 'ignore',
+        })),
+      )
+    },
+  )
 })

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -24,22 +24,14 @@ import { combineUrlAndPath, isDefined } from '@/helpers'
 import { isHttpMethod } from '@/helpers/httpMethods'
 import { schemaModel } from '@/helpers/schema-model'
 import { keysOf } from '@scalar/object-utils/arrays'
-import {
-  type LoadResult,
-  dereference,
-  load,
-  upgrade,
-} from '@scalar/openapi-parser'
+import { type LoadResult, dereference, load, upgrade } from '@scalar/openapi-parser'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import type { UnknownObject } from '@scalar/types/utils'
 import type { Entries } from 'type-fest'
 
 /** Takes a string or object and parses it into an openapi spec compliant schema */
-export const parseSchema = async (
-  spec: string | UnknownObject,
-  { shouldLoad = true } = {},
-) => {
+export const parseSchema = async (spec: string | UnknownObject, { shouldLoad = true } = {}) => {
   if (spec === null || (typeof spec === 'string' && spec.trim() === '')) {
     console.warn('[@scalar/oas-utils] Empty OpenAPI document provided.')
 
@@ -71,10 +63,7 @@ export const parseSchema = async (
   const { specification } = upgrade(filesystem)
   const { schema, errors: derefErrors = [] } = await dereference(specification)
 
-  if (!schema)
-    console.warn(
-      '[@scalar/oas-utils] OpenAPI Parser Warning: Schema is undefined',
-    )
+  if (!schema) console.warn('[@scalar/oas-utils] OpenAPI Parser Warning: Schema is undefined')
   return {
     /**
      * Temporary fix for the parser returning an empty array
@@ -87,34 +76,24 @@ export const parseSchema = async (
 
 /** Converts selected security requirements to uids */
 export const getSelectedSecuritySchemeUids = (
-  securityRequirements: SelectedSecuritySchemeUids,
-  preferredSecurityNames: SelectedSecuritySchemeUids = [],
-  securitySchemeMap: Record<string, string>,
+  securityRequirements: (string | string[])[],
+  preferredSecurityNames: (string | string[])[] = [],
+  securitySchemeMap: Record<string, SecurityScheme['uid']>,
 ): SelectedSecuritySchemeUids => {
   // Set the first security requirement if no preferred security schemes are set
   const names =
-    securityRequirements[0] && !preferredSecurityNames.length
-      ? [securityRequirements[0]]
-      : preferredSecurityNames
+    securityRequirements[0] && !preferredSecurityNames.length ? [securityRequirements[0]] : preferredSecurityNames
 
   // Map names to uids
   const uids = names.map((name) =>
-    Array.isArray(name)
-      ? name.map((k) => securitySchemeMap[k])
-      : securitySchemeMap[name],
+    Array.isArray(name) ? name.map((k) => securitySchemeMap[k]) : securitySchemeMap[name],
   )
 
   return uids
 }
 
-export type ImportSpecToWorkspaceArgs = Pick<
-  CollectionPayload,
-  'documentUrl' | 'watchMode'
-> &
-  Pick<
-    ReferenceConfiguration,
-    'authentication' | 'baseServerURL' | 'servers'
-  > & {
+export type ImportSpecToWorkspaceArgs = Pick<CollectionPayload, 'documentUrl' | 'watchMode'> &
+  Pick<ReferenceConfiguration, 'authentication' | 'baseServerURL' | 'servers'> & {
     /** Sets the preferred security scheme on the collection instead of the requests */
     setCollectionSecurity?: boolean
     /** Call the load step from the parser */
@@ -168,12 +147,9 @@ export async function importSpecToWorkspace(
   const requests: Request[] = []
 
   // Add the base server url to any relative servers
-  const servers: Server[] = getServersFromOpenApiDocument(
-    configuredServers || schema.servers,
-    {
-      baseServerURL,
-    },
-  )
+  const servers: Server[] = getServersFromOpenApiDocument(configuredServers || schema.servers, {
+    baseServerURL,
+  })
 
   // Fallback to the current window.location.origin if no servers are provided
   if (!servers.length) {
@@ -193,14 +169,9 @@ export async function importSpecToWorkspace(
   // ---------------------------------------------------------------------------
   // SECURITY HANDLING
 
-  const security =
-    schema.components?.securitySchemes ?? schema?.securityDefinitions ?? {}
+  const security = schema.components?.securitySchemes ?? schema?.securityDefinitions ?? {}
 
-  const securitySchemes = (
-    Object.entries(security) as Entries<
-      Record<string, OpenAPIV3_1.SecuritySchemeObject>
-    >
-  )
+  const securitySchemes = (Object.entries(security) as Entries<Record<string, OpenAPIV3_1.SecuritySchemeObject>>)
     .map?.(([nameKey, _scheme]) => {
       // Apply any transforms we need before parsing
       const payload = {
@@ -210,9 +181,7 @@ export async function importSpecToWorkspace(
 
       // For oauth2 we need to add the type to the flows + prefill from authentication
       if (payload.type === 'oauth2' && payload.flows) {
-        const flowKeys = Object.keys(payload.flows) as Array<
-          keyof typeof payload.flows
-        >
+        const flowKeys = Object.keys(payload.flows) as Array<keyof typeof payload.flows>
 
         flowKeys.forEach((key) => {
           if (!payload.flows?.[key]) return
@@ -223,8 +192,7 @@ export async function importSpecToWorkspace(
 
           // Prefill values from authorization config
           if (authentication?.oAuth2) {
-            if (authentication.oAuth2.accessToken)
-              flow.token = authentication.oAuth2.accessToken
+            if (authentication.oAuth2.accessToken) flow.token = authentication.oAuth2.accessToken
 
             if (flow.type === 'password') {
               flow.username = authentication.oAuth2.username
@@ -237,22 +205,16 @@ export async function importSpecToWorkspace(
           }
 
           // Convert scopes to an object
-          if (Array.isArray(flow.scopes))
-            flow.scopes = flow.scopes.reduce(
-              (prev, s) => ({ ...prev, [s]: '' }),
-              {},
-            )
+          if (Array.isArray(flow.scopes)) flow.scopes = flow.scopes.reduce((prev, s) => ({ ...prev, [s]: '' }), {})
 
           // Handle x-defaultClientId
-          if (flow['x-defaultClientId'])
-            flow['x-scalar-client-id'] = flow['x-defaultClientId']
+          if (flow['x-defaultClientId']) flow['x-scalar-client-id'] = flow['x-defaultClientId']
         })
       }
       // Otherwise we just prefill
       else if (authentication) {
         // ApiKey
-        if (payload.type === 'apiKey' && authentication.apiKey?.token)
-          payload.value = authentication.apiKey.token
+        if (payload.type === 'apiKey' && authentication.apiKey?.token) payload.value = authentication.apiKey.token
         // HTTP
         else if (payload.type === 'http') {
           if (payload.scheme === 'basic' && authentication.http?.basic) {
@@ -271,7 +233,7 @@ export async function importSpecToWorkspace(
     .filter((v) => !!v)
 
   // Map of security scheme names to UIDs
-  const securitySchemeMap: Record<string, string> = {}
+  const securitySchemeMap: Record<string, SecurityScheme['uid']> = {}
   securitySchemes.forEach((s) => {
     securitySchemeMap[s.nameKey] = s.uid
   })
@@ -292,9 +254,7 @@ export async function importSpecToWorkspace(
 
     methods.forEach((method) => {
       const operation: OpenAPIV3_1.OperationObject = path[method]
-      const operationServers = serverSchema
-        .array()
-        .parse(operation.servers ?? [])
+      const operationServers = serverSchema.array().parse(operation.servers ?? [])
 
       servers.push(...operationServers)
 
@@ -303,14 +263,9 @@ export async function importSpecToWorkspace(
       operation.tags?.forEach((t: string) => tagNames.add(t))
 
       // Remove security here and add it correctly below
-      const { security: operationSecurity, ...operationWithoutSecurity } =
-        operation
+      const { security: operationSecurity, ...operationWithoutSecurity } = operation
 
-      const securityRequirements: SelectedSecuritySchemeUids = (
-        operationSecurity ??
-        schema.security ??
-        []
-      )
+      const securityRequirements: (string | string[])[] = (operationSecurity ?? schema.security ?? [])
         .map((s: OpenAPIV3_1.SecurityRequirementObject) => {
           const keys = Object.keys(s)
           return keys.length > 1 ? keys : keys[0]
@@ -318,31 +273,21 @@ export async function importSpecToWorkspace(
         .filter(isDefined)
 
       // Filter the preferred security schemes to only include the ones that are in the security requirements
-      const preferredSecurityNames: SelectedSecuritySchemeUids = [
-        authentication?.preferredSecurityScheme ?? [],
-      ]
-        .flat()
-        .filter((name) => {
-          // Match up complex security requirements, array to array
-          if (Array.isArray(name)) {
-            // We match every element in the array
-            return securityRequirements.some(
-              (r) =>
-                Array.isArray(r) &&
-                r.length === name.length &&
-                r.every((v, i) => v === name[i]),
-            )
-          } else return securityRequirements.includes(name)
-        })
+      const preferredSecurityNames = [authentication?.preferredSecurityScheme ?? []].flat().filter((name) => {
+        // Match up complex security requirements, array to array
+        if (Array.isArray(name)) {
+          // We match every element in the array
+          return securityRequirements.some(
+            (r) => Array.isArray(r) && r.length === name.length && r.every((v, i) => v === name[i]),
+          )
+        }
+        return securityRequirements.includes(name)
+      })
 
       // Set the initially selected security scheme
       const selectedSecuritySchemeUids =
         securityRequirements.length && !setCollectionSecurity
-          ? getSelectedSecuritySchemeUids(
-              securityRequirements,
-              preferredSecurityNames,
-              securitySchemeMap,
-            )
+          ? getSelectedSecuritySchemeUids(securityRequirements, preferredSecurityNames, securitySchemeMap)
           : []
 
       const requestPayload: RequestPayload = {
@@ -352,43 +297,36 @@ export async function importSpecToWorkspace(
         security: operationSecurity,
         selectedSecuritySchemeUids,
         // Merge path and operation level parameters
-        parameters: [
-          ...(path?.parameters ?? []),
-          ...(operation.parameters ?? []),
-        ] as RequestParameterPayload[],
+        parameters: [...(path?.parameters ?? []), ...(operation.parameters ?? [])] as RequestParameterPayload[],
         servers: [...pathServers, ...operationServers].map((s) => s.uid),
       }
 
       // Remove any examples from the request payload as they conflict with our examples property and are not valid
       if (requestPayload.examples) {
-        console.warn(
-          '[@scalar/api-client] operation.examples is not a valid openapi property',
-        )
+        console.warn('[@scalar/api-client] operation.examples is not a valid openapi property')
         delete requestPayload.examples
       }
 
       // Add list of UIDs to associate security schemes
       // As per the spec if there is operation level security we ignore the top level requirements
       if (operationSecurity?.length)
-        requestPayload.security = operationSecurity.map(
-          (s: OpenAPIV3_1.SecurityRequirementObject) => {
-            const keys = Object.keys(s)
+        requestPayload.security = operationSecurity.map((s: OpenAPIV3_1.SecurityRequirementObject) => {
+          const keys = Object.keys(s)
 
-            // Handle the case of {} for optional
-            if (keys.length) {
-              const [key] = Object.keys(s)
-              return {
-                [key]: s[key],
-              }
-            } else return s
-          },
-        )
+          // Handle the case of {} for optional
+          if (keys.length) {
+            const [key] = Object.keys(s)
+            return {
+              [key]: s[key],
+            }
+          }
+          return s
+        })
 
       // Save parse the request
       const request = schemaModel(requestPayload, requestSchema, false)
 
-      if (!request)
-        importWarnings.push(`${method} Request at ${path} is invalid.`)
+      if (!request) importWarnings.push(`${method} Request at ${path} is invalid.`)
       else requests.push(request)
     })
   })
@@ -457,9 +395,7 @@ export async function importSpecToWorkspace(
   // Generate Collection
 
   // Grab the security requirements for this operation
-  const securityRequirements: SelectedSecuritySchemeUids = (
-    schema.security ?? []
-  )
+  const securityRequirements: SelectedSecuritySchemeUids = (schema.security ?? [])
     .map((s: OpenAPIV3_1.SecurityRequirementObject) => {
       const keys = Object.keys(s)
       return keys.length > 1 ? keys : keys[0]
@@ -467,19 +403,12 @@ export async function importSpecToWorkspace(
     .filter(isDefined)
 
   // Here we do not filter these as we let the preferredSecurityScheme override the requirements
-  const preferredSecurityNames: SelectedSecuritySchemeUids = [
-    authentication?.preferredSecurityScheme ?? [],
-  ].flat()
+  const preferredSecurityNames = [authentication?.preferredSecurityScheme ?? []].flat()
 
   // Set the initially selected security scheme
   const selectedSecuritySchemeUids =
-    (securityRequirements.length || preferredSecurityNames?.length) &&
-    setCollectionSecurity
-      ? getSelectedSecuritySchemeUids(
-          securityRequirements,
-          preferredSecurityNames,
-          securitySchemeMap,
-        )
+    (securityRequirements.length || preferredSecurityNames?.length) && setCollectionSecurity
+      ? getSelectedSecuritySchemeUids(securityRequirements, preferredSecurityNames, securitySchemeMap)
       : []
 
   const collection = collectionSchema.parse({
@@ -537,10 +466,7 @@ export function getServersFromOpenApiDocument(
         if (parsedSchema?.url?.startsWith('/')) {
           // Use the base server URL (if provided)
           if (baseServerURL) {
-            parsedSchema.url = combineUrlAndPath(
-              baseServerURL,
-              parsedSchema.url,
-            )
+            parsedSchema.url = combineUrlAndPath(baseServerURL, parsedSchema.url)
 
             return parsedSchema
           }
@@ -549,10 +475,7 @@ export function getServersFromOpenApiDocument(
           const fallbackUrl = getFallbackUrl()
 
           if (fallbackUrl) {
-            parsedSchema.url = combineUrlAndPath(
-              fallbackUrl,
-              parsedSchema.url.replace(/^\//, ''),
-            )
+            parsedSchema.url = combineUrlAndPath(fallbackUrl, parsedSchema.url.replace(/^\//, ''))
 
             return parsedSchema
           }
@@ -561,7 +484,7 @@ export function getServersFromOpenApiDocument(
         // Must be good, return it
         return parsedSchema
       } catch (error) {
-        console.warn(`Oops, that’s an invalid server configuration.`)
+        console.warn('Oops, that’s an invalid server configuration.')
         console.warn('Server:', server)
         console.warn('Error:', error)
 

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -350,7 +350,7 @@ export async function importSpecToWorkspace(
   })
 
   // Add all tags by default. We will remove nested ones
-  const collectionChildren = new Set(tags.map((t) => t.uid))
+  const collectionChildren = new Set<Collection['children'][number]>(tags.map((t) => t.uid))
 
   // Nested folders go before any requests
   tags.forEach((t) => {


### PR DESCRIPTION
# Branding PR 1/2

**Problem**
In another PR, claude was tabbing a long and accidentally added an operation.uid into a requestExampleMutator. Before merging that one I want to ensure that cannot happen through type safety.

**Solution**
I stumbled across zod brand which should do exactly that! This PR just did the minimum(😅) to add brands to the UIDs, with some `as` sprinkled in just to get it working.

The follow up PR will add the branded types to the mutators just because this PR is so large already. No need to test this PR as it would be better to test [that one](https://github.com/scalar/scalar/pull/4825) then merge em back to back.

For reviewing: alot of it is just formatting as we go from prettier -> biome, also ignore the test files and it becomes much more palatable 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
