### PR TITLE
docs(Scalar.AspNetCore): more detailed examples and explanations

### DIFF
--- a/integrations/aspnetcore/README.md
+++ b/integrations/aspnetcore/README.md
@@ -8,6 +8,13 @@ This .NET package `Scalar.AspNetCore` provides an easy way to render beautiful A
 
 Made possible by the wonderful work of [@captainsafia](https://github.com/captainsafia) on [building the integration and docs written](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/using-openapi-documents?view=aspnetcore-9.0#use-scalar-for-interactive-api-documentation) for the Scalar & .NET integration. Thanks to [@xC0dex](https://github.com/xC0dex) for making it awesome.
 
+## Features
+
+- Stunning API Reference
+- Compatible with .NET 8 and above
+- Independent of OpenAPI document generators
+- Fully AOT (Ahead-of-Time) compatible
+
 ![dotnet](https://raw.githubusercontent.com/scalar/scalar/refs/heads/main/integrations/aspnetcore/dotnet.jpg)
 
 ## Migration Guide
@@ -83,7 +90,9 @@ That's it! 🎉 You can now access the Scalar API Reference at `/scalar`. By def
 
 ## Configuration
 
-For a full configuration guide and examples, including OAuth integration and custom settings, refer to the [dotnet integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md).
+For detailed configuration options, refer to the [integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md). This documentation focuses on the features provided by the package.
+
+For more realistic examples and advanced usage scenarios, such as authentication, API versioning and handling multiple documents, check out our [extended examples documentation](TODO).
 
 ## Development
 

--- a/integrations/aspnetcore/README.md
+++ b/integrations/aspnetcore/README.md
@@ -86,13 +86,13 @@ if (app.Environment.IsDevelopment())
 }
 ```
 
-That's it! 🎉 You can now access the Scalar API Reference at `/scalar`. By default, the API Reference uses the `v1` document. You can add documents by calling the `AddDocument` method. Please check out the [dotnet integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md#multiple-openapi-documents) for more details. Alternatively, you can navigate to `/scalar/{documentName}` (e.g., `/scalar/v1`) to view the API reference for a specific document.
+That's it! 🎉 You can now access the Scalar API Reference at `/scalar`. By default, the API Reference uses the `v1` document. You can add documents by calling the `AddDocument` method. Alternatively, you can navigate to `/scalar/{documentName}` (e.g., `/scalar/v1`) to view the API Reference for a specific document. Please check out the [dotnet integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md#multiple-openapi-documents) for more details.
 
 ## Configuration
 
 For detailed configuration options, refer to the [integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md). This documentation focuses on the features provided by the package.
 
-For more realistic examples and advanced usage scenarios, such as authentication, API versioning and handling multiple documents, check out our [extended examples documentation](TODO).
+For more realistic examples and advanced usage scenarios, such as authentication, API versioning, and handling multiple documents, check out our [extended examples documentation](https://github.com/scalar/scalar/blob/main/integrations/aspnetcore/docs/README.md). This documentation is also useful if you need more context on what `Scalar.AspNetCore` is for.
 
 ## Development
 

--- a/integrations/aspnetcore/docs/README.md
+++ b/integrations/aspnetcore/docs/README.md
@@ -1,6 +1,6 @@
 # Scalar.AspNetCore Documentation
 
-Welcome to the documentation for the `Scalar.AspNetCore` package. This guide provides an in-depth look at OpenAPI document generation and `Scalar.AspNetCore`.
+Welcome to the documentation for the `Scalar.AspNetCore` package. This guide provides an in-depth look at OpenAPI document generation and `Scalar.AspNetCore`. For a comprehensive list of all available configuration options, please refer to the [integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md). 
 
 ## Table of Contents
 - [`Scalar.AspNetCore`](./scalar-vs-generators.md)

--- a/integrations/aspnetcore/docs/README.md
+++ b/integrations/aspnetcore/docs/README.md
@@ -1,0 +1,10 @@
+# Scalar.AspNetCore Documentation
+
+Welcome to the documentation for the `Scalar.AspNetCore` package. This guide provides an in-depth look at OpenAPI document generation and `Scalar.AspNetCore`.
+
+## Table of Contents
+- [`Scalar.AspNetCore`](./scalar-vs-generators.md)
+- [Authentication](./authentication.md)
+- [Multiple OpenAPI Documents](./multiple-openapi-documents.md)
+- [Multiple Scalar API References](./multiple-scalar-api-references.md)
+- [SubPath Deployment](./subpath-deployment.md)

--- a/integrations/aspnetcore/docs/authentication.md
+++ b/integrations/aspnetcore/docs/authentication.md
@@ -1,0 +1,201 @@
+# Authentication
+
+## Understanding Authentication in OpenAPI Documents
+
+In the .NET ecosystem, there is a distinction between authentication mechanisms and their representation in OpenAPI documents. Simply adding an authentication scheme to the Dependency Injection (DI) container does not automatically include it in the OpenAPI document.
+
+## How Scalar Works
+
+`Scalar.AspNetCore` relies on the OpenAPI document to determine security schemes and requirements. If the OpenAPI document does not specify any security schemes, Scalar will not display any authentication options.
+
+To include necessary authentication schemes in the OpenAPI document, implement an `OpenApiDocumentTransformer`. This allows you to add required security schemes to the OpenAPI document, ensuring `Scalar.AspNetCore` can recognize and display them. Multiple authentication schemes can be provided.
+There is an [open GitHub issue](https://github.com/dotnet/aspnetcore/issues/39761) for automating this with .NET 10.
+
+In the following sections, we will explain how to implement this transformer to add authentication schemes to your OpenAPI document.
+
+## HTTP Authentication
+
+### Configuring Bearer Authentication
+
+To set up Bearer authentication in your API, configure the authentication scheme in the DI container:
+
+```csharp
+builder.Services.AddAuthentication().AddJwtBearer(options =>
+{
+    options.Authority = "http://localhost:8080/realms/master/.well-known/openid-configuration";
+});
+```
+
+Next, add this security scheme to the OpenAPI document by creating a custom `OpenApiDocumentTransformer`:
+
+```csharp
+options.AddDocumentTransformer((document, _, _) =>
+{
+    var securityScheme = new OpenApiSecurityScheme
+    {
+        Type = SecuritySchemeType.Http,
+        In = ParameterLocation.Header,
+        Scheme = "bearer"
+    };
+    document.Components ??= new OpenApiComponents();
+    document.Components.SecuritySchemes.Add(JwtBearerDefaults.AuthenticationScheme, securityScheme);
+    return Task.CompletedTask;
+});
+```
+
+This transformer ensures that the required security scheme is included in the generated OpenAPI document. Once you start your project, you will see an option in the authentication dropdown.
+
+### Adding a Global Security Requirement
+
+Optionally, you can add a security requirement to the entire OpenAPI document. This step is not mandatory but can help enforce the use of the specified security scheme across all endpoints. Modify the `OpenApiDocumentTransformer` to include a security requirement:
+
+```csharp
+options.AddDocumentTransformer((document, _, _) =>
+{
+    var securityScheme = new OpenApiSecurityScheme
+    {
+        Type = SecuritySchemeType.Http,
+        In = ParameterLocation.Header,
+        Scheme = "bearer"
+    };
+    document.Components ??= new OpenApiComponents();
+    document.Components.SecuritySchemes.Add(JwtBearerDefaults.AuthenticationScheme, securityScheme);
+
+    // Adds a global security requirement
+    var referenceScheme = new OpenApiSecurityScheme
+    {
+        Reference = new OpenApiReference
+        {
+            Id = JwtBearerDefaults.AuthenticationScheme,
+            Type = ReferenceType.SecurityScheme
+        }
+    };
+    
+    document.SecurityRequirements.Add(new OpenApiSecurityRequirement
+    {
+        [referenceScheme] = []
+    });
+
+    return Task.CompletedTask;
+});
+```
+
+This addition ensures that the security scheme is applied globally to all operations in the OpenAPI document.
+
+### Prefilling the Token
+
+To make the usage of this scheme easier, you can prefill the `Token` in the `MapScalarApiReference()` method:
+
+```csharp
+app.MapScalarApiReference(options => options.Authentication = new ScalarAuthenticationOptions
+{
+    PreferredSecurityScheme = JwtBearerDefaults.AuthenticationScheme,
+    Http = new HttpOptions
+    {
+        Bearer = new HttpBearerOptions
+        {
+            Token = "my JWT token"
+        }
+    }
+});
+```
+
+This configuration preselects the `Bearer` authentication scheme in the API Reference and pre-fills the token with a given value.
+
+## OAuth Authentication
+
+OAuth is a widely used authorization standard that typically uses a Bearer Token to authenticate users. It supports various flows, including Authorization Code, Implicit, and Client Credentials.
+
+When integrating OAuth with your API, you need to configure the appropriate OAuth flow as a security scheme in your OpenAPI document. This ensures that `Scalar.AspNetCore` can recognize and display the necessary authentication options based on the selected OAuth flow. It is possible to provide multiple flows for a security scheme.
+
+### Configuring OAuth (Client Credentials Flow)
+
+To set up OAuth authentication in your API, configure the authentication scheme in the DI container:
+
+```csharp
+builder.Services.AddAuthentication().AddJwtBearer(options =>
+{
+    options.Authority = "http://localhost:8080/realms/master/.well-known/openid-configuration";
+});
+```
+
+Next, add this security scheme to the OpenAPI document by creating a custom `OpenApiDocumentTransformer`:
+
+```csharp
+options.AddDocumentTransformer((document, _, _) =>
+{
+    var securityScheme = new OpenApiSecurityScheme
+    {
+        Type = SecuritySchemeType.OAuth2,
+        Flows = new OpenApiOAuthFlows
+        {
+            ClientCredentials = new OpenApiOAuthFlow
+            {
+                TokenUrl = new Uri("https://your-authorization-server.com/connect/token")
+            }
+        }
+    };
+    document.Components ??= new OpenApiComponents();
+    document.Components.SecuritySchemes.Add("OAuth", securityScheme);
+    return Task.CompletedTask;
+});
+```
+
+This transformer ensures that the required security scheme is included in the generated OpenAPI document. Once you start your project, you will see an option in the authentication dropdown.
+
+### Adding a Global Security Requirement for OAuth
+
+Optionally, add a security requirement to the entire OpenAPI document:
+
+```csharp
+options.AddDocumentTransformer((document, _, _) =>
+{
+    var securityScheme = new OpenApiSecurityScheme
+    {
+        Type = SecuritySchemeType.OAuth2,
+        Flows = new OpenApiOAuthFlows
+        {
+            ClientCredentials = new OpenApiOAuthFlow
+            {
+                TokenUrl = new Uri("https://your-authorization-server.com/connect/token")
+            }
+        }
+    };
+    document.Components ??= new OpenApiComponents();
+    document.Components.SecuritySchemes.Add("OAuth", securityScheme);
+
+    // Adds a global security requirement
+    var referenceScheme = new OpenApiSecurityScheme
+    {
+        Reference = new OpenApiReference
+        {
+            Id = "OAuth",
+            Type = ReferenceType.SecurityScheme
+        }
+    };
+    
+    document.SecurityRequirements.Add(new OpenApiSecurityRequirement
+    {
+        [referenceScheme] = []
+    });
+
+    return Task.CompletedTask;
+});
+```
+
+### Prefilling Credentials for OAuth
+
+To make the usage of this scheme easier, you can prefill the `ClientId` in the `MapScalarApiReference()` method:
+
+```csharp
+app.MapScalarApiReference(options => options.Authentication = new ScalarAuthenticationOptions
+{
+    PreferredSecurityScheme = "OAuth",
+    OAuth2 = new OAuth2Options
+    {
+        ClientId = "your-client-id"
+    }
+});
+```
+
+This configuration preselects the `OAuth` authentication scheme in the API Reference and pre-fills the token with a given value.

--- a/integrations/aspnetcore/docs/multiple-openapi-documents.md
+++ b/integrations/aspnetcore/docs/multiple-openapi-documents.md
@@ -1,0 +1,79 @@
+# Multiple OpenAPI Documents
+
+## Understanding OpenAPI Documents with API Versioning
+
+When working with versioned APIs, generate separate OpenAPI documents for each version. This guide assumes you have API versioning configured using `Microsoft.AspNetCore.Mvc.Versioning` and `Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer`.
+
+Your existing code may look like this:
+
+```csharp
+services.AddApiVersioning().AddApiExplorer(options =>
+{
+    options.GroupNameFormat = "'v'VVV";
+    options.SubstituteApiVersionInUrl = true;
+});
+```
+
+## Configuring OpenAPI Generation
+
+To generate separate OpenAPI documents for each API version, configure the OpenAPI document generator as follows:
+
+```csharp
+string[] versions = ["v1", "v2"];
+
+foreach (var version in versions)
+{
+  builder.Services.AddOpenApi(version, options =>
+  {
+    // Add the appropriate API version information to the document
+    options.AddDocumentTransformer((document, context, _) =>
+    {
+      var descriptionProvider = context.ApplicationServices.GetRequiredService<IApiVersionDescriptionProvider>();
+      var versionDescription = descriptionProvider.ApiVersionDescriptions.FirstOrDefault(x => x.GroupName == version);
+      document.Info.Version = versionDescription?.ApiVersion.ToString();
+      return Task.CompletedTask;
+    });
+
+    // Indicate if the API is deprecated
+    options.AddOperationTransformer((operation, context, _) =>
+    {
+      var apiDescription = context.Description;
+      operation.Deprecated = apiDescription.IsDeprecated();
+      return Task.CompletedTask;
+    });
+  });
+}
+```
+
+## Integrating with Scalar.AspNetCore
+
+To configure the Scalar API Reference to use multiple OpenAPI documents, use either the `AddDocument` or `AddDocuments` methods. Here are two approaches:
+
+1. Using the Options Pattern
+
+Extend the foreach loop from above to update the `ScalarOptions` accordingly:
+
+```csharp
+string[] versions = ["v1", "v2"];
+
+foreach (var version in versions)
+{
+  builder.Services.Configure<ScalarOptions>(options => options.AddDocument(version));
+  builder.Services.AddOpenApi(version, options =>
+  {
+    // Existing configuration
+  });
+}
+```
+
+2. Using the `MapScalarApiReference` Overload
+
+```csharp
+string[] versions = ["v1", "v2"];
+
+app.MapScalarApiReference(options => options.AddDocuments(versions));
+// or
+app.MapScalarApiReference(options => options.AddDocuments("v1", "v2"));
+```
+
+With this setup, Scalar will display a version selector in the UI, allowing users to switch between different API versions and their corresponding documentation.

--- a/integrations/aspnetcore/docs/multiple-scalar-api-references.md
+++ b/integrations/aspnetcore/docs/multiple-scalar-api-references.md
@@ -1,0 +1,18 @@
+# Multiple Scalar API References
+
+This example demonstrates how to configure multiple Scalar API references, each mapped to a separate endpoint, and how to use separate OpenAPI documents for each reference.
+
+## Configuring Multiple API References
+
+To configure multiple API references, use the `MapScalarApiReference` method with a parameter to map the reference to a separate endpoint. Additionally, use the `AddDocument` method to specify the OpenAPI documents for each reference.
+
+### Example
+
+```csharp
+builder.Services.AddOpenApi("internal");
+builder.Services.AddOpenApi("public");
+
+// Map Scalar API references to separate endpoints
+app.MapScalarApiReference("/api-reference-internal", options => options.AddDocument("internal"));
+app.MapScalarApiReference("/api-reference", options => options.AddDocument("public"));
+```

--- a/integrations/aspnetcore/docs/scalar-vs-generators.md
+++ b/integrations/aspnetcore/docs/scalar-vs-generators.md
@@ -1,0 +1,18 @@
+# `Scalar.AspNetCore`
+
+## Historical Context
+
+Historically, OpenAPI generators like `Swashbuckle` and `NSwag` have provided an "all-in-one" solution, bundling both the documentation generation and a UI.
+
+With the release of .NET 9, Microsoft introduced a new OpenAPI generator, `Microsoft.AspNetCore.OpenApi`, that focuses solely on the generation aspect, without including a built-in UI. This shift has created a gap for developers who previously relied on the integrated UI.
+
+## Scalar.AspNetCore
+
+`Scalar.AspNetCore` is designed to bridge this gap by offering beautiful API Reference documentation. It provides a robust and customizable interface that enhances the usability and presentation of your API documentation.
+
+For more real-world examples and detailed guides, please refer to the following guides:
+
+- [Authentication](./authentication.md)
+- [Multiple OpenAPI Documents](./multiple-openapi-documents.md)
+- [Multiple Scalar API References](./multiple-scalar-api-references.md)
+- [SubPath Deployment](./subpath-deployment.md)

--- a/integrations/aspnetcore/docs/subpath-deployment.md
+++ b/integrations/aspnetcore/docs/subpath-deployment.md
@@ -1,0 +1,69 @@
+# Subpath Deployment
+
+When deploying your API under a subpath (e.g., `https://api.example.com/my-api`), Scalar automatically handles the OpenAPI document URLs by adjusting them according to the base path. This guide explains how to configure subpath deployment with Scalar.
+
+## Important Note on Root Deployment
+
+When your API is deployed under a subpath (e.g., `/my-api`), it's recommended to deploy Scalar under a subpath as well (e.g., `/my-api/scalar`). Deploying Scalar at the root path (`/`) while the API is under a subpath may lead to unexpected behavior with OpenAPI document URL resolution.
+
+Recommended configuration:
+- API: `https://api.example.com/my-api`
+- Scalar API Reference endpoint: `/scalar`
+- OpenAPI document endpoint: `/openapi/v1.json`
+
+## Automatic Base Path Detection
+
+Scalar automatically detects the base path of your application and updates the OpenAPI document URLs accordingly. This means you don't need any additional configuration for the UI to work correctly when following the recommended deployment pattern.
+
+## Configuration Options
+
+### 1. Path Stripping by Reverse Proxy
+
+If your reverse proxy strips the base path (common with nginx, Apache, or Caddy), no additional configuration is needed in your ASP.NET Core application:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+app.MapOpenApi();
+app.MapScalarApiReference("/scalar"); // Recommended: Deploy under a subpath
+```
+
+### 2. Without Path Stripping
+
+If your reverse proxy preserves the base path, configure your ASP.NET Core application to use the base path:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+// Configure the base path
+app.UsePathBase("/my-api");
+
+// Must be called after UsePathBase
+app.UseRouting();
+
+app.MapOpenApi();
+app.MapScalarApiReference();
+```
+
+## Example with Multiple Documents
+
+When using multiple OpenAPI documents with subpath deployment:
+
+```csharp
+string[] versions = ["v1", "v2"];
+
+app.UsePathBase("/my-api");
+app.UseRouting();
+
+app.MapScalarApiReference(options =>  options.AddDocuments("v1", "v2"));
+```
+
+Scalar will automatically handle the base path for all document URLs.


### PR DESCRIPTION
We had many questions regarding about .NET, OpenAPI and Scalar. I hope that these docs help to understand everything a bit better. My plan is to gradually enhance and improve these documentation/examples.

Currently, the docs are located here `/integrations/aspnetcore/docs`. Do you know a better place for multiple related doc files?

This documentation contains:

- Scalar.AspNetCore
- Authentication
- Multiple OpenAPI Documents
- Multiple Scalar API References
- SubPath Deployment


Later, I'd like to

- enhance Authentication → Even more examples.
- add Metadata → Describing endpoints (summaries, comments etc.).
- improve the existing integration documentation by adding docs for **all** configuration options.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
