### PR TITLE
fix: dead link in docs

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -54,7 +54,7 @@ You can use our hosted proxy:
 }
 ```
 
-If you like to run your own, check out our [example proxy written in Go](https://github.com/scalar/scalar/tree/main/examples/proxy-server).
+If you like to run your own, check out our [example proxy written in Go](https://github.com/scalar/scalar/tree/main/projects/proxy-scalar-com).
 
 #### showSidebar?: boolean
 


### PR DESCRIPTION
https://github.com/scalar/scalar/tree/main/examples/proxy-server to
https://github.com/scalar/scalar/tree/main/projects/proxy-scalar-com

**Problem**

Currently, …

**Solution**

With this PR …

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
