### PR TITLE
feat(api-client): address bar server deselection

### DIFF
--- a/.changeset/fuzzy-files-hide.md
+++ b/.changeset/fuzzy-files-hide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds server deselection

--- a/packages/api-client/src/components/Server/ServerDropdown.vue
+++ b/packages/api-client/src/components/Server/ServerDropdown.vue
@@ -102,8 +102,17 @@ const updateServerVariable = (key: string, value: string) => {
     <ScalarButton
       class="gap-0.75 z-context-plus h-6.5 hover:bg-b-2 font-code ml-0.75 text-c-2 whitespace-nowrap rounded border px-1.5 text-xs lg:text-sm"
       variant="ghost">
-      <span class="sr-only">Server:</span>
-      {{ serverUrlWithoutTrailingSlash }}
+      <template
+        v-if="operation?.selectedServerUid || collection.selectedServerUid">
+        <span class="sr-only">Server:</span>
+        {{ serverUrlWithoutTrailingSlash }}
+      </template>
+      <template v-else>
+        <span class="sr-only">Add Server</span>
+        <ScalarIcon
+          icon="Add"
+          size="xs" />
+      </template>
     </ScalarButton>
     <template #popover="{ close }">
       <div

--- a/packages/api-client/src/components/Server/ServerDropdownItem.vue
+++ b/packages/api-client/src/components/Server/ServerDropdownItem.vue
@@ -32,6 +32,24 @@ const { collectionMutators, requestMutators, servers } = useWorkspace()
 const updateSelectedServer = (serverUid: Server['uid'], event?: Event) => {
   if (hasVariables(serverUid)) event?.stopPropagation()
 
+  // Handle selected server deselection
+  if (isSelectedServer.value) {
+    // Clear selected server if selected
+    if (props.operation?.servers?.length) {
+      requestMutators.edit(props.operation.uid, 'selectedServerUid', null)
+    }
+    if (props.type === 'collection') {
+      collectionMutators.edit(
+        props.collection.uid,
+        'selectedServerUid',
+        undefined,
+      )
+    } else if (props.type === 'request' && props.operation) {
+      requestMutators.edit(props.operation.uid, 'selectedServerUid', null)
+    }
+    return
+  }
+
   // Set selected server on Collection
   if (props.type === 'collection' && props.collection) {
     // Clear the selected server on the request so that the collection can be updated
@@ -51,9 +69,17 @@ const updateSelectedServer = (serverUid: Server['uid'], event?: Event) => {
 }
 
 /** Set server checkbox in the dropdown */
-const isSelectedServer = computed(
-  () => props.server?.uid === props.serverOption.id,
-)
+const isSelectedServer = computed(() => {
+  if (props.type === 'collection') {
+    return props.collection.selectedServerUid === props.serverOption.id
+  }
+
+  if (props.type === 'request' && props.operation) {
+    return props.operation.selectedServerUid === props.serverOption.id
+  }
+
+  return false
+})
 
 const hasVariables = (serverUid: string) => {
   if (!serverUid) return false

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -156,14 +156,14 @@ export const createActiveEntitiesStore = ({
   /** The currently selected server in the addressBar */
   const activeServer = computed(() => {
     // Request has a selected server
-    if (isDefined(activeRequest.value?.selectedServerUid)) {
+    if (activeRequest.value?.selectedServerUid) {
       // Return server if selected
       const server = servers[activeRequest.value.selectedServerUid]
       if (server) return server
     }
 
     // Collection has a selected server
-    if (isDefined(activeCollection.value?.selectedServerUid)) {
+    if (activeCollection.value?.selectedServerUid) {
       // Return server if selected
       const server = servers[activeCollection.value.selectedServerUid]
       if (server) return server

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -154,15 +154,23 @@ export const createActiveEntitiesStore = ({
   })
 
   /** The currently selected server in the addressBar */
-  const activeServer = computed(
-    () =>
-      servers[
-        (activeRequest.value?.selectedServerUid ||
-          activeCollection.value?.selectedServerUid ||
-          activeCollection.value?.servers[0]) ??
-          ''
-      ],
-  )
+  const activeServer = computed(() => {
+    // Request has a selected server
+    if (isDefined(activeRequest.value?.selectedServerUid)) {
+      // Return server if selected
+      const server = servers[activeRequest.value.selectedServerUid]
+      if (server) return server
+    }
+
+    // Collection has a selected server
+    if (isDefined(activeCollection.value?.selectedServerUid)) {
+      // Return server if selected
+      const server = servers[activeCollection.value.selectedServerUid]
+      if (server) return server
+    }
+
+    return undefined
+  })
 
   /** Cookie associated with the current route */
   const activeCookieId = computed(() =>


### PR DESCRIPTION
**Problem**

currently a server cannot be deselected from the client address bar when set.

**Solution**

this pr introduces deselection capability while keeping the possibility to select back server.

| after |
| -------|
| <img width="643" alt="image" src="https://github.com/user-attachments/assets/50a9d417-0b95-49b4-90d6-98e60d80f25e" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
