### PR TITLE
fix(api-client): find correct request for route change

### DIFF
--- a/.changeset/wicked-hornets-change.md
+++ b/.changeset/wicked-hornets-change.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client-react': patch
+'@scalar/api-client': patch
+---
+
+fix: routing to the api client modal

--- a/examples/nextjs-api-reference/app/another-client/page.tsx
+++ b/examples/nextjs-api-reference/app/another-client/page.tsx
@@ -5,7 +5,10 @@ import { Button, ClientWrapper } from '../client/components'
 const Page = () => {
   return (
     <ClientWrapper>
-      <Button />
+      <Button
+        method="POST"
+        path="/auth/token"
+      />
       <Link href="/client">Go to client</Link>
     </ClientWrapper>
   )

--- a/examples/nextjs-api-reference/app/client/components/Button.tsx
+++ b/examples/nextjs-api-reference/app/client/components/Button.tsx
@@ -2,8 +2,8 @@
 
 import { useApiClientModal } from '@scalar/api-client-react'
 
-export const Button = () => {
+export const Button = ({ method, path }: { method: 'GET' | 'POST'; path: string }) => {
   const client = useApiClientModal()
 
-  return <button onClick={() => client?.open()}>Click me to open the Api Client</button>
+  return <button onClick={() => client?.open({ method, path })}>Click me to open the Api Client</button>
 }

--- a/examples/nextjs-api-reference/app/client/components/ClientWrapper.tsx
+++ b/examples/nextjs-api-reference/app/client/components/ClientWrapper.tsx
@@ -1,14 +1,18 @@
 'use client'
 
 import { ApiClientModalProvider } from '@scalar/api-client-react'
+import type { OpenClientPayload } from '@scalar/api-client-react'
 
 import '@scalar/api-client-react/style.css'
-
 import type { PropsWithChildren } from 'react'
 
-export const ClientWrapper = ({ children }: PropsWithChildren) => {
+export const ClientWrapper = ({
+  children,
+  initialRequest,
+}: PropsWithChildren<{ initialRequest?: OpenClientPayload }>) => {
   return (
     <ApiClientModalProvider
+      initialRequest={initialRequest}
       configuration={{
         spec: {
           url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',

--- a/examples/nextjs-api-reference/app/client/page.tsx
+++ b/examples/nextjs-api-reference/app/client/page.tsx
@@ -5,7 +5,10 @@ import { Button, ClientWrapper } from './components'
 const Page = () => {
   return (
     <ClientWrapper>
-      <Button />
+      <Button
+        method="POST"
+        path="/planets"
+      />
       <Link href="/another-client">Go to another client</Link>
     </ClientWrapper>
   )

--- a/packages/api-client-react/src/ApiClientModalProvider.tsx
+++ b/packages/api-client-react/src/ApiClientModalProvider.tsx
@@ -5,6 +5,8 @@ import type { ClientConfiguration, OpenClientPayload } from '@scalar/api-client/
 import type { PropsWithChildren } from 'react'
 import { createContext, useContext, useEffect, useRef, useSyncExternalStore } from 'react'
 
+export type { OpenClientPayload }
+
 import { clientStore } from './client-store'
 
 import './style.css'

--- a/packages/api-client/src/libs/get-request-uid-by-path-method.test.ts
+++ b/packages/api-client/src/libs/get-request-uid-by-path-method.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { getRequestUidByPathMethod } from './get-request-uid-by-path-method'
+import { operationSchema, type Operation } from '@scalar/oas-utils/entities/spec'
+
+describe('getRequestUidByPathMethod', () => {
+  // Mock requests data with various path patterns
+  const mockRequests: Record<string, Operation> = {
+    'request-1': operationSchema.parse({
+      uid: 'request-1',
+      path: '/users',
+      method: 'get',
+    }),
+    'request-2': operationSchema.parse({
+      uid: 'request-2',
+      path: '/users',
+      method: 'post',
+    }),
+    'request-3': operationSchema.parse({
+      uid: 'request-3',
+      path: '/products',
+      method: 'get',
+    }),
+    'request-4': operationSchema.parse({
+      uid: 'request-4',
+      path: '/users/{id}',
+      method: 'get',
+    }),
+    'request-5': operationSchema.parse({
+      uid: 'request-5',
+      path: '/orders',
+      method: 'put',
+    }),
+  }
+
+  // Empty requests object for edge case testing
+  const emptyRequests: Record<string, Operation> = {}
+
+  // Spy on console.log
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns requestUid when provided in payload', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      requestUid: 'request-2',
+      path: '/users',
+      method: 'GET',
+    })
+
+    expect(result).toBe('request-2')
+  })
+
+  test('returns requestUid even when it does not exist in requests', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      requestUid: 'non-existent-request',
+      path: '/users',
+      method: 'GET',
+    })
+
+    expect(result).toBe('non-existent-request')
+  })
+
+  test('finds request by exact path and method match', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      path: '/products',
+      method: 'GET',
+    })
+
+    expect(result).toBe('request-3')
+  })
+
+  test('finds request by path and method (case-insensitive for method)', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      path: '/users',
+      method: 'get',
+    })
+
+    expect(result).toBe('request-1')
+  })
+
+  test('finds request by path and method (case-insensitive for path)', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      path: '/Users',
+      method: 'GET',
+    })
+
+    expect(result).toBe('request-1')
+  })
+
+  test('finds request by path and method (case-insensitive for both)', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      path: '/Users',
+      method: 'get',
+    })
+
+    expect(result).toBe('request-1')
+  })
+
+  test('returns first request uid when no match found', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      path: '/nonexistent',
+      method: 'GET',
+    })
+
+    expect(result).toBe('request-1')
+  })
+
+  test('returns first request uid when payload is undefined', () => {
+    const result = getRequestUidByPathMethod(mockRequests)
+
+    expect(result).toBe('request-1')
+  })
+
+  test('returns first request uid when empty payload is provided', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {})
+
+    expect(result).toBe('request-1')
+  })
+
+  test('handles partial payload with only method', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      method: 'POST',
+    })
+
+    expect(result).toBe('request-1')
+  })
+
+  test('handles partial payload with only path', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      path: '/products',
+    })
+
+    expect(result).toBe('request-1')
+  })
+
+  test('handles empty requests object', () => {
+    const result = getRequestUidByPathMethod(emptyRequests, {
+      path: '/users',
+      method: 'GET',
+    })
+
+    expect(result).toBe(undefined)
+  })
+
+  test('handles null method in payload', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      path: '/users',
+      method: null as any,
+    })
+
+    expect(result).toBe('request-1')
+  })
+
+  test('handles null path in payload', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      path: null as any,
+      method: 'GET',
+    })
+
+    expect(result).toBe('request-1')
+  })
+
+  test('handles path with trailing slash', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      path: '/users/',
+      method: 'GET',
+    })
+
+    expect(result).toBe('request-1')
+  })
+
+  test('handles path with query parameters', () => {
+    const result = getRequestUidByPathMethod(mockRequests, {
+      path: '/users?sort=asc',
+      method: 'GET',
+    })
+
+    expect(result).toBe('request-1')
+  })
+})

--- a/packages/api-client/src/libs/get-request-uid-by-path-method.test.ts
+++ b/packages/api-client/src/libs/get-request-uid-by-path-method.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, test, expect } from 'vitest'
 import { getRequestUidByPathMethod } from './get-request-uid-by-path-method'
 import { operationSchema, type Operation } from '@scalar/oas-utils/entities/spec'
 
@@ -34,15 +34,6 @@ describe('getRequestUidByPathMethod', () => {
 
   // Empty requests object for edge case testing
   const emptyRequests: Record<string, Operation> = {}
-
-  // Spy on console.log
-  beforeEach(() => {
-    vi.spyOn(console, 'log').mockImplementation(() => {})
-  })
-
-  afterEach(() => {
-    vi.clearAllMocks()
-  })
 
   test('returns requestUid when provided in payload', () => {
     const result = getRequestUidByPathMethod(mockRequests, {

--- a/packages/api-client/src/libs/get-request-uid-by-path-method.ts
+++ b/packages/api-client/src/libs/get-request-uid-by-path-method.ts
@@ -1,0 +1,21 @@
+import type { OpenClientPayload } from '@/libs/create-client'
+import type { Operation } from '@scalar/oas-utils/entities/spec'
+
+/**
+ * Get the request uid by path and method
+ */
+export const getRequestUidByPathMethod = (
+  requests: Record<string, Operation>,
+  payload?: Omit<OpenClientPayload, '_source'>,
+) => {
+  const { requestUid, method, path } = payload ?? {}
+
+  // Find the request from path + method
+  const resolvedRequestUid =
+    requestUid ||
+    Object.values(requests).find(
+      (item) => item.path.toLowerCase() === path?.toLowerCase() && item.method?.toLowerCase() === method?.toLowerCase(),
+    )?.uid
+
+  return resolvedRequestUid || Object.keys(requests)[0]
+}

--- a/packages/api-client/src/libs/get-request-uid-by-path-method.ts
+++ b/packages/api-client/src/libs/get-request-uid-by-path-method.ts
@@ -14,7 +14,7 @@ export const getRequestUidByPathMethod = (
   const resolvedRequestUid =
     requestUid ||
     Object.values(requests).find(
-      (item) => item.path.toLowerCase() === path?.toLowerCase() && item.method?.toLowerCase() === method?.toLowerCase(),
+      (item) => item.path.toLowerCase() === path?.toLowerCase() && item.method.toLowerCase() === method?.toLowerCase(),
     )?.uid
 
   return resolvedRequestUid || Object.keys(requests)[0]

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ packages:
   - 'packages/**/*'
   - 'playwright'
   - 'projects/**/*'
+  - '!**/.next/**' # To prevent next.js duplicates
+  - '!**/dist/**' # To prevent dist duplicates


### PR DESCRIPTION
**Problem**

Currently, every time you open the modal it goes to the same request

**Solution**

With this PR we boot out the function into its own util so we can test it, also fixed it.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
