### PR TITLE
fix(fastify): missing script to build playground

### DIFF
--- a/.changeset/odd-trees-listen.md
+++ b/.changeset/odd-trees-listen.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: one final CI/docker fix for fastify

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "build": "scalar-build-rollup && pnpm copy:standalone",
+    "build:playground": "cd playground && pnpm build",
     "copy:standalone": "mkdir -p ./dist/js && cp ../../packages/api-reference/dist/browser/standalone.js ./dist/js/standalone.js",
     "dev": "cd playground && pnpm dev",
     "docker:build": "docker build --build-arg BASE_IMAGE=scalar-base -t fastify-api-reference -f Dockerfile .",


### PR DESCRIPTION
**Problem**

Currently, we were missing the build:playground script.

**Solution**

With this PR we add it back

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
