### PR TITLE
feat(api-client): accept the correct uids in the mutators

### DIFF
--- a/packages/api-client/src/components/CommandPalette/CommandPaletteCollection.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteCollection.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import IconSelector from '@/components/IconSelector.vue'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import { ScalarButton } from '@scalar/components'
 import { LibraryIcon } from '@scalar/icons'
 import { useToasts } from '@scalar/use-toasts'
 import { ref } from 'vue'
+
+import IconSelector from '@/components/IconSelector.vue'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -26,6 +27,10 @@ const handleSubmit = () => {
     toast('Please enter a name before creating a collection.', 'error')
     return
   }
+  if (!activeWorkspace.value?.uid) {
+    toast('No active workspace found.', 'error')
+    return
+  }
 
   collectionMutators.add(
     {
@@ -36,7 +41,7 @@ const handleSubmit = () => {
       },
       'x-scalar-icon': collectionIcon.value,
     },
-    activeWorkspace.value?.uid ?? '',
+    activeWorkspace.value?.uid,
   )
   emits('close')
 }
@@ -55,14 +60,14 @@ const handleSubmit = () => {
         v-model="collectionIcon"
         placement="bottom-start">
         <ScalarButton
-          class="aspect-square px-0 h-auto"
+          class="aspect-square h-auto px-0"
           variant="outlined">
           <LibraryIcon
-            class="size-4 text-c-2 stroke-[1.75]"
+            class="text-c-2 size-4 stroke-[1.75]"
             :src="collectionIcon" />
         </ScalarButton>
       </IconSelector>
     </template>
-    <template #submit>Create Collection</template>
+    <template #submit> Create Collection </template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
@@ -1,4 +1,14 @@
 <script setup lang="ts">
+import {
+  ScalarButton,
+  ScalarCodeBlock,
+  ScalarIcon,
+  ScalarTooltip,
+  useLoadingState,
+} from '@scalar/components'
+import { useToasts } from '@scalar/use-toasts'
+import { computed, ref, watch } from 'vue'
+
 import { useFileDialog } from '@/hooks'
 import {
   convertPostmanToOpenApi,
@@ -9,15 +19,6 @@ import {
 } from '@/libs'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import {
-  ScalarButton,
-  ScalarCodeBlock,
-  ScalarIcon,
-  ScalarTooltip,
-  useLoadingState,
-} from '@scalar/components'
-import { useToasts } from '@scalar/use-toasts'
-import { computed, ref, watch } from 'vue'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -39,9 +40,8 @@ const watchMode = ref(true)
 const documentDetails = computed(() => {
   if (isPostmanCollection(inputContent.value)) {
     return getPostmanDocumentDetails(inputContent.value)
-  } else {
-    return getOpenApiDocumentDetails(inputContent.value)
   }
+  return getOpenApiDocumentDetails(inputContent.value)
 })
 
 const documentType = computed(() =>
@@ -161,9 +161,9 @@ async function importCollection() {
     <template v-else>
       <!-- OpenAPI document preview -->
       <div class="flex justify-between">
-        <div class="pl-8 text-xs min-h-8 py-2 text-c-2">Preview</div>
+        <div class="text-c-2 min-h-8 py-2 pl-8 text-xs">Preview</div>
         <ScalarButton
-          class="ml-auto p-2 max-h-8 gap-1.5 text-xs hover:bg-b-2 relative"
+          class="hover:bg-b-2 relative ml-auto max-h-8 gap-1.5 p-2 text-xs"
           variant="ghost"
           @click="inputContent = ''">
           Clear
@@ -171,16 +171,16 @@ async function importCollection() {
       </div>
       <ScalarCodeBlock
         v-if="documentDetails && !isUrl(inputContent)"
-        class="border max-h-[40dvh] mt-1 bg-b-2 rounded [--scalar-small:--scalar-font-size-4]"
+        class="bg-b-2 mt-1 max-h-[40dvh] rounded border [--scalar-small:--scalar-font-size-4]"
         :content="inputContent"
         :copy="false"
         :lang="documentType" />
     </template>
     <template #options>
-      <div class="flex flex-row items-center justify-between gap-3 w-full">
+      <div class="flex w-full flex-row items-center justify-between gap-3">
         <!-- Upload -->
         <ScalarButton
-          class="p-2 max-h-8 gap-1.5 text-xs hover:bg-b-2 relative"
+          class="hover:bg-b-2 relative max-h-8 gap-1.5 p-2 text-xs"
           variant="outlined"
           @click="openSpecFileDialog">
           JSON, or YAML File
@@ -203,8 +203,8 @@ async function importCollection() {
           </template>
           <template #content>
             <div
-              class="grid gap-1.5 pointer-events-none max-w-[320px] w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
-              <div class="flex items-center text-c-2">
+              class="w-content bg-b-1 z-100 text-xxs text-c-1 pointer-events-none z-10 grid max-w-[320px] gap-1.5 rounded p-2 leading-5 shadow-lg">
+              <div class="text-c-2 flex items-center">
                 <span
                   v-if="isInputUrl"
                   class="text-pretty">
@@ -230,9 +230,11 @@ async function importCollection() {
         <template v-if="documentDetails.title">
           "{{ documentDetails.title }}"
         </template>
-        <template v-else>{{ documentDetails.version }}</template>
+        <template v-else>
+          {{ documentDetails.version }}
+        </template>
       </template>
-      <template v-else>Collection</template>
+      <template v-else> Collection </template>
     </template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteRequest.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
-import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import {
   ScalarButton,
-  type ScalarComboboxOption,
   ScalarIcon,
   ScalarListbox,
+  type ScalarComboboxOption,
 } from '@scalar/components'
 import { isHttpMethod } from '@scalar/oas-utils/helpers'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
+
+import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -70,7 +71,7 @@ const tags = computed(() =>
 )
 
 /** Currently selected collection with a reasonable default */
-const selectedCollection = ref<ScalarComboboxOption | undefined>(
+const selectedCollection = ref(
   props.metaData
     ? collections.value.find(
         (collection) =>
@@ -143,7 +144,7 @@ const handleSubmit = () => {
           v-model="selectedCollection"
           :options="collections">
           <ScalarButton
-            class="justify-between p-2 ml-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+            class="hover:bg-b-2 ml-2 max-h-8 w-full justify-between gap-1 p-2 text-xs"
             variant="outlined">
             <span
               class="whitespace-nowrap"
@@ -165,7 +166,7 @@ const handleSubmit = () => {
           v-model="selectedTag"
           :options="tags">
           <ScalarButton
-            class="justify-between p-2 ml-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+            class="hover:bg-b-2 ml-2 max-h-8 w-full justify-between gap-1 p-2 text-xs"
             variant="outlined">
             <span :class="selectedTag ? 'text-c-1' : 'text-c-3'">
               {{ selectedTag ? selectedTag.label : 'Select Tag' }}
@@ -178,6 +179,6 @@ const handleSubmit = () => {
         </ScalarListbox>
       </div>
     </template>
-    <template #submit>Create Request</template>
+    <template #submit> Create Request </template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
@@ -1,11 +1,5 @@
 <script setup lang="ts">
-import {
-  ScalarButton,
-  ScalarIcon,
-  ScalarListbox,
-  type ScalarComboboxOption,
-} from '@scalar/components'
-import type { Collection } from '@scalar/oas-utils/entities/spec'
+import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
 

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import {
   ScalarButton,
-  type ScalarComboboxOption,
   ScalarIcon,
   ScalarListbox,
+  type ScalarComboboxOption,
 } from '@scalar/components'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
+
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -28,7 +30,12 @@ const emits = defineEmits<{
 const { toast } = useToasts()
 
 const { activeCollection, activeWorkspaceCollections } = useActiveEntities()
-const { collectionMutators, serverMutators, events } = useWorkspace()
+const {
+  collectionMutators,
+  serverMutators,
+  events,
+  collections: _collections,
+} = useWorkspace()
 
 const url = ref('')
 
@@ -44,7 +51,7 @@ const collections = computed(() =>
 )
 
 /** Currently selected collection with a reasonable default */
-const selectedCollection = ref<ScalarComboboxOption | undefined>(
+const selectedCollection = ref(
   props.metaData
     ? collections.value.find(
         (collection) =>
@@ -61,16 +68,16 @@ const handleSubmit = () => {
     toast('Please enter a valid url before creating a server.', 'error')
     return
   }
-  const collectionUid = selectedCollection.value?.id
-  if (!collectionUid) {
+  const collection = _collections[selectedCollection.value?.id ?? '']
+  if (!collection) {
     toast('Please select a collection before creating a server.', 'error')
     return
   }
 
-  const server = serverMutators.add({ url: url.value }, collectionUid)
+  const server = serverMutators.add({ url: url.value }, collection.uid)
 
   // Select the server
-  collectionMutators.edit(collectionUid, 'selectedServerUid', server.uid)
+  collectionMutators.edit(collection.uid, 'selectedServerUid', server.uid)
 
   emits('close')
 }
@@ -94,7 +101,7 @@ const redirectToCreateCollection = () => {
         :options="collections">
         <ScalarButton
           v-if="collections.length > 0"
-          class="justify-between p-2 max-h-8 w-fit gap-1 text-xs hover:bg-b-2"
+          class="hover:bg-b-2 max-h-8 w-fit justify-between gap-1 p-2 text-xs"
           variant="outlined">
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
             selectedCollection ? selectedCollection.label : 'Select Collection'
@@ -106,13 +113,13 @@ const redirectToCreateCollection = () => {
         </ScalarButton>
         <ScalarButton
           v-else
-          class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2 w-fit"
+          class="hover:bg-b-2 max-h-8 w-fit justify-between gap-1 p-2 text-xs"
           variant="outlined"
           @click="redirectToCreateCollection">
           <span class="text-c-1">Create Collection</span>
         </ScalarButton>
       </ScalarListbox>
     </template>
-    <template #submit>Create Server</template>
+    <template #submit> Create Server </template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import {
   ScalarButton,
-  type ScalarComboboxOption,
   ScalarIcon,
   ScalarListbox,
+  type ScalarComboboxOption,
 } from '@scalar/components'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
+
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -30,7 +31,7 @@ const availableCollections = computed(() =>
 )
 
 const name = ref('')
-const selectedCollection = ref<ScalarComboboxOption | undefined>(
+const selectedCollection = ref(
   availableCollections.value.find(
     (option) => option.id === activeCollection.value?.uid,
   ),
@@ -66,7 +67,7 @@ const handleSubmit = () => {
         v-model="selectedCollection"
         :options="availableCollections">
         <ScalarButton
-          class="justify-between p-2 max-h-8 w-fit gap-1 text-xs hover:bg-b-2"
+          class="hover:bg-b-2 max-h-8 w-fit justify-between gap-1 p-2 text-xs"
           variant="outlined">
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
             selectedCollection ? selectedCollection.label : 'Select Collection'
@@ -78,6 +79,6 @@ const handleSubmit = () => {
         </ScalarButton>
       </ScalarListbox>
     </template>
-    <template #submit>Create Tag</template>
+    <template #submit> Create Tag </template>
   </CommandActionForm>
 </template>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
-import {
-  ScalarButton,
-  ScalarIcon,
-  ScalarListbox,
-  type ScalarComboboxOption,
-} from '@scalar/components'
+import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
 

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import type { Cookie } from '@scalar/oas-utils/entities/cookie'
+import type { Path, PathValue } from '@scalar/object-utils/nested'
+
 import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableInput from '@/components/DataTable/DataTableInput.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
@@ -12,7 +15,10 @@ defineProps<{
     placeholder: string
   }[]
   data: Record<string, any>
-  onUpdate: (key: string, value: any) => void
+  onUpdate: <P extends Path<Cookie>>(
+    key: P,
+    value: NonNullable<PathValue<Cookie, P>>,
+  ) => void
 }>()
 </script>
 <template>
@@ -34,7 +40,7 @@ defineProps<{
           <DataTableInput
             :modelValue="data[option.key] ?? ''"
             :placeholder="option.placeholder"
-            @update:modelValue="onUpdate(option.key, $event)">
+            @update:modelValue="onUpdate(option.key as Path<Cookie>, $event)">
             {{ option.label }}
           </DataTableInput>
         </DataTableRow>

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
@@ -1,27 +1,28 @@
 <script setup lang="ts">
-import WatchModeToggle from '@/components/CommandPalette/WatchModeToggle.vue'
-import ImportNowButton from '@/components/ImportCollection/ImportNowButton.vue'
-import IntegrationLogo from '@/components/ImportCollection/IntegrationLogo.vue'
-import PrefetchError from '@/components/ImportCollection/PrefetchError.vue'
-import WorkspaceSelector from '@/components/ImportCollection/WorkspaceSelector.vue'
-import { useUrlPrefetcher } from '@/components/ImportCollection/hooks/useUrlPrefetcher'
-import { getOpenApiDocumentVersion } from '@/components/ImportCollection/utils/getOpenApiDocumentVersion'
-import { isDocument } from '@/components/ImportCollection/utils/isDocument'
-import { isUrl } from '@/components/ImportCollection/utils/isUrl'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import { ScalarIcon, ScalarModal, useModal } from '@scalar/components'
 import { isLocalUrl } from '@scalar/oas-utils/helpers'
 import { normalize } from '@scalar/openapi-parser'
 import type { OpenAPI } from '@scalar/openapi-types'
 import {
-  type IntegrationThemeId,
   getThemeStyles,
   themeIds,
+  type IntegrationThemeId,
 } from '@scalar/themes'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
+
+import WatchModeToggle from '@/components/CommandPalette/WatchModeToggle.vue'
+import { useUrlPrefetcher } from '@/components/ImportCollection/hooks/useUrlPrefetcher'
+import ImportNowButton from '@/components/ImportCollection/ImportNowButton.vue'
+import IntegrationLogo from '@/components/ImportCollection/IntegrationLogo.vue'
+import PrefetchError from '@/components/ImportCollection/PrefetchError.vue'
+import { getOpenApiDocumentVersion } from '@/components/ImportCollection/utils/getOpenApiDocumentVersion'
+import { isDocument } from '@/components/ImportCollection/utils/isDocument'
+import { isUrl } from '@/components/ImportCollection/utils/isUrl'
+import WorkspaceSelector from '@/components/ImportCollection/WorkspaceSelector.vue'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 const props = defineProps<{
   source: string | null
@@ -202,7 +203,7 @@ function handleImportFinished() {
 
   if (shouldShowIntegrationIcon.value) {
     workspaceMutators.edit(
-      activeWorkspace.value?.uid ?? '',
+      activeWorkspace.value?.uid,
       'themeId',
       integrationThemeId,
     )
@@ -217,22 +218,22 @@ function handleImportFinished() {
     :state="modalState">
     <div
       v-if="themeStyleTag"
-      v-html="themeStyleTag"></div>
+      v-html="themeStyleTag" />
     <div
-      class="flex flex-col h-screen justify-center px-6 overflow-hidden relative md:px-0">
+      class="relative flex h-screen flex-col justify-center overflow-hidden px-6 md:px-0">
       <div class="section-flare">
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
-        <div class="section-flare-item"></div>
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
+        <div class="section-flare-item" />
       </div>
       <!-- Wait until the URL is fetched -->
       <div
-        class="flex items-center flex-col m-auto px-8 py-8 rounded-xl border-1/2 max-w-[380px] w-full transition-opacity"
+        class="border-1/2 m-auto flex w-full max-w-[380px] flex-col items-center rounded-xl px-8 py-8 transition-opacity"
         :class="{ 'opacity-0': prefetchResult.state === 'loading' }">
         <!-- Prefetch error -->
         <!-- Or: Document doesn’t even have an OpenAPI/Swagger version, something is probably wrong -->
@@ -241,7 +242,7 @@ function handleImportFinished() {
             prefetchResult.error && prefetchResult.state === 'idle' && !version
           ">
           <!-- Heading -->
-          <div class="text-center text-md font-bold mb-2 line-clamp-1">
+          <div class="text-md mb-2 line-clamp-1 text-center font-bold">
             No OpenAPI document found
           </div>
           <PrefetchError :url="prefetchResult?.input || props.source" />
@@ -251,8 +252,8 @@ function handleImportFinished() {
           <!-- Integration Logo -->
           <div
             v-if="shouldShowIntegrationIcon"
-            class="flex justify-center items-center mb-2 p-1">
-            <div class="rounded-xl size-10">
+            class="mb-2 flex items-center justify-center p-1">
+            <div class="size-10 rounded-xl">
               <IntegrationLogo :integration="integration" />
             </div>
           </div>
@@ -261,24 +262,24 @@ function handleImportFinished() {
           <img
             v-else-if="companyLogo"
             alt="Logo"
-            class="w-full object-contain mb-2"
+            class="mb-2 w-full object-contain"
             :src="companyLogo" />
 
           <!-- Title -->
           <div
             v-if="!companyLogo"
-            class="text-center text-md font-bold mb-2 line-clamp-1">
+            class="text-md mb-2 line-clamp-1 text-center font-bold">
             {{ title || 'Untitled Collection' }}
           </div>
 
-          <div class="text-c-1 text-sm font-medium text-center text-balance">
+          <div class="text-c-1 text-balance text-center text-sm font-medium">
             Import the OpenAPI document to instantly send API requests. No
             signup required.
           </div>
 
           <!-- Actions -->
           <template v-if="version">
-            <div class="inline-flex flex-col gap-2 items-center z-10 w-full">
+            <div class="z-10 inline-flex w-full flex-col items-center gap-2">
               <ImportNowButton
                 :source="
                   prefetchResult?.url ?? prefetchResult?.content ?? source
@@ -290,20 +291,20 @@ function handleImportFinished() {
             <!-- Select the workspace -->
             <div class="flex justify-center">
               <div
-                class="inline-flex py-1 px-4 items-center text-xs font-medium text-c-3">
+                class="text-c-3 inline-flex items-center px-4 py-1 text-xs font-medium">
                 Import to: <WorkspaceSelector />
               </div>
             </div>
             <!-- Watch Mode -->
             <template v-if="prefetchResult?.url">
-              <div class="text-sm overflow-hidden mt-5 pt-4 border-t-1/2">
+              <div class="border-t-1/2 mt-5 overflow-hidden pt-4 text-sm">
                 <div class="flex items-center justify-center">
                   <WatchModeToggle
                     v-model="watchMode"
                     :disableToolTip="true" />
                 </div>
                 <div
-                  class="pt-0 text-center text-balance font-medium text-xs text-c-3">
+                  class="text-c-3 text-balance pt-0 text-center text-xs font-medium">
                   Automatically update your API client when the OpenAPI document
                   content changes.
                 </div>
@@ -313,10 +314,10 @@ function handleImportFinished() {
         </template>
       </div>
       <!-- Download Link -->
-      <div class="flex flex-col justify-center items-center pb-8">
-        <div class="text-center flex items-center flex-col">
+      <div class="flex flex-col items-center justify-center pb-8">
+        <div class="flex flex-col items-center text-center">
           <div
-            class="mb-2 w-10 h-10 border rounded-[10px] flex items-center justify-center">
+            class="mb-2 flex h-10 w-10 items-center justify-center rounded-[10px] border">
             <a
               href="https://scalar.com/download"
               target="_blank">
@@ -325,9 +326,9 @@ function handleImportFinished() {
                 size="xl" />
             </a>
           </div>
-          <span class="text-c-2 leading-snug text-sm font-medium">
+          <span class="text-c-2 text-sm font-medium leading-snug">
             <a
-              class="hover:text-c-1 underline-offset-2 mb-1 inline-block"
+              class="hover:text-c-1 mb-1 inline-block underline-offset-2"
               href="https://scalar.com/download"
               target="_blank">
               Download Desktop App

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -246,7 +246,7 @@ export const createApiClient = ({
         store.serverMutators.reset()
         store.tagMutators.reset()
 
-        workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'collections', [])
+        workspaceMutators.edit(activeWorkspace.value?.uid, 'collections', [])
 
         updateSpec(newConfig.spec)
       }
@@ -363,7 +363,7 @@ export const createApiClient = ({
       const example = request.requestBody?.content?.[contentType]?.examples[exampleKey]
       if (!example) return
 
-      requestExampleMutators.edit(request.examples[0] ?? '', 'body.raw.value', prettyPrintJson(example.value))
+      requestExampleMutators.edit(request.examples[0], 'body.raw.value', prettyPrintJson(example.value))
     },
   }
 }

--- a/packages/api-client/src/store/collections.ts
+++ b/packages/api-client/src/store/collections.ts
@@ -13,11 +13,7 @@ import { reactive } from 'vue'
 /** Initiate the workspace collections */
 export function createStoreCollections(useLocalStorage: boolean) {
   const collections = reactive<Record<string, Collection>>({})
-  const collectionMutators = mutationFactory(
-    collections,
-    reactive({}),
-    useLocalStorage && LS_KEYS.COLLECTION,
-  )
+  const collectionMutators = mutationFactory(collections, reactive({}), useLocalStorage && LS_KEYS.COLLECTION)
 
   return {
     collections,
@@ -38,14 +34,11 @@ export function extendedCollectionDataFactory({
   tagMutators,
   serverMutators,
 }: StoreContext) {
-  const addCollection = (payload: CollectionPayload, workspaceUid: string) => {
+  const addCollection = (payload: CollectionPayload, workspaceUid: Workspace['uid']) => {
     const collection = collectionSchema.parse(payload)
     const workspace = workspaces[workspaceUid]
     if (workspace) {
-      workspaceMutators.edit(workspaceUid, 'collections', [
-        ...workspace.collections,
-        collection.uid,
-      ])
+      workspaceMutators.edit(workspaceUid, 'collections', [...workspace.collections, collection.uid])
     }
 
     collectionMutators.add(collection)
@@ -78,9 +71,7 @@ export function extendedCollectionDataFactory({
       if (!request) return
 
       requestMutators.delete(uid)
-      request.examples.forEach(
-        (e) => requestExamples[e] && requestExampleMutators.delete(e),
-      )
+      request.examples.forEach((e) => requestExamples[e] && requestExampleMutators.delete(e))
     })
 
     // Remove servers
@@ -103,7 +94,7 @@ export function extendedCollectionDataFactory({
   const addCollectionEnvironment = (
     environmentName: string,
     environment: XScalarEnvironment,
-    collectionUid: string,
+    collectionUid: Collection['uid'],
   ) => {
     const collection = collections[collectionUid]
     if (collection) {
@@ -115,20 +106,13 @@ export function extendedCollectionDataFactory({
     }
   }
 
-  const removeCollectionEnvironment = (
-    environmentName: string,
-    collectionUid: string,
-  ) => {
+  const removeCollectionEnvironment = (environmentName: string, collectionUid: Collection['uid']) => {
     const collection = collections[collectionUid]
     if (collection) {
       const currentEnvironments = collection['x-scalar-environments'] || {}
       if (environmentName in currentEnvironments) {
         delete currentEnvironments[environmentName]
-        collectionMutators.edit(
-          collectionUid,
-          'x-scalar-environments',
-          currentEnvironments,
-        )
+        collectionMutators.edit(collectionUid, 'x-scalar-environments', currentEnvironments)
       }
     }
   }

--- a/packages/api-client/src/store/environment.ts
+++ b/packages/api-client/src/store/environment.ts
@@ -1,8 +1,5 @@
 import type { StoreContext } from '@/store/store-context'
-import {
-  type Environment,
-  environmentSchema,
-} from '@scalar/oas-utils/entities/environment'
+import { type Environment, environmentSchema } from '@scalar/oas-utils/entities/environment'
 import { LS_KEYS } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { reactive } from 'vue'
@@ -11,11 +8,7 @@ import { reactive } from 'vue'
 export function createStoreEnvironments(useLocalStorage: boolean) {
   /** Initialize default environment */
   const environments = reactive<Record<string, Environment>>({})
-  const environmentMutators = mutationFactory(
-    environments,
-    reactive({}),
-    useLocalStorage && LS_KEYS.ENVIRONMENT,
-  )
+  const environmentMutators = mutationFactory(environments, reactive({}), useLocalStorage && LS_KEYS.ENVIRONMENT)
 
   // Add default environment
   environmentMutators.add(
@@ -35,11 +28,9 @@ export function createStoreEnvironments(useLocalStorage: boolean) {
 }
 
 /** Extended environment data factory where workspace access is needed */
-export function extendedEnvironmentDataFactory({
-  environmentMutators,
-}: StoreContext) {
+export function extendedEnvironmentDataFactory({ environmentMutators }: StoreContext) {
   /** prevent deletion of the default environment */
-  const deleteEnvironment = (uid: string) => {
+  const deleteEnvironment = (uid: Environment['uid']) => {
     if (uid === 'default') {
       console.warn('Default environment cannot be deleted.')
       return

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -1,22 +1,16 @@
 import { type ErrorResponse, normalizeError } from '@/libs'
 import type { StoreContext } from '@/store/store-context'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { createHash, fetchSpecFromUrl } from '@scalar/oas-utils/helpers'
-import {
-  type ImportSpecToWorkspaceArgs,
-  importSpecToWorkspace,
-} from '@scalar/oas-utils/transforms'
+import { type ImportSpecToWorkspaceArgs, importSpecToWorkspace } from '@scalar/oas-utils/transforms'
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import { toRaw } from 'vue'
 
 /** Maps the specs by URL */
-export const specDictionary: Record<
-  string,
-  { hash: number; schema: OpenAPIV3.Document | OpenAPIV3_1.Document }
-> = {}
+export const specDictionary: Record<string, { hash: number; schema: OpenAPIV3.Document | OpenAPIV3_1.Document }> = {}
 
-type ImportSpecFileArgs = ImportSpecToWorkspaceArgs &
-  Pick<ReferenceConfiguration, 'servers'>
+type ImportSpecFileArgs = ImportSpecToWorkspaceArgs & Pick<ReferenceConfiguration, 'servers'>
 
 /** Generate the import functions from a store context */
 export function importSpecFileFactory({
@@ -59,13 +53,11 @@ export function importSpecFileFactory({
     workspaceEntities.requests.forEach((r) => requestMutators.add(r))
     workspaceEntities.tags.forEach((t) => tagMutators.add(t))
     workspaceEntities.servers.forEach((s) => serverMutators.add(s))
-    workspaceEntities.securitySchemes.forEach((s) =>
-      securitySchemeMutators.add(s),
-    )
+    workspaceEntities.securitySchemes.forEach((s) => securitySchemeMutators.add(s))
     collectionMutators.add(workspaceEntities.collection)
 
     // Add the collection UID to the workspace
-    workspaceMutators.edit(workspaceUid, 'collections', [
+    workspaceMutators.edit(workspaceUid as Workspace['uid'], 'collections', [
       ...(workspaces[workspaceUid]?.collections ?? []),
       workspaceEntities.collection.uid,
     ])
@@ -81,11 +73,7 @@ export function importSpecFileFactory({
   async function importSpecFromUrl(
     url: string,
     workspaceUid: string,
-    {
-      proxyUrl,
-      ...options
-    }: Omit<ImportSpecFileArgs, 'documentUrl'> &
-      Pick<ReferenceConfiguration, 'proxyUrl'> = {},
+    { proxyUrl, ...options }: Omit<ImportSpecFileArgs, 'documentUrl'> & Pick<ReferenceConfiguration, 'proxyUrl'> = {},
   ): Promise<ErrorResponse<Awaited<ReturnType<typeof importSpecFile>>>> {
     try {
       const spec = await fetchSpecFromUrl(url, proxyUrl)

--- a/packages/api-client/src/store/router-params.ts
+++ b/packages/api-client/src/store/router-params.ts
@@ -1,30 +1,31 @@
 import { PathId } from '@/router'
+import type { Cookie } from '@scalar/oas-utils/entities/cookie'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
+import type { Collection, Request, RequestExample, Server } from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import type { Router } from 'vue-router'
-
-export type RouterPathParams = Record<PathId, string>
 
 /** Getter function for router parameters */
 export function getRouterParams(router?: Router) {
   return () => {
     const pathParams = {
-      [PathId.Collection]: 'default',
-      [PathId.Environment]: 'default',
-      [PathId.Request]: 'default',
-      [PathId.Examples]: 'default',
-      [PathId.Schema]: 'default',
-      [PathId.Cookies]: 'default',
-      [PathId.Servers]: 'default',
-      [PathId.Workspace]: 'default',
-      [PathId.Settings]: 'default',
-    } satisfies RouterPathParams
+      [PathId.Collection]: 'default' as Collection['uid'],
+      [PathId.Environment]: 'default' as Environment['uid'],
+      [PathId.Request]: 'default' as Request['uid'],
+      [PathId.Examples]: 'default' as RequestExample['uid'],
+      [PathId.Schema]: 'default' as string,
+      [PathId.Cookies]: 'default' as Cookie['uid'],
+      [PathId.Servers]: 'default' as Server['uid'],
+      [PathId.Workspace]: 'default' as Workspace['uid'],
+      [PathId.Settings]: 'default' as string,
+    } as const
 
     const currentRoute = router?.currentRoute.value
 
     if (currentRoute) {
-      Object.values(PathId).forEach((k) => {
-        if (currentRoute.params[k]) {
-          pathParams[k] = currentRoute.params[k] as string
-        }
+      ;(Object.keys(pathParams) as (keyof typeof pathParams)[]).forEach((k) => {
+        // @ts-expect-error this gives us good types without redoing PathId :)
+        if (currentRoute.params[k]) pathParams[k] = currentRoute.params[k]
       })
     }
 

--- a/packages/api-client/src/store/security-schemes.ts
+++ b/packages/api-client/src/store/security-schemes.ts
@@ -1,5 +1,10 @@
 import type { StoreContext } from '@/store/store-context'
-import { type SecurityScheme, type SecuritySchemePayload, securitySchemeSchema } from '@scalar/oas-utils/entities/spec'
+import {
+  type Collection,
+  type SecurityScheme,
+  type SecuritySchemePayload,
+  securitySchemeSchema,
+} from '@scalar/oas-utils/entities/spec'
 import { LS_KEYS } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { reactive } from 'vue'
@@ -31,7 +36,7 @@ export function extendedSecurityDataFactory({
   const addSecurityScheme = (
     payload: SecuritySchemePayload,
     /** Schemes will always live at the collection level */
-    collectionUid: string,
+    collectionUid: Collection['uid'],
   ) => {
     const scheme = securitySchemeSchema.parse(payload)
     securitySchemeMutators.add(scheme)

--- a/packages/api-client/src/store/servers.ts
+++ b/packages/api-client/src/store/servers.ts
@@ -1,5 +1,7 @@
 import type { StoreContext } from '@/store/store-context'
 import {
+  type Collection,
+  type Request,
   type Server,
   type ServerPayload,
   serverSchema,
@@ -12,11 +14,7 @@ import { reactive } from 'vue'
 export function createStoreServers(useLocalStorage: boolean) {
   const servers = reactive<Record<string, Server>>({})
 
-  const serverMutators = mutationFactory(
-    servers,
-    reactive({}),
-    useLocalStorage && LS_KEYS.SERVER,
-  )
+  const serverMutators = mutationFactory(servers, reactive({}), useLocalStorage && LS_KEYS.SERVER)
 
   return {
     servers,
@@ -41,17 +39,14 @@ export function extendedServerDataFactory({
 
     // Add to collection
     if (collections[parentUid]) {
-      collectionMutators.edit(parentUid, 'servers', [
+      collectionMutators.edit(parentUid as Collection['uid'], 'servers', [
         ...collections[parentUid].servers,
         server.uid,
       ])
     }
     // Add to request
     else if (requests[parentUid]) {
-      requestMutators.edit(parentUid, 'servers', [
-        ...requests[parentUid].servers,
-        server.uid,
-      ])
+      requestMutators.edit(parentUid as Request['uid'], 'servers', [...requests[parentUid].servers, server.uid])
     }
 
     // Add to servers
@@ -61,7 +56,7 @@ export function extendedServerDataFactory({
   }
 
   /** Delete a server */
-  const deleteServer = (serverUid: string, collectionUid: string) => {
+  const deleteServer = (serverUid: Server['uid'], collectionUid: Collection['uid']) => {
     if (!collections[collectionUid]) return
 
     // Remove from parent collection

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -1,38 +1,17 @@
-import {
-  createStoreCollections,
-  extendedCollectionDataFactory,
-} from '@/store/collections'
+import { createStoreCollections, extendedCollectionDataFactory } from '@/store/collections'
 import { createStoreCookies } from '@/store/cookies'
-import {
-  createStoreEnvironments,
-  extendedEnvironmentDataFactory,
-} from '@/store/environment'
+import { createStoreEnvironments, extendedEnvironmentDataFactory } from '@/store/environment'
 import { createStoreEvents } from '@/store/events'
 import { importSpecFileFactory } from '@/store/import-spec'
-import {
-  createStoreRequestExamples,
-  extendedExampleDataFactory,
-} from '@/store/request-example'
-import {
-  createStoreRequests,
-  extendedRequestDataFactory,
-} from '@/store/requests'
-import {
-  createStoreSecuritySchemes,
-  extendedSecurityDataFactory,
-} from '@/store/security-schemes'
+import { createStoreRequestExamples, extendedExampleDataFactory } from '@/store/request-example'
+import { createStoreRequests, extendedRequestDataFactory } from '@/store/requests'
+import { createStoreSecuritySchemes, extendedSecurityDataFactory } from '@/store/security-schemes'
 import { createStoreServers, extendedServerDataFactory } from '@/store/servers'
 import type { StoreContext } from '@/store/store-context'
 import { createStoreTags, extendedTagDataFactory } from '@/store/tags'
-import {
-  createStoreWorkspaces,
-  extendedWorkspaceDataFactory,
-} from '@/store/workspace'
+import { createStoreWorkspaces, extendedWorkspaceDataFactory } from '@/store/workspace'
 import { useModal } from '@scalar/components'
-import type {
-  RequestEvent,
-  SecurityScheme,
-} from '@scalar/oas-utils/entities/spec'
+import type { RequestEvent, SecurityScheme } from '@scalar/oas-utils/entities/spec'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import { type InjectionKey, inject, reactive, ref, toRaw } from 'vue'
@@ -60,10 +39,7 @@ type CreateWorkspaceStoreOptions = {
   themeId: ReferenceConfiguration['theme']
   /** Specifies the integration being used. This is primarily for internal purposes and should not be manually set. */
   integration: ReferenceConfiguration['_integration']
-} & Pick<
-  ReferenceConfiguration,
-  'proxyUrl' | 'showSidebar' | 'hideClientButton'
->
+} & Pick<ReferenceConfiguration, 'proxyUrl' | 'showSidebar' | 'hideClientButton'>
 
 /**
  /**
@@ -83,20 +59,15 @@ export const createWorkspaceStore = ({
   // ---------------------------------------------------------------------------
   // Initialize all storage objects
 
-  const { collections, collectionMutators } =
-    createStoreCollections(useLocalStorage)
+  const { collections, collectionMutators } = createStoreCollections(useLocalStorage)
   const { tags, tagMutators } = createStoreTags(useLocalStorage)
   const { requests, requestMutators } = createStoreRequests(useLocalStorage)
-  const { requestExamples, requestExampleMutators } =
-    createStoreRequestExamples(useLocalStorage)
+  const { requestExamples, requestExampleMutators } = createStoreRequestExamples(useLocalStorage)
   const { cookies, cookieMutators } = createStoreCookies(useLocalStorage)
-  const { environments, environmentMutators } =
-    createStoreEnvironments(useLocalStorage)
+  const { environments, environmentMutators } = createStoreEnvironments(useLocalStorage)
   const { servers, serverMutators } = createStoreServers(useLocalStorage)
-  const { securitySchemes, securitySchemeMutators } =
-    createStoreSecuritySchemes(useLocalStorage)
-  const { workspaces, workspaceMutators } =
-    createStoreWorkspaces(useLocalStorage)
+  const { securitySchemes, securitySchemeMutators } = createStoreSecuritySchemes(useLocalStorage)
+  const { workspaces, workspaceMutators } = createStoreWorkspaces(useLocalStorage)
 
   // ---------------------------------------------------------------------------
   // Extended Mutators - Adds side effects as needed
@@ -123,34 +94,24 @@ export const createWorkspaceStore = ({
     workspaceMutators,
   }
   const { addTag, deleteTag } = extendedTagDataFactory(storeContext)
-  const { addRequest, deleteRequest, findRequestParents } =
-    extendedRequestDataFactory(storeContext, addTag)
+  const { addRequest, deleteRequest, findRequestParents } = extendedRequestDataFactory(storeContext, addTag)
   const { deleteEnvironment } = extendedEnvironmentDataFactory(storeContext)
   const { addServer, deleteServer } = extendedServerDataFactory(storeContext)
-  const { addCollection, deleteCollection } =
-    extendedCollectionDataFactory(storeContext)
-  const { addRequestExample, deleteRequestExample } =
-    extendedExampleDataFactory(storeContext)
-  const { addWorkspace, deleteWorkspace } =
-    extendedWorkspaceDataFactory(storeContext)
-  const { addSecurityScheme, deleteSecurityScheme } =
-    extendedSecurityDataFactory(storeContext)
-  const { addCollectionEnvironment, removeCollectionEnvironment } =
-    extendedCollectionDataFactory(storeContext)
+  const { addCollection, deleteCollection } = extendedCollectionDataFactory(storeContext)
+  const { addRequestExample, deleteRequestExample } = extendedExampleDataFactory(storeContext)
+  const { addWorkspace, deleteWorkspace } = extendedWorkspaceDataFactory(storeContext)
+  const { addSecurityScheme, deleteSecurityScheme } = extendedSecurityDataFactory(storeContext)
+  const { addCollectionEnvironment, removeCollectionEnvironment } = extendedCollectionDataFactory(storeContext)
 
   // ---------------------------------------------------------------------------
   // OTHER HELPER DATA
   /** Running request history list */
   const requestHistory = reactive<RequestEvent[]>([])
 
-  const { importSpecFile, importSpecFromUrl } =
-    importSpecFileFactory(storeContext)
+  const { importSpecFile, importSpecFromUrl } = importSpecFileFactory(storeContext)
 
   /** Helper function to manage the sidebar width */
-  const sidebarWidth = ref(
-    (useLocalStorage ? localStorage?.getItem('sidebarWidth') : undefined) ||
-      '280px',
-  )
+  const sidebarWidth = ref((useLocalStorage ? localStorage?.getItem('sidebarWidth') : undefined) || '280px')
 
   // Set the sidebar width
   const setSidebarWidth = (width: string) => {
@@ -164,7 +125,7 @@ export const createWorkspaceStore = ({
   const modalState = useModal()
 
   // Set some defaults on all workspaces
-  Object.keys(workspaces).forEach((uid) => {
+  Object.values(workspaces).forEach(({ uid }) => {
     if (proxyUrl) workspaceMutators.edit(uid, 'proxyUrl', proxyUrl)
     if (themeId) workspaceMutators.edit(uid, 'themeId', themeId)
   })

--- a/packages/api-client/src/store/workspace.ts
+++ b/packages/api-client/src/store/workspace.ts
@@ -1,12 +1,6 @@
 import type { StoreContext } from '@/store/store-context'
-import {
-  collectionSchema,
-  requestExampleSchema,
-} from '@scalar/oas-utils/entities/spec'
-import {
-  type Workspace,
-  workspaceSchema,
-} from '@scalar/oas-utils/entities/workspace'
+import { collectionSchema, requestExampleSchema } from '@scalar/oas-utils/entities/spec'
+import { type Workspace, workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { LS_KEYS } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { reactive } from 'vue'
@@ -17,11 +11,7 @@ import { createInitialRequest } from './requests'
 export function createStoreWorkspaces(useLocalStorage: boolean) {
   /** Active workspace object (will be associated with an entry in the workspace collection) */
   const workspaces = reactive<Record<string, Workspace>>({})
-  const workspaceMutators = mutationFactory(
-    workspaces,
-    reactive({}),
-    useLocalStorage && LS_KEYS.WORKSPACE,
-  )
+  const workspaceMutators = mutationFactory(workspaces, reactive({}), useLocalStorage && LS_KEYS.WORKSPACE)
 
   return {
     workspaces,
@@ -71,7 +61,7 @@ export function extendedWorkspaceDataFactory({
   }
 
   /** Prevent deletion of the default workspace */
-  const deleteWorkspace = (uid: string) => {
+  const deleteWorkspace = (uid: Workspace['uid']) => {
     if (Object.keys(workspaces).length <= 1) {
       console.warn('The last workspace cannot be deleted.')
       return

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { cookieSchema, type Cookie } from '@scalar/oas-utils/entities/cookie'
+import type { Path, PathValue } from '@scalar/object-utils/nested'
 import { computed } from 'vue'
 
 import Form from '@/components/Form/Form.vue'
@@ -19,7 +20,7 @@ const fields = [
 
 const activeCookie = computed<Cookie>(
   () =>
-    cookies[activeCookieId.value as string] ||
+    cookies[activeCookieId.value] ||
     cookieSchema.parse({
       name: '',
       value: '',
@@ -27,10 +28,11 @@ const activeCookie = computed<Cookie>(
       path: '',
     }),
 )
-const updateCookie = (key: any, value: any) => {
-  if (activeCookieId.value) {
-    cookieMutators.edit(activeCookieId.value, key, value)
-  }
+const updateCookie = <P extends Path<Cookie>>(
+  key: P,
+  value: NonNullable<PathValue<Cookie, P>>,
+) => {
+  cookieMutators.edit(activeCookieId.value, key, value)
 }
 </script>
 <template>

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -1,4 +1,9 @@
 <script setup lang="ts">
+import { useModal } from '@scalar/components'
+import { cookieSchema, type Cookie } from '@scalar/oas-utils/entities/cookie'
+import { computed, onBeforeUnmount, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
 import { Sidebar } from '@/components'
 import EmptyState from '@/components/EmptyState.vue'
 import SidebarButton from '@/components/Sidebar/SidebarButton.vue'
@@ -9,10 +14,6 @@ import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import type { HotKeyEvent } from '@/libs'
 import { PathId } from '@/routes'
 import { useActiveEntities, useWorkspace } from '@/store'
-import { useModal } from '@scalar/components'
-import { type Cookie, cookieSchema } from '@scalar/oas-utils/entities/cookie'
-import { computed, onBeforeUnmount, onMounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
 
 import CookieForm from './CookieForm.vue'
 import CookieModal from './CookieModal.vue'
@@ -41,7 +42,7 @@ const addCookieHandler = (cookieData: {
   cookieMutators.add(cookie)
 
   // Attach cookie to workspace
-  workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'cookies', [
+  workspaceMutators.edit(activeWorkspace.value?.uid, 'cookies', [
     ...(activeWorkspace.value?.cookies ?? []),
     cookie.uid,
   ])
@@ -55,11 +56,11 @@ const addCookieHandler = (cookieData: {
   })
 }
 
-const removeCookie = (uid: string) => {
+const removeCookie = (uid: Cookie['uid']) => {
   cookieMutators.delete(uid)
 
   // Delete cookie from workspace
-  workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'cookies', [
+  workspaceMutators.edit(activeWorkspace.value?.uid, 'cookies', [
     ...(activeWorkspace.value?.cookies ?? []).filter((c) => c !== uid),
   ])
 
@@ -140,8 +141,8 @@ const hasCookies = computed(
             <li
               v-for="cookie in Object.values(cookies)"
               :key="cookie.uid"
-              class="flex flex-col gap-1/2">
-              <div class="mb-[.5px] last:mb-0 relative">
+              class="gap-1/2 flex flex-col">
+              <div class="relative mb-[.5px] last:mb-0">
                 <SidebarListElement
                   :key="cookie.uid"
                   class="text-xs"
@@ -160,7 +161,7 @@ const hasCookies = computed(
         <SidebarButton
           :click="openCookieModal"
           hotkey="N">
-          <template #title>Add Cookie</template>
+          <template #title> Add Cookie </template>
         </SidebarButton>
       </template>
     </Sidebar>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -1,4 +1,15 @@
 <script setup lang="ts">
+import {
+  ScalarButton,
+  ScalarIcon,
+  ScalarModal,
+  useModal,
+} from '@scalar/components'
+import { LibraryIcon } from '@scalar/icons'
+import { useToasts } from '@scalar/use-toasts'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
 import EditSidebarListElement from '@/components/Sidebar/Actions/EditSidebarListElement.vue'
 import Sidebar from '@/components/Sidebar/Sidebar.vue'
@@ -13,16 +24,6 @@ import type { HotKeyEvent } from '@/libs'
 import { PathId } from '@/routes'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import {
-  ScalarButton,
-  ScalarIcon,
-  ScalarModal,
-  useModal,
-} from '@scalar/components'
-import { LibraryIcon } from '@scalar/icons'
-import { useToasts } from '@scalar/use-toasts'
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
 
 import EnvironmentColorModal from './EnvironmentColorModal.vue'
 import EnvironmentModal from './EnvironmentModal.vue'
@@ -114,7 +115,7 @@ function handleEnvironmentUpdate(raw: string) {
 
     if (currentEnvironmentId.value === 'default') {
       workspaceMutators.edit(
-        activeWorkspace.value?.uid ?? '',
+        activeWorkspace.value?.uid,
         'environments',
         updatedValue,
       )
@@ -390,14 +391,14 @@ function handleRename(newName: string) {
             <li
               v-for="collection in activeWorkspaceCollections"
               :key="collection.uid"
-              class="flex flex-col gap-1/2">
+              class="gap-1/2 flex flex-col">
               <button
-                class="flex font-medium gap-1.5 group items-center p-1.5 text-left text-sm w-full break-words rounded hover:bg-b-2"
+                class="hover:bg-b-2 group flex w-full items-center gap-1.5 break-words rounded p-1.5 text-left text-sm font-medium"
                 type="button"
                 @click="toggleSidebarFolder(collection.uid)">
-                <span class="flex h-5 items-center justify-center max-w-[14px]">
+                <span class="flex h-5 max-w-[14px] items-center justify-center">
                   <LibraryIcon
-                    class="min-w-3.5 text-sidebar-c-2 size-3.5 stroke-2 group-hover:hidden"
+                    class="text-sidebar-c-2 size-3.5 min-w-3.5 stroke-2 group-hover:hidden"
                     :src="
                       collection['x-scalar-icon'] || 'interface-content-folder'
                     " />
@@ -406,7 +407,7 @@ function handleRename(newName: string) {
                       'rotate-90': collapsedSidebarFolders[collection.uid],
                     }">
                     <ScalarIcon
-                      class="text-c-3 hidden text-sm group-hover:block hover:text-c-1"
+                      class="text-c-3 hover:text-c-1 hidden text-sm group-hover:block"
                       icon="ChevronRight"
                       size="md" />
                   </div>
@@ -416,7 +417,7 @@ function handleRename(newName: string) {
               <div
                 v-show="showChildren(collection.uid)"
                 :class="{
-                  'before:bg-border before:pointer-events-none before:z-1 before:absolute before:left-3 before:top-0 before:h-[calc(100%_+_.5px)] last:before:h-full before:w-[.5px] mb-[.5px] last:mb-0 relative':
+                  'before:bg-border before:z-1 relative mb-[.5px] before:pointer-events-none before:absolute before:left-3 before:top-0 before:h-[calc(100%_+_.5px)] before:w-[.5px] last:mb-0 last:before:h-full':
                     Object.keys(collection['x-scalar-environments'] || {})
                       .length > 0,
                 }">
@@ -449,7 +450,7 @@ function handleRename(newName: string) {
                     Object.keys(collection['x-scalar-environments'] || {})
                       .length === 0
                   "
-                  class="flex gap-1.5 h-8 text-c-1 pl-6 py-0 justify-start text-xs w-full hover:bg-b-2"
+                  class="text-c-1 hover:bg-b-2 flex h-8 w-full justify-start gap-1.5 py-0 pl-6 text-xs"
                   variant="ghost"
                   @click="openEnvironmentModal(collection.uid)">
                   <ScalarIcon
@@ -466,7 +467,7 @@ function handleRename(newName: string) {
         <SidebarButton
           :click="openEnvironmentModal"
           hotkey="N">
-          <template #title>Add Environment</template>
+          <template #title> Add Environment </template>
         </SidebarButton>
       </template>
     </Sidebar>
@@ -481,7 +482,7 @@ function handleRename(newName: string) {
         </template>
         <CodeInput
           v-if="currentEnvironmentId"
-          class="border-t pl-px pr-2 md:px-4 py-2"
+          class="border-t py-2 pl-px pr-2 md:px-4"
           isCopyable
           language="json"
           lineNumbers

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -6,6 +6,7 @@ import {
   useModal,
 } from '@scalar/components'
 import { LibraryIcon } from '@scalar/icons'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
@@ -71,7 +72,7 @@ function environmentNameToast(
 function addEnvironment(environment: {
   name: string
   color: string
-  collectionId: string | undefined
+  collectionId: Collection['uid'] | undefined
 }) {
   const environmentNameUsed = activeWorkspaceCollections.value.some(
     (collection) => {

--- a/packages/api-client/src/views/Environment/EnvironmentModal.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentModal.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import CommandActionForm from '@/components/CommandPalette/CommandActionForm.vue'
-import CommandActionInput from '@/components/CommandPalette/CommandActionInput.vue'
-import { useWorkspace } from '@/store'
 import {
-  type ModalState,
   ScalarButton,
-  type ScalarComboboxOption,
   ScalarIcon,
   ScalarListbox,
   ScalarModal,
+  type ModalState,
 } from '@scalar/components'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref, watch } from 'vue'
+
+import CommandActionForm from '@/components/CommandPalette/CommandActionForm.vue'
+import CommandActionInput from '@/components/CommandPalette/CommandActionInput.vue'
+import { useWorkspace } from '@/store'
 
 import EnvironmentColors from './EnvironmentColors.vue'
 
@@ -30,7 +30,7 @@ const emit = defineEmits<{
       name: string
       color: string
       type: string
-      collectionId: string | undefined
+      collectionId: Collection['uid'] | undefined
     },
   ): void
 }>()
@@ -49,7 +49,7 @@ const collections = computed(() => [
     })),
 ])
 
-const selectedEnvironment = ref<ScalarComboboxOption | undefined>(
+const selectedEnvironment = ref(
   collections.value.find((collection) => collection.id === props.collectionId),
 )
 
@@ -108,7 +108,7 @@ const redirectToCreateCollection = () => {
       :disabled="!selectedEnvironment"
       @cancel="emit('cancel')"
       @submit="handleSubmit">
-      <div class="flex gap-2 items-start">
+      <div class="flex items-start gap-2">
         <EnvironmentColors
           :activeColor="selectedColor"
           class="peer"
@@ -116,7 +116,7 @@ const redirectToCreateCollection = () => {
           @select="handleColorSelect" />
         <CommandActionInput
           v-model="environmentName"
-          class="!p-0 peer-has-[.color-selector]:hidden -mt-[.5px]"
+          class="-mt-[.5px] !p-0 peer-has-[.color-selector]:hidden"
           placeholder="Environment name" />
       </div>
       <template #options>
@@ -126,7 +126,7 @@ const redirectToCreateCollection = () => {
           placeholder="Select Type">
           <ScalarButton
             v-if="collections.length > 0"
-            class="justify-between p-2 max-h-8 gap-1 text-xs hover:bg-b-2 w-fit"
+            class="hover:bg-b-2 max-h-8 w-fit justify-between gap-1 p-2 text-xs"
             variant="outlined">
             <span :class="selectedEnvironment ? 'text-c-1' : 'text-c-3'">{{
               selectedEnvironment
@@ -140,14 +140,14 @@ const redirectToCreateCollection = () => {
           </ScalarButton>
           <ScalarButton
             v-else
-            class="justify-between p-2 max-h-8 gap-1 text-xs hover:bg-b-2"
+            class="hover:bg-b-2 max-h-8 justify-between gap-1 p-2 text-xs"
             variant="outlined"
             @click="redirectToCreateCollection">
             <span class="text-c-1">Create Collection</span>
           </ScalarButton>
         </ScalarListbox>
       </template>
-      <template #submit>Add Environment</template>
+      <template #submit> Add Environment </template>
     </CommandActionForm>
   </ScalarModal>
 </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { DataTableCell, DataTableRow } from '@/components/DataTable'
-import { useWorkspace } from '@/store/store'
 import type { Workspace } from '@scalar/oas-utils/entities'
 import type {
   Collection,
@@ -9,6 +7,9 @@ import type {
 } from '@scalar/oas-utils/entities/spec'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import { capitalize, computed, ref } from 'vue'
+
+import { DataTableCell, DataTableRow } from '@/components/DataTable'
+import { useWorkspace } from '@/store/store'
 
 import OAuth2 from './OAuth2.vue'
 import RequestAuthDataTableInput from './RequestAuthDataTableInput.vue'
@@ -57,7 +58,10 @@ const generateLabel = (scheme: SecurityScheme) => {
 }
 
 /** Update the scheme */
-const updateScheme = <U extends string, P extends Path<SecurityScheme>>(
+const updateScheme = <
+  U extends SecurityScheme['uid'],
+  P extends Path<SecurityScheme>,
+>(
   uid: U,
   path: P,
   value: NonNullable<PathValue<SecurityScheme, P>>,
@@ -75,7 +79,7 @@ const updateScheme = <U extends string, P extends Path<SecurityScheme>>(
         'request-example-references-header': layout === 'reference',
       }">
       <DataTableCell
-        class="text-c-3 pl-2 font-medium flex items-center"
+        class="text-c-3 flex items-center pl-2 font-medium"
         :class="
           layout === 'reference' && `border-t ${index !== 0 ? 'mt-2' : ''}`
         ">
@@ -150,23 +154,23 @@ const updateScheme = <U extends string, P extends Path<SecurityScheme>>(
       <DataTableRow>
         <div
           v-if="Object.keys(scheme.flows).length > 1"
-          class="border-t min-h-8 flex text-sm">
-          <div class="flex h-8 gap-2.5 px-3 max-w-full overflow-x-auto">
+          class="flex min-h-8 border-t text-sm">
+          <div class="flex h-8 max-w-full gap-2.5 overflow-x-auto px-3">
             <button
               v-for="(_, key, ind) in scheme?.flows"
               :key="key"
-              class="floating-bg py-1 text-sm border-b-[1px] border-transparent relative cursor-pointer font-medium text-c-3"
+              class="floating-bg text-c-3 relative cursor-pointer border-b-[1px] border-transparent py-1 text-sm font-medium"
               :class="{
-                '!text-c-1 !border-current border-b-[1px] !rounded-none':
+                '!text-c-1 !rounded-none border-b-[1px] !border-current':
                   layout !== 'reference' &&
                   (activeFlow === key || (ind === 0 && !activeFlow)),
-                '!text-c-1 !border-current border-b-[1px] !rounded-none opacity-100':
+                '!text-c-1 !rounded-none border-b-[1px] !border-current opacity-100':
                   layout === 'reference' &&
                   (activeFlow === key || (ind === 0 && !activeFlow)),
               }"
               type="button"
               @click="activeFlow = key">
-              <span class="z-10 relative">{{ key }}</span>
+              <span class="relative z-10">{{ key }}</span>
             </button>
           </div>
         </div>
@@ -187,7 +191,7 @@ const updateScheme = <U extends string, P extends Path<SecurityScheme>>(
     <!-- Open ID Connect -->
     <template v-else-if="scheme?.type === 'openIdConnect'">
       <div
-        class="border-t text-c-3 px-4 text-sm min-h-16 justify-center flex items-center bg-b-1">
+        class="text-c-3 bg-b-1 flex min-h-16 items-center justify-center border-t px-4 text-sm">
         Coming soon
       </div>
     </template>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -11,7 +11,7 @@ import {
   type DraggingItem,
   type HoveredItem,
 } from '@scalar/draggable'
-import type { Request } from '@scalar/oas-utils/entities/spec'
+import type { Collection, Request } from '@scalar/oas-utils/entities/spec'
 import { shouldIgnoreEntity } from '@scalar/oas-utils/helpers'
 import { computed, ref } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
@@ -115,9 +115,9 @@ const item = computed<SidebarItem>(() => {
       warning:
         'This cannot be undone. You’re about to delete the tag and all requests inside it',
       edit: (name: string) => tagMutators.edit(tag.uid, 'name', name),
-      delete: () => {
-        if (parentUids[0]) tagMutators.delete(tag, parentUids[0])
-      },
+      delete: () =>
+        parentUids[0] &&
+        tagMutators.delete(tag, parentUids[0] as Collection['uid']),
     }
 
   if (request)
@@ -137,11 +137,9 @@ const item = computed<SidebarItem>(() => {
       children: request.examples.slice(1),
       edit: (name: string) =>
         requestMutators.edit(request.uid, 'summary', name),
-      delete: () => {
-        if (parentUids[0]) {
-          requestMutators.delete(request, parentUids[0])
-        }
-      },
+      delete: () =>
+        parentUids[0] &&
+        requestMutators.delete(request, parentUids[0] as Collection['uid']),
     }
 
   if (requestExample?.requestUid)

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
-import EditSidebarListElement from '@/components/Sidebar/Actions/EditSidebarListElement.vue'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import {
   ScalarButton,
   ScalarDropdown,
@@ -14,14 +10,20 @@ import {
   ScalarTooltip,
   useModal,
 } from '@scalar/components'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
+
+import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
+import EditSidebarListElement from '@/components/Sidebar/Actions/EditSidebarListElement.vue'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 const { activeWorkspace } = useActiveEntities()
 const { workspaces, workspaceMutators, events } = useWorkspace()
 const { push } = useRouter()
 
-const updateSelected = (uid: string) => {
+const updateSelected = (uid: Workspace['uid']) => {
   if (uid === activeWorkspace.value?.uid) return
 
   push({
@@ -38,11 +40,11 @@ const createNewWorkspace = () =>
   events.commandPalette.emit({ commandName: 'Create Workspace' })
 
 const tempName = ref('')
-const tempUid = ref('')
+const tempUid = ref('' as Workspace['uid'])
 const editModal = useModal()
 const deleteModal = useModal()
 
-const openRenameModal = (uid: string) => {
+const openRenameModal = (uid: Workspace['uid']) => {
   const workspace = workspaces[uid]
   if (!workspace) return
 
@@ -60,7 +62,7 @@ const handleWorkspaceEdit = (name: string) => {
   editModal.hide()
 }
 
-const openDeleteModal = (uid: string) => {
+const openDeleteModal = (uid: Workspace['uid']) => {
   const workspace = workspaces[uid]
   if (!workspace) return
 
@@ -96,13 +98,13 @@ const deleteWorkspace = async () => {
 
 <template>
   <div>
-    <div class="flex items-center text-sm w-[inherit]">
+    <div class="flex w-[inherit] items-center text-sm">
       <ScalarDropdown>
         <ScalarButton
-          class="font-normal h-full justify-start line-clamp-1 py-1.5 px-1.5 text-c-1 hover:bg-b-2 w-fit"
+          class="text-c-1 hover:bg-b-2 line-clamp-1 h-full w-fit justify-start px-1.5 py-1.5 font-normal"
           fullWidth
           variant="ghost">
-          <div class="font-bold m-0 flex gap-1.5 items-center">
+          <div class="m-0 flex items-center gap-1.5 font-bold">
             <h2 class="line-clamp-1 text-left">
               {{ activeWorkspace?.name }}
             </h2>
@@ -114,17 +116,17 @@ const deleteWorkspace = async () => {
           <ScalarDropdownItem
             v-for="(workspace, uid) in workspaces"
             :key="uid"
-            class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden w-full"
-            @click.stop="updateSelected(uid)">
+            class="group/item flex w-full items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap"
+            @click.stop="updateSelected(workspace.uid)">
             <ScalarListboxCheckbox :selected="activeWorkspace?.uid === uid" />
-            <span class="text-ellipsis overflow-hidden">{{
+            <span class="overflow-hidden text-ellipsis">{{
               workspace.name
             }}</span>
             <ScalarDropdown
               placement="right-start"
               teleport>
               <ScalarButton
-                class="px-0.5 py-0 hover:bg-b-3 group-hover/item:flex aspect-square ml-auto -mr-1 h-fit"
+                class="hover:bg-b-3 -mr-1 ml-auto aspect-square h-fit px-0.5 py-0 group-hover/item:flex"
                 size="sm"
                 type="button"
                 variant="ghost">
@@ -135,8 +137,8 @@ const deleteWorkspace = async () => {
               <template #items>
                 <ScalarDropdownItem
                   class="flex gap-2"
-                  @mousedown="openRenameModal(uid)"
-                  @touchend.prevent="openRenameModal(uid)">
+                  @mousedown="openRenameModal(workspace.uid)"
+                  @touchend.prevent="openRenameModal(workspace.uid)">
                   <ScalarIcon
                     class="inline-flex"
                     icon="Edit"
@@ -150,7 +152,7 @@ const deleteWorkspace = async () => {
                   side="bottom">
                   <template #trigger>
                     <ScalarDropdownItem
-                      class="flex gap-2 w-full"
+                      class="flex w-full gap-2"
                       disabled
                       @mousedown.prevent
                       @touchend.prevent>
@@ -164,8 +166,8 @@ const deleteWorkspace = async () => {
                   </template>
                   <template #content>
                     <div
-                      class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 z-context p-2 text-xxs leading-5 z-10 text-c-1">
-                      <div class="flex items-center text-c-2">
+                      class="w-content bg-b-1 text-xxs text-c-1 pointer-events-none z-10 grid min-w-48 gap-1.5 rounded p-2 leading-5 shadow-lg">
+                      <div class="text-c-2 flex items-center">
                         <span>Only workspace cannot be deleted.</span>
                       </div>
                     </div>
@@ -174,8 +176,8 @@ const deleteWorkspace = async () => {
                 <ScalarDropdownItem
                   v-else
                   class="flex !gap-2"
-                  @mousedown.prevent="openDeleteModal(uid)"
-                  @touchend.prevent="openDeleteModal(uid)">
+                  @mousedown.prevent="openDeleteModal(workspace.uid)"
+                  @touchend.prevent="openDeleteModal(workspace.uid)">
                   <ScalarIcon
                     class="inline-flex"
                     icon="Delete"
@@ -192,7 +194,7 @@ const deleteWorkspace = async () => {
           <ScalarDropdownItem
             class="flex items-center gap-1.5"
             @click="createNewWorkspace">
-            <div class="flex items-center justify-center h-4 w-4">
+            <div class="flex h-4 w-4 items-center justify-center">
               <ScalarIcon
                 icon="Add"
                 size="sm" />

--- a/packages/api-client/src/views/Request/handle-drag.ts
+++ b/packages/api-client/src/views/Request/handle-drag.ts
@@ -30,7 +30,7 @@ export function dragHandlerFactory(
     // Parent is the workspace
     if (!draggingParentUid) {
       workspaceMutators.edit(
-        activeWorkspace.value?.uid ?? '',
+        activeWorkspace.value?.uid,
         'collections',
         activeWorkspace.value?.collections.filter((uid) => uid !== draggingUid) ?? [],
       )
@@ -39,7 +39,7 @@ export function dragHandlerFactory(
     // Parent is collection
     else if (collections[draggingParentUid]) {
       collectionMutators.edit(
-        draggingParentUid,
+        draggingParentUid as Collection['uid'],
         'children',
         collections[draggingParentUid].children.filter((uid) => uid !== draggingUid),
       )
@@ -47,7 +47,7 @@ export function dragHandlerFactory(
     // Parent is a tag
     else if (tags[draggingParentUid]) {
       tagMutators.edit(
-        draggingParentUid,
+        draggingParentUid as Tag['uid'],
         'children',
         tags[draggingParentUid].children.filter((uid) => uid !== draggingUid),
       )
@@ -64,7 +64,7 @@ export function dragHandlerFactory(
       const hoveredIndex = newChildUids.findIndex((uid) => hoveredUid === uid) ?? 0
       newChildUids.splice(hoveredIndex + offset, 0, draggingUid as Collection['uid'])
 
-      workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'collections', newChildUids)
+      workspaceMutators.edit(activeWorkspace.value?.uid, 'collections', newChildUids)
     }
     // Place it into the list at an index
     else {

--- a/packages/api-client/src/views/Settings/SettingsGeneral.vue
+++ b/packages/api-client/src/views/Settings/SettingsGeneral.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
+import { cva, cx, ScalarButton, ScalarIcon } from '@scalar/components'
+import {
+  themeLabels,
+  type IntegrationThemeId,
+  type ThemeId,
+} from '@scalar/themes'
+
 import IntegrationLogo from '@/components/ImportCollection/IntegrationLogo.vue'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import { ScalarButton, ScalarIcon, cva, cx } from '@scalar/components'
-import {
-  type IntegrationThemeId,
-  type ThemeId,
-  themeLabels,
-} from '@scalar/themes'
 
 import SettingsGeneralAppearance from './components/SettingsAppearance.vue'
 import SettingsSection from './components/SettingsSection.vue'
@@ -56,9 +57,8 @@ const getThemeColors = (
   )
 }
 
-const changeTheme = (themeId: ThemeId) => {
-  workspaceMutators.edit(activeWorkspace.value?.uid ?? '', 'themeId', themeId)
-}
+const changeTheme = (themeId: ThemeId) =>
+  workspaceMutators.edit(activeWorkspace.value?.uid, 'themeId', themeId)
 
 const buttonStyles = cva({
   base: 'w-full shadow-none text-c-1 justify-start pl-2 gap-2 border-1/2',
@@ -69,19 +69,22 @@ const buttonStyles = cva({
     },
   },
 })
+
+const setProxy = (newProxy: string | undefined) =>
+  workspaceMutators.edit(activeWorkspace.value?.uid, 'proxyUrl', newProxy)
 </script>
 <template>
-  <div class="bg-b-1 w-full h-full overflow-auto">
-    <div class="px-5 py-5 max-w-[720px] ml-auto mr-auto w-full">
+  <div class="bg-b-1 h-full w-full overflow-auto">
+    <div class="ml-auto mr-auto w-full max-w-[720px] px-5 py-5">
       <div class="flex flex-col gap-8">
         <!-- Heading -->
         <div>
-          <h2 class="font-bold text-xl mt-10">Settings</h2>
+          <h2 class="mt-10 text-xl font-bold">Settings</h2>
         </div>
 
         <!-- Proxy -->
         <SettingsSection>
-          <template #title>CORS Proxy</template>
+          <template #title> CORS Proxy </template>
           <template #description>
             Browsers block cross-origin requests for security. We provide a
             public proxy to
@@ -111,21 +114,16 @@ const buttonStyles = cva({
                   }),
                 )
               "
-              @click="
-                workspaceMutators.edit(
-                  activeWorkspace?.uid ?? '',
-                  'proxyUrl',
-                  DEFAULT_PROXY_URL,
-                )
+              @click="setProxy(DEFAULT_PROXY_URL)">
               ">
               <div
-                class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1"
+                class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                 :class="{
-                  'bg-c-accent border-transparent text-b-1':
+                  'bg-c-accent text-b-1 border-transparent':
                     activeWorkspace?.proxyUrl === DEFAULT_PROXY_URL,
                 }">
                 <ScalarIcon
-                  v-if="activeWorkspace.proxyUrl === DEFAULT_PROXY_URL"
+                  v-if="activeWorkspace?.proxyUrl === DEFAULT_PROXY_URL"
                   icon="Checkmark"
                   size="xs"
                   thickness="3.5" />
@@ -143,21 +141,16 @@ const buttonStyles = cva({
                   }),
                 )
               "
-              @click="
-                workspaceMutators.edit(
-                  activeWorkspace?.uid ?? '',
-                  'proxyUrl',
-                  proxyUrl,
-                )
+              @click="setProxy(proxyUrl)">
               ">
               <div
-                class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1"
+                class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                 :class="{
-                  'bg-c-accent border-transparent text-b-1':
+                  'bg-c-accent text-b-1 border-transparent':
                     activeWorkspace?.proxyUrl === proxyUrl,
                 }">
                 <ScalarIcon
-                  v-if="activeWorkspace.proxyUrl === proxyUrl"
+                  v-if="activeWorkspace?.proxyUrl === proxyUrl"
                   icon="Checkmark"
                   size="xs"
                   thickness="3.5" />
@@ -168,18 +161,12 @@ const buttonStyles = cva({
             <!-- No proxy -->
             <ScalarButton
               :class="cx(buttonStyles({ active: !activeWorkspace?.proxyUrl }))"
-              @click="
-                workspaceMutators.edit(
-                  activeWorkspace?.uid ?? '',
-                  'proxyUrl',
-                  '',
-                )
-              ">
+              @click="setProxy(undefined)">
               <div
-                class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1"
+                class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                 :class="
                   !activeWorkspace?.proxyUrl &&
-                  'bg-c-accent border-transparent text-b-1'
+                  'bg-c-accent text-b-1 border-transparent'
                 ">
                 <ScalarIcon
                   v-if="!activeWorkspace?.proxyUrl"
@@ -194,7 +181,7 @@ const buttonStyles = cva({
 
         <!-- Themes -->
         <SettingsSection>
-          <template #title>Themes</template>
+          <template #title> Themes </template>
           <template #description>
             We’ve got a whole rainbow of themes for you to play with:
           </template>
@@ -214,9 +201,9 @@ const buttonStyles = cva({
                 @click="changeTheme(themeId)">
                 <div class="flex items-center gap-2">
                   <div
-                    class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1"
+                    class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                     :class="{
-                      'bg-c-accent border-transparent text-b-1':
+                      'bg-c-accent text-b-1 border-transparent':
                         activeWorkspace?.themeId === themeId,
                     }">
                     <ScalarIcon
@@ -229,23 +216,20 @@ const buttonStyles = cva({
                 </div>
                 <div class="flex items-center gap-1">
                   <span
-                    class="inline-block w-5 h-5 rounded-full border-c-3 -mr-3"
+                    class="border-c-3 -mr-3 inline-block h-5 w-5 rounded-full"
                     :style="{
                       backgroundColor: getThemeColors(themeId).light,
-                    }">
-                  </span>
+                    }" />
                   <span
-                    class="inline-block w-5 h-5 rounded-full border-c-3 -mr-3"
+                    class="border-c-3 -mr-3 inline-block h-5 w-5 rounded-full"
                     :style="{
                       backgroundColor: getThemeColors(themeId).dark,
-                    }">
-                  </span>
+                    }" />
                   <span
-                    class="inline-block w-5 h-5 rounded-full border-c-3"
+                    class="border-c-3 inline-block h-5 w-5 rounded-full"
                     :style="{
                       backgroundColor: getThemeColors(themeId).accent,
-                    }">
-                  </span>
+                    }" />
                 </div>
               </ScalarButton>
             </div>
@@ -254,7 +238,7 @@ const buttonStyles = cva({
 
         <!-- Frameworks -->
         <SettingsSection>
-          <template #title>Framework Themes</template>
+          <template #title> Framework Themes </template>
           <template #description>
             Are you a real fan? Show your support by using your favorite
             framework’s theme!
@@ -274,9 +258,9 @@ const buttonStyles = cva({
               @click="changeTheme(themeId)">
               <div class="flex items-center gap-2">
                 <div
-                  class="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] p-1"
+                  class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                   :class="{
-                    'bg-c-accent border-transparent text-b-1':
+                    'bg-c-accent text-b-1 border-transparent':
                       activeWorkspace?.themeId === themeId,
                   }">
                   <ScalarIcon
@@ -288,7 +272,7 @@ const buttonStyles = cva({
                 {{ themeLabels[themeId] }}
               </div>
               <div class="flex items-center gap-1">
-                <div class="rounded-xl size-7">
+                <div class="size-7 rounded-xl">
                   <IntegrationLogo :integration="themeId" />
                 </div>
               </div>
@@ -298,7 +282,7 @@ const buttonStyles = cva({
 
         <!-- Appearance -->
         <SettingsSection>
-          <template #title>Appearance</template>
+          <template #title> Appearance </template>
           <template #description>
             Choose between light, dark, or system-based appearance for your
             workspace.


### PR DESCRIPTION
# Branding PR 2/2 - DO NOT REBASE

**Problem**
The problem is explained in the other PR. Review both PRs but only test this one, merge the other one first!

**Solution**
- we type the mutators (edit + delete) so we cannot accidentally do `workspaceMutators.delete(collection.uid)`
- we allow `Brand | null | undefined` in the above and handle with a warning in the console so we don't need to do checks everwhere like `?? ''` or `if (entity.value) ...`

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
