### PR TITLE
fix(oas-utils): allow null as an oauth2 scope

### DIFF
--- a/.changeset/lemon-humans-sort.md
+++ b/.changeset/lemon-humans-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: allow null as a security scheme scope

--- a/packages/oas-utils/src/entities/spec/security.test.ts
+++ b/packages/oas-utils/src/entities/spec/security.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect } from 'vitest'
+import {
+  securityApiKeySchema,
+  securityHttpSchema,
+  securityOpenIdSchema,
+  securityOauthSchema,
+  securitySchemeSchema,
+  oasSecurityRequirementSchema,
+  pkceOptions,
+  type SecurityScheme,
+} from './security'
+
+describe('Security Schemas', () => {
+  describe('API Key Schema', () => {
+    it('should validate a valid API key schema', () => {
+      const apiKey = {
+        type: 'apiKey',
+        name: 'api_key',
+        in: 'header',
+        description: 'API Key Authentication',
+        uid: 'apikey123',
+        nameKey: 'x-api-key',
+        value: 'test-api-key',
+      }
+
+      const result = securityApiKeySchema.safeParse(apiKey)
+      expect(result.success).toBe(true)
+    })
+
+    it('should apply default values', () => {
+      const minimalApiKey = {
+        type: 'apiKey',
+        uid: 'apikey123',
+      }
+
+      const result = securityApiKeySchema.parse(minimalApiKey)
+      expect(result).toEqual({
+        type: 'apiKey',
+        uid: 'apikey123',
+        name: '',
+        in: 'header',
+        nameKey: '',
+        value: '',
+      })
+    })
+
+    it('should reject invalid "in" values', () => {
+      const invalidApiKey = {
+        type: 'apiKey',
+        name: 'api_key',
+        in: 'invalid',
+        uid: 'apikey123',
+      }
+
+      const result = securityApiKeySchema.safeParse(invalidApiKey)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('HTTP Schema', () => {
+    it('should validate a valid HTTP basic schema', () => {
+      const httpBasic = {
+        type: 'http',
+        scheme: 'basic',
+        description: 'Basic HTTP Authentication',
+        uid: 'http123',
+        username: 'user',
+        password: 'pass',
+      }
+
+      const result = securityHttpSchema.safeParse(httpBasic)
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate a valid HTTP bearer schema', () => {
+      const httpBearer = {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description: 'Bearer Authentication',
+        uid: 'http456',
+        token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+      }
+
+      const result = securityHttpSchema.safeParse(httpBearer)
+      expect(result.success).toBe(true)
+    })
+
+    it('should apply default values', () => {
+      const minimalHttp = {
+        type: 'http',
+        uid: 'http123',
+      }
+
+      const result = securityHttpSchema.parse(minimalHttp)
+      expect(result).toEqual({
+        type: 'http',
+        uid: 'http123',
+        scheme: 'basic',
+        bearerFormat: 'JWT',
+        nameKey: '',
+        username: '',
+        password: '',
+        token: '',
+      })
+    })
+
+    it('should reject invalid scheme values', () => {
+      const invalidHttp = {
+        type: 'http',
+        scheme: 'digest',
+        uid: 'http123',
+      }
+
+      const result = securityHttpSchema.safeParse(invalidHttp)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('OpenID Connect Schema', () => {
+    it('should validate a valid OpenID schema', () => {
+      const openId = {
+        type: 'openIdConnect',
+        openIdConnectUrl: 'https://example.com/.well-known/openid-configuration',
+        description: 'OpenID Connect',
+        uid: 'openid123',
+        nameKey: 'openid',
+      }
+
+      const result = securityOpenIdSchema.safeParse(openId)
+      expect(result.success).toBe(true)
+    })
+
+    it('should apply default values', () => {
+      const minimalOpenId = {
+        type: 'openIdConnect',
+        uid: 'openid123',
+      }
+
+      const result = securityOpenIdSchema.parse(minimalOpenId)
+      expect(result).toEqual({
+        type: 'openIdConnect',
+        uid: 'openid123',
+        openIdConnectUrl: '',
+        nameKey: '',
+      })
+    })
+  })
+
+  describe('OAuth2 Schema', () => {
+    it('should validate a valid OAuth2 implicit flow schema', () => {
+      const oauth2Implicit = {
+        type: 'oauth2',
+        description: 'OAuth2 Implicit Flow',
+        uid: 'oauth123',
+        flows: {
+          implicit: {
+            type: 'implicit',
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            scopes: {
+              'read:api': 'Read access',
+              'write:api': 'Write access',
+            },
+            selectedScopes: ['read:api'],
+            token: 'access-token-123',
+          },
+        },
+      }
+
+      const result = securityOauthSchema.safeParse(oauth2Implicit)
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate a valid OAuth2 with missing scopes', () => {
+      const oauth2Implicit = {
+        type: 'oauth2',
+        description: 'OAuth2 Implicit Flow',
+        uid: 'oauth123',
+        flows: {
+          implicit: {
+            type: 'implicit',
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            scopes: null,
+            selectedScopes: ['read:api'],
+            token: 'access-token-123',
+          },
+        },
+      }
+
+      const result = securityOauthSchema.safeParse(oauth2Implicit)
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate a valid OAuth2 authorization code flow schema', () => {
+      const oauth2AuthCode = {
+        type: 'oauth2',
+        description: 'OAuth2 Authorization Code Flow',
+        uid: 'oauth456',
+        flows: {
+          authorizationCode: {
+            type: 'authorizationCode',
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            tokenUrl: 'https://example.com/oauth/token',
+            'x-usePkce': 'SHA-256',
+            scopes: {
+              'read:api': 'Read access',
+              'write:api': 'Write access',
+            },
+            clientSecret: 'client-secret',
+            token: 'access-token-456',
+          },
+        },
+      }
+
+      const result = securityOauthSchema.safeParse(oauth2AuthCode)
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate a valid OAuth2 client credentials flow schema', () => {
+      const oauth2ClientCreds = {
+        type: 'oauth2',
+        description: 'OAuth2 Client Credentials Flow',
+        uid: 'oauth789',
+        flows: {
+          clientCredentials: {
+            type: 'clientCredentials',
+            tokenUrl: 'https://example.com/oauth/token',
+            scopes: {},
+            clientSecret: 'client-secret',
+            token: 'access-token-789',
+          },
+        },
+      }
+
+      const result = securityOauthSchema.safeParse(oauth2ClientCreds)
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate a valid OAuth2 password flow schema', () => {
+      const oauth2Password = {
+        type: 'oauth2',
+        description: 'OAuth2 Password Flow',
+        uid: 'oauth101',
+        flows: {
+          password: {
+            type: 'password',
+            tokenUrl: 'https://example.com/oauth/token',
+            scopes: {},
+            username: 'testuser',
+            password: 'testpass',
+            clientSecret: 'client-secret',
+            token: 'access-token-101',
+          },
+        },
+      }
+
+      const result = securityOauthSchema.safeParse(oauth2Password)
+      expect(result.success).toBe(true)
+    })
+
+    it('should apply default values', () => {
+      const minimalOauth2 = {
+        type: 'oauth2',
+        uid: 'oauth123',
+      }
+
+      const result = securityOauthSchema.parse(minimalOauth2)
+      expect(result.flows.implicit).toBeDefined()
+      expect(result.flows.implicit?.authorizationUrl).toBe('http://localhost:8080')
+      expect(result.flows.implicit?.scopes).toEqual({})
+      expect(result.flows.implicit?.selectedScopes).toEqual([])
+      expect(result.flows.implicit?.token).toBe('')
+      expect(result.nameKey).toBe('')
+    })
+
+    it('should validate PKCE options', () => {
+      expect(pkceOptions).toContain('SHA-256')
+      expect(pkceOptions).toContain('plain')
+      expect(pkceOptions).toContain('no')
+    })
+  })
+
+  describe('Security Requirement Schema', () => {
+    it('should validate a valid security requirement', () => {
+      const securityRequirement = {
+        'api_key': [],
+        'oauth2': ['read:api', 'write:api'],
+      }
+
+      const result = oasSecurityRequirementSchema.safeParse(securityRequirement)
+      expect(result.success).toBe(true)
+    })
+
+    it('should apply default values for empty scopes', () => {
+      const securityRequirement = {
+        'api_key': undefined,
+      }
+
+      const result = oasSecurityRequirementSchema.parse(securityRequirement)
+      expect(result).toEqual({
+        'api_key': [],
+      })
+    })
+  })
+
+  describe('Combined Security Scheme', () => {
+    it('should validate all security scheme types', () => {
+      const apiKey: SecurityScheme = {
+        type: 'apiKey',
+        name: 'api_key',
+        in: 'header',
+        uid: 'apikey123',
+        value: 'test-api-key',
+      }
+
+      const http: SecurityScheme = {
+        type: 'http',
+        scheme: 'bearer',
+        uid: 'http123',
+        token: 'bearer-token',
+      }
+
+      const openId: SecurityScheme = {
+        type: 'openIdConnect',
+        openIdConnectUrl: 'https://example.com/.well-known/openid-configuration',
+        uid: 'openid123',
+      }
+
+      const oauth2: SecurityScheme = {
+        type: 'oauth2',
+        uid: 'oauth123',
+        flows: {
+          implicit: {
+            type: 'implicit',
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            scopes: {},
+            token: '',
+          },
+        },
+      }
+
+      expect(securitySchemeSchema.safeParse(apiKey).success).toBe(true)
+      expect(securitySchemeSchema.safeParse(http).success).toBe(true)
+      expect(securitySchemeSchema.safeParse(openId).success).toBe(true)
+      expect(securitySchemeSchema.safeParse(oauth2).success).toBe(true)
+    })
+  })
+})

--- a/packages/oas-utils/src/entities/spec/security.ts
+++ b/packages/oas-utils/src/entities/spec/security.ts
@@ -112,7 +112,7 @@ const flowsCommon = z.object({
    * REQUIRED. The available scopes for the OAuth2 security scheme. A map
    * between the scope name and a short description for it. The map MAY be empty.
    */
-  'scopes': z.record(z.string(), z.string().optional().default('')).optional().default({}),
+  'scopes': z.record(z.string(), z.string().optional().default('')).optional().default({}).catch({}),
   'selectedScopes': z.array(z.string()).optional().default([]),
   /** Extension to save the client Id associated with an oauth flow */
   'x-scalar-client-id': z.string().optional().default(''),


### PR DESCRIPTION
**Problem**

Currently, having null a scope breaks everything

**Solution**

With this PR we add a catch for null values

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
