### PR TITLE
fix(api-client): multi form upload

### DIFF
--- a/.changeset/proud-spies-fetch.md
+++ b/.changeset/proud-spies-fetch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates request table form style and logic"

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -367,12 +367,22 @@ const removeBinaryFile = () =>
 function handleRemoveFileFormData(rowIdx: number) {
   const currentParams = formParams.value
   const updatedParams = [...currentParams]
+  const param = currentParams[rowIdx]
+  const file = param?.file as File | undefined
 
-  if (currentParams.length > 1) {
-    // Removes the row if not the last one
+  // Empty key value or non updated file name then remove the row
+  if (
+    currentParams.length > 1 &&
+    ((!param?.key && !param?.value) ||
+      (file && param?.key === file.name && param?.value === file.name))
+  ) {
     updatedParams.splice(rowIdx, 1)
   } else {
-    defaultRow()
+    // File name updated then remove file only
+    const param = updatedParams[rowIdx]
+    if (param) {
+      param.file = undefined
+    }
   }
   requestExampleMutators.edit(example.uid, 'body.formData.value', updatedParams)
 }

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -96,7 +96,7 @@ const flattenValue = (item: RequestExampleParameter) => {
               </template>
               <template #content>
                 <div
-                  class="w-content bg-b-1 z-100 text-xxs text-c-1 pointer-events-none z-10 grid max-w-[320px] gap-1.5 rounded p-2 leading-5 shadow-lg">
+                  class="w-content bg-b-1 text-xxs text-c-1 z-100 pointer-events-none z-10 grid max-w-[320px] gap-1.5 rounded p-2 leading-5 shadow-lg">
                   <div class="text-c-1 flex items-center">
                     <span class="text-pretty">
                       Global cookies are shared across the whole workspace.
@@ -173,10 +173,10 @@ const flattenValue = (item: RequestExampleParameter) => {
       </DataTableCell>
       <DataTableCell
         v-if="showUploadButton"
-        class="group/upload relative overflow-hidden text-ellipsis whitespace-nowrap p-1">
+        class="group/upload flex items-center justify-center whitespace-nowrap">
         <template v-if="item.file">
           <div
-            class="text-c-2 filemask flex max-w-[100%] items-end justify-end overflow-hidden">
+            class="text-c-2 filemask flex w-full max-w-[100%] items-end justify-end overflow-hidden p-1">
             <span>{{ item.file?.name }}</span>
           </div>
           <button
@@ -187,18 +187,20 @@ const flattenValue = (item: RequestExampleParameter) => {
           </button>
         </template>
         <template v-else>
-          <ScalarButton
-            class="bg-b-2 hover:bg-b-3 text-c-2 border-0 py-px shadow-none"
-            size="sm"
-            variant="outlined"
-            @click="handleFileUpload(idx)">
-            <span>Upload File</span>
-            <ScalarIcon
-              class="ml-1"
-              icon="UploadSimple"
-              size="xs"
-              thickness="2.5" />
-          </ScalarButton>
+          <div class="p-0.5">
+            <ScalarButton
+              class="bg-b-2 hover:bg-b-3 text-c-2 h-fit border-0 py-px shadow-none"
+              size="sm"
+              variant="outlined"
+              @click="handleFileUpload(idx)">
+              <span>Upload File</span>
+              <ScalarIcon
+                class="ml-1"
+                icon="UploadSimple"
+                size="xs"
+                thickness="2.5" />
+            </ScalarButton>
+          </div>
         </template>
       </DataTableCell>
     </DataTableRow>


### PR DESCRIPTION
**Problem**

currently the multi form upload style is broken.

**Solution**

this pr updates the multi form styles + its logic in order to remove the file only if the key have been updated, otherwise the all row.

| before | after |
| -------|------|
| <img width="612" alt="image" src="https://github.com/user-attachments/assets/4a27a21b-7dd0-460b-91c1-0288ecc54e1d" /> | <img width="612" alt="image" src="https://github.com/user-attachments/assets/73649c0d-0d23-470d-8de9-453aa5256ce6" /> |
| overflowing row creating a gap | row height is preserved | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
