### PR TITLE
fix(api-client): incorrect body being selected

### DIFF
--- a/.changeset/seven-monkeys-cover.md
+++ b/.changeset/seven-monkeys-cover.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: body showing none instead of json

--- a/integrations/nuxt/package.json
+++ b/integrations/nuxt/package.json
@@ -25,7 +25,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "pnpm dev:prepare && nuxt-module-build build",
+    "build": "NUXT_TELEMETRY_DISABLED=false pnpm dev:prepare && nuxt-module-build build",
     "dev": "pnpm dev:prepare && nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxi prepare && nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
@@ -64,7 +64,7 @@ describe('RequestBody.vue', () => {
 
   it('renders correctly with no body', async () => {
     const wrapper = mount(RequestBody, props)
-    expect(wrapper.text()).toContain('No Body')
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('None')
     wrapper.unmount()
   })
 
@@ -76,9 +76,9 @@ describe('RequestBody.vue', () => {
         value: [],
       },
     }
-    const wrapper = mount(RequestBody, props)
 
-    expect(wrapper.text()).toContain('Multipart Form')
+    const wrapper = mount(RequestBody, props)
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('Multipart Form')
     wrapper.unmount()
   })
 
@@ -92,7 +92,7 @@ describe('RequestBody.vue', () => {
     }
     const wrapper = mount(RequestBody, props)
 
-    expect(wrapper.text()).toContain('Form URL Encoded')
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('Form URL Encoded')
     wrapper.unmount()
   })
 
@@ -102,7 +102,7 @@ describe('RequestBody.vue', () => {
     }
     const wrapper = mount(RequestBody, props)
 
-    expect(wrapper.text()).toContain('Binary File')
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('Binary File')
     wrapper.unmount()
   })
 
@@ -116,7 +116,9 @@ describe('RequestBody.vue', () => {
     }
     const wrapper = mount(RequestBody, props)
 
-    expect(wrapper.text()).toContain('JSON')
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('JSON')
     wrapper.unmount()
   })
 
@@ -130,7 +132,7 @@ describe('RequestBody.vue', () => {
     }
     const wrapper = mount(RequestBody, props)
 
-    expect(wrapper.text()).toContain('XML')
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('XML')
     wrapper.unmount()
   })
 
@@ -144,7 +146,7 @@ describe('RequestBody.vue', () => {
     }
     const wrapper = mount(RequestBody, props)
 
-    expect(wrapper.text()).toContain('YAML')
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('YAML')
     wrapper.unmount()
   })
 
@@ -158,7 +160,7 @@ describe('RequestBody.vue', () => {
     }
     const wrapper = mount(RequestBody, props)
 
-    expect(wrapper.text()).toContain('EDN')
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('EDN')
     wrapper.unmount()
   })
 
@@ -172,7 +174,7 @@ describe('RequestBody.vue', () => {
     }
     const wrapper = mount(RequestBody, props)
 
-    expect(wrapper.text()).toContain('Other')
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('Other')
     wrapper.unmount()
   })
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -68,16 +68,16 @@ const contentTypeOptions = (
 /** Match the activeBody to the contentTypeOptions */
 const activeExampleContentType = computed(() => {
   const { activeBody, formData, raw } = example.body
-  if (raw?.mimeType) return raw.mimeType
+  // if (raw?.mimeType) return raw.mimeType
   // Form
   if (activeBody === 'formData')
     return formData?.encoding === 'urlencoded'
       ? 'formUrlEncoded'
       : 'multipartForm'
   // Binary
-  else if (activeBody === 'binary') return 'binaryFile'
+  if (activeBody === 'binary') return 'binaryFile'
   // Raw
-  else if (activeBody === 'raw' && raw?.encoding) {
+  if (activeBody === 'raw' && raw?.encoding) {
     if (raw.encoding === 'html') return 'other'
     return raw.encoding
   }

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -68,7 +68,7 @@ const contentTypeOptions = (
 /** Match the activeBody to the contentTypeOptions */
 const activeExampleContentType = computed(() => {
   const { activeBody, formData, raw } = example.body
-  // if (raw?.mimeType) return raw.mimeType
+
   // Form
   if (activeBody === 'formData')
     return formData?.encoding === 'urlencoded'


### PR DESCRIPTION
**Problem**

Currently, the body selected would be none due to an early return of mime type

**Solution**

With this PR we remove that early return and things seem to just work?

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
