### PR TITLE
fix(oas-utils): parameter examples array support

### DIFF
--- a/.changeset/flat-chefs-mate.md
+++ b/.changeset/flat-chefs-mate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: adds parameter examples array support

--- a/packages/oas-utils/src/entities/spec/parameters.test.ts
+++ b/packages/oas-utils/src/entities/spec/parameters.test.ts
@@ -51,4 +51,34 @@ describe('oasParameterSchema', () => {
 
     expect(() => oasParameterSchema.parse(invalidParameter)).toThrow(z.ZodError)
   })
+
+  it('should validate examples as an array', () => {
+    const validParameter = {
+      in: 'query',
+      name: 'galaxy',
+      examples: ['Milky Way', 'Andromeda'],
+    }
+
+    expect(() => oasParameterSchema.parse(validParameter)).not.toThrow()
+  })
+
+  it('should validate examples with a single array item', () => {
+    const validParameter = {
+      in: 'query',
+      name: 'galaxy',
+      examples: ['Milky Way'],
+    }
+
+    expect(() => oasParameterSchema.parse(validParameter)).not.toThrow()
+  })
+
+  it('should validate with an empty array of examples', () => {
+    const validParameter = {
+      in: 'query',
+      name: 'galaxy',
+      examples: [],
+    }
+
+    expect(() => oasParameterSchema.parse(validParameter)).not.toThrow()
+  })
 })

--- a/packages/oas-utils/src/entities/spec/parameters.ts
+++ b/packages/oas-utils/src/entities/spec/parameters.ts
@@ -32,13 +32,16 @@ export const oasParameterSchema = z.object({
   style: parameterStyleSchema.optional(),
   example: z.unknown().optional(),
   examples: z
-    .record(
-      z.string(),
-      z.object({
-        value: z.unknown(),
-        summary: z.string().optional(),
-      }),
-    )
+    .union([
+      z.record(
+        z.string(),
+        z.object({
+          value: z.unknown(),
+          summary: z.string().optional(),
+        }),
+      ),
+      z.array(z.unknown()),
+    ])
     .optional(),
 }) satisfies ZodSchema<OpenAPI.Parameter>
 

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -287,12 +287,18 @@ export function convertExampleToXScalar(example: RequestExample) {
 export function createParamInstance(param: RequestParameter) {
   const schema = param.schema as any
   const keys = Object.keys(param?.examples ?? {})
-  const firstExample =
-    keys.length && !Array.isArray(param.examples)
-      ? param.examples?.[keys[0]!]
-      : Array.isArray(param.examples) && param.examples.length > 0
-        ? { value: param.examples[0] }
-        : null
+
+  const firstExample = (() => {
+    if (keys.length && !Array.isArray(param.examples)) {
+      return param.examples?.[keys[0]!]
+    }
+
+    if (Array.isArray(param.examples) && param.examples.length > 0) {
+      return { value: param.examples[0] }
+    }
+
+    return null
+  })()
 
   /**
    * TODO:
@@ -305,12 +311,17 @@ export function createParamInstance(param: RequestParameter) {
   )
 
   // Handle non-string enums and enums within items for array types
-  const parseEnum =
-    schema?.enum && schema?.type !== 'string'
-      ? schema.enum?.map(String)
-      : schema?.items?.enum && schema?.type === 'array'
-        ? schema.items.enum.map(String)
-        : schema?.enum
+  const parseEnum = (() => {
+    if (schema?.enum && schema?.type !== 'string') {
+      return schema.enum?.map(String)
+    }
+
+    if (schema?.items?.enum && schema?.type === 'array') {
+      return schema.items.enum.map(String)
+    }
+
+    return schema?.enum
+  })()
 
   // Handle non-string examples
   const parseExamples = schema?.examples && schema?.type !== 'string' ? schema.examples?.map(String) : schema?.examples

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -287,7 +287,12 @@ export function convertExampleToXScalar(example: RequestExample) {
 export function createParamInstance(param: RequestParameter) {
   const schema = param.schema as any
   const keys = Object.keys(param?.examples ?? {})
-  const firstExample = keys.length ? param.examples?.[keys[0]!] : null
+  const firstExample =
+    keys.length && !Array.isArray(param.examples)
+      ? param.examples?.[keys[0]!]
+      : Array.isArray(param.examples) && param.examples.length > 0
+        ? { value: param.examples[0] }
+        : null
 
   /**
    * TODO:


### PR DESCRIPTION
**Problem**

currently parameter examples of type array or not well supported as seen in [sf compute api documentation](https://docs.sfcompute.com/api-reference#tag/orders/POST/v0/orders)

**Solution**

this pr updates the parameter entity to support examples of type array.

| before | after |
| -------|------|
| <img width="1193" alt="image" src="https://github.com/user-attachments/assets/2df61eb8-6e8f-4dfb-8c62-87749f3674af" /> | <img width="1193" alt="image" src="https://github.com/user-attachments/assets/a8c9831e-68b8-42c2-8b12-4a1b9a5debcc" /> |
| endpoint is not rendering properly | endpoint is not rendered | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
