### PR TITLE
fix(api-client): hitting hotkeys while in inputs

### DIFF
--- a/.changeset/shiny-ligers-yawn.md
+++ b/.changeset/shiny-ligers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: allow pressing modified hotkeys in inputs

--- a/.changeset/smooth-roses-lick.md
+++ b/.changeset/smooth-roses-lick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: allow hitting enter to submit in the address bar

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
+import { ScalarButton, ScalarIcon } from '@scalar/components'
+import type { RequestMethod } from '@scalar/oas-utils/entities/spec'
+import { REQUEST_METHODS } from '@scalar/oas-utils/helpers'
+import { ref, useId, watch } from 'vue'
+
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
 import { ServerDropdown } from '@/components/Server'
 import { useLayout } from '@/hooks'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
-import { ScalarButton, ScalarIcon } from '@scalar/components'
-import type { RequestMethod } from '@scalar/oas-utils/entities/spec'
-import { REQUEST_METHODS } from '@scalar/oas-utils/helpers'
-import { ref, useId, watch } from 'vue'
 
 import HttpMethod from '../HttpMethod/HttpMethod.vue'
 import AddressBarHistory from './AddressBarHistory.vue'
@@ -127,19 +128,19 @@ function updateRequestPath(url: string) {
   <div
     v-if="activeRequest && activeExample"
     :id="id"
-    class="scalar-address-bar order-last lg:order-none lg:w-auto w-full [--scalar-address-bar-height:32px] h-[--scalar-address-bar-height]">
+    class="scalar-address-bar order-last h-[--scalar-address-bar-height] w-full [--scalar-address-bar-height:32px] lg:order-none lg:w-auto">
     <div class="m-auto flex flex-row items-center">
       <!-- Address Bar -->
       <div
-        class="addressbar-bg-states group text-xxs relative flex w-full xl:min-w-[720px] xl:max-w-[720px] lg:min-w-[580px] lg:max-w-[580px] order-last lg:order-none flex-1 flex-row items-stretch rounded-lg p-0.75 max-w-[calc(100dvw-24px)]">
+        class="addressbar-bg-states text-xxs p-0.75 group relative order-last flex w-full max-w-[calc(100dvw-24px)] flex-1 flex-row items-stretch rounded-lg lg:order-none lg:min-w-[580px] lg:max-w-[580px] xl:min-w-[720px] xl:max-w-[720px]">
         <div
-          class="border rounded-lg pointer-events-none absolute left-0 top-0 block h-full w-full overflow-hidden">
+          class="pointer-events-none absolute left-0 top-0 block h-full w-full overflow-hidden rounded-lg border">
           <div
-            class="bg-mix-transparent bg-mix-amount-90 absolute left-0 top-0 h-full w-full z-context"
+            class="bg-mix-transparent bg-mix-amount-90 z-context absolute left-0 top-0 h-full w-full"
             :class="getBackgroundColor()"
-            :style="{ transform: `translate3d(-${percentage}%,0,0)` }"></div>
+            :style="{ transform: `translate3d(-${percentage}%,0,0)` }" />
         </div>
-        <div class="flex gap-1 z-context-plus">
+        <div class="z-context-plus flex gap-1">
           <HttpMethod
             :isEditable="layout !== 'modal'"
             isSquare
@@ -159,12 +160,12 @@ function updateRequestPath(url: string) {
             :server="activeServer"
             :target="id" />
 
-          <div class="fade-left"></div>
+          <div class="fade-left" />
           <!-- Path + URL + env vars -->
           <CodeInput
             ref="addressBarRef"
             aria-label="Path"
-            class="outline-none min-w-fit"
+            class="min-w-fit outline-none"
             disableCloseBrackets
             :disabled="layout === 'modal'"
             disableEnter
@@ -182,22 +183,22 @@ function updateRequestPath(url: string) {
             @curl="$emit('importCurl', $event)"
             @submit="handleExecuteRequest"
             @update:modelValue="updateRequestPath" />
-          <div class="fade-right"></div>
+          <div class="fade-right" />
         </div>
 
         <AddressBarHistory :target="id" />
         <ScalarButton
-          class="relative h-auto shrink-0 z-context-plus overflow-hidden pl-2 pr-2.5 py-1 font-bold"
+          class="z-context-plus relative h-auto shrink-0 overflow-hidden py-1 pl-2 pr-2.5 font-bold"
           :disabled="isRequesting"
           @click="handleExecuteRequest">
           <span
             aria-hidden="true"
-            class="inline-flex gap-1 items-center">
+            class="inline-flex items-center gap-1">
             <ScalarIcon
               class="relative shrink-0 fill-current"
               icon="Play"
               size="xs" />
-            <span class="text-xxs lg:flex hidden">Send</span>
+            <span class="text-xxs hidden lg:flex">Send</span>
           </span>
           <span class="sr-only"> Send Request </span>
         </ScalarButton>

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -206,6 +206,8 @@ const handleKeyDown = (key: string, event: KeyboardEvent) => {
       event.preventDefault()
       dropdownRef.value?.handleSelect()
     }
+  } else if (key === 'enter' && event.target instanceof HTMLDivElement) {
+    handleSubmit(event.target.textContent ?? '')
   }
 }
 

--- a/packages/api-client/src/libs/hot-keys.test.ts
+++ b/packages/api-client/src/libs/hot-keys.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { handleHotKeyDown, getModifiers, isInput } from './hot-keys'
+import { isMacOS } from '@scalar/use-tooltip'
+import type { EventBus } from '@/libs/event-bus'
+
+// Mock isMacOS
+vi.mock('@scalar/use-tooltip', () => ({
+  isMacOS: vi.fn().mockReturnValue(false),
+}))
+
+describe('hot-keys', () => {
+  // Helper to create keyboard events
+  const createKeyboardEvent = (key: string, options: Partial<KeyboardEvent> = {}) => {
+    return new KeyboardEvent('keydown', {
+      key,
+      ...options,
+    })
+  }
+
+  const mockEventBus = {
+    emit: vi.fn(),
+  } as unknown as EventBus<Partial<Record<string, KeyboardEvent>>>
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('handleHotKeyDown', () => {
+    describe('isInput', () => {
+      it('identifies input elements', () => {
+        const input = document.createElement('input')
+        const event = new KeyboardEvent('keydown', {})
+        Object.defineProperty(event, 'target', { value: input })
+        expect(isInput(event)).toBe(true)
+      })
+
+      it('identifies textarea elements', () => {
+        const textarea = document.createElement('textarea')
+        const event = new KeyboardEvent('keydown', {})
+        Object.defineProperty(event, 'target', { value: textarea })
+        expect(isInput(event)).toBe(true)
+      })
+
+      it('identifies contenteditable elements', () => {
+        const div = document.createElement('div')
+        div.contentEditable = 'true'
+        const event = new KeyboardEvent('keydown', {})
+        Object.defineProperty(event, 'target', { value: div })
+        expect(isInput(event)).toBe(true)
+      })
+
+      it('returns false for non-input elements', () => {
+        const div = document.createElement('div')
+        const event = new KeyboardEvent('keydown', {})
+        Object.defineProperty(event, 'target', { value: div })
+        expect(isInput(event)).toBe(false)
+      })
+
+      it('returns false for null target', () => {
+        const event = new KeyboardEvent('keydown', {})
+        Object.defineProperty(event, 'target', { value: null })
+        expect(isInput(event)).toBe(false)
+      })
+
+      it('handles elements with contentEditable="false"', () => {
+        const div = document.createElement('div')
+        div.contentEditable = 'false'
+        const event = new KeyboardEvent('keydown', {})
+        Object.defineProperty(event, 'target', { value: div })
+        expect(isInput(event)).toBe(false)
+      })
+    })
+
+    it('handles Escape key without modifiers', () => {
+      const event = createKeyboardEvent('Escape')
+      handleHotKeyDown(event, mockEventBus)
+      expect(mockEventBus.emit).toHaveBeenCalledWith({ closeModal: event })
+    })
+
+    it('handles Enter to executeRequest on windows/linux', () => {
+      const event = createKeyboardEvent('Enter', { ctrlKey: true })
+      handleHotKeyDown(event, mockEventBus)
+      expect(mockEventBus.emit).toHaveBeenCalledWith({ executeRequest: event })
+    })
+
+    it('handles Enter to executeRequest on macos', () => {
+      vi.mocked(isMacOS).mockReturnValue(true)
+      const event = createKeyboardEvent('Enter', { metaKey: true })
+      handleHotKeyDown(event, mockEventBus)
+
+      expect(mockEventBus.emit).toHaveBeenCalledWith({ executeRequest: event })
+    })
+
+    it('ignores hotkeys when in input fields', () => {
+      const event = createKeyboardEvent('b')
+      Object.defineProperty(event, 'target', {
+        value: document.createElement('input'),
+      })
+
+      handleHotKeyDown(event, mockEventBus)
+      expect(mockEventBus.emit).not.toHaveBeenCalled()
+    })
+
+    it('allows hotkeys with modifiers in inputs', () => {
+      const event = createKeyboardEvent('b', { ctrlKey: true })
+      Object.defineProperty(event, 'target', {
+        value: document.createElement('input'),
+      })
+
+      handleHotKeyDown(event, mockEventBus)
+      expect(mockEventBus.emit).toHaveBeenCalledWith({ toggleSidebar: event })
+    })
+
+    it('triggers the command palette windows/linux', () => {
+      const event = createKeyboardEvent('k', { ctrlKey: true })
+      handleHotKeyDown(event, mockEventBus)
+      expect(mockEventBus.emit).toHaveBeenCalledWith({ openCommandPalette: event })
+    })
+
+    it('triggers the command palette macos', () => {
+      vi.mocked(isMacOS).mockReturnValue(true)
+      const eventMacOS = createKeyboardEvent('k', { metaKey: true })
+      handleHotKeyDown(eventMacOS, mockEventBus)
+
+      expect(mockEventBus.emit).toHaveBeenCalledWith({ openCommandPalette: eventMacOS })
+    })
+  })
+
+  describe('getModifiers', () => {
+    it('converts default modifier to metaKey on macOS', () => {
+      vi.mocked(isMacOS).mockReturnValue(true)
+      expect(getModifiers(['default'])).toEqual(['metaKey'])
+    })
+
+    it('converts default modifier to ctrlKey on non-macOS', () => {
+      vi.mocked(isMacOS).mockReturnValue(false)
+      expect(getModifiers(['default'])).toEqual(['ctrlKey'])
+    })
+
+    it('handles multiple modifiers correctly', () => {
+      expect(getModifiers(['Alt', 'Shift'])).toEqual(['altKey', 'shiftKey'])
+    })
+  })
+})


### PR DESCRIPTION
**Problem**
You cannot execute the request from the address bar

**Solution**
With this PR we allow:
- allowing any hotkey with a modifier to trigger from within any inputs (ctrl+enter will work)
- allow hitting enter to submit in the address bar specifically

This one is for @DemonHa, I kept hitting this as well 😭 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
