### PR TITLE
fix(api-client): client empty state

### DIFF
--- a/.changeset/plenty-cups-own.md
+++ b/.changeset/plenty-cups-own.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: empty state with no collection requests

--- a/packages/api-client/src/layouts/Web/ApiClientWeb.vue
+++ b/packages/api-client/src/layouts/Web/ApiClientWeb.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
-import { ImportCollectionListener } from '@/components/ImportCollection'
-import MainLayout from '@/layouts/App/MainLayout.vue'
-import { type HotKeyEvent, handleHotKeyDown } from '@/libs'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import { addScalarClassesToHeadless } from '@scalar/components'
 import { getThemeStyles } from '@scalar/themes'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { ScalarToasts } from '@scalar/use-toasts'
 import { computed, onBeforeMount, onBeforeUnmount, onMounted } from 'vue'
 import { RouterView } from 'vue-router'
+
+import { ImportCollectionListener } from '@/components/ImportCollection'
+import MainLayout from '@/layouts/App/MainLayout.vue'
+import { handleHotKeyDown, type HotKeyEvent } from '@/libs'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 // Initialize color mode state globally
 useColorMode()
@@ -54,7 +55,7 @@ const themeStyleTag = computed(
 <template>
   <!-- Listen for paste and drop events, and look for `url` query parameters to import collections -->
   <ImportCollectionListener>
-    <div v-html="themeStyleTag"></div>
+    <div v-html="themeStyleTag" />
 
     <!-- Ensure we have the workspace loaded from localStorage above -->
     <MainLayout v-if="activeWorkspace?.uid">

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -43,12 +43,9 @@ export const createActiveEntitiesStore = ({
   const activeRouterParams = computed(getRouterParams(router))
 
   /** The currently selected workspace OR the first one */
-  const activeWorkspace = computed(() => {
-    const workspace =
-      workspaces[activeRouterParams.value[PathId.Workspace]] ?? workspaces[Object.keys(workspaces)[0] ?? '']
-
-    return workspace
-  })
+  const activeWorkspace = computed(
+    () => workspaces[activeRouterParams.value[PathId.Workspace]] ?? Object.values(workspaces)[0],
+  )
 
   /** Ordered list of the active workspace's collections with drafts last */
   const activeWorkspaceCollections = computed(
@@ -124,7 +121,7 @@ export const createActiveEntitiesStore = ({
     const collection =
       collections[activeRouterParams.value.collection] || collections[activeWorkspace.value?.collections[0] ?? '']
 
-    return requests[key] || requests[collection?.requests[0] ?? '']
+    return requests[key] || requests[collection?.requests[0] ?? ''] || Object.values(requests)[0]
   })
 
   /** Grabs the currently active example using the path param */

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -1,4 +1,13 @@
 <script setup lang="ts">
+import type { RequestPayload } from '@scalar/oas-utils/entities/spec'
+import { isDefined } from '@scalar/oas-utils/helpers'
+import { safeJSON } from '@scalar/object-utils/parse'
+import { useBreakpoints } from '@scalar/use-hooks/useBreakpoints'
+import { useToasts } from '@scalar/use-toasts'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+
+import EmptyState from '@/components/EmptyState.vue'
 import ImportCurlModal from '@/components/ImportCurl/ImportCurlModal.vue'
 import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
 import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
@@ -9,17 +18,10 @@ import { createRequestOperation } from '@/libs/send-request'
 import { PathId } from '@/routes'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
+import { useOpenApiWatcher } from '@/views/Request/hooks/useOpenApiWatcher'
 import RequestSection from '@/views/Request/RequestSection/RequestSection.vue'
 import RequestSubpageHeader from '@/views/Request/RequestSubpageHeader.vue'
 import ResponseSection from '@/views/Request/ResponseSection/ResponseSection.vue'
-import { useOpenApiWatcher } from '@/views/Request/hooks/useOpenApiWatcher'
-import type { RequestPayload } from '@scalar/oas-utils/entities/spec'
-import { isDefined } from '@scalar/oas-utils/helpers'
-import { safeJSON } from '@scalar/object-utils/parse'
-import { useBreakpoints } from '@scalar/use-hooks/useBreakpoints'
-import { useToasts } from '@scalar/use-toasts'
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
 
 import RequestSidebar from './RequestSidebar.vue'
 
@@ -225,10 +227,10 @@ function handleCurlImport(curl: string) {
 </script>
 <template>
   <div
-    v-if="activeCollection && activeRequest && activeWorkspace"
-    class="flex flex-1 flex-col pt-0 h-full bg-b-1 relative z-0 overflow-hidden"
+    v-if="activeCollection && activeWorkspace"
+    class="bg-b-1 relative z-0 flex h-full flex-1 flex-col overflow-hidden pt-0"
     :class="{
-      '!mr-0 !mb-0 !border-0': layout === 'modal',
+      '!mb-0 !mr-0 !border-0': layout === 'modal',
     }">
     <div class="flex h-full">
       <RequestSidebar
@@ -236,7 +238,11 @@ function handleCurlImport(curl: string) {
         :isSidebarOpen="isSidebarOpen"
         @newTab="$emit('newTab', $event)"
         @update:isSidebarOpen="(val) => (isSidebarOpen = val)" />
-      <div class="flex flex-1 flex-col h-full">
+
+      <!-- Ensure we have a request for this view -->
+      <div
+        v-if="activeRequest"
+        class="flex h-full flex-1 flex-col">
         <RequestSubpageHeader
           v-model="isSidebarOpen"
           :collection="activeCollection"
@@ -268,8 +274,15 @@ function handleCurlImport(curl: string) {
           </ViewLayoutContent>
         </ViewLayout>
       </div>
+
+      <!-- No active request -->
+      <EmptyState v-else />
     </div>
   </div>
+
+  <!-- No Collection or Workspace -->
+  <EmptyState v-else />
+
   <ImportCurlModal
     v-if="parsedCurl"
     :collectionUid="activeCollection?.uid ?? ''"

--- a/packages/api-client/src/views/Settings/SettingsGeneral.vue
+++ b/packages/api-client/src/views/Settings/SettingsGeneral.vue
@@ -115,7 +115,6 @@ const setProxy = (newProxy: string | undefined) =>
                 )
               "
               @click="setProxy(DEFAULT_PROXY_URL)">
-              ">
               <div
                 class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                 :class="{
@@ -142,7 +141,6 @@ const setProxy = (newProxy: string | undefined) =>
                 )
               "
               @click="setProxy(proxyUrl)">
-              ">
               <div
                 class="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] p-1"
                 :class="{


### PR DESCRIPTION
**Problem**
There was a completely blank view when your active collection has no requests.

**Solution**
Added a few failsafes, moved the if statement so the sidebar will show even if theres no active request, added some empty states.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
