### PR TITLE
ci: increase memory limit

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -36,16 +36,16 @@ runs:
       # GitHub Actions runners have two cores, so we can run two tasks in parallel
       run: pnpm turbo --concurrency=2 build
       env:
-        NODE_OPTIONS: '--max_old_space_size=4096'
+        NODE_OPTIONS: '--max_old_space_size=8192'
     - if: ${{ inputs.packages-only == 'true' }}
       name: Build packages
       shell: bash
       run: pnpm turbo --concurrency=2 --filter './packages/**' build
       env:
-        NODE_OPTIONS: '--max_old_space_size=4096'
+        NODE_OPTIONS: '--max_old_space_size=8192'
     - if: ${{ inputs.packages-only != 'true' && inputs.packages-only != 'false' }}
       name: Build package
       shell: bash
       run: pnpm turbo --concurrency=2 --filter './packages/${{inputs.packages-only}}' build
       env:
-        NODE_OPTIONS: '--max_old_space_size=4096'
+        NODE_OPTIONS: '--max_old_space_size=8192'

--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -3,6 +3,9 @@ FROM node:20-slim AS base
 # process init system
 RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
 
+# Set Node.js memory limit to 8GB
+ENV NODE_OPTIONS="--max-old-space-size=8192"
+
 RUN npm install pnpm@9.2.0 --global
 RUN pnpm config set store-dir ~/.pnpm-store
 


### PR DESCRIPTION
OMG, the build is failing way too often and I think we hit the memory limit again. GHA runners for public repositories have 16 GB, so let’s increase the limit to 8 GB.

If CI passes on the first run, we should merge this PR.

I have the impression that we/turborepo has a memory leak, but I couldn’t find a way to properly debug this (without spending too much time).

EDIT: It failed, but because of a flaky test.