### PR TITLE
feat(scalar_fastapi): Add authentication configuration for FastAPI

### DIFF
--- a/integrations/fastapi/README.md
+++ b/integrations/fastapi/README.md
@@ -43,6 +43,7 @@ Currently available [configuration options](https://github.com/scalar/scalar/blo
 - `hidden_clients` (default `[]`)
 - `servers` (default `[]`)
 - `default_open_all_tags` (default `false`)
+- `authentication` (default `{}`)
 
 ## Example
 

--- a/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
@@ -274,6 +274,15 @@ def get_scalar_api_reference(
             """
         ),
     ] = False,
+    authentication: Annotated[
+        dict,
+        Doc(
+            """
+            A dictionary of additional authentication information.
+            Default is {} which means no authentication information is provided.
+            """
+        ),
+    ] = {},
     integration: Annotated[
         str | None,
         Doc(
@@ -322,6 +331,7 @@ def get_scalar_api_reference(
         hiddenClients: {json.dumps(hidden_clients)},
         servers: {json.dumps(servers)},
         defaultOpenAllTags: {json.dumps(default_open_all_tags)},
+        authentication: {json.dumps(authentication)},
         _integration: {json.dumps(integration)},
       }}
 

--- a/integrations/fastapi/setup.py
+++ b/integrations/fastapi/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='scalar_fastapi',
-    version='1.0.1',
+    version='1.1.0',
     packages=find_packages(),
     install_requires=[
         # Add your package dependencies here


### PR DESCRIPTION
**Problem**

Currently, it is not possible to set the `authentication` configuration options for Scalar from the `scalar-fastapi` integration as it is not a supported argument.

**Solution**

With this PR it is possible to add the authentication options in the FastAPI integration, it defaults to an empty dictionary if no argument is passed.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (pnpm changeset).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
