### PR TITLE
fix(ci): move turbo cache restore up in deploy-examples

### DIFF
--- a/.changeset/selfish-eggs-behave.md
+++ b/.changeset/selfish-eggs-behave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: change order of turbo cache

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -24,17 +24,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+      - name: Restore Turborepo cache
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Install netlify
         run: pnpm install -g netlify
       - name: Generate Run UUID
         run: echo "DEPLOY_ID=$(uuidgen)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Install dependencies
         run: pnpm --filter web install
-      - name: Restore Turborepo cache
-        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Build
         run: cd examples/web && pnpm turbo run build
         env:


### PR DESCRIPTION
**Problem**

Currently, our example deploy breaks

**Solution**

With this PR we move the cache restore up to before the install

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
