### PR TITLE
fix(galaxy): ensure we move the api reference package into the galaxy dockerfile

### DIFF
--- a/.changeset/khaki-plums-doubt.md
+++ b/.changeset/khaki-plums-doubt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+fix: import api reference package in dockerfile

--- a/packages/galaxy/Dockerfile
+++ b/packages/galaxy/Dockerfile
@@ -18,6 +18,7 @@ RUN chown node:node /app
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/packages/mock-server /app/packages/mock-server
+COPY --from=builder /app/packages/api-reference /app/packages/api-reference
 COPY --from=builder /app/integrations/hono /app/integrations/hono
 COPY --from=builder /app/packages/oas-utils /app/packages/oas-utils
 COPY --from=builder /app/packages/openapi-parser /app/packages/openapi-parser


### PR DESCRIPTION
**Problem**

Currently, …

**Solution**

With this PR …

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
