### PR TITLE
fix(ci): void server deployment

### DIFF
--- a/.changeset/funny-dingos-rule.md
+++ b/.changeset/funny-dingos-rule.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+fix: void server docker deployment

--- a/packages/void-server/playground/index.ts
+++ b/packages/void-server/playground/index.ts
@@ -1,6 +1,6 @@
 import { serve } from '@hono/node-server'
 
-import { createVoidServer } from '../src/createVoidServer'
+import { createVoidServer } from '../src/createVoidServer.ts'
 
 const host = process.env.HOST || '0.0.0.0'
 const port = process.env.PORT || 5052

--- a/packages/void-server/tsconfig.json
+++ b/packages/void-server/tsconfig.json
@@ -6,5 +6,5 @@
       "@test/*": ["./test/*"]
     }
   },
-  "include": ["src/**/*.ts", "rollup.config.ts"]
+  "include": ["src/**/*.ts", "playground/**/*.ts", "rollup.config.ts"]
 }


### PR DESCRIPTION
**Problem**

Currently, we upgraded void server to tsconfig.node but forgot to include the playground.

**Solution**

With this PR we add the playground to the tsconfig and fix the type issue

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
