### PR TITLE
chore(api-reference): remove wildcard exports

### DIFF
--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -2,6 +2,7 @@ export { default as ApiReference } from '@/components/ApiReference.vue'
 export { default as ApiReferenceLayout } from '@/components/ApiReferenceLayout.vue'
 export { default as ModernLayout } from '@/components/Layouts/ModernLayout.vue'
 export { SearchButton, SearchModal } from '@/features/Search'
+// TODO: This component shouldn’t live in @scalar/api-reference. If it needs to live in scalar/scalar, it should be in @scalar/api-reference-editor
 export { default as GettingStarted } from '@/components/GettingStarted.vue'
 
 export { useReactiveSpec } from '@/hooks/useReactiveSpec'
@@ -11,10 +12,18 @@ export { Sidebar } from '@/components/Sidebar'
 export { Card, CardHeader, CardContent, CardFooter, CardTabHeader, CardTab } from '@/components/Card'
 export { Layouts } from '@/components/Layouts'
 
-export * from '@/stores'
-export * from '@/helpers'
-export * from '@/types'
-export * from '@/hooks'
+// TODO: Ideally, we’d remove those exports or at least not export them through the root index.
+export { parse } from '@/helpers/parse'
+export { createEmptySpecification } from '@/helpers/createEmptySpecification'
+export { useNavState } from '@/hooks/useNavState'
+export { useSidebar } from '@/hooks/useSidebar'
+export { useHttpClientStore } from '@/stores/useHttpClientStore'
+export type {
+  ApiReferenceConfiguration,
+  ReferenceProps,
+  // TODO: Deprecated 2025-03-12
+  ReferenceConfiguration,
+} from '@/types'
 
 // TODO: Deprecated 2025-03-12
 export { createScalarReferences } from '@/esm'


### PR DESCRIPTION
**Problem**

Currently, we’re doing this in the root index of `@scalar/api-reference`:

```ts
export * from '@/stores'
export * from '@/helpers'
export * from '@/types'
export * from '@/hooks'
```

This exposes all stores, helpers, types and hooks from the package. But we want to be able to move them around, rename them, drop them or change their API. Also, tree-shaking doesn’t work well in all environments.

**Solution**

Let’s trim down the list of exports to the stuff that we’re actually importing somewhere. Ideally, we’d move most of the remaining exports to other entrypoints, but that’s for a separate PR.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
