### PR TITLE
chore(dependabot): ignore tsup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       - dependency-name: 'vite'
       - dependency-name: 'vitest'
       - dependency-name: 'rollup'
+      - dependency-name: 'tsup'
   - package-ecosystem: 'nuget'
     directory: '/integrations/aspnetcore'
     schedule:


### PR DESCRIPTION
Nobody cares about updates for tsup. Let’s just replace it with rollup soon-ish.