### PR TITLE
feat(api-reference): show deprecated parameters

### DIFF
--- a/.changeset/happy-bees-search.md
+++ b/.changeset/happy-bees-search.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: show if a parameter is deprecated

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -30,7 +30,8 @@ const flattenDefaultValue = (value: Record<string, any>) => {
   <div class="property-heading">
     <div
       v-if="$slots.name"
-      class="property-name">
+      class="property-name"
+      :class="{ deprecated: value?.deprecated }">
       <slot
         v-if="!pattern"
         name="name" />
@@ -222,5 +223,9 @@ const flattenDefaultValue = (value: Record<string, any>) => {
 
 .property-const {
   color: var(--scalar-color-1);
+}
+
+.deprecated {
+  text-decoration: line-through;
 }
 </style>

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -92,11 +92,12 @@ const shouldShowParameter = computed(() => {
           :name="shouldCollapse ? '' : parameter.name"
           :noncollapsible="showChildren"
           :required="parameter.required"
-          :value="
-            parameter.content
+          :value="{
+            deprecated: parameter.deprecated,
+            ...(parameter.content
               ? parameter.content?.[selectedContentType]?.schema
-              : parameter.schema
-          "
+              : parameter.schema),
+          }"
           :withExamples="withExamples" />
       </DisclosurePanel>
     </Disclosure>


### PR DESCRIPTION
**Problem**

Currently, we don’t show whether a parameter is deprecated.

See #5077

**Solution**

We’ve had the styles already, with this PR we’re passing down the `deprecated` attribute to show whether a parameter is deprecated.

**Preview**

![Screenshot 2025-03-12 at 14 57 58](https://github.com/user-attachments/assets/b8003a40-f6b4-451a-a11d-a2da03b49ac3)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
