### PR TITLE
feat(use-codemirror):  undo/redo

### DIFF
--- a/.changeset/twelve-moose-leave.md
+++ b/.changeset/twelve-moose-leave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-codemirror': patch
+---
+
+feat: adds code mirror history commands

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -24,6 +24,7 @@ import {
   lineNumbers as lineNumbersExtension,
   placeholder as placeholderExtension,
 } from '@codemirror/view'
+import { history, historyKeymap } from '@codemirror/commands'
 import { ScalarIcon } from '@scalar/components'
 import { type MaybeRefOrGetter, type Ref, computed, h, onBeforeUnmount, ref, render, toValue, watch } from 'vue'
 
@@ -280,6 +281,8 @@ function getCodeMirrorExtensions({
 }) {
   const extensions: Extension[] = [
     highlightSpecialChars(),
+    history(),
+    keymap.of(historyKeymap),
     syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
     EditorView.theme({
       '.cm-line': {


### PR DESCRIPTION
**Problem**
currently we cannot from the api client input undo or redo value insertion.

**Solution**
this pr adds history support to codemirror in order to enable undo/redo action.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
