### PR TITLE
fix(api-reference): content type select

### DIFF
--- a/.changeset/six-pandas-fold.md
+++ b/.changeset/six-pandas-fold.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates content type select component

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
@@ -53,26 +53,35 @@ const selectedContentType = ref<ContentType>(
 .content-type {
   display: flex;
   align-items: center;
-  font-size: var(--scalar-heading-4);
+  font-size: var(--scalar-font-size-2);
   font-weight: var(--scalar-semibold);
   color: var(--scalar-color-1);
   line-height: 1.45;
   margin-top: 24px;
   padding-bottom: 12px;
-  border-bottom: 1px solid var(--scalar-border-color);
+  border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
   flex-flow: wrap;
 }
 .content-type-select {
   position: relative;
-  padding-left: 9px;
   height: fit-content;
-  color: var(--scalar-color-2);
-  font-size: var(--scalar-font-size-3);
+  margin-left: auto;
+  font-weight: var(--scalar-regular);
   display: flex;
   align-items: center;
+  color: var(--scalar-color-3);
+  font-size: var(--scalar-micro);
+  background: var(--scalar-background-2);
+  padding: 3px 6px 4px 8px;
+  border-radius: 12px;
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 .content-type-no-select.content-type-select {
+  padding: 3px 8px 4px 8px;
   pointer-events: none;
+}
+.content-type-no-select {
+  border: none;
 }
 .content-type-no-select.content-type-select:after {
   display: none;
@@ -83,19 +92,19 @@ const selectedContentType = ref<ContentType>(
 }
 .content-type-select:after {
   content: '';
-  width: 7px;
-  height: 7px;
-  transform: rotate(45deg) translate3d(-2px, -4px, 0);
+  width: 6px;
+  height: 6px;
+  transform: rotate(45deg) translate3d(0, -3px, 0);
   display: block;
-  margin-left: 7px;
+  margin-left: 6px;
   box-shadow: 1px 1px 0 currentColor;
+  margin-right: 5px;
 }
 .content-type-select select {
   border: none;
   outline: none;
   cursor: pointer;
   background: var(--scalar-background-3);
-  box-shadow: -2px 0 0 0 var(--scalar-background-3);
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -64,7 +64,7 @@ const shouldShowParameter = computed(() => {
     <Disclosure v-slot="{ open }">
       <DisclosureButton
         v-if="shouldCollapse"
-        class="parameter-item-trigger flex"
+        class="parameter-item-trigger group/parameter-item-trigger flex"
         :class="{ 'parameter-item-trigger-open': open }">
         <ScalarIcon
           class="parameter-item-icon"
@@ -82,7 +82,8 @@ const shouldShowParameter = computed(() => {
             class="markdown"
             :value="parameter.description" />
         </span>
-        <div class="absolute right-0">
+        <div
+          class="absolute right-0 top-2.5 opacity-0 group-hover/parameter-item-trigger:opacity-100">
           <ContentTypeSelect
             v-if="shouldCollapse && props.parameter.content"
             class="parameter-item-content-type"
@@ -226,19 +227,5 @@ const shouldShowParameter = computed(() => {
   outline: 1px solid var(--scalar-color-accent);
   outline-offset: 2px;
   border-radius: var(--scalar-radius);
-}
-.parameter-item-content-type {
-  margin-left: auto;
-  opacity: 0;
-  padding-left: 18px;
-  transition: opacity 0.1s ease-in-out;
-  color: var(--scalar-color-3);
-  font-size: var(--scalar-micro);
-  background: var(--scalar-background-2);
-  padding: 2px 6px;
-  border-radius: 12px;
-}
-.parameter-item-trigger:hover .parameter-item-content-type {
-  opacity: 1;
 }
 </style>

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ScalarMarkdown } from '@scalar/components'
 import type { ContentType, RequestBody } from '@scalar/types/legacy'
 import { computed, ref } from 'vue'
 
 import { Schema } from '@/components/Content/Schema'
+
+import ContentTypeSelect from './ContentTypeSelect.vue'
 
 const { requestBody } = defineProps<{ requestBody?: RequestBody }>()
 
@@ -23,28 +24,12 @@ if (requestBody?.content) {
   <div v-if="requestBody">
     <div class="request-body-title">
       <slot name="title" />
-      <div
-        class="request-body-title-select"
-        :class="{
-          'request-body-title-no-select': availableContentTypes.length <= 1,
-        }">
-        <span>{{ selectedContentType }}</span>
-        <select
-          v-if="requestBody && availableContentTypes.length > 1"
-          v-model="selectedContentType">
-          <option
-            v-for="(_, key) in requestBody?.content"
-            :key="key"
-            :value="key">
-            {{ key }}
-          </option>
-        </select>
-      </div>
-      <div
-        v-if="requestBody.description"
-        class="request-body-description">
-        <ScalarMarkdown :value="requestBody.description" />
-      </div>
+      <ContentTypeSelect
+        :defaultValue="selectedContentType"
+        :requestBody="requestBody"
+        @selectContentType="
+          ({ contentType }) => (selectedContentType = contentType)
+        " />
     </div>
     <div
       v-if="requestBody.content?.[selectedContentType]"
@@ -64,7 +49,6 @@ if (requestBody?.content) {
   font-size: var(--scalar-font-size-2);
   font-weight: var(--scalar-semibold);
   color: var(--scalar-color-1);
-  line-height: 1.45;
   margin-top: 24px;
   padding-bottom: 12px;
   border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);


### PR DESCRIPTION
**Problem**
currently the content type select style used in api reference response is broken

**Solution**
this pr updates content type select component style and uses it in request body also.

| before | after |
| -------|------|
| <img width="597" alt="image" src="https://github.com/user-attachments/assets/86e6f333-73ed-4744-9836-89f6d4415c99" /> | <img width="597" alt="image" src="https://github.com/user-attachments/assets/ce4ad61f-c5c0-46e5-8e92-694f2c404e02" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
