### PR TITLE
fix(api-reference): doesn’t clear state properly

### DIFF
--- a/.changeset/tall-bikes-crash.md
+++ b/.changeset/tall-bikes-crash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: sidebar doesn’t clear state properly

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -96,6 +96,31 @@ const transformResult = (originalSchema: OpenAPI.Document): Spec => {
     schema.paths = {}
   }
 
+  // Create empty components object
+  if (!schema.components) {
+    schema.components = {}
+  }
+
+  // Create empty webhooks object
+  if (!schema.webhooks) {
+    schema.webhooks = {}
+  }
+
+  // Servers
+  if (!schema.servers) {
+    schema.servers = []
+  }
+
+  // Security
+  if (!schema.security) {
+    schema.security = []
+  }
+
+  // External docs
+  if (!schema.externalDocs) {
+    schema.externalDocs = {}
+  }
+
   // Webhooks
   const newWebhooks: AnyObject = {}
 

--- a/packages/api-reference/src/hooks/useReactiveSpec.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.ts
@@ -63,7 +63,7 @@ export function useReactiveSpec({
   proxyUrl?: MaybeRefOrGetter<string>
 }) {
   /** OAS spec as a string */
-  const rawSpec = ref('')
+  const rawSpec = ref<string>('')
   /** Fully parsed and resolved OAS object */
   const parsedSpec = reactive(createEmptySpecification())
   /** Parser error messages when parsing fails */
@@ -85,7 +85,6 @@ export function useReactiveSpec({
 
         // Some specs don’t have servers, make sure they are defined
         Object.assign(parsedSpec, {
-          servers: [],
           ...validSpec,
         })
       })


### PR DESCRIPTION
**Problem**

Currently, the API reference doesn’t clear it’s state properly when the OpenAPI document changes. You can see this in the sidebar, that it keeps models and webhooks, even if you replace the document with an empty OpenAPI document.

This is especially a problem when used with an input or when switching between multiple API definitions.

**Solution**

With this PR we’re clearing the state properly. :)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
