### PR TITLE
fix(api-reference): style fixtures

### DIFF
--- a/.changeset/tasty-bats-grow.md
+++ b/.changeset/tasty-bats-grow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: adds badges + show more button fixtures

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -63,7 +63,7 @@ onMounted(() => config.value.onLoaded?.())
     <!-- If the #after slot is used, we need to add a gap to the section. -->
     <Section class="introduction-section gap-12">
       <SectionContent :loading="!info?.description && !info?.title">
-        <div class="badges">
+        <div class="flex gap-1">
           <Badge v-if="version">{{ version }}</Badge>
           <Badge v-if="oasVersion">OAS {{ oasVersion }}</Badge>
         </div>

--- a/packages/api-reference/src/components/ShowMoreButton.vue
+++ b/packages/api-reference/src/components/ShowMoreButton.vue
@@ -24,12 +24,11 @@ const { setCollapsedSidebarItem } = useSidebar()
 
 <style scoped>
 .show-more {
-  background: var(--scalar-background-1);
   appearance: none;
   border: none;
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   margin: auto;
-  padding: 8px 12px;
+  padding: 8px 12px 8px 16px;
   border-radius: 30px;
   color: var(--scalar-color-1);
   font-weight: var(--scalar-semibold);
@@ -41,7 +40,7 @@ const { setCollapsedSidebarItem } = useSidebar()
   top: -48px;
 }
 .show-more:hover {
-  color: var(--scalar-color-2);
+  background: var(--scalar-background-2);
   cursor: pointer;
 }
 .show-more-icon {


### PR DESCRIPTION
**Problem**

currently introduction badges are lacking gap when multiple and show more button is not optically centered.

**Solution**

this pr adds gap to introduction badges:
| before | after |
| -------|------|
| <img width="309" alt="image" src="https://github.com/user-attachments/assets/16ad1f82-e607-47ca-b6ef-445ec234e3a1" /> | <img width="309" alt="image" src="https://github.com/user-attachments/assets/c2a0f5b6-f0f1-4c50-b4b7-57076f6c73e0" /> |

optically correct show more content position and update style:
| before | after |
| -------|------|
| <img width="309" alt="image" src="https://github.com/user-attachments/assets/0bb623eb-f595-42f1-832c-e557ea34122c" /> | <img width="309" alt="image" src="https://github.com/user-attachments/assets/5249e66d-150e-4c86-8289-734064121490" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
