### PR TITLE
fix(api-reference): booleans incorrectly allowing null

### DIFF
--- a/.changeset/dry-seals-kick.md
+++ b/.changeset/dry-seals-kick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: missing requestBody description

--- a/.changeset/friendly-emus-remember.md
+++ b/.changeset/friendly-emus-remember.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: boolean values being nullable with tests

--- a/packages/api-client/src/components/CodeInput/CodeInput.test.ts
+++ b/packages/api-client/src/components/CodeInput/CodeInput.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import CodeInput from './CodeInput.vue'
+import { useCodeMirror, type Extension } from '@scalar/use-codemirror'
+import { useClipboard } from '@scalar/use-hooks/useClipboard'
+import { enableConsoleError, enableConsoleWarn } from '@/vitest.setup'
+import { ref } from 'vue'
+import { environmentSchema } from '@scalar/oas-utils/entities/environment'
+import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
+
+// Mock dependencies
+vi.mock('@scalar/use-codemirror', async (importOriginal) => {
+  const actual = await importOriginal<typeof useCodeMirror>()
+  return {
+    ...actual,
+    useCodeMirror: vi.fn(() => ({
+      codeMirror: ref({
+        focus: vi.fn(),
+        dispatch: vi.fn(),
+        state: { doc: { length: 10 } },
+      }),
+      view: { value: null },
+      container: { value: null },
+      updateExtensions: vi.fn(),
+    })),
+  }
+})
+
+vi.mock('@scalar/use-hooks/useClipboard', () => ({
+  useClipboard: vi.fn(() => ({
+    copy: vi.fn(),
+    copyToClipboard: vi.fn(),
+    copied: { value: false },
+  })),
+}))
+
+vi.mock('@/hooks', () => ({
+  useLayout: vi.fn(() => ({
+    layout: { value: { isMobile: false } },
+  })),
+}))
+
+describe('CodeInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    enableConsoleWarn()
+    enableConsoleError()
+  })
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount()
+    }
+  })
+
+  const createWrapper = (props = {}, attrs = {}) => {
+    return mount(CodeInput, {
+      props: {
+        modelValue: 'test value',
+        environment: environmentSchema.parse({}),
+        envVariables: [],
+        workspace: workspaceSchema.parse({}),
+        ...props,
+      },
+      attrs,
+      global: {
+        stubs: {
+          DataTableInputSelect: true,
+          ScalarIcon: true,
+          EnvironmentVariableDropdown: true,
+        },
+      },
+    })
+  }
+
+  let wrapper: VueWrapper<InstanceType<typeof CodeInput>>
+
+  it('renders correctly when not disabled', async () => {
+    wrapper = createWrapper()
+    expect(wrapper.exists()).toBe(true)
+    expect(useCodeMirror).toHaveBeenCalled()
+  })
+
+  it('renders in disabled state correctly', async () => {
+    wrapper = createWrapper({ disabled: true })
+    expect(wrapper.html()).toContain('data-testid="code-input-disabled"')
+  })
+
+  it('emits update:modelValue when value changes', async () => {
+    wrapper = createWrapper()
+    wrapper.vm.handleChange('new value')
+
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['new value'])
+  })
+
+  it('emits submit event when handleSubmit is called', async () => {
+    wrapper = createWrapper()
+    wrapper.vm.handleSubmit('test value')
+
+    expect(wrapper.emitted('submit')).toBeTruthy()
+    expect(wrapper.emitted('submit')?.[0]).toEqual(['test value'])
+  })
+
+  it('emits blur event when handleBlur is called', async () => {
+    wrapper = createWrapper()
+    wrapper.vm.handleBlur('test value')
+
+    expect(wrapper.emitted('blur')).toBeTruthy()
+    expect(wrapper.emitted('blur')?.[0]).toEqual(['test value'])
+  })
+
+  it('uses custom field handler when provided', async () => {
+    const handleFieldChange = vi.fn()
+    wrapper = createWrapper({ handleFieldChange })
+    wrapper.vm.handleChange('handle field change')
+
+    expect(handleFieldChange).toHaveBeenCalledWith('handle field change')
+  })
+
+  it('computes booleanOptions correctly for boolean type', async () => {
+    wrapper = createWrapper({
+      type: 'boolean',
+      nullable: false,
+    })
+    expect(wrapper.vm.booleanOptions).toEqual(['true', 'false'])
+  })
+
+  it('computes booleanOptions correctly for boolean type with nullable', async () => {
+    wrapper = createWrapper({
+      type: 'boolean',
+      nullable: true,
+    })
+    expect(wrapper.vm.booleanOptions).toEqual(['true', 'false', 'null'])
+  })
+
+  it('exposes focus method that calls codeMirror.focus', async () => {
+    wrapper = createWrapper()
+
+    // Get the mocked focus function from the useCodeMirror mock
+    const mockCodeMirror = vi.mocked(useCodeMirror).mock.results[0]?.value.codeMirror.value
+
+    // Call the exposed focus method
+    wrapper.vm.focus()
+
+    // Verify the mocked focus method was called
+    expect(mockCodeMirror.focus).toHaveBeenCalled()
+  })
+
+  it('copies content when copy button is clicked', async () => {
+    wrapper = createWrapper({ isCopyable: true })
+
+    const copyButton = wrapper.find('.copy-button')
+    await copyButton.trigger('click')
+
+    expect(vi.mocked(useClipboard).mock.results[0]?.value.copyToClipboard).toHaveBeenCalledWith(wrapper.vm.modelValue)
+  })
+
+  it('applies error class when error prop is true', async () => {
+    wrapper = createWrapper({ error: true })
+    expect(wrapper.html()).toContain('flow-code-input--error')
+  })
+
+  it('sets up extensions correctly based on props', async () => {
+    wrapper = createWrapper({
+      language: 'json',
+      colorPicker: true,
+      lineNumbers: true,
+      lint: true,
+    })
+
+    // Check that extensions are set up correctly
+    const extensions = vi.mocked(useCodeMirror).mock.calls[0]?.[0].extensions as Extension[]
+    expect(extensions.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -106,6 +106,7 @@ function handleChange(value: string) {
     // Prevent table value population on current request
     return null
   }
+
   return props.handleFieldChange
     ? props.handleFieldChange(value)
     : emit('update:modelValue', value)
@@ -184,20 +185,9 @@ const { handleDropdownSelect, updateDropdownVisibility } = useDropdown({
 })
 
 // Computed property to check if type is boolean and nullable
-const booleanOptions = computed(() => {
-  return props.type === 'boolean' ||
-    props.type?.includes('boolean') ||
-    props.nullable
-    ? ['true', 'false', 'null']
-    : ['true', 'false']
-})
-
-/** Expose focus method */
-defineExpose({
-  focus: () => {
-    codeMirror.value?.focus()
-  },
-})
+const booleanOptions = computed(() =>
+  props.nullable ? ['true', 'false', 'null'] : ['true', 'false'],
+)
 
 const handleKeyDown = (key: string, event: KeyboardEvent) => {
   if (showDropdown.value) {
@@ -225,6 +215,20 @@ const defaultType = computed(() => {
     : // If it’s not an array, just return the type
       props.type
 })
+
+defineExpose({
+  /** Expose focus method */
+  focus: () => {
+    codeMirror.value?.focus()
+  },
+  // Expose these methods for testing
+  handleChange,
+  handleSubmit,
+  handleBlur,
+  booleanOptions,
+  codeMirror,
+  modelValue: props.modelValue,
+})
 </script>
 <script lang="ts">
 // use normal <script> to declare options
@@ -235,6 +239,7 @@ export default {
 <template>
   <template v-if="disabled">
     <div
+      data-testid="code-input-disabled"
       class="text-c-2 flex cursor-default items-center justify-center"
       :class="layout === 'modal' ? 'font-code pl-1 pr-2 text-sm' : 'px-2'">
       <span class="whitespace-nowrap">{{ modelValue }}</span>

--- a/packages/api-client/src/vitest.setup.ts
+++ b/packages/api-client/src/vitest.setup.ts
@@ -21,6 +21,7 @@ let isConsoleWarnEnabled = false
 
 /** Spy on console.error */
 export const consoleErrorSpy = vi.spyOn(console, 'error')
+let isConsoleErrorEnabled = false
 
 /** Reset the spies */
 export const resetConsoleSpies = () => {
@@ -33,6 +34,12 @@ export const enableConsoleWarn = () => (isConsoleWarnEnabled = true)
 
 /** Helper to disable console warn checks */
 export const disableConsoleWarn = () => (isConsoleWarnEnabled = false)
+
+/** Helper to enable console error checks */
+export const enableConsoleError = () => (isConsoleErrorEnabled = true)
+
+/** Helper to disable console error checks */
+export const disableConsoleError = () => (isConsoleErrorEnabled = false)
 
 // Set default values for the mocks
 beforeEach(() => {
@@ -67,9 +74,14 @@ afterEach(() => {
     expect(consoleWarnSpy).not.toHaveBeenCalled()
   }
 
+  if (isConsoleErrorEnabled) {
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  }
+
   // Reset the spies
   resetConsoleSpies()
   disableConsoleWarn()
+  disableConsoleError()
 
   vi.clearAllMocks()
 })

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ScalarMarkdown } from '@scalar/components'
 import type { ContentType, RequestBody } from '@scalar/types/legacy'
 import { computed, ref } from 'vue'
 
@@ -30,6 +31,11 @@ if (requestBody?.content) {
         @selectContentType="
           ({ contentType }) => (selectedContentType = contentType)
         " />
+      <div
+        v-if="requestBody.description"
+        class="request-body-description">
+        <ScalarMarkdown :value="requestBody.description" />
+      </div>
     </div>
     <div
       v-if="requestBody.content?.[selectedContentType]"


### PR DESCRIPTION
**Problem**

Currently, boolean values can be null regardless of the spec

**Solution**

With this PR we only allow null when nullable is true. 

Also bonus fix added back in a lost request body description

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
