### PR TITLE
fix(api-reference): make useConfig reactive

### DIFF
--- a/.changeset/nine-suits-greet.md
+++ b/.changeset/nine-suits-greet.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: make useConfig reactive

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -291,7 +291,7 @@ provide(ACTIVE_ENTITIES_SYMBOL, activeEntitiesStore)
 provide(LAYOUT_SYMBOL, 'modal')
 
 // Provide the configuration
-provide(CONFIGURATION_SYMBOL, configuration.value)
+provide(CONFIGURATION_SYMBOL, configuration)
 
 // ---------------------------------------------------------------------------/
 // HANDLE MAPPING CONFIGURATION TO INTERNAL REFERENCE STATE

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -55,8 +55,8 @@ const version = computed(() => {
 })
 
 /** Trigger the onLoaded event when the component is mounted */
-const { onLoaded } = useConfig()
-onMounted(() => onLoaded?.())
+const config = useConfig()
+onMounted(() => config.value.onLoaded?.())
 </script>
 <template>
   <SectionContainer>

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -21,10 +21,10 @@ const updateServerVariable = (key: string, value: string) => {
 
   serverMutators.edit(activeServer.value.uid, 'variables', variables)
 }
-const { onServerChange } = useConfig()
+const config = useConfig()
 
 const updateServer = (server: string) => {
-  onServerChange?.(server)
+  config.value.onServerChange?.(server)
 }
 </script>
 <template>

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -13,16 +13,12 @@ import type { TransformedOperation } from '@scalar/types/legacy'
 import { useExampleStore } from '#legacy'
 import { computed, ref, useId, watch } from 'vue'
 
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-} from '../../components/Card'
-import { HttpMethod } from '../../components/HttpMethod'
-import ScreenReader from '../../components/ScreenReader.vue'
-import { useConfig } from '../../hooks/useConfig'
-import { useHttpClientStore, type HttpClientState } from '../../stores'
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/Card'
+import { HttpMethod } from '@/components/HttpMethod'
+import ScreenReader from '@/components/ScreenReader.vue'
+import { useConfig } from '@/hooks/useConfig'
+import { useHttpClientStore, type HttpClientState } from '@/stores'
+
 import ExamplePicker from './ExamplePicker.vue'
 import TextSelect from './TextSelect.vue'
 

--- a/packages/api-reference/src/features/Search/useSearchIndex.test.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { toRef } from 'vue'
 
 import { createEmptySpecification, parse } from '../../helpers'
 import { useSearchIndex } from './useSearchIndex'
+
+// Mock the useConfig hook
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: vi.fn().mockReturnValue({ value: {} }),
+}))
 
 describe('useSearchIndex', () => {
   it('should create the search index from an OpenAPI document', async () => {

--- a/packages/api-reference/src/features/TestRequestButton/TestRequestButton.test.ts
+++ b/packages/api-reference/src/features/TestRequestButton/TestRequestButton.test.ts
@@ -1,7 +1,7 @@
 import { CONFIGURATION_SYMBOL } from '@/hooks/useConfig'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import TestRequestButton from './TestRequestButton.vue'
 import { operationSchema } from '@scalar/oas-utils/entities/spec'
@@ -27,9 +27,9 @@ describe('TestRequestButton', () => {
     const wrapper = mount(TestRequestButton, {
       global: {
         provide: {
-          [CONFIGURATION_SYMBOL]: {
+          [CONFIGURATION_SYMBOL]: computed(() => ({
             hideTestRequestButton: true,
-          },
+          })),
         },
       },
       props: {

--- a/packages/api-reference/src/features/TestRequestButton/TestRequestButton.vue
+++ b/packages/api-reference/src/features/TestRequestButton/TestRequestButton.vue
@@ -15,7 +15,7 @@ const { client } = useApiClient()
 const config = useConfig()
 
 const isButtonVisible = computed(() => {
-  return config?.hideTestRequestButton !== true
+  return config.value.hideTestRequestButton !== true
 })
 
 const handleClick = () => {

--- a/packages/api-reference/src/features/TestRequestButton/TestRequestButton.vue
+++ b/packages/api-reference/src/features/TestRequestButton/TestRequestButton.vue
@@ -14,9 +14,9 @@ const { operation } = defineProps<{
 const { client } = useApiClient()
 const config = useConfig()
 
-const isButtonVisible = computed(() => {
-  return config.value.hideTestRequestButton !== true
-})
+const isButtonVisible = computed(
+  () => config.value.hideTestRequestButton !== true,
+)
 
 const handleClick = () => {
   if (operation && client?.value?.open) {

--- a/packages/api-reference/src/hooks/useConfig.test.ts
+++ b/packages/api-reference/src/hooks/useConfig.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, computed, inject } from 'vue'
+import { useConfig, CONFIGURATION_SYMBOL } from './useConfig'
+import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+
+// Mock Vue's inject function
+vi.mock('vue', async () => {
+  const actual = await vi.importActual('vue')
+  return {
+    ...actual,
+    inject: vi.fn(),
+  }
+})
+
+describe('useConfig', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns default config when no config is provided', () => {
+    // Mock inject to return the default computed value
+    vi.mocked(inject).mockReturnValue(computed(() => apiReferenceConfigurationSchema.parse({})))
+
+    const config = useConfig()
+    expect(config.value).toEqual(apiReferenceConfigurationSchema.parse({}))
+  })
+
+  it('returns the injected config', () => {
+    // Create a mock config
+    const mockConfig = apiReferenceConfigurationSchema.parse({
+      spec: { url: 'https://example.com/openapi.json' },
+      theme: 'default',
+    })
+
+    // Mock inject to return our mock config
+    vi.mocked(inject).mockReturnValue(computed(() => mockConfig))
+
+    const config = useConfig()
+    expect(config.value).toEqual(mockConfig)
+  })
+
+  it.only('reacts to changes in the injected config', async () => {
+    // Create a reactive source of truth
+    const configSource = ref(
+      apiReferenceConfigurationSchema.parse({
+        spec: { url: 'https://example.com/openapi.json' },
+        theme: 'default',
+      }),
+    )
+
+    // Create a computed property based on the ref
+    const computedConfig = computed(() => configSource.value)
+
+    // Mock inject to return our computed config
+    vi.mocked(inject).mockReturnValue(computedConfig)
+
+    // Get the config using our hook
+    const config = useConfig()
+
+    // Initial value check
+    expect(config.value.theme).toBe('default')
+
+    // Change the source config
+    configSource.value = {
+      ...configSource.value,
+      theme: 'alternate',
+    }
+
+    // The computed value should reflect the change
+    expect(config.value.theme).toBe('alternate')
+  })
+
+  it('integrates with provide/inject pattern', async () => {
+    // This test demonstrates how the hook would be used in a real component setup
+
+    // First, restore the real Vue inject implementation
+    const actualVue = await vi.importActual<typeof import('vue')>('vue')
+    vi.mocked(inject).mockImplementation(actualVue.inject)
+
+    // Create a test harness that simulates the component hierarchy
+    const createTestHarness = () => {
+      // Initial config
+      const configSource = ref(
+        apiReferenceConfigurationSchema.parse({
+          spec: { url: 'https://example.com/openapi.json' },
+          theme: 'default',
+        }),
+      )
+
+      // Computed config that will be provided
+      const computedConfig = computed(() => configSource.value)
+
+      // Create a fresh provide/inject context
+      const symbols = new Map()
+      const mockProvide = (key: symbol, value: any) => {
+        symbols.set(key, value)
+      }
+
+      // Override the inject mock for this test only
+      vi.mocked(inject).mockImplementation((key: symbol | string) => symbols.get(key))
+
+      // Simulate parent component providing the config
+      const parentComponent = {
+        setup() {
+          mockProvide(CONFIGURATION_SYMBOL, computedConfig)
+        },
+      }
+
+      // Simulate child component consuming the config
+      const childComponent = {
+        setup() {
+          return { config: useConfig() }
+        },
+      }
+
+      // Execute the setup functions as Vue would
+      parentComponent.setup()
+      const childSetupResult = childComponent.setup()
+
+      return {
+        configSource,
+        childConfig: childSetupResult?.config,
+      }
+    }
+
+    // Create our test harness
+    const { configSource, childConfig } = createTestHarness()
+
+    // Test initial value
+    expect(childConfig).toBeDefined()
+    expect(childConfig?.value.theme).toBe('default')
+
+    // Test reactivity
+    configSource.value.theme = 'alternate'
+    expect(childConfig?.value.theme).toBe('alternate')
+  })
+})

--- a/packages/api-reference/src/hooks/useConfig.test.ts
+++ b/packages/api-reference/src/hooks/useConfig.test.ts
@@ -39,7 +39,7 @@ describe('useConfig', () => {
     expect(config.value).toEqual(mockConfig)
   })
 
-  it.only('reacts to changes in the injected config', async () => {
+  it('reacts to changes in the injected config', async () => {
     // Create a reactive source of truth
     const configSource = ref(
       apiReferenceConfigurationSchema.parse({

--- a/packages/api-reference/src/hooks/useConfig.ts
+++ b/packages/api-reference/src/hooks/useConfig.ts
@@ -1,10 +1,13 @@
 import { apiReferenceConfigurationSchema, type ApiReferenceConfiguration } from '@scalar/types/api-reference'
-import { type InjectionKey, inject } from 'vue'
+import { type ComputedRef, type InjectionKey, computed, inject } from 'vue'
 
-export const CONFIGURATION_SYMBOL = Symbol() as InjectionKey<ApiReferenceConfiguration>
+export const CONFIGURATION_SYMBOL = Symbol() as InjectionKey<ComputedRef<ApiReferenceConfiguration>>
 
 /** Hook for easy access to the reference configuration */
 export const useConfig = () => {
-  const config = inject(CONFIGURATION_SYMBOL, apiReferenceConfigurationSchema.parse({}))
+  const config = inject(
+    CONFIGURATION_SYMBOL,
+    computed(() => apiReferenceConfigurationSchema.parse({})),
+  )
   return config
 }

--- a/packages/api-reference/src/hooks/useNavState.test.ts
+++ b/packages/api-reference/src/hooks/useNavState.test.ts
@@ -4,10 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNavState } from './useNavState'
 import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { computed } from 'vue'
 
 // Mock the useConfig hook
 vi.mock('@/hooks/useConfig', () => ({
-  useConfig: vi.fn().mockReturnValue({}),
+  useConfig: vi.fn().mockReturnValue({ value: {} }),
 }))
 
 describe('useNavState', () => {
@@ -81,13 +82,15 @@ describe('useNavState', () => {
 
   describe('custom slug generation', () => {
     beforeEach(() => {
-      const mockConfig = apiReferenceConfigurationSchema.parse({
-        generateHeadingSlug: vi.fn().mockReturnValue('custom-heading'),
-        generateModelSlug: vi.fn().mockReturnValue('custom-model'),
-        generateTagSlug: vi.fn().mockReturnValue('custom-tag'),
-        generateOperationSlug: vi.fn().mockReturnValue('custom-operation'),
-        generateWebhookSlug: vi.fn().mockReturnValue('custom-webhook'),
-      })
+      const mockConfig = computed(() =>
+        apiReferenceConfigurationSchema.parse({
+          generateHeadingSlug: vi.fn().mockReturnValue('custom-heading'),
+          generateModelSlug: vi.fn().mockReturnValue('custom-model'),
+          generateTagSlug: vi.fn().mockReturnValue('custom-tag'),
+          generateOperationSlug: vi.fn().mockReturnValue('custom-operation'),
+          generateWebhookSlug: vi.fn().mockReturnValue('custom-webhook'),
+        }),
+      )
       vi.mocked(useConfig).mockReturnValue(mockConfig)
       navState = useNavState()
     })

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -89,8 +89,8 @@ export const useNavState = () => {
    * ID creation methods
    */
   const getHeadingId = (heading: Heading) => {
-    if (typeof config?.generateHeadingSlug === 'function') {
-      return `${config.generateHeadingSlug(heading)}`
+    if (typeof config.value.generateHeadingSlug === 'function') {
+      return `${config.value.generateHeadingSlug(heading)}`
     }
 
     if (heading.slug) return `description/${heading.slug}`
@@ -100,22 +100,22 @@ export const useNavState = () => {
   const getModelId = (model?: { name: string }) => {
     if (!model?.name) return 'models'
 
-    if (typeof config?.generateModelSlug === 'function') {
-      return `model/${config.generateModelSlug(model)}`
+    if (typeof config.value.generateModelSlug === 'function') {
+      return `model/${config.value.generateModelSlug(model)}`
     }
     return `model/${slug(model.name)}`
   }
 
   const getTagId = (tag: Tag) => {
-    if (typeof config?.generateTagSlug === 'function') {
-      return `tag/${config.generateTagSlug(tag)}`
+    if (typeof config.value.generateTagSlug === 'function') {
+      return `tag/${config.value.generateTagSlug(tag)}`
     }
     return `tag/${slug(tag.name)}`
   }
 
   const getOperationId = (operation: TransformedOperation, parentTag: Tag) => {
-    if (typeof config?.generateOperationSlug === 'function') {
-      return `${getTagId(parentTag)}/${config.generateOperationSlug({
+    if (typeof config.value.generateOperationSlug === 'function') {
+      return `${getTagId(parentTag)}/${config.value.generateOperationSlug({
         path: operation.path,
         operationId: operation.operationId,
         method: operation.httpVerb,
@@ -128,8 +128,8 @@ export const useNavState = () => {
   const getWebhookId = (webhook?: { name: string; method?: string }) => {
     if (!webhook?.name) return 'webhooks'
 
-    if (typeof config?.generateWebhookSlug === 'function') {
-      return `webhook/${config.generateWebhookSlug(webhook)}`
+    if (typeof config.value.generateWebhookSlug === 'function') {
+      return `webhook/${config.value.generateWebhookSlug(webhook)}`
     }
     return `webhook/${webhook.method}/${slug(webhook.name)}`
   }

--- a/packages/api-reference/src/hooks/useSidebar.test.ts
+++ b/packages/api-reference/src/hooks/useSidebar.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import { toValue } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { computed, toValue } from 'vue'
 
 import { parse } from '../helpers'
 import { type SorterOption, useSidebar } from './useSidebar'
+import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+
+// Mock the useConfig hook
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: vi.fn().mockReturnValue(computed(() => apiReferenceConfigurationSchema.parse({}))),
+}))
 
 /**
  * Parse the given OpenAPI definition and return the items for the sidebar.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,16 @@
       "import": "./dist/libs/html-rendering/index.js",
       "types": "./dist/libs/html-rendering/index.d.ts",
       "default": "./dist/libs/html-rendering/index.js"
+    },
+    "./css/*.css": {
+      "import": "./dist/css/*.css",
+      "require": "./dist/css/*.css",
+      "default": "./dist/css/*.css"
+    },
+    "./*.css": {
+      "import": "./dist/*.css",
+      "require": "./dist/*.css",
+      "default": "./dist/*.css"
     }
   },
   "files": [


### PR DESCRIPTION
**Problem**

Currently, I live in a linear, synchronous world.

**Solution**

With this PR it becomes reactive.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
