### PR TITLE
fix(api-client): remove header update if initial body is set to raw

### DIFF
--- a/.changeset/twelve-points-raise.md
+++ b/.changeset/twelve-points-raise.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: remove header update if initial body is set to raw

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
@@ -203,4 +203,30 @@ describe('RequestBody.vue', () => {
 
     wrapper.unmount()
   })
+
+  it('removes Content-Type header when switching to none body type', async () => {
+    mockActiveExample.body = {
+      activeBody: 'raw',
+      raw: {
+        encoding: 'json',
+        value: '',
+      },
+    }
+
+    mockActiveExample.parameters = {
+      headers: [{ key: 'Content-Type', value: 'application/json', enabled: true }],
+      path: [],
+      cookies: [],
+      query: [],
+    }
+
+    const wrapper = mount(RequestBody, props)
+
+    const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+    await listbox.vm.$emit('update:modelValue', { id: 'none', label: 'None' })
+
+    expect(mockRequestExampleMutators.edit).toHaveBeenCalledWith('mockExampleUid', 'parameters.headers', [])
+
+    wrapper.unmount()
+  })
 })

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
@@ -175,4 +175,32 @@ describe('RequestBody.vue', () => {
     expect(wrapper.text()).toContain('Other')
     wrapper.unmount()
   })
+
+  it('keeps Content-Type header when switching to raw body type', async () => {
+    mockActiveExample.body = {
+      activeBody: 'formData',
+      formData: {
+        encoding: 'form-data',
+        value: [],
+      },
+    }
+
+    mockActiveExample.parameters = {
+      headers: [{ key: 'Content-Type', value: 'multipart/form-data', enabled: true }],
+      path: [],
+      cookies: [],
+      query: [],
+    }
+
+    const wrapper = mount(RequestBody, props)
+
+    const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+    await listbox.vm.$emit('update:modelValue', { id: 'json', label: 'JSON' })
+
+    expect(mockRequestExampleMutators.edit).toHaveBeenCalledWith('mockExampleUid', 'parameters.headers', [
+      { key: 'Content-Type', value: 'application/json', enabled: true },
+    ])
+
+    wrapper.unmount()
+  })
 })

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -303,7 +303,7 @@ const updateActiveBody = (type: Content) => {
       headers[contentTypeIdx].value = header
     }
     // Remove header if we don't want one
-    else if (headers[contentTypeIdx]) {
+    else if (headers[contentTypeIdx] && activeBody !== 'raw') {
       headers.splice(contentTypeIdx, 1)
     }
   }

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -281,7 +281,7 @@ const updateActiveBody = (type: Content) => {
       value: example.body.raw?.value ?? '',
     })
   } else if (encoding && activeBody === 'formData')
-    requestExampleMutators.edit(example.uid, `body.formData`, {
+    requestExampleMutators.edit(example.uid, 'body.formData', {
       encoding,
       value: example.body.formData?.value ?? [],
     })
@@ -303,7 +303,10 @@ const updateActiveBody = (type: Content) => {
       headers[contentTypeIdx].value = header
     }
     // Remove header if we don't want one
-    else if (headers[contentTypeIdx] && activeBody !== 'raw') {
+    else if (
+      headers[contentTypeIdx] &&
+      (activeBody !== 'raw' || type === 'none')
+    ) {
       headers.splice(contentTypeIdx, 1)
     }
   }


### PR DESCRIPTION
**Problem**
Currently, we remove content-type header if its added in the spec

**Solution**
With this PR we only set the content-type header if the body is selected

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
