### PR TITLE
fix(nest.js): incorrect type import in nest.js express playground 

### DIFF
--- a/.changeset/bright-tomatoes-walk.md
+++ b/.changeset/bright-tomatoes-walk.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nestjs-api-reference': patch
+---
+
+fix: apply the previous fix to the nestjs express integration as well

--- a/integrations/nestjs/playground/nestjs-api-reference-express/src/app.controller.ts
+++ b/integrations/nestjs/playground/nestjs-api-reference-express/src/app.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get } from '@nestjs/common'
-import type { AppService } from './app.service'
+// biome-ignore lint/style/useImportType: we need to import this for it to work
+import { AppService } from './app.service'
 
 @Controller()
 export class AppController {


### PR DESCRIPTION
Same fix but for nest + express

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
