### PR TITLE
fix(code-highlight): markdown alert

### DIFF
--- a/.changeset/fuzzy-spies-type.md
+++ b/.changeset/fuzzy-spies-type.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+fix: allows alert plugin classes in markdown

--- a/.changeset/loud-chairs-teach.md
+++ b/.changeset/loud-chairs-teach.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+feat: updates markdown alert style

--- a/documentation/markdown.md
+++ b/documentation/markdown.md
@@ -29,6 +29,7 @@ The following alert types are supported:
 - `important`
 - `warning`
 - `caution`
+- `success`
 
 [Have a look at our OpenAPI example](https://github.com/scalar/scalar/blob/main/packages/galaxy/src/documents/3.1.yaml)
 to see more examples.

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -304,32 +304,61 @@
     font-size: var(--scalar-small);
     gap: 12px;
     padding: 12px;
+    padding-left: 42px;
+    position: relative;
   }
-  .markdown .markdown-alert .markdown-alert-border {
-    border-radius: var(--scalar-radius-xl);
-    min-width: 1.5px;
-    width: 1.5px;
+
+  .markdown .markdown-alert::before {
+    content: "";
+    position: absolute;
+    left: 12px;
+    top: 12px;
+    width: 20px;
+    height: 20px;
+    background-color: currentColor;
+    mask-repeat: no-repeat;
+    mask-size: contain;
+    mask-position: center;
   }
+
+  .markdown .markdown-alert.markdown-alert-note::before,
+  .markdown .markdown-alert.markdown-alert-tip::before {
+    mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 17v-6a.5.5 0 0 0-.5-.5l-.5.001h-1M12 17h-2m2 0h2m-2 5c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Z" stroke="currentColor" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/><path fill-rule="evenodd" clip-rule="evenodd" d="M10.75 7.5a1 1 0 1 1 2 0 1 1 0 0 1-2 0Z" fill="currentColor"/></svg>');
+  }
+
+  .markdown .markdown-alert.markdown-alert-important::before,
+  .markdown .markdown-alert.markdown-alert-warning::before {
+    mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 8v4m10 0c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill-rule="evenodd" clip-rule="evenodd" d="M11 16a1 1 0 1 1 2 0 1 1 0 0 1-2 0Z" fill="currentColor"/></svg>');
+  }
+
+  .markdown .markdown-alert.markdown-alert-caution::before {
+    mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 8v4m3.312-10a2 2 0 0 1 1.414.586l4.688 4.688A2 2 0 0 1 22 8.688v6.624a2 2 0 0 1-.586 1.414l-4.688 4.688a2 2 0 0 1-1.414.586H8.688a2 2 0 0 1-1.414-.586l-4.688-4.688A2 2 0 0 1 2 15.312V8.688a2 2 0 0 1 .586-1.414l4.688-4.688A2 2 0 0 1 8.688 2h6.624Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill-rule="evenodd" clip-rule="evenodd" d="M11 16a1 1 0 1 1 2 0 1 1 0 0 1-2 0Z" fill="currentColor"/></svg>');
+    color: var(--scalar-color-red);
+  }
+
+  .markdown .markdown-alert.markdown-alert-success::before {
+    mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 9.5 10.5 15 8 12.5m14-.5c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+    color: var(--scalar-color-green);
+  }
+
+  .markdown .markdown-alert.markdown-alert-note::before {
+    color: var(--scalar-color-blue);
+  }
+
+  .markdown .markdown-alert.markdown-alert-tip::before {
+    color: var(--scalar-color-2);
+  }
+
+  .markdown .markdown-alert.markdown-alert-important::before {
+    color: var(--scalar-color-purple);
+  }
+
+  .markdown .markdown-alert.markdown-alert-warning::before {
+    color: var(--scalar-color-orange);
+  }
+
   .markdown .markdown-alert .markdown-alert-content {
     margin: 0;
     line-height: 1.5;
-  }
-  .markdown .markdown-alert .markdown-alert-title {
-    font-weight: var(--scalar-semibold);
-  }
-  .markdown .markdown-alert.markdown-alert-note .markdown-alert-border {
-    background-color: var(--scalar-color-blue);
-  }
-  .markdown .markdown-alert.markdown-alert-tip .markdown-alert-border {
-    background-color: var(--scalar-color-green);
-  }
-  .markdown .markdown-alert.markdown-alert-important .markdown-alert-border {
-    background-color: var(--scalar-color-purple);
-  }
-  .markdown .markdown-alert.markdown-alert-warning .markdown-alert-border {
-    background-color: var(--scalar-color-orange);
-  }
-  .markdown .markdown-alert.markdown-alert-caution .markdown-alert-border {
-    background-color: var(--scalar-color-red);
   }
 }

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -84,7 +84,6 @@ export function htmlFromMarkdown(
         abbr: ['title'],
         // Allow alert classes
         div: ['class', ['className', /^markdown-alert(-.*)?$/]],
-        span: ['class', ['className', /^markdown-alert(-.*)?$/]],
       },
     })
     // Syntax highlighting

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -68,6 +68,8 @@ export function htmlFromMarkdown(
     })
     // Allows any HTML tags
     .use(remarkRehype, { allowDangerousHtml: true })
+    // Adds GitHub alerts
+    .use(rehypeAlert)
     // Creates a HTML AST
     .use(rehypeRaw)
     // Removes disallowed tags
@@ -80,6 +82,9 @@ export function htmlFromMarkdown(
       attributes: {
         ...defaultSchema.attributes,
         abbr: ['title'],
+        // Allow alert classes
+        div: ['class', ['className', /^markdown-alert(-.*)?$/]],
+        span: ['class', ['className', /^markdown-alert(-.*)?$/]],
       },
     })
     // Syntax highlighting
@@ -88,8 +93,6 @@ export function htmlFromMarkdown(
       // Enable auto detection
       detect: true,
     })
-    // Adds GitHub alerts
-    .use(rehypeAlert)
     // Adds target="_blank" to external links
     .use(rehypeExternalLinks, { target: '_blank' })
     // Formats the HTML

--- a/packages/code-highlight/src/rehype-alert/rehype-alert.test.ts
+++ b/packages/code-highlight/src/rehype-alert/rehype-alert.test.ts
@@ -22,9 +22,7 @@ describe('rehype-alert', () => {
     const output = await process(input)
 
     expect(output).toContain('<div class="markdown-alert markdown-alert-note">')
-    expect(output).toContain('<span class="markdown-alert-border"></span>')
     expect(output).toContain('<div class="markdown-alert-content">')
-    expect(output).toContain('<span class="markdown-alert-title">Note:</span>')
     expect(output).toContain('This is a note callout.')
   })
 
@@ -33,7 +31,6 @@ describe('rehype-alert', () => {
     const output = await process(input)
 
     expect(output).toContain('<div class="markdown-alert markdown-alert-warning">')
-    expect(output).toContain('<span class="markdown-alert-title">Warning:</span>')
     expect(output).toContain('This is a warning callout.')
   })
 
@@ -42,7 +39,6 @@ describe('rehype-alert', () => {
     const output = await process(input)
 
     expect(output).toContain('<div class="markdown-alert markdown-alert-caution">')
-    expect(output).toContain('<span class="markdown-alert-title">Caution:</span>')
     expect(output).toContain('This is a caution callout.')
   })
 
@@ -51,7 +47,6 @@ describe('rehype-alert', () => {
     const output = await process(input)
 
     expect(output).toContain('<div class="markdown-alert markdown-alert-important">')
-    expect(output).toContain('<span class="markdown-alert-title">Important:</span>')
     expect(output).toContain('This is an important callout.')
   })
 
@@ -60,7 +55,6 @@ describe('rehype-alert', () => {
     const output = await process(input)
 
     expect(output).toContain('<div class="markdown-alert markdown-alert-tip">')
-    expect(output).toContain('<span class="markdown-alert-title">Tip:</span>')
     expect(output).toContain('This is a tip callout.')
   })
 

--- a/packages/code-highlight/src/rehype-alert/rehype-alert.ts
+++ b/packages/code-highlight/src/rehype-alert/rehype-alert.ts
@@ -2,7 +2,7 @@ import { visit } from 'unist-util-visit'
 import type { Element } from 'hast'
 import type { Root } from 'mdast'
 
-const ALERT_TYPES = ['note', 'tip', 'important', 'warning', 'caution'] as const
+const ALERT_TYPES = ['note', 'tip', 'important', 'warning', 'caution', 'success'] as const
 
 // Simple whitespace check function
 function isWhitespace(node: any): boolean {
@@ -65,8 +65,6 @@ export function rehypeAlert() {
         text.value = text.value.replace(/^\s*\[!.*?\]\s*/, '')
       }
 
-      const capitalizedType = alertType.charAt(0).toUpperCase() + alertType.slice(1)
-
       // Extract content from paragraphs to avoid wrapping in <p> tags
       const contentChildren = []
       for (let i = headIndex; i < node.children.length; i++) {
@@ -86,24 +84,9 @@ export function rehypeAlert() {
         children: [
           {
             type: 'element',
-            tagName: 'span',
-            properties: { className: ['markdown-alert-border'] },
-            children: [],
-          },
-          {
-            type: 'element',
             tagName: 'div',
             properties: { className: ['markdown-alert-content'] },
-            children: [
-              {
-                type: 'element',
-                tagName: 'span',
-                properties: { className: ['markdown-alert-title'] },
-                children: [{ type: 'text', value: `${capitalizedType}:` }],
-              },
-              { type: 'text', value: ' ' },
-              ...contentChildren,
-            ],
+            children: [{ type: 'text', value: ' ' }, ...contentChildren],
           },
         ],
       }


### PR DESCRIPTION
**Problem**

currently markdown alert are not being properly styled within api reference.

**Solution**

this pr fixes the markdown alert rendering + adds icon and update style.

| before | after |
| -------|------|
| <img width="620" alt="image" src="https://github.com/user-attachments/assets/f08a57d2-1118-4006-87ab-529adfb4df28" /> | <img width="620" alt="image" src="https://github.com/user-attachments/assets/eb626747-40e1-4ba6-b633-2216e785d274" /> |

<details>
<summary>All the supported alert</summary>

| code | preview |
| -------|------|
| [!note] | <img width="527" alt="image" src="https://github.com/user-attachments/assets/06104289-86e0-4696-9782-c18c5e29c7e9" /> |
| [!tip] | <img width="527" alt="image" src="https://github.com/user-attachments/assets/4e803e96-7c7d-4e26-add6-8afc41780294" /> |
| [!important] | <img width="527" alt="image" src="https://github.com/user-attachments/assets/4e09d18a-f171-4997-b8bc-ebfb8abb8fe4" /> |
| [!warning] | <img width="527" alt="image" src="https://github.com/user-attachments/assets/931c84b1-1671-4956-9d16-62aa28ce1ceb" /> |
| [!caution] | <img width="527" alt="image" src="https://github.com/user-attachments/assets/3cb5c09f-eb38-471b-bee8-f3d8a4f0a4a3" /> |
| [!success] | <img width="527" alt="image" src="https://github.com/user-attachments/assets/05d579d9-ec72-4f30-b3fc-adef40defa22" /> |
</details>

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
