### PR TITLE
fix(snippetz): doesn’t parse text for JSON requests

### DIFF
--- a/.changeset/stupid-birds-rescue.md
+++ b/.changeset/stupid-birds-rescue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+fix: handle case where mimeType application/json but only text is provided to body

--- a/packages/snippetz/src/utils/convertWithHttpSnippetLite.test.ts
+++ b/packages/snippetz/src/utils/convertWithHttpSnippetLite.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
+import type { HarRequest } from '@/types'
 import { convertWithHttpSnippetLite } from './convertWithHttpSnippetLite'
 
 describe('convertWithHttpSnippetLite', () => {
   it('converts a basic GET request', () => {
     const mockClient = {
-      convert: (request) => JSON.stringify(request, null, 2),
+      convert: (request: HarRequest) => JSON.stringify(request, null, 2),
     }
 
     const result = convertWithHttpSnippetLite(mockClient, {
@@ -21,7 +22,7 @@ describe('convertWithHttpSnippetLite', () => {
 
   it('handles query parameters', () => {
     const mockClient = {
-      convert: (request) => JSON.stringify(request, null, 2),
+      convert: (request: HarRequest) => JSON.stringify(request, null, 2),
     }
 
     const result = convertWithHttpSnippetLite(mockClient, {
@@ -42,7 +43,7 @@ describe('convertWithHttpSnippetLite', () => {
 
   it('processes headers correctly', () => {
     const mockClient = {
-      convert: (request) => JSON.stringify(request, null, 2),
+      convert: (request: HarRequest) => JSON.stringify(request, null, 2),
     }
 
     const result = convertWithHttpSnippetLite(mockClient, {
@@ -63,7 +64,7 @@ describe('convertWithHttpSnippetLite', () => {
 
   it('handles POST requests with JSON body', () => {
     const mockClient = {
-      convert: (request) => JSON.stringify(request, null, 2),
+      convert: (request: HarRequest) => JSON.stringify(request, null, 2),
     }
 
     const result = convertWithHttpSnippetLite(mockClient, {
@@ -85,7 +86,7 @@ describe('convertWithHttpSnippetLite', () => {
 
   it('handles invalid JSON body gracefully', () => {
     const mockClient = {
-      convert: (request) => JSON.stringify(request, null, 2),
+      convert: (request: HarRequest) => JSON.stringify(request, null, 2),
     }
 
     const result = convertWithHttpSnippetLite(mockClient, {
@@ -114,7 +115,7 @@ describe('convertWithHttpSnippetLite', () => {
 
   it('handles URLs with trailing slash correctly', () => {
     const mockClient = {
-      convert: (request) => JSON.stringify(request, null, 2),
+      convert: (request: HarRequest) => JSON.stringify(request, null, 2),
     }
 
     const result = convertWithHttpSnippetLite(mockClient, {

--- a/packages/snippetz/src/utils/convertWithHttpSnippetLite.test.ts
+++ b/packages/snippetz/src/utils/convertWithHttpSnippetLite.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertWithHttpSnippetLite } from './convertWithHttpSnippetLite'
+
+describe('convertWithHttpSnippetLite', () => {
+  it('converts a basic GET request', () => {
+    const mockClient = {
+      convert: (request) => JSON.stringify(request, null, 2),
+    }
+
+    const result = convertWithHttpSnippetLite(mockClient, {
+      url: 'https://api.example.com/users',
+      method: 'GET',
+    })
+
+    const parsed = JSON.parse(result)
+    expect(parsed.method).toBe('GET')
+    expect(parsed.url).toBe('https://api.example.com/users')
+    expect(parsed.headers).toEqual([])
+  })
+
+  it('handles query parameters', () => {
+    const mockClient = {
+      convert: (request) => JSON.stringify(request, null, 2),
+    }
+
+    const result = convertWithHttpSnippetLite(mockClient, {
+      url: 'https://api.example.com/search?q=test&page=1',
+      method: 'GET',
+    })
+
+    const parsed = JSON.parse(result)
+    expect(parsed.queryObj).toEqual({
+      q: 'test',
+      page: '1',
+    })
+    expect(parsed.queryString).toEqual([
+      { name: 'q', value: 'test' },
+      { name: 'page', value: '1' },
+    ])
+  })
+
+  it('processes headers correctly', () => {
+    const mockClient = {
+      convert: (request) => JSON.stringify(request, null, 2),
+    }
+
+    const result = convertWithHttpSnippetLite(mockClient, {
+      url: 'https://api.example.com/data',
+      method: 'GET',
+      headers: [
+        { name: 'Content-Type', value: 'application/json' },
+        { name: 'Authorization', value: 'Bearer token' },
+      ],
+    })
+
+    const parsed = JSON.parse(result)
+    expect(parsed.headersObj).toEqual({
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer token',
+    })
+  })
+
+  it('handles POST requests with JSON body', () => {
+    const mockClient = {
+      convert: (request) => JSON.stringify(request, null, 2),
+    }
+
+    const result = convertWithHttpSnippetLite(mockClient, {
+      url: 'https://api.example.com/users',
+      method: 'POST',
+      postData: {
+        mimeType: 'application/json',
+        text: JSON.stringify({ name: 'John', age: 30 }),
+      },
+    })
+
+    const parsed = JSON.parse(result)
+    expect(parsed.method).toBe('POST')
+    expect(parsed.postData.jsonObj).toEqual({
+      name: 'John',
+      age: 30,
+    })
+  })
+
+  it('handles invalid JSON body gracefully', () => {
+    const mockClient = {
+      convert: (request) => JSON.stringify(request, null, 2),
+    }
+
+    const result = convertWithHttpSnippetLite(mockClient, {
+      url: 'https://api.example.com/users',
+      method: 'POST',
+      postData: {
+        mimeType: 'application/json',
+        text: 'invalid json',
+      },
+    })
+
+    const parsed = JSON.parse(result)
+    expect(parsed.postData.jsonObj).toBeUndefined()
+  })
+
+  it('returns empty string if client.convert is not a function', () => {
+    const mockClient = {}
+
+    const result = convertWithHttpSnippetLite(mockClient, {
+      url: 'https://api.example.com/users',
+      method: 'GET',
+    })
+
+    expect(result).toBe('')
+  })
+
+  it('handles URLs with trailing slash correctly', () => {
+    const mockClient = {
+      convert: (request) => JSON.stringify(request, null, 2),
+    }
+
+    const result = convertWithHttpSnippetLite(mockClient, {
+      url: 'https://api.example.com/',
+    })
+
+    const parsed = JSON.parse(result)
+    expect(parsed.url).toBe('https://api.example.com')
+  })
+})

--- a/packages/snippetz/src/utils/convertWithHttpSnippetLite.ts
+++ b/packages/snippetz/src/utils/convertWithHttpSnippetLite.ts
@@ -114,6 +114,14 @@ export function convertWithHttpSnippetLite(
     cookiesObj: cookiesObj ?? {},
   } as Request
 
+  if (convertRequest.postData?.mimeType === 'application/json' && convertRequest.postData?.text) {
+    try {
+      convertRequest.postData.jsonObj = JSON.parse(convertRequest.postData.text)
+    } catch (error) {
+      console.error('Error parsing JSON:', error)
+    }
+  }
+
   if (typeof client.convert === 'function') {
     return client.convert(convertRequest)
   }

--- a/packages/snippetz/src/utils/convertWithHttpSnippetLite.ts
+++ b/packages/snippetz/src/utils/convertWithHttpSnippetLite.ts
@@ -3,6 +3,8 @@ import type { HarRequest } from '@/types'
 
 /**
  * Takes a httpsnippet-lite client and converts the given request to a code example with it.
+ *
+ * @deprecated This a temporary wrapper around httpsnippet-lite. Let’s write all the generators ourselves instead.
  */
 export function convertWithHttpSnippetLite(
   // Couldn’t find the proper type, there was always a mismatch.
@@ -114,6 +116,7 @@ export function convertWithHttpSnippetLite(
     cookiesObj: cookiesObj ?? {},
   } as Request
 
+  // If the request is a JSON request, parse the text as JSON
   if (convertRequest.postData?.mimeType === 'application/json' && convertRequest.postData?.text) {
     try {
       convertRequest.postData.jsonObj = JSON.parse(convertRequest.postData.text)


### PR DESCRIPTION
**Problem**

Currently, if a mimeType of `application/json` is provided & theres no jsonObj, we dont handle the scenario when a `text` is provided

Fixes #4870

**Solution**

With this PR we handle it

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
