### PR TITLE
fix(Scalar.AspNetCore): rename TagSorter property to TagsSorter

### DIFF
--- a/.changeset/tricky-boats-draw.md
+++ b/.changeset/tricky-boats-draw.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+fix(Scalar.AspNetCore): rename TagSorter property to TagsSorter

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -51,7 +51,7 @@ internal static class ScalarOptionsMapper
             Servers = options.Servers,
             MetaData = options.Metadata,
             Authentication = options.Authentication,
-            TagSorter = options.TagSorter?.ToStringFast(true),
+            TagsSorter = options.TagSorter?.ToStringFast(true),
             OperationsSorter = options.OperationSorter?.ToStringFast(true),
             HiddenClients = options.HiddenClients ? options.HiddenClients : GetHiddenClients(options),
             DefaultHttpClient = new DefaultHttpClient

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/ScalarConfiguration.cs
@@ -45,7 +45,7 @@ internal sealed class ScalarConfiguration
 
     public required bool? DefaultOpenAllTags { get; init; }
 
-    public required string? TagSorter { get; init; }
+    public required string? TagsSorter { get; init; }
 
     public required string? OperationsSorter { get; init; }
 

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -30,7 +30,7 @@ public class ScalarOptionsMapperTests
         configuration.Authentication.Should().BeNull();
         configuration.WithDefaultFonts.Should().BeTrue();
         configuration.DefaultOpenAllTags.Should().BeFalse();
-        configuration.TagSorter.Should().BeNull();
+        configuration.TagsSorter.Should().BeNull();
         configuration.OperationsSorter.Should().BeNull();
         configuration.Theme.Should().Be("purple");
         configuration.Integration.Should().Be("dotnet");
@@ -101,7 +101,7 @@ public class ScalarOptionsMapperTests
         configuration.Authentication.ApiKey!.Token.Should().Be("my-token");
         configuration.WithDefaultFonts.Should().BeFalse();
         configuration.DefaultOpenAllTags.Should().BeTrue();
-        configuration.TagSorter.Should().Be("alpha");
+        configuration.TagsSorter.Should().Be("alpha");
         configuration.OperationsSorter.Should().Be("method");
         configuration.Theme.Should().Be("saturn");
         configuration.Layout.Should().Be("classic");


### PR DESCRIPTION
Closes #4941 

**Problem**

We had a typo in the `ScalarConfiguration` and the tags sorter configuration was serialized to `tagSorter`.

**Solution**

I renamed the property to `TagsSorter` so it's correctly serialized to `tagsSorter`.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] ~I’ve added tests for the regression or new feature.~
- [ ] ~I’ve updated the documentation.~

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
