### PR TITLE
fix(api-reference): doesn’t switch the collection

### DIFF
--- a/.changeset/curly-plants-bow.md
+++ b/.changeset/curly-plants-bow.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+fix: update collection in multi doc

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -345,7 +345,7 @@ export const createApiClient = ({
       if (!request) return
 
       const contentType = Object.keys(request.requestBody?.content || {})[0] || ''
-      const example = request.requestBody?.content?.[contentType]?.examples[exampleKey]
+      const example = request.requestBody?.content?.[contentType]?.examples?.[exampleKey]
       if (!example) return
 
       requestExampleMutators.edit(request.examples[0], 'body.raw.value', prettyPrintJson(example.value))

--- a/packages/api-client/src/views/Request/RequestRoot.test.ts
+++ b/packages/api-client/src/views/Request/RequestRoot.test.ts
@@ -7,6 +7,7 @@ import { ref } from 'vue'
 import { mockUseLayout } from '@/vitest.setup'
 
 import RequestRoot from './RequestRoot.vue'
+import { collectionSchema } from '@scalar/oas-utils/entities/spec'
 
 // Mock vue-router
 vi.mock('vue-router', () => ({
@@ -29,6 +30,13 @@ const mockWorkspace = {
   hideClientButton: false,
   showSidebar: true,
   requestHistory: [],
+  collections: {},
+  cookies: {},
+  requestExamples: {},
+  requests: {},
+  securitySchemes: {},
+  servers: {},
+  tags: {},
   collectionMutators: {
     edit: vi.fn(),
   },
@@ -42,7 +50,7 @@ const mockUseActiveEntities = useActiveEntities as Mock
 const mockActiveEntities = {
   activeRequest: ref(null),
   activeExample: ref(null),
-  activeCollection: ref({ documentUrl: null, watchMode: false }),
+  activeCollection: ref(collectionSchema.parse({ watchMode: false })),
   activeEnvironment: ref(null),
   activeWorkspace: ref(null),
   activeWorkspaceRequests: ref([]),

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -59,6 +59,7 @@ const { layout } = useLayout()
 
 const workspaceContext = useWorkspace()
 const {
+  activeCollection,
   activeWorkspaceCollections,
   activeRequest,
   activeWorkspaceRequests,
@@ -249,6 +250,14 @@ const showGettingStarted = computed(() =>
     requests,
   ),
 )
+
+/** We ensure in modal mode we only show the current requests collection */
+const collections = computed(() => {
+  if (layout === 'modal' && activeCollection.value) {
+    return [activeCollection.value]
+  }
+  return activeWorkspaceCollections.value
+})
 </script>
 <template>
   <Sidebar
@@ -341,7 +350,7 @@ const showGettingStarted = computed(() =>
           class="contents">
           <!-- Collection -->
           <RequestSidebarItem
-            v-for="collection in activeWorkspaceCollections"
+            v-for="collection in collections"
             :key="collection.uid"
             :isDraggable="
               layout !== 'modal' && collection.info?.title !== 'Drafts'

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -19,10 +19,16 @@
     <!-- Initialize the Scalar API Reference -->
     <script type="module">
       Scalar.createApiReference('#app', {
-        spec: {
-          // The URL of the OpenAPI/Swagger document
-          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-        },
+        sources: [
+          {
+            url: 'https://petstore.swagger.io/v2/swagger.json',
+          },
+          {
+            title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
+            slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
+            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+          },
+        ],
         // Avoid CORS issues
         proxyUrl: 'https://proxy.scalar.com',
       })

--- a/packages/api-reference/src/blocks/hooks/useBlockProps.test.ts
+++ b/packages/api-reference/src/blocks/hooks/useBlockProps.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useBlockProps } from './useBlockProps'
+import { collectionSchema } from '@scalar/oas-utils/entities/spec'
+
+// Spy on unescapeJsonPointer instead of mocking it
+const unescapeJsonPointerSpy = vi.spyOn(await import('@scalar/openapi-parser'), 'unescapeJsonPointer')
+
+describe('useBlockProps', () => {
+  // Mock store data
+  const mockStore = {
+    collections: {
+      collection1: { id: 'collection1', name: 'Collection 1' },
+    },
+    requests: {
+      request1: { uid: 'request1', method: 'get', path: '/planets/{planetId}' },
+      request2: { uid: 'request2', method: 'post', path: '/planets' },
+      request3: { uid: 'request3', method: 'get', path: '/stars' },
+    },
+  }
+
+  // Mock collection
+  const mockCollection = collectionSchema.parse({
+    id: 'collection1',
+    name: 'Collection 1',
+    requests: ['request1', 'request2'],
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    unescapeJsonPointerSpy.mockClear()
+  })
+
+  it('returns undefined when store is undefined', () => {
+    const { operation } = useBlockProps({
+      store: undefined,
+      location: '#/paths/~1planets~1{planetId}/get',
+      collection: mockCollection,
+    })
+
+    expect(operation.value).toBeUndefined()
+  })
+
+  it('returns undefined when store collections or requests are undefined', () => {
+    const { operation } = useBlockProps({
+      store: {} as any,
+      location: '#/paths/~1planets~1{planetId}/get',
+      collection: mockCollection,
+    })
+
+    expect(operation.value).toBeUndefined()
+  })
+
+  it('throws an error for invalid location format', () => {
+    expect(() => {
+      const { operation } = useBlockProps({
+        store: mockStore as any,
+        location: '#/invalid/location',
+        collection: mockCollection,
+      })
+      // Force computed to evaluate
+      operation.value
+    }).toThrow(/Invalid location/)
+  })
+
+  it('finds the correct operation based on path and method', () => {
+    const { operation } = useBlockProps({
+      store: mockStore as any,
+      location: '#/paths/~1planets~1{planetId}/get',
+      collection: mockCollection,
+    })
+
+    expect(operation.value).toEqual(mockStore.requests.request1)
+    expect(unescapeJsonPointerSpy).toHaveBeenCalledWith('~1planets~1{planetId}')
+  })
+
+  it('returns undefined when no matching operation is found', () => {
+    const { operation } = useBlockProps({
+      store: mockStore as any,
+      location: '#/paths/~1nonexistent/get',
+      collection: mockCollection,
+    })
+
+    expect(operation.value).toBeUndefined()
+  })
+
+  it('filters operations by collection requests', () => {
+    const { operation } = useBlockProps({
+      store: mockStore as any,
+      location: '#/paths/~1stars/get',
+      collection: mockCollection,
+    })
+
+    // request3 has the right path/method but is not in the collection
+    expect(operation.value).toBeUndefined()
+  })
+
+  it('matches operations case-insensitively for HTTP methods', () => {
+    const { operation } = useBlockProps({
+      store: mockStore as any,
+      location: '#/paths/~1planets~1{planetId}/GET',
+      collection: mockCollection,
+    })
+
+    expect(operation.value).toEqual(mockStore.requests.request1)
+  })
+})

--- a/packages/api-reference/src/blocks/hooks/useBlockProps.ts
+++ b/packages/api-reference/src/blocks/hooks/useBlockProps.ts
@@ -1,5 +1,6 @@
 import type { createWorkspaceStore } from '@scalar/api-client/store'
-import type { Collection, Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 import { unescapeJsonPointer } from '@scalar/openapi-parser'
 import { type ComputedRef, computed } from 'vue'
 
@@ -21,31 +22,17 @@ export type BlockProps = {
    */
   location: `#/${string}`
   /**
-   * The name of the collection to use
-   *
-   * @default 'default'
+   * The collection to use
    */
-  collection?: string
+  collection: Collection
 }
 
 /**
  * Provides computed properties for the block, based on the standardized interface of the `createStore` function.
  */
-export function useBlockProps({ store, location }: BlockProps): {
+export function useBlockProps({ store, location, collection }: BlockProps): {
   operation: ComputedRef<RequestEntity | undefined>
 } {
-  // Just pick first collection for now
-  const collection = computed(() => {
-    return Object.values(store?.collections ?? {})[0]
-  }) as ComputedRef<Collection | undefined>
-
-  // TODO: Use the collection name from the props
-  //   const collection = computed(() => {
-  //     return Object.values(store.collections).find(
-  //       ({ name }) => name === (collection ?? 'default'),
-  //     )
-  //   })
-
   /** Resolve the operation (request) from the store */
   const operation = computed<RequestEntity | undefined>(() => {
     if (!store?.collections || !store.requests) {
@@ -53,7 +40,7 @@ export function useBlockProps({ store, location }: BlockProps): {
     }
 
     const collectionRequests = Object.values(store.requests).filter((request) =>
-      collection.value?.requests.includes(request.uid),
+      collection.requests.includes(request.uid),
     )
 
     // Check whether we’re using the correct location

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -26,13 +26,13 @@ import { ScalarToasts, useToasts } from '@scalar/use-toasts'
 import { useDebounceFn, useMediaQuery, useResizeObserver } from '@vueuse/core'
 import {
   computed,
-  getCurrentInstance,
   onBeforeMount,
   onMounted,
   onServerPrefetch,
   onUnmounted,
   provide,
   ref,
+  useId,
   useSSRContext,
   watch,
 } from 'vue'
@@ -243,24 +243,7 @@ onServerPrefetch(() => {
  *
  * @see https://github.com/tailwindlabs/headlessui/issues/2979
  */
-provideUseId(() => {
-  const instance = getCurrentInstance()
-  const ATTR_KEY = 'scalar-instance-id'
-
-  if (!instance) return ATTR_KEY
-  let instanceId = instance.uid
-
-  // SSR: grab the instance ID from vue and set it as an attribute
-  if (typeof window === 'undefined') {
-    instance.attrs ||= {}
-    instance.attrs[ATTR_KEY] = instanceId
-  }
-  // Client: grab the instanceId from the attribute and return it to headless UI
-  else if (instance.vnode.el?.getAttribute) {
-    instanceId = instance.vnode.el.getAttribute(ATTR_KEY)
-  }
-  return `${ATTR_KEY}-${instanceId}`
-})
+provideUseId(() => useId())
 
 // Create the workspace store and provide it
 const workspaceStore = createWorkspaceStore({

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -4,13 +4,13 @@ import { RequestAuth } from '@scalar/api-client/views/Request/RequestSection/Req
 import { ScalarErrorBoundary } from '@scalar/components'
 import { getSlugUid } from '@scalar/oas-utils/transforms'
 import type { Spec } from '@scalar/types/legacy'
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
 
 import { BaseUrl } from '@/features/BaseUrl'
+import { getModels, hasModels } from '@/helpers'
+import { useSidebar } from '@/hooks'
 import { useConfig } from '@/hooks/useConfig'
 
-import { getModels, hasModels } from '../../helpers'
-import { useSidebar } from '../../hooks'
 import { ClientLibraries } from './ClientLibraries'
 import { Introduction } from './Introduction'
 import { Loading } from './Lazy'

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { useActiveEntities } from '@scalar/api-client/store'
+import type { Collection, Server } from '@scalar/oas-utils/entities/spec'
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type {
   Spec,
@@ -39,6 +40,8 @@ import { lazyBus } from './lazyBus'
  */
 const props = withDefaults(
   defineProps<{
+    collection: Collection
+    server?: Server
     layout?: 'modern' | 'classic'
     parsedSpec: Spec
   }>(),
@@ -50,7 +53,6 @@ const hideTag = ref(false)
 const tags = ref<(TagType & { lazyOperations: TransformedOperation[] })[]>([])
 const models = ref<string[]>([])
 
-const { activeCollection, activeServer } = useActiveEntities()
 const { getModelId, getSectionId, getTagId, hash, isIntersectionEnabled } =
   useNavState()
 
@@ -161,14 +163,15 @@ onMounted(() => {
       :key="tag.name + idx">
       <TagSection
         v-if="tag.operations && tag.operations.length > 0"
+        :collection="collection"
         :spec="parsedSpec"
         :tag="tag">
         <Operation
           v-for="operation in tag.lazyOperations"
           :key="`${operation.httpVerb}-${operation.operationId}`"
-          :collection="activeCollection"
+          :collection="collection"
           :layout="layout"
-          :server="activeServer"
+          :server="server"
           :transformedOperation="operation" />
       </TagSection>
     </template>

--- a/packages/api-reference/src/components/Content/Tag/OperationsList.vue
+++ b/packages/api-reference/src/components/Content/Tag/OperationsList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Collection } from '@scalar/oas-utils/entities/spec'
 import type { Tag } from '@scalar/types/legacy'
 import { computed } from 'vue'
 
@@ -10,6 +11,7 @@ import OperationsListItem from './OperationsListItem.vue'
 
 const props = defineProps<{
   tag: Tag
+  collection: Collection
   isCollapsed?: boolean
 }>()
 
@@ -36,7 +38,8 @@ const tagName = computed(() => props.tag['x-displayName'] ?? props.tag.name)
             :key="getOperationId(operation, tag)"
             :isCollapsed="isCollapsed"
             :tag="tag"
-            :transformedOperation="operation" />
+            :transformedOperation="operation"
+            :collection="collection" />
         </ul>
       </CardContent>
     </Card>

--- a/packages/api-reference/src/components/Content/Tag/OperationsListItem.vue
+++ b/packages/api-reference/src/components/Content/Tag/OperationsListItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useWorkspace } from '@scalar/api-client/store'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
 import type { Tag, TransformedOperation } from '@scalar/types/legacy'
 import { computed } from 'vue'
 
@@ -11,9 +12,10 @@ import { useNavState } from '@/hooks/useNavState'
 import { useSidebar } from '@/hooks/useSidebar'
 import { isOperationDeprecated } from '@/libs/operation'
 
-const { transformedOperation, tag } = defineProps<{
+const { transformedOperation, tag, collection } = defineProps<{
   transformedOperation: TransformedOperation
   tag: Tag
+  collection: Collection
   isCollapsed?: boolean
 }>()
 
@@ -38,6 +40,7 @@ const store = useWorkspace()
  */
 const { operation } = useBlockProps({
   store,
+  collection,
   location: getPointer([
     'paths',
     transformedOperation.path,

--- a/packages/api-reference/src/components/Content/Tag/Tag.vue
+++ b/packages/api-reference/src/components/Content/Tag/Tag.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ScalarMarkdown } from '@scalar/components'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
 import type { Tag } from '@scalar/types/legacy'
 import { computed } from 'vue'
 
@@ -20,6 +21,7 @@ import OperationsList from './OperationsList.vue'
 const props = defineProps<{
   id?: string
   tag: Tag
+  collection: Collection
   headerId?: string
   isCollapsed?: boolean
 }>()
@@ -52,7 +54,9 @@ const title = computed(() => props.tag['x-displayName'] ?? props.tag.name)
             withImages />
         </SectionColumn>
         <SectionColumn>
-          <OperationsList :tag="tag" />
+          <OperationsList
+            :tag="tag"
+            :collection="collection" />
         </SectionColumn>
       </SectionColumns>
     </SectionContent>

--- a/packages/api-reference/src/components/Content/Tag/TagSection.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagSection.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Collection } from '@scalar/oas-utils/entities/spec'
 import type { Spec, Tag as TagType } from '@scalar/types/legacy'
 import { computed, nextTick, ref, useId } from 'vue'
 
@@ -10,6 +11,7 @@ import Tag from './Tag.vue'
 const props = defineProps<{
   id?: string
   tag: TagType
+  collection: Collection
   spec: Spec
 }>()
 
@@ -49,7 +51,8 @@ async function focusContents() {
       :id="id"
       :headerId="headerId"
       :isCollapsed="!collapsedSidebarItems[getTagId(tag)]"
-      :tag="tag" />
+      :tag="tag"
+      :collection="collection" />
     <ShowMoreButton
       v-if="!collapsedSidebarItems[getTagId(tag)] && moreThanOneTag"
       :id="id ?? ''"

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -3,25 +3,31 @@ import {
   ServerSelector,
   ServerVariablesForm,
 } from '@scalar/api-client/components/Server'
-import { useActiveEntities, useWorkspace } from '@scalar/api-client/store'
+import { useWorkspace } from '@scalar/api-client/store'
 import { ScalarMarkdown } from '@scalar/components'
+import type { Collection, Server } from '@scalar/oas-utils/entities/spec'
 import { useId } from 'vue'
 
 import { useConfig } from '@/hooks/useConfig'
 
-const { activeCollection, activeServer } = useActiveEntities()
 const { serverMutators } = useWorkspace()
 
-const id = useId()
-const updateServerVariable = (key: string, value: string) => {
-  if (!activeServer.value) return
+const { collection, server } = defineProps<{
+  collection: Collection
+  server?: Server
+}>()
 
-  const variables = activeServer.value.variables || {}
+const id = useId()
+const config = useConfig()
+
+const updateServerVariable = (key: string, value: string) => {
+  if (!server) return
+
+  const variables = server.variables || {}
   variables[key] = { ...variables[key], default: value }
 
-  serverMutators.edit(activeServer.value.uid, 'variables', variables)
+  serverMutators.edit(server.uid, 'variables', variables)
 }
-const config = useConfig()
 
 const updateServer = (server: string) => {
   config.value.onServerChange?.(server)
@@ -33,18 +39,18 @@ const updateServer = (server: string) => {
   </label>
   <div :id="id">
     <ServerSelector
-      v-if="activeCollection?.servers?.length"
-      :collection="activeCollection"
-      :server="activeServer"
+      v-if="collection?.servers?.length"
+      :collection="collection"
+      :server="server"
       :target="id"
       @updateServer="updateServer" />
   </div>
   <ServerVariablesForm
-    :variables="activeServer?.variables"
+    :variables="server?.variables"
     @update:variable="updateServerVariable" />
   <!-- Description -->
   <ScalarMarkdown
-    v-if="activeServer?.description"
+    v-if="server?.description"
     class="text-c-3 px-3 py-1.5"
-    :value="activeServer.description" />
+    :value="server.description" />
 </template>

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -19,7 +19,7 @@ const {
   id?: string
   layout?: 'modern' | 'classic'
   transformedOperation: TransformedOperation
-  collection: Collection | undefined
+  collection: Collection
   server: Server | undefined
 }>()
 
@@ -35,6 +35,7 @@ const store = useWorkspace()
  */
 const { operation } = useBlockProps({
   store,
+  collection,
   location: getPointer([
     'paths',
     transformedOperation.path,

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -1,3 +1,4 @@
+import { useNavState } from '@/hooks/useNavState'
 import { isDefined } from '@scalar/oas-utils/helpers'
 import {
   type ApiReferenceConfiguration,
@@ -65,6 +66,8 @@ const addSlugAndTitle = (source: SpecConfiguration, index = 0): SpecConfiguratio
 }
 
 export const useMultipleDocuments = ({ configuration, initialIndex }: UseMultipleDocumentsProps) => {
+  const { isIntersectionEnabled } = useNavState()
+
   /**
    * All available API definitions that can be selected
    */
@@ -105,8 +108,10 @@ export const useMultipleDocuments = ({ configuration, initialIndex }: UseMultipl
     url.hash = ''
     window.history.replaceState({}, '', url.toString())
 
-    // Scroll to the top of the page
+    // Scroll to the top of the page, disable scroll listener when doing so
+    isIntersectionEnabled.value = false
     window.scrollTo({ top: 0, behavior: 'instant' })
+    setTimeout(() => (isIntersectionEnabled.value = true), 300)
   }
 
   /**

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -103,11 +103,10 @@ export const useMultipleDocuments = ({ configuration, initialIndex }: UseMultipl
 
     // Reset location on the page
     url.hash = ''
+    window.history.replaceState({}, '', url.toString())
 
     // Scroll to the top of the page
     window.scrollTo({ top: 0, behavior: 'instant' })
-
-    window.history.replaceState({}, '', url.toString())
   }
 
   /**
@@ -143,6 +142,7 @@ export const useMultipleDocuments = ({ configuration, initialIndex }: UseMultipl
 
   /**
    * The currently selected API configuration
+   * we also add the source options (slug, title, etc) to the configuration
    */
   const selectedConfiguration = computed(() => {
     // Multiple sources
@@ -150,10 +150,15 @@ export const useMultipleDocuments = ({ configuration, initialIndex }: UseMultipl
       return apiReferenceConfigurationSchema.parse({
         ...configuration.value,
         ...configuration.value?.sources?.[selectedDocumentIndex.value],
+        ...availableDocuments.value[selectedDocumentIndex.value],
       })
     }
 
-    return apiReferenceConfigurationSchema.parse([configuration.value].flat()[selectedDocumentIndex.value] ?? {})
+    const flattenedConfig = [configuration.value].flat()[selectedDocumentIndex.value] ?? {}
+    return apiReferenceConfigurationSchema.parse({
+      ...flattenedConfig,
+      ...availableDocuments.value[selectedDocumentIndex.value],
+    })
   })
 
   // Update URL when selection changes

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -92,8 +92,11 @@ export const getSelectedSecuritySchemeUids = (
   return uids
 }
 
+/** Create a "uid" from a slug */
+export const getSlugUid = (slug: string) => `slug-uid-${slug}` as Collection['uid']
+
 export type ImportSpecToWorkspaceArgs = Pick<CollectionPayload, 'documentUrl' | 'watchMode'> &
-  Pick<ApiReferenceConfiguration, 'authentication' | 'baseServerURL' | 'servers'> & {
+  Pick<ApiReferenceConfiguration, 'authentication' | 'baseServerURL' | 'servers' | 'slug'> & {
     /** Sets the preferred security scheme on the collection instead of the requests */
     setCollectionSecurity?: boolean
     /** Call the load step from the parser */
@@ -121,6 +124,7 @@ export async function importSpecToWorkspace(
     documentUrl,
     servers: configuredServers,
     setCollectionSecurity = false,
+    slug,
     shouldLoad,
     watchMode = false,
   }: ImportSpecToWorkspaceArgs = {},
@@ -420,7 +424,11 @@ export async function importSpecToWorkspace(
       ? getSelectedSecuritySchemeUids(securityRequirements, preferredSecurityNames, securitySchemeMap)
       : []
 
+  // Set the uid as a prefixed slug if we have one
+  const slugObj = slug?.length ? { uid: getSlugUid(slug) } : {}
+
   const collection = collectionSchema.parse({
+    ...slugObj,
     ...schema,
     watchMode,
     documentUrl,


### PR DESCRIPTION
**Problem**

closes #5102

Currently, we have collection hard coded to [0] in a few places so we werent getting things like operation lists
![image](https://github.com/user-attachments/assets/8d62fc9a-606e-4adf-8a42-7c631177a815)

**Solution**

With this PR we add proper multi collection(doc) support by using the slug from the selector as the uid.
![image](https://github.com/user-attachments/assets/9d6fcf4d-f2d8-4bbc-88f1-79f324e7bde4)

To test just keep switching specs with the console open and see if there's any errors

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
