### PR TITLE
fix: copy over whole packages files in docker

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,16 +35,6 @@
       "import": "./dist/libs/html-rendering/index.js",
       "types": "./dist/libs/html-rendering/index.d.ts",
       "default": "./dist/libs/html-rendering/index.js"
-    },
-    "./css/*.css": {
-      "import": "./dist/css/*.css",
-      "require": "./dist/css/*.css",
-      "default": "./dist/css/*.css"
-    },
-    "./*.css": {
-      "import": "./dist/*.css",
-      "require": "./dist/*.css",
-      "default": "./dist/*.css"
     }
   },
   "files": [

--- a/packages/snippetz/Dockerfile
+++ b/packages/snippetz/Dockerfile
@@ -16,7 +16,7 @@ RUN chown node:node /app
 
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
-COPY --from=builder /app/packages/snippetz /app/packages/snippetz
+COPY --from=builder /app/packages /app/packages
 WORKDIR /app/packages/snippetz
 
 CMD ["http-server", "playground/dist"]

--- a/packages/void-server/Dockerfile
+++ b/packages/void-server/Dockerfile
@@ -19,7 +19,7 @@ RUN chown node:node /app
 
 # Copy root node modules and any utilized packages
 COPY --from=builder /app/node_modules /app/node_modules
-COPY --from=builder /app/packages/void-server /app/packages/void-server
+COPY --from=builder /app/packages /app/packages
 WORKDIR /app/packages/void-server
 
 CMD ["dumb-init", "node", "dist/playground/index.js"]


### PR DESCRIPTION
**Problem**

Currently we need some build files in docker

**Solution**

With this PR we copy over all packages

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
