### PR TITLE
fix(nest.js): incorrect type import in nest.js fastify playground

### DIFF
--- a/.changeset/chatty-ants-wait.md
+++ b/.changeset/chatty-ants-wait.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nestjs-api-reference': patch
+---
+
+fix: missing app.service nest.js playground import

--- a/integrations/nestjs/playground/nestjs-api-reference-fastify/src/app.controller.ts
+++ b/integrations/nestjs/playground/nestjs-api-reference-fastify/src/app.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get } from '@nestjs/common'
-import type { AppService } from './app.service'
+// biome-ignore lint/style/useImportType: we need to import this for it to work
+import { AppService } from './app.service'
 
 @Controller()
 export class AppController {


### PR DESCRIPTION
**Problem**

Currently, our cloudbuild is borked

**Solution**

With this PR we import the app.service normally.

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
