### PR TITLE
feat(mock-server): use stricter Node tsconfig

### DIFF
--- a/.changeset/pink-dogs-suffer.md
+++ b/.changeset/pink-dogs-suffer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+feat: use stricter Node tsconfig

--- a/packages/mock-server/src/createMockServer.test.ts
+++ b/packages/mock-server/src/createMockServer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { createMockServer } from './createMockServer'
+import { createMockServer } from './createMockServer.ts'
 
 describe('createMockServer', () => {
   it('GET /foobar -> example JSON', async () => {

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -1,18 +1,18 @@
 import { openapi } from '@scalar/openapi-parser'
 import type { OpenAPI, OpenAPIV3_1 } from '@scalar/openapi-types'
-import { Hono, type Context } from 'hono'
+import { type Context, Hono } from 'hono'
 import { cors } from 'hono/cors'
 
-import type { HttpMethod, MockServerOptions } from '@/types'
-import { getOperations } from '@/utils/getOperations'
-import { handleAuthentication } from '@/utils/handleAuthentication'
-import { honoRouteFromPath } from '@/utils/honoRouteFromPath'
-import { isAuthenticationRequired } from '@/utils/isAuthenticationRequired'
-import { logAuthenticationInstructions } from '@/utils/logAuthenticationInstructions'
-import { setupAuthenticationRoutes } from '@/utils/setupAuthenticationRoutes'
+import type { HttpMethod, MockServerOptions } from '@/types.ts'
+import { getOperations } from '@/utils/getOperations.ts'
+import { handleAuthentication } from '@/utils/handleAuthentication.ts'
+import { honoRouteFromPath } from '@/utils/honoRouteFromPath.ts'
+import { isAuthenticationRequired } from '@/utils/isAuthenticationRequired.ts'
+import { logAuthenticationInstructions } from '@/utils/logAuthenticationInstructions.ts'
+import { setupAuthenticationRoutes } from '@/utils/setupAuthenticationRoutes.ts'
 
-import { mockAnyResponse } from './routes/mockAnyResponse'
-import { respondWithOpenApiDocument } from './routes/respondWithOpenApiDocument'
+import { mockAnyResponse } from './routes/mockAnyResponse.ts'
+import { respondWithOpenApiDocument } from './routes/respondWithOpenApiDocument.ts'
 
 /**
  * Create a mock server instance

--- a/packages/mock-server/src/index.ts
+++ b/packages/mock-server/src/index.ts
@@ -1,1 +1,1 @@
-export * from './createMockServer'
+export { createMockServer } from './createMockServer.ts'

--- a/packages/mock-server/src/routes/mockAnyResponse.ts
+++ b/packages/mock-server/src/routes/mockAnyResponse.ts
@@ -6,8 +6,8 @@ import type { StatusCode } from 'hono/utils/http-status'
 // @ts-expect-error Doesn’t come with types
 import objectToXML from 'object-to-xml'
 
-import type { MockServerOptions } from '@/types'
-import { findPreferredResponseKey } from '@/utils/findPreferredResponseKey'
+import type { MockServerOptions } from '@/types.ts'
+import { findPreferredResponseKey } from '@/utils/findPreferredResponseKey.ts'
 
 /**
  * Mock any response
@@ -47,7 +47,9 @@ export function mockAnyResponse(c: Context, operation: OpenAPI.Operation, option
   const acceptedContentType = accepts(c, {
     header: 'Accept',
     supports: supportedContentTypes,
-    default: supportedContentTypes.includes('application/json') ? 'application/json' : supportedContentTypes[0],
+    default: supportedContentTypes.includes('application/json')
+      ? 'application/json'
+      : (supportedContentTypes[0] ?? 'text/plain;charset=UTF-8'),
   })
 
   c.header('Content-Type', acceptedContentType)

--- a/packages/mock-server/src/utils/findPreferredResponseKey.test.ts
+++ b/packages/mock-server/src/utils/findPreferredResponseKey.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { findPreferredResponseKey } from './findPreferredResponseKey'
+import { findPreferredResponseKey } from './findPreferredResponseKey.ts'
 
 describe('findPreferredResponseKey', () => {
   it('returns default over 200', () => {

--- a/packages/mock-server/src/utils/getOpenAuthTokenUrls.test.ts
+++ b/packages/mock-server/src/utils/getOpenAuthTokenUrls.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { createOpenApiDefinition } from './createOpenApiDefinition'
-import { getOpenAuthTokenUrls, getPathFromUrl } from './getOpenAuthTokenUrls'
+import { createOpenApiDefinition } from './createOpenApiDefinition.ts'
+import { getOpenAuthTokenUrls, getPathFromUrl } from './getOpenAuthTokenUrls.ts'
 
 describe('getOpenAuthTokenUrls', () => {
   it('returns an empty array for schema without securitySchemes', () => {

--- a/packages/mock-server/src/utils/getOperations.ts
+++ b/packages/mock-server/src/utils/getOperations.ts
@@ -1,6 +1,6 @@
 import type { OpenAPI, OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 
-import { httpMethods, type HttpMethod } from '@/types'
+import { type HttpMethod, httpMethods } from '@/types.ts'
 
 /**
  * Takes a dereferenced OpenAPI document and returns all operations.

--- a/packages/mock-server/src/utils/handleAuthentication.ts
+++ b/packages/mock-server/src/utils/handleAuthentication.ts
@@ -6,7 +6,7 @@ import { getCookie } from 'hono/cookie'
  * Handles authentication for incoming requests based on the OpenAPI specification.
  */
 export function handleAuthentication(schema?: OpenAPI.Document, operation?: OpenAPI.Operation) {
-  return async (c: Context, next: () => Promise<void>) => {
+  return async (c: Context, next: () => Promise<void>): Promise<Response | void> => {
     const operationSecuritySchemes = operation?.security || schema?.security
 
     if (operationSecuritySchemes && operationSecuritySchemes.length > 0) {

--- a/packages/mock-server/src/utils/honoRouteFromPath.test.ts
+++ b/packages/mock-server/src/utils/honoRouteFromPath.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { honoRouteFromPath } from './honoRouteFromPath'
+import { honoRouteFromPath } from './honoRouteFromPath.ts'
 
 describe('honoRouteFromPath', () => {
   it('returns correct route for a simple path', () => {

--- a/packages/mock-server/src/utils/isAuthenticationRequired.test.ts
+++ b/packages/mock-server/src/utils/isAuthenticationRequired.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isAuthenticationRequired } from './isAuthenticationRequired'
+import { isAuthenticationRequired } from './isAuthenticationRequired.ts'
 
 describe('isAuthenticationRequired', () => {
   it('returns false when security is undefined', () => {

--- a/packages/mock-server/src/utils/logAuthenticationInstructions.ts
+++ b/packages/mock-server/src/utils/logAuthenticationInstructions.ts
@@ -1,6 +1,6 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
-import { getPathFromUrl } from './getOpenAuthTokenUrls'
+import { getPathFromUrl } from './getOpenAuthTokenUrls.ts'
 
 /**
  * Log authentication instructions for different security schemes

--- a/packages/mock-server/src/utils/setupAuthenticationRoutes.ts
+++ b/packages/mock-server/src/utils/setupAuthenticationRoutes.ts
@@ -1,10 +1,10 @@
 import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Hono } from 'hono'
 
-import { respondWithAuthorizePage } from '@/routes/respondWithAuthorizePage'
-import { respondWithToken } from '@/routes/respondWithToken'
+import { respondWithAuthorizePage } from '@/routes/respondWithAuthorizePage.ts'
+import { respondWithToken } from '@/routes/respondWithToken.ts'
 
-import { getOpenAuthTokenUrls, getPathFromUrl } from './getOpenAuthTokenUrls'
+import { getOpenAuthTokenUrls, getPathFromUrl } from './getOpenAuthTokenUrls.ts'
 
 /**
  * Helper function to set up authentication routes for OAuth 2.0 flows

--- a/packages/mock-server/tsconfig.build.json
+++ b/packages/mock-server/tsconfig.build.json
@@ -1,11 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
-  "exclude": ["dist", "test", "vite.config.ts", "**/*.test.ts"],
   "compilerOptions": {
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
+    "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "dist/"
   }

--- a/packages/mock-server/tsconfig.json
+++ b/packages/mock-server/tsconfig.json
@@ -1,11 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["src", "test"],
-  "exclude": ["dist", "**/*.test.ts"],
+  "extends": "../../tsconfig.node.json",
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"],
       "@test/*": ["./test/*"]
     }
-  }
+  },
+  "include": ["src/**/*.ts", "rollup.config.ts"]
 }


### PR DESCRIPTION
We don't use the new and stricter Node TSConfig in the mock server, yet. Let’s add it.