### PR TITLE
fix(api-client): focus the client modal sidebar button when modal opens

### DIFF
--- a/.changeset/loud-donkeys-prove.md
+++ b/.changeset/loud-donkeys-prove.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): focus the client modal sidebar button when modal opens

--- a/packages/api-client/src/layouts/Modal/ApiClientModal.vue
+++ b/packages/api-client/src/layouts/Modal/ApiClientModal.vue
@@ -5,6 +5,7 @@ import {
 } from '@scalar/components'
 import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
 import {
+  nextTick,
   onBeforeMount,
   onBeforeUnmount,
   onMounted,
@@ -26,7 +27,6 @@ const id = useId()
 const { activate: activateFocusTrap, deactivate: deactivateFocusTrap } =
   useFocusTrap(client, {
     allowOutsideClick: true,
-    initialFocus: () => client.value,
     fallbackFocus: `#${id}`,
   })
 
@@ -42,8 +42,9 @@ watch(
       window.addEventListener('keydown', handleKeyDown)
       // Disable scrolling
       document.documentElement.style.overflow = 'hidden'
+
       // Focus trap the modal
-      activateFocusTrap()
+      activateFocusTrap({ checkCanFocusTrap: () => nextTick() })
     } else {
       // Remove the global hotkey listener
       window.removeEventListener('keydown', handleKeyDown)
@@ -82,7 +83,7 @@ onBeforeUnmount(() => {
         aria-modal="true"
         class="scalar-app-layout scalar-client"
         role="dialog"
-        tabindex="0">
+        tabindex="-1">
         <ScalarTeleportRoot>
           <RouterView key="$route.fullPath" />
         </ScalarTeleportRoot>

--- a/packages/api-client/src/views/Request/RequestRoot.vue
+++ b/packages/api-client/src/views/Request/RequestRoot.vue
@@ -117,14 +117,6 @@ onMounted(() => {
   events.cancelRequest.on(cancelRequest)
 })
 
-/** Focus the first button in the layout when the modal is mounted */
-onMounted(() => {
-  if (element.value && layout === 'modal') {
-    const button = element.value.querySelector('button')
-    if (button) button.focus()
-  }
-})
-
 useOpenApiWatcher()
 
 /**


### PR DESCRIPTION
Turns out this wasn't working in the references only in the playground. Now it works in the references.

https://github.com/user-attachments/assets/d1dcc864-482e-4b4c-982a-b851d0662014

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
