### PR TITLE
fix(themes): hide summary caret in reset

### DIFF
--- a/.changeset/shiny-ads-allow.md
+++ b/.changeset/shiny-ads-allow.md
@@ -1,0 +1,7 @@
+---
+'@scalar/docusaurus': patch
+'@scalar/code-highlight': patch
+'@scalar/themes': patch
+---
+
+fix(themes): hide summary caret in reset

--- a/integrations/docusaurus/src/theme.css
+++ b/integrations/docusaurus/src/theme.css
@@ -516,11 +516,6 @@ html[data-theme="light"] body .api-client-drawer {
     transform: rotate(90deg);
   }
 
-  /* Fix for Safari displaying default caret next to `<summary>` */
-  .markdown summary::-webkit-details-marker {
-    display: none;
-  }
-
   .markdown img {
     overflow: hidden;
     border-radius: var(--scalar-radius);

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -64,11 +64,6 @@
     transform: rotate(90deg);
   }
 
-  /* Fix for Safari displaying default caret next to `<summary>` */
-  .markdown summary::-webkit-details-marker {
-    display: none;
-  }
-
   .markdown img {
     overflow: hidden;
     border-radius: var(--scalar-radius);

--- a/packages/themes/src/reset.css
+++ b/packages/themes/src/reset.css
@@ -91,6 +91,11 @@
     appearance: none;
   }
 
+  /* Fix for Safari displaying default caret next to `<summary>` */
+  summary::-webkit-details-marker {
+    display: none;
+  }
+
   /** Remove yellow/blue autofill indicator */
   input:-webkit-autofill {
     background-clip: text !important;


### PR DESCRIPTION
We have an issue with a caret showing up in Safari on `<summary>` elements. It seems like we had a more specific fix in our markdown code but this moves it to the `reset.css`.

![Safari-2025-03-13-22-34-56@2x](https://github.com/user-attachments/assets/4f2b93e5-9b7a-49eb-8dd8-b7304fd3a256)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
