### PR TITLE
fix(oas-utils): regex helper slashes

### DIFF
--- a/.changeset/dirty-suits-agree.md
+++ b/.changeset/dirty-suits-agree.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: updates multiple slashes regex

--- a/packages/oas-utils/src/helpers/regexHelpers.ts
+++ b/packages/oas-utils/src/helpers/regexHelpers.ts
@@ -2,7 +2,7 @@ export const REGEX = {
   /** Checks for a valid scheme */
   PROTOCOL: /^(?:https?|ftp|file|mailto|tel|data|wss?)*:\/\//,
   /** Finds multiple slashes after the scheme to replace with a single slash */
-  MULTIPLE_SLASHES: /(?<!:)\/{2,}/g,
+  MULTIPLE_SLASHES: /([^:])\/\/+/g,
   VARIABLES: /{{((?:[^{}]|{[^{}]*})*)}}/g,
   PATH: /(?:{)([^{}]+)}(?!})/g,
   TEMPLATE_VARIABLE: /{{\s*([^}\s]+?)\s*}}|{\s*([^}\s]+?)\s*}|:\b[\w.]+\b/g,


### PR DESCRIPTION
**Problem**

currently on previous safari version that has stricter handling of named capture groups in regular expressions, reference are prevented from being displayed.

```
SyntaxError: Invalid regular expression: invalid group specifier name
```

**Solution**

this pr updates the multiple slashes regex in order to ensure safari support.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
