### PR TITLE
feat(api-reference): add multiple bearer auth

### DIFF
--- a/.changeset/chilled-keys-flow.md
+++ b/.changeset/chilled-keys-flow.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/oas-utils': patch
+'@scalar/types': patch
+---
+
+feat: allow multiple tokens for bearer auth

--- a/packages/api-reference/playground/esm/index.html
+++ b/packages/api-reference/playground/esm/index.html
@@ -23,21 +23,10 @@
 
       const reference = createScalarReferences(el, {
         spec: {
-          url: 'https://gist.githubusercontent.com/amritk/c329b63ccb8e28fafc77b9b33f11fb42/raw/d5bc16f27c939d088b94488575791d19e418d66a/test.json',
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         },
         pathRouting: {
           basePath: '/v1',
-        },
-        authentication: {
-          http: {
-            bearer: {
-              token: 'Default Bearer',
-              multiple: {
-                bearerAuth: 'Bearer token 1',
-                bearerAuth2: 'Bearer token 2',
-              },
-            },
-          },
         },
         redirect: (pathWithHash) => {
           if (pathWithHash.includes('#')) {

--- a/packages/api-reference/playground/esm/index.html
+++ b/packages/api-reference/playground/esm/index.html
@@ -23,10 +23,21 @@
 
       const reference = createScalarReferences(el, {
         spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+          url: 'https://gist.githubusercontent.com/amritk/c329b63ccb8e28fafc77b9b33f11fb42/raw/d5bc16f27c939d088b94488575791d19e418d66a/test.json',
         },
         pathRouting: {
           basePath: '/v1',
+        },
+        authentication: {
+          http: {
+            bearer: {
+              token: 'Default Bearer',
+              multiple: {
+                bearerAuth: 'Bearer token 1',
+                bearerAuth2: 'Bearer token 2',
+              },
+            },
+          },
         },
         redirect: (pathWithHash) => {
           if (pathWithHash.includes('#')) {

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -220,8 +220,17 @@ export async function importSpecToWorkspace(
           if (payload.scheme === 'basic' && authentication.http?.basic) {
             payload.username = authentication.http.basic.username ?? ''
             payload.password = authentication.http.basic.password ?? ''
-          } else if (payload.scheme === 'bearer' && authentication.http?.bearer)
-            payload.token = authentication.http.bearer.token ?? ''
+          }
+          // Bearer
+          else if (payload.scheme === 'bearer') {
+            if (authentication.http?.bearer?.token) {
+              payload.token = authentication.http.bearer.token ?? ''
+            }
+            // Temp multiple bearer
+            if (authentication.http?.bearer?.multiple?.[nameKey]) {
+              payload.token = authentication.http.bearer.multiple[nameKey]
+            }
+          }
         }
       }
 

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -528,12 +528,16 @@ export type AuthenticationState = {
     | OpenAPIV3.ComponentsObject['securitySchemes']
     | OpenAPIV3_1.ComponentsObject['securitySchemes']
   http: {
-    basic: {
+    basic?: {
       username: string
       password: string
     }
-    bearer: {
-      token: string
+    bearer?: {
+      token?: string
+      /**
+       * @deprecated this is just temporary until the new auth
+       */
+      multiple?: Record<string, string>
     }
   }
   apiKey: {


### PR DESCRIPTION
This is a super temp hack to get multiple bearer auth tokens in, we will add proper multi auth right after the config PR.

```ts
     authentication: {
          http: {
            bearer: {
              token: 'Default Bearer',
              multiple: {
                bearerAuth: 'Bearer token 1',
                bearerAuth2: 'Bearer token 2',
              },
            },
          },
        },
```
![image](https://github.com/user-attachments/assets/563e4e9c-6ddc-4030-a71c-1d963e012f04)
![image](https://github.com/user-attachments/assets/439697f6-1514-494b-badc-c59a54bc661f)
![image](https://github.com/user-attachments/assets/28ee1074-f610-47a3-b291-9df6887710a8)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
