### PR TITLE
fix(api-client): handle UTF-8 encoded file names for content-disposition header

### DIFF
--- a/.changeset/long-dancers-wash.md
+++ b/.changeset/long-dancers-wash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: handle utf-8 encoded file names for content-disposition header

--- a/packages/api-client/src/libs/extractAttachmentFilename.test.ts
+++ b/packages/api-client/src/libs/extractAttachmentFilename.test.ts
@@ -49,4 +49,11 @@ describe('extractFileName', () => {
     const result = extractFilename(contentDisposition)
     expect(result).toEqual('สวัสดี.pdf')
   })
+
+  it('should give priority to encoded utf-8 filenames', () => {
+    const contentDisposition = `attachment; filename=____________________28.02.2025.xlsx; filename*=UTF-8''%D0%98%D0%BD%D0%B4%D0%B8%D0%B2%D0%B8%D0%B4%D1%83%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%B9%D0%9E%D1%82%D1%87%D0%B5%D1%82_28.02.2025.xlsx`
+
+    const result = extractFilename(contentDisposition)
+    expect(result).toEqual('ИндивидуальныйОтчет_28.02.2025.xlsx')
+  })
 })

--- a/packages/api-client/src/libs/extractAttachmentFilename.ts
+++ b/packages/api-client/src/libs/extractAttachmentFilename.ts
@@ -1,7 +1,7 @@
 const decodeURIComponentSafe = (str: string) => {
   try {
     return decodeURIComponent(str)
-  } catch (e) {
+  } catch {
     return str
   }
 }
@@ -13,11 +13,13 @@ export function extractFilename(contentDisposition: string) {
   let filename = ''
 
   if (contentDisposition) {
-    const fileNameMatch = contentDisposition.match(/filename\s*=\s*"?([^";]+)"?/)
+    const fileNameMatch =
+      contentDisposition.match(/filename\*=UTF-8''([^;]+)/)?.[1] ??
+      contentDisposition.match(/filename\s*=\s*"?([^";]+)"?/)?.[1]
 
-    if (typeof fileNameMatch?.[1] === 'string') {
+    if (fileNameMatch) {
       // Decode filename
-      filename = decodeURIComponentSafe(fileNameMatch[1].trim())
+      filename = decodeURIComponentSafe(fileNameMatch.trim())
     }
   }
 


### PR DESCRIPTION
See related issue #4925 

**Checklist**

I’ve gone through the following:

- [X] I’ve added an explanation _why_ this change is needed.
- [X] I’ve added a changeset (`pnpm changeset`).
- [X] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
