### PR TITLE
chore: upgrade pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "pnpm": "^9.1.0"
+    "pnpm": "^10.5.2"
   },
+  "packageManager": "pnpm@10.5.2",
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@changesets/cli": "^2.27.10",
@@ -104,7 +105,6 @@
       "require": "./dist/*.css"
     }
   },
-  "packageManager": "pnpm@9.2.0",
   "remarkConfig": {
     "plugins": [
       "remark-validate-links",

--- a/packages/scalar-app/todesktop.json
+++ b/packages/scalar-app/todesktop.json
@@ -5,7 +5,7 @@
   "icon": "./build/icon.png",
   "nodeVersion": "20",
   "packageManager": "pnpm",
-  "pnpmVersion": "9.2.0",
+  "pnpmVersion": "10.5.2",
   "packageJson": {
     "extends": "package.json",
     "productName": "Scalar",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,9 @@
 packages:
-  - examples/**/*
-  - integrations/**/*
-  - packages/**/*
-  - playwright
-  - projects/**/*
+  - 'examples/**/*'
+  - 'integrations/**/*'
+  - 'packages/**/*'
+  - 'playwright'
+  - 'projects/**/*'
   - '!**/.next/**' # To prevent next.js duplicates
   - '!**/dist/**' # To prevent dist duplicates
 onlyBuiltDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,25 @@
 packages:
-  - 'examples/**/*'
-  - 'integrations/**/*'
-  - 'packages/**/*'
-  - 'playwright'
-  - 'projects/**/*'
+  - examples/**/*
+  - integrations/**/*
+  - packages/**/*
+  - playwright
+  - projects/**/*
   - '!**/.next/**' # To prevent next.js duplicates
   - '!**/dist/**' # To prevent dist duplicates
+onlyBuiltDependencies:
+  - '@biomejs/biome'
+  - '@todesktop/cli'
+  - core-js
+  - core-js-pure
+  - electron
+  - lefthook
+  - vue-demi
+ignoredBuiltDependencies:
+  - '@nestjs/core'
+  - '@swc/core'
+  - dtrace-provider
+  - esbuild
+  - msw
+  - protobufjs
+  - sharp
+  - workerd

--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
 # Set Node.js memory limit to 8GB
 ENV NODE_OPTIONS="--max-old-space-size=8192"
 
-RUN npm install pnpm@9.2.0 --global
+RUN npm install pnpm@10.5.2 --global
 RUN pnpm config set store-dir ~/.pnpm-store
 
 WORKDIR /app


### PR DESCRIPTION
**Problem**

Currently, our pnpm version is a bit stale.

**Solution**

With this PR we upgrade pnpm to get the new goodies (linking etc)

Also security (yay) I allowed these packages + core-js to run postbuild scripts, we can add the others if needed.

![image](https://github.com/user-attachments/assets/b86eb5ca-0889-41df-9393-41c27ca558f0)


**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
