### PR TITLE
fix(api-client): command palette routing

### DIFF
--- a/.changeset/silly-jeans-grab.md
+++ b/.changeset/silly-jeans-grab.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates command palette routing

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -162,13 +162,7 @@ const executeCommand = (
 ) => {
   // Route to the page
   if ('path' in command) {
-    router.push({
-      name: command.path,
-      params: {
-        [PathId.Workspace]: activeWorkspace.value?.uid,
-      },
-    })
-
+    router.push(command.path)
     closeHandler()
   }
 


### PR DESCRIPTION
**Problem**
currently users cannot navigate to pages through the command palette.

```console
Uncaught Error: No match for
 {"name":"/workspace/default/environment","params":{"workspace":"default"}}
```

**Solution**
this pr updates the command palette routing.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
