### PR TITLE
feat(api-client): rely less on local storage

### DIFF
--- a/.changeset/shaggy-waves-sin.md
+++ b/.changeset/shaggy-waves-sin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: rely less on localStorage


### PR DESCRIPTION
**Problem**

Currently, we have a flaky test that sometimes (actually way too often, but not always) says `localStorage is not defined` in CI.

<img width="1092" alt="Screenshot 2025-02-26 at 15 15 57" src="https://github.com/user-attachments/assets/4ed54a89-3588-46b5-9396-9ddf52657478" />

**Solution**

With this PR `createClient` doesn’t rely on localStorage to be available. Hopefully, this fixes the flaky test.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.