### PR TITLE
feat(api-reference): add version selector above server select

### DIFF
--- a/.changeset/few-lies-talk.md
+++ b/.changeset/few-lies-talk.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: added new version selector in the introduction

--- a/packages/api-reference/playground/esm/index.html
+++ b/packages/api-reference/playground/esm/index.html
@@ -28,6 +28,19 @@
         pathRouting: {
           basePath: '/v1',
         },
+        versionSelect: {
+          label: 'Applications',
+          callback: (option) => {
+            console.log('selected', option.id)
+            // Redirect to the applications page
+          },
+          initialVersion: 'app2', // set this based on which application page we are on
+          versions: [
+            { id: 'app1', label: 'App 1' },
+            { id: 'app2', label: 'App 2' },
+            { id: 'app3', label: 'App 3' },
+          ],
+        },
         redirect: (pathWithHash) => {
           if (pathWithHash.includes('#')) {
             const newPath = pathWithHash.replace(

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -5,7 +5,9 @@ import { ScalarErrorBoundary } from '@scalar/components'
 import type { Spec } from '@scalar/types/legacy'
 import { computed } from 'vue'
 
+import VersionSelect from '@/components/Content/Introduction/VersionSelect.vue'
 import { BaseUrl } from '@/features/BaseUrl'
+import { useConfig } from '@/hooks/useConfig'
 
 import { getModels, hasModels } from '../../helpers'
 import { useSidebar } from '../../hooks'
@@ -28,6 +30,8 @@ const props = withDefaults(
 
 const { hideModels } = useSidebar()
 const { securitySchemes } = useWorkspace()
+const { versionSelect } = useConfig()
+
 const {
   activeCollection,
   activeEnvVariables,
@@ -67,11 +71,21 @@ const introCardsSlot = computed(() =>
           <div
             class="introduction-card"
             :class="{ 'introduction-card-row': layout === 'classic' }">
+            <!-- Version Select -->
+            <div
+              v-if="versionSelect?.versions"
+              class="scalar-client introduction-card-item">
+              <VersionSelect :versionSelect="versionSelect" />
+            </div>
+
+            <!-- Server Selector -->
             <div
               v-if="activeCollection?.servers?.length"
               class="scalar-client introduction-card-item divide-y text-sm [--scalar-address-bar-height:0px]">
               <BaseUrl />
             </div>
+
+            <!-- Authentication -->
             <div
               v-if="
                 activeCollection &&
@@ -91,6 +105,8 @@ const introCardsSlot = computed(() =>
                 title="Authentication"
                 :workspace="activeWorkspace" />
             </div>
+
+            <!-- Client Libraries -->
             <ClientLibraries class="introduction-card-item" />
           </div>
         </ScalarErrorBoundary>

--- a/packages/api-reference/src/components/Content/Introduction/VersionSelect.vue
+++ b/packages/api-reference/src/components/Content/Introduction/VersionSelect.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import type { ReferenceConfiguration } from '@scalar/types/legacy'
+import { ref } from 'vue'
+
+const { versionSelect } = defineProps<{
+  versionSelect: NonNullable<ReferenceConfiguration['versionSelect']>
+}>()
+
+/** Grab the initial version from the versions array else the first version */
+const initialVersion =
+  versionSelect.versions.find(
+    ({ id }) => id === versionSelect.initialVersion,
+  ) || versionSelect.versions[0]
+
+/** Keep track of the currently selected version */
+const selectedVersion = ref<{ id: string; label: string }>(initialVersion)
+</script>
+<template>
+  <label class="bg-b-2 flex h-8 items-center px-3 py-2.5 text-sm font-medium">
+    {{ versionSelect?.label ?? 'Versions' }}
+  </label>
+
+  <ScalarListbox
+    v-if="versionSelect?.versions?.length"
+    :options="versionSelect?.versions"
+    v-model="selectedVersion"
+    @update:modelValue="versionSelect?.callback"
+    placement="bottom-start"
+    resize>
+    <ScalarButton
+      class="gap-0.75 text-c-1 h-6.5 w-full justify-start whitespace-nowrap rounded-b-lg px-3 py-1.5 text-xs font-normal -outline-offset-1 lg:text-sm"
+      variant="ghost">
+      {{ selectedVersion?.label }}
+      <ScalarIcon
+        class="text-c-2"
+        icon="ChevronDown"
+        size="sm" />
+    </ScalarButton>
+  </ScalarListbox>
+</template>

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -358,6 +358,28 @@ export type ReferenceConfiguration = {
    * @default false
    */
   hideClientButton?: boolean
+  /**
+   * A fully customizable list with callback which is placed above the server select
+   * This API is experimental and subject to change
+   */
+  versionSelect?: {
+    /**
+     * The label to display for the select
+     */
+    label: string
+    /**
+     * The callback to call when an option is selected
+     */
+    callback: (version: { id: string; label: string }) => void
+    /**
+     * The initial version to select by id
+     */
+    initialVersion?: string
+    /**
+     * The options for the select
+     */
+    versions: { id: string; label: string }[]
+  }
 }
 
 export type BaseParameter = {


### PR DESCRIPTION
Just built a "version" selector that can be used for anything really. Open to different naming

![image](https://github.com/user-attachments/assets/f06976dd-cb52-470c-b599-ab7dc848dae0)

To test:
```zsh
cd packages/api-reference
pnpm playground:esm
```

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
