### PR TITLE
feat: add server change callback

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -282,6 +282,18 @@ You can listen to changes with onSpecUpdate that runs on spec/swagger content ch
 }
 ```
 
+#### onServerChange?: (server: string) => void
+
+You can listen to changes with onServerChange that runs on server change
+
+```js
+{
+  onServerChange: (value: string) => {
+    console.log('Server updated:', value)
+  }
+}
+```
+
 #### authentication?: Partial<AuthenticationState>
 
 To make authentication easier you can prefill the credentials for your users:

--- a/packages/api-client/src/components/Server/ServerSelector.vue
+++ b/packages/api-client/src/components/Server/ServerSelector.vue
@@ -20,7 +20,7 @@ const { target, collection, server } = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: 'update:server', server: string): void
+  (e: 'updateServer', server: string): void
 }>()
 
 const { servers, collectionMutators } = useWorkspace()
@@ -45,8 +45,9 @@ const selectedServer = computed<ServerOption | undefined>({
       option.id as Server['uid'],
     )
     const serverUrl = servers[option.id]?.url
+    console.log('serverUrl', serverUrl)
     if (serverUrl) {
-      emit('update:server', serverUrl)
+      emit('updateServer', serverUrl)
     }
   },
 })
@@ -62,7 +63,7 @@ watch(
     if (firstServer) {
       collectionMutators.edit(collection.uid, 'selectedServerUid', firstServer)
       if (servers[firstServer]?.url) {
-        emit('update:server', servers[firstServer].url)
+        emit('updateServer', servers[firstServer].url)
       }
     }
   },

--- a/packages/api-client/src/components/Server/ServerSelector.vue
+++ b/packages/api-client/src/components/Server/ServerSelector.vue
@@ -45,7 +45,6 @@ const selectedServer = computed<ServerOption | undefined>({
       option.id as Server['uid'],
     )
     const serverUrl = servers[option.id]?.url
-    console.log('serverUrl', serverUrl)
     if (serverUrl) {
       emit('updateServer', serverUrl)
     }

--- a/packages/api-client/src/components/Server/ServerSelector.vue
+++ b/packages/api-client/src/components/Server/ServerSelector.vue
@@ -19,6 +19,10 @@ const { target, collection, server } = defineProps<{
   target: string
 }>()
 
+const emit = defineEmits<{
+  (e: 'update:server', server: string): void
+}>()
+
 const { servers, collectionMutators } = useWorkspace()
 
 const serverOptions = computed<ServerOption[]>(() =>
@@ -40,6 +44,10 @@ const selectedServer = computed<ServerOption | undefined>({
       'selectedServerUid',
       option.id as Server['uid'],
     )
+    const serverUrl = servers[option.id]?.url
+    if (serverUrl) {
+      emit('update:server', serverUrl)
+    }
   },
 })
 
@@ -51,8 +59,12 @@ watch(
 
     const firstServer = collection.servers?.[0]
 
-    if (firstServer)
+    if (firstServer) {
       collectionMutators.edit(collection.uid, 'selectedServerUid', firstServer)
+      if (servers[firstServer]?.url) {
+        emit('update:server', servers[firstServer].url)
+      }
+    }
   },
 )
 

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -26,7 +26,6 @@ const updateServerVariable = (key: string, value: string) => {
 const { onServerChange } = useConfig()
 
 const updateServer = (server: string) => {
-  console.log('Server changed:', server)
   onServerChange?.(server)
 }
 </script>

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -20,8 +20,6 @@ const updateServerVariable = (key: string, value: string) => {
   variables[key] = { ...variables[key], default: value }
 
   serverMutators.edit(activeServer.value.uid, 'variables', variables)
-
-  /** Trigger the onLoaded event when the component is mounted */
 }
 const { onServerChange } = useConfig()
 
@@ -39,7 +37,7 @@ const updateServer = (server: string) => {
       :collection="activeCollection"
       :server="activeServer"
       :target="id"
-      @update:server="updateServer" />
+      @updateServer="updateServer" />
   </div>
   <ServerVariablesForm
     :variables="activeServer?.variables"

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -7,6 +7,8 @@ import { useActiveEntities, useWorkspace } from '@scalar/api-client/store'
 import { ScalarMarkdown } from '@scalar/components'
 import { useId } from 'vue'
 
+import { useConfig } from '@/hooks/useConfig'
+
 const { activeCollection, activeServer } = useActiveEntities()
 const { serverMutators } = useWorkspace()
 
@@ -18,6 +20,14 @@ const updateServerVariable = (key: string, value: string) => {
   variables[key] = { ...variables[key], default: value }
 
   serverMutators.edit(activeServer.value.uid, 'variables', variables)
+
+  /** Trigger the onLoaded event when the component is mounted */
+}
+const { onServerChange } = useConfig()
+
+const updateServer = (server: string) => {
+  console.log('Server changed:', server)
+  onServerChange?.(server)
 }
 </script>
 <template>
@@ -29,7 +39,8 @@ const updateServerVariable = (key: string, value: string) => {
       v-if="activeCollection?.servers?.length"
       :collection="activeCollection"
       :server="activeServer"
-      :target="id" />
+      :target="id"
+      @update:server="updateServer" />
   </div>
   <ServerVariablesForm
     :variables="activeServer?.variables"

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -164,6 +164,8 @@ export type ReferenceConfiguration = {
   customCss?: string
   /** onSpecUpdate is fired on spec/swagger content change */
   onSpecUpdate?: (spec: string) => void
+  /** onServerChange is fired on selected server change */
+  onServerChange?: (server: string) => void
   /** Prefill authentication */
   authentication?: Partial<AuthenticationState>
   /**


### PR DESCRIPTION
**Problem**

Currently when a server changes we cant tell the outside world its changed

**Solution**

With this PR we allow a callback for when the active server changes

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
