### PR TITLE
fix(fastify):  location of standalone file

### DIFF
--- a/.changeset/clean-birds-peel.md
+++ b/.changeset/clean-birds-peel.md
@@ -1,0 +1,6 @@
+---
+'@scalar/fastify-api-reference': patch
+'@scalar/hono-api-reference': patch
+---
+
+fix: add reference as dependency with correct pathing

--- a/integrations/fastify/vite.config.ts
+++ b/integrations/fastify/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
-          src: '../api-reference/dist/browser/standalone.js',
+          src: '../../packages/api-reference/dist/browser/standalone.js',
           dest: './js',
         },
       ],

--- a/integrations/hono/Dockerfile
+++ b/integrations/hono/Dockerfile
@@ -24,6 +24,7 @@ RUN chown node:node /app
 
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/packages/api-reference /app/packages/api-reference
 COPY --from=builder /app/integrations/hono /app/integrations/hono
 
 WORKDIR /app/integrations/hono


### PR DESCRIPTION
**Problem**

Currently, we moved the fasify integration but did not update the path to the standalone.js, this was breaking cloudbuild.

**Solution**

We update the path back into the packages, we also copy the reference package into hono as its required there as well.

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
