### PR TITLE
chore: disable `vue/singleline-html-element-content-newline` ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,6 +109,8 @@ export default tslint.config(
           order: ['defineProps', 'defineEmits'],
         },
       ],
+      // Prettier doesn't play nice with this rule
+      'vue/singleline-html-element-content-newline': 'off',
       'vue/define-props-declaration': ['warn', 'type-based'],
       'vue/define-emits-declaration': ['warn', 'type-based'],
       'vue/html-button-has-type': [

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
-import { PathId } from '@/routes'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import {
   ScalarButton,
   ScalarDropdown,
@@ -14,6 +10,11 @@ import { isDefined } from '@scalar/oas-utils/helpers'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
+
+import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
+import { PathId } from '@/routes'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -95,7 +96,7 @@ const visibleRequests = computed<Request[]>(() =>
         placement="bottom"
         resize>
         <ScalarButton
-          class="justify-between p-2 max-h-8 w-full gap-1 text-xs hover:bg-b-2"
+          class="hover:bg-b-2 max-h-8 w-full justify-between gap-1 p-2 text-xs"
           variant="outlined"
           @click="handleSelect(selectedRequest)">
           {{ selectedRequest.summary }}
@@ -108,7 +109,7 @@ const visibleRequests = computed<Request[]>(() =>
           </div>
         </ScalarButton>
         <template #items>
-          <div class="max-h-40 custom-scroll">
+          <div class="custom-scroll max-h-40">
             <ScalarDropdownItem
               v-for="request in visibleRequests"
               :key="request.uid"


### PR DESCRIPTION
**Problem**
Eslint fixes it, then prettier breaks it.

**Solution**
We unfortunately need to comment the eslint rule, its much nicer but there's no way to configure it into prettier.

Lets remove prettier?

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
