### PR TITLE
fix: Biome removes React import

### DIFF
--- a/.changeset/fresh-rivers-leave.md
+++ b/.changeset/fresh-rivers-leave.md
@@ -1,0 +1,20 @@
+---
+'@scalar/api-reference-react': patch
+'@scalar/api-client-react': patch
+'@scalar/aspnetcore': patch
+'@scalar/docusaurus': patch
+'@scalar/code-highlight': patch
+'@scalar/openapi-parser': patch
+'@scalar/api-reference': patch
+'@scalar/build-tooling': patch
+'@scalar/openapi-types': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+'scalar-app': patch
+'@scalar/oas-utils': patch
+'@scalar/snippetz': patch
+'@scalar/fetch': patch
+'@scalar/cli': patch
+---
+
+chore: code style

--- a/biome.json
+++ b/biome.json
@@ -198,6 +198,12 @@
           "allowComments": true
         }
       }
+    },
+    {
+      "include": ["**/*.tsx"],
+      "javascript": {
+        "jsxRuntime": "reactClassic"
+      }
     }
   ]
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.js
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.js
@@ -3,7 +3,6 @@
  * @param {string} suffix - The suffix to remove from the end of the path.
  * @returns {string} The base path without the suffix.
  */
-// eslint-disable-next-line
 function getBasePath(suffix) {
   const path = window.location.pathname
   if (path.endsWith(suffix)) {

--- a/integrations/docusaurus/playground/src/components/HomepageFeatures/index.tsx
+++ b/integrations/docusaurus/playground/src/components/HomepageFeatures/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import Heading from '@theme/Heading'
 import clsx from 'clsx'
 

--- a/integrations/docusaurus/src/ScalarDocusaurus.tsx
+++ b/integrations/docusaurus/src/ScalarDocusaurus.tsx
@@ -1,5 +1,5 @@
 import BrowserOnly from '@docusaurus/BrowserOnly'
-import { type ReferenceProps } from '@scalar/api-reference-react'
+import type { ReferenceProps } from '@scalar/api-reference-react'
 import '@scalar/api-reference-react/style.css'
 import Layout from '@theme/Layout'
 import React from 'react'
@@ -16,7 +16,6 @@ export const ScalarDocusaurus = ({ route }: Props) => {
       <BrowserOnly>
         {() => {
           const ApiReferenceReact =
-            // eslint-disable-next-line @typescript-eslint/no-var-requires
             require('@scalar/api-reference-react').ApiReferenceReact
           return <ApiReferenceReact configuration={route.configuration} />
         }}

--- a/integrations/docusaurus/src/ScalarDocusaurusCommonJS.tsx
+++ b/integrations/docusaurus/src/ScalarDocusaurusCommonJS.tsx
@@ -11,7 +11,6 @@ type Props = {
 }
 
 class ScalarDocusaurusCommonJS extends Component<Props> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   observer: any = null
 
   constructor(props: Props) {
@@ -38,7 +37,7 @@ class ScalarDocusaurusCommonJS extends Component<Props> {
           this.props.route.configuration &&
           !document.getElementById('api-reference')
         ) {
-          console.log(`Loading Scalar script...`)
+          console.log('Loading Scalar script...')
           // Deep copy the configuration
           const config = JSON.parse(
             JSON.stringify(this.props.route.configuration),
@@ -55,7 +54,7 @@ class ScalarDocusaurusCommonJS extends Component<Props> {
           const loaded = document.body.getAttribute('data-scalar-loaded')
 
           if (loaded) {
-            console.log(`Scalar script already loaded, reloading app `)
+            console.log('Scalar script already loaded, reloading app')
             document.dispatchEvent(new Event('scalar:reload-references'))
             document.dispatchEvent(
               new CustomEvent('scalar:update-references-config', {

--- a/packages/api-client-react/src/shims.d.ts
+++ b/packages/api-client-react/src/shims.d.ts
@@ -1,6 +1,7 @@
-/* eslint-disable no-var */
+// biome-ignore lint/suspicious/useNamespaceKeyword: We want it to be a module here.
+// biome-ignore lint/style/noNamespace: We want it to be a module here.
 declare module globalThis {
-  var __VUE_OPTIONS_API__: boolean
-  var __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean
-  var __VUE_PROD_DEVTOOLS__: boolean
+  let __VUE_OPTIONS_API__: boolean
+  let __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean
+  let __VUE_PROD_DEVTOOLS__: boolean
 }

--- a/packages/api-client-react/src/shims.d.ts
+++ b/packages/api-client-react/src/shims.d.ts
@@ -1,7 +1,6 @@
-// biome-ignore lint/suspicious/useNamespaceKeyword: We want it to be a module here.
-// biome-ignore lint/style/noNamespace: We want it to be a module here.
+/* eslint-disable no-var */
 declare module globalThis {
-  let __VUE_OPTIONS_API__: boolean
-  let __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean
-  let __VUE_PROD_DEVTOOLS__: boolean
+  var __VUE_OPTIONS_API__: boolean
+  var __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean
+  var __VUE_PROD_DEVTOOLS__: boolean
 }

--- a/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
+++ b/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file */
 import { parseEnvVariables } from '@/libs'
 import { type EnvVariables, getEnvColor } from '@/libs/env-helpers'
 import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
@@ -50,14 +49,11 @@ class PillWidget extends WidgetType {
       props: { variableName: { type: String, default: null } },
       render: () => {
         const val = this.envVariables
-          ? parseEnvVariables(this.envVariables).find(
-              (thing) => thing.key === this.variableName,
-            )
+          ? parseEnvVariables(this.envVariables).find((thing) => thing.key === this.variableName)
           : undefined
 
         // Set the pill color based on the environment or fallback to grey
-        const pillColor =
-          val && this.environment ? getEnvColor(this.environment) : '#8E8E8E'
+        const pillColor = val && this.environment ? getEnvColor(this.environment) : '#8E8E8E'
 
         span.style.setProperty('--tw-bg-base', pillColor || '#8E8E8E')
 
@@ -135,9 +131,7 @@ class PillWidget extends WidgetType {
   }
 
   override eq(other: WidgetType) {
-    return (
-      other instanceof PillWidget && other.variableName === this.variableName
-    )
+    return other instanceof PillWidget && other.variableName === this.variableName
   }
 
   override ignoreEvent() {

--- a/packages/api-client/src/components/ScreenReader.vue
+++ b/packages/api-client/src/components/ScreenReader.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 withDefaults(
   defineProps<{
-    // eslint-disable-next-line vue/no-unused-properties
     if?: boolean
   }>(),
   {

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -1,38 +1,17 @@
-import {
-  createStoreCollections,
-  extendedCollectionDataFactory,
-} from '@/store/collections'
+import { createStoreCollections, extendedCollectionDataFactory } from '@/store/collections'
 import { createStoreCookies } from '@/store/cookies'
-import {
-  createStoreEnvironments,
-  extendedEnvironmentDataFactory,
-} from '@/store/environment'
+import { createStoreEnvironments, extendedEnvironmentDataFactory } from '@/store/environment'
 import { createStoreEvents } from '@/store/events'
 import { importSpecFileFactory } from '@/store/import-spec'
-import {
-  createStoreRequestExamples,
-  extendedExampleDataFactory,
-} from '@/store/request-example'
-import {
-  createStoreRequests,
-  extendedRequestDataFactory,
-} from '@/store/requests'
-import {
-  createStoreSecuritySchemes,
-  extendedSecurityDataFactory,
-} from '@/store/security-schemes'
+import { createStoreRequestExamples, extendedExampleDataFactory } from '@/store/request-example'
+import { createStoreRequests, extendedRequestDataFactory } from '@/store/requests'
+import { createStoreSecuritySchemes, extendedSecurityDataFactory } from '@/store/security-schemes'
 import { createStoreServers, extendedServerDataFactory } from '@/store/servers'
 import type { StoreContext } from '@/store/store-context'
 import { createStoreTags, extendedTagDataFactory } from '@/store/tags'
-import {
-  createStoreWorkspaces,
-  extendedWorkspaceDataFactory,
-} from '@/store/workspace'
+import { createStoreWorkspaces, extendedWorkspaceDataFactory } from '@/store/workspace'
 import { useModal } from '@scalar/components'
-import type {
-  RequestEvent,
-  SecurityScheme,
-} from '@scalar/oas-utils/entities/spec'
+import type { RequestEvent, SecurityScheme } from '@scalar/oas-utils/entities/spec'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import { type InjectionKey, inject, reactive, ref, toRaw } from 'vue'
@@ -43,7 +22,6 @@ export type UpdateScheme = <P extends Path<SecurityScheme>>(
 ) => void
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Window {
     dataDump: () => void
   }
@@ -60,10 +38,7 @@ type CreateWorkspaceStoreOptions = {
   themeId: ReferenceConfiguration['theme']
   /** Specifies the integration being used. This is primarily for internal purposes and should not be manually set. */
   integration: ReferenceConfiguration['_integration']
-} & Pick<
-  ReferenceConfiguration,
-  'proxyUrl' | 'showSidebar' | 'hideClientButton'
->
+} & Pick<ReferenceConfiguration, 'proxyUrl' | 'showSidebar' | 'hideClientButton'>
 
 /**
  /**
@@ -83,20 +58,15 @@ export const createWorkspaceStore = ({
   // ---------------------------------------------------------------------------
   // Initialize all storage objects
 
-  const { collections, collectionMutators } =
-    createStoreCollections(useLocalStorage)
+  const { collections, collectionMutators } = createStoreCollections(useLocalStorage)
   const { tags, tagMutators } = createStoreTags(useLocalStorage)
   const { requests, requestMutators } = createStoreRequests(useLocalStorage)
-  const { requestExamples, requestExampleMutators } =
-    createStoreRequestExamples(useLocalStorage)
+  const { requestExamples, requestExampleMutators } = createStoreRequestExamples(useLocalStorage)
   const { cookies, cookieMutators } = createStoreCookies(useLocalStorage)
-  const { environments, environmentMutators } =
-    createStoreEnvironments(useLocalStorage)
+  const { environments, environmentMutators } = createStoreEnvironments(useLocalStorage)
   const { servers, serverMutators } = createStoreServers(useLocalStorage)
-  const { securitySchemes, securitySchemeMutators } =
-    createStoreSecuritySchemes(useLocalStorage)
-  const { workspaces, workspaceMutators } =
-    createStoreWorkspaces(useLocalStorage)
+  const { securitySchemes, securitySchemeMutators } = createStoreSecuritySchemes(useLocalStorage)
+  const { workspaces, workspaceMutators } = createStoreWorkspaces(useLocalStorage)
 
   // ---------------------------------------------------------------------------
   // Extended Mutators - Adds side effects as needed
@@ -123,34 +93,24 @@ export const createWorkspaceStore = ({
     workspaceMutators,
   }
   const { addTag, deleteTag } = extendedTagDataFactory(storeContext)
-  const { addRequest, deleteRequest, findRequestParents } =
-    extendedRequestDataFactory(storeContext, addTag)
+  const { addRequest, deleteRequest, findRequestParents } = extendedRequestDataFactory(storeContext, addTag)
   const { deleteEnvironment } = extendedEnvironmentDataFactory(storeContext)
   const { addServer, deleteServer } = extendedServerDataFactory(storeContext)
-  const { addCollection, deleteCollection } =
-    extendedCollectionDataFactory(storeContext)
-  const { addRequestExample, deleteRequestExample } =
-    extendedExampleDataFactory(storeContext)
-  const { addWorkspace, deleteWorkspace } =
-    extendedWorkspaceDataFactory(storeContext)
-  const { addSecurityScheme, deleteSecurityScheme } =
-    extendedSecurityDataFactory(storeContext)
-  const { addCollectionEnvironment, removeCollectionEnvironment } =
-    extendedCollectionDataFactory(storeContext)
+  const { addCollection, deleteCollection } = extendedCollectionDataFactory(storeContext)
+  const { addRequestExample, deleteRequestExample } = extendedExampleDataFactory(storeContext)
+  const { addWorkspace, deleteWorkspace } = extendedWorkspaceDataFactory(storeContext)
+  const { addSecurityScheme, deleteSecurityScheme } = extendedSecurityDataFactory(storeContext)
+  const { addCollectionEnvironment, removeCollectionEnvironment } = extendedCollectionDataFactory(storeContext)
 
   // ---------------------------------------------------------------------------
   // OTHER HELPER DATA
   /** Running request history list */
   const requestHistory = reactive<RequestEvent[]>([])
 
-  const { importSpecFile, importSpecFromUrl } =
-    importSpecFileFactory(storeContext)
+  const { importSpecFile, importSpecFromUrl } = importSpecFileFactory(storeContext)
 
   /** Helper function to manage the sidebar width */
-  const sidebarWidth = ref(
-    (useLocalStorage ? localStorage?.getItem('sidebarWidth') : undefined) ||
-      '280px',
-  )
+  const sidebarWidth = ref((useLocalStorage ? localStorage?.getItem('sidebarWidth') : undefined) || '280px')
 
   // Set the sidebar width
   const setSidebarWidth = (width: string) => {

--- a/packages/api-reference-react/src/index.ts
+++ b/packages/api-reference-react/src/index.ts
@@ -1,2 +1,2 @@
 export * from './ApiReferenceReact'
-export type { ReferenceProps } from '@scalar/api-reference'
+export { type ReferenceProps } from '@scalar/api-reference'

--- a/packages/api-reference-react/src/index.ts
+++ b/packages/api-reference-react/src/index.ts
@@ -1,2 +1,2 @@
 export * from './ApiReferenceReact'
-export { type ReferenceProps } from '@scalar/api-reference'
+export type { ReferenceProps } from '@scalar/api-reference'

--- a/packages/api-reference-react/src/shims.d.ts
+++ b/packages/api-reference-react/src/shims.d.ts
@@ -1,9 +1,8 @@
-// biome-ignore lint/suspicious/useNamespaceKeyword: We want it to be a module here.
-// biome-ignore lint/style/noNamespace: We want it to be a module here.
+/* eslint-disable no-var */
 declare module globalThis {
-  let __VUE_OPTIONS_API__: boolean
-  let __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean
-  let __VUE_PROD_DEVTOOLS__: boolean
+  var __VUE_OPTIONS_API__: boolean
+  var __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean
+  var __VUE_PROD_DEVTOOLS__: boolean
 }
 
 declare module 'vue/dist/vue.esm-bundler.js' {

--- a/packages/api-reference-react/src/shims.d.ts
+++ b/packages/api-reference-react/src/shims.d.ts
@@ -1,8 +1,9 @@
-/* eslint-disable no-var */
+// biome-ignore lint/suspicious/useNamespaceKeyword: We want it to be a module here.
+// biome-ignore lint/style/noNamespace: We want it to be a module here.
 declare module globalThis {
-  var __VUE_OPTIONS_API__: boolean
-  var __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean
-  var __VUE_PROD_DEVTOOLS__: boolean
+  let __VUE_OPTIONS_API__: boolean
+  let __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: boolean
+  let __VUE_PROD_DEVTOOLS__: boolean
 }
 
 declare module 'vue/dist/vue.esm-bundler.js' {

--- a/packages/api-reference/src/components/Card/CardFooter.vue
+++ b/packages/api-reference/src/components/Card/CardFooter.vue
@@ -2,7 +2,6 @@
 import CardContent from './CardContent.vue'
 import type { CardContentProps } from './types'
 
-// eslint-disable-next-line vue/no-unused-properties
 const props = defineProps<CardContentProps>()
 </script>
 <template>

--- a/packages/api-reference/src/components/Card/CardHeader.vue
+++ b/packages/api-reference/src/components/Card/CardHeader.vue
@@ -2,7 +2,6 @@
 import CardContent from './CardContent.vue'
 import type { CardContentProps } from './types'
 
-// eslint-disable-next-line vue/no-unused-properties
 const props = defineProps<CardContentProps>()
 </script>
 <template>

--- a/packages/api-reference/src/components/Content/Tag/TagAccordion.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagAccordion.vue
@@ -1,7 +1,6 @@
-<!-- eslint-disable vue/no-unused-properties -->
 <script setup lang="ts">
 import { ScalarMarkdown } from '@scalar/components'
-import type { Spec, Tag } from '@scalar/types/legacy'
+import type { Tag } from '@scalar/types/legacy'
 
 import { useNavState } from '../../../hooks'
 import { Anchor } from '../../Anchor'
@@ -9,7 +8,6 @@ import { SectionContainerAccordion, SectionHeader } from '../../Section'
 
 defineProps<{
   tag: Tag
-  spec: Spec
 }>()
 
 const { getTagId } = useNavState()

--- a/packages/api-reference/src/components/Layouts/Layouts.vue
+++ b/packages/api-reference/src/components/Layouts/Layouts.vue
@@ -6,7 +6,6 @@ import type { ReferenceLayoutProps, ReferenceLayoutSlots } from '../../types'
 import ClassicLayout from './ClassicLayout.vue'
 import ModernLayout from './ModernLayout.vue'
 
-// eslint-disable-next-line vue/no-unused-properties
 const props = defineProps<ReferenceLayoutProps>()
 defineEmits<{
   (e: 'toggleDarkMode'): void
@@ -33,7 +32,7 @@ const layouts = {
       #[name]="slotProps">
       <slot
         :name="name"
-        v-bind="slotProps || {}"></slot>
+        v-bind="slotProps || {}" />
     </template>
   </component>
 </template>

--- a/packages/api-reference/src/components/ScreenReader.vue
+++ b/packages/api-reference/src/components/ScreenReader.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 withDefaults(
   defineProps<{
-    // eslint-disable-next-line vue/no-unused-properties
     if?: boolean
   }>(),
   {

--- a/packages/build-tooling/src/rollup-plugins/emptyOutDir.ts
+++ b/packages/build-tooling/src/rollup-plugins/emptyOutDir.ts
@@ -16,7 +16,6 @@ export default function emptyOutDir({ dir }: { dir: string }): Plugin {
     generateBundle: {
       // Run before all other `generateBundle` plugins
       order: 'pre',
-      // eslint-disable-next-line consistent-return
       handler(_options, _bundle, isWrite) {
         if (isWrite) {
           // Only remove before first write, but make all writes wait on the removal

--- a/packages/cli/src/commands/init/InitCommand.ts
+++ b/packages/cli/src/commands/init/InitCommand.ts
@@ -1,9 +1,9 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { cancel, confirm, isCancel, text } from '@clack/prompts'
 import { Command } from 'commander'
 import GithubSlugger from 'github-slugger'
 import kleur from 'kleur'
-import fs from 'node:fs'
-import path from 'node:path'
 
 import { CONFIG_FILE } from '../../utils'
 
@@ -44,9 +44,7 @@ export type ScalarSidebarEntry = {
 export function InitCommand() {
   const cmd = new Command('init')
 
-  cmd.description(
-    'Create a new `scalar.config.json` file to configure where your OpenAPI file is placed.',
-  )
+  cmd.description('Create a new `scalar.config.json` file to configure where your OpenAPI file is placed.')
   cmd.option('-f, --file [file]', 'your OpenAPI file')
   cmd.option('-s, --subdomain [url]', 'subdomain to publish on')
   cmd.option('--force', 'override existing configuration')
@@ -58,24 +56,12 @@ export function InitCommand() {
 
     const nextSteps = () => {
       console.log('What to do next:')
-      console.log(
-        `  ${kleur.cyan('scalar format')} ${kleur.gray('[options] [file|url]')} to format your OpenAPI file`,
-      )
-      console.log(
-        `  ${kleur.cyan('scalar validate')} ${kleur.gray('[file|url]')} to validate your OpenAPI file`,
-      )
-      console.log(
-        `  ${kleur.cyan('scalar bundle')} ${kleur.gray('[options] [file]')} to bundle your OpenAPI file`,
-      )
-      console.log(
-        `  ${kleur.cyan('scalar serve')} ${kleur.gray('[options] [file|url]')} to serve your OpenAPI file`,
-      )
+      console.log(`  ${kleur.cyan('scalar format')} ${kleur.gray('[options] [file|url]')} to format your OpenAPI file`)
+      console.log(`  ${kleur.cyan('scalar validate')} ${kleur.gray('[file|url]')} to validate your OpenAPI file`)
+      console.log(`  ${kleur.cyan('scalar bundle')} ${kleur.gray('[options] [file]')} to bundle your OpenAPI file`)
+      console.log(`  ${kleur.cyan('scalar serve')} ${kleur.gray('[options] [file|url]')} to serve your OpenAPI file`)
       console.log()
-      console.log(
-        kleur.white(
-          `Run ${kleur.magenta('scalar --help')} to see all available commands.`,
-        ),
-      )
+      console.log(kleur.white(`Run ${kleur.magenta('scalar --help')} to see all available commands.`))
     }
 
     // Handle cancel from the user
@@ -94,9 +80,7 @@ export function InitCommand() {
 
     // Check if `scalar.config.json` already exists
     if (fs.existsSync(configFile)) {
-      console.log(
-        `${kleur.green('⚠')} Found existing configuration: ${kleur.reset().green(`${CONFIG_FILE}`)}`,
-      )
+      console.log(`${kleur.green('⚠')} Found existing configuration: ${kleur.reset().green(`${CONFIG_FILE}`)}`)
 
       if (force) {
         console.log(`${kleur.green('✔')} Overwriting existing file…`)
@@ -151,7 +135,6 @@ export function InitCommand() {
       const slugger = new GithubSlugger()
       const slug = slugger.slug(response.toString())
 
-      // eslint-disable-next-line no-param-reassign
       subdomain = `${slug}.apidocumentation.com`
 
       console.log(`${kleur.green('✔')} Subdomain: ${kleur.green(subdomain)}`)
@@ -166,10 +149,7 @@ export function InitCommand() {
       const validExtensions = ['.json', '.yaml', '.yml']
       const extension = path.extname(input).toLowerCase()
       if (!validExtensions.includes(extension)) {
-        console.log(
-          kleur.red('✖'),
-          `Please enter a valid file path ${validExtensions.join(', ')}.`,
-        )
+        console.log(kleur.red('✖'), `Please enter a valid file path ${validExtensions.join(', ')}.`)
       }
     }
 
@@ -197,10 +177,7 @@ export function InitCommand() {
       if (isValidFile(input)) {
         validInput = true
       } else {
-        console.log(
-          kleur.red('✖'),
-          `Invalid file extension. Expected: ${['.json', '.yaml', '.yml'].join(', ')}.`,
-        )
+        console.log(kleur.red('✖'), `Invalid file extension. Expected: ${['.json', '.yaml', '.yml'].join(', ')}.`)
       }
     }
 

--- a/packages/cli/src/commands/serve/ServeCommand.ts
+++ b/packages/cli/src/commands/serve/ServeCommand.ts
@@ -4,12 +4,7 @@ import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import kleur from 'kleur'
 
-import {
-  getHtmlDocument,
-  loadOpenApiFile,
-  useGivenFileOrConfiguration,
-  watchFile,
-} from '../../utils'
+import { getHtmlDocument, loadOpenApiFile, useGivenFileOrConfiguration, watchFile } from '../../utils'
 import { printSpecificationBanner } from '../../utils/printSpecificationBanner'
 
 export function ServeCommand() {
@@ -21,15 +16,9 @@ export function ServeCommand() {
   cmd.argument('[file|url]', 'OpenAPI file or URL to show the reference for')
   cmd.option('-w, --watch', 'watch the file for changes')
   cmd.option('-o, --once', 'run the server only once and exit after that')
-  cmd.option(
-    '-p, --port <port>',
-    'set the HTTP port for the API reference server',
-  )
+  cmd.option('-p, --port <port>', 'set the HTTP port for the API reference server')
   cmd.action(
-    async (
-      inputArgument: string,
-      { watch, once, port }: { watch?: boolean; once?: boolean; port?: number },
-    ) => {
+    async (inputArgument: string, { watch, once, port }: { watch?: boolean; once?: boolean; port?: number }) => {
       const input = useGivenFileOrConfiguration(inputArgument)
       const result = await loadOpenApiFile(input)
 
@@ -44,14 +33,8 @@ export function ServeCommand() {
         schema: result.schema,
       })
 
-      if (
-        specification?.paths === undefined ||
-        Object.keys(specification?.paths).length === 0
-      ) {
-        console.log(
-          kleur.bold().yellow('[WARN]'),
-          kleur.grey('Couldn’t find any paths in the OpenAPI file.'),
-        )
+      if (specification?.paths === undefined || Object.keys(specification?.paths).length === 0) {
+        console.log(kleur.bold().yellow('[WARN]'), kleur.grey('Couldn’t find any paths in the OpenAPI file.'))
       }
 
       const app = new Hono()
@@ -74,15 +57,10 @@ export function ServeCommand() {
             watchFile(input, async () => {
               const newResult = await loadOpenApiFile(input)
               const specificationHasChanged =
-                newResult?.specification &&
-                JSON.stringify(specification) !==
-                  JSON.stringify(newResult.specification)
+                newResult?.specification && JSON.stringify(specification) !== JSON.stringify(newResult.specification)
 
               if (specificationHasChanged) {
-                console.log(
-                  kleur.bold().white('[INFO]'),
-                  kleur.grey('OpenAPI file modified'),
-                )
+                console.log(kleur.bold().white('[INFO]'), kleur.grey('OpenAPI file modified'))
 
                 printSpecificationBanner({
                   version: newResult.version,
@@ -96,7 +74,6 @@ export function ServeCommand() {
             })
           }
 
-          // eslint-disable-next-line no-constant-condition
           while (true) {
             await new Promise((resolve) => setTimeout(resolve, 100))
           }

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -24,11 +24,7 @@ type Options = {
  * Plugin to transform nodes in a Markdown AST
  */
 const transformNodes =
-  (
-    options?: Readonly<Options> | null | undefined,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    ..._ignored: any[]
-  ) =>
+  (options?: Readonly<Options> | null | undefined, ..._ignored: any[]) =>
   (tree: Node) => {
     if (!options?.transform || !options?.type) {
       return
@@ -57,10 +53,9 @@ export function htmlFromMarkdown(
 ) {
   // Add permitted tags and remove stripped ones
   const removeTags = options?.removeTags ?? []
-  const tagNames = [
-    ...(defaultSchema.tagNames ?? []),
-    ...(options?.allowTags ?? []),
-  ].filter((t) => !removeTags.includes(t))
+  const tagNames = [...(defaultSchema.tagNames ?? []), ...(options?.allowTags ?? [])].filter(
+    (t) => !removeTags.includes(t),
+  )
 
   const html = unified()
     // Parses markdown

--- a/packages/components/src/hooks/useBindCx.test.ts
+++ b/packages/components/src/hooks/useBindCx.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable vue/one-component-per-file */
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { defineComponent } from 'vue'
@@ -77,9 +76,7 @@ describe('useBindCx', () => {
       props: { active: true },
       attrs: { class: 'external-class another-class' },
     })
-    expect(wrapper.attributes('class')).toBe(
-      'bg-active external-class another-class',
-    )
+    expect(wrapper.attributes('class')).toBe('bg-active external-class another-class')
   })
 
   it('should apply external tailwind classes', () => {
@@ -93,9 +90,7 @@ describe('useBindCx', () => {
     const wrapper = mount(TestComponent, {
       attrs: { class: ['external-class', 'another-class'] },
     })
-    expect(wrapper.attributes('class')).toBe(
-      'bg-base external-class another-class',
-    )
+    expect(wrapper.attributes('class')).toBe('bg-base external-class another-class')
   })
 
   it('should apply classes in objects', () => {

--- a/packages/fetch/src/request.ts
+++ b/packages/fetch/src/request.ts
@@ -22,7 +22,6 @@ export async function request<T>({
   // Normalize headers
   const headers: { [x: string]: string } = {}
 
-  // eslint-disable-next-line guard-for-in
   for (const headerKey in config.headers) {
     if (config.headers[headerKey]) headers[headerKey.toLowerCase()] = config.headers[headerKey].toLowerCase()
   }

--- a/packages/oas-utils/src/helpers/fetchSpecFromUrl.ts
+++ b/packages/oas-utils/src/helpers/fetchSpecFromUrl.ts
@@ -12,14 +12,10 @@ const NEW_PROXY_URL = 'https://proxy.scalar.com'
  *
  * @throws an error if the fetch fails
  */
-export async function fetchSpecFromUrl(
-  url: string,
-  proxy?: string,
-  beautify = true,
-): Promise<string> {
+export async function fetchSpecFromUrl(url: string, proxy?: string, beautify = true): Promise<string> {
   // This replaces the OLD_PROXY_URL with the NEW_PROXY_URL on the fly.
   if (proxy === OLD_PROXY_URL) {
-    // eslint-disable-next-line no-param-reassign
+    // biome-ignore lint/style/noParameterAssign: It’s ok, let’s make an exception here.
     proxy = NEW_PROXY_URL
   }
 
@@ -28,9 +24,7 @@ export async function fetchSpecFromUrl(
 
   // Looks like the request failed
   if (response.status !== 200) {
-    console.error(
-      `[fetchSpecFromUrl] Failed to fetch the specification at ${url} (Status: ${response.status})`,
-    )
+    console.error(`[fetchSpecFromUrl] Failed to fetch the specification at ${url} (Status: ${response.status})`)
 
     if (!proxy) {
       console.warn(
@@ -38,9 +32,7 @@ export async function fetchSpecFromUrl(
       )
     }
 
-    throw new Error(
-      `Failed to fetch the specification (Status: ${response.status})`,
-    )
+    throw new Error(`Failed to fetch the specification (Status: ${response.status})`)
   }
 
   // If it’s JSON, make it pretty

--- a/packages/oas-utils/src/helpers/json2xml.ts
+++ b/packages/oas-utils/src/helpers/json2xml.ts
@@ -2,7 +2,7 @@
  * This function converts an object to XML.
  */
 export function json2xml(data: Record<string, any>, tab?: string) {
-  const toXml = function (value: any, key: string, indentation: string) {
+  const toXml = (value: any, key: string, indentation: string) => {
     let xml = ''
 
     if (value instanceof Array) {
@@ -14,8 +14,7 @@ export function json2xml(data: Record<string, any>, tab?: string) {
       xml += indentation + '<' + key
 
       for (const m in value) {
-        if (m.charAt(0) == '@')
-          xml += ' ' + m.substr(1) + '="' + value[m].toString() + '"'
+        if (m.charAt(0) == '@') xml += ' ' + m.substr(1) + '="' + value[m].toString() + '"'
         else hasChild = true
       }
 
@@ -25,14 +24,9 @@ export function json2xml(data: Record<string, any>, tab?: string) {
         for (const m in value) {
           if (m == '#text') xml += value[m]
           else if (m == '#cdata') xml += '<![CDATA[' + value[m] + ']]>'
-          else if (m.charAt(0) != '@')
-            xml += toXml(value[m], m, indentation + '\t')
+          else if (m.charAt(0) != '@') xml += toXml(value[m], m, indentation + '\t')
         }
-        xml +=
-          (xml.charAt(xml.length - 1) == '\n' ? indentation : '') +
-          '</' +
-          key +
-          '>'
+        xml += (xml.charAt(xml.length - 1) == '\n' ? indentation : '') + '</' + key + '>'
       }
     } else {
       xml += indentation + '<' + key + '>' + value.toString() + '</' + key + '>'
@@ -42,7 +36,7 @@ export function json2xml(data: Record<string, any>, tab?: string) {
 
   let xml = ''
 
-  // eslint-disable-next-line guard-for-in
+  // biome-ignore lint/nursery/useGuardForIn: Yeah, it’s ok. But feel free to fix it.
   for (const key in data) {
     xml += toXml(data[key], key, '')
   }

--- a/packages/openapi-parser/src/types/index.ts
+++ b/packages/openapi-parser/src/types/index.ts
@@ -95,7 +95,6 @@ declare global {
   /**
    * Available commands, can be extended dynamically
    */
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Commands {}
 }
 
@@ -147,10 +146,7 @@ export type EmptyCommandChainResult = {
  * This type enables the API to correctly infer the return type based on
  * the sequence of method calls in the fluent interface.
  */
-export type CommandChain<T extends Task[]> = T extends [
-  infer First,
-  ...infer Rest,
-]
+export type CommandChain<T extends Task[]> = T extends [infer First, ...infer Rest]
   ? First extends Task
     ? Rest extends Task[]
       ? Merge<Commands[First['name']]['result'], CommandChain<Rest>>

--- a/packages/openapi-parser/src/utils/betterAjvErrors/helpers.ts
+++ b/packages/openapi-parser/src/utils/betterAjvErrors/helpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import {
   concatAll,
   getChildren,
@@ -24,14 +23,10 @@ const JSON_POINTERS_REGEX = /\/[\w_-]+(\/\d+)?/g
 export function makeTree(ajvErrors = []) {
   const root = { children: {} }
   ajvErrors.forEach((ajvError) => {
-    const instancePath =
-      typeof ajvError.instancePath !== 'undefined'
-        ? ajvError.instancePath
-        : ajvError.dataPath
+    const instancePath = typeof ajvError.instancePath !== 'undefined' ? ajvError.instancePath : ajvError.dataPath
 
     // `dataPath === ''` is root
-    const paths =
-      instancePath === '' ? [''] : instancePath.match(JSON_POINTERS_REGEX)
+    const paths = instancePath === '' ? [''] : instancePath.match(JSON_POINTERS_REGEX)
     if (paths) {
       paths.reduce((obj, path, i) => {
         obj.children[path] = obj.children[path] || { children: {}, errors: [] }
@@ -89,17 +84,13 @@ export function filterRedundantErrors(root, parent, key) {
     }
   }
 
-  Object.entries(root.children).forEach(([k, child]) =>
-    filterRedundantErrors(child, root, k),
-  )
+  Object.entries(root.children).forEach(([k, child]) => filterRedundantErrors(child, root, k))
 }
 
 export function createErrorInstances(root, options) {
   const errors = getErrors(root)
   if (errors.length && errors.every(isEnumError)) {
-    const uniqueValues = new Set(
-      concatAll([])(errors.map((e) => e.params.allowedValues)),
-    )
+    const uniqueValues = new Set(concatAll([])(errors.map((e) => e.params.allowedValues)))
     const allowedValues = [...uniqueValues]
     const error = errors[0]
     return [

--- a/packages/openapi-parser/src/utils/betterAjvErrors/json/get-meta-from-path.js
+++ b/packages/openapi-parser/src/utils/betterAjvErrors/json/get-meta-from-path.js
@@ -1,32 +1,23 @@
 import { getPointers } from './utils'
 
-export default function getMetaFromPath(
-  jsonAst,
-  dataPath,
-  includeIdentifierLocation,
-) {
+export default function getMetaFromPath(jsonAst, dataPath, includeIdentifierLocation) {
   const pointers = getPointers(dataPath)
   const lastPointerIndex = pointers.length - 1
   return pointers.reduce((obj, pointer, idx) => {
     switch (obj?.type) {
       case 'Object': {
-        const filtered = obj.members.filter(
-          (child) => child.name.value === pointer,
-        )
+        const filtered = obj.members.filter((child) => child.name.value === pointer)
         if (filtered.length !== 1) {
           throw new Error(`Couldn't find property ${pointer} of ${dataPath}`)
         }
 
         const { name, value } = filtered[0]
-        return includeIdentifierLocation && idx === lastPointerIndex
-          ? name
-          : value
+        return includeIdentifierLocation && idx === lastPointerIndex ? name : value
       }
       case 'Array':
         return obj.elements[pointer]
       default:
         // Unexpected type
-        // eslint-disable-next-line no-console
         // console.log(obj)
 
         // Anyway, if there’s location, let’s just use it.

--- a/packages/openapi-parser/src/utils/betterAjvErrors/validation-errors/base.js
+++ b/packages/openapi-parser/src/utils/betterAjvErrors/validation-errors/base.js
@@ -3,11 +3,7 @@
 // import { getMetaFromPath } from '../json/index'
 
 export default class BaseValidationError {
-  // eslint-disable-next-line default-param-last
-  constructor(
-    options = { isIdentifierLocation: false },
-    { data, schema, jsonAst, jsonRaw },
-  ) {
+  constructor(options = { isIdentifierLocation: false }, { data, schema, jsonAst, jsonRaw }) {
     this.options = options
     this.data = data
     this.schema = schema
@@ -19,14 +15,10 @@ export default class BaseValidationError {
    * @return {string}
    */
   get instancePath() {
-    return typeof this.options.instancePath !== 'undefined'
-      ? this.options.instancePath
-      : this.options.dataPath
+    return typeof this.options.instancePath !== 'undefined' ? this.options.instancePath : this.options.dataPath
   }
 
   getError() {
-    throw new Error(
-      `Implement the 'getError' method inside ${this.constructor.name}!`,
-    )
+    throw new Error(`Implement the 'getError' method inside ${this.constructor.name}!`)
   }
 }

--- a/packages/openapi-parser/src/utils/openapi/commands/dereferenceCommand.ts
+++ b/packages/openapi-parser/src/utils/openapi/commands/dereferenceCommand.ts
@@ -8,7 +8,6 @@ import { toYaml } from '../actions/toYaml.ts'
 import { queueTask } from '../utils/queueTask.ts'
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Commands {
     dereference: {
       task: {
@@ -23,10 +22,7 @@ declare global {
 /**
  * Dereference the given OpenAPI document
  */
-export function dereferenceCommand<T extends Task[]>(
-  previousQueue: Queue<T>,
-  options?: DereferenceOptions,
-) {
+export function dereferenceCommand<T extends Task[]>(previousQueue: Queue<T>, options?: DereferenceOptions) {
   const task: Task = {
     name: 'dereference',
     options: {

--- a/packages/openapi-parser/src/utils/openapi/commands/filterCommand.ts
+++ b/packages/openapi-parser/src/utils/openapi/commands/filterCommand.ts
@@ -10,7 +10,6 @@ import { queueTask } from '../utils/queueTask.ts'
 import { dereferenceCommand } from './dereferenceCommand.ts'
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Commands {
     filter: {
       task: {
@@ -25,10 +24,7 @@ declare global {
 /**
  * Filter the given OpenAPI document
  */
-export function filterCommand<T extends Task[]>(
-  previousQueue: Queue<T>,
-  options?: FilterCallback,
-) {
+export function filterCommand<T extends Task[]>(previousQueue: Queue<T>, options?: FilterCallback) {
   const task: Task = {
     name: 'filter',
     options,
@@ -37,8 +33,7 @@ export function filterCommand<T extends Task[]>(
   const queue = queueTask<[...T, typeof task]>(previousQueue, task as Task)
 
   return {
-    dereference: (dereferenceOptions?: DereferenceOptions) =>
-      dereferenceCommand(queue, dereferenceOptions),
+    dereference: (dereferenceOptions?: DereferenceOptions) => dereferenceCommand(queue, dereferenceOptions),
     details: () => details(queue),
     files: () => files(queue),
     get: () => get(queue),

--- a/packages/openapi-parser/src/utils/openapi/commands/loadCommand.ts
+++ b/packages/openapi-parser/src/utils/openapi/commands/loadCommand.ts
@@ -1,10 +1,4 @@
-import type {
-  AnyApiDefinitionFormat,
-  AnyObject,
-  LoadResult,
-  Queue,
-  Task,
-} from '../../../types/index.ts'
+import type { AnyApiDefinitionFormat, AnyObject, LoadResult, Queue, Task } from '../../../types/index.ts'
 import type { DereferenceOptions } from '../../dereference.ts'
 import type { LoadOptions } from '../../load/load.ts'
 import type { ValidateOptions } from '../../validate.ts'
@@ -20,7 +14,6 @@ import { upgradeCommand } from './upgradeCommand.ts'
 import { validateCommand } from './validateCommand.ts'
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Commands {
     load: {
       task: {
@@ -58,17 +51,14 @@ export function loadCommand<T extends Task[]>(
   }
 
   return {
-    dereference: (dereferenceOptions?: DereferenceOptions) =>
-      dereferenceCommand(queue, dereferenceOptions),
+    dereference: (dereferenceOptions?: DereferenceOptions) => dereferenceCommand(queue, dereferenceOptions),
     details: () => details(queue),
     files: () => files(queue),
-    filter: (callback: (specification: AnyObject) => boolean) =>
-      filterCommand(queue, callback),
+    filter: (callback: (specification: AnyObject) => boolean) => filterCommand(queue, callback),
     get: () => get(queue),
     upgrade: () => upgradeCommand(queue),
     toJson: () => toJson(queue),
     toYaml: () => toYaml(queue),
-    validate: (validateOptions?: ValidateOptions) =>
-      validateCommand(queue, validateOptions),
+    validate: (validateOptions?: ValidateOptions) => validateCommand(queue, validateOptions),
   }
 }

--- a/packages/openapi-parser/src/utils/openapi/commands/upgradeCommand.ts
+++ b/packages/openapi-parser/src/utils/openapi/commands/upgradeCommand.ts
@@ -1,9 +1,4 @@
-import type {
-  AnyObject,
-  Queue,
-  Task,
-  UpgradeResult,
-} from '../../../types/index.ts'
+import type { AnyObject, Queue, Task, UpgradeResult } from '../../../types/index.ts'
 import type { DereferenceOptions } from '../../dereference.ts'
 import type { ValidateOptions } from '../../validate.ts'
 import { details } from '../actions/details.ts'
@@ -17,7 +12,6 @@ import { filterCommand } from './filterCommand.ts'
 import { validateCommand } from './validateCommand.ts'
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Commands {
     upgrade: {
       task: {
@@ -39,16 +33,13 @@ export function upgradeCommand<T extends Task[]>(previousQueue: Queue<T>) {
   const queue = queueTask<[...T, typeof task]>(previousQueue, task as Task)
 
   return {
-    dereference: (dereferenceOptions?: DereferenceOptions) =>
-      dereferenceCommand(queue, dereferenceOptions),
+    dereference: (dereferenceOptions?: DereferenceOptions) => dereferenceCommand(queue, dereferenceOptions),
     details: () => details(queue),
     files: () => files(queue),
-    filter: (callback: (specification: AnyObject) => boolean) =>
-      filterCommand(queue, callback),
+    filter: (callback: (specification: AnyObject) => boolean) => filterCommand(queue, callback),
     get: () => get(queue),
     toJson: () => toJson(queue),
     toYaml: () => toYaml(queue),
-    validate: (validateOptions?: ValidateOptions) =>
-      validateCommand(queue, validateOptions),
+    validate: (validateOptions?: ValidateOptions) => validateCommand(queue, validateOptions),
   }
 }

--- a/packages/openapi-parser/src/utils/openapi/commands/validateCommand.ts
+++ b/packages/openapi-parser/src/utils/openapi/commands/validateCommand.ts
@@ -1,9 +1,4 @@
-import type {
-  AnyObject,
-  Queue,
-  Task,
-  ValidateResult,
-} from '../../../types/index.ts'
+import type { AnyObject, Queue, Task, ValidateResult } from '../../../types/index.ts'
 import type { DereferenceOptions } from '../../dereference.ts'
 import type { ValidateOptions } from '../../validate.ts'
 import { details } from '../actions/details.ts'
@@ -17,7 +12,6 @@ import { filterCommand } from './filterCommand.ts'
 import { upgradeCommand } from './upgradeCommand.ts'
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Commands {
     validate: {
       task: {
@@ -32,10 +26,7 @@ declare global {
 /**
  * Validate the given OpenAPI document
  */
-export function validateCommand<T extends Task[]>(
-  previousQueue: Queue<T>,
-  options?: ValidateOptions,
-) {
+export function validateCommand<T extends Task[]>(previousQueue: Queue<T>, options?: ValidateOptions) {
   const task: Task = {
     name: 'validate',
     options: {
@@ -47,12 +38,10 @@ export function validateCommand<T extends Task[]>(
   const queue = queueTask<[...T, typeof task]>(previousQueue, task as Task)
 
   return {
-    dereference: (dereferenceOptions?: DereferenceOptions) =>
-      dereferenceCommand(queue, dereferenceOptions),
+    dereference: (dereferenceOptions?: DereferenceOptions) => dereferenceCommand(queue, dereferenceOptions),
     details: () => details(queue),
     files: () => files(queue),
-    filter: (callback: (specification: AnyObject) => boolean) =>
-      filterCommand(queue, callback),
+    filter: (callback: (specification: AnyObject) => boolean) => filterCommand(queue, callback),
     get: () => get(queue),
     toJson: () => toJson(queue),
     toYaml: () => toYaml(queue),

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/ban-types */
 /**
  * These types are copied from openapi-types, with two modifications:
  *
@@ -17,6 +15,7 @@ type AnyOtherAttribute = {
   [key: string]: any
 }
 
+// biome-ignore lint/style/noNamespace: We want it to be a module here.
 export namespace OpenAPI {
   // OpenAPI extensions can be declared using generics
   // e.g.:
@@ -40,15 +39,9 @@ export namespace OpenAPI {
     query?: object
   }
 
-  export type ResponseObject =
-    | OpenAPIV2.ResponseObject
-    | OpenAPIV3.ResponseObject
-    | OpenAPIV3_1.ResponseObject
+  export type ResponseObject = OpenAPIV2.ResponseObject | OpenAPIV3.ResponseObject | OpenAPIV3_1.ResponseObject
 
-  export type HeaderObject =
-    | OpenAPIV2.HeaderObject
-    | OpenAPIV3.HeaderObject
-    | OpenAPIV3_1.HeaderObject
+  export type HeaderObject = OpenAPIV2.HeaderObject | OpenAPIV3.HeaderObject | OpenAPIV3_1.HeaderObject
 
   export type Parameter =
     | OpenAPIV3_1.ReferenceObject
@@ -63,15 +56,9 @@ export namespace OpenAPI {
     | (OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject)[]
     | (OpenAPIV2.ReferenceObject | OpenAPIV2.Parameter)[]
 
-  export type ExampleObject =
-    | OpenAPIV2.ExampleObject
-    | OpenAPIV3.ExampleObject
-    | OpenAPIV3_1.ExampleObject
+  export type ExampleObject = OpenAPIV2.ExampleObject | OpenAPIV3.ExampleObject | OpenAPIV3_1.ExampleObject
 
-  export type SchemaObject =
-    | OpenAPIV2.SchemaObject
-    | OpenAPIV3.SchemaObject
-    | OpenAPIV3_1.SchemaObject
+  export type SchemaObject = OpenAPIV2.SchemaObject | OpenAPIV3.SchemaObject | OpenAPIV3_1.SchemaObject
 
   export type HttpMethod =
     | keyof typeof OpenAPIV2.HttpMethods
@@ -79,6 +66,7 @@ export namespace OpenAPI {
     | OpenAPIV3_1.HttpMethods
 }
 
+// biome-ignore lint/style/noNamespace: We want it to be a module here.
 export namespace OpenAPIV3_1 {
   type Modify<T, R> = Omit<T, keyof R> & R
 
@@ -101,12 +89,9 @@ export namespace OpenAPIV3_1 {
       jsonSchemaDialect?: string
       servers?: ServerObject[]
     } & (
-      | (Pick<PathsWebhooksComponents<T>, 'paths'> &
-          Omit<Partial<PathsWebhooksComponents<T>>, 'paths'>)
-      | (Pick<PathsWebhooksComponents<T>, 'webhooks'> &
-          Omit<Partial<PathsWebhooksComponents<T>>, 'webhooks'>)
-      | (Pick<PathsWebhooksComponents<T>, 'components'> &
-          Omit<Partial<PathsWebhooksComponents<T>>, 'components'>)
+      | (Pick<PathsWebhooksComponents<T>, 'paths'> & Omit<Partial<PathsWebhooksComponents<T>>, 'paths'>)
+      | (Pick<PathsWebhooksComponents<T>, 'webhooks'> & Omit<Partial<PathsWebhooksComponents<T>>, 'webhooks'>)
+      | (Pick<PathsWebhooksComponents<T>, 'components'> & Omit<Partial<PathsWebhooksComponents<T>>, 'components'>)
     ) &
       T &
       AnyOtherAttribute
@@ -145,10 +130,7 @@ export namespace OpenAPIV3_1 {
     }
   >
 
-  export type PathsObject<T = {}, P extends {} = {}> = Record<
-    string,
-    (PathItemObject<T> & P) | undefined
-  >
+  export type PathsObject<T = {}, P extends {} = {}> = Record<string, (PathItemObject<T> & P) | undefined>
 
   export type HttpMethods = OpenAPIV3.HttpMethods
 
@@ -174,8 +156,7 @@ export namespace OpenAPIV3_1 {
   > &
     T
 
-  export type ExternalDocumentationObject =
-    OpenAPIV3.ExternalDocumentationObject
+  export type ExternalDocumentationObject = OpenAPIV3.ExternalDocumentationObject
 
   export type ParameterObject = OpenAPIV3.ParameterObject
 
@@ -183,9 +164,7 @@ export namespace OpenAPIV3_1 {
 
   export type ParameterBaseObject = OpenAPIV3.ParameterBaseObject
 
-  export type NonArraySchemaObjectType =
-    | OpenAPIV3.NonArraySchemaObjectType
-    | 'null'
+  export type NonArraySchemaObjectType = OpenAPIV3.NonArraySchemaObjectType | 'null'
 
   export type ArraySchemaObjectType = OpenAPIV3.ArraySchemaObjectType
 
@@ -194,12 +173,7 @@ export namespace OpenAPIV3_1 {
    * 'items' will be always visible as optional
    * Casting schema object to ArraySchemaObject or NonArraySchemaObject will work fine
    */
-  export type SchemaObject = (
-    | ArraySchemaObject
-    | NonArraySchemaObject
-    | MixedSchemaObject
-    | boolean
-  ) &
+  export type SchemaObject = (ArraySchemaObject | NonArraySchemaObject | MixedSchemaObject | boolean) &
     AnyOtherAttribute
 
   export type ArraySchemaObject = {
@@ -324,6 +298,7 @@ export namespace OpenAPIV3_1 {
   export type TagObject = OpenAPIV3.TagObject
 }
 
+// biome-ignore lint/style/noNamespace: We want it to be a module here.
 export namespace OpenAPIV3 {
   export type Document<T = {}> = {
     /**
@@ -445,15 +420,9 @@ export namespace OpenAPIV3 {
     examples?: { [media: string]: ReferenceObject | ExampleObject }
     content?: { [media: string]: MediaTypeObject }
   }
-  export type NonArraySchemaObjectType =
-    | 'boolean'
-    | 'object'
-    | 'number'
-    | 'string'
-    | 'integer'
+  export type NonArraySchemaObjectType = 'boolean' | 'object' | 'number' | 'string' | 'integer'
   export type ArraySchemaObjectType = 'array'
-  export type SchemaObject = (ArraySchemaObject | NonArraySchemaObject) &
-    AnyOtherAttribute
+  export type SchemaObject = (ArraySchemaObject | NonArraySchemaObject) & AnyOtherAttribute
 
   export type ArraySchemaObject = {
     type?: ArraySchemaObjectType
@@ -654,6 +623,7 @@ export namespace OpenAPIV3 {
   } & AnyOtherAttribute
 }
 
+// biome-ignore lint/style/noNamespace: We want it to be a module here.
 export namespace OpenAPIV2 {
   export type Document<T = {}> = {
     /**
@@ -737,10 +707,7 @@ export namespace OpenAPIV2 {
     tokenUrl?: string
   } & SecuritySchemeOauth2Base
 
-  export type SecuritySchemeObject =
-    | SecuritySchemeBasic
-    | SecuritySchemeApiKey
-    | SecuritySchemeOauth2
+  export type SecuritySchemeObject = SecuritySchemeBasic | SecuritySchemeApiKey | SecuritySchemeOauth2
 
   export type SecurityDefinitionsObject = {
     [index: string]: SecuritySchemeObject

--- a/packages/scalar-app/src/main/index.ts
+++ b/packages/scalar-app/src/main/index.ts
@@ -1,9 +1,9 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import todesktop from '@todesktop/runtime'
 import { BrowserWindow, type IpcMainInvokeEvent, Menu, app, dialog, ipcMain, session, shell } from 'electron'
 import windowStateKeeper from 'electron-window-state'
-import fs from 'node:fs'
-import path from 'node:path'
 
 import icon from '../../build/icon.png?asset'
 import { resolve } from './resolve'
@@ -25,7 +25,6 @@ todesktop.init({
     showInstallAndRestartPrompt: async (context) => {
       if (!context.appIsInForeground) return
 
-      // eslint-disable-next-line consistent-return
       return {
         message: 'Update Available',
         detail: `Version ${context.updateInfo?.version} is ready to be installed.`,

--- a/packages/scalar-app/src/preload/index.ts
+++ b/packages/scalar-app/src/preload/index.ts
@@ -8,7 +8,6 @@ const api = {
 }
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Window {
     electron: typeof electronAPI
     api: typeof api

--- a/packages/snippetz/src/httpsnippet-lite/esm/helpers/code-builder.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/helpers/code-builder.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 const DEFAULT_INDENTATION_CHARACTER = ''
 const DEFAULT_LINE_JOIN = '\n'

--- a/packages/snippetz/src/httpsnippet-lite/esm/helpers/escape.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/helpers/escape.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * Escape characters within a value to make it safe to insert directly into a

--- a/packages/snippetz/src/httpsnippet-lite/esm/helpers/form-data.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/helpers/form-data.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @license https://raw.githubusercontent.com/node-fetch/node-fetch/master/LICENSE.md

--- a/packages/snippetz/src/httpsnippet-lite/esm/helpers/headers.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/helpers/headers.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * Given a headers object retrieve a specific header out of it via a case-insensitive key.

--- a/packages/snippetz/src/httpsnippet-lite/esm/helpers/reducer.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/helpers/reducer.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 export const reducer = (accumulator, pair) => {
   if (pair.value === void 0) {

--- a/packages/snippetz/src/httpsnippet-lite/esm/helpers/shell.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/helpers/shell.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * Use 'strong quoting' using single quotes so that we only need to deal with nested single quote characters.

--- a/packages/snippetz/src/httpsnippet-lite/esm/helpers/url.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/helpers/url.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 export function toSearchParams(obj) {
   return new URLSearchParams(

--- a/packages/snippetz/src/httpsnippet-lite/esm/helpers/utils.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/helpers/utils.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { targets } from '../targets/targets.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/c/libcurl/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/c/libcurl/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { CodeBuilder } from '../../../helpers/code-builder.js'
 import { escapeForDoubleQuotes } from '../../../helpers/escape.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/c/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/c/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { libcurl } from './libcurl/client.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/clojure/clj_http/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/clojure/clj_http/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/clojure/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/clojure/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { clj_http } from './clj_http/client.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/csharp/httpclient/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/csharp/httpclient/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { CodeBuilder } from '../../../helpers/code-builder.js'
 import { escapeForDoubleQuotes } from '../../../helpers/escape.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/csharp/restsharp/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/csharp/restsharp/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { CodeBuilder } from '../../../helpers/code-builder.js'
 import { escapeForDoubleQuotes } from '../../../helpers/escape.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/csharp/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/csharp/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { httpclient } from './httpclient/client.js'
 import { restsharp } from './restsharp/client.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/go/native/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/go/native/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/java/asynchttp/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/java/asynchttp/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/java/nethttp/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/java/nethttp/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/java/okhttp/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/java/okhttp/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/java/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/java/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { asynchttp } from './asynchttp/client.js'
 import { nethttp } from './nethttp/client.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/java/unirest/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/java/unirest/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/javascript/axios/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/javascript/axios/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/javascript/fetch/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/javascript/fetch/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description
@@ -52,7 +51,6 @@ export const fetch = {
           break
         }
         // The FormData API automatically adds a `Content-Type` header for `multipart/form-data` content and if we add our own here data won't be correctly transmitted.
-        // eslint-disable-next-line no-case-declarations -- We're only using `contentTypeHeader` within this block.
         const contentTypeHeader = getHeaderName(allHeaders, 'content-type')
         if (contentTypeHeader) {
           delete allHeaders[contentTypeHeader]

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/javascript/jquery/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/javascript/jquery/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/javascript/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/javascript/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { axios } from './axios/client.js'
 import { fetch } from './fetch/client.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/javascript/xhr/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/javascript/xhr/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/kotlin/okhttp/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/kotlin/okhttp/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/kotlin/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/kotlin/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { okhttp } from './okhttp/client.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/node/axios/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/node/axios/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/node/fetch/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/node/fetch/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description
@@ -63,7 +62,6 @@ export const fetch = {
           break
         }
         // The `form-data` module automatically adds a `Content-Type` header for `multipart/form-data` content and if we add our own here data won't be correctly transmitted.
-        // eslint-disable-next-line no-case-declarations -- We're only using `contentTypeHeader` within this block.
         const contentTypeHeader = getHeaderName(headersObj, 'content-type')
         if (contentTypeHeader) {
           delete headersObj[contentTypeHeader]

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/node/native/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/node/native/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/node/request/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/node/request/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/node/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/node/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { axios } from './axios/client.js'
 import { fetch } from './fetch/client.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/node/unirest/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/node/unirest/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/objc/helpers.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/objc/helpers.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * Create a string corresponding to a valid declaration and initialization of an Objective-C object literal.

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/objc/nsurlsession/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/objc/nsurlsession/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/objc/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/objc/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { nsurlsession } from './nsurlsession/client.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/ocaml/cohttp/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/ocaml/cohttp/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/ocaml/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/ocaml/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { cohttp } from './cohttp/client.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/php/curl/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/php/curl/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/php/guzzle/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/php/guzzle/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/php/helpers.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/php/helpers.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { escapeString } from '../../helpers/escape.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/php/http1/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/php/http1/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/php/http2/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/php/http2/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/php/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/php/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { curl } from './curl/client.js'
 import { guzzle } from './guzzle/client.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/powershell/common.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/powershell/common.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { CodeBuilder } from '../../helpers/code-builder.js'
 import { escapeString } from '../../helpers/escape.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/powershell/restmethod/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/powershell/restmethod/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { generatePowershellConvert } from '../common.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/powershell/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/powershell/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { restmethod } from './restmethod/client.js'
 import { webrequest } from './webrequest/client.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/powershell/webrequest/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/powershell/webrequest/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { generatePowershellConvert } from '../common.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/python/helpers.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/python/helpers.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * Create a string corresponding to a Dictionary or Array literal representation with pretty option

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/python/python3/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/python/python3/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/python/requests/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/python/requests/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/python/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/python/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { python3 } from './python3/client.js'
 import { requests } from './requests/client.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/r/httr/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/r/httr/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/r/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/r/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { httr } from './httr/client.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/ruby/native/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/ruby/native/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { CodeBuilder } from '../../../helpers/code-builder.js'
 import { escapeForSingleQuotes } from '../../../helpers/escape.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/ruby/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/ruby/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { native } from './native/client.js'
 

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/shell/curl/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/shell/curl/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/shell/httpie/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/shell/httpie/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/shell/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/shell/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { curl } from './curl/client.js'
 import { httpie } from './httpie/client.js'

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/shell/wget/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/shell/wget/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/swift/helpers.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/swift/helpers.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * Create an string of given length filled with blank spaces

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/swift/nsurlsession/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/swift/nsurlsession/client.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
  * @description

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/swift/target.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/swift/target.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { nsurlsession } from './nsurlsession/client.js'
 


### PR DESCRIPTION
**Problem**
Currently, Biome removes “unused” React imports. But (I don’t know why) they are necessary for those files to work.

**Solution**
Luckily, there’s a Biome setting to tell Biome it’s React, so it’ll keep the “unused” import.

I’ve also looked for `eslint-disable` comments and was able to remove a lot of them. And I applied the new formatting to more files.

```json
"javascript": {
  "jsxRuntime": "reactClassic"
}
```

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
