### PR TITLE
fix(api-reference): collapsible section trigger responsiveness

### DIFF
--- a/.changeset/dirty-readers-watch.md
+++ b/.changeset/dirty-readers-watch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates collapsible section trigger style

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -70,9 +70,7 @@ watch(
   display: flex;
   align-items: center;
   cursor: pointer;
-  padding: 10px;
-  margin-left: -10px;
-  margin-right: -10px;
+  padding: 10px 0;
   font-size: var(--scalar-font-size-3);
   z-index: 1;
   position: relative;


### PR DESCRIPTION
**Problem**

currently on certain screen size the collapsible section trigger or loosing their position and are not aligned anymore.

**Solution**

this pr updates the collapsible section trigger style to ensure same position behavior on all screen.

| before | after |
| -------|------|
| <img width="839" alt="image" src="https://github.com/user-attachments/assets/fda605f5-5ef1-44c3-ba08-7edc1afe4d5d" /> | <img width="839" alt="image" src="https://github.com/user-attachments/assets/19eb89de-52bd-49e8-a28a-c10bb2424e80" /> |
| collapsible trigger arrow are off positioned | collapsible arrow position remain |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
