### PR TITLE
fix(api-client): address bar path whitespace

### DIFF
--- a/.changeset/tidy-clouds-fetch.md
+++ b/.changeset/tidy-clouds-fetch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sets whitespace to disabled address bar path

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -235,7 +235,7 @@ export default {
     <div
       class="text-c-2 flex cursor-default items-center justify-center"
       :class="layout === 'modal' ? 'font-code pl-1 pr-2 text-sm' : 'px-2'">
-      <span>{{ modelValue }}</span>
+      <span class="whitespace-nowrap">{{ modelValue }}</span>
     </div>
   </template>
   <template v-else-if="props.enum && props.enum.length">


### PR DESCRIPTION
**Problem**
currently api reference modal address bar is wrapping on long path.

**Solution**
this pr sets no wrap to disabled address bar path.

| before | after |
| -------|------|
| <img width="548" alt="image" src="https://github.com/user-attachments/assets/37269bad-f4a0-456e-8e0a-0e4070913c05" /> | <img width="573" alt="image" src="https://github.com/user-attachments/assets/964d6ed2-4a26-4a4b-bc82-14b56cac4d85" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information.
