### PR TITLE
test(api-reference): add a CDN example

### DIFF
--- a/examples/cdn-api-reference/src/public/api-reference-jsdelivr.html
+++ b/examples/cdn-api-reference/src/public/api-reference-jsdelivr.html
@@ -7,10 +7,21 @@
       name="viewport"
       content="width=device-width, initial-scale=1" />
   </head>
+
   <body>
-    <script
-      id="api-reference"
-      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"></script>
+    <div id="app"></div>
+
+    <!-- Load the Script -->
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+
+    <!-- Initialize the Scalar API Reference -->
+    <script>
+      Scalar.createApiReference('#app', {
+        // The URL of the OpenAPI/Swagger document
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+        // Avoid CORS issues
+        proxyUrl: 'https://proxy.scalar.com',
+      })
+    </script>
   </body>
 </html>

--- a/examples/cdn-api-reference/src/public/api-reference-legacy-jsdelivr.html
+++ b/examples/cdn-api-reference/src/public/api-reference-legacy-jsdelivr.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Scalar API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>

--- a/examples/cdn-api-reference/src/public/api-reference-legacy-local.html
+++ b/examples/cdn-api-reference/src/public/api-reference-legacy-local.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Scalar API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
+      data-proxy-url="https://proxy.scalar.com"></script>
+    <script src="/api-reference/standalone.js"></script>
+  </body>
+</html>

--- a/examples/cdn-api-reference/src/public/api-reference-local.html
+++ b/examples/cdn-api-reference/src/public/api-reference-local.html
@@ -7,11 +7,21 @@
       name="viewport"
       content="width=device-width, initial-scale=1" />
   </head>
+
   <body>
-    <script
-      id="api-reference"
-      data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
-      data-proxy-url="https://proxy.scalar.com"></script>
+    <div id="app"></div>
+
+    <!-- Load the Script -->
     <script src="/api-reference/standalone.js"></script>
+
+    <!-- Initialize the Scalar API Reference -->
+    <script>
+      Scalar.createApiReference('#app', {
+        // The URL of the OpenAPI/Swagger document
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+        // Avoid CORS issues
+        proxyUrl: 'https://proxy.scalar.com',
+      })
+    </script>
   </body>
 </html>

--- a/playwright/tests/legacy-jsdelivr.spec.ts
+++ b/playwright/tests/legacy-jsdelivr.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test'
+
+import { testApiReference } from './testApiReference'
+
+const HOST = process.env.HOST || 'localhost'
+
+test('@scalar/api-reference legacy jsdelivr build', async ({ page, isMobile }) => {
+  await page.goto(`http://${HOST}:3173/api-reference-legacy-jsdelivr.html`)
+  await testApiReference(page, isMobile)
+
+  /**
+   * Visual Regression Testing
+   * use Playwright built in screenshot functionality https://playwright.dev/docs/screenshots
+   * Playwright uses pixelmatch to compare screenshots
+   * update screenshots with npx playwright test --update-snapshots
+   */
+  await expect(page).toHaveScreenshot('jsdelivr-snapshot.png', {
+    fullPage: true,
+    maxDiffPixelRatio: 0.02,
+  })
+
+  /**
+   * Capture into buffer
+   * If we are unsatisfied with the built in visual regression testing
+   * this is how we could pass it to a third party pixel diff facility eg. Chromatic
+   *   const buffer = await page.screenshot()
+   *   console.log(buffer.toString('base64'))
+   */
+})

--- a/playwright/tests/legacy.spec.ts
+++ b/playwright/tests/legacy.spec.ts
@@ -1,0 +1,30 @@
+import { test } from '@playwright/test'
+
+import { testApiReference } from './testApiReference'
+
+const HOST = process.env.HOST || 'localhost'
+
+test('@scalar/api-reference local build (data-url)', async ({ page, isMobile }) => {
+  await page.goto(`http://${HOST}:3173/api-reference-legacy-local.html`)
+  await testApiReference(page, isMobile)
+
+  // TODO: fix the dev workflow
+  /**
+   * Visual Regression Testing
+   * use Playwright built in screenshot functionality https://playwright.dev/docs/screenshots
+   * Playwright uses pixelmatch to compare screenshots
+   * update screenshots with npx playwright test --update-snapshots
+   */
+  //   await expect(page).toHaveScreenshot('cdn-snapshot.png', {
+  //     fullPage: true,
+  //     maxDiffPixelRatio: 0.02,
+  //   })
+
+  /**
+   * Capture into buffer
+   * If we are unsatisfied with the built in visual regression testing
+   * this is how we could pass it to a third party pixel diff facility eg. Chromatic
+   *   const buffer = await page.screenshot()
+   *   console.log(buffer.toString('base64'))
+   */
+})


### PR DESCRIPTION
WIP

Adds new CDN tests for the new JS API and the old data attributes API

Will fail until we release

**Problem**

Currently, …

**Solution**

With this PR …

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
