### PR TITLE
fix(api-client): response layout border

### DIFF
--- a/.changeset/warm-apricots-do.md
+++ b/.changeset/warm-apricots-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates response section border layout

--- a/packages/api-client/src/components/DataTable/DataTableCell.vue
+++ b/packages/api-client/src/components/DataTable/DataTableCell.vue
@@ -17,7 +17,7 @@ const { cx } = useBindCx()
     :is="is"
     v-bind="
       cx(
-        'max-h-8 min-h-8 min-w-8 border-l-0 border-t border-b-0 border-r flex text-sm last:border-r-0 group-last:border-b-transparent p-0 m-0 relative',
+        'box-content max-h-8 min-h-8 min-w-8 border-l-0 border-t border-b-0 border-r flex text-sm last:border-r-0 group-last:border-b-transparent p-0 m-0 relative',
       )
     "
     class="group-[.alert]:bg-b-alert group-[.error]:bg-b-danger"

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -16,13 +16,13 @@ const {
   <Disclosure
     v-slot="{ open }"
     as="div"
-    class="focus-within:text-c-1 text-c-2 request-item"
+    class="group/collapse focus-within:text-c-1 text-c-2 request-item"
     :defaultOpen="defaultOpen"
     :static="layout === 'reference'">
     <div class="bg-b-2 flex items-center">
       <DisclosureButton
         :class="[
-          'hover:text-c-1 group flex max-h-8 flex-1 items-center gap-2.5 overflow-hidden px-1 py-1.5 text-sm font-medium outline-none md:px-1.5 xl:pl-2 xl:pr-0.5',
+          'hover:text-c-1 group box-content flex max-h-8 flex-1 items-center gap-2.5 overflow-hidden px-1 py-1.5 text-sm font-medium outline-none group-last/collapse:border-b md:px-1.5 xl:pl-2 xl:pr-0.5',
           { '!pl-3': layout === 'reference' },
         ]"
         :disabled="layout === 'reference'">

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -47,8 +47,8 @@ const mediaConfig = computed(() => mediaTypes[mimeType.value.essence])
     </template>
     <div
       v-if="data"
-      class="border-t-1/2 bg-b-1 flex max-h-[calc(100%-32px)] flex-col overflow-hidden">
-      <div class="border-b-1/2 flex items-center justify-between px-3 py-1.5">
+      class="bg-b-1 flex max-h-[calc(100%-32px)] flex-col overflow-hidden">
+      <div class="flex items-center justify-between border-b px-3 py-1.5">
         <span class="text-xxs font-code leading-3">
           {{ mimeType.essence }}
         </span>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
@@ -17,7 +17,7 @@ const filenameExtension = computed(() => {
 </script>
 <template>
   <a
-    class="text-c-3 text-xxs hover:bg-b-3 flex items-center gap-1 rounded px-1.5 py-0.5 no-underline"
+    class="text-c-3 text-xxs hover:bg-b-3 no-underlin flex items-center gap-1 rounded px-1.5 py-0.5"
     :download="`${filenameExtension}`"
     :href="href"
     @click.stop>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseCookies.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseCookies.vue
@@ -26,7 +26,7 @@ defineProps<{
       <!-- Empty state -->
       <div
         v-else
-        class="text-c-3 border-t-1/2 bg-b-1 flex min-h-16 items-center justify-center px-4 text-sm">
+        class="text-c-3 border-t-1/2 bg-b-1 flex min-h-[65px] items-center justify-center px-4 text-sm">
         No cookies
       </div>
     </template>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -26,16 +26,16 @@ const findHeaderInfo = (name: string) => {
     <template #title>Headers</template>
     <div
       v-if="headers.length"
-      class="border-t-1/2 border-b-1/2 max-h-[calc(100%-32px)] overflow-y-auto">
+      class="max-h-[calc(100%-32px)] overflow-y-auto border-t">
       <DataTable
-        class="!mx-0 !border-0"
         :columns="['minmax(auto, min-content)', 'minmax(50%, 1fr)']"
         scroll>
         <DataTableRow
           v-for="item in headers"
           :key="item.name"
-          class="text-c-1">
-          <DataTableText class="z-1 bg-b-1 sticky left-0 max-w-48">
+          class="group/row text-c-1">
+          <DataTableText
+            class="z-1 bg-b-1 sticky left-0 max-w-48 group-first/row:border-t-0">
             <template v-if="typeof findHeaderInfo(item.name)?.url === 'string'">
               <HelpfulLink
                 class="decoration-c-3"
@@ -48,7 +48,7 @@ const findHeaderInfo = (name: string) => {
             </template>
           </DataTableText>
           <DataTableText
-            class="z-0"
+            class="z-0 group-first/row:border-t-0"
             :text="item.value" />
         </DataTableRow>
       </DataTable>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -135,7 +135,7 @@ const shouldVirtualize = computed(() => {
       </div>
     </template>
     <div
-      class="custom-scroll relative grid h-full justify-stretch"
+      class="custom-scroll relative grid h-full justify-stretch divide-y"
       :class="{
         'content-start': response,
       }">


### PR DESCRIPTION
**Problem**

Currently the api client response section is missing border + have size inconsistencies.

**Solution**

this pr updates the response section layout borders.

| before | after |
| -------|------|
| <img width="449" alt="image" src="https://github.com/user-attachments/assets/9978a9ca-6f5d-4d29-9dd2-fe445680611a" /> | <img width="449" alt="image" src="https://github.com/user-attachments/assets/8c9bee45-328e-47fb-8693-f53188753b62" /> |
| missing borders + misaligned rows | border + aligned rows | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
