### PR TITLE
feat(Scalar.AspNetCore): Support Multiple OpenAPI documents

### DIFF
--- a/.changeset/flat-spiders-sell.md
+++ b/.changeset/flat-spiders-sell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': minor
+---
+
+feat: Support Multiple OpenAPI documents. Please checkout [the related docs](https://github.com/scalar/scalar/blob/multiple-documents/documentation/integrations/dotnet.md#multiple-openapi-documents)!

--- a/integrations/aspnetcore/README.md
+++ b/integrations/aspnetcore/README.md
@@ -19,11 +19,11 @@ If you are upgrading from `1.x.x` to `2.x.x`, please refer to the [migration gui
 1. **Install the package**
 
 ```shell
-dotnet add package Scalar.AspNetCore --version 2.0.*
+dotnet add package Scalar.AspNetCore --version 2.1.*
 ```
 
 > [!NOTE]
-> We release new versions frequently to bring you the latest features and bug fixes. To reduce the noise in your project file, we recommend using a wildcard for the patch version, e.g., `2.0.*`.
+> We release new versions frequently to bring you the latest features and bug fixes. To reduce the noise in your project file, we recommend using a wildcard for the patch version, e.g., `2.1.*`.
 
 2. **Add the using directive**
 
@@ -35,7 +35,7 @@ using Scalar.AspNetCore;
 
 Add the following to `Program.cs` based on your OpenAPI generator:
 
-For .NET 9 using `Microsoft.AspNetCore.OpenApi`:
+For `Microsoft.AspNetCore.OpenApi`:
 
 ```csharp
 builder.Services.AddOpenApi();
@@ -47,7 +47,7 @@ if (app.Environment.IsDevelopment())
 }
 ```
 
-For .NET 8 using `Swashbuckle`:
+For `Swashbuckle`:
 
 ```csharp
 builder.Services.AddEndpointsApiExplorer();
@@ -63,7 +63,7 @@ if (app.Environment.IsDevelopment())
 }
 ```
 
-For .NET 8 using `NSwag`:
+For `NSwag`:
 
 ```csharp
 builder.Services.AddEndpointsApiExplorer();
@@ -79,7 +79,7 @@ if (app.Environment.IsDevelopment())
 }
 ```
 
-That’s it! 🎉 With the default settings, you can now access the Scalar API reference at `/scalar` to see the API reference for the `v1` document. Alternatively, you can navigate to `/scalar/{documentName}` (e.g., `/scalar/v2`) to view the API reference for a specific document.
+That's it! 🎉 You can now access the Scalar API Reference at `/scalar`. By default, the API Reference uses the `v1` document. You can add documents by calling the `AddDocument` method. Please check out the [dotnet integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md#multiple-openapi-documents) for more details. Alternatively, you can navigate to `/scalar/{documentName}` (e.g., `/scalar/v1`) to view the API reference for a specific document.
 
 ## Configuration
 

--- a/integrations/aspnetcore/package.json
+++ b/integrations/aspnetcore/package.json
@@ -19,7 +19,8 @@
     "format:check": "scalar-format-check",
     "format": "scalar-format",
     "lint:check": "scalar-lint-check",
-    "lint:fix": "scalar-lint-fix"
+    "lint:fix": "scalar-lint-fix",
+    "test": "vitest"
   },
   "dependencies": {
     "@scalar/api-reference": "workspace:*"

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Extensions/ServiceCollectionExtensions.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Extensions/ServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ internal static class ServiceCollectionExtensions
 
         foreach (var version in versions)
         {
+            services.Configure<ScalarOptions>(options => options.AddDocument(version, $"Version {version}"));
             services.AddOpenApi(version, options =>
             {
                 // Adds api key security scheme to the api

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
@@ -55,7 +55,7 @@ app.MapScalarApiReference("/", configureOptions);
 app.MapScalarApiReference("/scalar-url-pattern", (options, context) =>
 {
     configureOptions.Invoke(options);
-    options.OpenApiRoutePattern = $"{context.Request.Scheme}://{context.Request.Host}/openapi/v1.json";
+    options.OpenApiRoutePattern = $"{context.Request.Scheme}://{context.Request.Host}/openapi/{{documentName}}.json";
 });
 
 app.MapBookEndpoints();

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="APIWeaver.OpenApi" Version="2.7.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="Bogus" Version="35.6.2" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarConfiguration.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarConfiguration.cs
@@ -61,9 +61,7 @@ internal sealed class ScalarConfiguration
 
     public required bool HideClientButton { get; init; }
 
-    /// <remarks>This feature will be public once we support multiple OpenAPI documents</remarks>
-    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
-    internal IEnumerable<string> Documents { get; init; } = null!;
+    public required IEnumerable<ScalarSource> Sources { get; init; }
 }
 
 [JsonSerializable(typeof(ScalarConfiguration))]

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarSource.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarSource.cs
@@ -1,0 +1,8 @@
+namespace Scalar.AspNetCore;
+
+internal sealed class ScalarSource
+{
+    public required string Title { get; init; }
+
+    public required string Url { get; init; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.AspNetCore.Http;
 
 namespace Scalar.AspNetCore;
 
@@ -45,51 +44,51 @@ public static class ScalarOptionsExtensions
         return options;
     }
 
+
     /// <summary>
-    /// Adds the given document names to <see cref="ScalarOptions" />.
+    /// Adds the specified OpenAPI document to the Scalar API reference.
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
-    /// <param name="documentNames">The document names to add.</param>
-    /// <remarks>This feature will be public once we support multiple OpenAPI documents.</remarks>
-    internal static ScalarOptions AddDocument(this ScalarOptions options, params IEnumerable<string> documentNames)
+    /// <param name="documentName">The name identifier for the OpenAPI document.</param>
+    /// <param name="title">Optional display title for the document. If not provided, the document name will be used as the title.</param>
+    /// <remarks>
+    /// When multiple documents are added, they will be displayed as selectable options in a dropdown menu.
+    /// If no documents are explicitly added, a default document named 'v1' will be used.
+    /// </remarks>
+    public static ScalarOptions AddDocument(this ScalarOptions options, string documentName, string? title = null)
     {
-        options.Documents.AddRange(documentNames);
+        options.Documents.Add(new ScalarDocument(documentName, title));
         return options;
     }
 
     /// <summary>
-    /// Sets the document names provider.
+    /// Adds the specified OpenAPI documents to the Scalar API reference.
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
-    /// <param name="provider">The function to provide document names.</param>
-    /// <remarks>This feature will be public once we support multiple OpenAPI documents.</remarks>
-    internal static ScalarOptions WithDocumentNamesProvider(this ScalarOptions options, Func<HttpContext, IEnumerable<string>> provider)
+    /// <param name="documentNames">The name identifiers for the OpenAPI documents.</param>
+    /// <remarks>
+    /// When multiple documents are added, they will be displayed as selectable options in a dropdown menu.
+    /// If no documents are explicitly added, a default document named 'v1' will be used.
+    /// </remarks>
+    public static ScalarOptions AddDocuments(this ScalarOptions options, params IEnumerable<string> documentNames)
     {
-        options.DocumentNamesProvider = (context, _) => Task.FromResult(provider(context));
+        var documents = documentNames.Select(documentName => new ScalarDocument(documentName));
+        options.Documents.AddRange(documents);
         return options;
     }
 
     /// <summary>
-    /// Sets a async document names provider.
+    /// Adds the specified OpenAPI documents to the Scalar API reference.
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
-    /// <param name="provider">The async function to provide document names.</param>
-    /// <remarks>This feature will be public once we support multiple OpenAPI documents.</remarks>
-    internal static ScalarOptions WithDocumentNamesProvider(this ScalarOptions options, Func<HttpContext, CancellationToken, Task<IEnumerable<string>>> provider)
+    /// <param name="documents">A list of <see cref="ScalarDocument" />`s to add.</param>
+    /// <remarks>
+    /// When multiple documents are added, they will be displayed as selectable options in a dropdown menu.
+    /// If no documents are explicitly added, a default document named 'v1' will be used.
+    /// </remarks>
+    public static ScalarOptions AddDocuments(this ScalarOptions options, params IEnumerable<ScalarDocument> documents)
     {
-        options.DocumentNamesProvider = provider;
-        return options;
-    }
-
-    /// <summary>
-    /// Sets a async document names provider.
-    /// </summary>
-    /// <param name="options"><see cref="ScalarOptions" />.</param>
-    /// <param name="provider">The async function to provide document names.</param>
-    /// <remarks>This feature will be public once we support multiple OpenAPI documents.</remarks>
-    internal static ScalarOptions WithDocumentNamesProvider(this ScalarOptions options, Func<HttpContext, Task<IEnumerable<string>>> provider)
-    {
-        options.DocumentNamesProvider = (context, _) => provider.Invoke(context);
+        options.Documents.AddRange(documents);
         return options;
     }
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -30,7 +30,11 @@ internal static class ScalarOptionsMapper
     internal static ScalarConfiguration ToScalarConfiguration(this ScalarOptions options)
     {
         var trimmedOpenApiRoutePattern = options.OpenApiRoutePattern.TrimStart('/');
-        var documentUrls = options.Documents.Select(name => trimmedOpenApiRoutePattern.Replace(DocumentName, name));
+        var sources = options.Documents.Select(document => new ScalarSource
+        {
+            Title = document.Title ?? document.Name,
+            Url = trimmedOpenApiRoutePattern.Replace(DocumentName, document.Name)
+        });
         return new ScalarConfiguration
         {
             ProxyUrl = options.ProxyUrl,
@@ -61,7 +65,7 @@ internal static class ScalarOptionsMapper
             },
             Integration = options.DotNetFlag ? "dotnet" : null,
             HideClientButton = options.HideClientButton,
-            Documents = documentUrls
+            Sources = sources
         };
     }
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarDocument.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarDocument.cs
@@ -1,0 +1,8 @@
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents a document in the Scalar API Reference.
+/// </summary>
+/// <param name="Name">The name of the document.</param>
+/// <param name="Title">The optional title of the document.</param>
+public sealed record ScalarDocument(string Name, string? Title = null);

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.AspNetCore.Http;
 
 namespace Scalar.AspNetCore;
 
@@ -14,14 +13,7 @@ public sealed class ScalarOptions
     /// </summary>
     internal bool IsOpenApiRoutePatternUrl => RegexHelper.IsUrlRegex().IsMatch(OpenApiRoutePattern);
 
-    internal List<string> Documents { get; } = [];
-
-    /// <summary>
-    /// Gets or sets a function that provides document names.
-    /// </summary>
-    /// <value>A function that returns an <see cref="IEnumerable{T}" /> of document names.</value>
-    /// <remarks>This feature will be public once we support multiple OpenAPI documents. If this property is set, the <see cref="Documents" /> property will be ignored.</remarks>
-    internal Func<HttpContext, CancellationToken, Task<IEnumerable<string>>>? DocumentNamesProvider { get; set; }
+    internal List<ScalarDocument> Documents { get; } = [];
 
     /// <summary>
     /// Gets or sets the title of the HTML document.
@@ -237,7 +229,7 @@ public sealed class ScalarOptions
     /// <![CDATA[
     /// <body>
     ///     <header>Welcome to my API reference</header>
-    ///     <script id="api-reference"></script>
+    ///     <div id="app"></div>
     /// </body>
     /// ]]>
     /// </code>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="StaticAssets/*">
+    <EmbeddedResource Include="StaticAssets/*" Exclude="StaticAssets/*test.js">
       <LogicalName>ScalarStaticAssets.%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
   </ItemGroup>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.js
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.js
@@ -1,12 +1,61 @@
 /**
- * Gets the base path by removing the specified suffix from the end of the current path.
- * @param {string} suffix - The suffix to remove from the end of the path.
- * @returns {string} The base path without the suffix.
+ * Extracts the base path from the current URL by removing a specified suffix.
+ * This is useful for handling subdirectory deployments where the application
+ * might not be hosted at the root path.
+ *
+ * Example:
+ * - URL: /my-app/docs/
+ * - Suffix: /docs/
+ * - Result: /my-app
+ *
+ * @param {string} suffix - The URL suffix to remove (can be empty)
+ * @returns {string} The normalized base path with no trailing slash
  */
-function getBasePath(suffix) {
+export const getBasePath = (suffix) => {
   const path = window.location.pathname
   if (path.endsWith(suffix)) {
     return path.slice(0, -suffix.length)
   }
-  return path
+  return ''
+}
+
+/**
+ * Initializes the Scalar API reference documentation viewer.
+ * This function handles two deployment scenarios:
+ *
+ * 1. Relative paths: When OpenAPI specs are hosted alongside the application
+ * 2. Absolute paths: When OpenAPI specs are served from specific routes
+ *
+ * The function ensures URLs are correctly constructed regardless of whether
+ * the application is hosted in a subdirectory or at the root path.
+ *
+ * @param {string} path - The current request path used to calculate the base URL
+ * @param {boolean} isOpenApiRoutePatternUrl - When true, treats OpenAPI URLs as absolute paths
+ *                                            When false, prepends the base path to make URLs relative
+ * @param {Object} configuration - Scalar configuration object
+ * @param {Array<Object>} [configuration.sources=[]] - Array of OpenAPI source configurations
+ */
+export const initialize = (path, isOpenApiRoutePatternUrl, configuration = { sources: [] }) => {
+  const basePath = getBasePath(path)
+
+  const normalizedConfig = {
+    ...configuration,
+    sources: configuration?.sources?.map((source) => ({ ...source })) || [],
+  }
+
+  if (!isOpenApiRoutePatternUrl) {
+    // Construct full URLs for subdirectory hosting support
+    normalizedConfig.sources = normalizedConfig.sources.map((source) => {
+      if (!source.url) {
+        return source
+      }
+
+      return {
+        ...source,
+        url: new URL(source.url, `${window.location.origin}${basePath}/`).toString(),
+      }
+    })
+  }
+
+  Scalar.createApiReference('#app', normalizedConfig)
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.test.js
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.test.js
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getBasePath, initialize } from './scalar.aspnetcore'
+
+describe('scalar.aspnetcore', () => {
+  describe('getBasePath', () => {
+    beforeEach(() => {
+      // Create window object before modifying it
+      global.window = {
+        location: new URL('https://example.com/api/docs'),
+      }
+    })
+
+    afterEach(() => {
+      // Clean up after each test
+      delete global.window
+    })
+
+    it('removes suffix from path when present', () => {
+      const result = getBasePath('/docs')
+      expect(result).toBe('/api')
+    })
+
+    it('returns empty string when suffix is not present', () => {
+      const result = getBasePath('/other')
+      expect(result).toBe('')
+    })
+
+    it('handles empty suffix', () => {
+      const result = getBasePath('')
+      expect(result).toBe('')
+    })
+
+    it('removes only the last occurrence of suffix', () => {
+      global.window.location = new URL('https://example.com/docs/api/docs')
+      const result = getBasePath('/docs')
+      expect(result).toBe('/docs/api')
+    })
+  })
+
+  describe('initialize', () => {
+    let mockScalar
+
+    beforeEach(() => {
+      // Create a mock window object
+      global.window = {
+        location: new URL('https://example.com/api/docs'),
+      }
+    })
+
+    afterEach(() => {
+      // Clean up after each test
+      delete global.window
+    })
+
+    beforeEach(() => {
+      mockScalar = {
+        createApiReference: vi.fn(),
+      }
+      global.Scalar = mockScalar
+    })
+
+    it('transforms URLs to absolute paths when using relative URLs', () => {
+      const configuration = {
+        sources: [{ url: 'swagger.json' }, { url: 'openapi.json' }],
+      }
+
+      initialize('/docs', false, configuration)
+
+      // Get the configuration object passed to createApiReference
+      const normalizedConfig = mockScalar.createApiReference.mock.calls[0][1]
+      expect(normalizedConfig.sources[0].url).toBe('https://example.com/api/swagger.json')
+      expect(normalizedConfig.sources[1].url).toBe('https://example.com/api/openapi.json')
+      expect(mockScalar.createApiReference).toHaveBeenCalledWith('#app', normalizedConfig)
+    })
+
+    it('preserves URLs when using absolute paths', () => {
+      const configuration = {
+        sources: [{ url: 'swagger.json' }, { url: 'openapi.json' }],
+      }
+
+      const originalUrls = configuration.sources.map((s) => s.url)
+      initialize('/docs', true, configuration)
+
+      expect(configuration.sources[0].url).toBe(originalUrls[0])
+      expect(configuration.sources[1].url).toBe(originalUrls[1])
+      expect(mockScalar.createApiReference).toHaveBeenCalledWith('#app', configuration)
+    })
+
+    it('handles empty configuration gracefully', () => {
+      expect(() => initialize('/docs', false, {})).not.toThrow()
+    })
+
+    it('handles empty sources array', () => {
+      const configuration = { sources: [] }
+      initialize('/docs', false, configuration)
+      expect(mockScalar.createApiReference).toHaveBeenCalledWith('#app', configuration)
+    })
+
+    it('handles missing window.location.origin', () => {
+      delete global.window.location.origin
+      const configuration = {
+        sources: [{ url: 'swagger.json' }],
+      }
+
+      expect(() => initialize('/docs', false, configuration)).not.toThrow()
+    })
+
+    it('handles sources without url property', () => {
+      const configuration = {
+        sources: [{ title: 'Source without URL' }, { url: 'swagger.json' }],
+      }
+
+      initialize('/docs', false, configuration)
+
+      // Get the normalized config that was passed to createApiReference
+      const normalizedConfig = mockScalar.createApiReference.mock.calls[0][1]
+
+      // The configuration should remain unchanged for sources without URLs
+      expect(normalizedConfig.sources[0]).toEqual({ title: 'Source without URL' })
+      // Sources with URLs should still be processed normally
+      expect(normalizedConfig.sources[1].url).toBe('https://example.com/api/swagger.json')
+      expect(mockScalar.createApiReference).toHaveBeenCalledWith('#app', normalizedConfig)
+    })
+  })
+})

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="8.0.1" />
+    <PackageReference Include="AwesomeAssertions" Version="8.0.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -26,11 +26,11 @@
   </ItemGroup>
   
   <ItemGroup Condition="$(TargetFrameWork) == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.14" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFrameWork) == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -20,33 +20,30 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var response = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
 
         // Assert
-        const string expected = $$"""
-                                  <!doctype html>
-                                  <html>
-                                  <head>
-                                      <title>Scalar API Reference</title>
-                                      <meta charset="utf-8" />
-                                      <meta name="viewport" content="width=device-width, initial-scale=1" />
-                                      
-                                  </head>
-                                  <body>
-                                      
-                                      <script id="api-reference"></script>
-                                      <script src="scalar.aspnetcore.js"></script>
-                                      <script>
-                                          const basePath = getBasePath('/scalar/');
-                                          const openApiUrl = `${window.location.origin}${basePath}*`
-                                          const reference = document.getElementById('api-reference')
-                                          reference.dataset.url = openApiUrl;
-                                          reference.dataset.configuration = JSON.stringify(*)
-                                      </script>
-                                      <script src="{{ScalarEndpointRouteBuilderExtensions.ScalarJavaScriptFile}}"></script>
-                                  </body>
-                                  </html>
-                                  """;
+        const string expected = """
+                                <!doctype html>
+                                <html>
+                                <head>
+                                    <title>Scalar API Reference</title>
+                                    <meta charset="utf-8" />
+                                    <meta name="viewport" content="width=device-width, initial-scale=1" />
+                                    
+                                </head>
+                                <body>
+                                    
+                                    <div id="app"></div>
+                                    <script type="module" src="scalar.aspnetcore.js"></script>
+                                    <script type="module" src="scalar.js"></script>
+                                    <script type="module">
+                                        import { initialize } from './scalar.aspnetcore.js'
+                                        initialize('/scalar/', false, *)
+                                    </script>
+                                </body>
+                                </html>
+                                """;
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Match(expected);
+        content.Should().Match(expected);
     }
 
     [Fact]
@@ -86,7 +83,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         response.Headers.CacheControl!.NoCache.Should().BeTrue();
         response.Headers.ETag.Should().NotBeNull();
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain(expectedContent);
+        content.Should().Contain(expectedContent);
     }
 
     [Fact]
@@ -124,7 +121,8 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("`https://example.com/openapi.json`");
+        
+        content.Should().Contain("https://example.com/openapi.json").And.Match("*initialize('/external/document/scalar/', true, *]})*");
     }
 
     [Fact]
@@ -139,7 +137,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("/openapi/v1.json");
+        content.Should().Contain("openapi/v1.json");
     }
 
     [Fact]
@@ -154,28 +152,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("/openapi/v3.json").And.NotContain("/openapi/v1.json");
-    }
-
-    [Fact]
-    public async Task MapScalarApiReference_ShouldUseDocumentProvider_WhenSpecified()
-    {
-        // Arranges
-        var client = factory.WithWebHostBuilder(builder =>
-        {
-            builder.ConfigureTestServices(services =>
-            {
-                services.Configure<ScalarOptions>(options => options.WithDocumentNamesProvider(_ => ["v2"]));
-            });
-        }).CreateClient();
-
-        // Act
-        var response = await client.GetAsync("/scalar/", TestContext.Current.CancellationToken);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("/openapi/v2.json").And.NotContain("/openapi/v1.json");
+        content.Should().Contain("openapi/v3.json").And.NotContain("v1");
     }
 
     [Fact]
@@ -197,7 +174,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         index.StatusCode.Should().Be(HttpStatusCode.OK);
         var indexContent = await index.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        indexContent.ReplaceLineEndings().Should().Contain($"<script src=\"{cdnUrl}\"></script>");
+        indexContent.Should().Contain($"<script type=\"module\" src=\"{cdnUrl}\"></script>");
     }
 
     [Fact]
@@ -291,7 +268,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        content.ReplaceLineEndings().Should().Contain("<title>Scalar API Reference | v1</title>");
+        content.Should().Contain("<title>Scalar API Reference | v1</title>");
     }
 
     [Fact]

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -52,7 +52,6 @@ public class ScalarOptionsExtensionsTests
             .WithFavicon("/favicon.png")
             .WithDotNetFlag(false)
             .WithClientButton(false)
-            .WithDocumentNamesProvider(_ => Task.FromResult<IEnumerable<string>>(["v1"]))
             .AddHeadContent("<meta name=\"foo\" content=\"bar\"/>")
             .AddHeadContent("<meta name=\"bar\" content=\"foo\"/>")
             .AddHeaderContent("<h1>foo</h1>")
@@ -97,7 +96,6 @@ public class ScalarOptionsExtensionsTests
         options.Favicon.Should().Be("/favicon.png");
         options.DotNetFlag.Should().BeFalse();
         options.HideClientButton.Should().BeTrue();
-        options.DocumentNamesProvider.Should().NotBeNull();
         options.HeadContent.Should().Be("<meta name=\"foo\" content=\"bar\"/><meta name=\"bar\" content=\"foo\"/>");
         options.HeaderContent.Should().Be("<h1>foo</h1><h2>bar</h2>");
     }

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -34,7 +34,7 @@ public class ScalarOptionsMapperTests
         configuration.OperationsSorter.Should().BeNull();
         configuration.Theme.Should().Be("purple");
         configuration.Integration.Should().Be("dotnet");
-        configuration.Documents.Should().BeEmpty();
+        configuration.Sources.Should().BeEmpty();
     }
 
     [Fact]
@@ -107,7 +107,7 @@ public class ScalarOptionsMapperTests
         configuration.Layout.Should().Be("classic");
         configuration.Integration.Should().BeNull();
         configuration.HideClientButton.Should().BeTrue();
-        configuration.Documents.Should().ContainSingle().Which.Should().Be("openapi/v2.json");
+        configuration.Sources.Should().ContainSingle().Which.Url.Should().Be("openapi/v2.json");
     }
 
     [Fact]


### PR DESCRIPTION
This PR adds Multiple OpenAPI documents support to the `Scalar.AspNetCore` integration. This PR is based on the following wonderful PRs:

- https://github.com/scalar/scalar/pull/5013
- https://github.com/scalar/scalar/pull/4999
- https://github.com/scalar/scalar/pull/4872

**Multiple OpenAPI documents**

Basically, this PR adds 2 new methods `AddDocument` and `AddDocuments` for adding OpenAPI documents to the Scalar API Reference configuration (One configuration, multiple sources):

```c#
string[] versions = ["v1", "v2"];

// Adds a document with a title
app.MapScalarApiReference(options => options.AddDocument("v1", "My awesome version 1"));

// Adds multiple documents
app.MapScalarApiReference(options => options.AddDocuments("v1", "v2"));
app.MapScalarApiReference(options => options.AddDocuments(versions));

// Adds multiple documents using ScalarDocument class
app.MapScalarApiReference(options => options.AddDocuments(versions.Select(version => new ScalarDocument(version, $"My awesome version {version}"))));
```

Like before, if no document is provided by these methods, the default `v1` will be used.
During serialization, the `OpenApiRoutePattern` property is used to build the full OpenAPI document URLs. I also removed the `DocumentNamesProvider` property for now. It was internal and unused.

**Improved JS setup**
I moved most of the JS logic into a separate `initialize` method. It's now easier to write and understand the JS code. The configuration is no longer serialized into a string. Instead, the new `Scalar.createApiReference` method is used.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
