### PR TITLE
fix: add types to hono

### DIFF
--- a/.changeset/gentle-ears-end.md
+++ b/.changeset/gentle-ears-end.md
@@ -1,0 +1,5 @@
+---
+'@scalar/hono-api-reference': patch
+---
+
+fix: hono types cloud build

--- a/integrations/hono/Dockerfile
+++ b/integrations/hono/Dockerfile
@@ -24,6 +24,7 @@ RUN chown node:node /app
 
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/packages/types /app/packages/types
 COPY --from=builder /app/packages/api-reference /app/packages/api-reference
 COPY --from=builder /app/integrations/hono /app/integrations/hono
 


### PR DESCRIPTION
**Problem**

Currently, hono docker is missing types

**Solution**

With this PR we add types to docker

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
