### PR TITLE
chore: enable a few biome flags

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,9 @@
       "**/aspnetcore/**/bin/**"
     ]
   },
+  "organizeImports": {
+    "enabled": true
+  },
   "formatter": {
     "formatWithErrors": false,
     "ignore": [
@@ -118,7 +121,7 @@
         "noNamespace": "warn",
         "noParameterAssign": "warn",
         "useAsConstAssertion": "warn",
-        "useBlockStatements": "off",
+        "useBlockStatements": "warn",
         "useForOf": "warn",
         "useNodejsImportProtocol": "warn",
         "useNumberNamespace": "warn",
@@ -166,7 +169,8 @@
         "noExportsInTest": "warn"
       },
       "performance": {
-        "noDelete": "off"
+        "noDelete": "off",
+        "noReExportAll": "warn"
       },
       "nursery": {
         "noDescendingSpecificity": "warn",


### PR DESCRIPTION
**Problem**

Currently, we are missing import sorting!! I have been sorting my own imports like the 90s

**Solution**

With this PR we re-enable that plus a few more flags for perf and code consistency

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
