### PR TITLE
fix(cli): live reload close file watch on socket abort

### DIFF
--- a/.changeset/healthy-bananas-yawn.md
+++ b/.changeset/healthy-bananas-yawn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/cli': patch
+---
+
+Live reload handle the aborted session's file watch subscriptions

--- a/packages/cli/src/commands/serve/ServeCommand.ts
+++ b/packages/cli/src/commands/serve/ServeCommand.ts
@@ -54,7 +54,7 @@ export function ServeCommand() {
         return stream(c, async (s) => {
           // watch file for changes
           if (watch) {
-            watchFile(input, async () => {
+            const subscription = await watchFile(input, async () => {
               const newResult = await loadOpenApiFile(input)
               const specificationHasChanged =
                 newResult?.specification && JSON.stringify(specification) !== JSON.stringify(newResult.specification)
@@ -72,6 +72,7 @@ export function ServeCommand() {
                 s.write('data: file modified\n\n')
               }
             })
+            if (subscription) s.onAbort(() => subscription.unsubscribe());
           }
 
           while (true) {

--- a/packages/cli/src/utils/watchFile.ts
+++ b/packages/cli/src/utils/watchFile.ts
@@ -1,4 +1,4 @@
-import watcher from '@parcel/watcher'
+import watcher, { type AsyncSubscription } from '@parcel/watcher'
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -7,7 +7,7 @@ import { isUrl } from './isUrl'
 /**
  * Watch a foobar for changes and call a callback when it does.
  */
-export async function watchFile(file: string, callback: () => void, options?: { immediate?: boolean }) {
+export async function watchFile(file: string, callback: () => void, options?: { immediate?: boolean }): Promise<AsyncSubscription | void> {
   // Poll URLs
   if (isUrl(file)) {
     setInterval(callback, 5000)
@@ -28,7 +28,7 @@ export async function watchFile(file: string, callback: () => void, options?: { 
   const directory = path.dirname(absoluteFilePath)
 
   // Start the watcher
-  await watcher.subscribe(directory, (err, events) => {
+  const subscription = await watcher.subscribe(directory, (err, events) => {
     // Match the file path
     if (events.some((event) => event.path === absoluteFilePath)) {
       callback()
@@ -39,4 +39,6 @@ export async function watchFile(file: string, callback: () => void, options?: { 
   if (options?.immediate) {
     callback()
   }
+
+  return subscription;
 }


### PR DESCRIPTION
**Problem**

https://github.com/scalar/scalar/issues/4886

**Solution**

With this PR the file watch will unsubscribe.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
