### PR TITLE
fix(api-reference): sidebar arrows on all tags configuration

### DIFF
--- a/.changeset/giant-icons-pay.md
+++ b/.changeset/giant-icons-pay.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: hides sidebar arrow on default open all tags configuration

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -7,6 +7,7 @@ import {
 import { combineUrlAndPath } from '@scalar/oas-utils/helpers'
 
 import { scrollToId, sleep } from '@/helpers'
+import { useConfig } from '@/hooks/useConfig'
 
 import { useNavState } from '../../hooks'
 import SidebarHttpBadge from './SidebarHttpBadge.vue'
@@ -35,6 +36,8 @@ const emit = defineEmits<{
 
 const { getFullHash, isIntersectionEnabled, pathRouting, replaceUrlState } =
   useNavState()
+
+const config = useConfig()
 
 // We disable intersection observer on click
 const handleClick = async () => {
@@ -98,7 +101,7 @@ const onAnchorClick = async (ev: Event) => {
       <!-- If children are detected then show the nesting icon -->
       <!-- Use &hairsp; to vertically center scalar icon button to the first line of text in the sidebar heading link -->
       <p
-        v-if="hasChildren"
+        v-if="hasChildren && !config.defaultOpenAllTags"
         class="sidebar-heading-chevron">
         <button
           :aria-expanded="open"


### PR DESCRIPTION
**Problem**

currently when using `defaultOpenAllTags` configuration, sidebar arrows are still display even though they cannot be folded.

**Solution**

this pr avoids sidebar arrows from being displayed when the configuration is on.

| before | after |
| -------|------|
| <img width="886" alt="image" src="https://github.com/user-attachments/assets/523bf647-5d06-4c06-b9da-f17d4886c5f9" /> | <img width="886" alt="image" src="https://github.com/user-attachments/assets/9963dbe8-ec61-4147-a6be-46c9e7e7623a" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
