### PR TITLE
fix(api-client): multiple authentication description

### DIFF
--- a/.changeset/smooth-ways-yell.md
+++ b/.changeset/smooth-ways-yell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates multiple auth style

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
@@ -243,7 +243,7 @@ const dataTableInputProps = {
     <DataTableRow class="min-w-full">
       <div class="border-t-1/2 flex h-8 w-full items-center justify-end">
         <ScalarButton
-          class="mr-1 p-0 px-2 py-0.5"
+          class="mr-0.75 p-0 px-2 py-0.5"
           :loading="loadingState"
           size="sm"
           variant="outlined"

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
@@ -53,7 +53,7 @@ function setScope(id: string, checked: boolean) {
         <DisclosureButton
           v-slot="{ open }"
           :class="[
-            'group/scopes-accordion hover:text-c-1 flex h-auto min-h-8 cursor-pointer items-center gap-1.5 pl-3 pr-2.5 text-left',
+            'group/scopes-accordion hover:text-c-1 pr-2.25 flex h-auto min-h-8 cursor-pointer items-center gap-1.5 pl-3 text-left',
             (flow?.selectedScopes?.length || 0) > 0 ? 'text-c-1' : 'text-c-3',
           ]">
           <div class="flex-1">

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -46,8 +46,11 @@ const activeFlow = ref('')
 
 const generateLabel = (scheme: SecurityScheme) => {
   // ApiKeyHeader: header
+  const description = scheme.description ? `: ${scheme.description}` : ''
+  const baseLabel = `${capitalize(scheme.nameKey)}${description || `: ${scheme.type}`}`
+
   if (scheme.type === 'apiKey') {
-    return `${capitalize(scheme.nameKey)}: ${scheme.in}`
+    return `${capitalize(scheme.nameKey)}${description || `: ${scheme.in}`}`
   }
 
   // OAuth2: Authorization Code
@@ -56,16 +59,16 @@ const generateLabel = (scheme: SecurityScheme) => {
 
     return `${capitalize(scheme.nameKey)}: ${
       activeFlow.value ? activeFlow.value : (firstFlow?.type ?? '')
-    }`
+    }${description}`
   }
 
   // HTTP: Bearer
   if (scheme.type === 'http') {
-    return `${capitalize(scheme.nameKey)}: ${scheme.scheme}`
+    return `${capitalize(scheme.nameKey)}: ${scheme.scheme}${description}`
   }
 
   // Default
-  return `${capitalize(scheme.nameKey)}: ${scheme.type}`
+  return `${baseLabel}${description}`
 }
 
 /** Update the scheme */
@@ -88,7 +91,7 @@ const dataTableInputProps = {
 <template>
   <!-- Loop over for multiple auth selection -->
   <template
-    v-for="({ scheme }, index) in security"
+    v-for="{ scheme } in security"
     :key="scheme?.uid">
     <!-- Header -->
     <DataTableRow
@@ -97,18 +100,16 @@ const dataTableInputProps = {
         'request-example-references-header': layout === 'reference',
       }">
       <DataTableCell
-        class="text-c-3 flex items-center pl-3 font-medium"
-        :class="
-          layout === 'reference' && `border-t ${index !== 0 ? 'mt-2' : ''}`
-        ">
+        class="auth-bg-description text-c-2 flex items-center pl-3"
+        :class="layout === 'reference' && 'border-b'">
         {{ generateLabel(scheme!) }}
       </DataTableCell>
     </DataTableRow>
 
     <!-- Description -->
-    <DataTableRow v-if="scheme?.description">
+    <DataTableRow v-if="scheme?.description && security.length <= 1">
       <DataTableCell
-        class="text-c-3 flex items-center overflow-auto whitespace-nowrap pl-3 font-medium">
+        class="auth-bg-description text-c-2 flex items-center overflow-auto whitespace-nowrap pl-3">
         {{ scheme.description }}
       </DataTableCell>
     </DataTableRow>
@@ -242,5 +243,9 @@ const dataTableInputProps = {
   border-top: 0;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
+}
+
+.auth-bg-description {
+  background: color-mix(in srgb, var(--scalar-background-2), transparent 50%);
 }
 </style>


### PR DESCRIPTION
**Problem**

following the auth description introduction, information can be dense for multiple authentication. 

**Solution**

this pr is a proposal to merge description to generated label + some style fixes.

| before | after |
| -------|------|
| <img width="537" alt="image" src="https://github.com/user-attachments/assets/7584beaa-c68d-4d84-9543-93978d2537ae" /> | <img width="537" alt="image" src="https://github.com/user-attachments/assets/6fe2ccde-b03b-4cfe-b5c5-125a7d7ee216" /> |
| description of the issue in image | description of the change in image | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
