### PR TITLE
chore(api-client): remove focusAddressBar console.log

### DIFF
--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -109,7 +109,6 @@ events.requestStatus.on((status) => {
 
 /** Focus the address bar (or the send button if in modal layout) */
 events.focusAddressBar.on(() => {
-  console.log('focusAddressBar', sendButtonRef.value, addressBarRef.value)
   if (layout === 'modal') sendButtonRef.value?.$el?.focus()
   else addressBarRef.value?.focus()
 })


### PR DESCRIPTION
Let’s remove the console.log, doesn’t need a changelog, will be just part of the next release.