### PR TITLE
fix: treat png files as binary

### DIFF
--- a/.changeset/funny-ligers-jog.md
+++ b/.changeset/funny-ligers-jog.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: using config url data attribute import

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.png binary


### PR DESCRIPTION
**Problem**

Currently, we added a new line to git attributes which seems to be editing our snapshots

**Solution**

With this PR we ignore png files (may need to add other file types down the road)

Also added a changeset to bump references from a previous fix

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
