### PR TITLE
fix(import): importing of unescaped configuration urls

### DIFF
--- a/.changeset/rare-stingrays-lick.md
+++ b/.changeset/rare-stingrays-lick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/import': patch
+---
+
+fix: getting configuration for galaxy example

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -315,6 +315,28 @@ describe('resolve', () => {
     expect(result).toBe('https://example.com/openapi.json')
   })
 
+  it('finds embedded OpenAPI document URLs (JSON) unescaped', async () => {
+    const html = `<!DOCTYPE html>
+<html>
+  <head />
+  <body>
+    <script
+      id="api-reference"
+      type="application/json"
+      data-configuration='{"url":"/openapi.yaml","hideClientButton":false,"showSidebar":true,"theme":"default","_integration":"hono","layout":"modern","isEditable":false,"hideModels":false,"hideDownloadButton":false,"hideTestRequestButton":false,"hideSearch":false,"hideDarkModeToggle":false,"withDefaultFonts":true}'></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>
+    `
+
+    // @ts-expect-error Mocking types are missing
+    fetch.mockResolvedValue(createFetchResponse(html))
+
+    const result = await resolve('https://example.com/reference')
+
+    expect(result).toBe('https://example.com/openapi.yaml')
+  })
+
   it('finds embedded OpenAPI documents (YAML)', async () => {
     const html = `<!DOCTYPE html>
       <html>

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -116,7 +116,7 @@ export async function resolve(
           return makeUrlAbsolute(configUrl, forwardedHost || value)
         }
 
-        // Check for embedded OpenAPI document - also handles URLs
+        // Check for embedded OpenAPI document
         const embeddedSpec = parseEmbeddedOpenApi(content)
         if (embeddedSpec) {
           return embeddedSpec

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -265,13 +265,23 @@ function parseScriptContent(html: string): Record<string, any> | undefined {
  * @example <script id="api-reference" data-configuration="{&quot;spec&quot;:{&quot;content&quot;:&quot;foo&quot;}}"></script>
  */
 export function getConfigurationAttribute(html: string): string | undefined {
-  // Match both escaped and unescaped configurations
-  const pattern = /<script[^>]*id=["']api-reference["'][^>]*data-configuration=(["'])(.*?)\1[^>]*>(?:.*?)<\/script>/s
+  const patterns = [
+    // Double quotes
+    /<script[^>]*id="api-reference"[^>]*data-configuration=["]([^"]+)["][^>]*>(.*?)<\/script>/s,
+    // Single quotes
+    /<script[^>]*id='api-reference'[^>]*data-configuration=[']([^']+)['][^>]*>(.*?)<\/script>/s,
+    // Mix quote single first
+    /<script[^>]*id='api-reference'[^>]*data-configuration=["]([^"]+)["][^>]*>(.*?)<\/script>/s,
+    // Mix quote double first
+    /<script[^>]*id="api-reference"[^>]*data-configuration=[']([^']+)['][^>]*>(.*?)<\/script>/s,
+  ]
 
-  const match = html.match(pattern)
+  for (const pattern of patterns) {
+    const match = html.match(pattern)
 
-  if (match?.[2]) {
-    return match[2]
+    if (match?.[1]) {
+      return match[1]
+    }
   }
 
   return undefined


### PR DESCRIPTION
**Problem**

Currently, we aren't importing URLs from the config attribute

**Solution**

With this PR we grab them

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
