### PR TITLE
feat(api-client): security scheme auth description

### DIFF
--- a/.changeset/unlucky-shirts-switch.md
+++ b/.changeset/unlucky-shirts-switch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds security scheme auth description

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -307,7 +307,7 @@ export default {
   <slot name="icon" />
   <div
     v-if="required"
-    class="required centered-y text-xxs text-c-3 group-[.error]:text-red bg-b-1 pointer-events-none absolute right-0 pr-2 pt-px opacity-100 shadow-[-8px_0_4px_var(--scalar-background-1)] transition-opacity duration-150 group-[.alert]:bg-transparent group-[.error]:bg-transparent group-[.alert]:shadow-none group-[.error]:shadow-none peer-has-[.cm-focused]:opacity-0">
+    class="required centered-y text-xxs text-c-3 group-[.error]:text-red bg-b-1 pointer-events-none absolute right-0.5 pr-2 pt-px opacity-100 shadow-[-8px_0_4px_var(--scalar-background-1)] transition-opacity duration-150 group-[.alert]:bg-transparent group-[.error]:bg-transparent group-[.alert]:shadow-none group-[.error]:shadow-none peer-has-[.cm-focused]:opacity-0">
     Required
   </div>
   <EnvironmentVariableDropdown

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -7,6 +7,7 @@ import { computed, ref } from 'vue'
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
 import type { EnvVariable } from '@/store/active-entities'
 import type { VueClassProp } from '@/types/vue'
+import RequestTableTooltip from '@/views/Request/RequestSection/RequestTableTooltip.vue'
 
 import DataTableCell from './DataTableCell.vue'
 import DataTableInputSelect from './DataTableInputSelect.vue'
@@ -28,6 +29,7 @@ const props = withDefaults(
     environment: Environment
     envVariables: EnvVariable[]
     workspace: Workspace
+    description?: string | undefined
   }>(),
   { canAddCustomEnumValue: true, required: false, readOnly: false },
 )
@@ -90,7 +92,7 @@ const handleLabelClick = () => {
           v-if="mask && type === 'password'"
           v-bind="id ? { ...$attrs, id: id } : $attrs"
           autocomplete="off"
-          class="text-c-1 disabled:text-c-2 py-1.25 peer w-full min-w-0 border-none px-2 -outline-offset-2"
+          class="text-c-1 disabled:text-c-2 py-1.25 peer w-full min-w-0 border-none px-2 -outline-offset-1"
           data-1p-ignore
           :readOnly="readOnly"
           spellcheck="false"
@@ -107,7 +109,11 @@ const handleLabelClick = () => {
           ref="codeInput"
           v-bind="$attrs"
           :id="id"
-          class="text-c-1 disabled:text-c-2 peer w-full min-w-0 border-none"
+          class="text-c-1 disabled:text-c-2 peer w-full min-w-0 border-none -outline-offset-1"
+          :class="[
+            type === 'password' && description && 'pr-12',
+            description && 'pr-8',
+          ]"
           disableCloseBrackets
           disableTabIndent
           :envVariables="envVariables"
@@ -120,13 +126,23 @@ const handleLabelClick = () => {
           spellcheck="false"
           :type="inputType"
           :workspace="workspace"
+          :description="description"
           @blur="handleBlur"
           @focus="emit('inputFocus')"
           @update:modelValue="emit('update:modelValue', $event)" />
         <div
-          v-if="required"
-          class="scalar-input-required centered-y text-xxs text-c-3 bg-b-1 absolute right-2 pt-px opacity-100 shadow-[-8px_0_4px_var(--scalar-background-1)] transition-opacity duration-150 peer-has-[:focus-visible]:opacity-0">
-          Required
+          v-if="description"
+          class="centered-y text-xxs text-c-3 bg-b-1 absolute right-0 h-full opacity-100 shadow-[-8px_0_4px_var(--scalar-background-1)]">
+          <RequestTableTooltip
+            v-if="description"
+            class=""
+            :item="{
+              description: description,
+              required: required,
+              value: '',
+              key: '',
+              enabled: true,
+            }" />
         </div>
       </template>
     </div>
@@ -138,7 +154,8 @@ const handleLabelClick = () => {
     <slot name="icon" />
     <ScalarIconButton
       v-if="type === 'password'"
-      class="-ml-.5 mr-0.75 h-6 w-6 self-center p-1.5"
+      class="centered-y text-xxs text-c-3 bg-b-1 right-0.75 p-1.25 absolute h-6 w-6 shadow-[-8px_0_4px_var(--scalar-background-1)]"
+      :class="description && 'right-6'"
       :icon="mask ? 'Show' : 'Hide'"
       :label="mask ? 'Show Password' : 'Hide Password'"
       @click="mask = !mask" />

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
@@ -110,6 +110,7 @@ const dataTableInputProps = {
       <RequestAuthDataTableInput
         v-if="'authorizationUrl' in flow"
         v-bind="dataTableInputProps"
+        containerClass="border-r-0"
         :modelValue="flow.authorizationUrl"
         placeholder="https://galaxy.scalar.com/authorize"
         @update:modelValue="

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -105,6 +105,14 @@ const dataTableInputProps = {
       </DataTableCell>
     </DataTableRow>
 
+    <!-- Description -->
+    <DataTableRow v-if="scheme?.description">
+      <DataTableCell
+        class="text-c-3 flex items-center overflow-auto whitespace-nowrap pl-3 font-medium">
+        {{ scheme.description }}
+      </DataTableCell>
+    </DataTableRow>
+
     <!-- HTTP -->
     <template v-if="scheme?.type === 'http'">
       <!-- Bearer -->

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -15,7 +15,7 @@ const { item } = defineProps<{ item: RequestExampleParameter }>()
     triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 group-[.alert]:before:to-b-alert group-[.error]:before:to-b-danger before:min-h-[calc(100%-4px)] before:pointer-events-none before:right-[23px] before:top-0.5 before:w-3 absolute h-full right-0 -outline-offset-1">
     <template #trigger>
       <div
-        class="bg-b-1 mr-0.25 pr-1.5 pl-1 group-[.alert]:bg-transparent group-[.error]:bg-transparent">
+        class="bg-b-1 mr-0.25 pl-1 pr-1.5 group-[.alert]:bg-transparent group-[.error]:bg-transparent">
         <ScalarIcon
           :class="
             parameterIsInvalid(item).value
@@ -52,7 +52,7 @@ const { item } = defineProps<{ item: RequestExampleParameter }>()
         </div>
         <span
           v-if="item.description && !parameterIsInvalid(item).value"
-          class="text-sm leading-snug text-pretty"
+          class="text-pretty text-sm leading-snug"
           :style="{ maxWidth: '16rem' }"
           >{{ item.description }}</span
         >

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -15,7 +15,7 @@ const { item } = defineProps<{ item: RequestExampleParameter }>()
     triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 group-[.alert]:before:to-b-alert group-[.error]:before:to-b-danger before:min-h-[calc(100%-4px)] before:pointer-events-none before:right-[23px] before:top-0.5 before:w-3 absolute h-full right-0 -outline-offset-1">
     <template #trigger>
       <div
-        class="bg-b-1 mr-0.25 pl-1 pr-1.5 group-[.alert]:bg-transparent group-[.error]:bg-transparent">
+        class="bg-b-1 mr-0.25 pr-1.5 pl-1 group-[.alert]:bg-transparent group-[.error]:bg-transparent">
         <ScalarIcon
           :class="
             parameterIsInvalid(item).value
@@ -36,7 +36,13 @@ const { item } = defineProps<{ item: RequestExampleParameter }>()
           {{ parameterIsInvalid(item).value }}
         </div>
         <div
-          v-else
+          v-else-if="
+            item.type ||
+            item.format ||
+            item.minimum ||
+            item.maximum ||
+            item.default
+          "
           class="schema text-c-2 flex items-center">
           <span v-if="item.type">{{ item.type }}</span>
           <span v-if="item.format">{{ item.format }}</span>
@@ -46,7 +52,7 @@ const { item } = defineProps<{ item: RequestExampleParameter }>()
         </div>
         <span
           v-if="item.description && !parameterIsInvalid(item).value"
-          class="text-pretty text-sm leading-snug"
+          class="text-sm leading-snug text-pretty"
           :style="{ maxWidth: '16rem' }"
           >{{ item.description }}</span
         >


### PR DESCRIPTION
**Problem**

currently security scheme descriptions are not displayed within the api client.

**Solution**

this pr  adds security scheme description through already existing tooltip component usage. fixes #4934

| before | after |
| -------|------|
| <img width="601" alt="image" src="https://github.com/user-attachments/assets/46d7b4e7-2cf8-4344-8bd1-85a33e51938d" /> | <img width="643" alt="image" src="https://github.com/user-attachments/assets/e649ab89-a2cf-476f-8806-721dd80135ca" /> |
| no description available | description is available through tooltip hover |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
