### PR TITLE
fix(ci): remove turbo cache from deploy examples

### DIFF
--- a/.changeset/good-horses-approve.md
+++ b/.changeset/good-horses-approve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: remove turbo cache from deploy examples

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
-      - name: Restore Turborepo cache
-        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
+      # - name: Restore Turborepo cache
+      #   uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf
+      #   with:
+      #     path: .turbo
+      #     key: turbo-${{ runner.os }}-node-${{ matrix.node-version }}
       - name: Install netlify
         run: pnpm install -g netlify
       - name: Generate Run UUID


### PR DESCRIPTION
**Problem**

Currently, deploy examples always breaks on the first try. That makes it seem cache related

**Solution**

With this PR we remove restoring turbo cache to see if that helps

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
