### PR TITLE
fix(api-reference): use listbox for server selector

### DIFF
--- a/packages/api-client/src/components/Server/ServerDropdown.vue
+++ b/packages/api-client/src/components/Server/ServerDropdown.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import {
-  cva,
-  cx,
   ScalarButton,
   ScalarDropdownDivider,
   ScalarFloatingBackdrop,
@@ -20,16 +18,15 @@ import { useWorkspace } from '@/store/store'
 
 import ServerDropdownItem from './ServerDropdownItem.vue'
 
-const { target, collection, layout, operation, server } = defineProps<{
+const { target, collection, operation, server } = defineProps<{
   collection: Collection
   operation?: Operation
   server: Server | undefined
-  layout: 'client' | 'reference'
   /** The id of the target to use for the popover (e.g. address bar) */
   target: string
 }>()
 
-const { layout: clientLayout } = useLayout()
+const { layout } = useLayout()
 const { servers, collectionMutators, events, serverMutators } = useWorkspace()
 
 const requestServerOptions = computed(() =>
@@ -92,49 +89,30 @@ const updateServerVariable = (key: string, value: string) => {
 
   serverMutators.edit(server.uid, 'variables', variables)
 }
-
-// Define variants for the button
-const buttonVariants = cva({
-  base: 'gap-0.75 z-context-plus lg:text-sm text-xs whitespace-nowrap px-1.5 h-6.5',
-  variants: {
-    reference: {
-      true: '!font-normal justify-start px-3 py-1.5 rounded-b-lg text-c-1 w-full',
-      false: 'border hover:bg-b-2 font-code ml-0.75 rounded text-c-2',
-    },
-  },
-})
 </script>
 <template>
   <ScalarPopover
     class="max-h-[inherit] p-0 text-sm"
-    :offset="layout === 'reference' ? 6 : 0"
+    :offset="0"
     placement="bottom-start"
     resize
     :target="target"
     :teleport="`#${target}`">
     <ScalarButton
-      :class="cx(buttonVariants({ reference: layout === 'reference' }))"
+      class="gap-0.75 z-context-plus h-6.5 hover:bg-b-2 font-code ml-0.75 text-c-2 whitespace-nowrap rounded border px-1.5 text-xs lg:text-sm"
       variant="ghost">
       <span class="sr-only">Server:</span>
       {{ serverUrlWithoutTrailingSlash }}
-
-      <ScalarIcon
-        v-if="layout === 'reference'"
-        class="text-c-2"
-        icon="ChevronDown"
-        size="sm" />
     </ScalarButton>
     <template #popover="{ close }">
       <div
         class="custom-scroll flex max-h-[inherit] flex-col gap-1 p-1"
-        :class="layout !== 'reference' && 'border-t'"
         @click="close">
         <!-- Request -->
         <ServerDropdownItem
           v-for="serverOption in requestServerOptions"
           :key="serverOption.id"
           :collection="collection"
-          :layout="layout"
           :operation="operation"
           :server="server"
           :serverOption="serverOption"
@@ -149,14 +127,13 @@ const buttonVariants = cva({
           v-for="serverOption in collectionServerOptions"
           :key="serverOption.id"
           :collection="collection"
-          :layout="layout"
           :operation="operation"
           :server="server"
           :serverOption="serverOption"
           type="collection"
           @update:variable="updateServerVariable" />
         <!-- Add Server -->
-        <template v-if="clientLayout !== 'modal'">
+        <template v-if="layout !== 'modal'">
           <button
             class="text-xxs p-1.75 hover:bg-b-2 flex cursor-pointer items-center gap-1.5 rounded"
             type="button"

--- a/packages/api-client/src/components/Server/ServerDropdown.vue
+++ b/packages/api-client/src/components/Server/ServerDropdown.vue
@@ -106,7 +106,7 @@ const updateServerVariable = (key: string, value: string) => {
     </ScalarButton>
     <template #popover="{ close }">
       <div
-        class="custom-scroll flex max-h-[inherit] flex-col gap-1 p-1"
+        class="custom-scroll flex max-h-[inherit] flex-col gap-1 border-t p-1"
         @click="close">
         <!-- Request -->
         <ServerDropdownItem

--- a/packages/api-client/src/components/Server/ServerDropdownItem.vue
+++ b/packages/api-client/src/components/Server/ServerDropdownItem.vue
@@ -19,7 +19,6 @@ const props = defineProps<{
     label: string
   }
   type: 'collection' | 'request'
-  layout: 'client' | 'reference'
 }>()
 
 const emit = defineEmits<{
@@ -31,9 +30,7 @@ const { collectionMutators, requestMutators, servers } = useWorkspace()
 
 /** Update the currently selected server on the collection or request */
 const updateSelectedServer = (serverUid: Server['uid'], event?: Event) => {
-  if (hasVariables(serverUid) && props.layout !== 'reference') {
-    event?.stopPropagation()
-  }
+  if (hasVariables(serverUid)) event?.stopPropagation()
 
   // Set selected server on Collection
   if (props.type === 'collection' && props.collection) {
@@ -92,7 +89,7 @@ const updateServerVariable = (key: string, value: string) => {
     </button>
     <!-- Server variables -->
     <div
-      v-if="isExpanded && props.layout !== 'reference'"
+      v-if="isExpanded"
       :id="formId"
       class="bg-b-2 divide divide-y rounded-b border-t *:pl-4"
       @click.stop>

--- a/packages/api-client/src/components/Server/ServerSelector.vue
+++ b/packages/api-client/src/components/Server/ServerSelector.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import type { Collection, Server } from '@scalar/oas-utils/entities/spec'
+import { computed, watch } from 'vue'
+
+import { useWorkspace } from '@/store/store'
+
+type ServerOption = {
+  id: Server['uid']
+  label: string
+}
+
+const { target, collection, server } = defineProps<{
+  /** The collection */
+  collection: Collection
+  /** The selected server */
+  server: Server | undefined
+  /** The id of the target to use for the popover (e.g. address bar) */
+  target: string
+}>()
+
+const { servers, collectionMutators } = useWorkspace()
+
+const serverOptions = computed<ServerOption[]>(() =>
+  collection?.servers.map((serverUid) => ({
+    id: serverUid,
+    label: servers[serverUid]?.url ?? 'Unknown server',
+  })),
+)
+
+const selectedServer = computed<ServerOption | undefined>({
+  get: () =>
+    server
+      ? serverOptions.value.find((option) => option.id === server.uid)
+      : undefined,
+  set: (option) => {
+    if (!option) return
+    collectionMutators.edit(
+      collection.uid,
+      'selectedServerUid',
+      option.id as Server['uid'],
+    )
+  },
+})
+
+// Ensure we always have a selected server
+watch(
+  () => collection,
+  (newCollection) => {
+    if (!newCollection || newCollection.selectedServerUid) return
+
+    const firstServer = collection.servers?.[0]
+
+    if (firstServer)
+      collectionMutators.edit(collection.uid, 'selectedServerUid', firstServer)
+  },
+)
+
+const serverUrlWithoutTrailingSlash = computed(() => {
+  if (server?.url?.endsWith('/')) {
+    return server.url.slice(0, -1)
+  }
+  return server?.url || ''
+})
+</script>
+<template>
+  <ScalarListbox
+    v-model="selectedServer"
+    :options="serverOptions"
+    placement="bottom-start"
+    resize
+    :target="target"
+    :teleport="`#${target}`">
+    <ScalarButton
+      class="gap-0.75 z-context-plus text-c-1 h-6.5 w-full justify-start whitespace-nowrap rounded-b-lg px-3 py-1.5 text-xs font-normal lg:text-sm"
+      variant="ghost">
+      <span class="sr-only">Server:</span>
+      {{ serverUrlWithoutTrailingSlash }}
+      <ScalarIcon
+        class="text-c-2"
+        icon="ChevronDown"
+        size="sm" />
+    </ScalarButton>
+  </ScalarListbox>
+</template>

--- a/packages/api-client/src/components/Server/ServerSelector.vue
+++ b/packages/api-client/src/components/Server/ServerSelector.vue
@@ -65,6 +65,7 @@ const serverUrlWithoutTrailingSlash = computed(() => {
 </script>
 <template>
   <ScalarListbox
+    v-if="serverOptions.length > 1"
     v-model="selectedServer"
     :options="serverOptions"
     placement="bottom-start"
@@ -72,7 +73,7 @@ const serverUrlWithoutTrailingSlash = computed(() => {
     :target="target"
     :teleport="`#${target}`">
     <ScalarButton
-      class="gap-0.75 z-context-plus text-c-1 h-6.5 w-full justify-start whitespace-nowrap rounded-b-lg px-3 py-1.5 text-xs font-normal lg:text-sm"
+      class="gap-0.75 text-c-1 h-6.5 w-full justify-start whitespace-nowrap rounded-b-lg px-3 py-1.5 text-xs font-normal -outline-offset-1 lg:text-sm"
       variant="ghost">
       <span class="sr-only">Server:</span>
       {{ serverUrlWithoutTrailingSlash }}
@@ -82,4 +83,10 @@ const serverUrlWithoutTrailingSlash = computed(() => {
         size="sm" />
     </ScalarButton>
   </ScalarListbox>
+  <div
+    v-else
+    class="gap-0.75 text-c-1 h-6.5 flex w-full items-center whitespace-nowrap rounded-b-lg px-3 py-1.5 text-xs lg:text-sm">
+    <span class="sr-only">Server:</span>
+    {{ serverUrlWithoutTrailingSlash }}
+  </div>
 </template>

--- a/packages/api-client/src/components/Server/index.ts
+++ b/packages/api-client/src/components/Server/index.ts
@@ -1,2 +1,3 @@
 export { default as ServerVariablesForm } from './ServerVariablesForm.vue'
 export { default as ServerDropdown } from './ServerDropdown.vue'
+export { default as ServerSelector } from './ServerSelector.vue'

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -17,7 +17,7 @@ import type {
 } from '@scalar/oas-utils/entities/spec'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { isDefined } from '@scalar/oas-utils/helpers'
-import { computed, ref } from 'vue'
+import { computed, ref, useId } from 'vue'
 
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useLayout } from '@/hooks/useLayout'
@@ -63,6 +63,8 @@ const {
   requestMutators,
   collectionMutators,
 } = useWorkspace()
+
+const titleId = useId()
 
 const comboboxButtonRef = ref<typeof ScalarButtonType | null>(null)
 const deleteSchemeModal = useModal()
@@ -189,7 +191,9 @@ const schemeOptions = computed(() =>
     :itemCount="selectedSchemeOptions.length"
     :layout="layout">
     <template #title>
-      <div class="inline-flex items-center gap-1">
+      <div
+        :id="titleId"
+        class="inline-flex items-center gap-1">
         <span>{{ title }}</span>
         <!-- Authentication indicator -->
         <span
@@ -212,17 +216,23 @@ const schemeOptions = computed(() =>
           @update:modelValue="updateSelectedAuth">
           <ScalarButton
             ref="comboboxButtonRef"
+            :aria-describedby="titleId"
             class="py-0.75 hover:bg-b-3 text-c-1 hover:text-c-1 h-auto px-1.5 font-normal"
             fullWidth
             variant="ghost">
             <div class="text-c-1">
-              {{
-                selectedSchemeOptions.length === 0
-                  ? 'Auth Type'
-                  : selectedSchemeOptions.length === 1
-                    ? selectedSchemeOptions[0]?.label
-                    : 'Multiple'
-              }}
+              <template v-if="selectedSchemeOptions.length === 0">
+                <span class="sr-only">Select</span>
+                Auth Type
+              </template>
+              <template v-else-if="selectedSchemeOptions.length === 1">
+                <span class="sr-only">Selected Auth Type:</span>
+                {{ selectedSchemeOptions[0]?.label }}
+              </template>
+              <template v-else>
+                Multiple
+                <span class="sr-only">Auth Types Selected</span>
+              </template>
             </div>
             <ScalarIcon
               class="ml-1 shrink-0"

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import {
-  ServerDropdown,
+  ServerSelector,
   ServerVariablesForm,
 } from '@scalar/api-client/components/Server'
 import { useActiveEntities, useWorkspace } from '@scalar/api-client/store'
@@ -25,10 +25,9 @@ const updateServerVariable = (key: string, value: string) => {
     Server
   </label>
   <div :id="id">
-    <ServerDropdown
+    <ServerSelector
       v-if="activeCollection?.servers?.length"
       :collection="activeCollection"
-      layout="reference"
       :server="activeServer"
       :target="id" />
   </div>


### PR DESCRIPTION
Switches the references to use a listbox for the server selector for improved a11y. @antlio if you don't mind having a quick look to make sure I didn't miss anything 🙏 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
