### PR TITLE
fix(api-references): change search button outline from shadow to border

### DIFF
--- a/.changeset/real-elephants-begin.md
+++ b/.changeset/real-elephants-begin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-references): change search button outline from shadow to border

--- a/packages/api-reference/src/features/Search/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/SearchButton.vue
@@ -89,12 +89,14 @@ onBeforeUnmount(() => window.removeEventListener('keydown', handleHotKey))
   );
   color: var(--scalar-sidebar-color-2, var(--scalar-color-2));
   border-radius: var(--scalar-radius);
-  box-shadow: 0 0 0 0.5px
-    var(--scalar-sidebar-search-border-color, var(--scalar-border-color));
+  border-width: var(--scalar-border-width);
+  border-color: var(
+    --scalar-sidebar-search-border-color,
+    var(--scalar-border-color)
+  );
   /* prettier-ignore */
   cursor: pointer;
   appearance: none;
-  border: none;
 }
 
 .sidebar-search-input {


### PR DESCRIPTION
From Thompson Reuters:

> I noticed in this release there is a border shadow around the sidebar-search input field that shows up differently in different browsers. The screenshot is on our site, but i see the same behavior on [sandbox.scalar.com](http://sandbox.scalar.com/). This line is controlled by the css attribute box-shadow.
> 
> This shows safari, chrome, and firefox from left to right.
> 
> ![image](https://github.com/user-attachments/assets/4237fdea-82e2-492d-89d9-f8f05667dc21)

I wasn't able to produce on my Mac (but it might be because of my display) this should fix it? @cameronrohani let me know if there's a reason we shouldn't do this.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
