### PR TITLE
fix(types): make AuthenticationState bearer or basic optional

### DIFF
--- a/.changeset/twelve-fans-tap.md
+++ b/.changeset/twelve-fans-tap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/types': patch
+---
+
+fix: make AuthenticationState bearer or basic optional

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -507,11 +507,11 @@ export type AuthenticationState = {
     | OpenAPIV3.ComponentsObject['securitySchemes']
     | OpenAPIV3_1.ComponentsObject['securitySchemes']
   http: {
-    basic: {
+    basic?: {
       username: string
       password: string
     }
-    bearer: {
+    bearer?: {
       token: string
     }
   }


### PR DESCRIPTION
**Problem**

Currently, bearer + basic auth are both required, when only one should be :)

**Solution**

With this PR we make them both optional

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
