### PR TITLE
fix(galaxy): make galaxy playground private

### DIFF
--- a/.changeset/stale-ways-reply.md
+++ b/.changeset/stale-ways-reply.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+fix: make galaxy playground private so it does not publish

--- a/packages/galaxy/playground/package.json
+++ b/packages/galaxy/playground/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
+  "private": true,
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Problem**

Currently, our CI tries to deploy the @scalar-examples/galaxy but it does not exist.

**Solution**

With this PR we set it to private so it does not try to publish

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
