### PR TITLE
feat(oas-utils): Set example request body if Content-Type header exists

### DIFF
--- a/.changeset/shiny-llamas-obey.md
+++ b/.changeset/shiny-llamas-obey.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: Set example request body if Content-Type header exists

--- a/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.ts
@@ -170,7 +170,7 @@ export function getRequestBodyFromOperation(
 
     return {
       mimeType,
-      text: typeof body === 'string' ? body : JSON.stringify(body, null, 2),
+      text: body ? typeof body === 'string' ? body : JSON.stringify(body, null, 2) : undefined,
     }
   }
 


### PR DESCRIPTION
**Problem**
Currently, when the Content-Type header value exists but there is no requestBody, the API client sets the body to None.

**Solution**
With this PR, the API client will set an example request body if the Content-Type header exists.

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.

before:

https://github.com/user-attachments/assets/8d684c27-4fa0-4d9e-ab5c-3c278a7fc528

after:

https://github.com/user-attachments/assets/59826d4a-01c1-485f-b6bb-448271d1e2ab


