### PR TITLE
feat(themes): add font-sans for default scalar font

### DIFF
--- a/.changeset/two-buses-tell.md
+++ b/.changeset/two-buses-tell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+feat(themes): add font-sans for default scalar font

--- a/packages/themes/src/tailwind.ts
+++ b/packages/themes/src/tailwind.ts
@@ -35,6 +35,7 @@ export default {
     },
     fontFamily: {
       DEFAULT: 'var(--scalar-font)',
+      sans: 'var(--scalar-font)',
       code: 'var(--scalar-font-code)',
     },
     fontSize: {


### PR DESCRIPTION
Let's us override `font-code` by setting `font-sans`.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
