### PR TITLE
chore: update eol to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.prettierrc
+++ b/.prettierrc
@@ -10,6 +10,7 @@
   "singleQuote": true,
   "singleAttributePerLine": true,
   "bracketSameLine": true,
+  "endOfLine": "lf",
   "importOrder": [
     "<BUILTIN_MODULES>",
     "",


### PR DESCRIPTION
**Problem**

Windows users (✋) had issues with prettier and biome during a commit. The formatters replaced every EOL to `crlf`.

![image](https://github.com/user-attachments/assets/d37d2550-72f4-40fe-85bc-de198d7a6f23)


**Solution**
I added a `.gitattributes` file to the root of the project and updated the prettier config. Other big projects also have the `* text=auto` setting in the configuration. It looks like this works on my (windows) machine. It would be awesome if someone with a mac could verify that `pnpm format` works as expected.

With this PR …

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] ~I’ve added a changeset (`pnpm changeset`).~
- [ ] ~I’ve added tests for the regression or new feature.~
- [ ] ~I’ve updated the documentation.~

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
