### PR TITLE
fix(api-client): top nav icon collection not retrieved

### DIFF
--- a/.changeset/pink-eggs-return.md
+++ b/.changeset/pink-eggs-return.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates top nav icon logic

--- a/packages/api-client/src/components/TopNav/TopNavItem.vue
+++ b/packages/api-client/src/components/TopNav/TopNavItem.vue
@@ -9,6 +9,7 @@ import {
   ScalarTooltip,
   type Icon,
 } from '@scalar/components'
+import { LibraryIcon } from '@scalar/icons'
 
 import ScalarHotkey from '@/components/ScalarHotkey.vue'
 
@@ -17,6 +18,7 @@ defineProps<{
   active: boolean
   label: string
   icon: Icon
+  isCollection?: boolean
 }>()
 
 defineEmits<{
@@ -44,7 +46,12 @@ defineEmits<{
             @click="$emit('click')">
             <div
               class="nav-item-icon-copy flex flex-1 items-center justify-center gap-1.5">
+              <LibraryIcon
+                v-if="isCollection"
+                class="size-3.5 min-w-3.5 stroke-2"
+                :src="icon" />
               <ScalarIcon
+                v-else
                 :icon="icon"
                 size="xs"
                 thickness="2.5" />


### PR DESCRIPTION
**Problem**

currently the icon displayed on the top nav when in a collection is not matching with the collection icon.

**Solution**

this pr updates the top nav logic in order to reflect the collection icon:

| before | after |
| -------|------|
| <img width="788" alt="image" src="https://github.com/user-attachments/assets/afa9ba60-1f52-4fea-8e61-858fc48139d0" /> | <img width="788" alt="image" src="https://github.com/user-attachments/assets/b0a0f923-4459-4e43-9578-94cbadd7e033" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
