### PR TITLE
feat(api-reference): schema discriminator display

### DIFF
--- a/.changeset/short-dolphins-scream.md
+++ b/.changeset/short-dolphins-scream.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: updates schema discriminator display

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -78,6 +78,7 @@
     "@scalar/use-toasts": "workspace:*",
     "@unhead/vue": "^1.11.11",
     "@vueuse/core": "^10.10.0",
+    "flatted": "^3.3.1",
     "fuse.js": "^7.0.0",
     "github-slugger": "^2.0.0",
     "nanoid": "^5.0.9",

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -149,7 +149,8 @@ const introCardsSlot = computed(() =>
         :layout="layout"
         :server="activeServer"
         :spec="parsedSpec"
-        :tags="parsedSpec.tags" />
+        :tags="parsedSpec.tags"
+        :schemas="getModels(parsedSpec)" />
     </template>
 
     <template v-if="parsedSpec.webhooks">

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -85,7 +85,8 @@ const models = computed(() => {
               <Schema
                 :hideHeading="true"
                 noncollapsible
-                :value="(schemas as any)[name]" />
+                :value="(schemas as any)[name]"
+                :schemas="schemas" />
             </ScalarErrorBoundary>
           </CompactSection>
         </Lazy>

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -26,6 +26,11 @@ const props = withDefaults(
     /** Shows a toggle to hide/show children */
     noncollapsible?: boolean
     hideHeading?: boolean
+    schemas?:
+      | OpenAPIV2.DefinitionsObject
+      | Record<string, OpenAPIV3.SchemaObject>
+      | Record<string, OpenAPIV3_1.SchemaObject>
+      | unknown
   }>(),
   { level: 0 },
 )
@@ -51,13 +56,19 @@ const handleClick = (e: MouseEvent) =>
         { 'schema-card--compact': compact, 'schema-card--open': open },
       ]">
       <div
-        v-if="value?.description && typeof value.description === 'string'"
+        v-if="
+          value?.description &&
+          typeof value.description === 'string' &&
+          !value.allOf
+        "
         class="schema-card-description">
         <ScalarMarkdown :value="value.description" />
       </div>
       <div
         class="schema-properties"
-        :class="{ 'schema-properties-open': open }">
+        :class="{
+          'schema-properties-open': open,
+        }">
         <DisclosureButton
           v-show="!hideHeading && !(noncollapsible && compact)"
           :as="noncollapsible ? 'div' : 'button'"
@@ -113,7 +124,8 @@ const handleClick = (e: MouseEvent) =>
                   value.required?.includes(property) ||
                   value.properties?.[property]?.required === true
                 "
-                :value="value.properties?.[property]" />
+                :value="value.properties?.[property]"
+                :schemas="schemas" />
             </template>
             <template v-if="value.patternProperties">
               <SchemaProperty
@@ -123,7 +135,8 @@ const handleClick = (e: MouseEvent) =>
                 :level="level"
                 :name="property"
                 pattern
-                :value="value.patternProperties?.[property]" />
+                :value="value.patternProperties?.[property]"
+                :schemas="schemas" />
             </template>
             <template v-if="value.additionalProperties">
               <!--
@@ -153,7 +166,8 @@ const handleClick = (e: MouseEvent) =>
                 :compact="compact"
                 :level="level"
                 noncollapsible
-                :value="value.additionalProperties" />
+                :value="value.additionalProperties"
+                :schemas="schemas" />
             </template>
           </template>
           <template v-else>
@@ -161,7 +175,8 @@ const handleClick = (e: MouseEvent) =>
               :compact="compact"
               :level="level"
               :name="(value as OpenAPIV2.SchemaObject).name"
-              :value="value" />
+              :value="value"
+              :schemas="schemas" />
           </template>
         </DisclosurePanel>
       </div>
@@ -210,6 +225,9 @@ button.schema-card-title:hover {
 .schema-properties-open > .schema-properties {
   width: fit-content;
 }
+.schema-card-description {
+  margin-top: 6px;
+}
 .schema-card-description + .schema-properties {
   width: fit-content;
 }
@@ -220,23 +238,23 @@ button.schema-card-title:hover {
 .schema-properties-open > .schema-card--open {
   width: 100%;
 }
-.schema-card .property:last-of-type {
-  padding-bottom: 10px;
-}
 
 .schema-properties {
   display: flex;
   flex-direction: column;
 
   border: var(--scalar-border-width) solid var(--scalar-border-color);
-  border-radius: var(--scalar-radius-lg);
+  border-radius: var(--scalar-radius-xl);
   width: fit-content;
+}
+.schema-properties-name {
+  width: 100%;
 }
 .schema-properties .schema-properties {
   border-radius: 13.5px;
 }
 .schema-properties .schema-properties.schema-properties-open {
-  border-radius: 13.5px 13.5px 9px 9px;
+  border-radius: var(--scalar-radius-xl) var(--scalar-radius-xl) 9px 9px;
 }
 .schema-properties-open {
   width: 100%;
@@ -280,13 +298,7 @@ button.schema-card-title:hover {
   display: block;
   margin-bottom: 6px;
 }
-.schema-card-description:first-of-type {
-  padding-top: 10px;
-}
 .children .schema-card-description:first-of-type {
   padding-top: 0;
-}
-.models-list-item .schema-properties {
-  margin-bottom: 10px;
 }
 </style>

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -59,7 +59,10 @@ const handleClick = (e: MouseEvent) =>
         v-if="
           value?.description &&
           typeof value.description === 'string' &&
-          !value.allOf
+          !value.allOf &&
+          !value.oneOf &&
+          !value.anyOf &&
+          !compact
         "
         class="schema-card-description">
         <ScalarMarkdown :value="value.description" />
@@ -118,14 +121,15 @@ const handleClick = (e: MouseEvent) =>
                 v-for="property in Object.keys(value?.properties)"
                 :key="property"
                 :compact="compact"
-                :level="level"
+                :level="level + 1"
                 :name="property"
                 :required="
                   value.required?.includes(property) ||
                   value.properties?.[property]?.required === true
                 "
                 :value="value.properties?.[property]"
-                :schemas="schemas" />
+                :schemas="schemas"
+                :hideHeading="hideHeading" />
             </template>
             <template v-if="value.patternProperties">
               <SchemaProperty
@@ -136,7 +140,8 @@ const handleClick = (e: MouseEvent) =>
                 :name="property"
                 pattern
                 :value="value.patternProperties?.[property]"
-                :schemas="schemas" />
+                :schemas="schemas"
+                :hideHeading="hideHeading" />
             </template>
             <template v-if="value.additionalProperties">
               <!--
@@ -158,7 +163,9 @@ const handleClick = (e: MouseEvent) =>
                   ...(typeof value.additionalProperties === 'object'
                     ? value.additionalProperties
                     : {}),
-                }" />
+                }"
+                :hideHeading="hideHeading"
+                :schemas="schemas" />
               <!-- Allows a specific type of additional property value -->
               <SchemaProperty
                 v-else
@@ -167,16 +174,17 @@ const handleClick = (e: MouseEvent) =>
                 :level="level"
                 noncollapsible
                 :value="value.additionalProperties"
-                :schemas="schemas" />
+                :schemas="schemas"
+                :hideHeading="hideHeading" />
             </template>
           </template>
           <template v-else>
             <SchemaProperty
               :compact="compact"
-              :level="level"
               :name="(value as OpenAPIV2.SchemaObject).name"
               :value="value"
-              :schemas="schemas" />
+              :schemas="schemas"
+              :hideHeading="hideHeading" />
           </template>
         </DisclosurePanel>
       </div>
@@ -197,7 +205,7 @@ const handleClick = (e: MouseEvent) =>
 .schema-card-title {
   height: var(--schema-title-height);
 
-  padding: 6px 10px;
+  padding: 6px 8px;
 
   display: flex;
   align-items: center;
@@ -225,14 +233,11 @@ button.schema-card-title:hover {
 .schema-properties-open > .schema-properties {
   width: fit-content;
 }
-.schema-card-description {
-  margin-top: 6px;
-}
 .schema-card-description + .schema-properties {
   width: fit-content;
 }
 .schema-card-description + .schema-properties {
-  margin-top: 12px;
+  margin-top: 8px;
 }
 .schema-properties-open.schema-properties,
 .schema-properties-open > .schema-card--open {
@@ -254,7 +259,7 @@ button.schema-card-title:hover {
   border-radius: 13.5px;
 }
 .schema-properties .schema-properties.schema-properties-open {
-  border-radius: var(--scalar-radius-xl) var(--scalar-radius-xl) 9px 9px;
+  border-radius: var(--scalar-radius-lg);
 }
 .schema-properties-open {
   width: 100%;

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -2,6 +2,7 @@
 import { Tab, TabGroup, TabList, TabPanel } from '@headlessui/vue'
 import { cva, cx } from '@scalar/components'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
+import { stringify } from 'flatted'
 import { ref } from 'vue'
 
 import Schema from './Schema.vue'
@@ -84,7 +85,7 @@ const getModelNameFromSchema = (schema: any): string | null => {
   // returns a matching schema name based on the schema object
   if (props.schemas && typeof props.schemas === 'object') {
     for (const [schemaName, schemaValue] of Object.entries(props.schemas)) {
-      if (JSON.stringify(schemaValue) === JSON.stringify(schema)) {
+      if (stringify(schemaValue) === stringify(schema)) {
         return schemaName
       }
     }
@@ -110,7 +111,7 @@ const humanizeType = (type: string) => {
       <!-- Tabs -->
       <TabGroup>
         <TabList
-          class="discriminator-tab-list flex items-center gap-2 rounded-t-lg border border-b-0 px-2 py-1.25 pr-3">
+          class="discriminator-tab-list py-1.25 flex items-center gap-2 rounded-t-lg border border-b-0 px-2 pr-3">
           <span>{{ humanizeType(discriminator) }}</span>
           <div class="flex items-center gap-1.5 overflow-x-auto">
             <Tab

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -1,0 +1,168 @@
+<script lang="ts" setup>
+import { Tab, TabGroup, TabList, TabPanel } from '@headlessui/vue'
+import { cva, cx } from '@scalar/components'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
+import { ref } from 'vue'
+
+import Schema from './Schema.vue'
+
+const props = defineProps<{
+  discriminator: string
+  schemas?:
+    | OpenAPIV2.DefinitionsObject
+    | Record<string, OpenAPIV3.SchemaObject>
+    | Record<string, OpenAPIV3_1.SchemaObject>
+    | unknown
+  value: Record<string, any>
+  level: number
+  compact?: boolean
+  hideHeading?: boolean
+}>()
+
+const selectedOneOfIndex = ref(0)
+
+const buttonVariants = cva({
+  base: 'py-0.75 h-fit rounded-full border px-2 text-sm font-medium transition-colors',
+  variants: {
+    selected: {
+      true: 'bg-b-accent text-c-accent hover:text-c-accent',
+      false: 'bg-transparent text-c-2 hover:text-c-1',
+    },
+  },
+})
+
+// Function to merge allOf schemas
+const mergeAllOfSchemas = (schemas: any[]) => {
+  if (!Array.isArray(schemas) || schemas.length === 0) {
+    return {}
+  }
+
+  // Handle case where we have an array of objects with allOf properties
+  if (schemas.length > 0 && schemas[0].allOf) {
+    const allSchemas = schemas.flatMap((schema) => schema.allOf || [])
+    return mergeAllOfSchemas(allSchemas)
+  }
+
+  // Regular case - just merge the schemas directly
+  return schemas.reduce((result, schema) => {
+    if (!schema || typeof schema !== 'object') {
+      return result
+    }
+
+    const mergedResult = { ...result }
+
+    if (schema.properties) {
+      mergedResult.properties = {
+        ...mergedResult.properties,
+        ...schema.properties,
+      }
+    }
+
+    if (schema.required && Array.isArray(schema.required)) {
+      mergedResult.required = [
+        ...(mergedResult.required || []),
+        ...schema.required,
+      ]
+    }
+
+    if (schema.type && !mergedResult.type) {
+      mergedResult.type = schema.type
+    }
+
+    if (schema.description && !mergedResult.description) {
+      mergedResult.description = schema.description
+    }
+
+    return mergedResult
+  }, {})
+}
+
+// Get model name from schema
+const getModelNameFromSchema = (schema: any): string | null => {
+  if (!schema) return null
+
+  // returns a matching schema name based on the schema object
+  if (props.schemas && typeof props.schemas === 'object') {
+    for (const [schemaName, schemaValue] of Object.entries(props.schemas)) {
+      if (JSON.stringify(schemaValue) === JSON.stringify(schema)) {
+        return schemaName
+      }
+    }
+    return Object.keys(schema)[0]
+  }
+
+  return null
+}
+
+// Humanizes discriminator type name e.g. oneOf -> One of
+const humanizeType = (type: string) => {
+  return type
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (str) => str.toUpperCase())
+    .toLowerCase()
+    .replace(/^(\w)/, (c) => c.toUpperCase())
+}
+</script>
+
+<template>
+  <div class="property-rule">
+    <template v-if="discriminator === 'oneOf' || discriminator === 'anyOf'">
+      <!-- Tabs -->
+      <TabGroup>
+        <TabList
+          class="discriminator-tab-list flex items-center gap-2 rounded-t-lg border border-b-0 px-2 py-1.25 pr-3">
+          <span>{{ humanizeType(discriminator) }}</span>
+          <div class="flex items-center gap-1.5 overflow-x-auto">
+            <Tab
+              v-for="(schema, index) in value[discriminator]"
+              :key="index"
+              @click="selectedOneOfIndex = index"
+              class="cursor-pointer"
+              :class="
+                cx(buttonVariants({ selected: selectedOneOfIndex === index }))
+              ">
+              {{ getModelNameFromSchema(schema) || 'Schema' }}
+            </Tab>
+          </div>
+        </TabList>
+        <TabPanel
+          v-for="(schema, index) in value[discriminator]"
+          :key="index"
+          class="discriminator-panel">
+          <Schema
+            :compact="compact"
+            :noncollapsible="true"
+            :schemas="schemas"
+            :value="schema"
+            :hideHeading="hideHeading" />
+        </TabPanel>
+      </TabGroup>
+    </template>
+    <template v-else>
+      <Schema
+        :compact="compact"
+        :noncollapsible="level != 0 ? false : true"
+        :schemas="schemas"
+        :level="level"
+        :value="mergeAllOfSchemas(value[discriminator])" />
+    </template>
+  </div>
+</template>
+<style scoped>
+.discriminator-panel:has(.property--compact) {
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-bottom-left-radius: var(--scalar-radius-lg);
+  border-bottom-right-radius: var(--scalar-radius-lg);
+}
+.discriminator-panel :deep(.schema-properties .schema-properties-open) {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+.discriminator-panel :deep(.property--level-0),
+.discriminator-panel :deep(.property--compact.property--level-1) {
+  padding: 8px;
+}
+.discriminator-panel :deep(.property--compact.property--level-0) {
+  padding: 0;
+}
+</style>

--- a/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
@@ -30,10 +30,7 @@ defineProps<{
       <template v-if="value.type === 'array'"> [] </template>
       <template v-if="value.enum"> enum </template>
     </span>
-    <template v-if="value?.xml?.name && value?.xml?.name !== '##default'">
-      &lt;{{ value?.xml?.name }} /&gt;
-    </template>
-    <template v-else-if="name">
+    <template v-if="name">
       {{ name }}
     </template>
     <template v-else>

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -18,8 +18,6 @@ withDefaults(
   },
 )
 
-const discriminators = ['oneOf', 'anyOf', 'allOf', 'not']
-
 const flattenDefaultValue = (value: Record<string, any>) => {
   return Array.isArray(value?.default) && value.default.length === 1
     ? value.default[0]
@@ -144,16 +142,6 @@ const flattenDefaultValue = (value: Record<string, any>) => {
       class="property-read-only">
       read-only
     </div>
-    <template
-      v-for="discriminator in discriminators.filter(
-        (r) => value?.[r] || value?.items?.[r],
-      )"
-      :key="discriminator">
-      <!-- Only show anyOf, oneOf, allOf if there are more than one schema -->
-      <template v-if="value?.[discriminator]?.length > 1">
-        <Badge>{{ discriminator }}</Badge>
-      </template>
-    </template>
     <div
       v-if="required"
       class="property-required">

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -158,6 +158,11 @@ const flattenDefaultValue = (value: Record<string, any>) => {
   white-space: nowrap;
 }
 
+.property-heading:has(+ .children),
+.property-heading:has(+ .property-rule) {
+  margin-bottom: 9px;
+}
+
 .property-heading > * {
   margin-right: 9px;
 }

--- a/packages/api-reference/src/components/Content/Tag/TagList.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ScalarErrorBoundary } from '@scalar/components'
 import type { Collection, Server } from '@scalar/oas-utils/entities/spec'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Spec, Tag as TagType } from '@scalar/types/legacy'
 import { computed } from 'vue'
 
@@ -17,6 +18,11 @@ const { collection, tags, spec, layout, server } = defineProps<{
   spec: Spec
   layout?: 'modern' | 'classic'
   server?: Server
+  schemas?:
+    | OpenAPIV2.DefinitionsObject
+    | Record<string, OpenAPIV3.SchemaObject>
+    | Record<string, OpenAPIV3_1.SchemaObject>
+    | unknown
 }>()
 
 const { getOperationId, getTagId, hash } = useNavState()
@@ -49,8 +55,8 @@ const isLazy = (index: number) =>
     <Component
       :is="tagLayout"
       :id="getTagId(tag)"
-      :spec="spec"
       :collection="collection"
+      :spec="spec"
       :tag="tag">
       <Lazy
         v-for="(operation, operationIndex) in tag.operations"
@@ -65,6 +71,7 @@ const isLazy = (index: number) =>
             :id="getOperationId(operation, tag)"
             :collection="collection"
             :layout="layout"
+            :schemas="schemas"
             :server="server"
             :transformedOperation="operation" />
         </ScalarErrorBoundary>

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -75,13 +75,6 @@ watch(
   z-index: 1;
   position: relative;
 }
-.collapsible-section .collapsible-section-trigger:after {
-  content: '';
-  height: 10px;
-  width: 100%;
-  position: absolute;
-  bottom: 0;
-}
 .collapsible-section-trigger svg {
   color: var(--scalar-color-3);
   position: absolute;
@@ -97,5 +90,8 @@ watch(
   padding: 0;
   margin: 0;
   scroll-margin-top: 140px;
+}
+.collapsible-section:not(:last-child) .collapsible-section-content {
+  margin-bottom: 10px;
 }
 </style>

--- a/packages/api-reference/src/components/Section/SectionHeaderTag.vue
+++ b/packages/api-reference/src/components/Section/SectionHeaderTag.vue
@@ -11,5 +11,6 @@ const { level = 1 } = defineProps<{ level?: 1 | 2 | 3 | 4 | 5 | 6 }>()
 <style scoped>
 .section-header-label {
   display: inline;
+  user-select: none;
 }
 </style>

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { useWorkspace } from '@scalar/api-client/store'
 import type { Collection, Server } from '@scalar/oas-utils/entities/spec'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { TransformedOperation } from '@scalar/types/legacy'
 
 import { getPointer } from '@/blocks/helpers/getPointer'
@@ -21,6 +22,11 @@ const {
   transformedOperation: TransformedOperation
   collection: Collection
   server: Server | undefined
+  schemas?:
+    | OpenAPIV2.DefinitionsObject
+    | Record<string, OpenAPIV3.SchemaObject>
+    | Record<string, OpenAPIV3_1.SchemaObject>
+    | unknown
 }>()
 
 const store = useWorkspace()
@@ -52,7 +58,8 @@ const { operation } = useBlockProps({
         :collection="collection"
         :operation="operation"
         :server="server"
-        :transformedOperation="transformedOperation" />
+        :transformedOperation="transformedOperation"
+        :schemas="schemas" />
     </template>
     <template v-else>
       <ModernLayout
@@ -60,7 +67,8 @@ const { operation } = useBlockProps({
         :collection="collection"
         :operation="operation"
         :server="server"
-        :transformedOperation="transformedOperation" />
+        :transformedOperation="transformedOperation"
+        :schemas="schemas" />
     </template>
   </template>
 </template>

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 
 import ParameterList from './ParameterList.vue'
 import RequestBody from './RequestBody.vue'
 
 const props = defineProps<{
   operation?: Pick<RequestEntity, 'parameters' | 'requestBody'>
+  schemas?:
+    | OpenAPIV2.DefinitionsObject
+    | Record<string, OpenAPIV3.SchemaObject>
+    | Record<string, OpenAPIV3_1.SchemaObject>
+    | unknown
 }>()
 
 const filterParameters = (where: 'path' | 'query' | 'header' | 'cookie') =>
@@ -14,29 +20,38 @@ const filterParameters = (where: 'path' | 'query' | 'header' | 'cookie') =>
 </script>
 <template>
   <!-- Path parameters-->
-  <ParameterList :parameters="filterParameters('path')">
+  <ParameterList
+    :parameters="filterParameters('path')"
+    :schemas="schemas">
     <template #title>Path Parameters</template>
   </ParameterList>
 
   <!-- Query parameters -->
-  <ParameterList :parameters="filterParameters('query')">
+  <ParameterList
+    :parameters="filterParameters('query')"
+    :schemas="schemas">
     <template #title>Query Parameters</template>
   </ParameterList>
 
   <!-- Headers -->
-  <ParameterList :parameters="filterParameters('header')">
+  <ParameterList
+    :parameters="filterParameters('header')"
+    :schemas="schemas">
     <template #title>Headers</template>
   </ParameterList>
 
   <!-- Cookies -->
-  <ParameterList :parameters="filterParameters('cookie')">
+  <ParameterList
+    :parameters="filterParameters('cookie')"
+    :schemas="schemas">
     <template #title>Cookies</template>
   </ParameterList>
 
   <!-- Request body -->
   <RequestBody
     v-if="operation?.requestBody"
-    :requestBody="operation.requestBody">
+    :requestBody="operation.requestBody"
+    :schemas="schemas">
     <template #title>Body</template>
   </RequestBody>
 </template>

--- a/packages/api-reference/src/features/Operation/components/OperationResponses.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationResponses.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { TransformedOperation } from '@scalar/types/legacy'
 
 import { useResponses } from '../hooks/useResponses'
@@ -8,6 +9,11 @@ const props = withDefaults(
   defineProps<{
     operation: TransformedOperation
     collapsableItems?: boolean
+    schemas?:
+      | OpenAPIV2.DefinitionsObject
+      | Record<string, OpenAPIV3.SchemaObject>
+      | Record<string, OpenAPIV3_1.SchemaObject>
+      | unknown
   }>(),
   {
     collapsableItems: true,
@@ -20,7 +26,8 @@ const { responses } = useResponses(props.operation)
   <ParameterList
     :collapsableItems="collapsableItems"
     :parameters="responses"
-    :withExamples="false">
+    :withExamples="false"
+    :schemas="schemas">
     <template #title>Responses</template>
   </ParameterList>
 </template>

--- a/packages/api-reference/src/features/Operation/components/ParameterList.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 
 import ParameterListItem from './ParameterListItem.vue'
 
@@ -9,6 +10,11 @@ withDefaults(
     showChildren?: boolean
     collapsableItems?: boolean
     withExamples?: boolean
+    schemas?:
+      | OpenAPIV2.DefinitionsObject
+      | Record<string, OpenAPIV3.SchemaObject>
+      | Record<string, OpenAPIV3_1.SchemaObject>
+      | unknown
   }>(),
   {
     showChildren: false,
@@ -31,7 +37,8 @@ withDefaults(
         :collapsableItems="collapsableItems"
         :parameter="item"
         :showChildren="showChildren"
-        :withExamples="withExamples" />
+        :withExamples="withExamples"
+        :schemas="schemas" />
     </ul>
   </div>
 </template>

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -2,6 +2,7 @@
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { ContentType } from '@scalar/types/legacy'
 import { computed, ref } from 'vue'
 
@@ -19,6 +20,11 @@ const props = withDefaults(
     showChildren?: boolean
     collapsableItems?: boolean
     withExamples?: boolean
+    schemas?:
+      | OpenAPIV2.DefinitionsObject
+      | Record<string, OpenAPIV3.SchemaObject>
+      | Record<string, OpenAPIV3_1.SchemaObject>
+      | unknown
   }>(),
   {
     showChildren: false,
@@ -98,7 +104,8 @@ const shouldShowParameter = computed(() => {
               ? parameter.content?.[selectedContentType]?.schema
               : parameter.schema),
           }"
-          :withExamples="withExamples" />
+          :withExamples="withExamples"
+          :schemas="schemas" />
       </DisclosurePanel>
     </Disclosure>
     <div

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ScalarMarkdown } from '@scalar/components'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { ContentType, RequestBody } from '@scalar/types/legacy'
 import { computed, ref } from 'vue'
 
@@ -7,8 +8,14 @@ import { Schema } from '@/components/Content/Schema'
 
 import ContentTypeSelect from './ContentTypeSelect.vue'
 
-const { requestBody } = defineProps<{ requestBody?: RequestBody }>()
-
+const { requestBody, schemas } = defineProps<{
+  requestBody?: RequestBody
+  schemas?:
+    | OpenAPIV2.DefinitionsObject
+    | Record<string, OpenAPIV3.SchemaObject>
+    | Record<string, OpenAPIV3_1.SchemaObject>
+    | unknown
+}>()
 const availableContentTypes = computed(() =>
   Object.keys(requestBody?.content ?? {}),
 )
@@ -43,6 +50,7 @@ if (requestBody?.content) {
       <Schema
         compact
         noncollapsible
+        :schemas="schemas"
         :value="requestBody.content?.[selectedContentType]?.schema" />
     </div>
   </div>

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -9,6 +9,7 @@ import type {
   Operation,
   Server,
 } from '@scalar/oas-utils/entities/spec'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { TransformedOperation } from '@scalar/types/legacy'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { computed } from 'vue'
@@ -38,6 +39,11 @@ const { operation } = defineProps<{
   operation: Operation
   /** @deprecated Use `operation` instead */
   transformedOperation: TransformedOperation
+  schemas?:
+    | OpenAPIV2.DefinitionsObject
+    | Record<string, OpenAPIV3.SchemaObject>
+    | Record<string, OpenAPIV3_1.SchemaObject>
+    | unknown
 }>()
 
 const { copyToClipboard } = useClipboard()
@@ -107,12 +113,15 @@ const title = computed(() => operation.summary || operation.path)
     <div class="endpoint-content">
       <div class="operation-details-card">
         <div class="operation-details-card-item">
-          <OperationParameters :operation="operation" />
+          <OperationParameters
+            :operation="operation"
+            :schemas="schemas" />
         </div>
         <div class="operation-details-card-item">
           <OperationResponses
             :collapsableItems="false"
-            :operation="transformedOperation" />
+            :operation="transformedOperation"
+            :schemas="schemas" />
         </div>
       </div>
       <ExampleResponses :responses="operation.responses" />

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -5,6 +5,7 @@ import type {
   Operation,
   Server,
 } from '@scalar/oas-utils/entities/spec'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { TransformedOperation } from '@scalar/types/legacy'
 import { computed, useId } from 'vue'
 
@@ -38,6 +39,11 @@ const { operation } = defineProps<{
   operation: Operation
   /** @deprecated Use `operation` instead */
   transformedOperation: TransformedOperation
+  schemas?:
+    | OpenAPIV2.DefinitionsObject
+    | Record<string, OpenAPIV3.SchemaObject>
+    | Record<string, OpenAPIV3_1.SchemaObject>
+    | unknown
 }>()
 
 const labelId = useId()
@@ -75,8 +81,12 @@ const title = computed(() => operation.summary || operation.path)
             <ScalarMarkdown
               :value="operation.description"
               withImages />
-            <OperationParameters :operation="operation" />
-            <OperationResponses :operation="transformedOperation" />
+            <OperationParameters
+              :operation="operation"
+              :schemas="schemas" />
+            <OperationResponses
+              :operation="transformedOperation"
+              :schemas="schemas" />
           </div>
         </SectionColumn>
         <SectionColumn>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,6 +1043,9 @@ importers:
       '@vueuse/core':
         specifier: ^10.10.0
         version: 10.11.0(vue@3.5.12(typescript@5.6.2))
+      flatted:
+        specifier: ^3.3.1
+        version: 3.3.1
       fuse.js:
         specifier: ^7.0.0
         version: 7.0.0


### PR DESCRIPTION
**Problem**

currently discriminator description are duplicated, properties accordion gets duplicated.

**Solution**

this pr updates the way discriminator are displayed within api reference:
- allof are not merged
- anyof + one of are displaying a schema model dropdown

| before | after |
| -------|------|
| <img width="595" alt="image" src="https://github.com/user-attachments/assets/22b4f2fc-48cd-43fa-8166-916a65f7bf61" /> | ![image](https://github.com/user-attachments/assets/e4125d27-0128-4870-a38e-c7aad9e90ec8) |

<details>
<summary>OpenAPI specification testing document</summary>

```yaml
openapi: 3.0.3
info:
  title: Petstore API
  version: 1.0.0
tags:
  - name: pets
    description: Operations related to pets
paths:
  /pets/allof:
    get:
      summary: Get pets with allOf usage
      tags:
        - pets
      responses:
        '200':
          description: A pet with combined properties
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/AllOfPet'
    post:
      summary: Create a pet with allOf usage
      tags:
        - pets
      requestBody:
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/AllOfPet'
      responses:
        '201':
          description: Pet created successfully
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/AllOfPet'

  /pets/anyof:
    get:
      summary: Get pets with anyOf usage
      tags:
        - pets
      responses:
        '200':
          description: A pet that matches at least one of the conditions
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/AnyOfPet'
    post:
      summary: Create a pet with anyOf usage
      tags:
        - pets
      requestBody:
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/AnyOfPet'
      responses:
        '201':
          description: Pet created successfully
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/AnyOfPet'

  /pets/oneof:
    get:
      summary: Get pets with oneOf usage
      tags:
        - pets
      responses:
        '200':
          description: A pet that matches only one of the given schemas
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/OneOfPet'
    post:
      summary: Create a pet with oneOf usage
      tags:
        - pets
      requestBody:
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/OneOfPet'
      responses:
        '201':
          description: Pet created successfully
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/OneOfPet'

components:
  schemas:
    BasePet:
      type: object
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string

    Dog:
      allOf:
        - $ref: '#/components/schemas/BasePet'
        - type: object
          properties:
            breed:
              type: string

    Cat:
      allOf:
        - $ref: '#/components/schemas/BasePet'
        - type: object
          properties:
            color:
              type: string

    AllOfPet:
      allOf:
        - $ref: '#/components/schemas/Dog'
        - $ref: '#/components/schemas/Cat'

    AnyOfPet:
      anyOf:
        - $ref: '#/components/schemas/Dog'
        - $ref: '#/components/schemas/Cat'

    OneOfPet:
      oneOf:
        - $ref: '#/components/schemas/Dog'
        - $ref: '#/components/schemas/Cat'
```
</details>

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
