### PR TITLE
fix(api-client): add keyboard instructions for code inputs

### DIFF
--- a/.changeset/fuzzy-papayas-shop.md
+++ b/.changeset/fuzzy-papayas-shop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: add keyboard instructions for code inputs

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -211,6 +211,8 @@ const handleKeyDown = (key: string, event: KeyboardEvent) => {
       event.preventDefault()
       dropdownRef.value?.handleSelect()
     }
+  } else if (key === 'escape') {
+    if (!props.disableTabIndent) event.stopPropagation()
   } else if (key === 'enter' && event.target instanceof HTMLDivElement) {
     handleSubmit(event.target.textContent ?? '')
   }
@@ -265,12 +267,13 @@ export default {
       :id="uid"
       v-bind="$attrs"
       ref="codeMirrorRef"
-      class="group-[.alert]:outline-orange group-[.error]:outline-red font-code peer relative w-full overflow-hidden whitespace-nowrap text-xs leading-[1.44] -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline"
+      class="group/input group-[.alert]:outline-orange group-[.error]:outline-red font-code peer relative w-full overflow-hidden whitespace-nowrap text-xs leading-[1.44] -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline"
       :class="{
         'flow-code-input--error': error,
       }"
       @keydown.down.stop="handleKeyDown('down', $event)"
       @keydown.enter="handleKeyDown('enter', $event)"
+      @keydown.escape="handleKeyDown('escape', $event)"
       @keydown.up.stop="handleKeyDown('up', $event)">
       <div
         v-if="isCopyable"
@@ -285,6 +288,14 @@ export default {
             icon="Clipboard"
             size="md" />
         </button>
+      </div>
+      <div
+        v-if="!disableTabIndent"
+        class="z-context text-c-2 absolute bottom-1 right-1.5 hidden font-sans group-has-[:focus-visible]/input:block"
+        role="alert">
+        Press
+        <kbd class="-mx-0.25 rounded border px-0.5 font-mono">Esc</kbd> then
+        <kbd class="-mx-0.25 rounded border px-0.5 font-mono">Tab</kbd> to exit
       </div>
     </div>
   </template>


### PR DESCRIPTION
Adds visual and screen reader instructions for exiting the code mirror input. I tried to add a screen reader label to the code mirror input but wasn't able to get it working so this just uses an alert for now.

![Google Chrome-2025-03-05-03-45-20@2x](https://github.com/user-attachments/assets/f2569b20-2198-45d3-821a-eda4e80c9a4f)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
