### PR TITLE
fix: base docker image was missing git

### DIFF
--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-slim AS base
 
 # process init system
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init git
 
 # Set Node.js memory limit to 8GB
 ENV NODE_OPTIONS="--max-old-space-size=8192"


### PR DESCRIPTION
**Problem**

Currently, my fork of a package will not download as there's no git on the slim docker image.

**Solution**

With this PR we add git, which also adds quite a bit of disk space but 🤷🏾 

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
