### PR TITLE
feat(api-reference): content type select

### DIFF
--- a/.changeset/rich-suns-learn.md
+++ b/.changeset/rich-suns-learn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: favors scalar dropdown as content type selector

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.test.ts
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.test.ts
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import ContentTypeSelect from './ContentTypeSelect.vue'
+
+describe('ContentTypeSelect', () => {
+  it('renders with multiple content types as a dropdown', async () => {
+    const wrapper = mount(ContentTypeSelect, {
+      props: {
+        requestBody: {
+          content: {
+            'application/json': {},
+            'application/xml': {},
+          },
+        },
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).exists()).toBe(true)
+    expect(wrapper.text()).toContain('application/json')
+  })
+
+  it('renders with a single content type as plain text', async () => {
+    const wrapper = mount(ContentTypeSelect, {
+      props: {
+        requestBody: {
+          content: {
+            'application/json': {},
+          },
+        },
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).exists()).toBe(false)
+    expect(wrapper.text()).toContain('application/json')
+  })
+
+  it('uses the default value when provided', async () => {
+    const wrapper = mount(ContentTypeSelect, {
+      props: {
+        requestBody: {
+          content: {
+            'application/json': {},
+            'application/xml': {},
+          },
+        },
+        defaultValue: 'application/xml',
+      },
+    })
+
+    expect(wrapper.text()).toContain('application/xml')
+  })
+})

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
@@ -65,7 +65,7 @@ const contentTypeSelect = cva({
 <template>
   <ScalarListbox
     v-if="prop?.requestBody && contentTypes.length > 1"
-    :modelValue="selectedOption"
+    v-model="selectedOption"
     :options="options"
     placement="bottom-end"
     @update:modelValue="handleSelectContentType"

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
+import {
+  cva,
+  ScalarButton,
+  ScalarIcon,
+  ScalarListbox,
+} from '@scalar/components'
 import type { ContentType, RequestBody } from '@scalar/types/legacy'
 import { computed, ref } from 'vue'
+
+import ScreenReader from '@/components/ScreenReader.vue'
 
 const prop = defineProps<{
   requestBody?: RequestBody
@@ -11,13 +19,10 @@ const emit = defineEmits<{
   (e: 'selectContentType', payload: { contentType: ContentType }): void
 }>()
 
-const handleSelectChange = (event: Event) => {
-  const target = event.target as HTMLSelectElement
-  const contentType = target.value as ContentType
-
-  selectedContentType.value = contentType
-
-  emit('selectContentType', { contentType })
+const handleSelectContentType = (option: any) => {
+  if (option?.id) {
+    emit('selectContentType', { contentType: option.id as ContentType })
+  }
 }
 
 const contentTypes = computed(() => {
@@ -30,101 +35,58 @@ const contentTypes = computed(() => {
 const selectedContentType = ref<ContentType>(
   prop.defaultValue || (contentTypes.value[0] as ContentType),
 )
+
+const selectedOption = computed({
+  get: () =>
+    options.value.find((option) => option.id === selectedContentType.value),
+  set: (option) => {
+    if (option) selectedContentType.value = option.id as ContentType
+  },
+})
+
+const options = computed(() => {
+  return contentTypes.value.map((type) => ({
+    id: type,
+    label: type,
+  }))
+})
+
+// Content type select style variant based on dropdown availability
+const contentTypeSelect = cva({
+  base: 'font-normal text-c-2 bg-b-2 py-0.75 flex cursor-pointer items-center gap-1 rounded-full text-xs',
+  variants: {
+    dropdown: {
+      true: 'border hover:text-c-1 pl-2 pr-1.5',
+      false: 'px-2',
+    },
+  },
+})
 </script>
 <template>
-  <label
-    class="content-type-select"
-    :class="{ 'content-type-no-select': contentTypes.length <= 1 }">
+  <ScalarListbox
+    v-if="prop?.requestBody && contentTypes.length > 1"
+    :modelValue="selectedOption"
+    :options="options"
+    placement="bottom-end"
+    @update:modelValue="handleSelectContentType"
+    class="font-normal">
+    <ScalarButton
+      variant="ghost"
+      class="h-fit"
+      :class="contentTypeSelect({ dropdown: true })">
+      <ScreenReader>Selected Content Type:</ScreenReader>
+      <span>{{ selectedContentType }}</span>
+      <ScalarIcon
+        class="ui-open:rotate-180 ml-auto"
+        icon="ChevronDown"
+        size="sm"
+        thickness="2" />
+    </ScalarButton>
+  </ScalarListbox>
+  <div
+    v-else
+    :class="contentTypeSelect({ dropdown: false })"
+    tabindex="0">
     <span>{{ selectedContentType }}</span>
-    <select
-      v-if="prop?.requestBody && contentTypes.length > 1"
-      :value="selectedContentType"
-      @change="handleSelectChange($event)"
-      @keydown.stop>
-      <option
-        v-for="(_, key) in prop.requestBody?.content"
-        :key="key"
-        :value="key"
-        @keydown.stop>
-        {{ key }}
-      </option>
-    </select>
-  </label>
+  </div>
 </template>
-<style scoped>
-.content-type {
-  display: flex;
-  align-items: center;
-  font-size: var(--scalar-font-size-2);
-  font-weight: var(--scalar-semibold);
-  color: var(--scalar-color-1);
-  line-height: 1.45;
-  margin-top: 24px;
-  padding-bottom: 12px;
-  border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
-  flex-flow: wrap;
-}
-.content-type-select {
-  position: relative;
-  height: fit-content;
-  margin-left: auto;
-  font-weight: var(--scalar-regular);
-  display: flex;
-  align-items: center;
-  color: var(--scalar-color-3);
-  font-size: var(--scalar-micro);
-  background: var(--scalar-background-2);
-  padding: 3px 6px 4px 8px;
-  border-radius: 12px;
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
-}
-.content-type-no-select.content-type-select {
-  padding: 3px 8px 4px 8px;
-  pointer-events: none;
-}
-.content-type-no-select {
-  border: none;
-}
-.content-type-no-select.content-type-select:after {
-  display: none;
-}
-.content-type-select span {
-  display: flex;
-  align-items: center;
-}
-.content-type-select:after {
-  content: '';
-  width: 6px;
-  height: 6px;
-  transform: rotate(45deg) translate3d(0, -3px, 0);
-  display: block;
-  margin-left: 6px;
-  box-shadow: 1px 1px 0 currentColor;
-  margin-right: 5px;
-}
-.content-type-select select {
-  border: none;
-  outline: none;
-  cursor: pointer;
-  background: var(--scalar-background-3);
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  appearance: none;
-}
-.content-type-select:hover {
-  color: var(--scalar-color-1);
-}
-.content-type-select:has(select:focus-visible) {
-  outline: 1px solid var(--scalar-color-accent);
-}
-@media (max-width: 460px) {
-  .content-type-select {
-    margin-left: auto;
-    padding-right: 3px;
-  }
-}
-</style>

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -60,11 +60,11 @@ const shouldShowParameter = computed(() => {
 <template>
   <li
     v-if="shouldShowParameter"
-    class="parameter-item">
+    class="parameter-item group/parameter-item relative">
     <Disclosure v-slot="{ open }">
       <DisclosureButton
         v-if="shouldCollapse"
-        class="parameter-item-trigger group/parameter-item-trigger flex"
+        class="parameter-item-trigger flex"
         :class="{ 'parameter-item-trigger-open': open }">
         <ScalarIcon
           class="parameter-item-icon"
@@ -79,17 +79,6 @@ const shouldShowParameter = computed(() => {
             class="markdown"
             :value="parameter.description" />
         </span>
-        <div
-          class="absolute right-0 top-2.5 opacity-0 group-focus-within/parameter-item-trigger:opacity-100 group-hover/parameter-item-trigger:opacity-100">
-          <ContentTypeSelect
-            v-if="shouldCollapse && props.parameter.content"
-            class="parameter-item-content-type"
-            :defaultValue="selectedContentType"
-            :requestBody="props.parameter"
-            @selectContentType="
-              ({ contentType }) => (selectedContentType = contentType)
-            " />
-        </div>
       </DisclosureButton>
       <DisclosurePanel
         class="parameter-item-container parameter-item-container-markdown"
@@ -111,6 +100,17 @@ const shouldShowParameter = computed(() => {
           :withExamples="withExamples" />
       </DisclosurePanel>
     </Disclosure>
+    <div
+      class="absolute right-0 top-2.5 opacity-0 group-focus-within/parameter-item:opacity-100 group-hover/parameter-item:opacity-100">
+      <ContentTypeSelect
+        v-if="shouldCollapse && props.parameter.content"
+        class="parameter-item-content-type"
+        :defaultValue="selectedContentType"
+        :requestBody="props.parameter"
+        @selectContentType="
+          ({ contentType }) => (selectedContentType = contentType)
+        " />
+    </div>
   </li>
 </template>
 

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -46,6 +46,7 @@ if (requestBody?.content) {
 .request-body-title {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   font-size: var(--scalar-font-size-2);
   font-weight: var(--scalar-semibold);
   color: var(--scalar-color-1);

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -78,7 +78,8 @@ const { cx } = useBindCx()
           <!-- Scroll container -->
           <div class="custom-scroll min-h-0 flex-1">
             <!-- Options list -->
-            <ListboxOptions class="flex flex-col gap-0.75 p-0.75">
+            <ListboxOptions
+              class="flex flex-col gap-0.75 p-0.75 -outline-offset-1">
               <ScalarListboxOption
                 v-for="option in options"
                 :key="option.id"


### PR DESCRIPTION
**Problem**

currently the content type selector is using browser native dropdown.

**Solution**

this pr is a proposal to use the scalar dropdown component.

| before | after |
| -------|------|
| <img width="370" alt="image" src="https://github.com/user-attachments/assets/4a1d45c9-e5a5-4ca1-8fcc-a5845602b449" /> | <img width="370" alt="image" src="https://github.com/user-attachments/assets/c9f42d2b-78c2-4b00-a2e1-35a1cf4a12a8" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
