### PR TITLE
refactor(api-reference): fetch documents outside the components

### DIFF
--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -54,11 +54,10 @@ watch(
   },
 )
 
+// TODO:
 const { parsedSpec } = useReactiveSpec({
   proxyUrl: () => configuration.proxyUrl ?? '',
-  specConfig: () => ({
-    content: content.value,
-  }),
+  content: content.value,
 })
 </script>
 <template>

--- a/packages/api-reference-editor/src/components/ApiReferenceEditor.vue
+++ b/packages/api-reference-editor/src/components/ApiReferenceEditor.vue
@@ -121,9 +121,11 @@ function mapConfigToState<K extends keyof ApiReferenceConfiguration>(
 const { setExcludedClients } = useHttpClientStore()
 mapConfigToState('hiddenClients', setExcludedClients)
 
+// TODO: Fetch URLs
+
 const { parsedSpec, rawSpec } = useReactiveSpec({
   proxyUrl: toRef(() => configuration.value.proxyUrl || ''),
-  specConfig: toRef(() => configuration.value || {}),
+  content: toRef(() => configuration.value.content || ''),
 })
 </script>
 <template>

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -2,12 +2,6 @@
 import { provideUseId } from '@headlessui/vue'
 import { LAYOUT_SYMBOL } from '@scalar/api-client/hooks'
 import {
-  ACTIVE_ENTITIES_SYMBOL,
-  createActiveEntitiesStore,
-  createWorkspaceStore,
-  WORKSPACE_SYMBOL,
-} from '@scalar/api-client/store'
-import {
   addScalarClassesToHeadless,
   ScalarErrorBoundary,
 } from '@scalar/components'
@@ -254,39 +248,11 @@ onServerPrefetch(() => {
  */
 provideUseId(() => useId())
 
-// Create the workspace store and provide it
-const workspaceStore = createWorkspaceStore({
-  useLocalStorage: false,
-  ...configuration.value,
-})
-// Populate the workspace store
-watch(
-  () => props.rawSpec,
-  (spec) =>
-    spec &&
-    workspaceStore.importSpecFile(spec, 'default', {
-      shouldLoad: false,
-      documentUrl: configuration.value.spec?.url,
-      setCollectionSecurity: true,
-      ...configuration.value,
-    }),
-  { immediate: true },
-)
-
-provide(WORKSPACE_SYMBOL, workspaceStore)
-
-// Same for the active entities store
-const activeEntitiesStore = createActiveEntitiesStore(workspaceStore)
-provide(ACTIVE_ENTITIES_SYMBOL, activeEntitiesStore)
-
 // Provide the client layout
 provide(LAYOUT_SYMBOL, 'modal')
 
 // Provide the configuration
 provide(CONFIGURATION_SYMBOL, configuration)
-
-// ---------------------------------------------------------------------------/
-// HANDLE MAPPING CONFIGURATION TO INTERNAL REFERENCE STATE
 
 /** Helper utility to map configuration props to the ApiReference internal state */
 function mapConfigToState<K extends keyof ApiReferenceConfiguration>(

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -339,11 +339,11 @@ const themeStyleTag = computed(
     }"
     @scroll.passive="debouncedScroll">
     <!-- Header -->
-    <div class="references-header">
+    <!-- <div class="references-header">
       <slot
         v-bind="referenceSlotProps"
         name="header" />
-    </div>
+    </div> -->
     <!-- Navigation (sidebar) wrapper -->
     <aside
       v-if="configuration.showSidebar"

--- a/packages/api-reference/src/components/SingleApiReference.vue
+++ b/packages/api-reference/src/components/SingleApiReference.vue
@@ -32,9 +32,34 @@ if (configuration.metaData) {
   useSeoMeta(configuration.metaData)
 }
 
+// TODO: Fetch URLs
+
+const content = computed(() => {
+  if (typeof configuration.content === 'function') {
+    return configuration.content()
+  }
+
+  if (typeof configuration.content === 'string') {
+    return configuration.content
+  }
+
+  if (typeof configuration.content === 'object') {
+    return JSON.stringify(configuration.content)
+  }
+
+  return JSON.stringify({
+    openapi: '3.1.0',
+    info: {
+      title: 'Example',
+      version: '1.0.0',
+    },
+    paths: {},
+  })
+})
+
 const { parsedSpec, rawSpec } = useReactiveSpec({
   proxyUrl: toRef(() => configuration.proxyUrl || ''),
-  specConfig: toRef(() => configuration || {}),
+  content: toRef(() => content.value || ''),
 })
 
 // TODO: defineSlots
@@ -43,7 +68,7 @@ const favicon = computed(() => configuration.favicon)
 useFavicon(favicon)
 </script>
 <template>
-  <!-- SingleApiReference -->
+  content: {{ content }}
   <!-- Inject any custom CSS directly into a style tag -->
   <component
     :is="'style'"
@@ -66,6 +91,9 @@ useFavicon(favicon)
   </Layouts>
 </template>
 <style>
+* {
+  background: white;
+}
 @layer scalar-base {
   body {
     margin: 0;

--- a/packages/api-reference/src/components/SingleApiReference.vue
+++ b/packages/api-reference/src/components/SingleApiReference.vue
@@ -5,7 +5,9 @@ import { useSeoMeta } from '@unhead/vue'
 import { useFavicon } from '@vueuse/core'
 import { computed, toRef, watch } from 'vue'
 
-import { useReactiveSpec } from '../hooks'
+import { createStore } from '@/helpers/create-store'
+import { useReactiveSpec } from '@/hooks'
+
 import { Layouts } from './Layouts'
 
 const { configuration } = defineProps<{
@@ -50,17 +52,37 @@ const content = computed(() => {
   return JSON.stringify({
     openapi: '3.1.0',
     info: {
-      title: 'Example',
+      title: 'We should fetch URLs I guess',
       version: '1.0.0',
     },
-    paths: {},
+    paths: {
+      '/foobar': {
+        get: {
+          summary: 'Foobar',
+          responses: {
+            200: {
+              description: 'Success',
+              content: {
+                'application/json': {
+                  schema: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   })
 })
 
+// Old data
 const { parsedSpec, rawSpec } = useReactiveSpec({
   proxyUrl: toRef(() => configuration.proxyUrl || ''),
   content: toRef(() => content.value || ''),
 })
+
+// New data
+createStore(content, configuration)
 
 // TODO: defineSlots
 
@@ -69,7 +91,7 @@ useFavicon(favicon)
 </script>
 <template>
   <div class="debug">
-    <pre>{{ content }}</pre>
+    <pre>{{ JSON.stringify(JSON.parse(content), null, 2) }}</pre>
   </div>
   <!-- Inject any custom CSS directly into a style tag -->
   <component

--- a/packages/api-reference/src/components/SingleApiReference.vue
+++ b/packages/api-reference/src/components/SingleApiReference.vue
@@ -68,7 +68,9 @@ const favicon = computed(() => configuration.favicon)
 useFavicon(favicon)
 </script>
 <template>
-  content: {{ content }}
+  <div class="debug">
+    <pre>{{ content }}</pre>
+  </div>
   <!-- Inject any custom CSS directly into a style tag -->
   <component
     :is="'style'"
@@ -91,8 +93,10 @@ useFavicon(favicon)
   </Layouts>
 </template>
 <style>
-* {
+.debug {
   background: white;
+  font-family: monospace;
+  padding: 1rem;
 }
 @layer scalar-base {
   body {

--- a/packages/api-reference/src/helpers/create-store.ts
+++ b/packages/api-reference/src/helpers/create-store.ts
@@ -1,0 +1,55 @@
+import {
+  ACTIVE_ENTITIES_SYMBOL,
+  WORKSPACE_SYMBOL,
+  createActiveEntitiesStore,
+  createWorkspaceStore,
+} from '@scalar/api-client/store'
+import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
+import { type ComputedRef, type Ref, provide, watch } from 'vue'
+
+/**
+ * Create a store for the API Reference, holding all the information from the OpenAPI document(s).
+ */
+export function createStore(
+  content: string | Ref<string> | ComputedRef<string>,
+  configuration: ApiReferenceConfiguration,
+): {
+  store: ReturnType<typeof createWorkspaceStore>
+  activeEntitiesStore: ReturnType<typeof createActiveEntitiesStore>
+} {
+  // Create the workspace store
+  const store = createWorkspaceStore({
+    useLocalStorage: false,
+    ...configuration,
+  })
+
+  // TODO: Update configuration
+
+  // Keep the store up to date
+  watch(
+    () => (typeof content === 'string' ? content : content.value),
+    (value) => {
+      return (
+        value &&
+        store.importSpecFile(value, 'default', {
+          shouldLoad: false,
+          documentUrl: configuration.url,
+          setCollectionSecurity: true,
+          ...configuration,
+        })
+      )
+    },
+    { immediate: true },
+  )
+
+  // Create the active entities store
+  const activeEntitiesStore = createActiveEntitiesStore(store)
+
+  provide(WORKSPACE_SYMBOL, store)
+  provide(ACTIVE_ENTITIES_SYMBOL, activeEntitiesStore)
+
+  return {
+    store: store,
+    activeEntitiesStore,
+  }
+}

--- a/packages/api-reference/src/helpers/fetch-content.test.ts
+++ b/packages/api-reference/src/helpers/fetch-content.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fetchSpecFromUrl } from '@scalar/oas-utils/helpers'
+
+import { fetchContent } from './fetch-content'
+
+vi.mock('@scalar/oas-utils/helpers', () => ({
+  fetchSpecFromUrl: vi.fn(),
+  isValidUrl: (url: string) => url.startsWith('http'),
+  prettyPrintJson: (obj: unknown) => JSON.stringify(obj, null, 2),
+}))
+
+describe('fetchContent', () => {
+  it('fetches content from a URL', async () => {
+    const url = 'http://example.com/spec.json'
+    const mockContent = '{"openapi": "3.0.0"}'
+    vi.mocked(fetchSpecFromUrl).mockResolvedValue(mockContent)
+
+    const result = await fetchContent({ url })
+    expect(result).toBe(mockContent)
+    expect(fetchSpecFromUrl).toHaveBeenCalledWith(url, undefined)
+  })
+
+  it('fetches content from a URL with proxy', async () => {
+    const url = 'http://example.com/spec.json'
+    const proxyUrl = 'http://proxy.com'
+    const mockContent = '{"openapi": "3.0.0"}'
+    vi.mocked(fetchSpecFromUrl).mockResolvedValue(mockContent)
+
+    const result = await fetchContent({ url }, proxyUrl)
+    expect(result).toBe(mockContent)
+    expect(fetchSpecFromUrl).toHaveBeenCalledWith(url, proxyUrl)
+  })
+
+  it('fetches content from a local path without proxy', async () => {
+    const url = '/local/spec.json'
+    const proxyUrl = 'http://proxy.com'
+    const mockContent = '{"openapi": "3.0.0"}'
+    vi.mocked(fetchSpecFromUrl).mockResolvedValue(mockContent)
+
+    const result = await fetchContent({ url }, proxyUrl)
+    expect(result).toBe(mockContent)
+    expect(fetchSpecFromUrl).toHaveBeenCalledWith(url)
+  })
+
+  it('handles URL fetch errors', async () => {
+    const url = 'http://example.com/spec.json'
+    vi.mocked(fetchSpecFromUrl).mockRejectedValue(new Error('Fetch failed'))
+
+    const result = await fetchContent({ url })
+    expect(result).toBeUndefined()
+  })
+
+  it('handles string content directly', async () => {
+    const content = '{"openapi": "3.0.0"}'
+    const result = await fetchContent({ content })
+    expect(result).toBe(content)
+  })
+
+  it('handles object content by pretty printing', async () => {
+    const content = { openapi: '3.0.0' }
+    const result = await fetchContent({ content })
+    expect(result).toBe(JSON.stringify(content, null, 2))
+  })
+
+  it('handles function content by executing', async () => {
+    const content = () => '{"openapi": "3.0.0"}'
+    const result = await fetchContent({ content })
+    expect(result).toBe(content())
+  })
+
+  it('returns undefined for invalid content', async () => {
+    const result = await fetchContent({})
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/api-reference/src/helpers/fetch-content.ts
+++ b/packages/api-reference/src/helpers/fetch-content.ts
@@ -1,0 +1,51 @@
+import { fetchSpecFromUrl, isValidUrl, prettyPrintJson } from '@scalar/oas-utils/helpers'
+import type { SpecConfiguration } from '@scalar/types/api-reference'
+
+/**
+ * Get the spec content from the provided configuration:
+ *
+ * 1. If the URL is provided, fetch the spec from the URL.
+ * 2. If the content is a string, return it.
+ * 3. If the content is an object, stringify it.
+ * 4. If the content is a function, call it and get the content.
+ * 5. Otherwise, return an empty string.
+ */
+export const fetchContent = async (
+  { url, content }: SpecConfiguration,
+  proxyUrl?: string,
+): Promise<string | undefined> => {
+  // If the URL is provided, fetch the API definition from the URL
+  if (url) {
+    const start = performance.now()
+
+    try {
+      // TODO: Use the resolved URL, not the given URL for the download link.
+      // If the url is not valid, we can assume its a path and
+      // if it’s a path we can skip the proxy.
+      const result = !isValidUrl(url) ? await fetchSpecFromUrl(url) : await fetchSpecFromUrl(url, proxyUrl)
+
+      const end = performance.now()
+      console.log(`fetch: ${Math.round(end - start)} ms (${url})`)
+      console.log('size:', Math.round(result.length / 1024), 'kB')
+
+      return result
+    } catch (error) {
+      console.error(`Failed to fetch content from URL (${url}):`, error)
+    }
+  }
+
+  // Callback
+  const activeContent = typeof content === 'function' ? content() : content
+
+  // Strings are fine
+  if (typeof activeContent === 'string') {
+    return activeContent
+  }
+
+  // Pretty print objects
+  if (typeof activeContent === 'object') {
+    return prettyPrintJson(activeContent)
+  }
+
+  return undefined
+}

--- a/packages/api-reference/src/hooks/index.ts
+++ b/packages/api-reference/src/hooks/index.ts
@@ -1,6 +1,6 @@
 export * from './useClientStore'
 export * from './useNavState'
 export * from './useOperation'
-export * from './useReactiveSpec'
+export { useReactiveSpec } from './useReactiveSpec'
 export * from './useRefOnMount'
 export * from './useSidebar'

--- a/packages/api-reference/src/hooks/useReactiveSpec.test.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.test.ts
@@ -1,7 +1,5 @@
-import { prettyPrintJson } from '@scalar/oas-utils/helpers'
-import type { SpecConfiguration } from '@scalar/types/api-reference'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, nextTick, reactive, ref, watch } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { nextTick, ref } from 'vue'
 
 import { useReactiveSpec } from './useReactiveSpec'
 
@@ -13,31 +11,20 @@ const basicSpec = {
 
 const basicSpecString = JSON.stringify(basicSpec)
 
-global.fetch = vi.fn()
-
 describe('useReactiveSpec', () => {
-  beforeEach(() => {
-    // @ts-expect-error
-    global.fetch.mockReset()
-  })
-
   it('returns the content', async () => {
     const { rawSpec } = useReactiveSpec({
-      specConfig: {
-        content: basicSpec,
-      },
+      content: basicSpecString,
     })
 
     await nextTick()
 
-    expect(rawSpec.value).toBe(prettyPrintJson(basicSpecString))
+    expect(rawSpec.value).toBe(basicSpecString)
   })
 
   it('returns an empty string', async () => {
     const { rawSpec } = useReactiveSpec({
-      specConfig: {
-        content: '',
-      },
+      content: '',
     })
 
     await nextTick()
@@ -45,163 +32,44 @@ describe('useReactiveSpec', () => {
     expect(rawSpec.value).toBe('')
   })
 
-  it('calls the content callback', async () => {
+  it('works with refs', async () => {
+    const content = ref(basicSpecString)
+
     const { rawSpec } = useReactiveSpec({
-      specConfig: {
-        content: () => {
-          return basicSpec
-        },
-      },
-    })
-
-    await nextTick()
-    await nextTick()
-
-    expect(rawSpec.value).toBe(prettyPrintJson(basicSpecString))
-  })
-
-  it('works with strings', async () => {
-    const { rawSpec } = useReactiveSpec({
-      specConfig: {
-        content: basicSpecString,
-      },
+      content,
     })
 
     await nextTick()
 
     expect(rawSpec.value).toBe(basicSpecString)
-  })
-
-  it('works with strings in callbacks', async () => {
-    const { rawSpec } = useReactiveSpec({
-      specConfig: {
-        content: () => basicSpecString,
-      },
-    })
-
-    await nextTick()
-
-    expect(rawSpec.value).toBe(basicSpecString)
-  })
-
-  function createFetchResponse(data: string) {
-    return {
-      status: 200,
-      ok: true,
-      text: () => new Promise((resolve) => resolve(data)),
-    }
-  }
-
-  it('fetches JSON from an URL', async () => {
-    // @ts-expect-error TODO
-    fetch.mockResolvedValue(createFetchResponse(basicSpecString))
-
-    const { rawSpec } = useReactiveSpec({
-      specConfig: {
-        url: 'https://example.com/openapi.json',
-      },
-    })
-
-    await nextTick()
-
-    expect(fetch).toHaveBeenCalledWith('https://example.com/openapi.json')
-
-    await new Promise((resolve) => {
-      watch(rawSpec, (value) => {
-        if (!value) {
-          return
-        }
-        expect(JSON.parse(value)).toMatchObject({
-          openapi: '3.1.0',
-          info: {
-            title: 'Example',
-          },
-          paths: {},
-        })
-
-        resolve(null)
-      })
-    })
-  })
-
-  it('uses a ref', async () => {
-    const specConfig = reactive<SpecConfiguration>({
-      content: basicSpec,
-    })
-
-    const { rawSpec } = useReactiveSpec({
-      specConfig,
-    })
-
-    await nextTick()
-
-    expect(rawSpec.value).toBe(prettyPrintJson(basicSpecString))
   })
 
   it('reacts to ref changes', async () => {
-    const configurationRef = reactive<SpecConfiguration>({
-      content: basicSpec,
-    })
+    const content = ref(basicSpecString)
 
-    // Pass the configuration as a ComputedRef
-    const specConfig = computed(() => configurationRef)
-
-    const { rawSpec } = useReactiveSpec({ specConfig })
+    const { rawSpec } = useReactiveSpec({ content })
 
     await nextTick()
 
-    expect(rawSpec.value).toBe(prettyPrintJson(basicSpecString))
+    expect(rawSpec.value).toBe(basicSpecString)
 
-    // Change the configuration …
-    Object.assign(configurationRef, {
-      content: {
-        ...basicSpec,
-        info: {
-          ...basicSpec.info,
-          title: 'My Changed Title',
-        },
-      },
-    })
+    // Change the content
+    content.value = basicSpecString.replace('Example', 'My Changed Title')
 
     await nextTick()
 
-    expect(rawSpec.value).toBe(prettyPrintJson(basicSpecString.replace('Example', 'My Changed Title')))
+    expect(rawSpec.value).toBe(basicSpecString.replace('Example', 'My Changed Title'))
 
-    // Change the configuration to empty
-    Object.assign(configurationRef, { content: '' })
+    // Change the content to empty
+    content.value = ''
     await nextTick()
 
     expect(rawSpec.value).toBe('')
   })
 
-  it('content isn’t overwritten if there’s nothing configured', async () => {
-    const configurationRef = reactive<SpecConfiguration>({ content: basicSpec })
-
-    // Pass the configuration as a ComputedRef
-    const specConfig = computed(() => configurationRef)
-
-    const { rawSpec } = useReactiveSpec({ specConfig })
-
-    await nextTick()
-
-    expect(rawSpec.value).toBe(prettyPrintJson(basicSpecString))
-
-    // Change the configuration …
-    Object.assign(configurationRef, {
-      content: undefined,
-    })
-
-    await nextTick()
-
-    // … but the content shouldn’t be overwritten
-    expect(rawSpec.value).toBe(prettyPrintJson(basicSpecString))
-  })
-
-  it('returns the content', async () => {
+  it('returns the parsed content', async () => {
     const { parsedSpec } = useReactiveSpec({
-      specConfig: {
-        content: basicSpec,
-      },
+      content: basicSpecString,
     })
 
     await nextTick()
@@ -211,28 +79,11 @@ describe('useReactiveSpec', () => {
     expect(parsedSpec.info?.title).toBe('Example')
   })
 
-  it('works with refs', async () => {
-    const rawSpecConfig = ref({
-      content: basicSpecString,
-    })
-
-    const { parsedSpec } = useReactiveSpec({
-      specConfig: rawSpecConfig,
-    })
-
-    // Sleep for 300ms to wait for the debouncer and the parser
-    await new Promise((resolve) => setTimeout(resolve, 300))
-
-    expect(parsedSpec.info?.title).toBe('Example')
-  })
-
   it('watches the ref', async () => {
-    const rawSpecConfig = ref({
-      content: basicSpecString,
-    })
+    const content = ref(basicSpecString)
 
     const { parsedSpec } = useReactiveSpec({
-      specConfig: rawSpecConfig,
+      content,
     })
 
     // Sleep for 300ms to wait for the debouncer and the parser
@@ -240,9 +91,7 @@ describe('useReactiveSpec', () => {
 
     expect(parsedSpec.info?.title).toBe('Example')
 
-    rawSpecConfig.value = {
-      content: JSON.stringify(basicSpecString.replace('Example', 'Foobar')),
-    }
+    content.value = basicSpecString.replace('Example', 'Foobar')
 
     // Sleep for 300ms to wait for the debouncer and the parser
     await new Promise((resolve) => setTimeout(resolve, 300))
@@ -261,9 +110,7 @@ describe('useReactiveSpec', () => {
 
   it('deals with empty input', async () => {
     const { parsedSpec } = useReactiveSpec({
-      specConfig: {
-        content: '',
-      },
+      content: '',
     })
 
     // Sleep for 10ms to wait for the parser to finish
@@ -274,9 +121,7 @@ describe('useReactiveSpec', () => {
 
   it('returns errors', async () => {
     const { specErrors } = useReactiveSpec({
-      specConfig: {
-        content: '{"foo}',
-      },
+      content: '{"foo}',
     })
 
     // Sleep for 10ms to wait for the parser to finish
@@ -286,8 +131,8 @@ describe('useReactiveSpec', () => {
   })
 
   it('resets schemas when the API definition changes', async () => {
-    const specConfig = ref({
-      content: {
+    const content = ref(
+      JSON.stringify({
         openapi: '3.1.0',
         info: { title: 'API #1' },
         paths: {},
@@ -296,11 +141,11 @@ describe('useReactiveSpec', () => {
             Planet: { type: 'object' },
           },
         },
-      },
-    })
+      }),
+    )
 
     const { parsedSpec } = useReactiveSpec({
-      specConfig,
+      content,
     })
 
     // Sleep for 10ms to wait for the parser to finish
@@ -310,13 +155,11 @@ describe('useReactiveSpec', () => {
     expect(parsedSpec.components?.schemas).toBeDefined()
     expect(Object.keys(parsedSpec.components?.schemas ?? {})).toStrictEqual(['Planet'])
 
-    // Change the configuration …
-    Object.assign(specConfig.value, {
-      content: {
-        openapi: '3.1.0',
-        info: { title: 'API #2' },
-        paths: {},
-      },
+    // Change the content
+    content.value = JSON.stringify({
+      openapi: '3.1.0',
+      info: { title: 'API #2' },
+      paths: {},
     })
 
     // Sleep for 10ms to wait for the parser to finish

--- a/packages/api-reference/src/hooks/useReactiveSpec.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.ts
@@ -1,69 +1,20 @@
-import { fetchSpecFromUrl, isValidUrl, prettyPrintJson } from '@scalar/oas-utils/helpers'
-import type { SpecConfiguration } from '@scalar/types/api-reference'
-import { type MaybeRefOrGetter, reactive, ref, toValue, watch } from 'vue'
+import { type MaybeRefOrGetter, reactive, ref, toRef, toValue, watch } from 'vue'
 
-import { createEmptySpecification } from '../helpers'
-import { parse } from '../helpers/parse'
+import { createEmptySpecification } from '@/helpers/createEmptySpecification'
+import { parse } from '@/helpers/parse'
 
 /**
- * Get the spec content from the provided configuration:
+ * Parse the OpenAPI document (immediately and when the content changes).
  *
- * 1. If the URL is provided, fetch the spec from the URL.
- * 2. If the content is a string, return it.
- * 3. If the content is an object, stringify it.
- * 4. If the content is a function, call it and get the content.
- * 5. Otherwise, return an empty string.
- */
-const getSpecContent = async ({ url, content }: SpecConfiguration, proxyUrl?: string): Promise<string | undefined> => {
-  // If the URL is provided, fetch the API definition from the URL
-  if (url) {
-    const start = performance.now()
-
-    try {
-      // TODO: Use the resolve URL, not the given URL for the download link
-
-      // If the url is not valid, we can assume its a path and
-      // if it’s a path we can skip the proxy.
-      const result = !isValidUrl(url) ? await fetchSpecFromUrl(url) : await fetchSpecFromUrl(url, proxyUrl)
-
-      const end = performance.now()
-      console.log(`fetch: ${Math.round(end - start)} ms (${url})`)
-      console.log('size:', Math.round(result.length / 1024), 'kB')
-
-      return result
-    } catch (error) {
-      console.error('Failed to fetch spec from URL:', error)
-    }
-  }
-
-  // Callback
-  const activeContent = typeof content === 'function' ? content() : content
-
-  // Strings are fine
-  if (typeof activeContent === 'string') {
-    return activeContent
-  }
-
-  // Pretty print objects
-  if (typeof activeContent === 'object') {
-    return prettyPrintJson(activeContent)
-  }
-
-  return undefined
-}
-
-/**
- * Keep the raw spec content in a ref and update it when the configuration changes.
+ * @deprecated This is still in use, but want to refactor everything to use the new store.
  */
 export function useReactiveSpec({
-  specConfig,
+  content,
   proxyUrl,
 }: {
-  specConfig?: MaybeRefOrGetter<SpecConfiguration>
+  content: MaybeRefOrGetter<string>
   proxyUrl?: MaybeRefOrGetter<string>
 }) {
-  /** OAS spec as a string */
-  const rawSpec = ref<string>('')
   /** Fully parsed and resolved OAS object */
   const parsedSpec = reactive(createEmptySpecification())
   /** Parser error messages when parsing fails */
@@ -85,7 +36,7 @@ export function useReactiveSpec({
       .then((validSpec) => {
         specErrors.value = null
 
-        // Some specs don’t have servers, make sure they are defined
+        // Some specs don't have servers, make sure they are defined
         Object.assign(parsedSpec, {
           ...validSpec,
         })
@@ -97,24 +48,15 @@ export function useReactiveSpec({
   }
 
   watch(
-    () => toValue(specConfig),
-    async (newConfig) => {
-      if (newConfig) {
-        const specContent = (await getSpecContent(newConfig, toValue(proxyUrl)))?.trim()
-        if (typeof specContent === 'string') {
-          rawSpec.value = specContent
-        }
-      }
+    () => toValue(content),
+    (newContent) => {
+      parseInput(newContent)
     },
     { immediate: true, deep: true },
   )
 
-  watch(rawSpec, () => {
-    parseInput(rawSpec.value)
-  })
-
   return {
-    rawSpec,
+    rawSpec: toRef(content),
     parsedSpec,
     specErrors,
   }

--- a/packages/api-reference/src/standalone/lib/html-api/create-api-reference.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api/create-api-reference.test.ts
@@ -1,14 +1,14 @@
+import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createApiReference,
   createContainer,
   findDataAttributes,
   getConfigurationFromDataAttributes,
-} from '@/standalone/lib/html-api'
-import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
-import { flushPromises } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+} from './create-api-reference'
 
-describe('html-api', () => {
+describe('create-api-reference', () => {
   beforeEach(() => {
     global.document = createHtmlDocument(`
       <html>

--- a/packages/api-reference/src/standalone/lib/html-api/create-api-reference.ts
+++ b/packages/api-reference/src/standalone/lib/html-api/create-api-reference.ts
@@ -1,8 +1,8 @@
 import type { ReferenceProps } from '@/types'
 import {
   type ApiReferenceConfiguration,
-  apiReferenceConfigurationSchema,
   type MultiReferenceConfiguration,
+  apiReferenceConfigurationSchema,
 } from '@scalar/types/api-reference'
 import { createHead } from '@unhead/vue'
 import { type App, createApp, h, reactive } from 'vue'
@@ -199,6 +199,8 @@ export const createApiReference: CreateApiReference = (
   elementOrSelectorOrConfig,
   optionalConfiguration?: MultiReferenceConfiguration,
 ) => {
+  console.log('createApiReference', elementOrSelectorOrConfig, optionalConfiguration)
+
   const props = reactive<ReferenceProps>({
     // Either the configuration will be the second arugment or it MUST be the first (configuration only)
     configuration: optionalConfiguration ?? (elementOrSelectorOrConfig as MultiReferenceConfiguration) ?? {},

--- a/packages/api-reference/src/standalone/lib/html-api/index.ts
+++ b/packages/api-reference/src/standalone/lib/html-api/index.ts
@@ -1,0 +1,7 @@
+export {
+  createApiReference,
+  type CreateApiReference,
+  type ApiReferenceInstance,
+  findDataAttributes,
+  getConfigurationFromDataAttributes,
+} from './create-api-reference'

--- a/packages/api-reference/src/standalone/lib/register-globals.test.ts
+++ b/packages/api-reference/src/standalone/lib/register-globals.test.ts
@@ -1,6 +1,6 @@
-import { registerGlobals } from './register-globals'
 import { describe, expect, it } from 'vitest'
-import { createApiReference } from './html-api'
+import { createApiReference } from './html-api/create-api-reference'
+import { registerGlobals } from './register-globals'
 
 describe('registerGlobals', () => {
   it('registers the createApiReference method on the global window', () => {

--- a/packages/api-reference/src/standalone/lib/register-globals.ts
+++ b/packages/api-reference/src/standalone/lib/register-globals.ts
@@ -1,4 +1,4 @@
-import { createApiReference, type CreateApiReference } from '@/standalone/lib/html-api'
+import { type CreateApiReference, createApiReference } from '@/standalone/lib/html-api'
 
 // Register the createApiReference function in the global Scalar object (new)
 declare global {

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -500,7 +500,7 @@ export type ApiReferenceConfigurationWithSources = Omit<
   'proxy' | 'spec'
 >
 
-/** Configuration for multiple Api References */
+/** Configuration for multiple API References */
 export type MultiReferenceConfiguration =
   | Partial<ApiReferenceConfiguration>
   | Partial<ApiReferenceConfiguration>[]


### PR DESCRIPTION
WIP

**Issues**

- [ ] If we want to fetch documents outside the components, we need to refactor the multi document logic.
- [ ] Currently, we don't fetch document URLs at all
- [ ] Currently, you can’t use ApiReferenceLayout anymore

**Problem**

It feels wrong that useReactiveSpec fetches URLs, we want to move away from useReactiveSpec. Let’s move the fetching out.

**Solution**

With this PR …

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
