### PR TITLE
fix(api-reference): removes reference editor z index

### DIFF
--- a/.changeset/hip-walls-accept.md
+++ b/.changeset/hip-walls-accept.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: resets reference editor z index

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -486,7 +486,6 @@ const themeStyleTag = computed(
   display: flex;
   min-width: 0;
   background: var(--scalar-background-1);
-  z-index: 1;
 }
 
 .references-navigation {


### PR DESCRIPTION
**Problem**

Currently the reference editor within docs is overflowing the topbar menu.

**Solution**

this pr resets z-index from the reference editor element.

| before | after |
| -------|------|
| <img width="618" alt="image" src="https://github.com/user-attachments/assets/f9daca6e-3507-4331-89e2-133a19a8d3e3" /> | <img width="618" alt="image" src="https://github.com/user-attachments/assets/aeb8f9b4-8dcc-44b8-ad07-cbc0a4ff2c6d" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
