### PR TITLE
fix(api-client): complex auth indicator is not retrieved

### DIFF
--- a/.changeset/thin-seahorses-tickle.md
+++ b/.changeset/thin-seahorses-tickle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: adds auth indicator complex auth support

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.test.ts
@@ -49,6 +49,20 @@ vi.mock('@/store/store', () => ({
         password: 'pass',
         token: '123456',
       },
+      'client-id': {
+        uid: 'client-id',
+        type: 'apiKey',
+        nameKey: 'Client ID',
+        in: 'header',
+        value: 'client123',
+      },
+      'client-key': {
+        uid: 'client-key',
+        type: 'apiKey',
+        nameKey: 'Client Key',
+        in: 'header',
+        value: 'key456',
+      },
     },
     collectionMutators,
     requestMutators,
@@ -61,7 +75,7 @@ describe('RequestAuth.vue', () => {
     ({
       collection: collectionSchema.parse({
         uid: 'test-collection',
-        securitySchemes: ['bearer-auth', 'api-key-auth', 'basic-auth'],
+        securitySchemes: ['bearer-auth', 'api-key-auth', 'basic-auth', 'client-id', 'client-key'],
         security: [{ bearerAuth: [] }, { apiKeyAuth: [] }, { basicAuth: [] }],
       }),
       operation: requestSchema.parse({
@@ -140,5 +154,16 @@ describe('RequestAuth.vue', () => {
 
     expect(wrapper.text()).toContain('Multiple')
     expect(wrapper.text()).toContain('Bearer Token')
+  })
+
+  it('handles complex auth requirements with multiple keys', async () => {
+    const props = createBaseProps()
+    props.operation.security = [{ 'Client ID': [], 'Client Key': [] }, {}]
+
+    const wrapper = mount(RequestAuth, {
+      props,
+    })
+
+    expect(wrapper.text()).toContain('Client ID & Client Key Required')
   })
 })

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -87,16 +87,31 @@ const authIndicator = computed(() => {
   const { filteredRequirements, requirements } = securityRequirements.value
   if (!requirements.length) return null
 
-  /** Security is optional if one empty object exists in the array */
-  const isOptional = filteredRequirements.length < requirements.length
+  /**
+   * Security is optional if one empty object exists in the array &
+   * no complex auth requirements (with multiple auth)
+   */
+  const hasComplexRequirement = requirements.some(
+    (req) => Object.keys(req).length > 1,
+  )
+  const isOptional =
+    !hasComplexRequirement && filteredRequirements.length < requirements.length
+
   const icon: Icon = isOptional ? 'Unlock' : 'Lock'
 
   /** Dynamic text to indicate auth requirements */
   const requiredText = isOptional ? 'Optional' : 'Required'
   const nameKey =
     filteredRequirements.length === 1
-      ? Object.keys(filteredRequirements[0] || {})[0]
+      ? (() => {
+          // Get the keys of the first requirement
+          const keys = Object.keys(filteredRequirements[0] || {})
+
+          // If there are multiple keys, join them with ' & '
+          return keys.length > 1 ? keys.join(' & ') : keys[0] || ''
+        })()
       : ''
+
   const text = `${nameKey} ${requiredText}`
 
   return { icon, text }

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -97,7 +97,7 @@ const dataTableInputProps = {
         'request-example-references-header': layout === 'reference',
       }">
       <DataTableCell
-        class="text-c-3 flex items-center pl-2 font-medium"
+        class="text-c-3 flex items-center pl-3 font-medium"
         :class="
           layout === 'reference' && `border-t ${index !== 0 ? 'mt-2' : ''}`
         ">


### PR DESCRIPTION
**Problem**

currently when using complex auth within the client the indicator is not displaying the right value.

**Solution**

this pr updates the auth indicator function to support complex auth and fixes #4933.

| before | after |
| -------|------|
| <img width="605" alt="image" src="https://github.com/user-attachments/assets/4a06e06c-5bc1-4cf4-8da7-01eea6cd6eb8" /> | <img width="605" alt="image" src="https://github.com/user-attachments/assets/24a291be-8b15-4d9b-92d7-30b7eebe4ded" /> |
| auth is only required for one requirement | auth required for both requirements | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
