### PR TITLE
fix(components): use nearest for combobox scrollIntoView

### DIFF
--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -68,7 +68,7 @@ onMounted(async () => {
     setTimeout(() => {
       document
         ?.getElementById(getOptionId(selected.value[0]))
-        ?.scrollIntoView({ block: 'center' })
+        ?.scrollIntoView({ block: 'nearest' })
     }, 10)
   }
 })


### PR DESCRIPTION
Should prevent an issue with combobox options scrolling the entire page.

Video of problem:

https://github.com/user-attachments/assets/e91cc829-5af4-466d-87c8-0f325eb32b89

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
