### PR TITLE
feat(nextjs): use HTML rendering lib from `@scalar/core`

### DIFF
--- a/.changeset/young-ladybugs-taste.md
+++ b/.changeset/young-ladybugs-taste.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/nextjs-api-reference': patch
+'@scalar/nextjs-api-reference': minor
 ---
 
 feat: use html rendering lib from @scalar/core

--- a/.changeset/young-ladybugs-taste.md
+++ b/.changeset/young-ladybugs-taste.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nextjs-api-reference': patch
+---
+
+feat: use html rendering lib from @scalar/core

--- a/integrations/nextjs/package.json
+++ b/integrations/nextjs/package.json
@@ -44,7 +44,8 @@
   ],
   "module": "./dist/index.js",
   "dependencies": {
-    "@scalar/types": "workspace:*"
+    "@scalar/types": "workspace:*",
+    "@scalar/core": "workspace:*"
   },
   "devDependencies": {
     "@scalar/api-reference": "workspace:*",

--- a/integrations/nextjs/src/ApiReference.ts
+++ b/integrations/nextjs/src/ApiReference.ts
@@ -18,7 +18,7 @@ const DEFAULT_CONFIGURATION: Partial<ApiReferenceConfiguration> = {
  * @params config - the Api Reference config object
  * @params options - reserved for future use to add customization to the response
  */
-export const ApiReference = (givenConfiguration: ApiReferenceConfiguration) => {
+export const ApiReference = (givenConfiguration: Partial<ApiReferenceConfiguration>) => {
   // Merge the defaults
   const configuration = {
     ...DEFAULT_CONFIGURATION,

--- a/integrations/nextjs/src/ApiReference.ts
+++ b/integrations/nextjs/src/ApiReference.ts
@@ -23,7 +23,7 @@ export const ApiReference = (givenConfiguration: Partial<ApiReferenceConfigurati
   const configuration = {
     ...DEFAULT_CONFIGURATION,
     ...givenConfiguration,
-  } satisfies ApiReferenceConfiguration
+  } satisfies Partial<ApiReferenceConfiguration>
 
   return async () => {
     return new Response(getHtmlDocument(configuration, customTheme), {

--- a/integrations/nextjs/src/ApiReference.ts
+++ b/integrations/nextjs/src/ApiReference.ts
@@ -1,9 +1,13 @@
-import type { ReferenceConfiguration } from '@scalar/types/legacy'
+import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
 
-import { nextjsThemeCss } from './theme'
+import { customTheme } from './custom-theme'
+import type { ApiReferenceConfiguration } from './types'
 
-export type ApiReferenceOptions = ReferenceConfiguration & {
-  cdn?: string
+/**
+ * The default configuration for the API Reference.
+ */
+const DEFAULT_CONFIGURATION: Partial<ApiReferenceConfiguration> = {
+  _integration: 'nextjs',
 }
 
 /**
@@ -14,79 +18,19 @@ export type ApiReferenceOptions = ReferenceConfiguration & {
  * @params config - the Api Reference config object
  * @params options - reserved for future use to add customization to the response
  */
-export const ApiReference = (config: ApiReferenceOptions) => {
-  // If no spec is passed, show a warning.
-  if (!config.spec?.content && !config.spec?.url) {
-    throw new Error(
-      '[@scalar/nextjs-api-reference] You didn’t provide a spec.content or spec.url. Please provide one of these options.',
-    )
-  }
-
-  // Execute content function if it exists
-  if (typeof config.spec?.content === 'function') {
-    config.spec.content = config.spec.content()
-  }
-
-  // Convert the document to a string
-  const documentString = config?.spec?.content
-    ? typeof config?.spec?.content === 'string'
-      ? config.spec.content
-      : JSON.stringify(config.spec.content)
-    : ''
-
-  // Delete content from configuration
-  if (config?.spec?.content) {
-    delete config.spec.content
-  }
-
-  // Add the default CSS
-  if (!config?.customCss && !config?.theme) {
-    config.customCss = nextjsThemeCss
-  }
-
-  // Check the config for a custom CDN string or set to default
-  const cdnString = config?.cdn ? config.cdn : 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest'
-
-  // Add _integration: 'nextjs' to the configuration, but allow user to overwrite.
-  const defaultConfiguration = {
-    _integration: 'nextjs',
-  }
-
-  // Convert the configuration to a string
-  const configString = JSON.stringify({
-    ...defaultConfiguration,
-    ...(config ?? {}),
-  })
-    .split('"')
-    .join('&quot;')
+export const ApiReference = (givenConfiguration: ApiReferenceConfiguration) => {
+  // Merge the defaults
+  const configuration = {
+    ...DEFAULT_CONFIGURATION,
+    ...givenConfiguration,
+  } satisfies ApiReferenceConfiguration
 
   return async () => {
-    return new Response(
-      `
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Scalar API Reference</title>
-  </head>
-  <body>
-    <script
-      id="api-reference"
-      type="application/json"
-      data-configuration="${configString}">
-      ${documentString}
-    </script>
-    <script src="${cdnString}"></script>
-  </body>
-</html>
-      `,
-      {
-        status: 200,
-        headers: {
-          'Content-Type': 'text/html',
-        },
+    return new Response(getHtmlDocument(configuration, customTheme), {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html',
       },
-    )
+    })
   }
 }

--- a/integrations/nextjs/src/custom-theme.ts
+++ b/integrations/nextjs/src/custom-theme.ts
@@ -1,4 +1,7 @@
-export const nextjsThemeCss = `
+/**
+ * The custom theme for Next.js
+ */
+export const customTheme = `
 /* basic theme */
 .dark-mode {
   --scalar-color-1: rgba(255, 255, 255, 0.9);

--- a/integrations/nextjs/src/types.ts
+++ b/integrations/nextjs/src/types.ts
@@ -1,0 +1,6 @@
+import type { HtmlRenderingConfiguration } from '@scalar/core/libs/html-rendering'
+
+/**
+ * The configuration for the Scalar API Reference for Hono
+ */
+export type ApiReferenceConfiguration = HtmlRenderingConfiguration

--- a/integrations/nextjs/src/types.ts
+++ b/integrations/nextjs/src/types.ts
@@ -1,6 +1,6 @@
 import type { HtmlRenderingConfiguration } from '@scalar/core/libs/html-rendering'
 
 /**
- * The configuration for the Scalar API Reference for Hono
+ * The configuration for the Scalar API Reference for Next.js
  */
 export type ApiReferenceConfiguration = HtmlRenderingConfiguration

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,16 +35,6 @@
       "import": "./dist/libs/html-rendering/index.js",
       "types": "./dist/libs/html-rendering/index.d.ts",
       "default": "./dist/libs/html-rendering/index.js"
-    },
-    "./css/*.css": {
-      "import": "./dist/css/*.css",
-      "require": "./dist/css/*.css",
-      "default": "./dist/css/*.css"
-    },
-    "./*.css": {
-      "import": "./dist/*.css",
-      "require": "./dist/*.css",
-      "default": "./dist/*.css"
     }
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -708,6 +708,9 @@ importers:
 
   integrations/nextjs:
     dependencies:
+      '@scalar/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@scalar/types':
         specifier: workspace:*
         version: link:../../packages/types


### PR DESCRIPTION
With this PR we’re using the central HTML rendering library from `@scalar/core` in the Next.js integration.

This will make it so easy to add the multi document feature.