### PR TITLE
fix(integrations): express and fastify examples not running

### DIFF
--- a/.changeset/cool-brooms-add.md
+++ b/.changeset/cool-brooms-add.md
@@ -1,0 +1,6 @@
+---
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+---
+
+fix: cloudbuild not running latest integrations

--- a/integrations/express/Dockerfile
+++ b/integrations/express/Dockerfile
@@ -22,6 +22,7 @@ RUN chown node:node /app
 
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/packages/api-reference /app/packages/api-reference
 COPY --from=builder /app/integrations/express /app/integrations/express
 
 WORKDIR /app/integrations/express/playground

--- a/integrations/fastify/Dockerfile
+++ b/integrations/fastify/Dockerfile
@@ -22,6 +22,7 @@ RUN chown node:node /app
 
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/packages/api-reference /app/packages/api-reference
 COPY --from=builder /app/integrations/fastify /app/integrations/fastify
 
 WORKDIR /app/integrations/fastify


### PR DESCRIPTION
**Problem**

We recently added the html builder to api-reference.
pnpm will only replace the `workspace:*` dependencies on publish, here we are using the monorepo packages so it could not find the api-reference in the docker containers

**Solution**

We could either replace all `workspace:*` dependencies before pnpm i OR just copy over the dependencies into the docker container. Since there was only one dependency in this case I just copied it and it worked. Open to the other method as well. 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
