### PR TITLE
fix(api-client): when importing a collection we navigate to the collection page

### DIFF
--- a/.changeset/wicked-berries-fold.md
+++ b/.changeset/wicked-berries-fold.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: when importing a collection we navigate to the collection page


### PR DESCRIPTION
**Problem**
Currently, you import a collection and you have to click it

**Solution**
With this PR it navigates to our new collection page :)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
