### PR TITLE
fix(components): scalar modal position

### DIFF
--- a/.changeset/flat-camels-do.md
+++ b/.changeset/flat-camels-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: removes auto margin in scalar modal

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -25,7 +25,7 @@ const { size = 'md' } = defineProps<{
 const modal = cva({
   base: [
     'scalar-modal',
-    'flex flex-col relative mx-auto mb-0 rounded-lg bg-b-1 p-0 text-left leading-snug text-c-1 opacity-0 w-[calc(100vw-12px)] md:w-[calc(100vw-16px)] lg:w-[calc(100vw-32px)]',
+    'flex flex-col relative mb-0 rounded-lg bg-b-1 p-0 text-left leading-snug text-c-1 opacity-0 w-[calc(100vw-12px)] md:w-[calc(100vw-16px)] lg:w-[calc(100vw-32px)]',
   ].join(' '),
   variants: {
     size: {


### PR DESCRIPTION
**Problem**

Currently the modal is centered when opening the client from an api reference.

**Solution**

this pr removes the x axis margin from the scalar modal component.

| before | after |
| -------|------|
| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/b230e37d-2a73-4531-a5e6-abeb705ff088" /> | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/e6b0e841-ca39-407a-8493-ca2ffbafaca6" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
