### PR TITLE
feat(code-highlight): markdown alert callout support

### DIFF
--- a/.changeset/olive-parrots-attend.md
+++ b/.changeset/olive-parrots-attend.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+feat: adds markdown alert support

--- a/documentation/markdown.md
+++ b/documentation/markdown.md
@@ -10,7 +10,25 @@ What’s working here, is probably also working in the API reference:
 - links
 - tables
 - images
+- alerts
 - …
+
+## Alerts
+
+You can use markdown alerts in your descriptions.
+
+```markdown
+> [!tip]
+> You can now use markdown alerts in your descriptions.
+```
+
+The following alert types are supported:
+
+- `note`
+- `tip`
+- `important`
+- `warning`
+- `caution`
 
 [Have a look at our OpenAPI example](https://github.com/scalar/scalar/blob/main/packages/galaxy/src/documents/3.1.yaml)
 to see more examples.

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -43,6 +43,11 @@
       "types": "./dist/rehype-highlight/index.d.ts",
       "default": "./dist/rehype-highlight/index.js"
     },
+    "./rehype-alert": {
+      "import": "./dist/rehype-alert/index.js",
+      "types": "./dist/rehype-alert/index.d.ts",
+      "default": "./dist/rehype-alert/index.js"
+    },
     "./markdown": {
       "import": "./dist/markdown/index.js",
       "types": "./dist/markdown/index.d.ts",

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -293,4 +293,43 @@
   .markdown tr > [align="center"] {
     text-align: center;
   }
+
+  /* Markdown Alert */
+  .markdown .markdown-alert {
+    align-items: stretch;
+    border-radius: var(--scalar-radius-lg);
+    background-color: color-mix(in srgb, var(--scalar-background-2), transparent);
+    border: var(--scalar-border-width) solid var(--scalar-border-color);
+    display: flex;
+    font-size: var(--scalar-small);
+    gap: 12px;
+    padding: 12px;
+  }
+  .markdown .markdown-alert .markdown-alert-border {
+    border-radius: var(--scalar-radius-xl);
+    min-width: 1.5px;
+    width: 1.5px;
+  }
+  .markdown .markdown-alert .markdown-alert-content {
+    margin: 0;
+    line-height: 1.5;
+  }
+  .markdown .markdown-alert .markdown-alert-title {
+    font-weight: var(--scalar-semibold);
+  }
+  .markdown .markdown-alert.markdown-alert-note .markdown-alert-border {
+    background-color: var(--scalar-color-blue);
+  }
+  .markdown .markdown-alert.markdown-alert-tip .markdown-alert-border {
+    background-color: var(--scalar-color-green);
+  }
+  .markdown .markdown-alert.markdown-alert-important .markdown-alert-border {
+    background-color: var(--scalar-color-purple);
+  }
+  .markdown .markdown-alert.markdown-alert-warning .markdown-alert-border {
+    background-color: var(--scalar-color-orange);
+  }
+  .markdown .markdown-alert.markdown-alert-caution .markdown-alert-border {
+    background-color: var(--scalar-color-red);
+  }
 }

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -14,7 +14,7 @@ import { SKIP, visit } from 'unist-util-visit'
 
 import { standardLanguages } from '@/languages'
 import { rehypeHighlight } from '@/rehype-highlight'
-
+import { rehypeAlert } from '@/rehype-alert'
 type Options = {
   transform?: (node: Record<string, any>) => Record<string, any>
   type?: string
@@ -88,6 +88,8 @@ export function htmlFromMarkdown(
       // Enable auto detection
       detect: true,
     })
+    // Adds GitHub alerts
+    .use(rehypeAlert)
     // Adds target="_blank" to external links
     .use(rehypeExternalLinks, { target: '_blank' })
     // Formats the HTML

--- a/packages/code-highlight/src/rehype-alert/index.ts
+++ b/packages/code-highlight/src/rehype-alert/index.ts
@@ -1,0 +1,1 @@
+export { rehypeAlert } from './rehype-alert'

--- a/packages/code-highlight/src/rehype-alert/rehype-alert.test.ts
+++ b/packages/code-highlight/src/rehype-alert/rehype-alert.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import { rehypeAlert } from './rehype-alert'
+
+describe('rehype-alert', () => {
+  const process = async (markdown: string) => {
+    const file = await unified()
+      .use(remarkParse)
+      .use(remarkRehype, { allowDangerousHtml: true })
+      .use(rehypeAlert)
+      .use(rehypeStringify)
+      .process(markdown)
+
+    return String(file)
+  }
+
+  it('transforms note alerts correctly', async () => {
+    const input = '> [!note]\n> This is a note callout.'
+    const output = await process(input)
+
+    expect(output).toContain('<div class="markdown-alert markdown-alert-note">')
+    expect(output).toContain('<span class="markdown-alert-border"></span>')
+    expect(output).toContain('<div class="markdown-alert-content">')
+    expect(output).toContain('<span class="markdown-alert-title">Note:</span>')
+    expect(output).toContain('This is a note callout.')
+  })
+
+  it('transforms warning alerts correctly', async () => {
+    const input = '> [!warning]\n> This is a warning callout.'
+    const output = await process(input)
+
+    expect(output).toContain('<div class="markdown-alert markdown-alert-warning">')
+    expect(output).toContain('<span class="markdown-alert-title">Warning:</span>')
+    expect(output).toContain('This is a warning callout.')
+  })
+
+  it('transforms caution alerts correctly', async () => {
+    const input = '> [!caution]\n> This is a caution callout.'
+    const output = await process(input)
+
+    expect(output).toContain('<div class="markdown-alert markdown-alert-caution">')
+    expect(output).toContain('<span class="markdown-alert-title">Caution:</span>')
+    expect(output).toContain('This is a caution callout.')
+  })
+
+  it('transforms important alerts correctly', async () => {
+    const input = '> [!important]\n> This is an important callout.'
+    const output = await process(input)
+
+    expect(output).toContain('<div class="markdown-alert markdown-alert-important">')
+    expect(output).toContain('<span class="markdown-alert-title">Important:</span>')
+    expect(output).toContain('This is an important callout.')
+  })
+
+  it('transforms tip alerts correctly', async () => {
+    const input = '> [!tip]\n> This is a tip callout.'
+    const output = await process(input)
+
+    expect(output).toContain('<div class="markdown-alert markdown-alert-tip">')
+    expect(output).toContain('<span class="markdown-alert-title">Tip:</span>')
+    expect(output).toContain('This is a tip callout.')
+  })
+
+  it('ignores blockquotes without alert syntax', async () => {
+    const input = '> This is a regular blockquote.'
+    const output = await process(input)
+
+    expect(output).not.toContain('markdown-alert')
+    expect(output).toContain('<blockquote>')
+    expect(output).toContain('This is a regular blockquote.')
+  })
+
+  it('ignores invalid alert types', async () => {
+    const input = '> [!invalid]\n> This is an invalid alert type.'
+    const output = await process(input)
+
+    expect(output).not.toContain('markdown-alert')
+    expect(output).toContain('<blockquote>')
+    expect(output).toContain('[!invalid]')
+    expect(output).toContain('This is an invalid alert type.')
+  })
+
+  it('handles multiline alert content correctly', async () => {
+    const input = '> [!note]\n> First line\n> Second line\n> Third line'
+    const output = await process(input)
+
+    expect(output).toContain('<div class="markdown-alert markdown-alert-note">')
+    expect(output).toContain('First line')
+    expect(output).toContain('Second line')
+    expect(output).toContain('Third line')
+  })
+
+  it('preserves HTML structure in alert content', async () => {
+    const input = '> [!note]\n> This is a note with **bold** and *italic* text.'
+    const output = await process(input)
+
+    expect(output).toContain('<div class="markdown-alert markdown-alert-note">')
+    expect(output).toContain('<strong>bold</strong>')
+    expect(output).toContain('<em>italic</em>')
+  })
+})

--- a/packages/code-highlight/src/rehype-alert/rehype-alert.ts
+++ b/packages/code-highlight/src/rehype-alert/rehype-alert.ts
@@ -1,0 +1,112 @@
+import { visit } from 'unist-util-visit'
+import type { Element } from 'hast'
+import type { Root } from 'mdast'
+
+const ALERT_TYPES = ['note', 'tip', 'important', 'warning', 'caution'] as const
+
+// Simple whitespace check function
+function isWhitespace(node: any): boolean {
+  return node.type === 'text' && typeof node.value === 'string' && /^\s*$/.test(node.value)
+}
+
+export function rehypeAlert() {
+  return (tree: Root) => {
+    visit(tree, 'element', (node: Element, index, parent: any) => {
+      if (node.tagName !== 'blockquote' || typeof index !== 'number' || !parent || parent.type !== 'root') {
+        return
+      }
+
+      // Find the first non-whitespace child
+      const headIndex = node.children.findIndex((child) => !isWhitespace(child))
+      if (headIndex === -1) return
+
+      const head = node.children[headIndex]
+
+      if (!head || head.type !== 'element' || head.tagName !== 'p') return
+
+      const text = head.children[0]
+      if (!text || text.type !== 'text' || !text.value.startsWith('[!')) return
+
+      const end = text.value.indexOf(']')
+      if (end === -1) return
+
+      // Extract the alert type
+      const alertType = text.value.slice(2, end).toLowerCase() as (typeof ALERT_TYPES)[number]
+      if (!ALERT_TYPES.includes(alertType)) return
+
+      // Remove the blockquote if it's empty
+      if (end + 1 === text.value.length) {
+        const next = head.children[1]
+        if (next) {
+          if (next.type !== 'element' || next.tagName !== 'br') return
+          if (!head.children[2]) return
+          head.children = head.children.slice(2)
+          const node = head.children[0]
+          if (node && node.type === 'text' && node.value.charAt(0) === '\n') {
+            node.value = node.value.slice(1)
+          }
+        } else {
+          const skipped = headIndex + 1 < node.children.length && isWhitespace(node.children[headIndex + 1])
+          const nextIndex = skipped ? headIndex + 2 : headIndex + 1
+          if (nextIndex >= node.children.length || node.children[nextIndex].type !== 'element') {
+            return
+          }
+
+          node.children = node.children.slice(nextIndex)
+        }
+      } else if (
+        text.value.charAt(end + 1) === '\n' &&
+        // Check if the next character is a newline or a non-whitespace character
+        (end + 2 === text.value.length || !/^\s*$/.test(text.value.slice(end + 2)))
+      ) {
+        text.value = text.value.slice(end + 2)
+      } else {
+        // Remove the alert marker if it’s not followed by a newline or a non-whitespace character
+        text.value = text.value.replace(/^\s*\[!.*?\]\s*/, '')
+      }
+
+      const capitalizedType = alertType.charAt(0).toUpperCase() + alertType.slice(1)
+
+      // Extract content from paragraphs to avoid wrapping in <p> tags
+      const contentChildren = []
+      for (let i = headIndex; i < node.children.length; i++) {
+        const child = node.children[i]
+        if (child.type === 'element' && child.tagName === 'p' && child.children) {
+          contentChildren.push(...child.children)
+        } else {
+          contentChildren.push(child)
+        }
+      }
+
+      // Replace the blockquote with a div containing the alert
+      parent.children[index] = {
+        type: 'element',
+        tagName: 'div',
+        properties: { className: ['markdown-alert', `markdown-alert-${alertType}`] },
+        children: [
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: ['markdown-alert-border'] },
+            children: [],
+          },
+          {
+            type: 'element',
+            tagName: 'div',
+            properties: { className: ['markdown-alert-content'] },
+            children: [
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: { className: ['markdown-alert-title'] },
+                children: [{ type: 'text', value: `${capitalizedType}:` }],
+              },
+              { type: 'text', value: ' ' },
+              ...contentChildren,
+            ],
+          },
+        ],
+      }
+    })
+  }
+}

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -42,6 +42,11 @@ info:
 
       ![Empty placeholder image showing the width/height](https://images.placeholders.dev/?width=1280&height=720)
 
+      **Alerts**
+
+      > [!tip]
+      > You can now use markdown alerts in your descriptions.
+
     </details>
   version: 1.0.0
   contact:


### PR DESCRIPTION
**Problem**

there are no support of markdown alert as of today.

**Solution**

this pr is a proposal to support markdown alert using the following:
```md
> [!note]
> This is a note callout.
```

| before | after |
| -------|------|
| <img width="569" alt="image" src="https://github.com/user-attachments/assets/21ae3b89-469f-43d7-9539-c5e141bc5e91" /> | <img width="569" alt="image" src="https://github.com/user-attachments/assets/a7573823-3f4d-40ba-8fbe-1cffbd39109f" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
