### PR TITLE
feat(api-client): schema based validation

### DIFF
--- a/.changeset/mean-brooms-decide.md
+++ b/.changeset/mean-brooms-decide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: adds alert icon

--- a/.changeset/mighty-eggs-do.md
+++ b/.changeset/mighty-eggs-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds request parameter value validation alert

--- a/.changeset/wise-actors-tease.md
+++ b/.changeset/wise-actors-tease.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+feat: updates danger variable + add background alert variable

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -63,7 +63,7 @@ const emit = defineEmits<{
   (e: 'curl', v: string): void
 }>()
 
-const attrs = useAttrs()
+const attrs = useAttrs() as { id?: string }
 const uid = (attrs.id as string) || `id-${nanoid()}`
 
 const isFocused = ref(false)
@@ -258,7 +258,7 @@ export default {
       :id="uid"
       v-bind="$attrs"
       ref="codeMirrorRef"
-      class="font-code peer relative w-full overflow-hidden whitespace-nowrap text-xs leading-[1.44] -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline"
+      class="group-[.alert]:outline-orange font-code peer relative w-full overflow-hidden whitespace-nowrap text-xs leading-[1.44] -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline"
       :class="{
         'flow-code-input--error': error,
       }"
@@ -289,7 +289,7 @@ export default {
   <slot name="icon" />
   <div
     v-if="required"
-    class="required centered-y text-xxs text-c-3 bg-b-1 pointer-events-none absolute right-0 pr-2 pt-px opacity-100 shadow-[-8px_0_4px_var(--scalar-background-1)] transition-opacity duration-150 peer-has-[.cm-focused]:opacity-0">
+    class="required centered-y text-xxs text-c-3 bg-b-1 pointer-events-none absolute right-0 pr-2 pt-px opacity-100 shadow-[-8px_0_4px_var(--scalar-background-1)] transition-opacity duration-150 group-[.alert]:bg-transparent group-[.alert]:shadow-none peer-has-[.cm-focused]:opacity-0">
     Required
   </div>
   <EnvironmentVariableDropdown

--- a/packages/api-client/src/components/DataTable/DataTableCell.vue
+++ b/packages/api-client/src/components/DataTable/DataTableCell.vue
@@ -20,6 +20,7 @@ const { cx } = useBindCx()
         'max-h-8 min-h-8 min-w-8 border-l-0 border-t border-b-0 border-r flex text-sm last:border-r-0 group-last:border-b-transparent p-0 m-0 relative',
       )
     "
+    class="group-[.alert]:bg-b-alert"
     role="cell">
     <slot />
   </component>

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -89,14 +89,14 @@ const updateSelectedOptions = (selectedOptions: any) => {
 
 <template>
   <div
-    class="pr-4 w-full has-[:focus-visible]:outline has-[:focus-visible]:rounded-[4px] -outline-offset-1">
+    class="group-[.alert]:outline-orange w-full pr-4 -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline">
     <template v-if="type === 'array'">
       <ScalarComboboxMultiselect
         :modelValue="selectedArrayOptions"
         :options="arrayOptions"
         @update:modelValue="updateSelectedOptions">
         <ScalarButton
-          class="gap-1.5 font-normal h-full justify-start px-2 py-1.5 custom-scroll pr-6 outline-none"
+          class="custom-scroll h-full justify-start gap-1.5 px-2 py-1.5 pr-6 font-normal outline-none"
           fullWidth
           variant="ghost">
           <span class="text-c-1 whitespace-nowrap">{{
@@ -114,7 +114,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
       <input
         ref="inputRef"
         v-model="customValue"
-        class="border-none text-c-1 min-w-0 w-full px-2 py-1.5 outline-none"
+        class="text-c-1 w-full min-w-0 border-none px-2 py-1.5 outline-none"
         placeholder="Value"
         type="text"
         @blur="handleBlur"
@@ -125,7 +125,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
         resize
         :value="initialValue">
         <ScalarButton
-          class="gap-1.5 font-normal h-full justify-start px-2 py-1.5 outline-none overflow-auto whitespace-nowrap"
+          class="h-full justify-start gap-1.5 overflow-auto whitespace-nowrap px-2 py-1.5 font-normal outline-none"
           fullWidth
           variant="ghost">
           <span class="text-c-1">{{ initialValue || 'Select a value' }}</span>
@@ -137,11 +137,11 @@ const updateSelectedOptions = (selectedOptions: any) => {
           <ScalarDropdownItem
             v-for="option in options"
             :key="option"
-            class="flex gap-1.5 group/item items-center whitespace-nowrap text-ellipsis overflow-hidden"
+            class="group/item flex items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap"
             :value="option"
             @click="updateSelected(option)">
             <div
-              class="flex items-center justify-center rounded-full p-[3px] w-4 h-4"
+              class="flex h-4 w-4 items-center justify-center rounded-full p-[3px]"
               :class="
                 isSelected(option)
                   ? 'bg-c-accent text-b-1'
@@ -159,7 +159,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
             <ScalarDropdownItem
               class="flex items-center gap-1.5"
               @click="addingCustomValue = true">
-              <div class="flex items-center justify-center h-4 w-4">
+              <div class="flex h-4 w-4 items-center justify-center">
                 <ScalarIcon
                   icon="Add"
                   size="sm" />

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
+import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
+import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
+import type { RouteLocationRaw } from 'vue-router'
+
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
 import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableCell from '@/components/DataTable/DataTableCell.vue'
 import DataTableCheckbox from '@/components/DataTable/DataTableCheckbox.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
-import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
-import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
-import { computed } from 'vue'
-import type { RouteLocationRaw } from 'vue-router'
 
-import { hasItemProperties } from '../libs/request'
+import { hasItemProperties, parameterIsInvalid } from '../libs/request'
 import RequestTableTooltip from './RequestTableTooltip.vue'
 
 const props = withDefaults(
@@ -54,21 +54,6 @@ const handleFileUpload = (idx: number) => {
   emit('uploadFile', idx)
 }
 
-const valueOutOfRange = (item: RequestExampleParameter) => {
-  return computed(() => {
-    if (item.type === 'integer' && item.value !== undefined) {
-      const value = Number(item.value)
-      if (item.minimum !== undefined && value < item.minimum) {
-        return `Min is ${item.minimum}`
-      }
-      if (item.maximum !== undefined && value > item.maximum) {
-        return `Max is ${item.maximum}`
-      }
-    }
-    return false
-  })
-}
-
 const flattenValue = (item: RequestExampleParameter) => {
   return Array.isArray(item.default) && item.default.length === 1
     ? item.default[0]
@@ -77,15 +62,18 @@ const flattenValue = (item: RequestExampleParameter) => {
 </script>
 <template>
   <DataTable
-    class="flex-1"
+    class="group/table flex-1"
     :columns="columns">
     <DataTableRow
       v-for="(item, idx) in items"
-      :key="idx">
+      :key="idx"
+      :class="{
+        alert: parameterIsInvalid(item).value,
+      }">
       <label class="contents">
         <template v-if="isGlobal">
           <RouterLink
-            class="!border-r-1/2 border-t-1/2 text-c-2 flex justify-center items-center"
+            class="!border-r-1/2 border-t-1/2 text-c-2 flex items-center justify-center"
             :to="item.route ?? {}">
             <span class="sr-only">Global</span>
             <ScalarTooltip
@@ -99,8 +87,8 @@ const flattenValue = (item: RequestExampleParameter) => {
               </template>
               <template #content>
                 <div
-                  class="grid gap-1.5 pointer-events-none max-w-[320px] w-content shadow-lg rounded bg-b-1 z-100 p-2 text-xxs leading-5 z-10 text-c-1">
-                  <div class="flex items-center text-c-1">
+                  class="w-content bg-b-1 z-100 text-xxs text-c-1 pointer-events-none z-10 grid max-w-[320px] gap-1.5 rounded p-2 leading-5 shadow-lg">
+                  <div class="text-c-1 flex items-center">
                     <span class="text-pretty">
                       Global cookies are shared across the whole workspace.
                     </span>
@@ -161,11 +149,6 @@ const flattenValue = (item: RequestExampleParameter) => {
           @update:modelValue="
             (v: string) => emit('updateRow', idx, 'value', v)
           ">
-          <template
-            v-if="valueOutOfRange(item).value"
-            #warning>
-            {{ valueOutOfRange(item).value }}
-          </template>
           <template #icon>
             <RequestTableTooltip
               v-if="hasItemProperties(item)"
@@ -175,14 +158,14 @@ const flattenValue = (item: RequestExampleParameter) => {
       </DataTableCell>
       <DataTableCell
         v-if="showUploadButton"
-        class="group/upload p-1 overflow-hidden relative text-ellipsis whitespace-nowrap">
+        class="group/upload relative overflow-hidden text-ellipsis whitespace-nowrap p-1">
         <template v-if="item.file">
           <div
-            class="text-c-2 max-w-[100%] overflow-hidden filemask flex items-end justify-end">
+            class="text-c-2 filemask flex max-w-[100%] items-end justify-end overflow-hidden">
             <span>{{ item.file?.name }}</span>
           </div>
           <button
-            class="absolute bg-b-2 font-medium centered-x centered-y hidden rounded text-center p-0.5 w-[calc(100%_-_8px)] group-hover/upload:block text-xs"
+            class="bg-b-2 centered-x centered-y absolute hidden w-[calc(100%_-_8px)] rounded p-0.5 text-center text-xs font-medium group-hover/upload:block"
             type="button"
             @click="emit('removeFile', idx)">
             Delete
@@ -190,7 +173,7 @@ const flattenValue = (item: RequestExampleParameter) => {
         </template>
         <template v-else>
           <ScalarButton
-            class="bg-b-2 hover:bg-b-3 border-0 py-px text-c-2 shadow-none"
+            class="bg-b-2 hover:bg-b-3 text-c-2 border-0 py-px shadow-none"
             size="sm"
             variant="outlined"
             @click="handleFileUpload(idx)">

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -2,7 +2,9 @@
 import { ScalarIcon, ScalarTooltip } from '@scalar/components'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
 
-defineProps<{ item: RequestExampleParameter }>()
+import { parameterIsInvalid } from '../libs/request'
+
+const { item } = defineProps<{ item: RequestExampleParameter }>()
 </script>
 <template>
   <ScalarTooltip
@@ -10,20 +12,31 @@ defineProps<{ item: RequestExampleParameter }>()
     class="w-full pr-px"
     :delay="0"
     side="left"
-    triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 before:min-h-[calc(100%-4px)] before:pointer-events-none before:right-[23px] before:top-0.5 before:w-3 absolute h-full right-0 -outline-offset-1">
+    triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 group-[.alert]:before:to-b-alert before:min-h-[calc(100%-4px)] before:pointer-events-none before:right-[23px] before:top-0.5 before:w-3 absolute h-full right-0 -outline-offset-1">
     <template #trigger>
-      <div class="bg-b-1 pl-1 pr-1.5 mr-0.25">
+      <div class="bg-b-1 mr-0.25 pl-1 pr-1.5 group-[.alert]:bg-transparent">
         <ScalarIcon
-          class="text-c-3 group-hover/info:text-c-1"
-          icon="Info"
+          :class="
+            parameterIsInvalid(item).value
+              ? 'text-orange brightness-[.9]'
+              : 'text-c-3 group-hover/info:text-c-1'
+          "
+          :icon="parameterIsInvalid(item).value ? 'Alert' : 'Info'"
           size="sm"
           thickness="1.5" />
       </div>
     </template>
     <template #content>
       <div
-        class="grid gap-1.5 pointer-events-none min-w-48 w-content shadow-lg rounded bg-b-1 p-2 text-xxs leading-5 text-c-1">
-        <div class="schema flex items-center text-c-2">
+        class="w-content bg-b-1 text-xxs text-c-1 pointer-events-none grid min-w-48 gap-1.5 rounded p-2 leading-5 shadow-lg">
+        <div
+          v-if="parameterIsInvalid(item).value"
+          class="text-error-1">
+          {{ parameterIsInvalid(item).value }}
+        </div>
+        <div
+          v-else
+          class="schema text-c-2 flex items-center">
           <span v-if="item.type">{{ item.type }}</span>
           <span v-if="item.format">{{ item.format }}</span>
           <span v-if="item.minimum">min: {{ item.minimum }}</span>
@@ -31,8 +44,8 @@ defineProps<{ item: RequestExampleParameter }>()
           <span v-if="item.default">default: {{ item.default }}</span>
         </div>
         <span
-          v-if="item.description"
-          class="leading-snug text-pretty text-sm"
+          v-if="item.description && !parameterIsInvalid(item).value"
+          class="text-pretty text-sm leading-snug"
           :style="{ maxWidth: '16rem' }"
           >{{ item.description }}</span
         >

--- a/packages/api-client/src/views/Request/libs/request.test.ts
+++ b/packages/api-client/src/views/Request/libs/request.test.ts
@@ -1,7 +1,7 @@
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
-import { hasItemProperties } from './request'
+import { hasItemProperties, parameterIsInvalid } from './request'
 
 describe('hasAllowedProperties', () => {
   it('should return true if item has a description', () => {
@@ -51,5 +51,133 @@ describe('hasAllowedProperties', () => {
       enabled: true,
     }
     expect(hasItemProperties(item)).toBe(false)
+  })
+})
+
+describe('parameterIsValid', () => {
+  it('should return false if value is undefined or empty', () => {
+    const item: RequestExampleParameter = {
+      key: 'key',
+      value: '',
+      enabled: true,
+    }
+    expect(parameterIsInvalid(item).value).toBe(false)
+  })
+
+  describe('integer validation', () => {
+    it('should validate integer type', () => {
+      const item: RequestExampleParameter = {
+        key: 'key',
+        value: 'abc',
+        type: 'integer',
+        enabled: true,
+      }
+      expect(parameterIsInvalid(item).value).toBe('Value must be a whole number (e.g., 42)')
+    })
+
+    it('should validate minimum value', () => {
+      const item: RequestExampleParameter = {
+        key: 'key',
+        value: '5',
+        type: 'integer',
+        minimum: 10,
+        enabled: true,
+      }
+      expect(parameterIsInvalid(item).value).toBe('Value must be 10 or greater')
+    })
+
+    it('should validate maximum value', () => {
+      const item: RequestExampleParameter = {
+        key: 'key',
+        value: '15',
+        type: 'integer',
+        maximum: 10,
+        enabled: true,
+      }
+      expect(parameterIsInvalid(item).value).toBe('Value must be 10 or less')
+    })
+  })
+
+  describe('string format validation', () => {
+    it('should validate date format', () => {
+      const item: RequestExampleParameter = {
+        key: 'key',
+        value: 'invalid-date',
+        type: 'string',
+        format: 'date',
+        enabled: true,
+      }
+      expect(parameterIsInvalid(item).value).toBe('Please enter a valid date in YYYY-MM-DD format (e.g., 2024-03-20)')
+    })
+
+    it('should validate email format', () => {
+      const item: RequestExampleParameter = {
+        key: 'key',
+        value: 'invalid-email',
+        type: 'string',
+        format: 'email',
+        enabled: true,
+      }
+      expect(parameterIsInvalid(item).value).toBe('Please enter a valid email address (e.g., user@example.com)')
+    })
+
+    it('should validate date-time format', () => {
+      const item: RequestExampleParameter = {
+        key: 'key',
+        value: 'invalid-datetime',
+        type: 'string',
+        format: 'date-time',
+        enabled: true,
+      }
+      expect(parameterIsInvalid(item).value).toBe(
+        'Please enter a valid date and time in RFC 3339 format (e.g., 2024-03-20T13:45:30Z)',
+      )
+
+      item.value = '2023-04-01T12:00:00Z'
+      expect(parameterIsInvalid(item).value).toBe(false)
+    })
+
+    it('should validate uri format with various schemes', () => {
+      const item: RequestExampleParameter = {
+        key: 'key',
+        value: 'invalid-uri',
+        type: 'string',
+        format: 'uri',
+        enabled: true,
+      }
+      expect(parameterIsInvalid(item).value).toBe('Please enter a valid URI (e.g., https://example.com)')
+
+      item.value = 'http://example.com'
+      expect(parameterIsInvalid(item).value).toBe(false)
+
+      item.value = 'ftp://example.com'
+      expect(parameterIsInvalid(item).value).toBe(false)
+
+      item.value = 'mailto:user@example.com'
+      expect(parameterIsInvalid(item).value).toBe(false)
+    })
+  })
+
+  describe('valid values', () => {
+    it('should return false for valid integer', () => {
+      const item: RequestExampleParameter = {
+        key: 'key',
+        value: '42',
+        type: 'integer',
+        enabled: true,
+      }
+      expect(parameterIsInvalid(item).value).toBe(false)
+    })
+
+    it('should return false for valid email', () => {
+      const item: RequestExampleParameter = {
+        key: 'key',
+        value: 'test@example.com',
+        type: 'string',
+        format: 'email',
+        enabled: true,
+      }
+      expect(parameterIsInvalid(item).value).toBe(false)
+    })
   })
 })

--- a/packages/api-client/src/views/Request/libs/request.ts
+++ b/packages/api-client/src/views/Request/libs/request.ts
@@ -1,4 +1,5 @@
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
+import { computed } from 'vue'
 
 /**
  * Check if a RequestExampleParameter has any of the following properties:
@@ -10,11 +11,63 @@ import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
  * - maximum
  */
 export const hasItemProperties = (item: RequestExampleParameter) =>
-  Boolean(
-    item.description ||
-      item.type ||
-      item.default ||
-      item.format ||
-      item.minimum ||
-      item.maximum,
-  )
+  Boolean(item.description || item.type || item.default || item.format || item.minimum || item.maximum)
+
+/**
+ * Checks if the value of a RequestExampleParameter is the expected type or format
+ * Returns an alert message if the value is not in the correct type or format, otherwise false
+ */
+export const parameterIsInvalid = (item: RequestExampleParameter) => {
+  return computed(() => {
+    if (item.value === undefined || item.value === '') return false
+
+    // Type validation
+    if (item.type) {
+      if (item.type === 'integer') {
+        const value = Number(item.value)
+        if (isNaN(value) || !Number.isInteger(value)) {
+          return 'Value must be a whole number (e.g., 42)'
+        }
+        if (item.minimum !== undefined && value < item.minimum) {
+          return `Value must be ${item.minimum} or greater`
+        }
+        if (item.maximum !== undefined && value > item.maximum) {
+          return `Value must be ${item.maximum} or less`
+        }
+      }
+
+      if (item.type === 'number') {
+        const value = Number(item.value)
+        if (isNaN(value)) {
+          return 'Value must be a number (e.g., 42.5)'
+        }
+        if (item.minimum !== undefined && value < item.minimum) {
+          return `Value must be ${item.minimum} or greater`
+        }
+        if (item.maximum !== undefined && value > item.maximum) {
+          return `Value must be ${item.maximum} or less`
+        }
+      }
+
+      if (item.type === 'string' && item.format) {
+        if (item.format === 'date' && !/^\d{4}-\d{2}-\d{2}$/.test(item.value)) {
+          return 'Please enter a valid date in YYYY-MM-DD format (e.g., 2024-03-20)'
+        }
+        if (
+          item.format === 'date-time' &&
+          !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/.test(item.value)
+        ) {
+          return 'Please enter a valid date and time in RFC 3339 format (e.g., 2024-03-20T13:45:30Z)'
+        }
+        if (item.format === 'email' && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(item.value)) {
+          return 'Please enter a valid email address (e.g., user@example.com)'
+        }
+        if (item.format === 'uri' && !/^[a-zA-Z][a-zA-Z0-9+.-]*:.+$/.test(item.value)) {
+          return 'Please enter a valid URI (e.g., https://example.com)'
+        }
+      }
+    }
+
+    return false
+  })
+}

--- a/packages/components/src/components/ScalarIcon/icons/Alert.svg
+++ b/packages/components/src/components/ScalarIcon/icons/Alert.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 8v4m0 4h.01M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/components/src/components/ScalarIcon/icons/index.ts
+++ b/packages/components/src/components/ScalarIcon/icons/index.ts
@@ -1,6 +1,7 @@
 export const ICONS = [
   'Add',
   'AddTab',
+  'Alert',
   'ArrowLeft',
   'ArrowRight',
   'Brackets',

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -57,7 +57,10 @@
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
   --scalar-button-1-color: rgba(255, 255, 255, 0.9);
 
-  --scalar-danger-color: color-mix(in srgb, var(--scalar-color-red), var(--scalar-color-1) 20%);
+  --scalar-color-danger: color-mix(in srgb, var(--scalar-color-red), var(--scalar-color-1) 20%);
+
+  --scalar-background-alert: color-mix(in srgb, var(--scalar-color-orange), var(--scalar-background-1) 95%);
+  --scalar-background-danger: color-mix(in srgb, var(--scalar-color-red), var(--scalar-background-1) 95%);
 }
 .dark-mode {
   --scalar-color-green: #00b648;
@@ -71,5 +74,8 @@
   --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
   --scalar-button-1-color: black;
 
-  --scalar-danger-color: color-mix(in srgb, var(--scalar-color-red), var(--scalar-background-1) 20%);
+  --scalar-color-danger: color-mix(in srgb, var(--scalar-color-red), var(--scalar-background-1) 20%);
+
+  --scalar-background-alert: color-mix(in srgb, var(--scalar-color-orange), var(--scalar-background-1) 95%);
+  --scalar-background-danger: color-mix(in srgb, var(--scalar-color-red), var(--scalar-background-1) 95%);
 }

--- a/packages/themes/src/tailwind.ts
+++ b/packages/themes/src/tailwind.ts
@@ -63,6 +63,8 @@ export default {
         4: 'var(--scalar-background-3)',
         accent: 'var(--scalar-background-accent)',
         btn: 'var(--scalar-button-1)',
+        danger: 'var(--scalar-background-danger)',
+        alert: 'var(--scalar-background-alert)',
       },
 
       // Foreground / Text Colors
@@ -74,7 +76,8 @@ export default {
         ghost: 'var(--scalar-color-ghost)',
         disabled: 'var(--scalar-color-disabled)',
         btn: 'var(--scalar-button-1-color)',
-        danger: 'var(--scalar-danger-color)',
+        danger: 'var(--scalar-color-danger)',
+        alert: 'var(--scalar-color-alert)',
       },
 
       // Hover Colors


### PR DESCRIPTION
**Problem**
currently when using a different type or expected value in a request parameter, no visual cue is given.

**Solution**
this pr is adding in order to incentive the user regarding the expected type or value:
- lib function that return warning message according to the expected type/value
- visual alert on the given row receiving a non valid type/value
- keeps allowing request to be sent

| before | after |
| -------|------|
| <img width="617" alt="image" src="https://github.com/user-attachments/assets/05ba09d2-48f2-480b-9864-794e914c9818" /> | <img width="617" alt="image" src="https://github.com/user-attachments/assets/d8177ade-3fc7-40c1-8e6d-622e4c555fad" /> |
| no visual cue is used | row is highlighted along displaying a warning message | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.