### PR TITLE
fix(api-client): improve api client sidebar and address bar a11y

### DIFF
--- a/.changeset/grumpy-flowers-know.md
+++ b/.changeset/grumpy-flowers-know.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix(api-client): improve api client sidebar and address bar a11y

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
-import {
-  Listbox,
-  ListboxButton,
-  ListboxOption,
-  ListboxOptions,
-} from '@headlessui/vue'
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
 import {
   ScalarFloating,
   ScalarFloatingBackdrop,
@@ -12,7 +7,7 @@ import {
 } from '@scalar/components'
 import type { Operation, RequestEvent } from '@scalar/oas-utils/entities/spec'
 import { httpStatusCodes } from '@scalar/oas-utils/helpers'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { formatMs } from '@/libs/formatters'
@@ -31,8 +26,6 @@ const { operation, target } = defineProps<{
 const { requestHistory, requestExampleMutators } = useWorkspace()
 
 const router = useRouter()
-
-const selectedRequest = ref(requestHistory[0] ?? null)
 
 /** Use a local copy to prevent mutation of the reactive object */
 const history = computed(() =>
@@ -79,34 +72,36 @@ function handleHistoryClick(historicalRequest: RequestEvent) {
 }
 </script>
 <template>
-  <Listbox
+  <Menu
     v-slot="{ open }"
-    v-model="selectedRequest">
+    as="div">
     <ScalarFloating
       :offset="0"
       resize
       :target="target">
       <!-- History -->
-      <ListboxButton
+      <MenuButton
         v-if="history?.length"
-        class="address-bar-history-button z-context-plus text-c-3 focus:text-c-1 mr-1 rounded-lg p-1.5">
+        class="address-bar-history-button z-context-plus text-c-3 focus:text-c-1 relative mr-1 rounded-lg p-1.5">
         <ScalarIcon
           icon="History"
           size="sm"
           thickness="2.25" />
         <span class="sr-only">Request History</span>
-      </ListboxButton>
+      </MenuButton>
       <!-- History shadow and placement-->
       <template
         v-if="open"
         #floating="{ width }">
         <!-- History Item -->
-        <ListboxOptions
+        <MenuItems
           class="custom-scroll p-0.75 grid max-h-[inherit] grid-cols-[44px,1fr,repeat(3,auto)] items-center border-t"
+          static
           :style="{ width }">
-          <ListboxOption
+          <MenuItem
             v-for="(entry, index) in history"
             :key="entry.timestamp"
+            as="button"
             class="font-code *:ui-active:bg-b-2 text-c-2 contents text-sm font-medium *:flex *:h-8 *:cursor-pointer *:items-center *:rounded-none *:px-1.5 first:*:rounded-l last:*:rounded-r"
             :value="index"
             @click="handleHistoryClick(entry)">
@@ -126,13 +121,13 @@ function handleHistoryClick(historicalRequest: RequestEvent) {
             <div>
               {{ httpStatusCodes[entry.response.status]?.name }}
             </div>
-          </ListboxOption>
-        </ListboxOptions>
+          </MenuItem>
+        </MenuItems>
         <ScalarFloatingBackdrop
           class="-top-[--scalar-address-bar-height] rounded-lg" />
       </template>
     </ScalarFloating>
-  </Listbox>
+  </Menu>
 </template>
 <style scoped>
 .address-bar-history-button:hover {

--- a/packages/api-client/src/components/Sidebar/SidebarToggle.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarToggle.vue
@@ -5,6 +5,7 @@ const { isSidebarOpen, toggleSidebarOpen } = useSidebar()
 </script>
 <template>
   <button
+    :aria-pressed="isSidebarOpen"
     class="scalar-sidebar-toggle text-c-3 hover:bg-b-2 active:text-c-1 rounded-lg p-2"
     type="button"
     @click="toggleSidebarOpen">

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
@@ -17,7 +17,6 @@ export const createApiClientModal = async ({
   // Default sidebar to closed in the modal
   const _configuration = {
     ...configuration,
-    showSidebar: false,
   }
 
   const client = createApiClient({

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -13,9 +13,11 @@ import RequestSection from '@/views/Request/RequestSection/RequestSection.vue'
 import RequestSubpageHeader from '@/views/Request/RequestSubpageHeader.vue'
 import ResponseSection from '@/views/Request/ResponseSection/ResponseSection.vue'
 
-const { events } = useWorkspace()
+const { invalidParams } = defineProps<{
+  invalidParams: Set<string>
+}>()
 defineEmits<(e: 'newTab', item: { name: string; uid: string }) => void>()
-
+const { events } = useWorkspace()
 const { isSidebarOpen } = useSidebar()
 
 const workspaceContext = useWorkspace()
@@ -32,10 +34,6 @@ const {
   activeWorkspaceRequests,
 } = useActiveEntities()
 const { modalState, requestHistory } = workspaceContext
-
-const { invalidParams } = defineProps<{
-  invalidParams: Set<string>
-}>()
 
 const activeHistoryEntry = computed(() =>
   requestHistory.findLast((r) => r.request.uid === activeExample.value?.uid),

--- a/packages/api-client/src/views/Request/RequestRoot.test.ts
+++ b/packages/api-client/src/views/Request/RequestRoot.test.ts
@@ -1,0 +1,92 @@
+import { useWorkspace } from '@/store'
+import { createStoreEvents } from '@/store/events'
+import { useActiveEntities } from '@/store/active-entities'
+import { mount } from '@vue/test-utils'
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import RequestRoot from './RequestRoot.vue'
+
+// Mock vue-router
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    currentRoute: {
+      query: {},
+    },
+  }),
+  RouterView: vi.fn(),
+}))
+
+// Mock the useWorkspace hook
+vi.mock('@/store', () => ({
+  useWorkspace: vi.fn(),
+}))
+const mockUseWorkspace = useWorkspace as Mock
+const mockWorkspace = {
+  isReadOnly: false,
+  events: createStoreEvents(),
+  hideClientButton: false,
+  showSidebar: true,
+  requestHistory: [],
+  collectionMutators: {
+    edit: vi.fn(),
+  },
+}
+
+// Add mock for useActiveEntities
+vi.mock('@/store/active-entities', () => ({
+  useActiveEntities: vi.fn(),
+}))
+const mockUseActiveEntities = useActiveEntities as Mock
+const mockActiveEntities = {
+  activeRequest: ref(null),
+  activeExample: ref(null),
+  activeCollection: ref({ documentUrl: null, watchMode: false }),
+  activeEnvironment: ref(null),
+  activeWorkspace: ref(null),
+  activeWorkspaceRequests: ref([]),
+  activeWorkspaceCollections: ref([]),
+  activeWorkspaceServers: ref([]),
+  activeEnvVariables: ref([]),
+  activeRouterParams: ref({}),
+  setActiveRequest: vi.fn(),
+  setActiveExample: vi.fn(),
+}
+
+describe('RequestRoot', () => {
+  const createWrapper = (options = {}) =>
+    mount(RequestRoot, {
+      attachTo: document.body,
+      ...options,
+    })
+
+  // Mock our request + example
+  beforeEach(() => {
+    mockUseWorkspace.mockReturnValue(mockWorkspace)
+    mockUseActiveEntities.mockReturnValue(mockActiveEntities)
+  })
+
+  it('renders correctly', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('shows SidebarToggle when showSidebar is true', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(true)
+  })
+
+  it('hides SidebarToggle when showSidebar is false', async () => {
+    mockUseWorkspace.mockReturnValue({ ...mockWorkspace, showSidebar: false })
+    const wrapper = createWrapper()
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(false)
+  })
+
+  it('emits update:modelValue when SidebarToggle is clicked', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.scalar-sidebar-toggle').trigger('click')
+    expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(true)
+  })
+})

--- a/packages/api-client/src/views/Request/RequestRoot.test.ts
+++ b/packages/api-client/src/views/Request/RequestRoot.test.ts
@@ -4,6 +4,7 @@ import { useActiveEntities } from '@/store/active-entities'
 import { mount } from '@vue/test-utils'
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
+import { mockUseLayout } from '@/vitest.setup'
 
 import RequestRoot from './RequestRoot.vue'
 
@@ -88,5 +89,12 @@ describe('RequestRoot', () => {
     const wrapper = createWrapper()
     await wrapper.find('.scalar-sidebar-toggle').trigger('click')
     expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(true)
+  })
+
+  it('applies correct classes for modal layout', async () => {
+    mockUseLayout.mockReturnValue({ layout: 'modal' })
+    const wrapper = createWrapper()
+    const sidebarToggle = wrapper.find('.scalar-sidebar-toggle')
+    expect(sidebarToggle.classes()).toContain('!flex')
   })
 })

--- a/packages/api-client/src/views/Request/RequestRoot.vue
+++ b/packages/api-client/src/views/Request/RequestRoot.vue
@@ -5,7 +5,9 @@ import { useToasts } from '@scalar/use-toasts'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { RouterView } from 'vue-router'
 
+import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
 import { useLayout } from '@/hooks'
+import { useSidebar } from '@/hooks/useSidebar'
 import { ERRORS } from '@/libs'
 import { createRequestOperation } from '@/libs/send-request'
 import { validateParameters } from '@/libs/validate-parameters'
@@ -29,6 +31,7 @@ const {
 } = useActiveEntities()
 const { cookies, requestHistory, showSidebar, securitySchemes, events } =
   workspaceContext
+const { isSidebarOpen } = useSidebar()
 
 const requestAbortController = ref<AbortController>()
 const invalidParams = ref<Set<string>>(new Set())
@@ -138,6 +141,15 @@ watch(
     :class="{
       '!mb-0 !mr-0 !border-0': layout === 'modal',
     }">
+    <SidebarToggle
+      v-if="showSidebar"
+      v-model="isSidebarOpen"
+      class="absolute left-3 top-2 z-50"
+      :class="[
+        { hidden: isSidebarOpen },
+        { 'xl:!flex': !isSidebarOpen },
+        { '!flex': layout === 'modal' },
+      ]" />
     <div class="flex h-full">
       <!-- Sidebar -->
       <RequestSidebar

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -29,7 +29,6 @@ import HttpMethod from '@/components/HttpMethod/HttpMethod.vue'
 import ScalarAsciiArt from '@/components/ScalarAsciiArt.vue'
 import { useSearch } from '@/components/Search/useSearch'
 import SidebarButton from '@/components/Sidebar/SidebarButton.vue'
-import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
 import { useLayout } from '@/hooks/useLayout'
 import { useSidebar } from '@/hooks/useSidebar'
 import type { HotKeyEvent } from '@/libs'
@@ -249,9 +248,10 @@ const showGettingStarted = computed(() =>
       #header />
     <template #content>
       <div class="bg-b-1 sticky top-0 z-20 flex h-12 items-center px-3">
-        <SidebarToggle
-          class="xl:hidden"
-          :class="[{ '!flex': layout === 'modal' }]" />
+        <!-- Holds space for the sidebar toggle -->
+        <div
+          class="size-8"
+          :class="{ 'xl:hidden': layout !== 'modal' }" />
         <WorkspaceDropdown v-if="layout !== 'modal'" />
         <span
           v-if="layout !== 'modal'"

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
@@ -71,19 +71,6 @@ describe('RequestSubpageHeader', () => {
     expect(wrapper.exists()).toBe(true)
   })
 
-  it('shows SidebarToggle when showSidebar is true', () => {
-    const wrapper = createWrapper()
-    expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(true)
-  })
-
-  it('hides SidebarToggle when showSidebar is false', async () => {
-    mockUseWorkspace.mockReturnValue({ ...mockWorkspace, showSidebar: false })
-    const wrapper = createWrapper()
-
-    await wrapper.vm.$nextTick()
-    expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(false)
-  })
-
   it('shows OpenApiClientButton when layout is modal and document URL is present', async () => {
     mockUseLayout.mockReturnValue({ layout: 'modal' })
     mockUseWorkspace.mockReturnValue({
@@ -94,12 +81,6 @@ describe('RequestSubpageHeader', () => {
 
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.open-api-client-button').exists()).toBe(true)
-  })
-
-  it('emits update:modelValue when SidebarToggle is clicked', async () => {
-    const wrapper = createWrapper()
-    await wrapper.find('.scalar-sidebar-toggle').trigger('click')
-    expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(true)
   })
 
   it('emits hideModal when close button is clicked', async () => {

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.test.ts
@@ -94,11 +94,4 @@ describe('RequestSubpageHeader', () => {
     await wrapper.find('.app-exit-button').trigger('click')
     expect(wrapper.emitted('hideModal')).toBeTruthy()
   })
-
-  it('applies correct classes for modal layout', async () => {
-    mockUseLayout.mockReturnValue({ layout: 'modal' })
-    const wrapper = createWrapper()
-    const sidebarToggle = wrapper.find('.scalar-sidebar-toggle')
-    expect(sidebarToggle.classes()).toContain('!flex')
-  })
 })

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -11,7 +11,6 @@ import { useRouter } from 'vue-router'
 
 import { OpenApiClientButton } from '@/components'
 import AddressBar from '@/components/AddressBar/AddressBar.vue'
-import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
 import { useLayout } from '@/hooks/useLayout'
 import { useSidebar } from '@/hooks/useSidebar'
 import { useWorkspace } from '@/store'
@@ -43,16 +42,11 @@ const { currentRoute } = useRouter()
     class="lg:min-h-client-header t-app__top-container border-b-1/2 flex w-full flex-wrap items-center justify-center p-2 pt-2 lg:p-1 lg:pt-1">
     <div
       class="mb-2 flex w-1/2 flex-row items-center gap-1 lg:mb-0 lg:flex-1 lg:px-1">
-      <SidebarToggle
+      <!-- Holds space for the sidebar toggle -->
+      <div
         v-if="showSidebar"
-        v-model="isSidebarOpen"
-        class="ml-1"
-        :class="[
-          { hidden: isSidebarOpen },
-          { 'xl:!flex': !isSidebarOpen },
-          { '!flex': layout === 'modal' },
-          { '!hidden': layout === 'modal' && isSidebarOpen },
-        ]" />
+        class="size-8"
+        :class="{ hidden: layout === 'modal' && !isSidebarOpen }" />
     </div>
     <!-- Address Bar - we should always have a collection and operation -->
     <AddressBar

--- a/packages/api-reference/src/features/ApiClientModal/useApiClient.ts
+++ b/packages/api-reference/src/features/ApiClientModal/useApiClient.ts
@@ -14,7 +14,7 @@ export const useApiClient = (): {
   client: typeof client
   init: (args: Props) => Promise<ApiClient>
 } => {
-  /** Iniitialize the API Client, must be called only once or we will reset the state */
+  /** Initialize the API Client, must be called only once or we will reset the state */
   const init = async (props: Props): Promise<ApiClient> => {
     const _client = (await createApiClientModal(props)) as ApiClient
 


### PR DESCRIPTION
Improves the client sidebar toggle, search and address bar. I moved the toggle to an overlay in a single location so it doesn't break focus when opening the sidebar. As a bonus we get the toggle animation back ✨ @cameronrohani if you want to double check I didn't break the sidebar.

https://github.com/user-attachments/assets/12d266a5-79b3-44bc-a4da-4912dcbc205b

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
