### PR TITLE
fix(cli): load configuration references correctly

### DIFF
--- a/.changeset/new-carpets-bake.md
+++ b/.changeset/new-carpets-bake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/cli': patch
+---
+
+fix: load references correctly from configuration file

--- a/.changeset/wise-starfishes-collect.md
+++ b/.changeset/wise-starfishes-collect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/config': patch
+---
+
+chore: export types

--- a/packages/cli/src/commands/bundle/BundleCommand.ts
+++ b/packages/cli/src/commands/bundle/BundleCommand.ts
@@ -15,7 +15,7 @@ export function BundleCommand() {
 
     const startTime = performance.now()
 
-    const file = useGivenFileOrConfiguration(fileArgument)
+    const file = useGivenFileOrConfiguration(fileArgument)[0]
 
     const { specification: newContent } = await loadOpenApiFile(file)
 

--- a/packages/cli/src/commands/format/FormatCommand.ts
+++ b/packages/cli/src/commands/format/FormatCommand.ts
@@ -17,7 +17,7 @@ export function FormatCommand() {
   cmd.action(async (inputArgument: string, { output }: { output?: string }) => {
     const startTime = performance.now()
 
-    const input = useGivenFileOrConfiguration(inputArgument)
+    const input = useGivenFileOrConfiguration(inputArgument)[0]
     const specification = await getFileOrUrl(input)
 
     if (!specification) {

--- a/packages/cli/src/commands/mock/MockCommand.ts
+++ b/packages/cli/src/commands/mock/MockCommand.ts
@@ -30,7 +30,7 @@ export function MockCommand() {
       let server: ReturnType<typeof serve>
 
       // Configuration
-      const input = useGivenFileOrConfiguration(fileArgument)
+      const input = useGivenFileOrConfiguration(fileArgument)[0]
 
       // Load OpenAPI file
       const result = await loadOpenApiFile(input)

--- a/packages/cli/src/commands/serve/ServeCommand.ts
+++ b/packages/cli/src/commands/serve/ServeCommand.ts
@@ -19,7 +19,7 @@ export function ServeCommand() {
   cmd.option('-p, --port <port>', 'set the HTTP port for the API reference server')
   cmd.action(
     async (inputArgument: string, { watch, once, port }: { watch?: boolean; once?: boolean; port?: number }) => {
-      const input = useGivenFileOrConfiguration(inputArgument)
+      const input = useGivenFileOrConfiguration(inputArgument)[0]
       const result = await loadOpenApiFile(input)
 
       if (!result.valid) {

--- a/packages/cli/src/commands/share/ShareCommand.ts
+++ b/packages/cli/src/commands/share/ShareCommand.ts
@@ -13,7 +13,7 @@ export function ShareCommand() {
     'pass a token to update an existing sandbox',
   )
   cmd.action(async (fileArgument: string, { token }: { token?: string }) => {
-    const file = useGivenFileOrConfiguration(fileArgument)
+    const file = useGivenFileOrConfiguration(fileArgument)[0]
 
     const url =
       'https://sandbox.scalar.com/api/share' + (token ? `?token=${token}` : '')

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,1 +1,2 @@
 export * from './check'
+export * from './configTypes';


### PR DESCRIPTION
**Problem**
Currently, when user does not provide a file name we don't load references correctly

See #4480 

**Solution**
With this PR, it loads references from configuration file correctly when the user does not specify a file name

**Checklist**

I’ve gone through the following:

- [X] I’ve added an explanation _why_ this change is needed.
- [X] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
