### PR TITLE
chore(api-client): add tests for create client

### DIFF
--- a/.changeset/famous-rules-kick.md
+++ b/.changeset/famous-rules-kick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+chore: removed isReadOnly property as it isn't used anymore

--- a/packages/api-client/src/libs/create-client.test.ts
+++ b/packages/api-client/src/libs/create-client.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createApiClient, type CreateApiClientParams, type OpenClientPayload } from './create-client'
+import { createWorkspaceStore, type CreateWorkspaceStoreOptions } from '@/store/store'
+import { createActiveEntitiesStore } from '@/store/active-entities'
+import { createSidebarState } from '@/hooks/useSidebar'
+import { loadAllResources } from '@/libs/local-storage'
+import { getRequestUidByPathMethod } from '@/libs/get-request-uid-by-path-method'
+
+// Mock dependencies
+vi.mock('@/store/store', () => ({
+  createWorkspaceStore: vi.fn(() => ({
+    workspaceMutators: {
+      add: vi.fn(),
+      rawAdd: vi.fn(),
+      edit: vi.fn(),
+    },
+    collectionMutators: {
+      edit: vi.fn(),
+      reset: vi.fn(),
+    },
+    requestMutators: { reset: vi.fn() },
+    requestExampleMutators: {
+      reset: vi.fn(),
+      edit: vi.fn(),
+    },
+    securitySchemeMutators: {
+      reset: vi.fn(),
+      edit: vi.fn(),
+    },
+    serverMutators: { reset: vi.fn() },
+    tagMutators: { reset: vi.fn() },
+    importSpecFile: vi.fn(),
+    importSpecFromUrl: vi.fn(),
+    modalState: { open: false },
+    requests: {},
+    securitySchemes: {},
+    servers: {},
+  })),
+  WORKSPACE_SYMBOL: Symbol('workspace'),
+}))
+
+vi.mock('@/store/active-entities', () => ({
+  createActiveEntitiesStore: vi.fn(() => ({
+    activeCollection: { value: { uid: 'collection-1' } },
+    activeWorkspace: { value: { uid: 'workspace-1' } },
+  })),
+  ACTIVE_ENTITIES_SYMBOL: Symbol('active-entities'),
+}))
+
+vi.mock('@/hooks/useSidebar', () => ({
+  createSidebarState: vi.fn(() => ({})),
+  SIDEBAR_SYMBOL: Symbol('sidebar'),
+}))
+
+vi.mock('@/hooks/useLayout', () => ({
+  LAYOUT_SYMBOL: Symbol('layout'),
+}))
+
+vi.mock('@/libs/local-storage', () => ({
+  loadAllResources: vi.fn(),
+}))
+
+vi.mock('@/libs/get-request-uid-by-path-method', () => ({
+  getRequestUidByPathMethod: vi.fn(),
+}))
+
+vi.mock('@scalar/types/api-reference', () => ({
+  apiClientConfigurationSchema: {
+    parse: vi.fn((config) => config),
+  },
+}))
+
+vi.mock('vue', () => ({
+  createApp: vi.fn(() => ({
+    use: vi.fn(),
+    provide: vi.fn(),
+    mount: vi.fn(),
+  })),
+  watch: vi.fn((getter, callback) => {
+    // Store the callback for testing
+    watchCallbacks.push({ getter, callback })
+  }),
+}))
+
+// Store watch callbacks for testing
+const watchCallbacks: Array<{ getter: Function; callback: Function }> = []
+
+describe('createApiClient', () => {
+  const mockRouter = {
+    push: vi.fn(),
+  }
+
+  const mockElement = document.createElement('div')
+
+  const defaultWorkspaceOptions = {
+    useLocalStorage: true,
+    showSidebar: true,
+    proxyUrl: 'https://proxy.scalar.com',
+    theme: 'alternate',
+    hideClientButton: false,
+    _integration: 'vue',
+  } satisfies CreateWorkspaceStoreOptions
+
+  const defaultParams: CreateApiClientParams = {
+    el: mockElement,
+    appComponent: {},
+    router: mockRouter as any,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    watchCallbacks.length = 0
+
+    // Mock console methods
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'table').mockImplementation(() => {})
+
+    // Mock localStorage
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: vi.fn(),
+        setItem: vi.fn(),
+      },
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should create an API client with default parameters', () => {
+    const client = createApiClient(defaultParams)
+
+    expect(createWorkspaceStore).toHaveBeenCalled()
+    expect(createActiveEntitiesStore).toHaveBeenCalled()
+    expect(createSidebarState).toHaveBeenCalled()
+
+    expect(client).toHaveProperty('app')
+    expect(client).toHaveProperty('updateSpec')
+    expect(client).toHaveProperty('updateConfig')
+    expect(client).toHaveProperty('updateServer')
+    expect(client).toHaveProperty('onUpdateServer')
+    expect(client).toHaveProperty('updateAuth')
+    expect(client).toHaveProperty('route')
+    expect(client).toHaveProperty('open')
+    expect(client).toHaveProperty('mount')
+    expect(client).toHaveProperty('modalState')
+    expect(client).toHaveProperty('store')
+    expect(client).toHaveProperty('updateExample')
+  })
+
+  it('should use provided store if available', () => {
+    const mockStore = createWorkspaceStore(defaultWorkspaceOptions)
+
+    createApiClient({
+      ...defaultParams,
+      store: mockStore,
+    })
+
+    // Should not create a new store
+    expect(createWorkspaceStore).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not mount if mountOnInitialize is false', () => {
+    const client = createApiClient({
+      ...defaultParams,
+      mountOnInitialize: false,
+    })
+
+    // Vue app's mount should not be called
+    expect(client.app.mount).not.toHaveBeenCalled()
+
+    // But mount method should be available
+    client.mount(mockElement)
+    expect(client.app.mount).toHaveBeenCalledWith(mockElement)
+  })
+
+  it('should handle localStorage loading when available', () => {
+    // Mock localStorage to have workspace data
+    window.localStorage.getItem = vi.fn().mockReturnValue('{}')
+
+    createApiClient(defaultParams)
+
+    expect(loadAllResources).toHaveBeenCalled()
+  })
+
+  it('should update config and reset store when spec is provided', () => {
+    const client = createApiClient(defaultParams)
+    const mockStore = client.store
+
+    client.updateConfig({
+      spec: {
+        url: 'https://example.com/openapi.json',
+      },
+    })
+
+    // Should reset all stores
+    expect(mockStore.collectionMutators.reset).toHaveBeenCalled()
+    expect(mockStore.requestMutators.reset).toHaveBeenCalled()
+    expect(mockStore.requestExampleMutators.reset).toHaveBeenCalled()
+    expect(mockStore.securitySchemeMutators.reset).toHaveBeenCalled()
+    expect(mockStore.serverMutators.reset).toHaveBeenCalled()
+    expect(mockStore.tagMutators.reset).toHaveBeenCalled()
+
+    // Should update workspace collections
+    expect(mockStore.workspaceMutators.edit).toHaveBeenCalledWith('workspace-1', 'collections', [])
+
+    // Should import spec from URL
+    expect(mockStore.importSpecFromUrl).toHaveBeenCalledWith(
+      'https://example.com/openapi.json',
+      'workspace-1',
+      expect.any(Object),
+    )
+  })
+
+  it.only('should update server correctly', () => {
+    const client = createApiClient(defaultParams)
+    const mockStore = client.store
+
+    console.log(mockStore)
+
+    // Mock servers data
+    mockStore.servers = {
+      'server-1': { uid: 'server-1', url: 'https://api.example.com' },
+    }
+
+    client.updateServer('https://api.example.com')
+
+    expect(mockStore.collectionMutators.edit).toHaveBeenCalledWith('collection-1', 'selectedServerUid', 'server-1')
+  })
+
+  it('should handle onUpdateServer callback', () => {
+    const client = createApiClient(defaultParams)
+    const mockStore = client.store
+
+    // Mock servers data
+    mockStore.servers = {
+      'server-1': { uid: 'server-1', url: 'https://api.example.com' },
+    }
+
+    const callback = vi.fn()
+    client.onUpdateServer(callback)
+
+    // Find the watch callback and trigger it
+    const watchCallback = watchCallbacks.find((w) => w.getter.toString().includes('activeCollection'))
+    if (watchCallback) {
+      watchCallback.callback('server-1')
+      expect(callback).toHaveBeenCalledWith('https://api.example.com')
+    } else {
+      fail('Watch callback not found')
+    }
+  })
+
+  it('should update auth values correctly', () => {
+    const client = createApiClient(defaultParams)
+    const mockStore = client.store
+
+    // Mock security schemes
+    mockStore.securitySchemes = {
+      'scheme-1': { uid: 'scheme-1', nameKey: 'api_key', type: 'apiKey' },
+    }
+
+    client.updateAuth({
+      nameKey: 'api_key',
+      propertyKey: 'value',
+      value: 'my-api-key',
+    })
+
+    expect(mockStore.securitySchemeMutators.edit).toHaveBeenCalledWith('scheme-1', 'value', 'my-api-key')
+  })
+
+  it('should route to a request correctly', () => {
+    const client = createApiClient(defaultParams)
+
+    // Mock getRequestUidByPathMethod to return a request UID
+    getRequestUidByPathMethod.mockReturnValue('request-1')
+
+    const payload: OpenClientPayload = {
+      path: '/users',
+      method: 'get',
+    }
+
+    client.route(payload)
+
+    expect(mockRouter.push).toHaveBeenCalledWith({
+      name: 'request',
+      query: {},
+      params: {
+        workspace: 'default',
+        request: 'request-1',
+      },
+    })
+  })
+
+  it('should handle source in route payload', () => {
+    const client = createApiClient(defaultParams)
+
+    // Mock getRequestUidByPathMethod to return a request UID
+    getRequestUidByPathMethod.mockReturnValue('request-1')
+
+    const payload: OpenClientPayload = {
+      path: '/users',
+      method: 'get',
+      _source: 'api-reference',
+    }
+
+    client.route(payload)
+
+    expect(mockRouter.push).toHaveBeenCalledWith({
+      name: 'request',
+      query: { source: 'api-reference' },
+      params: {
+        workspace: 'default',
+        request: 'request-1',
+      },
+    })
+  })
+
+  it('should open the modal and route to a request', () => {
+    const client = createApiClient(defaultParams)
+    const routeSpy = vi.spyOn(client, 'route')
+
+    const payload: OpenClientPayload = {
+      path: '/users',
+      method: 'get',
+    }
+
+    client.open(payload)
+
+    expect(routeSpy).toHaveBeenCalledWith(payload)
+    expect(client.modalState.open).toBe(true)
+  })
+
+  it('should update example correctly', () => {
+    const client = createApiClient(defaultParams)
+    const mockStore = client.store
+
+    // Mock requests data
+    mockStore.requests = {
+      'request-1': {
+        uid: 'request-1',
+        operationId: 'getUsers',
+        path: '/users',
+        requestBody: {
+          content: {
+            'application/json': {
+              examples: {
+                'example-1': {
+                  value: { name: 'John' },
+                },
+              },
+            },
+          },
+        },
+        examples: ['example-uid-1'],
+      },
+    }
+
+    client.updateExample('example-1', 'getUsers')
+
+    expect(mockStore.requestExampleMutators.edit).toHaveBeenCalledWith(
+      'example-uid-1',
+      'body.raw.value',
+      expect.any(String),
+    )
+  })
+})

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -165,7 +165,6 @@ export const createApiClient = ({
     const workspace = workspaceSchema.parse({
       uid: 'default',
       name: 'Workspace',
-      isReadOnly: true,
       proxyUrl: configuration.proxyUrl,
     })
     store.workspaceMutators.rawAdd(workspace)

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -27,7 +27,7 @@ declare global {
   }
 }
 
-type CreateWorkspaceStoreOptions = {
+export type CreateWorkspaceStoreOptions = {
   /**
    * When true, changes made to the store will be saved in the browser’s localStorage.
    *


### PR DESCRIPTION
**Problem**

Currently, we have no testing on create-client.

**Solution**

With this PR we add  basic testing to create-client. This is just part one of a series to improve live store updates by using sync tech. Currently we just destroy the store everytime but that will soon change

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
