### PR TITLE
feat(api-reference): add version logged to the console

### DIFF
--- a/.changeset/sixty-maps-battle.md
+++ b/.changeset/sixty-maps-battle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: added standalone reference version log to the console

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -7,7 +7,7 @@ import { getConfigurationFromDataAttributes, mountScalarApiReference } from '@/s
 
 // Log the version of the API Reference
 if (process.env.SCALAR_API_REFERENCE_VERSION) {
-  console.info('Scalar API Reference version: ', process.env.SCALAR_API_REFERENCE_VERSION)
+  console.info('Scalar API Reference version:', process.env.SCALAR_API_REFERENCE_VERSION)
 }
 
 mountScalarApiReference(document, getConfigurationFromDataAttributes(document))

--- a/packages/api-reference/src/standalone.ts
+++ b/packages/api-reference/src/standalone.ts
@@ -5,4 +5,9 @@
  */
 import { getConfigurationFromDataAttributes, mountScalarApiReference } from '@/standalone/lib/html-api'
 
+// Log the version of the API Reference
+if (process.env.SCALAR_API_REFERENCE_VERSION) {
+  console.info('Scalar API Reference version: ', process.env.SCALAR_API_REFERENCE_VERSION)
+}
+
 mountScalarApiReference(document, getConfigurationFromDataAttributes(document))

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -2,11 +2,13 @@ import { URL, fileURLToPath } from 'node:url'
 import { autoCSSInject, createViteBuildOptions } from '@scalar/build-tooling'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vitest/config'
+import { version } from './package.json'
 
 export default defineConfig({
   plugins: [vue()],
   define: {
     'process.env.NODE_ENV': '"production"',
+    'process.env.SCALAR_API_REFERENCE_VERSION': `"${version}"`,
   },
   resolve: {
     alias: {

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -17,6 +17,7 @@ function replaceVariables(template: string, variables: Record<string, string>) {
 export default defineConfig({
   define: {
     'process.env.NODE_ENV': '"production"',
+    'process.env.SCALAR_API_REFERENCE_VERSION': `"${version}"`,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
**Problem**

Currently, its kind of hard to know what version of references users are on when debugging.

**Solution**

With this PR we log the version so we can grab it from the console.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
