### PR TITLE
fix(api-client): missing authentication in code snippet

### DIFF
--- a/.changeset/shiny-pans-notice.md
+++ b/.changeset/shiny-pans-notice.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: use operation security scheme if available in request

--- a/packages/api-client/src/views/Components/CodeSnippet/helpers/get-snippet.ts
+++ b/packages/api-client/src/views/Components/CodeSnippet/helpers/get-snippet.ts
@@ -43,6 +43,7 @@ export const getSnippet = <T extends TargetId>(
     try {
       new URL(harRequest.url)
     } catch (error) {
+      console.error('[getSnippet] Invalid URL', error)
       harRequest.url = `${INVALID_URLS_PREFIX}${separator}${harRequest.url}`
     }
 
@@ -51,6 +52,7 @@ export const getSnippet = <T extends TargetId>(
       try {
         JSON.parse(harRequest.postData.text || '{}')
       } catch (error) {
+        console.error('[getSnippet] Invalid JSON body', error)
         return [new Error('Invalid JSON body'), null]
       }
     }
@@ -64,7 +66,7 @@ export const getSnippet = <T extends TargetId>(
       return [null, payload.replace(`${INVALID_URLS_PREFIX}${separator}`, '')]
     }
   } catch (error) {
-    console.error('[getSnippet]', error)
+    console.error('[getSnippet] Error generating snippet', error)
     return [new Error('Error generating snippet'), null]
   }
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.test.ts
@@ -3,8 +3,8 @@ import {
   collectionSchema,
   operationSchema,
   requestExampleSchema,
+  securitySchemeSchema,
   serverSchema,
-  type SecurityScheme,
 } from '@scalar/oas-utils/entities/spec'
 import type { ClientId, TargetId } from '@scalar/snippetz'
 
@@ -124,18 +124,19 @@ describe('RequestCodeExample.vue', () => {
   })
 
   it('filters security schemes correctly', async () => {
+    const scheme = securitySchemeSchema.parse({
+      uid: 'authUid',
+      type: 'apiKey',
+      nameKey: 'auth',
+      value: 'test-key',
+      in: 'header',
+    })
     const securitySchemes = {
-      'auth': {
-        uid: 'auth',
-        type: 'apiKey',
-        value: 'test-key',
-        nameKey: 'X-API-Key',
-        in: 'header',
-      },
+      [scheme.uid]: scheme,
     }
 
-    mockOperation.security = [{ 'auth': [] }]
-    mockOperation.selectedSecuritySchemeUids = ['auth'] as SecurityScheme['uid'][]
+    mockOperation.security = [{ [scheme.nameKey]: [] }]
+    mockOperation.selectedSecuritySchemeUids = [scheme.uid]
     ;(useWorkspace as Mock).mockReturnValue({
       securitySchemes,
       workspaceMutators: mockWorkspaceMutators,
@@ -146,7 +147,7 @@ describe('RequestCodeExample.vue', () => {
     })
 
     expect((wrapper.vm as any).selectedSecuritySchemes.length).toBe(1)
-    expect((wrapper.vm as any).selectedSecuritySchemes[0]).toEqual(securitySchemes['auth'])
+    expect((wrapper.vm as any).selectedSecuritySchemes[0]).toEqual(securitySchemes[scheme.uid])
 
     wrapper.unmount()
   })

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.test.ts
@@ -1,0 +1,153 @@
+import { useWorkspace } from '@/store'
+import {
+  collectionSchema,
+  operationSchema,
+  requestExampleSchema,
+  serverSchema,
+  type SecurityScheme,
+} from '@scalar/oas-utils/entities/spec'
+import type { ClientId, TargetId } from '@scalar/snippetz'
+
+import { mount } from '@vue/test-utils'
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
+
+import RequestCodeExample from './RequestCodeExample.vue'
+
+// Mock the useWorkspace hook
+vi.mock('@/store', () => ({
+  useWorkspace: vi.fn(),
+}))
+
+// Mock the snippetz library
+vi.mock('@scalar/snippetz', () => ({
+  snippetz: () => ({
+    clients: () => [
+      {
+        key: 'js',
+        title: 'JavaScript',
+        clients: [
+          { client: 'fetch', title: 'Fetch' },
+          { client: 'axios', title: 'Axios' },
+        ],
+      },
+      {
+        key: 'shell',
+        title: 'Shell',
+        clients: [{ client: 'curl', title: 'Curl' }],
+      },
+    ],
+  }),
+}))
+
+// Mock the operation
+const mockOperation = operationSchema.parse({
+  uid: 'mockOperationUid',
+  method: 'get',
+  security: [],
+})
+
+// Mock the collection
+const mockCollection = collectionSchema.parse({
+  uid: 'mockCollectionUid',
+  security: [],
+})
+
+// Mock the example
+const mockExample = requestExampleSchema.parse({
+  uid: 'mockExampleUid',
+})
+
+// Mock the server
+const mockServer = serverSchema.parse({
+  uid: 'mockServerUid',
+  url: 'https://api.example.com',
+})
+
+// Mock the workspace
+const mockWorkspace = workspaceSchema.parse({
+  uid: 'mockWorkspaceUid',
+  selectedHttpClient: {
+    targetKey: 'js' as TargetId,
+    clientKey: 'fetch' as ClientId<'js'>,
+  },
+})
+
+// Mock the workspace mutators
+const mockWorkspaceMutators = {
+  edit: vi.fn(),
+}
+
+describe('RequestCodeExample.vue', () => {
+  beforeEach(() => {
+    ;(useWorkspace as Mock).mockReturnValue({
+      securitySchemes: {},
+      workspaceMutators: mockWorkspaceMutators,
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const props = {
+    collection: mockCollection,
+    example: mockExample,
+    operation: mockOperation,
+    server: mockServer,
+    workspace: mockWorkspace,
+  }
+
+  it('renders correctly with default props', async () => {
+    const wrapper = mount(RequestCodeExample, {
+      props,
+    })
+
+    expect(wrapper.find('.w-full').exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'ViewLayoutCollapse' }).exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('selects a different client when dropdown changes', async () => {
+    const wrapper = mount(RequestCodeExample, {
+      props,
+    })
+
+    await (wrapper.vm as any).selectClient({ id: 'shell,curl', label: 'curl' })
+
+    expect(mockWorkspaceMutators.edit).toHaveBeenCalledWith('mockWorkspaceUid', 'selectedHttpClient', {
+      targetKey: 'shell' as TargetId,
+      clientKey: 'curl' as ClientId<'shell'>,
+    })
+
+    wrapper.unmount()
+  })
+
+  it('filters security schemes correctly', async () => {
+    const securitySchemes = {
+      'auth': {
+        uid: 'auth',
+        type: 'apiKey',
+        value: 'test-key',
+        nameKey: 'X-API-Key',
+        in: 'header',
+      },
+    }
+
+    mockOperation.security = [{ 'auth': [] }]
+    mockOperation.selectedSecuritySchemeUids = ['auth'] as SecurityScheme['uid'][]
+    ;(useWorkspace as Mock).mockReturnValue({
+      securitySchemes,
+      workspaceMutators: mockWorkspaceMutators,
+    })
+
+    const wrapper = mount(RequestCodeExample, {
+      props,
+    })
+
+    expect((wrapper.vm as any).selectedSecuritySchemes.length).toBe(1)
+    expect((wrapper.vm as any).selectedSecuritySchemes[0]).toEqual(securitySchemes['auth'])
+
+    wrapper.unmount()
+  })
+})

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -36,24 +36,14 @@ const { securitySchemes, workspaceMutators } = useWorkspace()
 /**
  * Just the relevant security schemes for the selected request
  */
-const selectedSecuritySchemes = computed(() => {
-  const schema = filterSecurityRequirements(
+const selectedSecuritySchemes = computed(() =>
+  filterSecurityRequirements(
     operation.security || collection.security || [],
     operation.selectedSecuritySchemeUids ||
       collection.selectedSecuritySchemeUids,
     securitySchemes,
-  )
-
-  // If no schema - use the operation selectedSecuritySchemeUids
-  if (!schema.length) {
-    return operation.selectedSecuritySchemeUids
-      ?.flatMap((uids) => (Array.isArray(uids) ? uids : [uids]))
-      .map((uid) => securitySchemes[uid])
-      .filter((scheme) => scheme !== undefined)
-  }
-
-  return schema
-})
+  ),
+)
 
 /** Group plugins by target/language to show in a dropdown, also build a dictionary in the same loop */
 const snippets = computed(() => {

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -36,13 +36,24 @@ const { securitySchemes, workspaceMutators } = useWorkspace()
 /**
  * Just the relevant security schemes for the selected request
  */
-const selectedSecuritySchemes = computed(() =>
-  filterSecurityRequirements(
+const selectedSecuritySchemes = computed(() => {
+  const schema = filterSecurityRequirements(
     operation.security || collection.security || [],
-    collection.selectedSecuritySchemeUids,
+    operation.selectedSecuritySchemeUids ||
+      collection.selectedSecuritySchemeUids,
     securitySchemes,
-  ),
-)
+  )
+
+  // If no schema - use the operation selectedSecuritySchemeUids
+  if (!schema.length) {
+    return operation.selectedSecuritySchemeUids
+      ?.flatMap((uids) => (Array.isArray(uids) ? uids : [uids]))
+      .map((uid) => securitySchemes[uid])
+      .filter((scheme) => scheme !== undefined)
+  }
+
+  return schema
+})
 
 /** Group plugins by target/language to show in a dropdown, also build a dictionary in the same loop */
 const snippets = computed(() => {


### PR DESCRIPTION
**Problem**

currently the authentication is missing from the code snippet

**Solution**

this pr sets the operation security scheme uid in the request code example.

| before | after |
| -------|------|
| <img width="628" alt="image" src="https://github.com/user-attachments/assets/c8834344-06a2-4e07-ae9e-1ff07dde1b81" /> | <img width="628" alt="image" src="https://github.com/user-attachments/assets/1c8f6ac1-db70-4a0c-9429-be7f3bd7ac1c" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
