### PR TITLE
feat(api-reference-react): re-export config types from the react integration + fix ci

### DIFF
--- a/.changeset/itchy-lions-laugh.md
+++ b/.changeset/itchy-lions-laugh.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: the tj actions in ci reference commit

--- a/.changeset/many-cobras-promise.md
+++ b/.changeset/many-cobras-promise.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference-react': patch
+---
+
+chore: export types from the react package for ease of use

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Check whether the Dockerfile or any of its contents were modified
         id: changed-files
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: tj-actions/changed-files@a284dc1814e3fd07f2e34267fc8f81227ed29fb8
         with:
           files_yaml: |
             api_reference_docker:
@@ -301,7 +301,7 @@ jobs:
       - if: startsWith(github.event.head_commit.message, 'RELEASING:')
         name: Check whether there’s a new version of the app
         id: changed-files
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: tj-actions/changed-files@a284dc1814e3fd07f2e34267fc8f81227ed29fb8
         with:
           files_yaml: |
             api_client_app:
@@ -331,7 +331,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Check which files were touched
         id: changed-files
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: tj-actions/changed-files@a284dc1814e3fd07f2e34267fc8f81227ed29fb8
         with:
           files_yaml: |
             api_client:
@@ -369,7 +369,7 @@ jobs:
       - if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
         name: Check for new @scalar/api-client version
         id: client-version
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: tj-actions/changed-files@a284dc1814e3fd07f2e34267fc8f81227ed29fb8
         with:
           files_yaml: |
             api_client:
@@ -454,7 +454,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Check which files were touched
         id: changed-files
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: tj-actions/changed-files@a284dc1814e3fd07f2e34267fc8f81227ed29fb8
         with:
           files_yaml: |
             components:
@@ -560,7 +560,7 @@ jobs:
       - if: startsWith(github.event.head_commit.message, 'RELEASING:')
         name: Check for new NuGet package version
         id: changed-files
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: tj-actions/changed-files@a284dc1814e3fd07f2e34267fc8f81227ed29fb8
         with:
           files_yaml: |
             aspnetcore_package:

--- a/packages/api-reference-react/src/index.ts
+++ b/packages/api-reference-react/src/index.ts
@@ -1,2 +1,9 @@
 export * from './ApiReferenceReact'
+
+/** Re-export types for ease of use */
+export type {
+  ApiReferenceConfiguration,
+  ApiReferenceConfigurationWithSources,
+  MultiReferenceConfiguration,
+} from '@scalar/types/api-reference'
 export type { ReferenceProps } from '@scalar/api-reference'


### PR DESCRIPTION
**Problem**

Currently, we only export the props for the component

**Solution**

With this PR we export a few of the key config types for ease of use.

Also fixed the ci cuz its broke

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
