### PR TITLE
fix(oas-utils): request examples type

### DIFF
--- a/.changeset/dull-carpets-grab.md
+++ b/.changeset/dull-carpets-grab.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: updates request examples schema type support"

--- a/packages/oas-utils/src/entities/spec/request-example.test.ts
+++ b/packages/oas-utils/src/entities/spec/request-example.test.ts
@@ -233,6 +233,31 @@ describe('createParamInstance', () => {
       value: '',
     })
   })
+
+  it('works with schema examples containing numbers', () => {
+    const result = createParamInstance({
+      in: 'query',
+      name: 'foo',
+      required: true,
+      deprecated: false,
+      schema: {
+        default: 1,
+        type: 'integer',
+        examples: [1, 2, 3],
+      },
+    })
+
+    expect(result).toEqual({
+      key: 'foo',
+      value: '1',
+      enabled: true,
+      description: undefined,
+      required: true,
+      examples: ['1', '2', '3'],
+      type: 'integer',
+      default: 1,
+    })
+  })
 })
 
 describe('parameterArrayToObject', () => {

--- a/packages/oas-utils/src/entities/spec/request-example.test.ts
+++ b/packages/oas-utils/src/entities/spec/request-example.test.ts
@@ -229,7 +229,6 @@ describe('createParamInstance', () => {
       description: undefined,
       required: true,
       type: 'string',
-      nullable: true,
       value: '',
     })
   })
@@ -256,6 +255,29 @@ describe('createParamInstance', () => {
       examples: ['1', '2', '3'],
       type: 'integer',
       default: 1,
+    })
+  })
+
+  it('works with nested array types', () => {
+    const result = createParamInstance({
+      in: 'path',
+      name: 'foo',
+      required: true,
+      deprecated: false,
+      schema: {
+        type: [['string', 'number'], 'null'],
+      },
+    })
+
+    expect(result).toEqual({
+      key: 'foo',
+      enabled: true,
+      enum: undefined,
+      examples: undefined,
+      description: undefined,
+      required: true,
+      type: ['string', 'number'],
+      value: '',
     })
   })
 })

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -27,7 +27,10 @@ export const requestExampleParametersSchema = z
     description: z.string().optional(),
     required: z.boolean().optional(),
     enum: z.array(z.string()).optional(),
-    examples: z.array(z.string()).optional(),
+    examples: z
+      .array(z.union([z.string(), z.number()]))
+      .transform((examples) => examples?.map(String))
+      .optional(),
     type: z
       .union([
         // 'string'


### PR DESCRIPTION
**Problem**

currently on number usage in examples or array usage in type.

**Solution**

this pr updates the support accordingly.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
