### PR TITLE
docs: Update link in changelog

### DIFF
--- a/.changeset/flat-spiders-sell.md
+++ b/.changeset/flat-spiders-sell.md
@@ -2,4 +2,4 @@
 '@scalar/aspnetcore': minor
 ---
 
-feat: Support Multiple OpenAPI documents. Please checkout [the related docs](https://github.com/scalar/scalar/blob/multiple-documents/documentation/integrations/dotnet.md#multiple-openapi-documents)!
+feat: Support Multiple OpenAPI documents. Please checkout [the related docs](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md#multiple-openapi-documents)!


### PR DESCRIPTION
I noticed that I used a dead link into the changelog 👀. I updated the link to point to the correct file.
