### PR TITLE
feat(api-reference): remove `spec` prefix 🌶️

### DIFF
--- a/.changeset/mighty-mayflies-buy.md
+++ b/.changeset/mighty-mayflies-buy.md
@@ -1,0 +1,21 @@
+---
+'@scalar/api-reference-editor': minor
+'@scalar/api-reference-react': minor
+'@scalar/api-client-react': minor
+'@scalar/docusaurus': minor
+'@scalar/nextjs-openapi': minor
+'@scalar/api-reference': minor
+'@scalar/express-api-reference': minor
+'@scalar/fastify-api-reference': minor
+'@scalar/mock-server': minor
+'@scalar/play-button': minor
+'@scalar/nestjs-api-reference': minor
+'@scalar/nextjs-api-reference': minor
+'@scalar/api-client': minor
+'@scalar/hono-api-reference': minor
+'@scalar/nuxt': minor
+'@scalar/import': minor
+'@scalar/types': minor
+---
+
+feat!: remove the spec prefix, make content and url top-level attributes

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -12,27 +12,45 @@ Whether the Swagger editor should be shown.
 }
 ```
 
-#### spec.content?: string
+#### content?: string | Record<string, any> | () => Record<string, any>
 
-Directly pass an OpenAPI/Swagger document (JSON or YAML).
+Directly pass an OpenAPI/Swagger document (JSON or YAML) as a string:
 
 ```js
 {
-  spec: {
-    content: '{ … }'
+  content: '{ "openapi": "3.1.1" }'
+}
+```
+
+Or as a JavaScript object:
+
+```js
+{
+  content: {
+    openapi: '3.1.1',
   }
 }
 ```
 
-#### spec.url?: string
+Or as a callback returning the actual document:
+
+```js
+{
+  content() {
+    return {
+      openapi: '3.1.1',
+    }
+  }
+}
+```
+
+#### url?: string
 
 Pass the URL of an OpenAPI document (JSON or YAML).
 
 ```js
 {
-  spec: {
-    url: '/openapi.json'
-  }
+  url: '/openapi.json'
 }
 ```
 

--- a/documentation/integrations/docusaurus.md
+++ b/documentation/integrations/docusaurus.md
@@ -59,10 +59,8 @@ const config = {
         label: 'Scalar',
         route: '/scalar',
         configuration: {
-          spec: {
-            // Put the URL to your OpenAPI document here:
-            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-          },
+          // Put the URL to your OpenAPI document here:
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         },
       },
     ],
@@ -92,10 +90,8 @@ const config: Config = {
         label: 'Scalar',
         route: '/scalar',
         configuration: {
-          spec: {
-            // Put the URL to your OpenAPI document here:
-            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-          },
+          // Put the URL to your OpenAPI document here:
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         },
       } as ScalarOptions,
     ],

--- a/documentation/integrations/nextjs.md
+++ b/documentation/integrations/nextjs.md
@@ -49,9 +49,7 @@ npm add @scalar/nextjs-api-reference
 import { ApiReference } from '@scalar/nextjs-api-reference'
 
 const config = {
-  spec: {
-    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-  },
+  url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
 }
 
 export const GET = ApiReference(config)
@@ -78,9 +76,7 @@ export default function References() {
   return (
     <ApiReferenceReact
       configuration={{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
       }}
     />
   )

--- a/documentation/integrations/react.md
+++ b/documentation/integrations/react.md
@@ -68,9 +68,7 @@ function App() {
   return (
     <ApiReferenceReact
       configuration={{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
       }}
     />
   )

--- a/examples/nextjs-api-reference/app/another-reference/page.tsx
+++ b/examples/nextjs-api-reference/app/another-reference/page.tsx
@@ -6,9 +6,7 @@ export default function ApiReferencePage() {
   return (
     <ApiReferenceReact
       configuration={{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
         withDefaultFonts: false,
         hideModels: true,
         tagsSorter: 'alpha',

--- a/examples/nextjs-api-reference/app/client/components/ClientWrapper.tsx
+++ b/examples/nextjs-api-reference/app/client/components/ClientWrapper.tsx
@@ -14,9 +14,7 @@ export const ClientWrapper = ({
     <ApiClientModalProvider
       initialRequest={initialRequest}
       configuration={{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       }}>
       {children}
     </ApiClientModalProvider>

--- a/examples/nextjs-api-reference/app/reference/route.ts
+++ b/examples/nextjs-api-reference/app/reference/route.ts
@@ -1,9 +1,7 @@
 import { ApiReference } from '@scalar/nextjs-api-reference'
 
 const config = {
-  spec: {
-    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-  },
+  url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
 }
 
 export const GET = ApiReference(config)

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -24,9 +24,7 @@ function App() {
   return (
     <ApiReferenceReact
       configuration={{
-        spec: {
-          content: spec,
-        },
+        content: spec,
       }}
     />
   )

--- a/examples/ssg/src/App.vue
+++ b/examples/ssg/src/App.vue
@@ -8,9 +8,7 @@ import '@scalar/api-reference/style.css'
   <div>
     <ApiReference
       :configuration="{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       }" />
   </div>
 </template>

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -19,7 +19,7 @@ const configuration = reactive<Partial<ApiReferenceConfiguration>>({
   isEditable: false,
   showSidebar: true,
   layout: 'modern',
-  spec: { content },
+  content,
   // authentication: {
   //   // The OpenAPI file has keys for all security schemes:
   //   // Which one should be used by default?

--- a/examples/web/src/pages/ApiReferenceTestPage.vue
+++ b/examples/web/src/pages/ApiReferenceTestPage.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { ApiReference, type ReferenceLayoutType } from '@scalar/api-reference'
+import { ApiReference } from '@scalar/api-reference'
 import content from '@scalar/galaxy/latest.yaml?raw'
-import type { ThemeId } from '@scalar/themes'
 import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
 import { reactive } from 'vue'
 import { useRoute } from 'vue-router'
@@ -14,7 +13,7 @@ const configuration = reactive(
     isEditable: false,
     layout: `${route.params['layout']}`,
     darkMode: !!route.query['darkMode'],
-    spec: { content },
+    content,
   }),
 )
 </script>

--- a/examples/web/src/pages/ClassicApiReferencePage.vue
+++ b/examples/web/src/pages/ClassicApiReferencePage.vue
@@ -10,7 +10,7 @@ const configuration = reactive(
     proxyUrl: import.meta.env.VITE_REQUEST_PROXY_URL,
     isEditable: false,
     layout: 'classic',
-    spec: { content },
+    content,
   }),
 )
 </script>

--- a/examples/web/src/pages/StandaloneApiReferencePage.vue
+++ b/examples/web/src/pages/StandaloneApiReferencePage.vue
@@ -16,9 +16,7 @@ const configuration = reactive(
           pathRouting: { basePath: '/path-routing' },
         }
       : {}),
-    spec: {
-      content,
-    },
+    content,
   }),
 )
 </script>

--- a/integrations/docusaurus/README.md
+++ b/integrations/docusaurus/README.md
@@ -28,9 +28,7 @@ plugins: [
       route: '/scalar',
       showNavLink: true, // optional, default is true
       configuration: {
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
       },
     } as ScalarOptions,
   ],
@@ -57,9 +55,7 @@ plugins: [
       route: '/scalar',
       showNavLink: true, // optional, default is true
       configuration: {
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       },
     } as ScalarOptions,
   ],
@@ -73,9 +69,7 @@ plugins: [
       route: '/petstore',
       showNavLink: true, // optional, default is true
       configuration: {
-        spec: {
-          url: 'https://petstore3.swagger.io/api/v3/openapi.json',
-        },
+        url: 'https://petstore3.swagger.io/api/v3/openapi.json',
       },
     } as ScalarOptions,
   ],

--- a/integrations/docusaurus/package.json
+++ b/integrations/docusaurus/package.json
@@ -38,7 +38,8 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@scalar/api-reference-react": "workspace:*"
+    "@scalar/api-reference-react": "workspace:*",
+    "@scalar/types": "workspace:*"
   },
   "devDependencies": {
     "@docusaurus/types": "^3.6.0",

--- a/integrations/docusaurus/playground/docusaurus.config.ts
+++ b/integrations/docusaurus/playground/docusaurus.config.ts
@@ -60,9 +60,7 @@ const config: Config = {
         label: 'json-url',
         route: '/json-url',
         configuration: {
-          spec: {
-            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-          },
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         },
       } as ScalarOptions,
     ],
@@ -73,9 +71,7 @@ const config: Config = {
         label: 'yaml-url',
         route: '/yaml-url',
         configuration: {
-          spec: {
-            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-          },
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
         },
       } as ScalarOptions,
     ],
@@ -86,8 +82,7 @@ const config: Config = {
         label: 'json-string',
         route: '/json-string',
         configuration: {
-          spec: {
-            content: `{
+          content: `{
   "openapi": "3.1.0",
   "info": {
     "title": "JSON Docs",
@@ -95,7 +90,6 @@ const config: Config = {
   },
   "paths": {}
 }`,
-          },
         },
       } as ScalarOptions,
     ],
@@ -106,14 +100,12 @@ const config: Config = {
         label: 'yaml-string',
         route: '/yaml-string',
         configuration: {
-          spec: {
-            content: `openapi: 3.1.0
+          content: `openapi: 3.1.0
 info:
   title: YAML Docs
   version: 1.0.0
 paths: {}
 `,
-          },
         },
       } as ScalarOptions,
     ],

--- a/integrations/docusaurus/src/ScalarDocusaurusCommonJS.tsx
+++ b/integrations/docusaurus/src/ScalarDocusaurusCommonJS.tsx
@@ -58,20 +58,20 @@ class ScalarDocusaurusCommonJS extends Component<Props> {
             )
           } else {
             // Execute content function if it exists
-            if (typeof config.spec?.content === 'function') {
-              config.spec.content = config.spec.content()
+            if (typeof config?.content === 'function') {
+              config.content = config.content()
             }
 
             // Convert the document to a string
-            const documentString = config?.spec?.content
-              ? typeof config?.spec?.content === 'string'
-                ? config.spec.content
-                : JSON.stringify(config.spec.content)
+            const documentString = config?.content
+              ? typeof config?.content === 'string'
+                ? config.content
+                : JSON.stringify(config.content)
               : ''
 
             // Delete content from configuration
-            if (config?.spec?.content) {
-              delete config.spec.content
+            if (config?.content) {
+              delete config.content
             }
 
             // Convert the configuration to a string

--- a/integrations/express/README.md
+++ b/integrations/express/README.md
@@ -25,10 +25,8 @@ import { apiReference } from '@scalar/express-api-reference'
 app.use(
   '/reference',
   apiReference({
-    spec: {
-      // Put your OpenAPI url here:
-      url: '/openapi.json',
-    },
+    // Put your OpenAPI url here:
+    url: '/openapi.json',
   }),
 )
 ```
@@ -46,9 +44,7 @@ app.use(
   '/reference',
   apiReference({
     theme: 'purple',
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
   }),
 )
 ```
@@ -64,9 +60,7 @@ app.use(
   '/reference',
   apiReference({
     cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
   }),
 )
 ```

--- a/integrations/express/playground/src/index.ts
+++ b/integrations/express/playground/src/index.ts
@@ -131,9 +131,7 @@ app.get('/openapi.json', (_, res) => {
 app.use(
   '/',
   apiReference({
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
   }),
 )
 

--- a/integrations/express/src/apiReference.test.ts
+++ b/integrations/express/src/apiReference.test.ts
@@ -9,7 +9,7 @@ describe('apiReference', () => {
     const app = express()
     const options = {
       cdn: 'https://cdn.example.com',
-      spec: { content: { info: { title: 'Test API' } } },
+      content: { info: { title: 'Test API' } },
     }
     app.use(apiReference(options))
 
@@ -27,7 +27,7 @@ describe('apiReference', () => {
     app.use(
       apiReference({
         cdn: 'https://cdn.example.com',
-        spec: { content: { info: { title: 'Test API' } } },
+        content: { info: { title: 'Test API' } },
         theme: 'kepler',
       }),
     )
@@ -61,7 +61,7 @@ describe('apiReference', () => {
   it('should use default CDN when no CDN is provided', async () => {
     const app = express()
     const options = {
-      spec: { content: { info: { title: 'Test API' } } },
+      content: { info: { title: 'Test API' } },
     }
     app.use(apiReference(options))
 
@@ -74,7 +74,7 @@ describe('apiReference', () => {
 
   it('doesn’t have the content twice', async () => {
     const app = express()
-    app.use(apiReference({ spec: { content: { info: { title: 'Test API' } } } }))
+    app.use(apiReference({ content: { info: { title: 'Test API' } } }))
 
     const response = await request(app).get('/')
     expect(response.status).toBe(200)
@@ -93,9 +93,7 @@ describe('apiReference', () => {
 
     app.use(
       apiReference({
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       }),
     )
 
@@ -133,7 +131,7 @@ describe('apiReference', () => {
   it('handles content as function', async () => {
     const app = express()
     const contentFn = () => ({ info: { title: 'Function API' } })
-    app.use(apiReference({ spec: { content: contentFn } }))
+    app.use(apiReference({ content: contentFn }))
 
     const response = await request(app).get('/')
     expect(response.text).toContain('Function API')
@@ -143,10 +141,8 @@ describe('apiReference', () => {
     const app = express()
     app.use(
       apiReference({
-        spec: {
-          url: 'https://example.com/api.json',
-          content: { info: { title: 'Test API' } },
-        },
+        url: 'https://example.com/api.json',
+        content: { info: { title: 'Test API' } },
       }),
     )
 

--- a/integrations/fastify/README.md
+++ b/integrations/fastify/README.md
@@ -33,9 +33,7 @@ fastify.register(import('@scalar/fastify-api-reference'), {
   routePrefix: '/reference',
   configuration: {
     title: 'Our API Reference',
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
   },
 })
 ```

--- a/integrations/fastify/src/fastifyApiReference.test.ts
+++ b/integrations/fastify/src/fastifyApiReference.test.ts
@@ -48,7 +48,7 @@ describe('fastifyApiReference', () => {
     await fastify.register(fastifyApiReference, {
       routePrefix: '/reference',
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
     })
 
@@ -71,7 +71,7 @@ describe('fastifyApiReference', () => {
     await fastify.register(fastifyApiReference, {
       routePrefix: '/reference',
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
     })
 
@@ -88,7 +88,7 @@ describe('fastifyApiReference', () => {
     await fastify.register(fastifyApiReference, {
       routePrefix: '/reference',
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
     })
 
@@ -103,7 +103,7 @@ describe('fastifyApiReference', () => {
     await fastify.register(fastifyApiReference, {
       routePrefix: '/reference',
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
     })
 
@@ -118,7 +118,7 @@ describe('fastifyApiReference', () => {
 
     await fastify.register(fastifyApiReference, {
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
     })
 
@@ -130,8 +130,8 @@ describe('fastifyApiReference', () => {
   describe('OpenAPI document endpoints', () => {
     describe.each([
       { specProvidedVia: '@fastify/swagger' },
-      { specProvidedVia: 'spec: { content: spec }' },
-      { specProvidedVia: 'spec: { content: () => spec }' },
+      { specProvidedVia: 'content: spec' },
+      { specProvidedVia: 'content: () => spec' },
     ] as const)('provided via $specProvidedVia', ({ specProvidedVia }) => {
       type LocalTestContext = {
         spec: ReturnType<typeof exampleSpec>
@@ -167,20 +167,20 @@ describe('fastifyApiReference', () => {
               })
               break
             }
-            case 'spec: { content: spec }': {
+            case 'content: spec': {
               await fastify.register(fastifyApiReference, {
                 openApiDocumentEndpoints,
                 configuration: {
-                  spec: { content: spec },
+                  content: spec,
                 },
               })
               break
             }
-            case 'spec: { content: () => spec }': {
+            case 'content: () => spec': {
               await fastify.register(fastifyApiReference, {
                 openApiDocumentEndpoints,
                 configuration: {
-                  spec: { content: () => spec },
+                  content: () => spec,
                 },
               })
               break
@@ -243,7 +243,7 @@ describe('fastifyApiReference', () => {
     await fastify.register(fastifyApiReference, {
       routePrefix: '/reference',
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
     })
 
@@ -258,10 +258,10 @@ describe('fastifyApiReference', () => {
 
     it.each([
       { expectedUrl: urlOwn, specProvidedVia: '@fastify/swagger' },
-      { expectedUrl: urlOwn, specProvidedVia: 'spec: { content: spec }' },
-      { expectedUrl: urlOwn, specProvidedVia: 'spec: { content: () => spec }' },
-      { expectedUrl: urlOwn, specProvidedVia: 'spec: { url: urlOwn },' },
-      { expectedUrl: urlExt, specProvidedVia: 'spec: { url: urlExt, }' },
+      { expectedUrl: urlOwn, specProvidedVia: 'content: spec' },
+      { expectedUrl: urlOwn, specProvidedVia: 'content: () => spec' },
+      { expectedUrl: urlOwn, specProvidedVia: 'url: urlOwn' },
+      { expectedUrl: urlExt, specProvidedVia: 'url: urlExt' },
     ] as const)('when spec is provided via $specProvidedVia', async ({ expectedUrl, specProvidedVia }) => {
       const spec = exampleSpec()
       const fastify = Fastify({
@@ -274,27 +274,27 @@ describe('fastifyApiReference', () => {
           await fastify.register(fastifyApiReference)
           break
         }
-        case 'spec: { content: spec }': {
+        case 'content: spec': {
           await fastify.register(fastifyApiReference, {
-            configuration: { spec: { content: spec } },
+            configuration: { content: spec },
           })
           break
         }
-        case 'spec: { content: () => spec }': {
+        case 'content: () => spec': {
           await fastify.register(fastifyApiReference, {
-            configuration: { spec: { content: () => spec } },
+            configuration: { content: () => spec },
           })
           break
         }
-        case 'spec: { url: urlOwn },': {
+        case 'url: urlOwn': {
           await fastify.register(fastifyApiReference, {
-            configuration: { spec: { url: urlOwn } },
+            configuration: { url: urlOwn },
           })
           break
         }
-        case 'spec: { url: urlExt, }': {
+        case 'url: urlExt': {
           await fastify.register(fastifyApiReference, {
-            configuration: { spec: { url: urlExt } },
+            configuration: { url: urlExt },
           })
           break
         }
@@ -314,7 +314,7 @@ describe('fastifyApiReference', () => {
     await fastify.register(fastifyApiReference, {
       routePrefix: '/reference',
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
     })
 
@@ -331,7 +331,7 @@ describe('fastifyApiReference', () => {
     await fastify.register(fastifyApiReference, {
       routePrefix: '/reference',
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
     })
 
@@ -349,7 +349,7 @@ describe('fastifyApiReference', () => {
 
     await fastify.register(fastifyApiReference, {
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
       hooks: {
         onRequest: fastify.basicAuth,
@@ -372,7 +372,7 @@ describe('fastifyApiReference', () => {
 
     await fastify.register(fastifyApiReference, {
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
       hooks: {
         onRequest: fastify.basicAuth,
@@ -416,7 +416,7 @@ describe('fastifyApiReference', () => {
 
     await fastify.register(fastifyApiReference, {
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
       logLevel: 'silent',
     })

--- a/integrations/fastify/src/fastifyApiReference.test.ts
+++ b/integrations/fastify/src/fastifyApiReference.test.ts
@@ -22,7 +22,7 @@ function basicAuthEncode(username: string, password: string) {
   return 'Basic ' + Buffer.from(username + ':' + password).toString('base64')
 }
 
-function exampleSpec() {
+function exampleDocument() {
   return {
     openapi: '3.1.0',
     info: {
@@ -134,7 +134,7 @@ describe('fastifyApiReference', () => {
       { specProvidedVia: 'content: () => spec' },
     ] as const)('provided via $specProvidedVia', ({ specProvidedVia }) => {
       type LocalTestContext = {
-        spec: ReturnType<typeof exampleSpec>
+        spec: ReturnType<typeof exampleDocument>
         address: string
       }
 
@@ -149,7 +149,7 @@ describe('fastifyApiReference', () => {
         },
       ] as const)('on the $endpointConfig endpoint', ({ json, yaml }) => {
         beforeEach<LocalTestContext>(async (context) => {
-          const spec = exampleSpec()
+          const spec = exampleDocument()
           const fastify = Fastify({
             logger: false,
           })
@@ -160,7 +160,7 @@ describe('fastifyApiReference', () => {
 
           switch (specProvidedVia) {
             case '@fastify/swagger': {
-              await fastify.register(fastifySwagger, { openapi: exampleSpec() })
+              await fastify.register(fastifySwagger, { openapi: exampleDocument() })
               await fastify.register(fastifyApiReference, {
                 openApiDocumentEndpoints,
                 configuration: {},
@@ -263,14 +263,14 @@ describe('fastifyApiReference', () => {
       { expectedUrl: urlOwn, specProvidedVia: 'url: urlOwn' },
       { expectedUrl: urlExt, specProvidedVia: 'url: urlExt' },
     ] as const)('when spec is provided via $specProvidedVia', async ({ expectedUrl, specProvidedVia }) => {
-      const spec = exampleSpec()
+      const spec = exampleDocument()
       const fastify = Fastify({
         logger: false,
       })
 
       switch (specProvidedVia) {
         case '@fastify/swagger': {
-          await fastify.register(fastifySwagger, { openapi: exampleSpec() })
+          await fastify.register(fastifySwagger, { openapi: exampleDocument() })
           await fastify.register(fastifyApiReference)
           break
         }

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -145,7 +145,7 @@ const fastifyApiReference = fp<
     }
 
     const specSource = (() => {
-      const { content, url } = configuration?.spec ?? {}
+      const { content, url } = configuration ?? {}
       if (content)
         return {
           type: 'content' as const,

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -288,10 +288,8 @@ const fastifyApiReference = fp<
         if (specSource.type !== 'url') {
           configuration = {
             ...configuration,
-            spec: {
-              // Use a relative URL in case we're proxied
-              url: `.${getOpenApiDocumentEndpoints(options.openApiDocumentEndpoints).json}`,
-            },
+            // Use a relative URL in case we're proxied
+            url: `.${getOpenApiDocumentEndpoints(options.openApiDocumentEndpoints).json}`,
           }
         }
 

--- a/integrations/fastify/src/proxy.test.ts
+++ b/integrations/fastify/src/proxy.test.ts
@@ -14,7 +14,7 @@ describe('fastifyApiReference', () => {
     await origin.register(Scalar, {
       routePrefix: '/documentation',
       configuration: {
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       },
     })
 

--- a/integrations/fastify/test/exports.test.ts
+++ b/integrations/fastify/test/exports.test.ts
@@ -11,7 +11,7 @@ describe('exports', () => {
       fastify.register(import('../dist/index.js'), {
         routePrefix: '/foobar',
         configuration: {
-          spec: { url: '/openapi.json' },
+          url: '/openapi.json',
         },
       })
 

--- a/integrations/hono/README.md
+++ b/integrations/hono/README.md
@@ -25,9 +25,7 @@ import { apiReference } from '@scalar/hono-api-reference'
 app.get(
   '/reference',
   apiReference({
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
   }),
 )
 ```
@@ -45,9 +43,7 @@ app.get(
   '/reference',
   apiReference({
     theme: 'purple',
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
   }),
 )
 ```
@@ -63,9 +59,7 @@ app.get(
   '/reference',
   apiReference({
     pageTitle: 'Hono API Reference',
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
   }),
 )
 ```
@@ -85,9 +79,7 @@ app.use(
   '/reference',
   apiReference({
     cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
   }),
 )
 ```

--- a/integrations/hono/playground/index.ts
+++ b/integrations/hono/playground/index.ts
@@ -179,9 +179,7 @@ app.doc('/openapi.json', {
 app.get(
   '/',
   apiReference({
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
     pageTitle: 'Hono API Reference Demo',
   }),
 )

--- a/integrations/hono/src/honoApiReference.test.ts
+++ b/integrations/hono/src/honoApiReference.test.ts
@@ -7,8 +7,9 @@ describe('apiReference', () => {
     const app = new Hono()
     const config = {
       cdn: 'https://cdn.example.com',
-      spec: { content: { info: { title: 'Test API' } } },
+      content: { info: { title: 'Test API' } },
     }
+
     app.get('/', apiReference(config))
 
     const response = await app.request('/')
@@ -26,7 +27,7 @@ describe('apiReference', () => {
     app.get(
       '/',
       apiReference({
-        spec: { content: { info: { title: 'Test API' } } },
+        content: { info: { title: 'Test API' } },
         theme: 'kepler',
         cdn: 'https://cdn.example.com',
       }),
@@ -63,7 +64,7 @@ describe('apiReference', () => {
   it('should use default CDN when no CDN is provided', async () => {
     const app = new Hono()
     const options = {
-      spec: { content: { info: { title: 'Test API' } } },
+      content: { info: { title: 'Test API' } },
     }
     app.get('/', apiReference(options))
 
@@ -77,7 +78,7 @@ describe('apiReference', () => {
 
   it("doesn't have the content twice", async () => {
     const app = new Hono()
-    app.get('/', apiReference({ spec: { content: { info: { title: 'Test API' } } } }))
+    app.get('/', apiReference({ content: { info: { title: 'Test API' } } }))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
@@ -96,9 +97,7 @@ describe('apiReference', () => {
     app.get(
       '/',
       apiReference({
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       }),
     )
 
@@ -140,7 +139,7 @@ describe('apiReference', () => {
   it('handles content as function', async () => {
     const app = new Hono()
     const contentFn = () => ({ info: { title: 'Function API' } })
-    app.get('/', apiReference({ spec: { content: contentFn } }))
+    app.get('/', apiReference({ content: contentFn }))
 
     const response = await app.request('/')
     const text = await response.text()
@@ -152,10 +151,8 @@ describe('apiReference', () => {
     app.get(
       '/',
       apiReference({
-        spec: {
-          url: 'https://example.com/api.json',
-          content: { info: { title: 'Test API' } },
-        },
+        url: 'https://example.com/api.json',
+        content: { info: { title: 'Test API' } },
       }),
     )
 

--- a/integrations/nestjs/README.md
+++ b/integrations/nestjs/README.md
@@ -40,9 +40,7 @@ const OpenApiSpecification =
   app.use(
     '/reference',
     apiReference({
-      spec: {
-        content: document,
-      },
+      content: document,
     }),
   )
 ```
@@ -55,9 +53,7 @@ import { apiReference } from '@scalar/nestjs-api-reference'
 app.use(
   '/reference',
   apiReference({
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
   }),
 )
 ```
@@ -75,9 +71,7 @@ app.use(
   '/reference',
   apiReference({
     theme: 'purple',
-    spec: {
-      url: '/openapi.json',
-    },
+    url: '/openapi.json',
   }),
 )
 ```
@@ -97,9 +91,7 @@ app.use(
   '/reference',
   apiReference({
     cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
-    spec: {
-      content: OpenApiSpecification,
-    },
+    content: OpenApiSpecification,
   }),
 )
 ```

--- a/integrations/nestjs/playground/nestjs-api-reference-express/src/main.ts
+++ b/integrations/nestjs/playground/nestjs-api-reference-express/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core'
-import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger'
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import { AppModule } from './app.module'
 
 import { apiReference } from '@scalar/nestjs-api-reference'
@@ -21,9 +21,7 @@ async function bootstrap() {
   app.use(
     '/',
     apiReference({
-      spec: {
-        content: document,
-      },
+      content: document,
     }),
   )
 

--- a/integrations/nestjs/playground/nestjs-api-reference-fastify/src/main.ts
+++ b/integrations/nestjs/playground/nestjs-api-reference-fastify/src/main.ts
@@ -1,8 +1,8 @@
 import { NestFactory } from '@nestjs/core'
-import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger'
-import { AppModule } from './app.module'
+import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify'
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import { apiReference } from '@scalar/nestjs-api-reference'
-import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify'
+import { AppModule } from './app.module'
 
 const PORT = Number(process.env.PORT) || 5057
 const HOST = process.env.HOST || '0.0.0.0'
@@ -22,9 +22,7 @@ async function bootstrap() {
     '/',
     apiReference({
       withFastify: true,
-      spec: {
-        content: document,
-      },
+      content: document,
     }),
   )
 

--- a/integrations/nestjs/src/nestJSApiReference.ts
+++ b/integrations/nestjs/src/nestJSApiReference.ts
@@ -98,10 +98,10 @@ export const ApiReference = (options: ApiReferenceOptions) => {
       id="api-reference"
       type="application/json"
       data-configuration="${JSON.stringify(configuration).split('"').join('&quot;')}">${
-        configuration.spec?.content
-          ? typeof configuration.spec?.content === 'function'
-            ? JSON.stringify(configuration.spec?.content())
-            : JSON.stringify(configuration.spec?.content)
+        configuration.content
+          ? typeof configuration.content === 'function'
+            ? JSON.stringify(configuration.content())
+            : JSON.stringify(configuration.content)
           : ''
       }</script>
     <script src="${configuration.cdn || 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'}"></script>

--- a/integrations/nestjs/src/nestJSApiReference.ts
+++ b/integrations/nestjs/src/nestJSApiReference.ts
@@ -1,14 +1,14 @@
 import type { ServerResponse } from 'node:http'
-import type { ReferenceConfiguration } from '@scalar/types/legacy'
+import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import type { Request, Response } from 'express'
 import type { FastifyRequest } from 'fastify'
 
-export type NestJSReferenceConfiguration = ReferenceConfiguration & {
+export type NestJSReferenceConfiguration = ApiReferenceConfiguration & {
   withFastify?: boolean
   cdn?: string
 }
 
-export type ApiReferenceOptions = ReferenceConfiguration & {
+export type ApiReferenceOptions = ApiReferenceConfiguration & {
   cdn?: string
 }
 

--- a/integrations/nestjs/src/nestJSApiReference.ts
+++ b/integrations/nestjs/src/nestJSApiReference.ts
@@ -1,7 +1,7 @@
+import type { ServerResponse } from 'node:http'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import type { Request, Response } from 'express'
 import type { FastifyRequest } from 'fastify'
-import type { ServerResponse } from 'node:http'
 
 export type NestJSReferenceConfiguration = ReferenceConfiguration & {
   withFastify?: boolean

--- a/integrations/nestjs/test/index.test.ts
+++ b/integrations/nestjs/test/index.test.ts
@@ -6,18 +6,14 @@ describe('ApiReference', () => {
   const url = 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml'
 
   it('renders the given spec URL', () => {
-    expect(ApiReference({ spec: { url } }).toString()).toContain(
-      'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-    )
+    expect(ApiReference({ url }).toString()).toContain('https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml')
   })
 
   it('renders the given spec URL with custom cdn', () => {
     expect(
       ApiReference({
-        spec: {
-          url,
-          cdn: 'https://fastly.jsdelivr.net/npm/@scalar/api-reference',
-        },
+        url,
+        cdn: 'https://fastly.jsdelivr.net/npm/@scalar/api-reference',
       }).toString(),
     ).toContain('https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml')
   })

--- a/integrations/nextjs/README.md
+++ b/integrations/nextjs/README.md
@@ -33,9 +33,7 @@ If you have a OpenAPI/Swagger file already, you can pass a URL to the plugin in 
 import { ApiReference } from '@scalar/nextjs-api-reference'
 
 const config = {
-  spec: {
-    url: '/openapi.json',
-  },
+  url: '/openapi.json',
 }
 
 export const GET = ApiReference(config)
@@ -45,9 +43,7 @@ Or, if you just have a static OpenAPI spec, you can directly pass it as well:
 
 ```ts
 const config = {
-  spec: {
-    content: '...',
-  },
+  content: '{ "openapi": "3.1.1", … }',
 }
 ```
 
@@ -84,9 +80,7 @@ export default function References() {
   return (
     <ApiReferenceReact
       configuration={{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       }}
     />
   )
@@ -106,9 +100,7 @@ You can find all available CDN versions [here](https://www.jsdelivr.com/package/
 import { ApiReference } from '@scalar/nextjs-api-reference'
 
 const config = {
-  spec: {
-    url: '/openapi.json',
-  },
+  url: '/openapi.json',
   cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
 }
 

--- a/integrations/nuxt/README.md
+++ b/integrations/nuxt/README.md
@@ -41,9 +41,7 @@ If you would like to add your own OpenAPI document you can do so with the follow
 export default defineNuxtConfig({
   modules: ['@scalar/nuxt'],
   scalar: {
-    spec: {
-      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-    },
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
   },
 })
 ```
@@ -67,9 +65,7 @@ export default defineNuxtConfig({
     pathRouting: {
       basePath: '/scalar',
     },
-    spec: {
-      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-    },
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
   },
 })
 ```
@@ -88,17 +84,13 @@ export default defineNuxtConfig({
     proxyUrl: 'https://proxy.scalar.com',
     configurations: [
       {
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml,
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml,
         pathRouting: {
           basePath: '/yaml',
         },
       },
       {
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         pathRouting: {
           basePath: '/json',
         },

--- a/integrations/nuxt/playground/nuxt.config.ts
+++ b/integrations/nuxt/playground/nuxt.config.ts
@@ -6,17 +6,13 @@ export default defineNuxtConfig({
   scalar: {
     configurations: [
       {
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
         pathRouting: {
           basePath: '/yaml',
         },
       },
       {
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         pathRouting: {
           basePath: '/json',
         },

--- a/integrations/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/integrations/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -11,22 +11,27 @@ const props = defineProps<{
 
 const isDark = ref(props.configuration.darkMode)
 
+// @ts-expect-error support the old syntax for a bit
+const content = props.configuration.spec?.content ?? props.configuration.content
+// @ts-expect-error support the old syntax for a bit
+const url = props.configuration.spec?.url ?? props.configuration.url
+
 // Grab spec if we can
-const content =
-  typeof props.configuration.spec?.content === 'function'
-    ? toRaw(props.configuration.spec.content())
-    : props.configuration.spec?.content
-      ? toRaw(props.configuration.spec.content)
-      : props.configuration.spec?.url
-        ? await $fetch<string>(props.configuration.spec?.url)
+const document =
+  typeof content === 'function'
+    ? toRaw(content())
+    : content
+      ? toRaw(content)
+      : url
+        ? await $fetch<string>(url)
         : await $fetch<string>('/_openapi.json')
 
 // Check for empty spec
-if (!content)
+if (!document)
   throw new Error('You must provide a document for Scalar API References')
 
-const parsedSpec = reactive(await parse(content))
-const rawSpec = JSON.stringify(content)
+const parsedSpec = reactive(await parse(document))
+const rawSpec = JSON.stringify(document)
 
 // Load up the metadata
 if (props.configuration?.metaData) useSeoMeta(props.configuration.metaData)

--- a/integrations/nuxt/src/runtime/pages/ScalarPage.vue
+++ b/integrations/nuxt/src/runtime/pages/ScalarPage.vue
@@ -8,7 +8,11 @@ const meta = route.meta as Meta
 // Ensure we have a spec
 if (
   !meta.isOpenApiEnabled &&
+  !meta.configuration?.url &&
+  !meta.configuration?.content &&
+  // @ts-expect-error support the old syntax for a bit
   !meta.configuration?.spec?.url &&
+  // @ts-expect-error support the old syntax for a bit
   !meta.configuration?.spec?.content
 )
   throw new Error(

--- a/packages/api-client-react/README.md
+++ b/packages/api-client-react/README.md
@@ -21,9 +21,7 @@ import { ApiClientModalProvider } from '@scalar/api-client-react'
 import '@scalar/api-client-react/style.css'
 ;<ApiClientModalProvider
   configuration={{
-    spec: {
-      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-    },
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
   }}>
   {children}
 </ApiClientModalProvider>

--- a/packages/api-client-react/playground/main.tsx
+++ b/packages/api-client-react/playground/main.tsx
@@ -8,25 +8,19 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ApiClientModalProvider
       configuration={{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       }}>
       <App />
     </ApiClientModalProvider>
     <ApiClientModalProvider
       configuration={{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       }}>
       <App initialRequest={{ path: '/auth/token', method: 'post' }} />
     </ApiClientModalProvider>
     <ApiClientModalProvider
       configuration={{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       }}>
       <App initialRequest={{ path: '/planets', method: 'get' }} />
     </ApiClientModalProvider>

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -59,9 +59,7 @@ import { createApiClientApp } from '@/App'
 
 // Initialize
 await createApiClientApp(document.getElementById('scalar-client'), {
-  spec: {
-    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-  },
+  url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
   proxyUrl: 'https://proxy.scalar.com',
 })
 ```
@@ -78,9 +76,7 @@ import { createApiClientApp } from '@/App'
 const { open } = await createApiClientApp(
   document.getElementById('scalar-client'),
   {
-    spec: {
-      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-    },
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
     proxyUrl: 'https://proxy.scalar.com',
   },
 )

--- a/packages/api-client/playground/modal/main.ts
+++ b/packages/api-client/playground/modal/main.ts
@@ -3,9 +3,7 @@ import { createApiClientModal } from '@/layouts/Modal'
 const { open } = await createApiClientModal({
   el: document.getElementById('app'),
   configuration: {
-    spec: {
-      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-    },
+    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
     proxyUrl: 'https://proxy.scalar.com',
   },
 })

--- a/packages/api-client/src/layouts/App/create-api-client-app.ts
+++ b/packages/api-client/src/layouts/App/create-api-client-app.ts
@@ -1,6 +1,6 @@
 import { createApiClient } from '@/libs'
-import type { ApiClientConfiguration } from '@scalar/types/api-reference'
 import { createWebHistoryRouter, saveActiveWorkspace } from '@/router'
+import type { ApiClientConfiguration } from '@scalar/types/api-reference'
 
 import ApiClientApp from './ApiClientApp.vue'
 
@@ -33,12 +33,12 @@ export const createApiClientApp = async (
   router.afterEach(saveActiveWorkspace)
 
   // Import the spec if needed
-  if (configuration.spec?.url) {
-    await importSpecFromUrl(configuration.spec.url, 'default', {
+  if (configuration.url) {
+    await importSpecFromUrl(configuration.url, 'default', {
       proxyUrl: configuration.proxyUrl,
     })
-  } else if (configuration.spec?.content) {
-    await importSpecFile(configuration.spec?.content, 'default')
+  } else if (configuration.content) {
+    await importSpecFile(configuration.content, 'default')
   }
 
   return client

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
@@ -35,14 +35,14 @@ export const createApiClientModal = async ({
 
   // Import the spec if we don't pass in a store
   if (!store) {
-    if (configuration.spec?.url)
-      await importSpecFromUrl(configuration.spec.url, 'default', {
+    if (configuration.url)
+      await importSpecFromUrl(configuration.url, 'default', {
         proxyUrl: configuration.proxyUrl,
         setCollectionSecurity: true,
         ...configuration,
       })
-    else if (configuration.spec?.content)
-      await importSpecFile(configuration.spec?.content, 'default', {
+    else if (configuration.content)
+      await importSpecFile(configuration.content, 'default', {
         setCollectionSecurity: true,
         ...configuration,
       })

--- a/packages/api-client/src/layouts/Web/create-api-client-web.ts
+++ b/packages/api-client/src/layouts/Web/create-api-client-web.ts
@@ -1,6 +1,6 @@
 import { createApiClient } from '@/libs'
-import type { ApiClientConfiguration } from '@scalar/types/api-reference'
 import { createWebHistoryRouter, saveActiveWorkspace } from '@/router'
+import type { ApiClientConfiguration } from '@scalar/types/api-reference'
 
 import ApiClientWeb from './ApiClientWeb.vue'
 
@@ -32,12 +32,12 @@ export const createApiClientWeb = async (
   router.afterEach(saveActiveWorkspace)
 
   // Import the spec if needed
-  if (configuration.spec?.url) {
-    await importSpecFromUrl(configuration.spec.url, 'default', {
+  if (configuration.url) {
+    await importSpecFromUrl(configuration.url, 'default', {
       proxyUrl: configuration.proxyUrl,
     })
-  } else if (configuration.spec?.content) {
-    await importSpecFile(configuration.spec?.content, 'default')
+  } else if (configuration.content) {
+    await importSpecFile(configuration.content, 'default')
   }
 
   return client

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -1,5 +1,5 @@
 import { type ClientLayout, LAYOUT_SYMBOL } from '@/hooks/useLayout'
-import { createSidebarState, SIDEBAR_SYMBOL } from '@/hooks/useSidebar'
+import { SIDEBAR_SYMBOL, createSidebarState } from '@/hooks/useSidebar'
 import { getRequestUidByPathMethod } from '@/libs/get-request-uid-by-path-method'
 import { loadAllResources } from '@/libs/local-storage'
 import { ACTIVE_ENTITIES_SYMBOL, createActiveEntitiesStore } from '@/store/active-entities'
@@ -230,7 +230,7 @@ export const createApiClient = ({
     } else {
       console.error(
         '[@scalar/api-client-modal] Could not create the API client.',
-        'Please provide an OpenAPI document: { spec: { url: "…" } }',
+        'Please provide an OpenAPI document: { url: "…" }',
         'Read more: https://github.com/scalar/scalar/tree/main/packages/api-client',
       )
     }

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -10,8 +10,8 @@ import { LS_KEYS, objectMerge, prettyPrintJson } from '@scalar/oas-utils/helpers
 import { DATA_VERSION, DATA_VERSION_LS_LEY } from '@scalar/oas-utils/migrations'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import { type ApiClientConfiguration, apiClientConfigurationSchema } from '@scalar/types/api-reference'
-import type { OpenAPI } from '@scalar/types/legacy'
 import type { SpecConfiguration } from '@scalar/types/api-reference'
+import type { OpenAPI } from '@scalar/types/legacy'
 import { type Component, createApp, watch } from 'vue'
 import type { Router } from 'vue-router'
 
@@ -144,7 +144,7 @@ export const createApiClient = ({
     }
   }
   // Create the default store
-  else if (!isReadOnly || !configuration.spec) {
+  else if (!isReadOnly || (!configuration.url && !configuration.content)) {
     // Create default workspace
     store.workspaceMutators.add({
       uid: 'default' as Workspace['uid'],

--- a/packages/api-reference-editor/README.md
+++ b/packages/api-reference-editor/README.md
@@ -58,7 +58,7 @@ If you wish to have external UI that updates the spec then `updateSpecValue` can
 
       const { updateSpecValue} = mountApiReferenceEditable(
         '#scalar-api-reference',
-        { spec: {content: ''}},
+        { content: '' },
         (v: string) => {
           console.log('The value is updated!')
           updateSpecValue(v) // Updates the rendered spec

--- a/packages/api-reference-editor/src/api-reference-editor.ts
+++ b/packages/api-reference-editor/src/api-reference-editor.ts
@@ -58,7 +58,7 @@ export function mountApiReferenceEditable(
     },
     /** Update only the spec value - used for external state mode */
     updateSpecValue: (specString: string) => {
-      props.configuration.spec = { content: specString }
+      props.configuration.content = specString
     },
   }
 }

--- a/packages/api-reference-editor/src/components/ApiReferenceEditor.vue
+++ b/packages/api-reference-editor/src/components/ApiReferenceEditor.vue
@@ -61,7 +61,10 @@ function setSpec({ url, content }: SpecConfiguration) {
 
 // Set the content whenever the input props change
 watchEffect(() => {
-  setSpec(props.configuration?.spec ?? { content: '' })
+  setSpec({
+    content: props.configuration?.content || '',
+    url: props.configuration?.url,
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/api-reference-editor/src/components/ApiReferenceEditor.vue
+++ b/packages/api-reference-editor/src/components/ApiReferenceEditor.vue
@@ -120,7 +120,7 @@ mapConfigToState('hiddenClients', setExcludedClients)
 
 const { parsedSpec, rawSpec } = useReactiveSpec({
   proxyUrl: toRef(() => configuration.value.proxyUrl || ''),
-  specConfig: toRef(() => configuration.value.spec || {}),
+  specConfig: toRef(() => configuration.value || {}),
 })
 </script>
 <template>

--- a/packages/api-reference-react/README.md
+++ b/packages/api-reference-react/README.md
@@ -26,9 +26,7 @@ function App() {
   return (
     <ApiReferenceReact
       configuration={{
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
       }}
     />
   )

--- a/packages/api-reference-react/playground/App.tsx
+++ b/packages/api-reference-react/playground/App.tsx
@@ -37,9 +37,7 @@ function App() {
   return (
     <ApiReferenceReact
       configuration={{
-        spec: {
-          content: ScalarGalaxy,
-        },
+        content: ScalarGalaxy,
         authentication: auth,
       }}
     />

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -109,9 +109,7 @@ import { type ReferenceProps } from './types'
 const ev = new CustomEvent('scalar:update-references-config', {
   detail: {
     configuration: {
-      spec: {
-        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-      },
+      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
     },
   } satisfies ReferenceProps,
 })
@@ -138,9 +136,7 @@ import '@scalar/api-reference/style.css'
 <template>
   <ApiReference
     :configuration="{
-      spec: {
-        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-      },
+      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
     }" />
 </template>
 ```

--- a/packages/api-reference/playground/esm/index.html
+++ b/packages/api-reference/playground/esm/index.html
@@ -20,50 +20,48 @@
       // import { createApiReference } from 'https://esm.run/@scalar/api-reference';
 
       createApiReference('#app', {
-        spec: {
-          sources: [
-            {
-              title: 'Scalar Galaxy',
-              url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-            },
-            {
-              title: 'Scalar Galaxy (YAML)',
-              url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
-            },
-            // {
-            //   title: 'Stripe',
-            //   url: 'https://raw.githubusercontent.com/stripe/openapi/refs/heads/master/openapi/spec3.yaml',
-            // },
-            {
-              title: 'Swagger Petstore (2.0)',
-              url: 'https://petstore.swagger.io/v2/swagger.json',
-            },
-            {
-              title: 'Swagger Petstore (3.0)',
-              url: 'https://petstore3.swagger.io/api/v3/openapi.json',
-            },
-            // {
-            //   title: 'Swagger Petstore (3.1)',
-            //   url: 'https://petstore31.swagger.io/api/v31/openapi.json',
-            // },
-            {
-              title: 'Val Town',
-              url: 'https://docs.val.town/openapi.documented.json',
-            },
-            {
-              title: 'Outline',
-              url: 'https://raw.githubusercontent.com/outline/openapi/refs/heads/main/spec3.yml',
-            },
-            // {
-            //   title: 'Sentry',
-            //   url: 'https://raw.githubusercontent.com/getsentry/sentry/refs/heads/master/api-docs/openapi.json',
-            // },
-            {
-              title: 'Vercel',
-              url: 'https://openapi.vercel.sh/',
-            },
-          ],
-        },
+        sources: [
+          {
+            title: 'Scalar Galaxy',
+            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+          },
+          {
+            title: 'Scalar Galaxy (YAML)',
+            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
+          },
+          // {
+          //   title: 'Stripe',
+          //   url: 'https://raw.githubusercontent.com/stripe/openapi/refs/heads/master/openapi/spec3.yaml',
+          // },
+          {
+            title: 'Swagger Petstore (2.0)',
+            url: 'https://petstore.swagger.io/v2/swagger.json',
+          },
+          {
+            title: 'Swagger Petstore (3.0)',
+            url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+          },
+          // {
+          //   title: 'Swagger Petstore (3.1)',
+          //   url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+          // },
+          {
+            title: 'Val Town',
+            url: 'https://docs.val.town/openapi.documented.json',
+          },
+          {
+            title: 'Outline',
+            url: 'https://raw.githubusercontent.com/outline/openapi/refs/heads/main/spec3.yml',
+          },
+          // {
+          //   title: 'Sentry',
+          //   url: 'https://raw.githubusercontent.com/getsentry/sentry/refs/heads/master/api-docs/openapi.json',
+          // },
+          {
+            title: 'Vercel',
+            url: 'https://openapi.vercel.sh/',
+          },
+        ],
       })
     </script>
   </body>

--- a/packages/api-reference/src/components/ApiReference.test.ts
+++ b/packages/api-reference/src/components/ApiReference.test.ts
@@ -9,18 +9,16 @@ describe('ApiReference', () => {
       const wrapper = mount(ApiReference, {
         props: {
           configuration: {
-            spec: {
-              content: {
-                openapi: '3.1.0',
-                info: {
-                  title: 'My API',
-                  version: '1.0.0',
-                },
-                paths: {
-                  '/api/v1/users': {
-                    get: {
-                      summary: 'Get users',
-                    },
+            content: {
+              openapi: '3.1.0',
+              info: {
+                title: 'My API',
+                version: '1.0.0',
+              },
+              paths: {
+                '/api/v1/users': {
+                  get: {
+                    summary: 'Get users',
                   },
                 },
               },
@@ -42,13 +40,11 @@ describe('ApiReference', () => {
         props: {
           configuration: [
             {
-              spec: {
-                content: {
-                  openapi: '3.1.0',
-                  info: {
-                    title: 'My API',
-                    version: '1.0.0',
-                  },
+              content: {
+                openapi: '3.1.0',
+                info: {
+                  title: 'My API',
+                  version: '1.0.0',
                 },
               },
             },
@@ -73,24 +69,20 @@ describe('ApiReference', () => {
         props: {
           configuration: [
             {
-              spec: {
-                content: {
-                  openapi: '3.1.0',
-                  info: {
-                    title: 'My API #1',
-                    version: '1.0.0',
-                  },
+              content: {
+                openapi: '3.1.0',
+                info: {
+                  title: 'My API #1',
+                  version: '1.0.0',
                 },
               },
             },
             {
-              spec: {
-                content: {
-                  openapi: '3.1.0',
-                  info: {
-                    title: 'My API #2',
-                    version: '1.0.0',
-                  },
+              content: {
+                openapi: '3.1.0',
+                info: {
+                  title: 'My API #2',
+                  version: '1.0.0',
                 },
               },
             },
@@ -115,26 +107,22 @@ describe('ApiReference', () => {
         props: {
           configuration: [
             {
-              spec: {
-                slug: 'my-api-1',
-                content: {
-                  openapi: '3.1.0',
-                  info: {
-                    title: 'My API #1',
-                    version: '1.0.0',
-                  },
+              slug: 'my-api-1',
+              content: {
+                openapi: '3.1.0',
+                info: {
+                  title: 'My API #1',
+                  version: '1.0.0',
                 },
               },
             },
             {
-              spec: {
-                slug: 'my-api-2',
-                content: {
-                  openapi: '3.1.0',
-                  info: {
-                    title: 'My API #2',
-                    version: '1.0.0',
-                  },
+              slug: 'my-api-2',
+              content: {
+                openapi: '3.1.0',
+                info: {
+                  title: 'My API #2',
+                  version: '1.0.0',
                 },
               },
             },
@@ -165,18 +153,16 @@ describe('ApiReference', () => {
       const wrapper = mount(ApiReference, {
         props: {
           configuration: {
-            spec: {
-              sources: [
-                {
-                  url: 'https://api.example.com/v1/openapi.yaml',
-                  slug: 'my-api-1',
-                },
-                {
-                  url: 'https://api.example.com/v2/openapi.yaml',
-                  slug: 'my-api-2',
-                },
-              ],
-            },
+            sources: [
+              {
+                url: 'https://api.example.com/v1/openapi.yaml',
+                slug: 'my-api-1',
+              },
+              {
+                url: 'https://api.example.com/v2/openapi.yaml',
+                slug: 'my-api-2',
+              },
+            ],
           },
         },
       })

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -82,7 +82,7 @@ watch(hash, (newHash, oldHash) => {
           buttonSource="sidebar"
           :integration="configuration._integration"
           :isDevelopment="isDevelopment"
-          :url="configuration.spec?.url" />
+          :url="configuration.url" />
         <!-- Override the dark mode toggle slot to hide it -->
         <template #toggle>
           <ScalarColorModeToggleButton

--- a/packages/api-reference/src/components/SingleApiReference.vue
+++ b/packages/api-reference/src/components/SingleApiReference.vue
@@ -34,7 +34,7 @@ if (configuration.metaData) {
 
 const { parsedSpec, rawSpec } = useReactiveSpec({
   proxyUrl: toRef(() => configuration.proxyUrl || ''),
-  specConfig: toRef(() => configuration.spec || {}),
+  specConfig: toRef(() => configuration || {}),
 })
 
 // TODO: defineSlots

--- a/packages/api-reference/src/esm.ts
+++ b/packages/api-reference/src/esm.ts
@@ -53,7 +53,7 @@ export function createScalarReferences(
       if (Array.isArray(configuration)) {
         console.error('Cannot update the content for multiple configurations.')
       } else {
-        configuration.spec = spec
+        Object.assign(configuration, spec)
       }
     },
     /** Mount the references to a given element */

--- a/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
+++ b/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
@@ -18,11 +18,11 @@ const handleDownloadClick = () => {
   <div class="download">
     <template v-if="!config?.hideDownloadButton">
       <!-- Direct URL -->
-      <template v-if="config?.spec?.url">
+      <template v-if="config?.url">
         <a
           class="download-button"
           download
-          :href="config?.spec?.url"
+          :href="config?.url"
           target="_blank">
           Download OpenAPI Document
         </a>

--- a/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
@@ -28,7 +28,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(1)
-      expect(selectedConfiguration.value).toEqual(multiConfig.configuration.value[1])
+      expect(selectedConfiguration.value).toMatchObject(multiConfig.configuration.value[1])
     })
 
     it('should select document using slug from query parameter', () => {
@@ -45,7 +45,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(1)
-      expect(selectedConfiguration.value).toEqual(multiConfig.configuration.value[1])
+      expect(selectedConfiguration.value).toMatchObject(multiConfig.configuration.value[1])
     })
 
     it('should default to first API when query parameter is invalid', () => {
@@ -62,7 +62,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(0)
-      expect(selectedConfiguration.value).toEqual(multiConfig.configuration.value[0])
+      expect(selectedConfiguration.value).toMatchObject(multiConfig.configuration.value[0])
     })
 
     it('omits sources without url and content', () => {
@@ -89,7 +89,7 @@ describe('useMultipleDocuments', () => {
 
       expect(replaceStateSpy).toHaveBeenCalledWith({}, '', 'http://example.com/?api=first-api')
       expect(selectedDocumentIndex.value).toBe(0)
-      expect(selectedConfiguration.value).toEqual(multiConfig.configuration.value[0])
+      expect(selectedConfiguration.value).toMatchObject(multiConfig.configuration.value[0])
     })
 
     it('should not update URL when there is only one document', () => {
@@ -112,7 +112,7 @@ describe('useMultipleDocuments', () => {
       const { selectedConfiguration, availableDocuments } = useMultipleDocuments(singleConfig)
 
       expect(availableDocuments.value).toHaveLength(1)
-      expect(selectedConfiguration.value).toEqual(singleConfig.configuration.value)
+      expect(selectedConfiguration.value).toMatchObject(singleConfig.configuration.value)
     })
 
     it('should handle undefined configuration', () => {
@@ -123,7 +123,7 @@ describe('useMultipleDocuments', () => {
       const { selectedConfiguration, availableDocuments } = useMultipleDocuments(emptyConfig)
 
       expect(availableDocuments.value).toHaveLength(0)
-      expect(selectedConfiguration.value).toEqual({
+      expect(selectedConfiguration.value).toMatchObject({
         hideClientButton: false,
         showSidebar: true,
         theme: 'default',
@@ -145,7 +145,7 @@ describe('useMultipleDocuments', () => {
 
       const { availableDocuments } = useMultipleDocuments(configWithUndefinedSpec)
 
-      expect(availableDocuments.value).toHaveLength(0)
+      expect(availableDocuments.value).toHaveLength(1)
     })
   })
 
@@ -163,7 +163,7 @@ describe('useMultipleDocuments', () => {
             },
             {
               url: '/openapi-2.yaml',
-              slug: 'second-a pi',
+              slug: 'second-api',
             },
           ],
         }),
@@ -172,7 +172,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(1)
-      expect(selectedConfiguration.value).toEqual({
+      expect(selectedConfiguration.value).toMatchObject({
         url: '/openapi-2.yaml',
         slug: 'second-api',
       })
@@ -200,7 +200,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(1)
-      expect(selectedConfiguration.value).toEqual({
+      expect(selectedConfiguration.value).toMatchObject({
         url: '/openapi-2.yaml',
         slug: 'second-api',
       })
@@ -228,7 +228,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(0)
-      expect(selectedConfiguration.value).toEqual({
+      expect(selectedConfiguration.value).toMatchObject({
         url: '/openapi-1.yaml',
         slug: 'first-api',
       })

--- a/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
@@ -20,8 +20,8 @@ describe('useMultipleDocuments', () => {
 
       const multiConfig = {
         configuration: ref([
-          { spec: { url: '/openapi.json', slug: 'first-api' } },
-          { spec: { url: '/openapi-2.yaml', slug: 'second-api' } },
+          { url: '/openapi.json', slug: 'first-api' },
+          { url: '/openapi-2.yaml', slug: 'second-api' },
         ]),
       }
 
@@ -37,8 +37,8 @@ describe('useMultipleDocuments', () => {
 
       const multiConfig = {
         configuration: ref([
-          { spec: { url: '/openapi.json', slug: 'first-api' } },
-          { spec: { url: '/openapi-2.yaml', slug: 'second-api' } },
+          { url: '/openapi.json', slug: 'first-api' },
+          { url: '/openapi-2.yaml', slug: 'second-api' },
         ]),
       }
 
@@ -53,7 +53,10 @@ describe('useMultipleDocuments', () => {
       vi.spyOn(window, 'location', 'get').mockReturnValue(mockUrl as any)
 
       const multiConfig = {
-        configuration: ref([{ spec: { slug: 'first-api' } }, { spec: { slug: 'second-api' } }]),
+        configuration: ref([
+          { url: '/openapi.json', slug: 'first-api' },
+          { url: '/openapi-2.yaml', slug: 'second-api' },
+        ]),
       }
 
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
@@ -64,7 +67,7 @@ describe('useMultipleDocuments', () => {
 
     it('omits sources without url and content', () => {
       const multiConfig = {
-        configuration: ref({ spec: { sources: [{}] } }),
+        configuration: ref({ sources: [{}] }),
       }
 
       const { availableDocuments } = useMultipleDocuments(multiConfig)
@@ -77,8 +80,8 @@ describe('useMultipleDocuments', () => {
     it.todo('should update URL when initializing with a selection', () => {
       const multiConfig = {
         configuration: ref([
-          { spec: { url: '/openapi.json', slug: 'first-api' } },
-          { spec: { url: '/openapi-2.yaml', slug: 'second-api' } },
+          { url: '/openapi.json', slug: 'first-api' },
+          { url: '/openapi-2.yaml', slug: 'second-api' },
         ]),
       }
 
@@ -91,7 +94,7 @@ describe('useMultipleDocuments', () => {
 
     it('should not update URL when there is only one document', () => {
       const singleConfig = {
-        configuration: ref([{ spec: { url: '/openapi.json', slug: 'single-api' } }]),
+        configuration: ref([{ url: '/openapi.json', slug: 'single-api' }]),
       }
 
       useMultipleDocuments(singleConfig)
@@ -103,7 +106,7 @@ describe('useMultipleDocuments', () => {
   describe('edge cases', () => {
     it('should handle single API configuration', () => {
       const singleConfig = {
-        configuration: ref({ spec: { url: '/openapi.json', slug: 'single-api' } }),
+        configuration: ref({ url: '/openapi.json', slug: 'single-api' }),
       }
 
       const { selectedConfiguration, availableDocuments } = useMultipleDocuments(singleConfig)
@@ -137,7 +140,7 @@ describe('useMultipleDocuments', () => {
 
     it('should filter out APIs with undefined sources/url/content', () => {
       const configWithUndefinedSpec = {
-        configuration: ref([{ spec: undefined }, { spec: { slug: 'valid-api' } }]),
+        configuration: ref([{ url: undefined }, { url: '/openapi-2.yaml', slug: 'valid-api' }]),
       }
 
       const { availableDocuments } = useMultipleDocuments(configWithUndefinedSpec)
@@ -153,18 +156,16 @@ describe('useMultipleDocuments', () => {
 
       const multiConfig = {
         configuration: ref({
-          spec: {
-            sources: [
-              {
-                url: '/openapi-1.yaml',
-                slug: 'first-api',
-              },
-              {
-                url: '/openapi-2.yaml',
-                slug: 'second-api',
-              },
-            ],
-          },
+          sources: [
+            {
+              url: '/openapi-1.yaml',
+              slug: 'first-api',
+            },
+            {
+              url: '/openapi-2.yaml',
+              slug: 'second-a pi',
+            },
+          ],
         }),
       }
 
@@ -183,18 +184,16 @@ describe('useMultipleDocuments', () => {
 
       const multiConfig = {
         configuration: ref({
-          spec: {
-            sources: [
-              {
-                url: '/openapi-1.yaml',
-                slug: 'first-api',
-              },
-              {
-                url: '/openapi-2.yaml',
-                slug: 'second-api',
-              },
-            ],
-          },
+          sources: [
+            {
+              url: '/openapi-1.yaml',
+              slug: 'first-api',
+            },
+            {
+              url: '/openapi-2.yaml',
+              slug: 'second-api',
+            },
+          ],
         }),
       }
 
@@ -213,18 +212,16 @@ describe('useMultipleDocuments', () => {
 
       const multiConfig = {
         configuration: ref({
-          spec: {
-            sources: [
-              {
-                url: '/openapi-1.yaml',
-                slug: 'first-api',
-              },
-              {
-                url: '/openapi-2.yaml',
-                slug: 'second-api',
-              },
-            ],
-          },
+          sources: [
+            {
+              url: '/openapi-1.yaml',
+              slug: 'first-api',
+            },
+            {
+              url: '/openapi-2.yaml',
+              slug: 'second-api',
+            },
+          ],
         }),
       }
 
@@ -244,18 +241,16 @@ describe('useMultipleDocuments', () => {
 
       const multiConfig = {
         configuration: ref({
-          spec: {
-            sources: [
-              {
-                url: '/openapi-1.yaml',
-                slug: 'first-api',
-              },
-              {
-                url: '/openapi-2.yaml',
-                slug: 'second-api',
-              },
-            ],
-          },
+          sources: [
+            {
+              url: '/openapi-1.yaml',
+              slug: 'first-api',
+            },
+            {
+              url: '/openapi-2.yaml',
+              slug: 'second-api',
+            },
+          ],
         }),
       }
 
@@ -269,15 +264,13 @@ describe('useMultipleDocuments', () => {
     it('should filter out undefined sources', () => {
       const configWithUndefinedSource = {
         configuration: ref({
-          spec: {
-            sources: [
-              undefined,
-              {
-                url: '/openapi.yaml',
-                slug: 'valid-api',
-              },
-            ],
-          },
+          sources: [
+            undefined,
+            {
+              url: '/openapi.yaml',
+              slug: 'valid-api',
+            },
+          ],
         }),
       }
 
@@ -293,14 +286,12 @@ describe('useMultipleDocuments', () => {
     it('should generate slug from title if only title exists', () => {
       const config = {
         configuration: ref({
-          spec: {
-            sources: [
-              {
-                url: '/openapi-1.yaml',
-                title: 'My Cool API',
-              },
-            ],
-          },
+          sources: [
+            {
+              url: '/openapi-1.yaml',
+              title: 'My Cool API',
+            },
+          ],
         }),
       }
 
@@ -315,14 +306,12 @@ describe('useMultipleDocuments', () => {
     it('should use slug as title if only slug exists', () => {
       const config = {
         configuration: ref({
-          spec: {
-            sources: [
-              {
-                url: '/openapi-1.yaml',
-                slug: 'my-api',
-              },
-            ],
-          },
+          sources: [
+            {
+              url: '/openapi-1.yaml',
+              slug: 'my-api',
+            },
+          ],
         }),
       }
 
@@ -337,16 +326,14 @@ describe('useMultipleDocuments', () => {
     it('should generate both title and slug from index if neither exists', () => {
       const config = {
         configuration: ref({
-          spec: {
-            sources: [
-              {
-                url: '/openapi-1.yaml',
-              },
-              {
-                url: '/openapi-2.yaml',
-              },
-            ],
-          },
+          sources: [
+            {
+              url: '/openapi-1.yaml',
+            },
+            {
+              url: '/openapi-2.yaml',
+            },
+          ],
         }),
       }
 
@@ -365,15 +352,13 @@ describe('useMultipleDocuments', () => {
     it('should preserve existing slug when title is present', () => {
       const config = {
         configuration: ref({
-          spec: {
-            sources: [
-              {
-                url: '/openapi-1.yaml',
-                title: 'My Cool API',
-                slug: 'custom-slug',
-              },
-            ],
-          },
+          sources: [
+            {
+              url: '/openapi-1.yaml',
+              title: 'My Cool API',
+              slug: 'custom-slug',
+            },
+          ],
         }),
       }
 
@@ -393,18 +378,16 @@ describe('useMultipleDocuments', () => {
 
       const multiConfig = {
         configuration: ref({
-          spec: {
-            sources: [
-              {
-                url: '/openapi-1.yaml',
-                title: 'First API',
-              },
-              {
-                url: '/openapi-2.yaml',
-                title: 'Second API',
-              },
-            ],
-          },
+          sources: [
+            {
+              url: '/openapi-1.yaml',
+              title: 'First API',
+            },
+            {
+              url: '/openapi-2.yaml',
+              title: 'Second API',
+            },
+          ],
         }),
       }
 

--- a/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
@@ -28,7 +28,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(1)
-      expect(selectedConfiguration.value.spec).toEqual(multiConfig.configuration.value[1].spec)
+      expect(selectedConfiguration.value).toEqual(multiConfig.configuration.value[1])
     })
 
     it('should select document using slug from query parameter', () => {
@@ -45,7 +45,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(1)
-      expect(selectedConfiguration.value.spec).toEqual(multiConfig.configuration.value[1].spec)
+      expect(selectedConfiguration.value).toEqual(multiConfig.configuration.value[1])
     })
 
     it('should default to first API when query parameter is invalid', () => {
@@ -59,7 +59,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(0)
-      expect(selectedConfiguration.value.spec).toEqual(multiConfig.configuration.value[0].spec)
+      expect(selectedConfiguration.value).toEqual(multiConfig.configuration.value[0])
     })
 
     it('omits sources without url and content', () => {
@@ -86,7 +86,7 @@ describe('useMultipleDocuments', () => {
 
       expect(replaceStateSpy).toHaveBeenCalledWith({}, '', 'http://example.com/?api=first-api')
       expect(selectedDocumentIndex.value).toBe(0)
-      expect(selectedConfiguration.value.spec).toEqual(multiConfig.configuration.value[0].spec)
+      expect(selectedConfiguration.value).toEqual(multiConfig.configuration.value[0])
     })
 
     it('should not update URL when there is only one document', () => {
@@ -109,7 +109,7 @@ describe('useMultipleDocuments', () => {
       const { selectedConfiguration, availableDocuments } = useMultipleDocuments(singleConfig)
 
       expect(availableDocuments.value).toHaveLength(1)
-      expect(selectedConfiguration.value.spec).toEqual(singleConfig.configuration.value.spec)
+      expect(selectedConfiguration.value).toEqual(singleConfig.configuration.value)
     })
 
     it('should handle undefined configuration', () => {
@@ -171,7 +171,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(1)
-      expect(selectedConfiguration.value.spec).toEqual({
+      expect(selectedConfiguration.value).toEqual({
         url: '/openapi-2.yaml',
         slug: 'second-api',
       })
@@ -201,7 +201,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(1)
-      expect(selectedConfiguration.value.spec).toEqual({
+      expect(selectedConfiguration.value).toEqual({
         url: '/openapi-2.yaml',
         slug: 'second-api',
       })
@@ -231,7 +231,7 @@ describe('useMultipleDocuments', () => {
       const { selectedDocumentIndex, selectedConfiguration } = useMultipleDocuments(multiConfig)
 
       expect(selectedDocumentIndex.value).toBe(0)
-      expect(selectedConfiguration.value.spec).toEqual({
+      expect(selectedConfiguration.value).toEqual({
         url: '/openapi-1.yaml',
         slug: 'first-api',
       })

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -75,8 +75,8 @@ export const useMultipleDocuments = ({ configuration, initialIndex }: UseMultipl
 
     // Map the sources down to an array of specs
     const sources = isConfigurationWithSources(configuration.value)
-      ? (configuration.value.spec?.sources ?? [])
-      : [configuration.value].flat().map((config) => config.spec)
+      ? (configuration.value?.sources ?? [])
+      : [configuration.value].flat().map((config) => config)
 
     // Process them
     return sources.map((source, index) => source && addSlugAndTitle(source, index)).filter(isDefined)
@@ -149,7 +149,7 @@ export const useMultipleDocuments = ({ configuration, initialIndex }: UseMultipl
     if (configuration.value && isConfigurationWithSources(configuration.value)) {
       return apiReferenceConfigurationSchema.parse({
         ...configuration.value,
-        spec: configuration.value.spec?.sources[selectedDocumentIndex.value],
+        spec: configuration.value?.sources?.[selectedDocumentIndex.value],
       })
     }
 

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -149,7 +149,7 @@ export const useMultipleDocuments = ({ configuration, initialIndex }: UseMultipl
     if (configuration.value && isConfigurationWithSources(configuration.value)) {
       return apiReferenceConfigurationSchema.parse({
         ...configuration.value,
-        spec: configuration.value?.sources?.[selectedDocumentIndex.value],
+        ...configuration.value?.sources?.[selectedDocumentIndex.value],
       })
     }
 

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -31,8 +31,8 @@ type UseMultipleDocumentsProps = {
 const slugger = new GithubSlugger()
 
 /** Process a single spec configuration so that it has a title and a slug */
-const addSlugAndTitle = (spec: SpecConfiguration, index = 0): SpecConfiguration | undefined => {
-  if (!spec?.url && !spec?.content) {
+const addSlugAndTitle = (source: SpecConfiguration, index = 0): SpecConfiguration | undefined => {
+  if (!source?.url && !source?.content) {
     return undefined
   }
 
@@ -40,25 +40,25 @@ const addSlugAndTitle = (spec: SpecConfiguration, index = 0): SpecConfiguration 
   slugger.reset()
 
   // Case 1: Title exists, generate slug from it
-  if (spec.title) {
+  if (source.title) {
     return {
-      ...spec,
-      slug: spec.slug || slugger.slug(spec.title),
-      title: spec.title,
+      ...source,
+      slug: source.slug || slugger.slug(source.title),
+      title: source.title,
     }
   }
 
   // Case 2: Slug exists but no title, use slug as title
-  if (spec.slug) {
+  if (source.slug) {
     return {
-      ...spec,
-      title: spec.slug,
+      ...source,
+      title: source.slug,
     }
   }
 
   // Case 3: Neither exists, use index
   return {
-    ...spec,
+    ...source,
     slug: `api-${index + 1}`,
     title: `API #${index + 1}`,
   }

--- a/packages/api-reference/src/standalone.test.ts
+++ b/packages/api-reference/src/standalone.test.ts
@@ -48,6 +48,7 @@ describe.sequential('standalone', { retry: 3, timeout: 10000 }, () => {
     const event = new CustomEvent('scalar:update-references-config', {
       detail: {
         configuration: {
+          // @ts-expect-error old format
           spec: {
             content: galaxyContent,
           },

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -111,9 +111,7 @@ describe('html-api', () => {
 
       // Update configuration after creation
       const newConfig = {
-        spec: {
-          content: '{"openapi":"3.1.0", "info": {"title": "Updated API", "version": "1.0.0"}}',
-        },
+        content: '{"openapi":"3.1.0", "info": {"title": "Updated API", "version": "1.0.0"}}',
       }
       app.updateConfiguration(newConfig)
       expect(app).toBeDefined()
@@ -160,7 +158,7 @@ describe('html-api', () => {
       expect(getConfigurationFromDataAttributes(document)).toStrictEqual({
         ...baseConfig,
         proxyUrl: undefined,
-        spec: { url: '/openapi.json' },
+        url: '/openapi.json',
       })
     })
 
@@ -176,7 +174,7 @@ describe('html-api', () => {
       expect(getConfigurationFromDataAttributes(document)).toStrictEqual({
         ...baseConfig,
         proxyUrl: undefined,
-        spec: { content: '{"openapi":"3.1.0"}' },
+        content: '{"openapi":"3.1.0"}',
       })
     })
 
@@ -192,7 +190,7 @@ describe('html-api', () => {
       expect(getConfigurationFromDataAttributes(document)).toStrictEqual({
         ...baseConfig,
         proxyUrl: 'https://proxy.example.com',
-        spec: { url: '/spec.json' },
+        url: '/spec.json',
       })
     })
 
@@ -209,7 +207,7 @@ describe('html-api', () => {
         ...baseConfig,
         darkMode: true,
         proxyUrl: undefined,
-        spec: { url: '/custom.json' },
+        url: '/custom.json',
       })
     })
 
@@ -225,7 +223,7 @@ describe('html-api', () => {
       expect(getConfigurationFromDataAttributes(document)).toStrictEqual({
         ...baseConfig,
         proxyUrl: undefined,
-        spec: { content: '{"openapi":"3.1.0"}' },
+        content: '{"openapi":"3.1.0"}',
       })
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('The [data-spec] HTML API is deprecated'))
@@ -243,7 +241,7 @@ describe('html-api', () => {
       expect(getConfigurationFromDataAttributes(doc)).toStrictEqual({
         ...baseConfig,
         proxyUrl: undefined,
-        spec: { url: '/deprecated.json' },
+        url: '/deprecated.json',
       })
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('The [data-spec-url] HTML API is deprecated'))
@@ -274,7 +272,7 @@ describe('html-api', () => {
       expect(getConfigurationFromDataAttributes(doc)).toStrictEqual({
         ...baseConfig,
         proxyUrl: undefined,
-        spec: { url: '/priority.json' },
+        url: '/priority.json',
       })
     })
   })

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -31,8 +31,12 @@ export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceC
     return apiReferenceConfigurationSchema.parse({ _integration: 'html' })
   }
 
-  const getSpecUrl = () => {
+  const getUrl = () => {
     // Let’s first check if the user passed a spec URL in the configuration.
+    if (getConfiguration().url) {
+      return getConfiguration().url
+    }
+
     if (getConfiguration().spec?.url) {
       return getConfiguration().spec?.url
     }
@@ -62,7 +66,7 @@ export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceC
     return undefined
   }
 
-  const getSpec = (): string | undefined => {
+  const getContent = (): string | undefined => {
     // <script id="api-reference" type="application/json">{"openapi":"3.1.0","info":{"title":"Example"},"paths":{}}</script>
     const specScriptTag = getSpecScriptTag(doc)
     if (specScriptTag) {
@@ -106,13 +110,13 @@ export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceC
   if (!specUrlElement && !specElement && !getSpecScriptTag(doc)) {
     // Stay quiet.
   } else {
-    const specOrSpecUrl = getSpec() ? { content: getSpec() } : { url: getSpecUrl() }
+    const urlOrContent = getContent() ? { content: getContent() } : { url: getUrl() }
 
     return apiReferenceConfigurationSchema.parse({
       _integration: 'html',
       proxyUrl: getProxyUrl(),
       ...getConfiguration(),
-      spec: { ...specOrSpecUrl },
+      ...urlOrContent,
     })
   }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,16 +35,6 @@
       "import": "./dist/libs/html-rendering/index.js",
       "types": "./dist/libs/html-rendering/index.d.ts",
       "default": "./dist/libs/html-rendering/index.js"
-    },
-    "./css/*.css": {
-      "import": "./dist/css/*.css",
-      "require": "./dist/css/*.css",
-      "default": "./dist/css/*.css"
-    },
-    "./*.css": {
-      "import": "./dist/*.css",
-      "require": "./dist/*.css",
-      "default": "./dist/*.css"
     }
   },
   "files": [

--- a/packages/core/src/libs/html-rendering/index.test.ts
+++ b/packages/core/src/libs/html-rendering/index.test.ts
@@ -4,7 +4,7 @@ import {
   htmlRenderingConfigurationSchema,
 } from '@scalar/types/api-reference'
 import { describe, expect, it } from 'vitest'
-import { getConfiguration, getHtmlDocument, getScriptTagContent, getScriptTags } from './index.ts'
+import { getConfiguration, getHtmlDocument, getScriptTagContent, getScriptTags } from './index'
 
 describe('html-rendering', () => {
   describe('getHtmlDocument', () => {
@@ -39,18 +39,16 @@ describe('html-rendering', () => {
       expect(config).toBe('{&quot;theme&quot;:&quot;kepler&quot;}')
     })
 
-    it('removes spec when url is not provided', () => {
-      const config = getConfiguration(apiReferenceConfigurationSchema.parse({ spec: { content: { foo: 'bar' } } }))
-      expect(config).not.toContain('spec')
+    it('removes content when url is not provided', () => {
+      const config = getConfiguration(apiReferenceConfigurationSchema.parse({ content: { foo: 'bar' } }))
+      expect(config).not.toContain('content')
     })
 
     it('removes spec.content when url is provided', () => {
       const config = getConfiguration(
         apiReferenceConfigurationSchema.parse({
-          spec: {
-            url: 'https://api.example.com/spec',
-            content: { foo: 'bar' },
-          },
+          url: 'https://api.example.com/spec',
+          content: { foo: 'bar' },
         }),
       )
       expect(config).toContain('url')
@@ -67,7 +65,7 @@ describe('html-rendering', () => {
     it('stringifies spec content object', () => {
       const content = getScriptTagContent(
         apiReferenceConfigurationSchema.parse({
-          spec: { content: { foo: 'bar' } },
+          content: { foo: 'bar' },
         }),
       )
       expect(content).toBe('{"foo":"bar"}')
@@ -76,7 +74,7 @@ describe('html-rendering', () => {
     it('executes and stringifies content function', () => {
       const content = getScriptTagContent(
         apiReferenceConfigurationSchema.parse({
-          spec: { content: () => ({ foo: 'bar' }) },
+          content: () => ({ foo: 'bar' }),
         }),
       )
       expect(content).toBe('{"foo":"bar"}')

--- a/packages/core/src/libs/html-rendering/index.ts
+++ b/packages/core/src/libs/html-rendering/index.ts
@@ -62,10 +62,8 @@ export const getConfiguration = (givenConfiguration: ApiReferenceConfiguration) 
     ...givenConfiguration,
   }
 
-  if (!configuration.spec?.url) {
-    delete configuration.spec
-  } else if (configuration.spec?.content) {
-    delete configuration.spec?.content
+  if (configuration.content) {
+    delete configuration.content
   }
 
   return JSON.stringify(configuration).split('"').join('&quot;')
@@ -75,8 +73,8 @@ export const getConfiguration = (givenConfiguration: ApiReferenceConfiguration) 
  * The content to pass to the @scalar/api-reference package as the <script> tag content.
  */
 export const getScriptTagContent = (configuration: ApiReferenceConfiguration) =>
-  configuration.spec?.content
-    ? typeof configuration.spec?.content === 'function'
-      ? JSON.stringify(configuration.spec?.content())
-      : JSON.stringify(configuration.spec?.content)
+  configuration.content
+    ? typeof configuration.content === 'function'
+      ? JSON.stringify(configuration.content())
+      : JSON.stringify(configuration.content)
     : ''

--- a/packages/galaxy/playground/src/index.ts
+++ b/packages/galaxy/playground/src/index.ts
@@ -1,7 +1,7 @@
+import fs from 'node:fs/promises'
 import { serve } from '@hono/node-server'
 import { apiReference } from '@scalar/hono-api-reference'
 import { createMockServer } from '@scalar/mock-server'
-import fs from 'node:fs/promises'
 
 const specification = await readOpenApiDocumentFromDisk()
 
@@ -26,10 +26,8 @@ const app = await createMockServer({
 app.get(
   '/',
   apiReference({
-    spec: {
-      // Served by createMockServer
-      url: '/openapi.yaml',
-    },
+    // Served by createMockServer
+    url: '/openapi.yaml',
     pageTitle: 'Scalar Galaxy',
   }),
 )

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -463,7 +463,7 @@ info:
         layout: "classic",
         darkMode: false,
         searchHotKey: "nope",
-        spec: { url: "/docs/files/openapi.json" },
+        url: "/docs/files/openapi.json",
       }
       var apiReference = document.getElementById('api-reference')
       apiReference.dataset.configuration = JSON.stringify(configuration)

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -289,13 +289,13 @@ function parseEmbeddedOpenApi(html: string): object | undefined {
     const config = JSON.parse(decodeHtmlEntities(configString))
 
     // Handle both direct JSON content and YAML content
-    if (config.spec?.content) {
+    if (config.content) {
       // If content is a string, assume it's YAML
-      if (typeof config.spec.content === 'string') {
-        return parse(config.spec.content)
+      if (typeof config.content === 'string') {
+        return parse(config.content)
       }
       // If content is an object, return it directly
-      return config.spec.content
+      return config.content
     }
   } catch (error) {
     console.error('[@scalar/import] Failed to parse embedded OpenAPI document:', error)

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -282,20 +282,22 @@ export function getConfigurationAttribute(html: string): string | undefined {
  */
 function parseEmbeddedOpenApi(html: string): object | undefined {
   const configString = getConfigurationAttribute(html)
-
   if (!configString) return undefined
 
   try {
     const config = JSON.parse(decodeHtmlEntities(configString))
 
+    // Handle the old spec format while we transition to the new one
+    const content = config.content || config.spec?.content
+
     // Handle both direct JSON content and YAML content
-    if (config.content) {
+    if (content) {
       // If content is a string, assume it's YAML
-      if (typeof config.content === 'string') {
-        return parse(config.content)
+      if (typeof content === 'string') {
+        return parse(content)
       }
       // If content is an object, return it directly
-      return config.content
+      return content
     }
   } catch (error) {
     console.error('[@scalar/import] Failed to parse embedded OpenAPI document:', error)

--- a/packages/mock-server/playground/index.ts
+++ b/packages/mock-server/playground/index.ts
@@ -30,9 +30,7 @@ app.get(
   '/',
   apiReference({
     pageTitle: 'Scalar Galaxy',
-    spec: {
-      url: '/openapi.yaml',
-    },
+    url: '/openapi.yaml',
     baseServerURL: `http://localhost:${port}`,
   }),
 )

--- a/packages/nextjs-openapi/src/openapi.ts
+++ b/packages/nextjs-openapi/src/openapi.ts
@@ -111,9 +111,7 @@ export const OpenAPI = (config: OpenAPIConfig = {}) => {
       // References
 
       return await ApiReference({
-        spec: {
-          url: req.nextUrl.pathname + '/schema.json',
-        },
+        url: req.nextUrl.pathname + '/schema.json',
       })()
     },
   }

--- a/packages/nextjs-openapi/src/openapi.ts
+++ b/packages/nextjs-openapi/src/openapi.ts
@@ -1,7 +1,7 @@
+import { readFileSync } from 'node:fs'
 import { ApiReference } from '@scalar/nextjs-api-reference'
 import type { ReferenceConfiguration } from '@scalar/types/legacy'
 import { sync } from 'fast-glob'
-import { readFileSync } from 'node:fs'
 import type { NextRequest } from 'next/server'
 import type { OpenAPIV3_1 } from 'openapi-types'
 import {

--- a/packages/play-button/src/index.ts
+++ b/packages/play-button/src/index.ts
@@ -82,7 +82,9 @@ if (!specUrlElement && !specElement && !specScriptTag) {
     const { open } = await createApiClientModal({
       el: container as HTMLElement,
       configuration: {
-        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+        spec: {
+          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+        },
         proxyUrl: 'https://proxy.scalar.com',
       },
     })

--- a/packages/play-button/src/index.ts
+++ b/packages/play-button/src/index.ts
@@ -82,9 +82,7 @@ if (!specUrlElement && !specElement && !specScriptTag) {
     const { open } = await createApiClientModal({
       el: container as HTMLElement,
       configuration: {
-        spec: {
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
         proxyUrl: 'https://proxy.scalar.com',
       },
     })

--- a/packages/scalar-app/src/main/resolve.ts
+++ b/packages/scalar-app/src/main/resolve.ts
@@ -131,8 +131,9 @@ function parseEmbeddedOpenApi(html: string): object | undefined {
   try {
     const configString = decodeHtmlEntities(match[1])
     const config = JSON.parse(configString)
-    if (config.content) {
-      return config.content
+    const content = config.content || config.spec?.content
+    if (content) {
+      return content
     }
   } catch (error) {
     console.error('[@scalar/import] Failed to parse embedded OpenAPI document:', error)

--- a/packages/scalar-app/src/main/resolve.ts
+++ b/packages/scalar-app/src/main/resolve.ts
@@ -131,8 +131,8 @@ function parseEmbeddedOpenApi(html: string): object | undefined {
   try {
     const configString = decodeHtmlEntities(match[1])
     const config = JSON.parse(configString)
-    if (config.spec?.content) {
-      return config.spec.content
+    if (config.content) {
+      return config.content
     }
   } catch (error) {
     console.error('[@scalar/import] Failed to parse embedded OpenAPI document:', error)

--- a/packages/types/src/api-reference/api-reference-configuration.test.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.test.ts
@@ -223,15 +223,30 @@ describe('api-reference-configuration', () => {
       expect(migratedConfig.customCss).toContain('--scalar-color-red')
     })
 
-    it('prefixes url with spec', () => {
+    it('api reference migrates spec.url to url', () => {
       const config = {
-        url: 'https://example.com/openapi.json',
+        spec: {
+          url: 'https://example.com/openapi.json',
+        },
       }
 
       const migratedConfig = apiReferenceConfigurationSchema.parse(config)
 
-      expect(migratedConfig.spec?.url).toBe('https://example.com/openapi.json')
-      expect(migratedConfig.url).toBeUndefined()
+      expect(migratedConfig.spec?.url).toBeUndefined()
+      expect(migratedConfig.url).toBe('https://example.com/openapi.json')
+    })
+
+    it('migrates spec.content to content', () => {
+      const config = {
+        spec: {
+          content: '{"openapi": "3.1.0"}',
+        },
+      }
+
+      const migratedConfig = apiReferenceConfigurationSchema.parse(config)
+
+      expect(migratedConfig.spec?.content).toBeUndefined()
+      expect(migratedConfig.content).toBe('{"openapi": "3.1.0"}')
     })
   })
 })

--- a/packages/types/src/api-reference/api-reference-configuration.test.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.test.ts
@@ -91,20 +91,20 @@ describe('api-reference-configuration', () => {
       })
     })
 
-    it('validates spec configuration', () => {
+    it('validates content and url configuration', () => {
       const validConfigs = [
-        { spec: { url: 'https://example.com/openapi.json' } },
-        { spec: { content: '{"openapi": "3.1.0"}' } },
-        { spec: { content: { openapi: '3.1.0' } } },
-        { spec: { content: () => ({ openapi: '3.1.0' }) } },
-        { spec: { content: null } },
+        { url: 'https://example.com/openapi.json' },
+        { content: '{"openapi": "3.1.0"}' },
+        { content: { openapi: '3.1.0' } },
+        { content: () => ({ openapi: '3.1.0' }) },
+        { content: null },
       ]
 
       validConfigs.forEach((config) => {
         expect(() => apiReferenceConfigurationSchema.parse(config)).not.toThrow()
       })
 
-      const invalidConfigs = [{ spec: { url: 999 } }, { spec: { content: 123 } }]
+      const invalidConfigs = [{ url: 999 }, { content: 123 }]
 
       invalidConfigs.forEach((config) => {
         expect(() => apiReferenceConfigurationSchema.parse(config)).toThrow()

--- a/packages/types/src/api-reference/api-reference-configuration.test.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.test.ts
@@ -223,7 +223,7 @@ describe('api-reference-configuration', () => {
       expect(migratedConfig.customCss).toContain('--scalar-color-red')
     })
 
-    it('api reference migrates spec.url to url', () => {
+    it('migrates spec.url to url', () => {
       const config = {
         spec: {
           url: 'https://example.com/openapi.json',
@@ -232,7 +232,7 @@ describe('api-reference-configuration', () => {
 
       const migratedConfig = apiReferenceConfigurationSchema.parse(config)
 
-      expect(migratedConfig.spec?.url).toBeUndefined()
+      expect(migratedConfig.spec).toBeUndefined()
       expect(migratedConfig.url).toBe('https://example.com/openapi.json')
     })
 
@@ -245,7 +245,7 @@ describe('api-reference-configuration', () => {
 
       const migratedConfig = apiReferenceConfigurationSchema.parse(config)
 
-      expect(migratedConfig.spec?.content).toBeUndefined()
+      expect(migratedConfig.spec).toBeUndefined()
       expect(migratedConfig.content).toBe('{"openapi": "3.1.0"}')
     })
   })

--- a/packages/types/src/api-reference/api-reference-configuration.test.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.test.ts
@@ -222,5 +222,16 @@ describe('api-reference-configuration', () => {
       expect(migratedConfig.customCss).not.toContain('--theme-color-red')
       expect(migratedConfig.customCss).toContain('--scalar-color-red')
     })
+
+    it('prefixes url with spec', () => {
+      const config = {
+        url: 'https://example.com/openapi.json',
+      }
+
+      const migratedConfig = apiReferenceConfigurationSchema.parse(config)
+
+      expect(migratedConfig.spec?.url).toBe('https://example.com/openapi.json')
+      expect(migratedConfig.url).toBeUndefined()
+    })
   })
 })

--- a/packages/types/src/api-reference/html-rendering-configuration.ts
+++ b/packages/types/src/api-reference/html-rendering-configuration.ts
@@ -26,4 +26,5 @@ export const htmlRenderingConfigurationSchema = z.object({
  *
  * It’s the ApiReferenceConfiguration, but extended with the `pageTitle` and `cdn` options.
  */
-export type HtmlRenderingConfiguration = ApiReferenceConfiguration & z.infer<typeof htmlRenderingConfigurationSchema>
+export type HtmlRenderingConfiguration = Partial<ApiReferenceConfiguration> &
+  z.infer<typeof htmlRenderingConfigurationSchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,9 @@ importers:
       '@scalar/api-reference-react':
         specifier: workspace:*
         version: link:../../packages/api-reference-react
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       react:
         specifier: ^18.0.0
         version: 18.3.1


### PR DESCRIPTION
**Problem**

Currently, we add a `spec` prefix to the content sources (for some reason):

```diff
const configuration = {
-  spec: {
-    url: '/openapi.json',
-  }
}
```

It might make sense to nest a few of the settings, but the content and the URL is so important it should be top-level.

Every time I see code that deals with it, it feels strange to tap into the nested object.

**Solution**

With this PR we’re removing the `spec` prefix. We still understand the old syntax, warn about it in the browser console and in TypeScript and migrate to the new syntax using the new Zod pipeline for the configuration.

```diff
const configuration = {
+  url: '/openapi.json',
}
```

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
