### PR TITLE
fix(api-client): mime type transformation issue

### DIFF
--- a/.changeset/cold-years-cross.md
+++ b/.changeset/cold-years-cross.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+fix: mime type transformation issue

--- a/.changeset/spotty-walls-crash.md
+++ b/.changeset/spotty-walls-crash.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+'@scalar/types': patch
+---
+
+fix: adds vendor specific mime type support

--- a/packages/api-client/src/libs/importers/curl.ts
+++ b/packages/api-client/src/libs/importers/curl.ts
@@ -66,7 +66,7 @@ export function importCurlCommand(curlCommand: string): CurlCommandResult {
     })),
   ] as RequestParameterPayload[]
 
-  return {
+  const a =  {
     method,
     url,
     path,
@@ -89,4 +89,6 @@ export function importCurlCommand(curlCommand: string): CurlCommandResult {
     }),
     parameters,
   }
+  console.log(a, 'marc')
+  return a
 }

--- a/packages/api-client/src/libs/importers/curl.ts
+++ b/packages/api-client/src/libs/importers/curl.ts
@@ -66,7 +66,7 @@ export function importCurlCommand(curlCommand: string): CurlCommandResult {
     })),
   ] as RequestParameterPayload[]
 
-  const a =  {
+  return {
     method,
     url,
     path,
@@ -89,6 +89,4 @@ export function importCurlCommand(curlCommand: string): CurlCommandResult {
     }),
     parameters,
   }
-  console.log(a, 'marc')
-  return a
 }

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -68,6 +68,7 @@ const contentTypeOptions = (
 /** Match the activeBody to the contentTypeOptions */
 const activeExampleContentType = computed(() => {
   const { activeBody, formData, raw } = example.body
+  if (raw?.mimeType) return raw.mimeType
   // Form
   if (activeBody === 'formData')
     return formData?.encoding === 'urlencoded'
@@ -235,12 +236,16 @@ const getBodyType = (type: Content) => {
       encoding: undefined,
       header: 'application/octet-stream',
     } as const
-  if (type === 'json')
+  if (type === 'json' || type.endsWith('+json')) {
+    console.log('marc', type)
     return {
       activeBody: 'raw',
       encoding: 'json',
-      header: 'application/json',
+      header: type.endsWith('+json')
+        ? `application/${type}`
+        : 'application/json',
     } as const
+  }
   if (type === 'xml')
     return {
       activeBody: 'raw',
@@ -271,6 +276,7 @@ const getBodyType = (type: Content) => {
 
 /** Set active body AND encoding */
 const updateActiveBody = (type: Content) => {
+  console.log('marc', type)
   const { activeBody, encoding, header } = getBodyType(type)
   requestExampleMutators.edit(example.uid, 'body.activeBody', activeBody)
 
@@ -404,6 +410,11 @@ watch(
 watch(
   () => example.uid,
   () => {
+    console.log(
+      JSON.parse(JSON.stringify(example, null, 2)),
+      'marc',
+      JSON.parse(JSON.stringify(operation, null, 2)),
+    )
     operation.method &&
       canMethodHaveBody(operation.method) &&
       updateActiveBody(activeExampleContentType.value as Content)

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -237,7 +237,6 @@ const getBodyType = (type: Content) => {
       header: 'application/octet-stream',
     } as const
   if (type === 'json' || type.endsWith('+json')) {
-    console.log('marc', type)
     return {
       activeBody: 'raw',
       encoding: 'json',
@@ -276,7 +275,6 @@ const getBodyType = (type: Content) => {
 
 /** Set active body AND encoding */
 const updateActiveBody = (type: Content) => {
-  console.log('marc', type)
   const { activeBody, encoding, header } = getBodyType(type)
   requestExampleMutators.edit(example.uid, 'body.activeBody', activeBody)
 
@@ -410,11 +408,6 @@ watch(
 watch(
   () => example.uid,
   () => {
-    console.log(
-      JSON.parse(JSON.stringify(example, null, 2)),
-      'marc',
-      JSON.parse(JSON.stringify(operation, null, 2)),
-    )
     operation.method &&
       canMethodHaveBody(operation.method) &&
       updateActiveBody(activeExampleContentType.value as Content)

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -448,7 +448,6 @@ export function createExampleFromRequest(request: Request, name: string, server?
 
   const serverVariables = server ? getServerVariableExamples(server) : {}
 
-  console.log('okay whats going on', JSON.parse(JSON.stringify(parameters)), JSON.parse(JSON.stringify(body)))
   // safe parse the example
   const example = schemaModel(
     {
@@ -461,8 +460,6 @@ export function createExampleFromRequest(request: Request, name: string, server?
     requestExampleSchema,
     false,
   )
-
-  console.log('okay whats going on2', JSON.parse(JSON.stringify(example)))
 
   if (!example) {
     console.warn(`Example at ${request.uid} is invalid.`)

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -398,12 +398,12 @@ export function createExampleFromRequest(request: Request, name: string, server?
     const contentType = request.requestBody ? requestBody?.mimeType : contentTypeHeader?.value
 
     // Handle JSON and JSON-like mimetypes
-    if (requestBody?.mimeType?.includes('/json') || requestBody?.mimeType?.endsWith('+json')) {
+    if (contentType?.includes('/json') || contentType?.endsWith('+json')) {
       body.activeBody = 'raw'
       body.raw = {
         encoding: 'json',
-        mimeType: requestBody.mimeType,
-        value: requestBody.text ?? JSON.stringify({}),
+        mimeType: contentType,
+        value: requestBody?.text ?? JSON.stringify({}),
       }
     }
 

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -51,7 +51,7 @@ export const requestExampleParametersSchema = z
       data.nullable = true
     }
 
-    // Hey, if it's just one value and 'null', we can make it a string and ditch the 'null'.
+    // Hey, if it’s just one value and 'null', we can make it a string and ditch the 'null'.
     if (Array.isArray(data.type) && data.type.length === 2 && data.type.includes('null')) {
       data.type = data.type.find((item) => item !== 'null')
     }

--- a/packages/oas-utils/src/helpers/normalizeMimeType.test.ts
+++ b/packages/oas-utils/src/helpers/normalizeMimeType.test.ts
@@ -21,14 +21,8 @@ describe('normalizeMimeType', () => {
     expect(normalizeMimeType(content)).toBe('application/json')
   })
 
-  it('removes mimetype variants', async () => {
+  it('removes unsupported mimetype variants', async () => {
     const content = 'application/problem+json'
-
-    expect(normalizeMimeType(content)).toBe('application/json')
-  })
-
-  it('removes mimetype variants with special characters', async () => {
-    const content = 'application/vnd.api+json'
 
     expect(normalizeMimeType(content)).toBe('application/json')
   })
@@ -37,5 +31,17 @@ describe('normalizeMimeType', () => {
     const content = 'application/problem-foobar+json; charset=utf-8'
 
     expect(normalizeMimeType(content)).toBe('application/json')
+  })
+
+  it('keeps vendor specific mimetypes', async () => {
+    const content = 'application/vnd.api+json'
+
+    expect(normalizeMimeType(content)).toBe('application/vnd.api+json')
+  })
+
+  it('removes all the clutter but keeps vendor specific part', async () => {
+    const content = 'application/fhir+json; charset=utf-8'
+
+    expect(normalizeMimeType(content)).toBe('application/fhir+json')
   })
 })

--- a/packages/oas-utils/src/helpers/normalizeMimeType.ts
+++ b/packages/oas-utils/src/helpers/normalizeMimeType.ts
@@ -15,8 +15,8 @@ export function normalizeMimeType(contentType?: string) {
     contentType
       // Remove '; charset=utf-8'
       .replace(/;.*$/, '')
-      // Remove 'problem+'
-      .replace(/\/.+\+/, '/')
+      // Remove 'problem+' but keep vendor-specific vnd and fhir mime types
+      .replace(/\/(?!.*vnd\.|fhir\+).*\+/, '/')
       // Remove whitespace
       .trim() as ContentType
   )

--- a/packages/oas-utils/src/helpers/normalizeMimeTypeObject.test.ts
+++ b/packages/oas-utils/src/helpers/normalizeMimeTypeObject.test.ts
@@ -45,7 +45,7 @@ describe('normalizeMimeTypeObject', () => {
 
   it('removes mimetype variants with special characters', async () => {
     const content = {
-      'application/vnd.api+json': {},
+      'application/problem+json': {},
     }
 
     expect(normalizeMimeTypeObject(content)).toMatchObject({

--- a/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.test.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.test.ts
@@ -277,4 +277,36 @@ describe('getRequestBodyFromOperation', () => {
       ],
     })
   })
+
+  it('handles vendor-specific MIME types', () => {
+    const body = getRequestBodyFromOperation({
+      path: '/foobar',
+      information: {
+        requestBody: {
+          content: {
+            'application/vnd.github+json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  id: {
+                    type: 'integer',
+                    example: 1,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const expectedResult = {
+      id: 1,
+    }
+
+    expect(body).toMatchObject({
+      mimeType: 'application/vnd.github+json',
+      text: JSON.stringify(expectedResult, null, 2),
+    })
+  })
 })

--- a/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.ts
@@ -148,7 +148,6 @@ export function getRequestBodyFromOperation(
   // Get example from operation
   const example = requestBodyObject?.example ? requestBodyObject?.example : undefined
 
-  console.log(isJsonLike, 'marc')
 
   // Update the JSON handling section
   if (isJsonLike) {
@@ -161,7 +160,6 @@ export function getRequestBodyFromOperation(
 
     const body = example ?? exampleFromSchema
 
-    console.log(mimeType, 'marc', body)
 
     return {
       mimeType,

--- a/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.ts
+++ b/packages/oas-utils/src/spec-getters/getRequestBodyFromOperation.ts
@@ -95,7 +95,6 @@ export function getRequestBodyFromOperation(
   const bodyParameters = getParametersFromOperation(operation, 'body', false)
 
   if (bodyParameters.length > 0) {
-    console.log('here1')
     return {
       mimeType: 'application/json',
       text: prettyPrintJson(bodyParameters[0].value),

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -388,6 +388,8 @@ export type ContentType =
   | `application/x-www-form-urlencoded${OptionalCharset}`
   | `multipart/form-data${OptionalCharset}`
   | `*/*${OptionalCharset}`
+  | `application/vnd.${string}+json${OptionalCharset}`
+
 export type Cookie = {
   name: string
   value: string


### PR DESCRIPTION
**Problem**
Currently we convert everything to a `json` type and not respecting the proper mime type definition 

**Solution**
With this PR it respects the mime type definition if available ans fixes #4525 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
