### PR TITLE
feat(api-reference): multiple documents in the HTML API

### DIFF
--- a/.changeset/witty-humans-promise.md
+++ b/.changeset/witty-humans-promise.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: support multiple configurations through the HTML API

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -12,7 +12,11 @@
     <!-- Add your own OpenAPI/Swagger specification URL here: -->
     <!-- Note: The example is our public proxy (to avoid CORS issues). You can remove the `data-proxy-url` attribute if you don’t need it. -->
     <script
-      id="api-reference"
+      data-scalar-api-reference
+      data-proxy-url="https://proxy.scalar.com"
+      data-url="https://petstore.swagger.io/v2/swagger.json"></script>
+    <script
+      data-scalar-api-reference
       data-proxy-url="https://proxy.scalar.com"
       data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json"></script>
 
@@ -25,8 +29,9 @@
         // },
       }
 
-      document.getElementById('api-reference').dataset.configuration =
-        JSON.stringify(configuration)
+      document.querySelector(
+        '[data-scalar-api-reference]',
+      ).dataset.configuration = JSON.stringify(configuration)
     </script>
 
     <script

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -142,7 +142,7 @@ describe('html-api', () => {
 
       expect(getConfigurationFromDataAttributes(doc)).toStrictEqual({})
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Couldn’t find a [data-spec], [data-spec-url] or <script data-scalar-api-reference /> element. Try adding it like this: %c<div data-spec-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml" />',
+        'Could not find a <script data-scalar-api-reference /> element. Try adding it like this: %c<div data-spec-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml" />',
         'font-family: monospace;',
       )
       consoleSpy.mockRestore()

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -219,6 +219,121 @@ describe('html-api', () => {
         },
       ])
     })
+
+    it('handles multiple documents with mixed spec sources', () => {
+      const doc = createHtmlDocument(`
+        <html>
+          <body>
+            <script data-scalar-api-reference data-url="/openapi-1.json"></script>
+            <script data-scalar-api-reference type="application/json">{"openapi":"3.1.0"}</script>
+          </body>
+        </html>
+      `)
+
+      expect(getConfigurationFromDataAttributes(doc)).toStrictEqual([
+        {
+          _integration: 'html',
+          proxyUrl: undefined,
+          spec: { url: '/openapi-1.json' },
+        },
+        {
+          _integration: 'html',
+          proxyUrl: undefined,
+          spec: { content: '{"openapi":"3.1.0"}' },
+        },
+      ])
+    })
+
+    it('handles multiple documents with proxy configuration', () => {
+      const doc = createHtmlDocument(`
+        <html>
+          <body>
+            <script data-scalar-api-reference data-url="/spec-1.json" data-proxy-url="https://proxy1.example.com"></script>
+            <script data-scalar-api-reference data-url="/spec-2.json" data-proxy-url="https://proxy2.example.com"></script>
+          </body>
+        </html>
+      `)
+
+      expect(getConfigurationFromDataAttributes(doc)).toStrictEqual([
+        {
+          _integration: 'html',
+          proxyUrl: 'https://proxy1.example.com',
+          spec: { url: '/spec-1.json' },
+        },
+        {
+          _integration: 'html',
+          proxyUrl: 'https://proxy2.example.com',
+          spec: { url: '/spec-2.json' },
+        },
+      ])
+    })
+
+    it('handles multiple documents with complex configurations', () => {
+      const doc = createHtmlDocument(`
+        <html>
+          <body>
+            <script
+              data-scalar-api-reference
+              data-url="/spec-1.json"
+              data-proxy-url="https://proxy.example.com"
+              data-configuration='{"darkMode":true,"layout":"stacked"}'
+            ></script>
+            <script
+              data-scalar-api-reference
+              type="application/json"
+              data-configuration='{"darkMode":false,"layout":"sidebar"}'
+            >{"openapi":"3.1.0"}</script>
+          </body>
+        </html>
+      `)
+
+      expect(getConfigurationFromDataAttributes(doc)).toStrictEqual([
+        {
+          _integration: 'html',
+          darkMode: true,
+          layout: 'stacked',
+          proxyUrl: 'https://proxy.example.com',
+          spec: { url: '/spec-1.json' },
+        },
+        {
+          _integration: 'html',
+          darkMode: false,
+          layout: 'sidebar',
+          proxyUrl: undefined,
+          spec: { content: '{"openapi":"3.1.0"}' },
+        },
+      ])
+    })
+
+    it('handles multiple documents with deprecated attributes', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const doc = createHtmlDocument(`
+        <html>
+          <body>
+            <div data-spec-url="/deprecated-1.json"></div>
+            <div data-spec='{"openapi":"3.1.0"}'></div>
+          </body>
+        </html>
+      `)
+
+      expect(getConfigurationFromDataAttributes(doc)).toStrictEqual([
+        {
+          _integration: 'html',
+          proxyUrl: undefined,
+          spec: { url: '/deprecated-1.json' },
+        },
+        {
+          _integration: 'html',
+          proxyUrl: undefined,
+          spec: { content: '{"openapi":"3.1.0"}' },
+        },
+      ])
+
+      expect(consoleSpy).toHaveBeenCalledTimes(2)
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('The [data-spec-url] HTML API is deprecated'))
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('The [data-spec] HTML API is deprecated'))
+      consoleSpy.mockRestore()
+    })
   })
 })
 

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -3,21 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 
 describe('html-api', () => {
   describe('identifier', () => {
-    it('works with id="api-reference"', async () => {
-      const doc = createHtmlDocument(`
-    <html>
-      <body>
-        <script id="api-reference" data-url="/openapi.json"></script>
-    </html>
-  `)
-
-      expect(getConfigurationFromDataAttributes(doc)).toStrictEqual({
-        _integration: 'html',
-        proxyUrl: undefined,
-        spec: { url: '/openapi.json' },
-      })
-    })
-
     it('works with data-scalar-api-reference', async () => {
       const doc = createHtmlDocument(`
     <html>
@@ -39,7 +24,7 @@ describe('html-api', () => {
     const doc = createHtmlDocument(`
       <html>
         <body>
-          <script id="api-reference" type="application/json">{"openapi":"3.1.0"}</script>
+          <script data-scalar-api-reference type="application/json">{"openapi":"3.1.0"}</script>
         </body>
       </html>
     `)
@@ -56,7 +41,7 @@ describe('html-api', () => {
       const doc = createHtmlDocument(`
       <html>
         <body>
-          <script id="api-reference" data-proxy-url="https://proxy.example.com" data-url="/spec.json"></script>
+          <script data-scalar-api-reference data-proxy-url="https://proxy.example.com" data-url="/spec.json"></script>
         </body>
       </html>
     `)
@@ -74,7 +59,7 @@ describe('html-api', () => {
       const doc = createHtmlDocument(`
       <html>
         <body>
-          <script id="api-reference" data-configuration='{"darkMode":true,"spec":{"url":"/custom.json"}}'></script>
+          <script data-scalar-api-reference data-configuration='{"darkMode":true,"spec":{"url":"/custom.json"}}'></script>
         </body>
       </html>
     `)
@@ -89,6 +74,21 @@ describe('html-api', () => {
   })
 
   describe('deprecated', () => {
+    it('works with data-scalar-api-reference', async () => {
+      const doc = createHtmlDocument(`
+    <html>
+      <body>
+        <script data-scalar-api-reference data-url="/openapi.json"></script>
+    </html>
+  `)
+
+      expect(getConfigurationFromDataAttributes(doc)).toStrictEqual({
+        _integration: 'html',
+        proxyUrl: undefined,
+        spec: { url: '/openapi.json' },
+      })
+    })
+
     it('handles deprecated data-spec attribute with warning', () => {
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const doc = createHtmlDocument(`
@@ -142,7 +142,7 @@ describe('html-api', () => {
 
       expect(getConfigurationFromDataAttributes(doc)).toStrictEqual({})
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Couldn’t find a [data-spec], [data-spec-url] or <script id="api-reference" /> element. Try adding it like this: %c<div data-spec-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml" />',
+        'Couldn’t find a [data-spec], [data-spec-url] or <script data-scalar-api-reference /> element. Try adding it like this: %c<div data-spec-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml" />',
         'font-family: monospace;',
       )
       consoleSpy.mockRestore()
@@ -153,7 +153,7 @@ describe('html-api', () => {
       <html>
         <body>
           <script
-            id="api-reference"
+            data-scalar-api-reference
             data-url="/spec.json"
             data-configuration='{"spec":{"url":"/priority.json"}}'>
           </script>

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -6,7 +6,7 @@ import { createApp, h, reactive } from 'vue'
 import { default as ApiReference } from '@/components/ApiReference.vue'
 
 const getSpecScriptTag = (doc: Document) =>
-  doc.getElementById('api-reference') || doc.querySelector('[data-scalar-api-reference]')
+  doc.querySelector('[data-scalar-api-reference]') || doc.getElementById('api-reference')
 
 /**
  * Reading the configuration from the data-attributes.
@@ -14,7 +14,9 @@ const getSpecScriptTag = (doc: Document) =>
 export function getConfigurationFromDataAttributes(doc: Document): ReferenceConfiguration {
   const specElement = doc.querySelector('[data-spec]')
   const specUrlElement = doc.querySelector('[data-spec-url]')
-  const configurationScriptElement = doc.querySelector('#api-reference[data-configuration]')
+  const configurationScriptElement =
+    doc.querySelector('[data-scalar-api-reference][data-configuration]') ||
+    doc.querySelector('#api-reference[data-configuration]')
 
   const getConfiguration = (): ReferenceConfiguration => {
     // <script data-configuration="{ … }" />
@@ -38,7 +40,7 @@ export function getConfigurationFromDataAttributes(doc: Document): ReferenceConf
       return getConfiguration().spec?.url
     }
 
-    // <script id="api-reference" data-url="/scalar.json" />
+    // <script data-scalar-api-reference data-url="/scalar.json" />
     const specScriptTag = getSpecScriptTag(doc)
     if (specScriptTag) {
       const urlFromScriptTag = specScriptTag.getAttribute('data-url')?.trim()
@@ -51,7 +53,7 @@ export function getConfigurationFromDataAttributes(doc: Document): ReferenceConf
     // <div data-spec-url="/scalar.json" />
     if (specUrlElement) {
       console.warn(
-        '[@scalar/api-reference] The [data-spec-url] HTML API is deprecated. Use the new <script id="api-reference" data-url="/scalar.json" /> API instead.',
+        '[@scalar/api-reference] The [data-spec-url] HTML API is deprecated. Use the new <script data-scalar-api-reference data-url="/scalar.json" /> API instead.',
       )
       const urlFromSpecUrlElement = specUrlElement.getAttribute('data-spec-url')
 
@@ -64,7 +66,7 @@ export function getConfigurationFromDataAttributes(doc: Document): ReferenceConf
   }
 
   const getSpec = (): string | undefined => {
-    // <script id="api-reference" type="application/json">{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}</script>
+    // <script data-scalar-api-reference type="application/json">{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}</script>
     const specScriptTag = getSpecScriptTag(doc)
     if (specScriptTag) {
       const specFromScriptTag = specScriptTag.innerHTML?.trim()
@@ -77,7 +79,7 @@ export function getConfigurationFromDataAttributes(doc: Document): ReferenceConf
     // <div data-spec='{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}' />
     if (specElement) {
       console.warn(
-        '[@scalar/api-reference] The [data-spec] HTML API is deprecated. Use the new <script id="api-reference" type="application/json">{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}</script> API instead.',
+        '[@scalar/api-reference] The [data-spec] HTML API is deprecated. Use the new <script data-scalar-api-reference type="application/json">{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}</script> API instead.',
       )
       const specFromSpecElement = specElement.getAttribute('data-spec')?.trim()
 
@@ -90,7 +92,7 @@ export function getConfigurationFromDataAttributes(doc: Document): ReferenceConf
   }
 
   const getProxyUrl = () => {
-    // <script id="api-reference" data-proxy-url="https://proxy.scalar.com">…</script>
+    // <script data-scalar-api-reference data-proxy-url="https://proxy.scalar.com">…</script>
     const specScriptTag = getSpecScriptTag(doc)
     if (specScriptTag) {
       const proxyUrl = specScriptTag.getAttribute('data-proxy-url')
@@ -106,7 +108,7 @@ export function getConfigurationFromDataAttributes(doc: Document): ReferenceConf
   // Ensure Reference Props are reactive
   if (!specUrlElement && !specElement && !getSpecScriptTag(doc)) {
     console.error(
-      'Couldn’t find a [data-spec], [data-spec-url] or <script id="api-reference" /> element. Try adding it like this: %c<div data-spec-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml" />',
+      'Couldn’t find a [data-spec], [data-spec-url] or <script data-scalar-api-reference /> element. Try adding it like this: %c<div data-spec-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml" />',
       'font-family: monospace;',
     )
   } else {
@@ -128,9 +130,9 @@ export function getConfigurationFromDataAttributes(doc: Document): ReferenceConf
  * Read the HTML data-attributes for configuration.
  */
 export function mountScalarApiReference(doc: Document, configuration: ReferenceConfiguration) {
-  /** @deprecated Use the new <script id="api-reference" data-url="/scalar.json" /> API instead. */
+  /** @deprecated Use the new <script data-scalar-api-reference data-url="/scalar.json" /> API instead. */
   const specElement = doc.querySelector('[data-spec]')
-  /** @deprecated Use the new <script id="api-reference" data-url="/scalar.json" /> API instead. */
+  /** @deprecated Use the new <script data-scalar-api-reference data-url="/scalar.json" /> API instead. */
   const specUrlElement = doc.querySelector('[data-spec-url]')
 
   const props = reactive<ReferenceProps>({

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -152,6 +152,14 @@ export function mountScalarApiReference(
     configuration: Array.isArray(configuration) ? configuration[0] : configuration,
   })
 
+  // TODO: Just always use the first configuration for now. Once we support multiple configurations, we change this.
+  if (Array.isArray(configuration) && configuration.length > 1) {
+    console.warn(
+      '[@scalar/api-reference] We found multiple <script data-scalar-api-reference /> elements. ' +
+        'We will only use the first one for now. But you’re ready for the future!',
+    )
+  }
+
   if (props.configuration?.darkMode) {
     doc.body?.classList.add('dark-mode')
   } else {

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -5,7 +5,8 @@ import { createApp, h, reactive } from 'vue'
 
 import { default as ApiReference } from '@/components/ApiReference.vue'
 
-const getSpecScriptTag = (doc: Document) => doc.getElementById('api-reference')
+const getSpecScriptTag = (doc: Document) =>
+  doc.getElementById('api-reference') || doc.querySelector('[data-scalar-api-reference]')
 
 /**
  * Reading the configuration from the data-attributes.


### PR DESCRIPTION
**Problem**

Currently, we only support passing a single document/configuration through the HTML API. But we need a way to pass more than one very soon.

See #4872

**Solution**

With this PR we’re adding support for multiple documents/configurations.

Until now, we expected an `id="api-reference"`, but you can only have one ID with the same name. So we might want to switch to a data-attribute? Excited to hear your feedback!

This PR adds the support, but only passes the first configuration, until #4872 is done.

**Example**

```html
  <script data-scalar-api-reference data-url="/openapi-1.json"></script>
  <script data-scalar-api-reference data-url="/openapi-2.json"></script>
```

You can even mix the formats:

```html
  <script data-scalar-api-reference data-url="/openapi-1.json"></script>
  <script data-scalar-api-reference type="application/json">{"openapi":"3.1.0"}</script>
```

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.