### PR TITLE
fix(galaxy): types missing from galaxy docker file

### DIFF
--- a/.changeset/mean-flowers-shave.md
+++ b/.changeset/mean-flowers-shave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+fix: add types package to galaxy docker file

--- a/packages/galaxy/Dockerfile
+++ b/packages/galaxy/Dockerfile
@@ -19,6 +19,7 @@ RUN chown node:node /app
 COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/packages/mock-server /app/packages/mock-server
 COPY --from=builder /app/packages/api-reference /app/packages/api-reference
+COPY --from=builder /app/packages/types /app/packages/types
 COPY --from=builder /app/integrations/hono /app/integrations/hono
 COPY --from=builder /app/packages/oas-utils /app/packages/oas-utils
 COPY --from=builder /app/packages/openapi-parser /app/packages/openapi-parser


### PR DESCRIPTION
**Problem**

Currently, the types package was missing from galaxy

**Solution**

With this PR we add the types package

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
