### PR TITLE
fix(api-reference): show */* mimetype in example response

### DIFF
--- a/.changeset/tough-owls-compete.md
+++ b/.changeset/tough-owls-compete.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+fix: show _/_ mimetype in example response

--- a/packages/api-reference/playground/examples/src/App.vue
+++ b/packages/api-reference/playground/examples/src/App.vue
@@ -38,122 +38,7 @@ onMounted(async () => {
 const configuration = reactive<ReferenceConfiguration>({
   proxyUrl: 'https://proxy.scalar.com',
   spec: {
-    content: {
-      openapi: '3.0.1',
-      info: {
-        title: 'OpenAPI definition',
-        version: 'v0',
-      },
-      servers: [
-        {
-          url: '/',
-        },
-      ],
-      paths: {
-        '/api/widgets/{id}': {
-          get: {
-            tags: ['Widgets'],
-            summary: "Doesn't Work",
-            operationId: 'read',
-            parameters: [
-              {
-                name: 'id',
-                in: 'path',
-                required: true,
-                schema: {
-                  type: 'integer',
-                  format: 'int64',
-                },
-              },
-            ],
-            responses: {
-              '200': {
-                description: 'OK',
-                content: {
-                  '*/*': {
-                    schema: {
-                      $ref: '#/components/schemas/WidgetResponseDto',
-                    },
-                  },
-                },
-              },
-            },
-          },
-          put: {
-            tags: ['Widgets'],
-            summary: 'Works',
-            operationId: 'read',
-            parameters: [
-              {
-                name: 'id',
-                in: 'path',
-                required: true,
-                schema: {
-                  type: 'integer',
-                  format: 'int64',
-                },
-              },
-            ],
-            responses: {
-              '200': {
-                description: 'OK',
-                content: {
-                  'application/json': {
-                    schema: {
-                      $ref: '#/components/schemas/WidgetResponseDto',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      components: {
-        schemas: {
-          WidgetResponseDto: {
-            type: 'object',
-            properties: {
-              id: {
-                type: 'integer',
-                format: 'int64',
-              },
-              position: {
-                type: 'integer',
-                format: 'int32',
-              },
-              type: {
-                type: 'string',
-                enum: [
-                  'PRODUCT_GRID',
-                  'PRODUCT_SLIDER',
-                  'PRODUCT_CAROUSEL',
-                  'IMAGE_CAROUSEL',
-                  'IMAGE_SLIDER',
-                  'IMAGE_GRID',
-                  'IMAGE_BANNER',
-                  'VIDEO_BANNER',
-                  'EXPANDABLE_VIEW',
-                ],
-              },
-              config: {
-                type: 'object',
-                additionalProperties: {
-                  type: 'object',
-                },
-              },
-            },
-          },
-        },
-        securitySchemes: {
-          JWT: {
-            type: 'http',
-            scheme: 'bearer',
-            bearerFormat: 'JWT',
-          },
-        },
-      },
-    },
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
   },
 })
 
@@ -174,6 +59,13 @@ function selectRandomExample() {
 }
 
 /** Update configuration when URL changes */
+watch(url, (newUrl) => {
+  Object.assign(configuration, {
+    spec: {
+      url: newUrl,
+    },
+  })
+})
 </script>
 
 <template>

--- a/packages/api-reference/playground/examples/src/App.vue
+++ b/packages/api-reference/playground/examples/src/App.vue
@@ -38,7 +38,122 @@ onMounted(async () => {
 const configuration = reactive<ReferenceConfiguration>({
   proxyUrl: 'https://proxy.scalar.com',
   spec: {
-    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+    content: {
+      openapi: '3.0.1',
+      info: {
+        title: 'OpenAPI definition',
+        version: 'v0',
+      },
+      servers: [
+        {
+          url: '/',
+        },
+      ],
+      paths: {
+        '/api/widgets/{id}': {
+          get: {
+            tags: ['Widgets'],
+            summary: "Doesn't Work",
+            operationId: 'read',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: {
+                  type: 'integer',
+                  format: 'int64',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  '*/*': {
+                    schema: {
+                      $ref: '#/components/schemas/WidgetResponseDto',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          put: {
+            tags: ['Widgets'],
+            summary: 'Works',
+            operationId: 'read',
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: {
+                  type: 'integer',
+                  format: 'int64',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/WidgetResponseDto',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          WidgetResponseDto: {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'integer',
+                format: 'int64',
+              },
+              position: {
+                type: 'integer',
+                format: 'int32',
+              },
+              type: {
+                type: 'string',
+                enum: [
+                  'PRODUCT_GRID',
+                  'PRODUCT_SLIDER',
+                  'PRODUCT_CAROUSEL',
+                  'IMAGE_CAROUSEL',
+                  'IMAGE_SLIDER',
+                  'IMAGE_GRID',
+                  'IMAGE_BANNER',
+                  'VIDEO_BANNER',
+                  'EXPANDABLE_VIEW',
+                ],
+              },
+              config: {
+                type: 'object',
+                additionalProperties: {
+                  type: 'object',
+                },
+              },
+            },
+          },
+        },
+        securitySchemes: {
+          JWT: {
+            type: 'http',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+          },
+        },
+      },
+    },
   },
 })
 
@@ -59,13 +174,6 @@ function selectRandomExample() {
 }
 
 /** Update configuration when URL changes */
-watch(url, (newUrl) => {
-  Object.assign(configuration, {
-    spec: {
-      url: newUrl,
-    },
-  })
-})
 </script>
 
 <template>

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponses.test.ts
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponses.test.ts
@@ -368,4 +368,29 @@ describe('ExampleResponses', () => {
     expect(wrapper.text()).not.toContain('type')
     expect(wrapper.text()).not.toContain('properties')
   })
+
+  it('renders wildcard mimetype correctly', () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              '*/*': {
+                example: { message: 'Wildcard mimetype' },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'CardTab' })
+    const codeBlock = wrapper.findAllComponents({ name: 'ScalarCodeBlock' })
+
+    expect(tabs.length).toBe(1)
+    expect(tabs[0].text()).toContain('200')
+    expect(codeBlock.length).toBe(1)
+    expect(wrapper.text()).toContain('Wildcard mimetype')
+  })
 })

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
@@ -51,8 +51,6 @@ const currentJsonResponse = computed(() => {
     currentResponse.value?.content,
   )
 
-  console.log('marc', normalizedContent)
-
   return (
     // OpenAPI 3.x
     normalizedContent?.['application/json'] ??

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
@@ -51,12 +51,15 @@ const currentJsonResponse = computed(() => {
     currentResponse.value?.content,
   )
 
+  console.log('marc', normalizedContent)
+
   return (
     // OpenAPI 3.x
     normalizedContent?.['application/json'] ??
     normalizedContent?.['application/xml'] ??
     normalizedContent?.['text/plain'] ??
     normalizedContent?.['text/html'] ??
+    normalizedContent?.['*/*'] ??
     // Swagger 2.0
     currentResponse.value
   )
@@ -124,7 +127,7 @@ const showSchema = ref(false)
             :aria-controls="id"
             class="scalar-card-checkbox-input"
             type="checkbox" />
-          <span class="scalar-card-checkbox-checkmark"></span>
+          <span class="scalar-card-checkbox-checkmark" />
         </label>
       </template>
     </CardTabHeader>

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -355,7 +355,7 @@ export type ContentType =
   | `application/octet-stream${OptionalCharset}`
   | `application/x-www-form-urlencoded${OptionalCharset}`
   | `multipart/form-data${OptionalCharset}`
-
+  | `*/*${OptionalCharset}`
 export type Cookie = {
   name: string
   value: string


### PR DESCRIPTION
**Problem**
Currently, we don't handle `*/*` mimeTypes

**Solution**
With this PR we render it :) 

before:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/670c4d7e-3e38-475c-96de-d28086c50659" />


after:
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/0945e39e-9537-41f4-9ad3-00a8ad392c2f" />


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
