### PR TITLE
chore(openapi-parser): remove warning for Swagger 2.0 upgrade

### DIFF
--- a/.changeset/dull-avocados-cheer.md
+++ b/.changeset/dull-avocados-cheer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+chore: remove Swagger 2.0 upgrade warning

--- a/packages/openapi-parser/README.md
+++ b/packages/openapi-parser/README.md
@@ -101,8 +101,6 @@ const { specification } = filter(
 
 There’s an `upgrade` command to upgrade all your OpenAPI documents to the latest OpenAPI version.
 
-> ⚠️ The upgrade from Swagger 2.0 is still experimental and probably lacks features.
-
 ```ts
 import { upgrade } from '@scalar/openapi-parser'
 

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -20,10 +20,6 @@ export function upgradeFromTwoToThree(originalSpecification: UnknownObject) {
     return specification
   }
 
-  console.warn(
-    `[upgradeFromTwoToThree] The upgrade from Swagger 2.0 to OpenAPI 3.0 documents is experimental and lacks features.`,
-  )
-
   // Servers
   if (specification.host) {
     const schemes =


### PR DESCRIPTION
Time to remove the warning for the Swagger 2.0 upgrade, it’s running fine in production for months.