### PR TITLE
chore: ignore some aspnetcore folders

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,9 @@
       "examples/nestjs-api-reference-express/**",
       "*/storybook-static/*",
       "**/httpsnippet-lite/**",
-      "**/.next/**"
+      "**/.next/**",
+      "**/aspnetcore/**/obj/**",
+      "**/aspnetcore/**/bin/**"
     ]
   },
   "formatter": {


### PR DESCRIPTION
We’ve got some problems with Biome and the ASP.NET Core integration, this should fix it.