### PR TITLE
chore(Scalar.AspNetCore): Cleanup and test improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,7 +540,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab
         with:
-          dotnet-version: 9.x
+          dotnet-version: |
+            9.x
+            8.x
 
       - name: Build @scalar/api-reference
         uses: ./.github/actions/build
@@ -597,7 +599,9 @@ jobs:
         name: Setup .NET
         uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab
         with:
-          dotnet-version: 9.x
+          dotnet-version: |
+            9.x
+            8.x
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Extract version from package.json

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Books/BookEndpoints.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Books/BookEndpoints.cs
@@ -11,7 +11,7 @@ internal static class BookEndpoints
             .HasApiVersion(new ApiVersion(1))
             .HasApiVersion(new ApiVersion(2))
             .Build();
-        
+
         var books = builder.MapGroup("v{version:apiVersion}/books")
             .WithTags("bookstore")
             .WithApiVersionSet(apiVersionSet)

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
@@ -35,7 +35,7 @@ app.MapStaticAssets();
 
 app.MapOpenApi();
 
-Action<ScalarOptions> configureOptions = options => 
+Action<ScalarOptions> configureOptions = options =>
     options
         .WithCdnUrl("https://cdn.jsdelivr.net/npm/@scalar/api-reference")
         .WithFavicon("/favicon.png")

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="APIWeaver.OpenApi" Version="2.7.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageReference Include="Bogus" Version="35.6.1" />
+    <PackageReference Include="Bogus" Version="35.6.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
   </ItemGroup>
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/ScalarClient.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/ScalarClient.cs
@@ -26,7 +26,7 @@ public enum ScalarClient
     /// </summary>
     [Description("httpclient")]
     HttpClient,
-    
+
     /// <summary>
     /// Http client.
     /// </summary>
@@ -188,7 +188,7 @@ public enum ScalarClient
     /// </summary>
     [Description("wget")]
     Wget,
-    
+
     /// <summary>
     /// OFetch client.
     /// </summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTarget.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTarget.cs
@@ -32,7 +32,7 @@ public enum ScalarTarget
     /// </summary>
     [Description("dart")]
     Dart,
-    
+
     /// <summary>
     /// Go programming language.
     /// </summary>
@@ -80,7 +80,7 @@ public enum ScalarTarget
     /// </summary>
     [Description("ocaml")]
     OCaml,
-    
+
     /// <summary>
     /// PHP programming language.
     /// </summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -53,7 +53,7 @@ public static class ScalarOptionsExtensions
     /// <remarks>This feature will be public once we support multiple OpenAPI documents.</remarks>
     internal static ScalarOptions AddDocument(this ScalarOptions options, params IEnumerable<string> documentNames)
     {
-        options.DocumentNames.AddRange(documentNames);
+        options.Documents.AddRange(documentNames);
         return options;
     }
 
@@ -68,7 +68,7 @@ public static class ScalarOptionsExtensions
         options.DocumentNamesProvider = (context, _) => Task.FromResult(provider(context));
         return options;
     }
-    
+
     /// <summary>
     /// Sets a async document names provider.
     /// </summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -24,12 +24,13 @@ internal static class ScalarOptionsMapper
         { ScalarTarget.Swift, [ScalarClient.Nsurlsession] },
         { ScalarTarget.Go, [ScalarClient.Native] },
         { ScalarTarget.Kotlin, [ScalarClient.OkHttp] },
-        { ScalarTarget.Dart , [ScalarClient.Http]}
+        { ScalarTarget.Dart, [ScalarClient.Http] }
     };
 
     internal static ScalarConfiguration ToScalarConfiguration(this ScalarOptions options)
     {
-        var documentUrls = options.DocumentNames.Select(name => options.OpenApiRoutePattern.Replace(DocumentName, name));
+        var trimmedOpenApiRoutePattern = options.OpenApiRoutePattern.TrimStart('/');
+        var documentUrls = options.Documents.Select(name => trimmedOpenApiRoutePattern.Replace(DocumentName, name));
         return new ScalarConfiguration
         {
             ProxyUrl = options.ProxyUrl,

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 
 namespace Scalar.AspNetCore;
@@ -8,24 +7,20 @@ namespace Scalar.AspNetCore;
 /// Represents all available options for the Scalar API reference.
 /// Based on <a href="https://github.com/scalar/scalar/blob/main/documentation/configuration.md">Configuration</a>.
 /// </summary>
-public sealed partial class ScalarOptions
+public sealed class ScalarOptions
 {
-
-    [GeneratedRegex("^[a-zA-Z]+://.*", RegexOptions.IgnoreCase)]
-    private static partial Regex OpenApiRoutePatternIsUrlRegex();
-    
     /// <summary>
-    /// Returns whether the <see cref="OpenApiRoutePattern"/> is set to a URL (true) or a route/path (false).
+    /// Returns whether the <see cref="OpenApiRoutePattern" /> is set to a URL (true) or a route/path (false).
     /// </summary>
-    internal bool IsOpenApiRoutePatternUrl => OpenApiRoutePatternIsUrlRegex().IsMatch(OpenApiRoutePattern);
-    
-    internal List<string> DocumentNames { get; } = [];
+    internal bool IsOpenApiRoutePatternUrl => RegexHelper.IsUrlRegex().IsMatch(OpenApiRoutePattern);
+
+    internal List<string> Documents { get; } = [];
 
     /// <summary>
     /// Gets or sets a function that provides document names.
     /// </summary>
     /// <value>A function that returns an <see cref="IEnumerable{T}" /> of document names.</value>
-    /// <remarks>This feature will be public once we support multiple OpenAPI documents. If this property is set, the <see cref="DocumentNames" /> property will be ignored.</remarks>
+    /// <remarks>This feature will be public once we support multiple OpenAPI documents. If this property is set, the <see cref="Documents" /> property will be ignored.</remarks>
     internal Func<HttpContext, CancellationToken, Task<IEnumerable<string>>>? DocumentNamesProvider { get; set; }
 
     /// <summary>
@@ -56,11 +51,7 @@ public sealed partial class ScalarOptions
     /// Can also be a complete URL to a remote OpenAPI document, just be aware of CORS restrictions in this case.
     /// </summary>
     /// <value>The default value is <c>'/openapi/{documentName}.json'</c>.</value>
-    public string OpenApiRoutePattern
-    {
-        get => field.TrimStart('/');
-        set;
-    } = "/openapi/{documentName}.json";
+    public string OpenApiRoutePattern { get; set; } = "/openapi/{documentName}.json";
 
     /// <summary>
     /// Proxy URL for the API requests.

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/RegexHelper.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/RegexHelper.cs
@@ -1,0 +1,9 @@
+using System.Text.RegularExpressions;
+
+namespace Scalar.AspNetCore;
+
+internal static partial class RegexHelper
+{
+    [GeneratedRegex("^[a-zA-Z]+://.*", RegexOptions.IgnoreCase)]
+    internal static partial Regex IsUrlRegex();
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
@@ -35,7 +35,7 @@ internal sealed class ScalarConfiguration
     public required DefaultHttpClient? DefaultHttpClient { get; init; }
 
     /// <remarks>
-    /// This could be a dictionary of <see cref="ScalarTarget"/> and <see cref="ScalarClient"/> arrays or a boolean if all clients are hidden.
+    /// This could be a dictionary of <see cref="ScalarTarget" /> and <see cref="ScalarClient" /> arrays or a boolean if all clients are hidden.
     /// </remarks>
     public required object? HiddenClients { get; init; }
 

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -11,12 +11,11 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="8.0.0" />
+    <PackageReference Include="AwesomeAssertions" Version="8.0.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.v3" Version="1.1.0" />
@@ -24,6 +23,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup Condition="$(TargetFrameWork) == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFrameWork) == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointRouteBuilderExtensionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointRouteBuilderExtensionsTests.cs
@@ -15,6 +15,5 @@ public class ScalarEndpointRouteBuilderExtensionsTests
 
         // Assert
         act.Should().Throw<ArgumentException>().WithMessage("The endpoint prefix cannot contain the '{documentName}' placeholder. (Parameter 'endpointPrefix')");
-        
     }
 }

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -112,7 +112,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotModified);
     }
-    
+
     [Fact]
     public async Task MapScalarApiReference_ShouldNotPrefixOpenApiUrlWithOrigin_WhenRouteIsUrl()
     {
@@ -193,7 +193,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         }).CreateClient();
 
         // Act
-        var index = await client.GetAsync($"/scalar", TestContext.Current.CancellationToken);
+        var index = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
 
         // Assert
         index.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -270,7 +270,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
 
         localFactory.Services.GetRequiredService<IOptions<ScalarOptions>>().Value.Theme.Should().Be(ScalarTheme.Mars);
     }
-    
+
     [Fact]
     public async Task MapScalarApiReference_ShouldReplaceDocumentNamePlaceholder_WhenOnlyOneDocumentWasAdded()
     {

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -79,7 +79,7 @@ public class ScalarOptionsExtensionsTests
         options.Authentication!.Http!.Basic!.Username.Should().Contain("my-username");
         options.Authentication!.Http!.Basic!.Password.Should().Contain("my-password");
         options.Authentication!.Http!.Bearer!.Token.Should().Contain("my-bearer-token");
-        options.OpenApiRoutePattern.Should().Be("swagger/{documentName}");
+        options.OpenApiRoutePattern.Should().Be("/swagger/{documentName}");
         options.CdnUrl.Should().Be("http://localhost:8080");
         options.DefaultFonts.Should().BeFalse();
         options.DefaultOpenAllTags.Should().BeTrue();

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsTests.cs
@@ -10,7 +10,7 @@ public class ScalarOptionsTests
         // Arrange
         var options = new ScalarOptions
         {
-            OpenApiRoutePattern = openApiRoute,
+            OpenApiRoutePattern = openApiRoute
         };
 
         // Act
@@ -19,7 +19,7 @@ public class ScalarOptionsTests
         // Assert
         result.Should().BeTrue();
     }
-    
+
     [Theory]
     [InlineData("relative/path/openapi.json")]
     [InlineData("/absolute/path/openapi.json")]
@@ -30,7 +30,7 @@ public class ScalarOptionsTests
         // Arrange
         var options = new ScalarOptions
         {
-            OpenApiRoutePattern = openApiRoute,
+            OpenApiRoutePattern = openApiRoute
         };
 
         // Act

--- a/integrations/aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Program.cs
+++ b/integrations/aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Program.cs
@@ -4,14 +4,11 @@ using Scalar.AspNetCore.Tests.Api;
 
 var builder = WebApplication.CreateSlimBuilder(args);
 
-builder.Services.AddOpenApi();
 builder.Services.AddAuthentication("api-key")
     .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationSchemeHandler>("api-key", null);
 builder.Services.AddAuthorizationBuilder().AddFallbackPolicy("fallback", policyBuilder => policyBuilder.RequireAuthenticatedUser());
 
 var app = builder.Build();
-
-app.MapOpenApi();
 
 app.MapScalarApiReference().AllowAnonymous();
 

--- a/integrations/aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj
+++ b/integrations/aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj
@@ -1,12 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Scalar.AspNetCore\Scalar.AspNetCore.csproj"/>


### PR DESCRIPTION
Some maintenance work for the `Scalar.AspNetCore` integration.

- Update depdendencies
- Run cleanup profile for code
- Run tests for all target frameworks
- Minor refactoring by splitting the regex generation from the `ScalarOptions`


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] ~I’ve added tests for the regression or new feature.~
- [ ] ~I’ve updated the documentation.~
