### PR TITLE
fix(components): modal position

### DIFF
--- a/.changeset/eight-bags-breathe.md
+++ b/.changeset/eight-bags-breathe.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: removes scalar modal scoped position

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -130,10 +130,6 @@ export function useModal() {
 .scalar-modal {
   animation: fadein-modal ease-in-out 0.3s forwards;
   animation-delay: 0.1s;
-  position: fixed;
-  left: 0;
-  top: 0;
-  right: 0;
   box-shadow: var(--scalar-shadow-2);
   transform: translate3d(0, 10px, 0);
 }


### PR DESCRIPTION
**Problem**

recent updates to scalar modal broke its position in org usage due to a utility class precedence issue.

**Solution**

this pr removes scoped style to maintain modal position.

| before | after |
| -------|------|
| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/dae738f1-ee66-43da-b3a5-e3507bb14f9a" /> | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/4c0d84d2-78b1-453b-b34d-d52ebf642992" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
