### PR TITLE
feat(api-reference): add redirect

### DIFF
--- a/.changeset/red-gorillas-mix.md
+++ b/.changeset/red-gorillas-mix.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: add front-end redirect

--- a/packages/api-reference/playground/esm/index.html
+++ b/packages/api-reference/playground/esm/index.html
@@ -25,6 +25,20 @@
         spec: {
           url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         },
+        pathRouting: {
+          basePath: '/v1',
+        },
+        redirect: (pathWithHash) => {
+          if (pathWithHash.includes('#')) {
+            const newPath = pathWithHash.replace(
+              '/#tag/planets/GET/planets/{planetId}',
+              '/v1/tag/planets/GET/planets/{planetId}',
+            )
+
+            return newPath
+          }
+          return null
+        },
         onLoaded: () => {
           console.log('references loaded')
         },

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -115,7 +115,7 @@ if (props.configuration.redirect && typeof window !== 'undefined') {
   const newPath = props.configuration.redirect(
     (pathRouting.value ? window.location.pathname : '') + window.location.hash,
   )
-  history.replaceState({}, '', newPath)
+  if (newPath) history.replaceState({}, '', newPath)
 }
 
 // Ideally this triggers absolutely first on the client so we can set hash value

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -105,7 +105,18 @@ const {
   replaceUrlState,
 } = useNavState()
 
-pathRouting.value = props.configuration.pathRouting
+// Need to set these in navState as a hack
+if (props.configuration.pathRouting) {
+  pathRouting.value = props.configuration.pathRouting
+}
+
+// Front-end redirect
+if (props.configuration.redirect && typeof window !== 'undefined') {
+  const newPath = props.configuration.redirect(
+    window.location.pathname + window.location.hash,
+  )
+  history.replaceState({}, '', newPath)
+}
 
 // Ideally this triggers absolutely first on the client so we can set hash value
 onBeforeMount(() => updateHash())

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -113,7 +113,7 @@ if (props.configuration.pathRouting) {
 // Front-end redirect
 if (props.configuration.redirect && typeof window !== 'undefined') {
   const newPath = props.configuration.redirect(
-    window.location.pathname + window.location.hash,
+    (pathRouting.value ? window.location.pathname : '') + window.location.hash,
   )
   history.replaceState({}, '', newPath)
 }

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -1,10 +1,8 @@
 import { useConfig } from '@/hooks/useConfig'
 import { combineUrlAndPath, ssrState } from '@scalar/oas-utils/helpers'
-import type { Heading, Tag, TransformedOperation } from '@scalar/types/legacy'
+import type { Heading, PathRouting, Tag, TransformedOperation } from '@scalar/types/legacy'
 import { slug } from 'github-slugger'
 import { ref } from 'vue'
-
-import type { PathRouting } from '../types'
 
 const hashPrefix = ref('')
 

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -16,10 +16,6 @@ export type ReferenceLayoutProps = {
   isDark: boolean
 }
 
-export type PathRouting = {
-  basePath: string
-}
-
 export type GettingStartedExamples = 'Petstore' | 'CoinMarketCap'
 
 export type Parameter = {

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -178,6 +178,26 @@ export type ReferenceConfiguration = {
    */
   pathRouting?: PathRouting
   /**
+   * To handle redirects, pass a function that will recieve:
+   * - The current path with hash if pathRouting is enabled
+   * - The current hash if hashRouting (default)
+   *
+   * @example hashRouting (default)
+   * ```ts
+   * redirect: (hash: string) => hash.replace('#v1/old-path', '#v2/new-path')
+   * ```
+   * @example pathRouting
+   * ```ts
+   * redirect: (pathWithHash: string) => {
+   *   if (pathWithHash.includes('#')) {
+   *     return pathWithHash.replace('/v1/tags/user#operation/get-user', '/v1/tags/user/operation/get-user')
+   *   }
+   *   return null
+   * }
+   * ```
+   */
+  redirect?: (pathWithHash: string) => string | null | undefined
+  /**
    * If you want to customize the heading portion of the hash you can pass in a function that receives the heading
    * and returns a string ID. This will then be used to generate the url hash. You control the whole hash with this
    * function.

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -181,6 +181,7 @@ export type ReferenceConfiguration = {
    * To handle redirects, pass a function that will recieve:
    * - The current path with hash if pathRouting is enabled
    * - The current hash if hashRouting (default)
+   * And then passes that to history.replaceState
    *
    * @example hashRouting (default)
    * ```ts


### PR DESCRIPTION
**Solution**

With this PR we add a front-end redirect.

To test:
```zsh
cd packages/api-reference
pnpm playground:esm
```
then hit [http://localhost:5173/#tag/planets/GET/planets/{planetId}](http://localhost:5173/#tag/planets/GET/planets/%7BplanetId%7D) and you should land on the path version

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
