### PR TITLE
fix(fastify-api-reference): ensure we copy over the standalone file into the correct directory

### DIFF
--- a/.changeset/red-windows-juggle.md
+++ b/.changeset/red-windows-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: fastify docker build standalone copy

--- a/.changeset/six-impalas-return.md
+++ b/.changeset/six-impalas-return.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: auth selected security scheme undefined

--- a/integrations/fastify/vite.config.ts
+++ b/integrations/fastify/vite.config.ts
@@ -1,7 +1,8 @@
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import { defineConfig } from 'vitest/config'
+import { resolve } from 'node:path'
 
-import pkg from './package.json'
+import pkg from './package.json' assert { type: 'json' }
 import { nodeExternals } from './vite-plugins/nodeExternals.ts'
 
 export default defineConfig({
@@ -10,7 +11,7 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
-          src: '../../packages/api-reference/dist/browser/standalone.js',
+          src: resolve(__dirname, '../../packages/api-reference/dist/browser/standalone.js'),
           dest: './js',
         },
       ],

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -85,9 +85,9 @@ export const getSelectedSecuritySchemeUids = (
     securityRequirements[0] && !preferredSecurityNames.length ? [securityRequirements[0]] : preferredSecurityNames
 
   // Map names to uids
-  const uids = names.map((name) =>
-    Array.isArray(name) ? name.map((k) => securitySchemeMap[k]) : securitySchemeMap[name],
-  )
+  const uids = names
+    .map((name) => (Array.isArray(name) ? name.map((k) => securitySchemeMap[k]) : securitySchemeMap[name]))
+    .filter(isDefined)
 
   return uids
 }


### PR DESCRIPTION
**Problem**

Currently, the standalone file seems to be missing

**Solution**

With this PR we find it using resolve so its relative to the current file. ALSO as a bonus we remove undefined selected security schemes.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
