### PR TITLE
feat(api-reference): add multiple openapi document support

### DIFF
--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -11,10 +11,7 @@
   <body>
     <!-- Add your own OpenAPI/Swagger specification URL here: -->
     <!-- Note: The example is our public proxy (to avoid CORS issues). You can remove the `data-proxy-url` attribute if you don’t need it. -->
-    <script
-      id="api-reference"
-      data-proxy-url="https://proxy.scalar.com"
-      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json"></script>
+    <script id="api-reference"></script>
 
     <!-- Optional: You can set a full configuration object like this: -->
     <script>
@@ -23,6 +20,13 @@
         //   targetKey: 'node',
         //   clientKey: 'undici',
         // },
+        specs: [
+          {
+            url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+            name: 'PET STORE',
+          },
+          { url: 'https://galaxy.scalar.com/openapi.yaml', name: 'GALAXY' },
+        ],
       }
 
       document.getElementById('api-reference').dataset.configuration =

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -33,19 +33,40 @@ const customCss = computed(() => {
   return migrateThemeVariables(props.configuration?.customCss)
 })
 
+// Replace useRoute with direct URL parsing
+const selectedApiName = computed(() => {
+  const params = new URLSearchParams(window.location.search)
+  return params.get('selectedAPI') || ''
+})
+
+// Find matching spec or fallback to first spec
+const specOverRide = computed(() => {
+  if (!selectedApiName.value || !props.configuration?.specs?.length) {
+    return props.configuration?.specs?.[0]
+  }
+
+  return (
+    props.configuration?.specs?.find(
+      (spec) =>
+        spec.name?.toLowerCase() === selectedApiName.value.toLowerCase(),
+    ) ?? props.configuration?.specs?.[0]
+  )
+})
+
 // Set defaults as needed on the provided configuration
 const configuration = computed<ReferenceConfiguration>(() => ({
-  spec: {
-    content: undefined,
-    url: undefined,
-    ...props.configuration?.spec,
-  },
   proxyUrl: undefined,
   theme: 'default',
   showSidebar: true,
   isEditable: false,
   ...props.configuration,
   customCss: customCss.value,
+  spec: {
+    content: undefined,
+    url: undefined,
+    ...props.configuration?.spec,
+    ...specOverRide.value,
+  },
 }))
 
 if (configuration.value?.metaData) {

--- a/packages/api-reference/src/components/Layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ClassicLayout.vue
@@ -18,6 +18,27 @@ const slots = defineSlots<ReferenceLayoutSlots>()
 
 // Override the sidebar value and hide it
 const config = computed(() => ({ ...props.configuration, showSidebar: false }))
+
+// Add API selection functionality
+const handleSpecChange = (event: Event) => {
+  const value = (event.target as HTMLSelectElement).value
+
+  // Update URL query parameter and reload page
+  const url = new URL(window.location.href)
+  url.searchParams.set('selectedAPI', value)
+  window.location.href = url.toString() // This will trigger a page reload
+}
+
+const selectedApiName = computed(() => {
+  const params = new URLSearchParams(window.location.search)
+  const selected = params.get('selectedAPI')
+
+  // Return selected API name if it exists in specs, otherwise return first spec name
+  return selected &&
+    props.configuration?.specs?.find((s) => s.name === selected)
+    ? selected
+    : props.configuration?.specs?.[0]?.name
+})
 </script>
 <template>
   <ApiReferenceLayout
@@ -31,10 +52,27 @@ const config = computed(() => ({ ...props.configuration, showSidebar: false }))
       #[name]="slotProps">
       <slot
         :name="name"
-        v-bind="slotProps || {}"></slot>
+        v-bind="slotProps || {}" />
     </template>
     <template #content-start="{ spec }">
       <ClassicHeader>
+        <!-- Add API selector -->
+        <div
+          v-if="
+            props.configuration?.specs && props.configuration.specs.length > 1
+          ">
+          <select
+            class="spec-selector"
+            :value="selectedApiName"
+            @change="handleSpecChange">
+            <option
+              v-for="spec in props.configuration.specs"
+              :key="spec.name"
+              :value="spec.name">
+              {{ spec.name }}
+            </option>
+          </select>
+        </div>
         <SearchButton
           v-if="!props.configuration.hideSearch"
           class="t-doc__sidebar"

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -5,7 +5,7 @@ import {
   ScalarSidebarFooter,
 } from '@scalar/components'
 import { useBreakpoints } from '@scalar/use-hooks/useBreakpoints'
-import { watch } from 'vue'
+import { computed, watch } from 'vue'
 
 import { SearchButton } from '../../features/Search'
 import { useNavState, useSidebar } from '../../hooks'
@@ -36,6 +36,26 @@ watch(hash, (newHash, oldHash) => {
     isSidebarOpen.value = false
   }
 })
+
+const handleSpecChange = (event: Event) => {
+  const value = (event.target as HTMLSelectElement).value
+
+  // Update URL query parameter and reload page
+  const url = new URL(window.location.href)
+  url.searchParams.set('selectedAPI', value)
+  window.location.href = url.toString() // This will trigger a page reload
+}
+
+const selectedApiName = computed(() => {
+  const params = new URLSearchParams(window.location.search)
+  const selected = params.get('selectedAPI')
+
+  // Return selected API name if it exists in specs, otherwise return first spec name
+  return selected &&
+    props.configuration?.specs?.find((s) => s.name === selected)
+    ? selected
+    : props.configuration?.specs?.[0]?.name
+})
 </script>
 <template>
   <ApiReferenceLayout
@@ -51,7 +71,7 @@ watch(hash, (newHash, oldHash) => {
       #[name]="slotProps">
       <slot
         :name="name"
-        v-bind="slotProps || {}"></slot>
+        v-bind="slotProps || {}" />
     </template>
     <template #header>
       <MobileHeader
@@ -59,6 +79,22 @@ watch(hash, (newHash, oldHash) => {
         v-model:open="isSidebarOpen" />
     </template>
     <template #sidebar-start="{ spec }">
+      <div>
+        <select
+          v-if="
+            props.configuration?.specs && props.configuration.specs.length > 1
+          "
+          class="spec-selector"
+          :value="selectedApiName"
+          @change="handleSpecChange">
+          <option
+            v-for="spec in props.configuration.specs"
+            :key="spec.name"
+            :value="spec.name">
+            {{ spec.name }}
+          </option>
+        </select>
+      </div>
       <div
         v-if="!props.configuration.hideSearch"
         class="scalar-api-references-standalone-search">

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -71,6 +71,8 @@ export type ReferenceConfiguration = {
   layout?: 'modern' | 'classic'
   /** The Swagger/OpenAPI spec to render */
   spec?: SpecConfiguration
+  /** The Swagger/OpenAPI specs to render */
+  specs?: SpecConfiguration[]
   /**
    * URL to a request proxy for the API client
    *
@@ -474,6 +476,10 @@ export type SpecConfiguration = {
    * @remark It’s recommended to pass an `url` instead of `content`.
    */
   content?: string | Record<string, any> | (() => Record<string, any>) | null
+  /**
+   * The name of the API.
+   */
+  name?: string
 }
 
 export type Schema = {


### PR DESCRIPTION
**Problem**
Currently we only support one "spec"

**Solution**
With this PR we allow for a new configuration type, called "specs" which means you can load multiple versions of an API, different APIs and it shows in the header above the sidebar.

currently we save it as a query parameter, or load the first one in the array. but in the future we can load all these in our workspace store and select them without a refresh.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/03457b56-8b1a-4d25-bce6-6ba2a76ef5ce" />

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/b6febb72-afee-402f-a2f5-c7c59797fade" />


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
