### PR TITLE
fix(components): set the submenu z-index above the menu

### DIFF
--- a/.changeset/flat-deers-hang.md
+++ b/.changeset/flat-deers-hang.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+fix(components): set the submenu z-index above the menu

--- a/packages/api-client/tailwind.config.ts
+++ b/packages/api-client/tailwind.config.ts
@@ -1,6 +1,6 @@
 import headlessPlugin from '@headlessui/tailwindcss'
 import scalarPreset from '@scalar/themes/tailwind'
-import { type Config } from 'tailwindcss'
+import type { Config } from 'tailwindcss'
 import colorMix from 'tailwindcss-color-mix'
 
 import { desktopVariants } from './src/tailwind/desktop-variants'

--- a/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
@@ -52,7 +52,7 @@ defineOptions({ inheritAttrs: false })
     <DropdownMenu.Portal>
       <DropdownMenu.SubContent
         :as="ScalarDropdownMenu"
-        class="max-h-radix-popper"
+        class="max-h-radix-popper z-context-plus"
         :sideOffset="3">
         <DropdownMenu.RadioGroup
           v-model="model"

--- a/packages/components/tailwind.config.ts
+++ b/packages/components/tailwind.config.ts
@@ -1,6 +1,6 @@
 import headlessPlugin from '@headlessui/tailwindcss'
 import scalarPreset from '@scalar/themes/tailwind'
-import { type Config } from 'tailwindcss'
+import type { Config } from 'tailwindcss'
 import colorMix from 'tailwindcss-color-mix'
 import plugin from 'tailwindcss/plugin'
 
@@ -65,6 +65,8 @@ export default {
       zIndex: {
         // Contextual overlays like dropdowns, popovers, tooltips
         context: '1000',
+        // Just above context
+        'context-plus': '1001',
         // Full screen overlays / modals
         overlay: '10000',
       },


### PR DESCRIPTION
Before / after:

<img width="350px" src="https://github.com/user-attachments/assets/1c0e9e73-0a2f-4fd8-bb48-b4f31627672b" />
<img width="350px" src="https://github.com/user-attachments/assets/391c38f8-8c65-4d61-a1e2-6ee42f4f7ca4" />


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
