### PR TITLE
fix(api-reference): fix headings and add / organize regions 

### DIFF
--- a/.changeset/spotty-queens-pretend.md
+++ b/.changeset/spotty-queens-pretend.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): fix headings and add / organize regions

--- a/examples/web/src/pages/EmbeddedApiReferencePage.vue
+++ b/examples/web/src/pages/EmbeddedApiReferencePage.vue
@@ -15,14 +15,14 @@ const configuration = reactive<ReferenceConfiguration>({
 })
 </script>
 <template>
-  <main class="main">
+  <div class="main">
     <h1>This is my super duper web application</h1>
     <div class="container">
       <ApiReference :configuration="configuration">
         <template #footer><SlotPlaceholder>footer</SlotPlaceholder></template>
       </ApiReference>
     </div>
-  </main>
+  </div>
 </template>
 <style scoped>
 .main {

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
+import { useId } from 'vue'
 
 import { useNavState } from '@/hooks'
 
@@ -9,6 +10,8 @@ defineProps<{
   id: string
 }>()
 
+const labelId = useId()
+
 const { copyToClipboard } = useClipboard()
 const { getHashedUrl } = useNavState()
 const getUrlWithId = (id: string) => {
@@ -17,16 +20,21 @@ const getUrlWithId = (id: string) => {
 </script>
 <template>
   <span class="label">
-    <slot />
+    <span
+      :id="labelId"
+      class="contents">
+      <slot />
+    </span>
     <span class="anchor">
       <!-- Position anchor to align the copy button to the last line of text  -->
       <span>&ZeroWidthSpace;</span>
       <button
+        :aria-describedby="labelId"
         class="anchor-copy"
         type="button"
         @click.stop="copyToClipboard(getUrlWithId(id))">
         <span aria-hidden="true">#</span>
-        <ScreenReader>Copy link to "<slot />"</ScreenReader>
+        <ScreenReader>Copy link</ScreenReader>
       </button>
     </span>
   </span>

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -313,7 +313,7 @@ const themeStyleTag = computed(
 )
 </script>
 <template>
-  <div v-html="themeStyleTag"></div>
+  <div v-html="themeStyleTag" />
   <div
     ref="documentEl"
     class="scalar-app scalar-api-reference references-layout"
@@ -340,6 +340,7 @@ const themeStyleTag = computed(
     <!-- Navigation (sidebar) wrapper -->
     <aside
       v-if="configuration.showSidebar"
+      :aria-label="`Sidebar for ${parsedSpec.info?.title}`"
       class="references-navigation t-doc__sidebar">
       <!-- Navigation tree / Table of Contents -->
       <div class="references-navigation-list">
@@ -374,7 +375,7 @@ const themeStyleTag = computed(
     </div>
     <!-- Rendered reference -->
     <template v-if="showRenderedContent">
-      <section
+      <main
         :aria-label="`Open API Documentation for ${parsedSpec.info?.title}`"
         class="references-rendered">
         <Content
@@ -401,7 +402,7 @@ const themeStyleTag = computed(
               name="content-end" />
           </template>
         </Content>
-      </section>
+      </main>
       <div
         v-if="$slots.footer"
         class="references-footer">

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -15,6 +15,7 @@ import {
   SectionContainer,
   SectionContent,
   SectionHeader,
+  SectionHeaderTag,
 } from '../../Section'
 import Description from './Description.vue'
 
@@ -67,10 +68,11 @@ onMounted(() => onLoaded?.())
           <Badge v-if="oasVersion">OAS {{ oasVersion }}</Badge>
         </div>
         <SectionHeader
-          :level="1"
           :loading="!info.title"
           tight>
-          {{ info.title }}
+          <SectionHeaderTag :level="1">
+            {{ info.title }}
+          </SectionHeaderTag>
         </SectionHeader>
         <DownloadLink :specTitle="filenameFromTitle" />
         <SectionColumns>

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -18,6 +18,7 @@ import {
   SectionContainer,
   SectionContent,
   SectionHeader,
+  SectionHeaderTag,
 } from '../../Section'
 import { Schema } from '../Schema'
 import { Tag } from '../Tag'
@@ -180,12 +181,14 @@ onMounted(() => {
         :label="name">
         <template v-if="getModels(parsedSpec)?.[name]">
           <SectionContent>
-            <SectionHeader :level="2">
+            <SectionHeader>
               <Anchor :id="getModelId({ name })">
-                {{
-                  (getModels(parsedSpec)?.[name] as OpenAPIV3.SchemaObject)
-                    .title ?? name
-                }}
+                <SectionHeaderTag :level="2">
+                  {{
+                    (getModels(parsedSpec)?.[name] as OpenAPIV3.SchemaObject)
+                      .title ?? name
+                  }}
+                </SectionHeaderTag>
               </Anchor>
             </SectionHeader>
             <Schema

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ScalarErrorBoundary } from '@scalar/components'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
-import { computed } from 'vue'
+import { computed, useId } from 'vue'
 
 import { useNavState, useSidebar } from '../../../hooks'
 import {
@@ -22,6 +22,8 @@ const props = defineProps<{
     | Record<string, OpenAPIV3_1.SchemaObject>
     | unknown
 }>()
+
+const headerId = useId()
 
 const MAX_MODELS_INITIALLY_SHOWN = 10
 
@@ -49,9 +51,13 @@ const models = computed(() => {
   <SectionContainer
     v-if="schemas"
     id="models">
-    <Section>
+    <Section :aria-labelledby="headerId">
       <SectionHeader>
-        <SectionHeaderTag :level="2">Models</SectionHeaderTag>
+        <SectionHeaderTag
+          :id="headerId"
+          :level="2">
+          Models
+        </SectionHeaderTag>
       </SectionHeader>
       <Lazy
         id="models"

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -9,6 +9,7 @@ import {
   Section,
   SectionContainer,
   SectionHeader,
+  SectionHeaderTag,
 } from '../../Section'
 import ShowMoreButton from '../../ShowMoreButton.vue'
 import { Lazy } from '../Lazy'
@@ -49,11 +50,12 @@ const models = computed(() => {
     v-if="schemas"
     id="models">
     <Section>
-      <SectionHeader :level="2">Models</SectionHeader>
+      <SectionHeader>
+        <SectionHeaderTag :level="2">Models</SectionHeaderTag>
+      </SectionHeader>
       <Lazy
         id="models"
-        :isLazy="false">
-      </Lazy>
+        :isLazy="false" />
       <div
         class="models-list"
         :class="{ 'models-list-truncated': !showAllModels }">
@@ -67,9 +69,11 @@ const models = computed(() => {
             class="models-list-item"
             :label="name">
             <template #heading>
-              <SchemaHeading
-                :name="name"
-                :value="(schemas as any)[name]" />
+              <SectionHeaderTag :level="3">
+                <SchemaHeading
+                  :name="name"
+                  :value="(schemas as any)[name]" />
+              </SectionHeaderTag>
             </template>
             <ScalarErrorBoundary>
               <Schema

--- a/packages/api-reference/src/components/Content/Models/ModelsAccordion.vue
+++ b/packages/api-reference/src/components/Content/Models/ModelsAccordion.vue
@@ -8,6 +8,7 @@ import {
   SectionAccordion,
   SectionContainerAccordion,
   SectionHeader,
+  SectionHeaderTag,
 } from '../../Section'
 import { SchemaHeading, SchemaProperty } from '../Schema'
 
@@ -48,10 +49,12 @@ const { getModelId } = useNavState()
         <Anchor
           :id="getModelId({ name })"
           class="reference-models-anchor">
-          <SchemaHeading
-            class="reference-models-label"
-            :name="name"
-            :value="schema" />
+          <SectionHeaderTag :level="3">
+            <SchemaHeading
+              class="reference-models-label"
+              :name="name"
+              :value="schema" />
+          </SectionHeaderTag>
         </Anchor>
       </template>
       <!-- Schema -->

--- a/packages/api-reference/src/components/Content/Tag/Endpoints.vue
+++ b/packages/api-reference/src/components/Content/Tag/Endpoints.vue
@@ -19,7 +19,12 @@ import {
   SectionHeaderTag,
 } from '../../Section'
 
-const props = defineProps<{ id?: string; tag: Tag; isCollapsed?: boolean }>()
+const props = defineProps<{
+  id?: string
+  tag: Tag
+  headerId?: string
+  isCollapsed?: boolean
+}>()
 
 const { getOperationId, getTagId } = useNavState()
 const { scrollToOperation } = useSidebar()
@@ -35,10 +40,13 @@ const scrollHandler = async (operation: TransformedOperation) => {
 <template>
   <Section
     :id="id"
-    :label="tag.name.toUpperCase()">
+    :label="tag.name.toUpperCase()"
+    role="none">
     <SectionHeader>
       <Anchor :id="getTagId(tag)">
-        <SectionHeaderTag :level="2">
+        <SectionHeaderTag
+          :id="headerId"
+          :level="2">
           {{ tagName }}
           <ScreenReader v-if="isCollapsed"> (Collapsed)</ScreenReader>
         </SectionHeaderTag>
@@ -74,13 +82,12 @@ const scrollHandler = async (operation: TransformedOperation) => {
                       v-if="isCollapsed"
                       class="sr-only"
                       :level="3">
-                      {{ operation.name }} (Collapsed)
+                      {{ operation.name }} (Hidden)
                     </SectionHeaderTag>
                     <a
                       class="endpoint"
                       :href="`#${getOperationId(operation, tag)}`"
                       @click.prevent="scrollHandler(operation)">
-                      <ScreenReader>Operation: </ScreenReader>
                       <HttpMethod :method="operation.httpVerb" />
                       <span
                         class="endpoint-path"

--- a/packages/api-reference/src/components/Content/Tag/Endpoints.vue
+++ b/packages/api-reference/src/components/Content/Tag/Endpoints.vue
@@ -40,6 +40,7 @@ const scrollHandler = async (operation: TransformedOperation) => {
       <Anchor :id="getTagId(tag)">
         <SectionHeaderTag :level="2">
           {{ tagName }}
+          <ScreenReader v-if="isCollapsed"> (Collapsed)</ScreenReader>
         </SectionHeaderTag>
       </Anchor>
     </SectionHeader>
@@ -68,10 +69,18 @@ const scrollHandler = async (operation: TransformedOperation) => {
                     v-for="operation in tag.operations"
                     :key="getOperationId(operation, tag)"
                     class="contents">
+                    <!-- If collapsed add hidden headers so they show up for screen readers -->
+                    <SectionHeaderTag
+                      v-if="isCollapsed"
+                      class="sr-only"
+                      :level="3">
+                      {{ operation.name }} (Collapsed)
+                    </SectionHeaderTag>
                     <a
                       class="endpoint"
                       :href="`#${getOperationId(operation, tag)}`"
                       @click.prevent="scrollHandler(operation)">
+                      <ScreenReader>Operation: </ScreenReader>
                       <HttpMethod :method="operation.httpVerb" />
                       <span
                         class="endpoint-path"

--- a/packages/api-reference/src/components/Content/Tag/Endpoints.vue
+++ b/packages/api-reference/src/components/Content/Tag/Endpoints.vue
@@ -16,6 +16,7 @@ import {
   SectionColumns,
   SectionContent,
   SectionHeader,
+  SectionHeaderTag,
 } from '../../Section'
 
 const props = defineProps<{ id?: string; tag: Tag; isCollapsed?: boolean }>()
@@ -35,8 +36,12 @@ const scrollHandler = async (operation: TransformedOperation) => {
   <Section
     :id="id"
     :label="tag.name.toUpperCase()">
-    <SectionHeader :level="2">
-      <Anchor :id="getTagId(tag)">{{ tagName }}</Anchor>
+    <SectionHeader>
+      <Anchor :id="getTagId(tag)">
+        <SectionHeaderTag :level="2">
+          {{ tagName }}
+        </SectionHeaderTag>
+      </Anchor>
     </SectionHeader>
     <SectionContent>
       <SectionColumns>

--- a/packages/api-reference/src/components/Content/Tag/Tag.vue
+++ b/packages/api-reference/src/components/Content/Tag/Tag.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Spec, Tag } from '@scalar/types/legacy'
-import { computed, nextTick, ref } from 'vue'
+import { computed, nextTick, ref, useId } from 'vue'
 
 import { useNavState, useSidebar } from '../../../hooks'
 import { SectionContainer } from '../../Section'
@@ -15,6 +15,8 @@ const props = defineProps<{
 
 const sectionContainerRef = ref<HTMLElement>()
 const contentsRef = ref<HTMLElement>()
+
+const headerId = useId()
 
 const { collapsedSidebarItems } = useSidebar()
 const { getTagId } = useNavState()
@@ -38,10 +40,13 @@ async function focusContents() {
 <template>
   <SectionContainer
     ref="sectionContainerRef"
-    class="tag-section-container">
+    :aria-labelledby="headerId"
+    class="tag-section-container"
+    role="region">
     <Endpoints
       v-if="moreThanOneDefaultTag"
       :id="id"
+      :headerId="headerId"
       :isCollapsed="!collapsedSidebarItems[getTagId(tag)]"
       :tag="tag" />
     <ShowMoreButton

--- a/packages/api-reference/src/components/Content/Tag/TagAccordion.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagAccordion.vue
@@ -4,7 +4,11 @@ import type { Tag } from '@scalar/types/legacy'
 
 import { useNavState } from '../../../hooks'
 import { Anchor } from '../../Anchor'
-import { SectionContainerAccordion, SectionHeader } from '../../Section'
+import {
+  SectionContainerAccordion,
+  SectionHeader,
+  SectionHeaderTag,
+} from '../../Section'
 
 defineProps<{
   tag: Tag
@@ -15,11 +19,11 @@ const { getTagId } = useNavState()
 <template>
   <SectionContainerAccordion class="tag-section">
     <template #title>
-      <SectionHeader
-        class="tag-name"
-        :level="2">
+      <SectionHeader class="tag-name">
         <Anchor :id="getTagId(tag)">
-          {{ tag.name }}
+          <SectionHeaderTag :level="2">
+            {{ tag.name }}
+          </SectionHeaderTag>
         </Anchor>
       </SectionHeader>
       <ScalarMarkdown

--- a/packages/api-reference/src/components/Section/SectionContainer.vue
+++ b/packages/api-reference/src/components/Section/SectionContainer.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="section-container"><slot /></div>
 </template>
-
 <style scoped>
 .section-container {
   position: relative;

--- a/packages/api-reference/src/components/Section/SectionHeader.vue
+++ b/packages/api-reference/src/components/Section/SectionHeader.vue
@@ -1,26 +1,21 @@
 <script setup lang="ts">
 import LoadingSkeleton from '../LoadingSkeleton.vue'
 
-withDefaults(
-  defineProps<{ loading?: boolean; tight?: boolean; level?: number }>(),
-  {
-    loading: false,
-    tight: false,
-    level: 1,
-  },
-)
+defineProps<{
+  loading?: boolean
+  tight?: boolean
+}>()
 </script>
 
 <template>
   <div class="section-header-wrapper">
     <LoadingSkeleton v-if="loading" />
-    <component
-      :is="`h${level}`"
+    <div
       v-else
       class="section-header"
       :class="{ tight }">
       <slot />
-    </component>
+    </div>
   </div>
 </template>
 

--- a/packages/api-reference/src/components/Section/SectionHeaderTag.vue
+++ b/packages/api-reference/src/components/Section/SectionHeaderTag.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+const { level = 1 } = defineProps<{ level?: 1 | 2 | 3 | 4 | 5 | 6 }>()
+</script>
+<template>
+  <component
+    :is="`h${level}`"
+    class="section-header-label">
+    <slot />
+  </component>
+</template>
+<style scoped>
+.section-header-label {
+  display: inline;
+}
+</style>

--- a/packages/api-reference/src/components/Section/index.ts
+++ b/packages/api-reference/src/components/Section/index.ts
@@ -6,5 +6,5 @@ export { default as SectionContainer } from './SectionContainer.vue'
 export { default as SectionContainerAccordion } from './SectionContainerAccordion.vue'
 export { default as SectionContent } from './SectionContent.vue'
 export { default as SectionHeader } from './SectionHeader.vue'
-
+export { default as SectionHeaderTag } from './SectionHeaderTag.vue'
 export { default as CompactSection } from './CompactSection.vue'

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -73,7 +73,7 @@ onMounted(() => {
     <slot name="sidebar-start" />
     <nav
       ref="scrollerEl"
-      :aria-label="`Contents of ${parsedSpec.info?.title}`"
+      :aria-label="`Table of contents for ${parsedSpec.info?.title}`"
       class="sidebar-pages custom-scroll custom-scroll-self-contain-overflow">
       <SidebarGroup :level="0">
         <template

--- a/packages/api-reference/src/features/Operation/Webhooks.vue
+++ b/packages/api-reference/src/features/Operation/Webhooks.vue
@@ -10,6 +10,7 @@ import {
   Section,
   SectionContainer,
   SectionHeader,
+  SectionHeaderTag,
 } from '@/components/Section'
 import ShowMoreButton from '@/components/ShowMoreButton.vue'
 import { useNavState, useSidebar } from '@/hooks'
@@ -48,11 +49,12 @@ const webhooksFiltered = computed(() => {
     v-if="webhookKeys.length"
     id="webhooks">
     <Section>
-      <SectionHeader :level="2">Webhooks</SectionHeader>
+      <SectionHeader>
+        <SectionHeaderTag :level="2">Webhooks</SectionHeaderTag>
+      </SectionHeader>
       <Lazy
         id="webhooks"
-        :isLazy="false">
-      </Lazy>
+        :isLazy="false" />
       <div
         class="webhooks-list"
         :class="{ 'webhooks-list-truncated': !showAllWebhooks }">
@@ -73,7 +75,9 @@ const webhooksFiltered = computed(() => {
               :label="name">
               <template #heading>
                 <!-- Title -->
-                {{ webhooks[name][httpVerb]?.name }}
+                <SectionHeaderTag :level="3">
+                  {{ webhooks[name][httpVerb]?.name }}
+                </SectionHeaderTag>
               </template>
               <!-- Description -->
               <ScalarMarkdown

--- a/packages/api-reference/src/features/Operation/Webhooks.vue
+++ b/packages/api-reference/src/features/Operation/Webhooks.vue
@@ -2,7 +2,7 @@
 import { ScalarMarkdown } from '@scalar/components'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Webhooks } from '@scalar/types/legacy'
-import { computed } from 'vue'
+import { computed, useId } from 'vue'
 
 import { Lazy } from '@/components/Content/Lazy'
 import {
@@ -24,6 +24,8 @@ const props = defineProps<{
 const webhookKeys = computed(() => {
   return Object.keys(props.webhooks ?? {})
 })
+
+const headerId = useId()
 
 const { getWebhookId } = useNavState()
 
@@ -48,9 +50,13 @@ const webhooksFiltered = computed(() => {
   <SectionContainer
     v-if="webhookKeys.length"
     id="webhooks">
-    <Section>
+    <Section :aria-labelledby="headerId">
       <SectionHeader>
-        <SectionHeaderTag :level="2">Webhooks</SectionHeaderTag>
+        <SectionHeaderTag
+          :id="headerId"
+          :level="2">
+          Webhooks
+        </SectionHeaderTag>
       </SectionHeader>
       <Lazy
         id="webhooks"

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -48,7 +48,7 @@ const config = useConfig()
     class="reference-endpoint"
     transparent>
     <template #title>
-      <h3 class="operation-title">
+      <div class="operation-title">
         <div class="operation-details">
           <HttpMethod
             class="endpoint-type"
@@ -57,7 +57,7 @@ const config = useConfig()
           <Anchor
             :id="id ?? ''"
             class="endpoint-anchor">
-            <div class="endpoint-label">
+            <h3 class="endpoint-label">
               <div class="endpoint-label-path">
                 <OperationPath
                   :deprecated="isOperationDeprecated(transformedOperation)"
@@ -71,10 +71,10 @@ const config = useConfig()
                 :class="getOperationStabilityColor(transformedOperation)">
                 {{ getOperationStability(transformedOperation) }}
               </Badge>
-            </div>
+            </h3>
           </Anchor>
         </div>
-      </h3>
+      </div>
     </template>
     <template #actions="{ active }">
       <TestRequestButton

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -6,7 +6,7 @@ import type {
   Server,
 } from '@scalar/oas-utils/entities/spec'
 import type { TransformedOperation } from '@scalar/types/legacy'
-import { defineProps } from 'vue'
+import { defineProps, useId } from 'vue'
 
 import { Anchor } from '@/components/Anchor'
 import { Badge } from '@/components/Badge'
@@ -39,10 +39,13 @@ defineProps<{
   /** @deprecated Use `operation` instead */
   transformedOperation: TransformedOperation
 }>()
+
+const labelId = useId()
 </script>
 <template>
   <Section
     :id="id"
+    :aria-labelledby="labelId"
     :label="transformedOperation.name">
     <SectionContent>
       <Badge
@@ -56,7 +59,9 @@ defineProps<{
         ">
         <SectionHeader>
           <Anchor :id="id ?? ''">
-            <SectionHeaderTag :level="3">
+            <SectionHeaderTag
+              :id="labelId"
+              :level="3">
               {{ transformedOperation.name }}
             </SectionHeaderTag>
           </Anchor>

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -17,6 +17,7 @@ import {
   SectionColumns,
   SectionContent,
   SectionHeader,
+  SectionHeaderTag,
 } from '@/components/Section'
 import { ExampleRequest } from '@/features/ExampleRequest'
 import { ExampleResponses } from '@/features/ExampleResponses'
@@ -53,9 +54,11 @@ defineProps<{
         :class="
           isOperationDeprecated(transformedOperation) ? 'deprecated' : ''
         ">
-        <SectionHeader :level="3">
+        <SectionHeader>
           <Anchor :id="id ?? ''">
-            {{ transformedOperation.name }}
+            <SectionHeaderTag :level="3">
+              {{ transformedOperation.name }}
+            </SectionHeaderTag>
           </Anchor>
         </SectionHeader>
       </div>

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -150,7 +150,7 @@ export function mountScalarApiReference(doc: Document, configuration: ReferenceC
     const specScriptTag = getSpecScriptTag(doc)
 
     if (specScriptTag) {
-      _container = doc.createElement('main')
+      _container = doc.createElement('div')
       specScriptTag?.parentNode?.insertBefore(_container, specScriptTag)
     } else {
       _container = specElement || specUrlElement || doc.body


### PR DESCRIPTION
More a11y! This PR cleans up our headings so users get a proper tree with the heading names and labels our regions correctly so you can navigate the page sections. Models and webhooks still need a bit more work but this is still an improvement.

I also added hidden headings so the full heading tree structure is available to screen readers even if the "Show More" buttons are collapsed. 

Here's a before and after video with NVDA, it also works well with voiceover but I can't take a screen recording of that because running the screen recorder confuses voiceover.

https://github.com/user-attachments/assets/06300a38-3c11-4cb0-b265-a2e23584bd30

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
