### PR TITLE
ci: build Docker base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-${{ github.sha }}-v2
 
   docker-base:
-    name: Build and Tag Base Docker Image
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -62,7 +61,6 @@ jobs:
           cache-to: type=gha,mode=max
 
   docker-api-reference:
-    name: Build and Tag Docker Image
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,30 @@ jobs:
           path: .turbo
           key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}-${{ github.sha }}-v2
 
-  docker:
+  docker-base:
+    name: Build and Tag Base Docker Image
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
+
+      - name: Build and tag Docker image
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991
+        with:
+          context: .
+          file: tooling/base-docker-builder/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: scalar-base:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-api-reference:
     name: Build and Tag Docker Image
     runs-on: ubuntu-22.04
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
       - name: Set up Docker
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
-
       - name: Build and tag Docker image
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991
         with:
@@ -80,16 +78,13 @@ jobs:
               - packages/api-reference/docker/**
             api_reference_docker_version:
               - packages/api-reference/docker/package.json
-
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Set up Docker
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
-
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Get version from package.json
         id: package-version
         run: echo "VERSION=$(node -p "require('./packages/api-reference/docker/package.json').version")" >> "$GITHUB_OUTPUT"
-
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Build and tag Docker image
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991
@@ -103,7 +98,6 @@ jobs:
           tags: |
             scalarapi/api-reference:latest
             scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
-
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Scan for vulnerabilities
         uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0
@@ -117,7 +111,6 @@ jobs:
           severity: 'CRITICAL,HIGH'
           retry-count: 3
           retry-delay: 30s
-
       - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
         name: Log in to DockerHub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
@@ -126,7 +119,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           # https://app.docker.com/settings/personal-access-tokens
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
         name: Push Docker image
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991


### PR DESCRIPTION
**Problem**

Currently, we build the Docker images only in main and we break them every few days.

**Solution**

This PR builds the base Docker image in PRs.

I failed to build the other Docker images, but at least we’re building the one. Tiny step.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
