### PR TITLE
fix(api-client): overall border style

### DIFF
--- a/.changeset/rich-carpets-build.md
+++ b/.changeset/rich-carpets-build.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates overall border style

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -72,7 +72,7 @@ const handleLabelClick = () => {
     :class="containerClass">
     <div
       v-if="$slots.default"
-      class="text-c-1 flex items-center pr-0 pl-3"
+      class="text-c-1 flex items-center pl-3 pr-0"
       :for="id ?? ''"
       @click="handleLabelClick">
       <slot />:
@@ -90,7 +90,7 @@ const handleLabelClick = () => {
           v-if="mask && type === 'password'"
           v-bind="id ? { ...$attrs, id: id } : $attrs"
           autocomplete="off"
-          class="text-c-1 disabled:text-c-2 peer w-full min-w-0 border-none px-2 py-1.25 -outline-offset-2"
+          class="text-c-1 disabled:text-c-2 py-1.25 peer w-full min-w-0 border-none px-2 -outline-offset-2"
           data-1p-ignore
           :readOnly="readOnly"
           spellcheck="false"

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -43,6 +43,7 @@ defineOptions({ inheritAttrs: false })
 
 const mask = ref(true)
 const interactingWithDropdown = ref(false)
+const codeInput = ref<InstanceType<typeof CodeInput> | null>(null)
 
 const handleBlur = () => {
   if (!interactingWithDropdown.value) {
@@ -57,6 +58,13 @@ const inputType = computed(() =>
       : 'text'
     : (props.type ?? 'text'),
 )
+
+// If not an enum nor read only, focus the code input
+const handleLabelClick = () => {
+  if (!props.enum?.length && !props.readOnly) {
+    codeInput.value?.focus()
+  }
+}
 </script>
 <template>
   <DataTableCell
@@ -64,11 +72,9 @@ const inputType = computed(() =>
     :class="containerClass">
     <div
       v-if="$slots.default"
-      class="text-c-1 flex items-center pl-3 pr-0"
+      class="text-c-1 flex items-center pr-0 pl-3"
       :for="id ?? ''"
-      @click="
-        !props.enum?.length && !props.readOnly && $refs.codeInput?.focus()
-      ">
+      @click="handleLabelClick">
       <slot />:
     </div>
     <div class="row-1 overflow-x-auto">
@@ -84,7 +90,7 @@ const inputType = computed(() =>
           v-if="mask && type === 'password'"
           v-bind="id ? { ...$attrs, id: id } : $attrs"
           autocomplete="off"
-          class="text-c-1 disabled:text-c-2 py-1.25 peer w-full min-w-0 border-none px-2 -outline-offset-2"
+          class="text-c-1 disabled:text-c-2 peer w-full min-w-0 border-none px-2 py-1.25 -outline-offset-2"
           data-1p-ignore
           :readOnly="readOnly"
           spellcheck="false"

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -16,14 +16,13 @@ const {
   <Disclosure
     v-slot="{ open }"
     as="div"
-    class="focus-within:text-c-1 text-c-2 request-item border-b"
-    :class="{ 'first:border-t': layout === 'client' }"
+    class="focus-within:text-c-1 text-c-2 request-item"
     :defaultOpen="defaultOpen"
     :static="layout === 'reference'">
     <div class="bg-b-2 flex items-center">
       <DisclosureButton
         :class="[
-          'hover:text-c-1 group flex max-h-8 flex-1 items-center gap-2.5 overflow-hidden px-1 py-1.5 text-sm font-medium outline-none md:px-1.5 xl:pl-2 xl:pr-0.5',
+          'hover:text-c-1 group flex max-h-8 flex-1 items-center gap-2.5 overflow-hidden px-1 py-1.5 text-sm font-medium outline-none md:px-1.5 xl:pr-0.5 xl:pl-2',
           { '!pl-3': layout === 'reference' },
         ]"
         :disabled="layout === 'reference'">

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -22,7 +22,7 @@ const {
     <div class="bg-b-2 flex items-center">
       <DisclosureButton
         :class="[
-          'hover:text-c-1 group flex max-h-8 flex-1 items-center gap-2.5 overflow-hidden px-1 py-1.5 text-sm font-medium outline-none md:px-1.5 xl:pr-0.5 xl:pl-2',
+          'hover:text-c-1 group flex max-h-8 flex-1 items-center gap-2.5 overflow-hidden px-1 py-1.5 text-sm font-medium outline-none md:px-1.5 xl:pl-2 xl:pr-0.5',
           { '!pl-3': layout === 'reference' },
         ]"
         :disabled="layout === 'reference'">

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -11,7 +11,7 @@ const { cx } = useBindCx()
     ">
     <div
       v-if="$slots.title"
-      class="-mb-0.25 bg-b-1 z-1 sticky top-0 flex min-h-11 items-center border-b px-2.5 text-sm font-medium xl:rounded-none">
+      class="bg-b-1 sticky top-0 z-1 flex min-h-11 items-center border-b px-2.5 text-sm font-medium xl:rounded-none">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -11,7 +11,7 @@ const { cx } = useBindCx()
     ">
     <div
       v-if="$slots.title"
-      class="bg-b-1 sticky top-0 z-1 flex min-h-11 items-center border-b px-2.5 text-sm font-medium xl:rounded-none">
+      class="bg-b-1 z-1 sticky top-0 flex min-h-11 items-center border-b px-2.5 text-sm font-medium xl:rounded-none">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/views/Cookies/CookieForm.vue
+++ b/packages/api-client/src/views/Cookies/CookieForm.vue
@@ -40,8 +40,5 @@ const updateCookie = <P extends Path<Cookie>>(
     :data="activeCookie"
     :onUpdate="updateCookie"
     :options="fields">
-    <template #title>
-      <span class="text-c-2">Edit Cookie</span>
-    </template>
   </Form>
 </template>

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -11,6 +11,7 @@ import SidebarList from '@/components/Sidebar/SidebarList.vue'
 import SidebarListElement from '@/components/Sidebar/SidebarListElement.vue'
 import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
 import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
+import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
 import type { HotKeyEvent } from '@/libs'
 import { PathId } from '@/routes'
 import { useActiveEntities, useWorkspace } from '@/store'
@@ -174,9 +175,12 @@ const hasCookies = computed(
 
     <ViewLayoutContent class="flex-1">
       <template v-if="hasCookies">
-        <CookieForm />
-        <!--  Untested and disabled for now. -->
-        <!-- <CookieRaw /> -->
+        <ViewLayoutSection class="*:border-b-0">
+          <template #title>Edit Cookie</template>
+          <CookieForm />
+          <!--  Untested and disabled for now. -->
+          <!-- <CookieRaw /> -->
+        </ViewLayoutSection>
       </template>
       <EmptyState v-else />
     </ViewLayoutContent>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -404,7 +404,7 @@ function handleRename(newName: string) {
               :key="collection.uid"
               class="gap-1/2 flex flex-col">
               <button
-                class="hover:bg-b-2 group flex w-full items-center gap-1.5 break-words rounded p-1.5 text-left text-sm font-medium"
+                class="hover:bg-b-2 group flex w-full items-center gap-1.5 rounded p-1.5 text-left text-sm font-medium break-words"
                 type="button"
                 @click="toggleSidebarFolder(collection.uid)">
                 <span class="flex h-5 max-w-[14px] items-center justify-center">
@@ -428,7 +428,7 @@ function handleRename(newName: string) {
               <div
                 v-show="showChildren(collection.uid)"
                 :class="{
-                  'before:bg-border before:z-1 relative mb-[.5px] before:pointer-events-none before:absolute before:left-3 before:top-0 before:h-[calc(100%_+_.5px)] before:w-[.5px] last:mb-0 last:before:h-full':
+                  'before:bg-border relative mb-[.5px] before:pointer-events-none before:absolute before:top-0 before:left-3 before:z-1 before:h-[calc(100%_+_.5px)] before:w-[.5px] last:mb-0 last:before:h-full':
                     Object.keys(collection['x-scalar-environments'] || {})
                       .length > 0,
                 }">
@@ -500,7 +500,7 @@ function handleRename(newName: string) {
         </template>
         <CodeInput
           v-if="currentEnvironmentId && activeWorkspace"
-          class="border-t py-2 pl-px pr-2 md:px-4"
+          class="py-2 pr-2 pl-px md:px-4"
           :envVariables="activeEnvVariables"
           :environment="activeEnvironment"
           isCopyable

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -404,7 +404,7 @@ function handleRename(newName: string) {
               :key="collection.uid"
               class="gap-1/2 flex flex-col">
               <button
-                class="hover:bg-b-2 group flex w-full items-center gap-1.5 rounded p-1.5 text-left text-sm font-medium break-words"
+                class="hover:bg-b-2 group flex w-full items-center gap-1.5 break-words rounded p-1.5 text-left text-sm font-medium"
                 type="button"
                 @click="toggleSidebarFolder(collection.uid)">
                 <span class="flex h-5 max-w-[14px] items-center justify-center">
@@ -428,7 +428,7 @@ function handleRename(newName: string) {
               <div
                 v-show="showChildren(collection.uid)"
                 :class="{
-                  'before:bg-border relative mb-[.5px] before:pointer-events-none before:absolute before:top-0 before:left-3 before:z-1 before:h-[calc(100%_+_.5px)] before:w-[.5px] last:mb-0 last:before:h-full':
+                  'before:bg-border before:z-1 relative mb-[.5px] before:pointer-events-none before:absolute before:left-3 before:top-0 before:h-[calc(100%_+_.5px)] before:w-[.5px] last:mb-0 last:before:h-full':
                     Object.keys(collection['x-scalar-environments'] || {})
                       .length > 0,
                 }">
@@ -500,7 +500,7 @@ function handleRename(newName: string) {
         </template>
         <CodeInput
           v-if="currentEnvironmentId && activeWorkspace"
-          class="py-2 pr-2 pl-px md:px-4"
+          class="py-2 pl-px pr-2 md:px-4"
           :envVariables="activeEnvVariables"
           :environment="activeEnvironment"
           isCopyable

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -115,9 +115,8 @@ const selectClient = ({ id }: ScalarComboboxOption) => {
 <template>
   <div class="w-full">
     <ViewLayoutCollapse
-      class="group/preview -mt-0.25 w-full border-b-0"
-      :defaultOpen="false"
-      :hasIcon="false">
+      class="group/preview w-full border-b-0"
+      :defaultOpen="false">
       <template #title>Code Snippet</template>
       <template #actions>
         <div class="-mx-1 flex flex-1">
@@ -127,7 +126,7 @@ const selectClient = ({ id }: ScalarComboboxOption) => {
             placement="bottom-end"
             @update:modelValue="selectClient">
             <ScalarButton
-              class="py-0.75 text-c-1 hover:bg-b-3 flex h-full w-fit gap-1.5 px-1.5 font-normal"
+              class="text-c-1 hover:bg-b-3 flex h-full w-fit gap-1.5 px-1.5 py-0.75 font-normal"
               fullWidth
               variant="ghost">
               <span>{{ selectedPlugin?.label }}</span>

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -126,7 +126,7 @@ const selectClient = ({ id }: ScalarComboboxOption) => {
             placement="bottom-end"
             @update:modelValue="selectClient">
             <ScalarButton
-              class="text-c-1 hover:bg-b-3 flex h-full w-fit gap-1.5 px-1.5 py-0.75 font-normal"
+              class="text-c-1 hover:bg-b-3 py-0.75 flex h-full w-fit gap-1.5 px-1.5 font-normal"
               fullWidth
               variant="ghost">
               <span>{{ selectedPlugin?.label }}</span>

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -124,12 +124,12 @@ const activeWorkspaceCookies = computed(() =>
         class="group pointer-events-none flex flex-1 items-center gap-1 lg:pr-24">
         <label
           v-if="layout !== 'modal'"
-          class="pointer-events-auto absolute top-0 left-0 h-full w-full cursor-text opacity-0"
+          class="pointer-events-auto absolute left-0 top-0 h-full w-full cursor-text opacity-0"
           for="requestname" />
         <input
           v-if="layout !== 'modal'"
           id="requestname"
-          class="text-c-1 group-hover-input pointer-events-auto relative z-10 -ml-0.5 h-8 w-full rounded pl-1.25 has-[:focus-visible]:outline md:-ml-1.25"
+          class="text-c-1 group-hover-input pl-1.25 md:-ml-1.25 pointer-events-auto relative z-10 -ml-0.5 h-8 w-full rounded has-[:focus-visible]:outline"
           placeholder="Request Name"
           :value="operation.summary"
           @input="updateRequestNameHandler" />

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -124,12 +124,12 @@ const activeWorkspaceCookies = computed(() =>
         class="group pointer-events-none flex flex-1 items-center gap-1 lg:pr-24">
         <label
           v-if="layout !== 'modal'"
-          class="pointer-events-auto absolute left-0 top-0 h-full w-full cursor-text opacity-0"
+          class="pointer-events-auto absolute top-0 left-0 h-full w-full cursor-text opacity-0"
           for="requestname" />
         <input
           v-if="layout !== 'modal'"
           id="requestname"
-          class="text-c-1 pl-1.25 md:-ml-1.25 group-hover-input pointer-events-auto relative z-10 -ml-0.5 h-8 w-full rounded has-[:focus-visible]:outline"
+          class="text-c-1 group-hover-input pointer-events-auto relative z-10 -ml-0.5 h-8 w-full rounded pl-1.25 has-[:focus-visible]:outline md:-ml-1.25"
           placeholder="Request Name"
           :value="operation.summary"
           @input="updateRequestNameHandler" />
@@ -145,7 +145,7 @@ const activeWorkspaceCookies = computed(() =>
         @setActiveSection="activeSection = $event" />
     </template>
     <div
-      class="request-section-content custom-scroll relative flex flex-1 flex-col">
+      class="request-section-content custom-scroll relative flex flex-1 flex-col divide-y">
       <RequestAuth
         v-if="
           collection &&
@@ -219,7 +219,7 @@ const activeWorkspaceCookies = computed(() =>
         :workspace="workspace" />
 
       <!-- Spacer -->
-      <div class="flex flex-grow" />
+      <div class="-my-0.25 flex flex-grow" />
 
       <!-- Code Snippet -->
       <ScalarErrorBoundary>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -34,7 +34,7 @@ onMounted(() => events.hotKeys.on(handleHotKey))
 onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
 </script>
 <template>
-  <div class="col-1 flex-center relative gap-6 border-t p-2 capitalize">
+  <div class="col-1 flex-center relative gap-6 p-2 capitalize">
     <div
       class="flex h-[calc(100%_-_50px)] flex-col items-center justify-center"
       :class="{


### PR DESCRIPTION
**Problem**
currently some outline are hidden by overflow within the api client.

**Solution**
this pr fixes a focus type issue + refactor overall border style management.

| before | after |
| -------|------|
| <img width="754" alt="image" src="https://github.com/user-attachments/assets/3b75c967-eacd-4c83-8199-d1419d0945e1" /> | <img width="754" alt="image" src="https://github.com/user-attachments/assets/013907a4-7f26-4193-b450-d64b42807f1c" /> |
| outline overflow | outline fully visible | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
