### PR TITLE
fix(build-tooling): ci build

### DIFF
--- a/.changeset/good-seas-swim.md
+++ b/.changeset/good-seas-swim.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+fix: update turbo cache key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-${{ github.sha }}
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-${{ github.sha }}-v2
 
   docker:
     name: Build and Tag Docker Image


### PR DESCRIPTION
**Problem**

Currently our CI has broken, build tooling seems to be missing although it is there locally.

**Solution**

With this PR we just kill the turbo cache in case that is the issue, as we didn't change anything.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
