### PR TITLE
feat(api-client): request duplication, improved top nav 

### DIFF
--- a/.changeset/mighty-dodos-shout.md
+++ b/.changeset/mighty-dodos-shout.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+support request duplication, improved top nav tab behaviour

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -28,6 +28,9 @@ const { copyToClipboard } = useClipboard()
 
 type DecoratedNavItem = { label: string; path: string; icon: Icon }
 
+/**
+ * Get param from existing route location.
+ */
 function getParam(params: RouteParams, key: string): string | null {
   const matchingParam = params[key]
 
@@ -56,7 +59,8 @@ function getDecoratedNavItem(itemIdx?: number): DecoratedNavItem {
   const requestUid = getParam(matchingItem.route.params, 'request')
   if (requestUid) {
     return {
-      label: requests[requestUid]?.summary || 'Untitled Request',
+      label:
+        (requests[requestUid] || Object.values(requests)[0])?.summary || '',
       path: matchingItem.route.path,
       icon: 'ExternalLink',
     }

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -1,29 +1,31 @@
 <script setup lang="ts">
 // TODO: Disabled until we polished the UI.
 // import { ImportCollectionListener } from '@/components/ImportCollection'
-import TopNav from '@/components/TopNav/TopNav.vue'
-import MainLayout from '@/layouts/App/MainLayout.vue'
-import { DEFAULT_HOTKEYS, type HotKeyEvent, handleHotKeyDown } from '@/libs'
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 import { addScalarClassesToHeadless } from '@scalar/components'
 import { getThemeStyles } from '@scalar/themes'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { ScalarToasts } from '@scalar/use-toasts'
 import { computed, onBeforeMount, onBeforeUnmount, onMounted, ref } from 'vue'
-import { RouterView } from 'vue-router'
+import { RouterView, type RouteLocationNormalizedLoaded } from 'vue-router'
+
+import TopNav from '@/components/TopNav/TopNav.vue'
+import MainLayout from '@/layouts/App/MainLayout.vue'
+import { DEFAULT_HOTKEYS, handleHotKeyDown, type HotKeyEvent } from '@/libs'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
+import type { TopNavRoute } from '@/store/top-nav'
 
 import { APP_HOTKEYS } from './hotkeys'
 
 defineEmits<{
-  (e: 'newTab', item: { name: string; uid: string }): void
+  (e: 'newTab', route: TopNavRoute): void
 }>()
 
 const hotKeys = { ...DEFAULT_HOTKEYS, ...APP_HOTKEYS }
 
-const newTab = ref<{ name: string; uid: string } | null>(null)
+const newTab = ref<TopNavRoute | null>(null)
 
-const handleNewTab = (item: { name: string; uid: string }) => {
+const handleNewTab = (item: TopNavRoute) => {
   newTab.value = item
 }
 
@@ -73,7 +75,7 @@ const themeStyleTag = computed(
     class="contents">
     <!-- Listen for paste and drop events, and look for `url` query parameters to import collections -->
     <!-- <ImportCollectionListener> -->
-    <div v-html="themeStyleTag"></div>
+    <div v-html="themeStyleTag" />
     <TopNav :openNewTab="newTab" />
 
     <!-- Ensure we have the workspace loaded from localStorage above -->

--- a/packages/api-client/src/routes.ts
+++ b/packages/api-client/src/routes.ts
@@ -59,11 +59,17 @@ const requestRoutes = [
       {
         name: 'request',
         path: `request/:${PathId.Request}`,
+        meta: {
+          isRequest: true,
+        },
         component: () => import('@/views/Request/Request.vue'),
       },
       {
         name: 'request.examples',
         path: `request/:${PathId.Request}/examples/:${PathId.Examples}`,
+        meta: {
+          isRequest: true,
+        },
         component: () => import('@/views/Request/Request.vue'),
       },
       {
@@ -74,6 +80,9 @@ const requestRoutes = [
           return {
             name: 'collection.overview',
           }
+        },
+        meta: {
+          isCollection: true,
         },
         children: [
           {

--- a/packages/api-client/src/store/collections.test.ts
+++ b/packages/api-client/src/store/collections.test.ts
@@ -2,7 +2,7 @@ import { collectionSchema, serverSchema } from '@scalar/oas-utils/entities/spec'
 import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { describe, expect, it, vi } from 'vitest'
-import { reactive } from 'vue'
+import { reactive, ref } from 'vue'
 
 import { createStoreCollections, extendedCollectionDataFactory } from './collections'
 import { createStoreServers } from './servers'
@@ -53,6 +53,8 @@ const createStoreContext = () => {
     servers,
     securitySchemes: {},
     securitySchemeMutators: mutationFactory({}, reactive({})),
+    topNav: { items: {}, navState: [], activeItemIdx: ref(0) },
+    topNavItemMutator: mutationFactory({}, reactive({})),
   }
 }
 

--- a/packages/api-client/src/store/requests.ts
+++ b/packages/api-client/src/store/requests.ts
@@ -136,6 +136,11 @@ export function extendedRequestDataFactory(
     newRequest.uid = nanoid()
 
     /**
+     * Make it easier to see that it's a duplicate request.
+     */
+    if (newRequest.summary) newRequest.summary += ' #1'
+
+    /**
      * For every request example, we create a
      * duplicate with a new UID.
      */
@@ -157,13 +162,13 @@ export function extendedRequestDataFactory(
        */
       requestExampleMutators.add(newExample)
 
-      return newExample.uid 
+      return newExample.uid
     })
 
     /**
      * Assign any new valid examples to the new request.
      */
-    newRequest.examples = newExamples.filter((e): e is string & BRAND<"example"> => Boolean(e))
+    newRequest.examples = newExamples.filter((e): e is string & BRAND<'example'> => Boolean(e))
 
     /**
      * Add new request instance to the workspace.
@@ -187,8 +192,8 @@ export function extendedRequestDataFactory(
      * we just append it to the collection children.
      */
     if (!newRequest.tags?.length) {
-       collectionMutators.edit(collectionUid, 'children', [...collection.children, newRequest.uid])
-       return newRequest
+      collectionMutators.edit(collectionUid, 'children', [...collection.children, newRequest.uid])
+      return newRequest
     }
 
     /**

--- a/packages/api-client/src/store/store-context.ts
+++ b/packages/api-client/src/store/store-context.ts
@@ -1,15 +1,10 @@
+import type { TopNavItemStore } from '@/store/top-nav'
 import type { Cookie } from '@scalar/oas-utils/entities/cookie'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
-import type {
-  Collection,
-  Request,
-  RequestExample,
-  SecurityScheme,
-  Server,
-  Tag,
-} from '@scalar/oas-utils/entities/spec'
+import type { Collection, Request, RequestExample, SecurityScheme, Server, Tag } from '@scalar/oas-utils/entities/spec'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import type { Mutators } from '@scalar/object-utils/mutator-record'
+import type { Reactive, Ref } from 'vue'
 
 export type StoreContext = {
   collections: Record<string, Collection>
@@ -38,4 +33,11 @@ export type StoreContext = {
   //
   workspaces: Record<string, Workspace>
   workspaceMutators: Mutators<Workspace>
+  //
+  topNav: {
+    items: Record<string, TopNavItemStore>
+    navState: Reactive<string[]>
+    activeItemIdx: Ref<number, number>
+  }
+  topNavItemMutator: Mutators<TopNavItemStore>
 }

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -9,6 +9,7 @@ import { createStoreSecuritySchemes, extendedSecurityDataFactory } from '@/store
 import { createStoreServers, extendedServerDataFactory } from '@/store/servers'
 import type { StoreContext } from '@/store/store-context'
 import { createStoreTags, extendedTagDataFactory } from '@/store/tags'
+import { createTopNavStore, extendedTopNavDataFactory } from '@/store/top-nav'
 import { createStoreWorkspaces, extendedWorkspaceDataFactory } from '@/store/workspace'
 import { useModal } from '@scalar/components'
 import type { RequestEvent, SecurityScheme } from '@scalar/oas-utils/entities/spec'
@@ -67,6 +68,7 @@ export const createWorkspaceStore = ({
   const { servers, serverMutators } = createStoreServers(useLocalStorage)
   const { securitySchemes, securitySchemeMutators } = createStoreSecuritySchemes(useLocalStorage)
   const { workspaces, workspaceMutators } = createStoreWorkspaces(useLocalStorage)
+  const { topNav, topNavItemMutator } = createTopNavStore(useLocalStorage)
 
   // ---------------------------------------------------------------------------
   // Extended Mutators - Adds side effects as needed
@@ -91,9 +93,14 @@ export const createWorkspaceStore = ({
     securitySchemeMutators,
     workspaces,
     workspaceMutators,
+    topNav,
+    topNavItemMutator,
   }
   const { addTag, deleteTag } = extendedTagDataFactory(storeContext)
-  const { addRequest, deleteRequest, duplicateRequest, findRequestParents } = extendedRequestDataFactory(storeContext, addTag)
+  const { addRequest, deleteRequest, duplicateRequest, findRequestParents } = extendedRequestDataFactory(
+    storeContext,
+    addTag,
+  )
   const { deleteEnvironment } = extendedEnvironmentDataFactory(storeContext)
   const { addServer, deleteServer } = extendedServerDataFactory(storeContext)
   const { addCollection, deleteCollection } = extendedCollectionDataFactory(storeContext)
@@ -101,6 +108,14 @@ export const createWorkspaceStore = ({
   const { addWorkspace, deleteWorkspace } = extendedWorkspaceDataFactory(storeContext)
   const { addSecurityScheme, deleteSecurityScheme } = extendedSecurityDataFactory(storeContext)
   const { addCollectionEnvironment, removeCollectionEnvironment } = extendedCollectionDataFactory(storeContext)
+  const {
+    getTopNavItem,
+    updateTopNavItem,
+    addTopNavItem,
+    setActiveTopNavItem,
+    deleteTopNavItem,
+    deleteOtherTopNavItems,
+  } = extendedTopNavDataFactory(storeContext)
 
   // ---------------------------------------------------------------------------
   // OTHER HELPER DATA
@@ -154,6 +169,7 @@ export const createWorkspaceStore = ({
     // ---------------------------------------------------------------------------
     // STATE
     workspaces,
+    topNav,
     collections,
     tags,
     cookies,
@@ -228,6 +244,14 @@ export const createWorkspaceStore = ({
       rawAdd: workspaceMutators.add,
       add: addWorkspace,
       delete: deleteWorkspace,
+    },
+    topNavMutators: {
+      getItem: getTopNavItem,
+      updateItem: updateTopNavItem,
+      addItem: addTopNavItem,
+      deleteItem: deleteTopNavItem,
+      deleteOtherItems: deleteOtherTopNavItems,
+      setActive: setActiveTopNavItem,
     },
     addCollectionEnvironment,
     removeCollectionEnvironment,

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -93,7 +93,7 @@ export const createWorkspaceStore = ({
     workspaceMutators,
   }
   const { addTag, deleteTag } = extendedTagDataFactory(storeContext)
-  const { addRequest, deleteRequest, findRequestParents } = extendedRequestDataFactory(storeContext, addTag)
+  const { addRequest, deleteRequest, duplicateRequest, findRequestParents } = extendedRequestDataFactory(storeContext, addTag)
   const { deleteEnvironment } = extendedEnvironmentDataFactory(storeContext)
   const { addServer, deleteServer } = extendedServerDataFactory(storeContext)
   const { addCollection, deleteCollection } = extendedCollectionDataFactory(storeContext)
@@ -195,6 +195,7 @@ export const createWorkspaceStore = ({
       rawAdd: requestMutators.add,
       add: addRequest,
       delete: deleteRequest,
+      duplicate: duplicateRequest,
     },
     findRequestParents,
     requestExampleMutators: {

--- a/packages/api-client/src/store/top-nav.ts
+++ b/packages/api-client/src/store/top-nav.ts
@@ -1,0 +1,205 @@
+import type { StoreContext } from '@/store/store-context'
+import { LS_KEYS } from '@scalar/oas-utils/helpers'
+import { mutationFactory } from '@scalar/object-utils/mutator-record'
+import { nanoid } from 'nanoid'
+import { reactive, ref } from 'vue'
+
+export type TopNavItemStore = {
+  uid: string
+  path: string
+  route: string
+  collectionUid: string | null
+  requestUid: string | null
+}
+
+/** Create storage objects for top nav items */
+export function createTopNavStore(useLocalStorage: boolean) {
+  /**
+   * Init top nav store with a default item.
+   */
+  const itemUid = nanoid()
+
+  /**
+   * Use existing mutator only for nav items.
+   *
+   * Storing nav state as an array of items alongside
+   * a separate active index is a better data structure
+   * to determine item positioning.
+   */
+  const topNavItems = reactive<Record<string, TopNavItemStore>>({})
+  const topNavItemMutator = mutationFactory(topNavItems, reactive({}), useLocalStorage && LS_KEYS.TOP_NAV)
+
+  /**
+   * Add initial nav item
+   */
+  topNavItemMutator.add({ uid: itemUid, path: '', route: '', collectionUid: null, requestUid: null })
+
+  /**
+   * List of items in workspace (tabs)
+   */
+  const navState = reactive<string[]>([itemUid])
+
+  /**
+   * Active nav item
+   */
+  const activeItemIdx = ref(0)
+
+  return {
+    topNav: {
+      items: topNavItems,
+      navState,
+      activeItemIdx,
+    },
+    topNavItemMutator,
+  }
+}
+
+/** Extended mutators and data for servers */
+export function extendedTopNavDataFactory({ topNav, topNavItemMutator }: StoreContext) {
+  /**
+   * Add a new nav item by appending it
+   * to the end of the items array. Optionally
+   * set the new item as the active one.
+   */
+  const addTopNavItem = (options: Partial<TopNavItemStore>, setAsActive: boolean = true) => {
+    const newNavItem: TopNavItemStore = {
+      uid: options.uid || nanoid(),
+      path: options.path || '',
+      route: options.route || '',
+      requestUid: null,
+      collectionUid: null,
+    }
+
+    /**
+     * Add new nav item to the mutator items map.
+     */
+    topNavItemMutator.add(newNavItem)
+
+    /**
+     * Append new nav item UID at then end of the list.
+     */
+    topNav.navState.push(newNavItem.uid)
+
+    /**
+     * Update active item.
+     */
+    if (setAsActive) topNav.activeItemIdx.value = topNav.navState.length - 1
+
+    return newNavItem
+  }
+
+  /** Set active nav item */
+  const setActiveTopNavItem = (itemIdx: number) => {
+    const { matchingNavState, matchingItem } = getTopNavItem(itemIdx)
+    if (!matchingNavState || !matchingItem) return console.error('[TOP_NAV MUTATORS]: Unable to find matching item.')
+
+    topNav.activeItemIdx.value = itemIdx
+  }
+
+  /**
+   * Retrieve top nav item from state idx. Defaults
+   * to active item index.
+   */
+  function getTopNavItem(itemIdx?: number) {
+    /**
+     * Find item UID from nav state
+     */
+    const matchingNavState = topNav.navState[itemIdx ?? topNav.activeItemIdx.value]
+    if (!matchingNavState) return {}
+
+    /**
+     * Find matching item data from store
+     */
+    const matchingItem = topNav.items[matchingNavState]
+    if (!matchingItem) return { matchingNavState }
+
+    return {
+      matchingItem,
+      matchingNavState,
+    }
+  }
+
+  /**
+   * Update top nav item from state idx. Defaults
+   * to active item index.
+   */
+  const updateTopNavItem = (item: Omit<TopNavItemStore, 'uid'>, itemIdx?: number) => {
+    const { matchingItem } = getTopNavItem(itemIdx)
+    if (!matchingItem) return console.error('[TOP_NAV MUTATORS]: Unable to find matching item.')
+
+    topNavItemMutator.set({
+      ...matchingItem,
+      ...item,
+    })
+  }
+
+  /** Delete a nav item */
+  const deleteTopNavItem = (itemIdx: number) => {
+    const { matchingNavState, matchingItem } = getTopNavItem(itemIdx)
+    if (!matchingNavState || !matchingItem) return console.error('[TOP_NAV MUTATORS]: Unable to find matching item.')
+
+    /**
+     * Top nav should always have one default item.
+     */
+    if (topNav.navState.length === 1) return console.error('[TOP_NAV_MUTATORS]: Cannot delete your only nav item.')
+
+    /**
+     * Remove item from nav state
+     */
+    topNav.navState.splice(itemIdx, 1)
+
+    /**
+     * Set new active nav item
+     */
+    const newNavStateIdx = itemIdx === 0 ? 1 : itemIdx - 1
+
+    /**
+     * If the item being deleted is the currently active one,
+     * we update the active item.
+     */
+    if (matchingItem.uid === topNav.navState[topNav.activeItemIdx.value]) topNav.activeItemIdx.value = newNavStateIdx
+
+    /**
+     * Remove nav item from state
+     */
+    topNavItemMutator.delete(matchingNavState)
+  }
+
+  /**
+   * Deletes all other items apart from the selected one.
+   */
+  const deleteOtherTopNavItems = (itemIdx: number) => {
+    const { matchingNavState, matchingItem } = getTopNavItem(itemIdx)
+    if (!matchingNavState || !matchingItem) return console.error('[TOP_NAV MUTATORS]: Unable to find matching item.')
+
+    /**
+     * Top nav should always have one default item.
+     */
+    if (topNav.navState.length === 1) return console.error('[TOP_NAV_MUTATORS]: Cannot delete your only nav item.')
+
+    /**
+     * Set new nav state to only required item.
+     */
+    topNav.navState = [matchingItem.uid]
+
+    /**
+     * Ensure the active nav item is set to the selected item.
+     */
+    topNav.activeItemIdx.value = 0
+
+    /**
+     * Delete any items that are no longer needed.
+     */
+    const itemsToDelete = Object.keys(topNav.items).filter((key) => key !== matchingNavState)
+    itemsToDelete.forEach((item) => topNavItemMutator.delete(item))
+  }
+
+  return {
+    getTopNavItem,
+    addTopNavItem,
+    updateTopNavItem,
+    deleteTopNavItem,
+    deleteOtherTopNavItems,
+    setActiveTopNavItem,
+  }
+}

--- a/packages/api-client/src/store/top-nav.ts
+++ b/packages/api-client/src/store/top-nav.ts
@@ -140,21 +140,30 @@ export function extendedTopNavDataFactory({ topNav, topNavItemMutator }: StoreCo
      */
     if (topNav.navState.length === 1) return console.error('[TOP_NAV_MUTATORS]: Cannot delete your only nav item.')
 
+    const activeItemIdx = topNav.activeItemIdx.value
+
     /**
-     * Set new active nav item
+     * When the item index is greater than the current item index,
+     * we need to shift it left.
+     *
+     * If it's equal and above 0, we also shift it to the
+     * tab on the left.
+     *
+     * If it's below the current item index, it does not need
+     * shifting and can remain the same.
      */
-    const newNavStateIdx = itemIdx - 1 >= 0 ? itemIdx - 1 : 0
+    const newNavStateIdx =
+      activeItemIdx > itemIdx || (activeItemIdx === itemIdx && itemIdx > 0) ? activeItemIdx - 1 : activeItemIdx
+
+    /**
+     * Update the currently active item
+     */
+    topNav.activeItemIdx.value = newNavStateIdx
 
     /**
      * Remove item from nav state
      */
     topNav.navState.splice(itemIdx, 1)
-
-    /**
-     * If the item being deleted is the currently active one,
-     * we update the active item.
-     */
-    if (itemIdx === topNav.activeItemIdx.value) topNav.activeItemIdx.value = newNavStateIdx
 
     /**
      * Remove nav item from state

--- a/packages/api-client/src/store/top-nav.ts
+++ b/packages/api-client/src/store/top-nav.ts
@@ -3,13 +3,13 @@ import { LS_KEYS } from '@scalar/oas-utils/helpers'
 import { mutationFactory } from '@scalar/object-utils/mutator-record'
 import { nanoid } from 'nanoid'
 import { reactive, ref } from 'vue'
+import type { RouteLocation } from 'vue-router'
+
+export type TopNavRoute = RouteLocation
 
 export type TopNavItemStore = {
   uid: string
-  path: string
-  route: string
-  collectionUid: string | null
-  requestUid: string | null
+  route: TopNavRoute | null
 }
 
 /** Create storage objects for top nav items */
@@ -32,7 +32,7 @@ export function createTopNavStore(useLocalStorage: boolean) {
   /**
    * Add initial nav item
    */
-  topNavItemMutator.add({ uid: itemUid, path: '', route: '', collectionUid: null, requestUid: null })
+  topNavItemMutator.add({ uid: itemUid, route: null })
 
   /**
    * List of items in workspace (tabs)
@@ -64,10 +64,7 @@ export function extendedTopNavDataFactory({ topNav, topNavItemMutator }: StoreCo
   const addTopNavItem = (options: Partial<TopNavItemStore>, setAsActive: boolean = true) => {
     const newNavItem: TopNavItemStore = {
       uid: options.uid || nanoid(),
-      path: options.path || '',
-      route: options.route || '',
-      requestUid: null,
-      collectionUid: null,
+      route: options.route || null,
     }
 
     /**
@@ -144,20 +141,20 @@ export function extendedTopNavDataFactory({ topNav, topNavItemMutator }: StoreCo
     if (topNav.navState.length === 1) return console.error('[TOP_NAV_MUTATORS]: Cannot delete your only nav item.')
 
     /**
+     * Set new active nav item
+     */
+    const newNavStateIdx = itemIdx - 1 >= 0 ? itemIdx - 1 : 0
+
+    /**
      * Remove item from nav state
      */
     topNav.navState.splice(itemIdx, 1)
 
     /**
-     * Set new active nav item
-     */
-    const newNavStateIdx = itemIdx === 0 ? 1 : itemIdx - 1
-
-    /**
      * If the item being deleted is the currently active one,
      * we update the active item.
      */
-    if (matchingItem.uid === topNav.navState[topNav.activeItemIdx.value]) topNav.activeItemIdx.value = newNavStateIdx
+    if (itemIdx === topNav.activeItemIdx.value) topNav.activeItemIdx.value = newNavStateIdx
 
     /**
      * Remove nav item from state

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -13,11 +13,12 @@ import { importCurlCommand } from '@/libs/importers/curl'
 import { PathId } from '@/routes'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
+import type { TopNavRoute } from '@/store/top-nav'
 import RequestSection from '@/views/Request/RequestSection/RequestSection.vue'
 import RequestSubpageHeader from '@/views/Request/RequestSubpageHeader.vue'
 import ResponseSection from '@/views/Request/ResponseSection/ResponseSection.vue'
 
-defineEmits<(e: 'newTab', item: { name: string; uid: string }) => void>()
+defineEmits<(e: 'newTab', item: TopNavRoute) => void>()
 
 const { isSidebarOpen } = useSidebarToggle()
 

--- a/packages/api-client/src/views/Request/RequestRoot.vue
+++ b/packages/api-client/src/views/Request/RequestRoot.vue
@@ -10,11 +10,12 @@ import { ERRORS } from '@/libs'
 import { createRequestOperation } from '@/libs/send-request'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
+import type { TopNavRoute } from '@/store/top-nav'
 import { useOpenApiWatcher } from '@/views/Request/hooks/useOpenApiWatcher'
 
 import RequestSidebar from './RequestSidebar.vue'
 
-defineEmits<(e: 'newTab', item: { name: string; uid: string }) => void>()
+defineEmits<(e: 'newTab', item: TopNavRoute) => void>()
 const workspaceContext = useWorkspace()
 const { toast } = useToasts()
 const { layout } = useLayout()

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -37,6 +37,7 @@ import { PathId } from '@/routes'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 import { createInitialRequest } from '@/store/requests'
+import type { TopNavRoute } from '@/store/top-nav'
 import { dragHandlerFactory } from '@/views/Request/handle-drag'
 import RequestSidebarItemMenu from '@/views/Request/RequestSidebarItemMenu.vue'
 import type { SidebarItem, SidebarMenuItem } from '@/views/Request/types'
@@ -46,7 +47,7 @@ import { isGettingStarted } from './RequestSection/helpers/getting-started'
 import RequestSidebarItem from './RequestSidebarItem.vue'
 
 const emit = defineEmits<{
-  (e: 'newTab', { name, uid }: { name: string; uid: string }): void
+  (e: 'newTab', route: TopNavRoute): void
   (e: 'clearDrafts'): void
 }>()
 
@@ -338,7 +339,7 @@ const showGettingStarted = computed(() =>
             :menuItem="menuItem"
             :parentUids="[]"
             :uid="collection.uid"
-            @newTab="(name, uid) => emit('newTab', { name, uid })"
+            @newTab="(route) => emit('newTab', route)"
             @onDragEnd="handleDragEnd"
             @openMenu="(item) => Object.assign(menuItem, item)">
             <template #leftIcon>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -150,6 +150,8 @@ const item = computed<SidebarItem>(() => {
       delete: () =>
         parentUids[0] &&
         requestMutators.delete(request, parentUids[0] as Collection['uid']),
+      duplicate: () =>
+        requestMutators.duplicate(request, parentUids[0] as Collection['uid']),
     }
 
   if (requestExample?.requestUid)

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -22,6 +22,7 @@ import { getModifiers } from '@/libs'
 import { PathId } from '@/router'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
+import type { TopNavRoute } from '@/store/top-nav'
 import type { SidebarItem, SidebarMenuItem } from '@/views/Request/types'
 
 const {
@@ -53,7 +54,7 @@ const {
 
 const emit = defineEmits<{
   onDragEnd: [draggingItem: DraggingItem, hoveredItem: HoveredItem]
-  newTab: [name: string, uid: string]
+  newTab: [route: TopNavRoute]
   openMenu: [menuItem: SidebarMenuItem]
 }>()
 
@@ -278,8 +279,9 @@ const handleNavigation = (event: KeyboardEvent, _item: SidebarItem) => {
     const modifier = getModifiers(['default'])
     const isModifierPressed = modifier.some((key) => event[key])
 
-    if (isModifierPressed) emit('newTab', _item.title || '', _item.entity.uid)
-    else if (_item.to) router.push(_item.to)
+    if (isModifierPressed && _item.to) {
+      emit('newTab', router.resolve(_item.to))
+    } else if (_item.to) router.push(_item.to)
   }
 }
 
@@ -622,7 +624,7 @@ const shouldShowItem = computed(() => {
           :menuItem="menuItem"
           :parentUids="[...parentUids, uid]"
           :uid="childUid"
-          @newTab="(name, uid) => $emit('newTab', name, uid)"
+          @newTab="(route) => $emit('newTab', route)"
           @onDragEnd="(...args) => $emit('onDragEnd', ...args)"
           @openMenu="(item) => $emit('openMenu', item)" />
         <ScalarButton

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -36,7 +36,7 @@ const {
   activeWorkspaceCollections,
   activeWorkspaceRequests,
 } = useActiveEntities()
-const { events, requestMutators } = useWorkspace()
+const { events, requestMutators, topNavMutators, topNav } = useWorkspace()
 
 const { toast } = useToasts()
 
@@ -68,6 +68,14 @@ const handleItemDuplicate = () => {
   const newItem = props.menuItem.item?.duplicate()
 
   if (!newItem) return toast('Unable to duplicate item.', 'error')
+
+  /**
+   * Add new tab on duplicate
+   */
+  topNavMutators.addItem({
+    path: newItem.path,
+    requestUid: newItem.uid,
+  })
 
   /**
    * Navigate to new request

--- a/packages/api-client/src/views/Request/types/sidebar-item.ts
+++ b/packages/api-client/src/views/Request/types/sidebar-item.ts
@@ -23,6 +23,7 @@ export type SidebarItem = {
   icon?: string
   edit: (name: string, icon?: string) => void
   delete: () => void
+  duplicate?: () => void | Request
   documentUrl?: string | undefined
   watchMode?: boolean
 }

--- a/packages/oas-utils/src/helpers/local-storage.ts
+++ b/packages/oas-utils/src/helpers/local-storage.ts
@@ -12,4 +12,5 @@ export const LS_KEYS = {
   SERVER: 'server',
   TAG: 'tag',
   WORKSPACE: 'workspace',
+  TOP_NAV: 'topNav',
 } as const


### PR DESCRIPTION
**Problem**
Just noting that this is a small experiment with request duplication and better top nav tab handling; completely happy for this to be closed if there were other things in the works or if a better approach is needed, but just wanted to have a go at implementing it.

At the moment, we can't duplicate requests (which I often find that I need to do, and it's a mess to create a new request and copy over all of the info).

When looking into request duplication, I also noticed that the nav bar was quite limited in a few aspects, so I moved the state to a store to allow some extra goodies.

**Solution**
This PR adds support for duplicating requests specifically (and only shows the dropdown menu item for duplication for requests only). I don't think there would be much need to implement it for other nav items (apart from examples, so let me know if you would like that added as well). The duplication works my deep copying the store request item and creating a new one with updated UID references.

This solution also addresses some current limitations with the top nav bar, and attempts to address them by making top nav bar items 1-1 with router navigation. I.e. instead of the tab holding custom state driven by route logic all over the place, it just stores the router destination data, and then we derive the title, icon and anything else from it.

I'm aware I could've created a new tab with the request summary, icon and then set it as default + navigate, but that seemed quite backwards to me, so I experimented with simplifying the nav.

Here's a quick demonstration of both:

https://github.com/user-attachments/assets/c325dfe7-4ac9-45d3-be00-2b08801ea6d3

If we are happy with this solution and the nav changes, just lmk and I'll add some tests to the duplication logic and nav behaviour before we merge :)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
