### PR TITLE
fix(api-reference): path parameter in operation 

### DIFF
--- a/.changeset/itchy-rats-search.md
+++ b/.changeset/itchy-rats-search.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: normlizes nav state operation id

--- a/packages/api-reference/src/hooks/useNavState.test.ts
+++ b/packages/api-reference/src/hooks/useNavState.test.ts
@@ -78,6 +78,21 @@ describe('useNavState', () => {
     it('should generate webhook ID', () => {
       expect(navState.getWebhookId({ name: 'Test Webhook', method: 'POST' })).toBe('webhook/POST/test-webhook')
     })
+
+    it('should normalize operation ID with path parameters', () => {
+      const operation = {
+        httpVerb: 'GET',
+        path: '/environments/{environmentId}/scoped-variables',
+      } as const
+      const parentTag = {
+        name: 'Test Tag',
+        description: 'Test Description',
+        operations: [],
+      } satisfies Tag
+      expect(navState.getOperationId(operation, parentTag)).toBe(
+        'tag/test-tag/GET/environments/environmentId/scoped-variables',
+      )
+    })
   })
 
   describe('custom slug generation', () => {

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -122,7 +122,11 @@ export const useNavState = () => {
         summary: operation.information?.summary,
       })}`
     }
-    return `${getTagId(parentTag)}/${operation.httpVerb}${operation.path}`
+
+    // Normalizes path including path parameters
+    const normalizedPath = operation.path.split('{').join('').split('}').join('')
+
+    return `${getTagId(parentTag)}/${operation.httpVerb}${normalizedPath}`
   }
 
   const getWebhookId = (webhook?: { name: string; method?: string }) => {


### PR DESCRIPTION
**Problem**

currently operations with path parameters maintain curly braces in the operation id, while it gets encoded in the url, leading to issue when sharing a url.

**Solution**

this pr is a proposal to normalize path parameter at the nav state level to keep matching id and url. fixes #5052 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
