### PR TITLE
feat(api-reference): expose isLoading in config & "fix" config reactivity

### DIFF
--- a/.changeset/soft-pets-look.md
+++ b/.changeset/soft-pets-look.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: expose the isLoading prop to control loading of references

--- a/.changeset/thirty-peas-tap.md
+++ b/.changeset/thirty-peas-tap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: re-create store every time we update the config

--- a/packages/api-client-react/src/ApiClientModalProvider.tsx
+++ b/packages/api-client-react/src/ApiClientModalProvider.tsx
@@ -62,8 +62,8 @@ export const ApiClientModalProvider = ({ children, initialRequest, configuration
       configuration,
     })
 
-    const updateSpec = async () => {
-      await _client.updateSpec(configuration.spec!)
+    const updateConfig = async () => {
+      await _client.updateConfig(configuration!)
       if (initialRequest) {
         _client.route(initialRequest)
       }
@@ -74,11 +74,7 @@ export const ApiClientModalProvider = ({ children, initialRequest, configuration
     clientDict[key] = _client
 
     // We update the config as we are using the sync version
-    if (configuration.spec) {
-      updateSpec()
-    } else if (initialRequest) {
-      _client.route(initialRequest)
-    }
+    updateConfig()
 
     // Ensure we unmount the vue app on unmount
     return () => {

--- a/packages/api-client/src/libs/create-client.test.ts
+++ b/packages/api-client/src/libs/create-client.test.ts
@@ -133,7 +133,6 @@ describe('createApiClient', () => {
     expect(createSidebarState).toHaveBeenCalled()
 
     expect(client).toHaveProperty('app')
-    expect(client).toHaveProperty('updateSpec')
     expect(client).toHaveProperty('updateConfig')
     expect(client).toHaveProperty('updateServer')
     expect(client).toHaveProperty('onUpdateServer')
@@ -184,9 +183,7 @@ describe('createApiClient', () => {
     const mockStore = client.store
 
     client.updateConfig({
-      spec: {
-        url: 'https://example.com/openapi.json',
-      },
+      url: 'https://example.com/openapi.json',
     })
 
     // Should reset all stores

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -62,7 +62,8 @@ onMounted(() => config.value.onLoaded?.())
   <SectionContainer>
     <!-- If the #after slot is used, we need to add a gap to the section. -->
     <Section class="introduction-section gap-12">
-      <SectionContent :loading="!info?.description && !info?.title">
+      <SectionContent
+        :loading="config.isLoading ?? (!info?.description && !info?.title)">
         <div class="flex gap-1">
           <Badge v-if="version">{{ version }}</Badge>
           <Badge v-if="oasVersion">OAS {{ oasVersion }}</Badge>

--- a/packages/api-reference/src/components/Content/Tag/Tag.vue
+++ b/packages/api-reference/src/components/Content/Tag/Tag.vue
@@ -14,6 +14,7 @@ import {
   SectionHeader,
   SectionHeaderTag,
 } from '@/components/Section'
+import { useConfig } from '@/hooks/useConfig'
 import { useNavState } from '@/hooks/useNavState'
 
 import OperationsList from './OperationsList.vue'
@@ -27,6 +28,7 @@ const props = defineProps<{
 }>()
 
 const { getTagId } = useNavState()
+const config = useConfig()
 
 const title = computed(() => props.tag['x-displayName'] ?? props.tag.name)
 </script>
@@ -35,7 +37,7 @@ const title = computed(() => props.tag['x-displayName'] ?? props.tag.name)
     :id="id"
     :label="tag.name.toUpperCase()"
     role="none">
-    <SectionHeader>
+    <SectionHeader v-show="!config.isLoading">
       <Anchor :id="getTagId(tag)">
         <SectionHeaderTag
           :id="headerId"
@@ -45,7 +47,7 @@ const title = computed(() => props.tag['x-displayName'] ?? props.tag.name)
         </SectionHeaderTag>
       </Anchor>
     </SectionHeader>
-    <SectionContent>
+    <SectionContent :loading="config.isLoading">
       <SectionColumns>
         <SectionColumn>
           <ScalarMarkdown

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -23,6 +23,7 @@ import {
 import { ExampleRequest } from '@/features/ExampleRequest'
 import { ExampleResponses } from '@/features/ExampleResponses'
 import { TestRequestButton } from '@/features/TestRequestButton'
+import { useConfig } from '@/hooks/useConfig'
 import {
   getOperationStability,
   getOperationStabilityColor,
@@ -47,6 +48,7 @@ const { operation } = defineProps<{
 }>()
 
 const labelId = useId()
+const config = useConfig()
 
 /** The title of the operation (summary or path) */
 const title = computed(() => operation.summary || operation.path)
@@ -58,7 +60,7 @@ const title = computed(() => operation.summary || operation.path)
     :aria-labelledby="labelId"
     :label="title"
     tabindex="-1">
-    <SectionContent>
+    <SectionContent :loading="config.isLoading">
       <Badge
         v-if="getOperationStability(operation)"
         :class="getOperationStabilityColor(operation)">

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,16 @@
       "import": "./dist/libs/html-rendering/index.js",
       "types": "./dist/libs/html-rendering/index.d.ts",
       "default": "./dist/libs/html-rendering/index.js"
+    },
+    "./css/*.css": {
+      "import": "./dist/css/*.css",
+      "require": "./dist/css/*.css",
+      "default": "./dist/css/*.css"
+    },
+    "./*.css": {
+      "import": "./dist/*.css",
+      "require": "./dist/*.css",
+      "default": "./dist/*.css"
     }
   },
   "files": [

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -214,7 +214,7 @@ export type ApiClientConfiguration = z.infer<typeof apiClientConfigurationSchema
 const OLD_PROXY_URL = 'https://api.scalar.com/request-proxy'
 const NEW_PROXY_URL = 'https://proxy.scalar.com'
 
-/** Configuration for the Api Reference without the transform since it cannot be merged */
+/** Configuration for the Api Client without the transform since it cannot be merged */
 const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
   z.object({
     /**
@@ -232,6 +232,11 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
      * @default false
      */
     isEditable: z.boolean().optional().default(false).catch(false),
+    /**
+     * Controls whether the references show a loading state in the intro
+     * @default false
+     */
+    isLoading: z.boolean().optional().default(false).catch(false),
     /**
      * Whether to show models in the sidebar, search, and content.
      * @default false


### PR DESCRIPTION
**Problem**

Currently, if you change the servers in the reference config, it will not get updated as it is not active.

**Solution**

With this PR we don't make it reactive, but instead do a quick fix of just re-creating the store whenever anything changes. This is much slower, but should be ok for now. If we run into performance issues we can bump up priority of using sync for the config.

Also exposed the `isLoading` prop to control loading of references
![image](https://github.com/user-attachments/assets/ae2b7d6c-e118-47f0-9c2a-ddd64e10d1ae)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
