### PR TITLE
feat(api-client): request required field validation

### DIFF
--- a/.changeset/many-balloons-smash.md
+++ b/.changeset/many-balloons-smash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds request required empty parameter error

--- a/.changeset/mean-brooms-decide.md
+++ b/.changeset/mean-brooms-decide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: adds alert icon

--- a/.changeset/mighty-eggs-do.md
+++ b/.changeset/mighty-eggs-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds request parameter value validation alert

--- a/.changeset/wise-actors-tease.md
+++ b/.changeset/wise-actors-tease.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+feat: updates danger variable + add background alert variable

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -263,7 +263,7 @@ export default {
       :id="uid"
       v-bind="$attrs"
       ref="codeMirrorRef"
-      class="group-[.alert]:outline-orange font-code peer relative w-full overflow-hidden whitespace-nowrap text-xs leading-[1.44] -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline"
+      class="group-[.alert]:outline-orange group-[.error]:outline-red font-code peer relative w-full overflow-hidden whitespace-nowrap text-xs leading-[1.44] -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline"
       :class="{
         'flow-code-input--error': error,
       }"
@@ -294,7 +294,7 @@ export default {
   <slot name="icon" />
   <div
     v-if="required"
-    class="required centered-y text-xxs text-c-3 bg-b-1 pointer-events-none absolute right-0 pr-2 pt-px opacity-100 shadow-[-8px_0_4px_var(--scalar-background-1)] transition-opacity duration-150 group-[.alert]:bg-transparent group-[.alert]:shadow-none peer-has-[.cm-focused]:opacity-0">
+    class="required centered-y text-xxs text-c-3 group-[.error]:text-red bg-b-1 pointer-events-none absolute right-0 pr-2 pt-px opacity-100 shadow-[-8px_0_4px_var(--scalar-background-1)] transition-opacity duration-150 group-[.alert]:bg-transparent group-[.error]:bg-transparent group-[.alert]:shadow-none group-[.error]:shadow-none peer-has-[.cm-focused]:opacity-0">
     Required
   </div>
   <EnvironmentVariableDropdown

--- a/packages/api-client/src/components/DataTable/DataTableCell.vue
+++ b/packages/api-client/src/components/DataTable/DataTableCell.vue
@@ -20,7 +20,7 @@ const { cx } = useBindCx()
         'max-h-8 min-h-8 min-w-8 border-l-0 border-t border-b-0 border-r flex text-sm last:border-r-0 group-last:border-b-transparent p-0 m-0 relative',
       )
     "
-    class="group-[.alert]:bg-b-alert"
+    class="group-[.alert]:bg-b-alert group-[.error]:bg-b-danger"
     role="cell">
     <slot />
   </component>

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -89,7 +89,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
 
 <template>
   <div
-    class="group-[.alert]:outline-orange w-full pr-4 -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline">
+    class="group-[.alert]:outline-orange group-[.error]:outline-red w-full pr-4 -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline">
     <template v-if="type === 'array'">
       <ScalarComboboxMultiselect
         :modelValue="selectedArrayOptions"

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -12,7 +12,11 @@ import DataTableCheckbox from '@/components/DataTable/DataTableCheckbox.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import type { EnvVariable } from '@/store/active-entities'
 
-import { hasItemProperties, parameterIsInvalid } from '../libs/request'
+import {
+  hasEmptyRequiredParameter,
+  hasItemProperties,
+  parameterIsInvalid,
+} from '../libs/request'
 import RequestTableTooltip from './RequestTableTooltip.vue'
 
 const props = withDefaults(
@@ -75,6 +79,7 @@ const flattenValue = (item: RequestExampleParameter) => {
       :key="idx"
       :class="{
         alert: parameterIsInvalid(item).value,
+        error: hasEmptyRequiredParameter(item),
       }">
       <label class="contents">
         <template v-if="isGlobal">

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -12,9 +12,10 @@ const { item } = defineProps<{ item: RequestExampleParameter }>()
     class="w-full pr-px"
     :delay="0"
     side="left"
-    triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 group-[.alert]:before:to-b-alert before:min-h-[calc(100%-4px)] before:pointer-events-none before:right-[23px] before:top-0.5 before:w-3 absolute h-full right-0 -outline-offset-1">
+    triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 group-[.alert]:before:to-b-alert group-[.error]:before:to-b-danger before:min-h-[calc(100%-4px)] before:pointer-events-none before:right-[23px] before:top-0.5 before:w-3 absolute h-full right-0 -outline-offset-1">
     <template #trigger>
-      <div class="bg-b-1 mr-0.25 pl-1 pr-1.5 group-[.alert]:bg-transparent">
+      <div
+        class="bg-b-1 mr-0.25 pl-1 pr-1.5 group-[.alert]:bg-transparent group-[.error]:bg-transparent">
         <ScalarIcon
           :class="
             parameterIsInvalid(item).value

--- a/packages/api-client/src/views/Request/libs/request.test.ts
+++ b/packages/api-client/src/views/Request/libs/request.test.ts
@@ -1,7 +1,7 @@
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
-import { hasItemProperties, parameterIsInvalid } from './request'
+import { hasEmptyRequiredParameter, hasItemProperties, parameterIsInvalid } from './request'
 
 describe('hasAllowedProperties', () => {
   it('should return true if item has a description', () => {
@@ -179,5 +179,37 @@ describe('parameterIsValid', () => {
       }
       expect(parameterIsInvalid(item).value).toBe(false)
     })
+  })
+})
+
+describe('hasEmptyRequiredParameter', () => {
+  it('returns true if required item has empty value', () => {
+    const item: RequestExampleParameter = {
+      key: 'A key',
+      value: '',
+      required: true,
+      enabled: true,
+    }
+    expect(hasEmptyRequiredParameter(item)).toBe(true)
+  })
+
+  it('returns false if required item has value', () => {
+    const item: RequestExampleParameter = {
+      key: 'A key',
+      value: 'A value',
+      required: true,
+      enabled: true,
+    }
+    expect(hasEmptyRequiredParameter(item)).toBe(false)
+  })
+
+  it('returns false if non-required item has empty value', () => {
+    const item: RequestExampleParameter = {
+      key: 'A key',
+      value: '',
+      required: false,
+      enabled: true,
+    }
+    expect(hasEmptyRequiredParameter(item)).toBe(false)
   })
 })

--- a/packages/api-client/src/views/Request/libs/request.ts
+++ b/packages/api-client/src/views/Request/libs/request.ts
@@ -71,3 +71,8 @@ export const parameterIsInvalid = (item: RequestExampleParameter) => {
     return false
   })
 }
+
+/**
+ * Checks if a RequestExampleParameter is required and has an empty value
+ */
+export const hasEmptyRequiredParameter = (item: RequestExampleParameter) => Boolean(item.required && item.value === '')


### PR DESCRIPTION
**Problem**
currently request can be sent out with empty required field and no visual cue is given.

**Solution**
this pr adds visual cue when a required field value is empty and prevents the request to be sent.

| before | after |
| -------|------|
| <img width="1466" alt="image" src="https://github.com/user-attachments/assets/cbb114d8-a64d-4d93-9345-224a2a6f2104" /> | <img width="1466" alt="image" src="https://github.com/user-attachments/assets/2722f218-ceff-4377-bfcc-79b2df27cb3b" /> |
| no required field visual cue nor error | required field visual cue + toast | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.