### PR TITLE
fix(components): improve ScalarCombobox screen reader a11y

### DIFF
--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.test.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.test.ts
@@ -1,25 +1,239 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
 
 import ScalarCombobox from './ScalarCombobox.vue'
+import ScalarComboboxMultiselect from './ScalarComboboxMultiselect.vue'
+import ScalarComboboxOption from './ScalarComboboxOption.vue'
+import ScalarComboboxOptions from './ScalarComboboxOptions.vue'
+import ScalarComboboxOptionGroup from './ScalarComboboxOptionGroup.vue'
+import ScalarComboboxPopover from './ScalarComboboxPopover.vue'
+
+// Mock data
+const singleOptions = [
+  { id: '1', label: 'Option 1' },
+  { id: '2', label: 'Option 2' },
+  { id: '3', label: 'Option 3' },
+]
+
+const groupedOptions = [
+  {
+    label: 'Group 1',
+    options: [
+      { id: '1', label: 'Option 1' },
+      { id: '2', label: 'Option 2' },
+    ],
+  },
+  {
+    label: 'Group 2',
+    options: [
+      { id: '3', label: 'Option 3' },
+      { id: '4', label: 'Option 4' },
+    ],
+  },
+]
 
 describe('ScalarCombobox', () => {
-  it('renders properly', async () => {
-    const wrapper = mount(ScalarCombobox, {
+  describe('with single options', () => {
+    it('emits update:modelValue when option is selected', async () => {
+      const wrapper = mount(ScalarCombobox, {
+        props: { options: singleOptions },
+        slots: { default: '<button>Toggle</button>' },
+      })
+
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+
+      const option = wrapper.findComponent(ScalarComboboxOption)
+      await option.trigger('click')
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([singleOptions[0]])
+    })
+  })
+
+  describe('with grouped options', () => {
+    it('emits update:modelValue when option is selected', async () => {
+      const wrapper = mount(ScalarCombobox, {
+        props: { options: groupedOptions },
+        slots: { default: '<button>Toggle</button>' },
+      })
+
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+
+      const option = wrapper.findComponent(ScalarComboboxOption)
+      await option.trigger('click')
+
+      expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([groupedOptions[0].options[0]])
+    })
+  })
+})
+
+describe('ScalarComboboxMultiselect', () => {
+  describe('with single options', () => {
+    it('allows multiple selections', async () => {
+      const wrapper = mount(ScalarComboboxMultiselect, {
+        props: {
+          options: singleOptions,
+          modelValue: [],
+          'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+        },
+        slots: { default: '<button>Toggle</button>' },
+      })
+
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+
+      const optionElements = wrapper.findAllComponents(ScalarComboboxOption)
+      await optionElements[0].trigger('click')
+      await optionElements[1].trigger('click')
+
+      const emitted = wrapper.emitted('update:modelValue')
+      expect(emitted).toBeTruthy()
+      expect(emitted?.[emitted.length - 1]?.[0]).toHaveLength(2)
+    })
+  })
+
+  describe('with grouped options', () => {
+    it('allows multiple selections', async () => {
+      const wrapper = mount(ScalarComboboxMultiselect, {
+        props: {
+          options: groupedOptions,
+          modelValue: [],
+          'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+        },
+        slots: { default: '<button>Toggle</button>' },
+      })
+
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+
+      const optionElements = wrapper.findAllComponents(ScalarComboboxOption)
+      await optionElements[0].trigger('click')
+      await optionElements[1].trigger('click')
+
+      const emitted = wrapper.emitted('update:modelValue')
+      expect(emitted).toBeTruthy()
+      console.log(JSON.stringify(emitted, null, 2))
+      expect(emitted?.[emitted.length - 1]?.[0]).toHaveLength(2)
+    })
+  })
+})
+
+describe('ScalarComboboxOptions', () => {
+  describe('with single options', () => {
+    it('filters options based on search query', async () => {
+      const wrapper = mount(ScalarComboboxOptions, {
+        props: { options: singleOptions },
+      })
+
+      const input = wrapper.find('input[type="text"]')
+      await input.setValue('Option 2')
+
+      const filteredOptions = wrapper.findAllComponents(ScalarComboboxOption)
+      expect(filteredOptions).toHaveLength(1)
+      expect(filteredOptions[0].text()).toBe('Option 2')
+    })
+  })
+
+  describe('with grouped options', () => {
+    it('filters options based on search query', async () => {
+      const wrapper = mount(ScalarComboboxOptions, {
+        props: { options: groupedOptions },
+      })
+
+      const input = wrapper.find('input[type="text"]')
+      await input.setValue('Option 2')
+
+      const filteredOptions = wrapper.findAllComponents(ScalarComboboxOption)
+      expect(filteredOptions).toHaveLength(1)
+      expect(filteredOptions[0].text()).toBe('Option 2')
+    })
+  })
+})
+
+describe('ScalarComboboxOptionGroup', () => {
+  it('renders group label when not hidden', () => {
+    const wrapper = mount(ScalarComboboxOptionGroup, {
       props: {
-        options: [
-          { id: '1', label: 'Option 1' },
-          { id: '2', label: 'Option 2' },
-          { id: '3', label: 'Option 3' },
-        ],
+        id: 'test-group',
       },
       slots: {
-        default: `<button>Button</button>`,
-        before: `<div>Before</div>`,
-        after: `<div>After</div>`,
+        label: 'Group Label',
+        default: '<div>Group Content</div>',
       },
     })
 
-    expect(wrapper.exists()).toBeTruthy()
+    expect(wrapper.text()).toContain('Group Label')
+    expect(wrapper.text()).toContain('Group Content')
+  })
+
+  it('hides group label when hidden prop is true', () => {
+    const wrapper = mount(ScalarComboboxOptionGroup, {
+      props: {
+        id: 'test-group',
+        hidden: true,
+      },
+      slots: {
+        label: 'Group Label',
+        default: '<div>Group Content</div>',
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('Group Label')
+    expect(wrapper.text()).toContain('Group Content')
+  })
+})
+
+describe('ScalarComboboxOption', () => {
+  it('renders option with correct styles', () => {
+    const wrapper = mount(ScalarComboboxOption, {
+      props: {
+        active: true,
+        selected: true,
+        style: 'checkbox',
+      },
+      slots: {
+        default: 'Option Text',
+      },
+    })
+
+    expect(wrapper.text()).toContain('Option Text')
+    expect(wrapper.classes()).toContain('bg-b-2')
+  })
+
+  it('emits delete event when delete icon is clicked', async () => {
+    const wrapper = mount(ScalarComboboxOption, {
+      props: {
+        isDeletable: true,
+      },
+      slots: {
+        default: 'Option Text',
+      },
+    })
+
+    const deleteIcon = wrapper.find('[aria-label="Delete"]')
+    await deleteIcon.trigger('click')
+
+    expect(wrapper.emitted('delete')).toBeTruthy()
+  })
+})
+
+describe('ScalarComboboxPopover', () => {
+  it('handles keyboard events correctly', async () => {
+    const wrapper = mount(ScalarComboboxPopover, {
+      slots: {
+        default: '<button>Toggle</button>',
+        popover: '<div test-id="popover-content">Popover Content</div>',
+      },
+    })
+
+    const button = wrapper.find('button')
+    await button.trigger('keydown', { key: 'ArrowDown' })
+
+    // Check that the popover content exists instead of the wrapper
+    expect(wrapper.find('[test-id="popover-content"]').exists()).toBeTruthy()
   })
 })

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
@@ -35,7 +35,10 @@ const variants = cva({
 })
 </script>
 <template>
-  <li :class="cx(variants({ active, selected }))">
+  <li
+    :aria-selected="selected"
+    :class="cx(variants({ active, selected }))"
+    role="option">
     <ScalarListboxCheckbox
       :selected="selected"
       :style="style" />

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
@@ -38,7 +38,8 @@ const variants = cva({
   <li
     :aria-selected="selected"
     :class="cx(variants({ active, selected }))"
-    role="option">
+    role="option"
+    tabindex="-1">
     <ScalarListboxCheckbox
       :selected="selected"
       :style="style" />

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOption.vue
@@ -46,6 +46,7 @@ const variants = cva({
     <span class="inline-block min-w-0 flex-1 truncate text-c-1"><slot /></span>
     <ScalarIcon
       v-if="isDeletable"
+      aria-label="Delete"
       class="text-c-2 opacity-0 group-hover/item:opacity-100"
       icon="Delete"
       size="md"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptionGroup.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptionGroup.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { useId } from 'vue'
+
+const { id = useId(), hidden = false } = defineProps<{
+  id?: string
+  hidden?: boolean
+}>()
+</script>
+<template>
+  <div
+    :id="id"
+    :aria-labelledby="id ? `${id}-label` : undefined"
+    class="contents"
+    :role="hidden ? undefined : 'group'">
+    <div
+      v-if="!hidden"
+      :id="`${id}-label`"
+      class="min-w-0 truncate px-2.5 py-1.5 text-left text-c-2">
+      <slot name="label" />
+    </div>
+    <slot />
+  </div>
+</template>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { nanoid } from 'nanoid'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, useId, watch } from 'vue'
 
 import { ScalarIcon } from '../ScalarIcon'
 import ComboboxOption from './ScalarComboboxOption.vue'
+import ComboboxOptionGroup from './ScalarComboboxOptionGroup.vue'
 import {
   type ComboboxSlots,
   type Option,
@@ -29,7 +29,7 @@ defineSlots<Omit<ComboboxSlots, 'default'>>()
 defineOptions({ inheritAttrs: false })
 
 /** A unique ID for the combobox */
-const id = `scalar-combobox-items-${nanoid()}`
+const id = `scalar-combobox-items-${useId()}`
 
 /** Generate a unique ID for an option */
 function getOptionId(option: Option) {
@@ -133,7 +133,7 @@ function moveActive(dir: 1 | -1) {
       :aria-activedescendant="active ? getOptionId(active) : undefined"
       aria-autocomplete="list"
       :aria-controls="id"
-      class="min-w-0 flex-1 rounded-none border-0 py-2.5 pl-8 pr-3 leading-none text-c-1 outline-none"
+      class="min-w-0 flex-1 rounded border-0 py-2.5 pl-8 pr-3 leading-none text-c-1 -outline-offset-1"
       data-1p-ignore
       :placeholder="placeholder"
       role="combobox"
@@ -148,24 +148,22 @@ function moveActive(dir: 1 | -1) {
     :id="id"
     :aria-multiselectable="multiselect"
     class="border-t p-0.75 custom-scroll overscroll-contain flex-1 min-h-0"
-    role="listbox">
+    role="listbox"
+    tabindex="-1">
     <slot name="before" />
-    <div
+    <ComboboxOptionGroup
       v-for="(group, i) in groups"
+      :id="`${id}-group-${i}`"
       :key="i"
-      :aria-labelledby="group.label ? `${id}-group-label-${i}` : undefined"
-      class="contents"
-      :role="group.label ? 'group' : undefined">
-      <div
-        v-if="
-          group.label &&
-          // Only show the group label if there are some results
-          group.options.some((o) => filtered.some((f) => f.id === o.id))
-        "
-        :id="`${id}-group-label-${i}`"
-        class="min-w-0 truncate px-2.5 py-1.5 text-left text-c-2">
+      :hidden="
+        // Only show the group label if there are some results
+        !group.options.some((o) => filtered.some((f) => f.id === o.id)) ||
+        // And it has a label
+        !group.label
+      ">
+      <template #label>
         {{ group.label }}
-      </div>
+      </template>
       <template
         v-for="option in filtered"
         :key="option.id">
@@ -183,7 +181,7 @@ function moveActive(dir: 1 | -1) {
           {{ option.label }}
         </ComboboxOption>
       </template>
-    </div>
+    </ComboboxOptionGroup>
     <slot name="after" />
   </ul>
 </template>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -130,6 +130,7 @@ function moveActive(dir: 1 | -1) {
       size="md" />
     <input
       v-model="query"
+      :aria-activedescendant="active ? getOptionId(active) : undefined"
       aria-autocomplete="list"
       :aria-controls="id"
       class="min-w-0 flex-1 rounded-none border-0 py-2.5 pl-8 pr-3 leading-none text-c-1 outline-none"
@@ -145,17 +146,23 @@ function moveActive(dir: 1 | -1) {
   <ul
     v-show="filtered.length || $slots.before || $slots.after"
     :id="id"
-    class="border-t p-0.75 custom-scroll overscroll-contain flex-1 min-h-0">
+    :aria-multiselectable="multiselect"
+    class="border-t p-0.75 custom-scroll overscroll-contain flex-1 min-h-0"
+    role="listbox">
     <slot name="before" />
-    <template
+    <div
       v-for="(group, i) in groups"
-      :key="i">
+      :key="i"
+      :aria-labelledby="group.label ? `${id}-group-label-${i}` : undefined"
+      class="contents"
+      :role="group.label ? 'group' : undefined">
       <div
         v-if="
           group.label &&
           // Only show the group label if there are some results
           group.options.some((o) => filtered.some((f) => f.id === o.id))
         "
+        :id="`${id}-group-label-${i}`"
         class="min-w-0 truncate px-2.5 py-1.5 text-left text-c-2">
         {{ group.label }}
       </div>
@@ -176,7 +183,7 @@ function moveActive(dir: 1 | -1) {
           {{ option.label }}
         </ComboboxOption>
       </template>
-    </template>
+    </div>
     <slot name="after" />
   </ul>
 </template>


### PR DESCRIPTION
Substantially improves screen reader accessibility for the ScalarCombobox. I had thought that I had added the aria attributes back when I built the component but I guess not 😅

Before / After with NVDA:

...

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
