### PR TITLE
fix(api-reference): focus and screenreader improvements for client libraries, endpoints list and API client

### DIFF
--- a/.changeset/gorgeous-ghosts-confess.md
+++ b/.changeset/gorgeous-ghosts-confess.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix(api-reference): focus and screenreader improvements for client libraries, endpoints list and API client

--- a/packages/api-client/src/components/DataTable/DataTableHeader.vue
+++ b/packages/api-client/src/components/DataTable/DataTableHeader.vue
@@ -8,7 +8,7 @@ const { cx } = useBindCx()
 <template>
   <DataTableCell
     is="th"
-    v-bind="cx('truncate font-medium px-2 py-1.5')">
+    v-bind="cx('items-center font-medium px-2 min-w-0 -outline-offset-1')">
     <slot />
   </DataTableCell>
 </template>

--- a/packages/api-client/src/components/DataTable/DataTableRow.vue
+++ b/packages/api-client/src/components/DataTable/DataTableRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <tr class="group contents w-fit min-w-full">
+  <tr class="group contents">
     <slot />
   </tr>
 </template>

--- a/packages/api-client/src/views/Request/RequestRoot.vue
+++ b/packages/api-client/src/views/Request/RequestRoot.vue
@@ -33,6 +33,8 @@ const { cookies, requestHistory, showSidebar, securitySchemes, events } =
   workspaceContext
 const { isSidebarOpen } = useSidebar()
 
+const element = ref<HTMLDivElement>()
+
 const requestAbortController = ref<AbortController>()
 const invalidParams = ref<Set<string>>(new Set())
 
@@ -115,6 +117,14 @@ onMounted(() => {
   events.cancelRequest.on(cancelRequest)
 })
 
+/** Focus the first button in the layout when the modal is mounted */
+onMounted(() => {
+  if (element.value && layout === 'modal') {
+    const button = element.value.querySelector('button')
+    if (button) button.focus()
+  }
+})
+
 useOpenApiWatcher()
 
 /**
@@ -137,6 +147,7 @@ watch(
 <template>
   <!-- Layout -->
   <div
+    ref="element"
     class="bg-b-1 relative z-0 flex h-full flex-1 flex-col overflow-hidden pt-0"
     :class="{
       '!mb-0 !mr-0 !border-0': layout === 'modal',

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -9,6 +9,7 @@ import CodeInput from '@/components/CodeInput/CodeInput.vue'
 import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableCell from '@/components/DataTable/DataTableCell.vue'
 import DataTableCheckbox from '@/components/DataTable/DataTableCheckbox.vue'
+import DataTableHeader from '@/components/DataTable/DataTableHeader.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import type { EnvVariable } from '@/store/active-entities'
 
@@ -71,10 +72,15 @@ const flattenValue = (item: RequestExampleParameter) => {
   <DataTable
     class="group/table flex-1"
     :columns="columns">
+    <DataTableRow class="sr-only !block">
+      <DataTableHeader><span class="sr-only">Enabled</span></DataTableHeader>
+      <DataTableHeader>Key</DataTableHeader>
+      <DataTableHeader>Value</DataTableHeader>
+    </DataTableRow>
     <DataTableRow
       v-for="(item, idx) in items"
-      :key="idx"
       :id="item.key"
+      :key="idx"
       :class="{
         alert: parameterIsInvalid(item).value,
         error: invalidParams && invalidParams.has(item.key),

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { ScalarIcon, ScalarTooltip } from '@scalar/components'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
+import { computed } from 'vue'
 
 import { parameterIsInvalid } from '../libs/request'
 
 const { item } = defineProps<{ item: RequestExampleParameter }>()
+
+const isInvalid = computed(() => !!parameterIsInvalid(item).value)
 </script>
 <template>
   <ScalarTooltip
@@ -15,14 +18,16 @@ const { item } = defineProps<{ item: RequestExampleParameter }>()
     triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 group-[.alert]:before:to-b-alert group-[.error]:before:to-b-danger before:min-h-[calc(100%-4px)] before:pointer-events-none before:right-[23px] before:top-0.5 before:w-3 absolute h-full right-0 -outline-offset-1">
     <template #trigger>
       <div
-        class="bg-b-1 mr-1 pl-1 pr-1.5 group-[.alert]:bg-transparent group-[.error]:bg-transparent">
+        :aria-label="isInvalid ? 'Input is invalid' : 'More Information'"
+        class="bg-b-1 mr-1 pl-1 pr-1.5 group-[.alert]:bg-transparent group-[.error]:bg-transparent"
+        :role="isInvalid ? 'alert' : 'none'">
         <ScalarIcon
           :class="
-            parameterIsInvalid(item).value
+            isInvalid
               ? 'text-orange brightness-[.9]'
               : 'text-c-3 group-hover/info:text-c-1'
           "
-          :icon="parameterIsInvalid(item).value ? 'Alert' : 'Info'"
+          :icon="isInvalid ? 'Alert' : 'Info'"
           size="sm"
           thickness="1.5" />
       </div>
@@ -31,7 +36,7 @@ const { item } = defineProps<{ item: RequestExampleParameter }>()
       <div
         class="w-content bg-b-1 text-xxs text-c-1 pointer-events-none grid min-w-48 gap-1.5 rounded p-2 leading-5 shadow-lg">
         <div
-          v-if="parameterIsInvalid(item).value"
+          v-if="isInvalid"
           class="text-error-1">
           {{ parameterIsInvalid(item).value }}
         </div>
@@ -51,11 +56,11 @@ const { item } = defineProps<{ item: RequestExampleParameter }>()
           <span v-if="item.default">default: {{ item.default }}</span>
         </div>
         <span
-          v-if="item.description && !parameterIsInvalid(item).value"
+          v-if="item.description && !isInvalid"
           class="text-pretty text-sm leading-snug"
-          :style="{ maxWidth: '16rem' }"
-          >{{ item.description }}</span
-        >
+          :style="{ maxWidth: '16rem' }">
+          {{ item.description }}
+        </span>
       </div>
     </template>
   </ScalarTooltip>

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -10,6 +10,8 @@ const {
   availableTargets,
   httpTargetTitle,
   httpClientTitle,
+  getClientTitle,
+  getTargetTitle,
   httpClient,
   setHttpClient,
 } = useHttpClientStore()
@@ -23,8 +25,12 @@ watch(
   (client) => {
     if (!client) return
 
-    if (isFeatured(client))
-      index.value = featuredClients.findIndex((tab) => tab === client)
+    console.log('is featured', client, featuredClients)
+    index.value = featuredClients.findIndex(
+      (tab) =>
+        tab.targetKey === client.targetKey &&
+        tab.clientKey === client.clientKey,
+    )
   },
   { immediate: true },
 )
@@ -49,21 +55,18 @@ function handleChange(i: number) {
       </TabList>
       <TabPanels>
         <template v-if="httpClient && isFeatured(httpClient)">
-          <!-- We just add fake tabs and swap the content -->
           <TabPanel
-            v-for="(_, i) in featuredClients"
+            v-for="(client, i) in featuredClients"
             :key="i"
-            class="selected-client card-footer -outline-offset-2"
-            muted>
-            {{ httpClientTitle }}
-            {{ httpTargetTitle }}
+            class="selected-client card-footer -outline-offset-2">
+            {{ getClientTitle(client) }}
+            {{ getTargetTitle(client) }}
           </TabPanel>
         </template>
         <div
           v-else
           :id="morePanel"
           class="selected-client card-footer -outline-offset-2"
-          muted
           role="tabpanel"
           tabindex="0">
           {{ httpClientTitle }}

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -26,7 +26,6 @@ watch(
   (client) => {
     if (!client) return
 
-    console.log('is featured', client, featuredClients)
     index.value = featuredClients.findIndex(
       (tab) =>
         tab.targetKey === client.targetKey &&

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -18,6 +18,7 @@ const {
 const { featuredClients, isFeatured } = useFeaturedHttpClients()
 
 const index = ref(0)
+const headingId = useId()
 const morePanel = useId()
 
 watch(
@@ -47,8 +48,14 @@ function handleChange(i: number) {
       manual
       :selectedIndex="index"
       @change="handleChange">
-      <div class="client-libraries-heading">Client Libraries</div>
-      <TabList>
+      <div
+        :id="headingId"
+        class="client-libraries-heading">
+        Client Libraries
+      </div>
+      <TabList
+        :aria-labelledby="headingId"
+        class="client-libraries-list">
         <ClientSelector
           :featured="featuredClients"
           :morePanel="morePanel" />

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -66,7 +66,6 @@ const isSelectedClient = (language: HttpClientState) => {
       :class="{
         'client-libraries__active': httpClient && !isFeatured(httpClient),
       }">
-      <span class="sr-only">Select from all clients</span>
       <select
         :aria-controls="morePanel"
         class="language-select"
@@ -130,10 +129,10 @@ const isSelectedClient = (language: HttpClientState) => {
       </div>
       <span
         v-if="availableTargets.length"
-        aria-hidden="true"
-        class="client-libraries-text">
+        class="client-libraries-text client-libraries-text-more">
         More
       </span>
+      <span class="sr-only">Select from all clients</span>
     </label>
   </div>
 </template>
@@ -235,7 +234,7 @@ const isSelectedClient = (language: HttpClientState) => {
     transform: rotate(1turn);
   }
 }
-.client-libraries .client-libraries-text:last-of-type {
+.client-libraries .client-libraries-text {
   font-size: var(--scalar-mini);
   font-weight: var(--scalar-semibold);
   position: relative;

--- a/packages/api-reference/src/components/Content/Tag/OperationsListItem.vue
+++ b/packages/api-reference/src/components/Content/Tag/OperationsListItem.vue
@@ -23,7 +23,7 @@ const { scrollToOperation } = useSidebar()
 // TODO in V2 we need to do the same loading trick as the initial load
 const scrollHandler = async (givenOperation: TransformedOperation) => {
   const operationId = getOperationId(givenOperation, tag)
-  scrollToOperation(operationId)
+  scrollToOperation(operationId, true)
 }
 
 const store = useWorkspace()

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -50,7 +50,8 @@ const title = computed(() => operation.summary || operation.path)
   <Section
     :id="id"
     :aria-labelledby="labelId"
-    :label="title">
+    :label="title"
+    tabindex="-1">
     <SectionContent>
       <Badge
         v-if="getOperationStability(operation)"

--- a/packages/api-reference/src/helpers/scrollToId.ts
+++ b/packages/api-reference/src/helpers/scrollToId.ts
@@ -1,6 +1,11 @@
 /**
  * Tiny wrapper around the scrollIntoView API
+ *
+ * Also focuses the element if the focus flag is true
  */
-export const scrollToId = async (id: string) => {
-  document.getElementById(id)?.scrollIntoView()
+export const scrollToId = async (id: string, focus?: boolean) => {
+  const el = document.getElementById(id)
+  if (!el) return
+  el.scrollIntoView()
+  if (focus) el.focus()
 }

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -337,7 +337,7 @@ export type SorterOption = {
  * it uses the lazyBus to ensure the section is open before scrolling to it
  *
  */
-export const scrollToOperation = (operationId: string) => {
+export const scrollToOperation = (operationId: string, focus?: boolean) => {
   const sectionId = navState.value?.getSectionId(operationId)
 
   if (sectionId && sectionId !== operationId) {
@@ -345,12 +345,12 @@ export const scrollToOperation = (operationId: string) => {
     if (!collapsedSidebarItems[sectionId]) {
       const unsubscribe = lazyBus.on((ev) => {
         if (ev.id === operationId) {
-          scrollToId(operationId)
+          scrollToId(operationId, focus)
           unsubscribe()
         }
       })
       setCollapsedSidebarItem(sectionId, true)
-    } else scrollToId(operationId)
+    } else scrollToId(operationId, focus)
   }
 }
 


### PR DESCRIPTION
Changes:

1. Client libraries tabs switch elements correctly
2. Client libraries tabs are labelled by the heading
3. Added screen reader table headers to the request tables
4. Add a label to the request table help tooltip
5. Focus the sidebar toggle on modal load
6. Focus the selected operation from the endpoints list when clicked

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
