### PR TITLE
chore(api-reference): remove spec prefix

### DIFF
--- a/.changeset/nice-pugs-eat.md
+++ b/.changeset/nice-pugs-eat.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+'@scalar/core': patch
+---
+
+chore: remove spec prefix

--- a/examples/web/src/pages/EmbeddedApiReferencePage.vue
+++ b/examples/web/src/pages/EmbeddedApiReferencePage.vue
@@ -10,7 +10,7 @@ const configuration = reactive(
   apiReferenceConfigurationSchema.parse({
     proxyUrl: import.meta.env.VITE_REQUEST_PROXY_URL,
     isEditable: false,
-    spec: { content },
+    content,
   }),
 )
 </script>

--- a/packages/api-reference/playground/vue/src/App.vue
+++ b/packages/api-reference/playground/vue/src/App.vue
@@ -13,14 +13,12 @@ const containerRef = ref<HTMLDivElement>()
 const configuration = reactive({
   layout: 'modern' as const,
   theme: 'default' as const,
-  spec: {
-    sources: [
-      {
-        title: 'Scalar Galaxy',
-        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-      },
-    ],
-  },
+  sources: [
+    {
+      title: 'Scalar Galaxy',
+      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+    },
+  ],
   showSidebar: true,
   withDefaultFonts: true,
 })

--- a/packages/api-reference/playground/vue/src/components/DebugBar.vue
+++ b/packages/api-reference/playground/vue/src/components/DebugBar.vue
@@ -143,31 +143,22 @@ const themes = [
             :key="source.url"
             class="flex items-center gap-2">
             <input
-              :checked="
-                modelValue.spec?.sources?.some((s) => s.url === source.url)
-              "
+              :checked="modelValue.sources?.some((s) => s.url === source.url)"
               class="rounded border-stone-700 bg-stone-800"
               type="checkbox"
               @change="
                 $emit('update:modelValue', {
                   ...modelValue,
-                  spec: {
-                    ...modelValue.spec,
-                    sources: modelValue.spec?.sources?.some(
-                      (s) => s.url === source.url,
-                    )
-                      ? modelValue.spec.sources.filter(
-                          (s) => s.url !== source.url,
-                        ).length > 0
-                        ? modelValue.spec.sources.filter(
-                            (s) => s.url !== source.url,
-                          )
-                        : []
-                      : [
-                          ...(modelValue.spec?.sources || []),
-                          { title: source.title, url: source.url },
-                        ],
-                  },
+
+                  sources: modelValue.sources?.some((s) => s.url === source.url)
+                    ? modelValue.sources.filter((s) => s.url !== source.url)
+                        .length > 0
+                      ? modelValue.sources.filter((s) => s.url !== source.url)
+                      : []
+                    : [
+                        ...(modelValue.sources || []),
+                        { title: source.title, url: source.url },
+                      ],
                 })
               " />
             <span>{{ source.title }}</span>

--- a/packages/api-reference/src/hooks/useConfig.test.ts
+++ b/packages/api-reference/src/hooks/useConfig.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ref, computed, inject } from 'vue'
-import { useConfig, CONFIGURATION_SYMBOL } from './useConfig'
 import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, inject, ref } from 'vue'
+import { CONFIGURATION_SYMBOL, useConfig } from './useConfig'
 
 // Mock Vue's inject function
 vi.mock('vue', async () => {
@@ -28,7 +28,7 @@ describe('useConfig', () => {
   it('returns the injected config', () => {
     // Create a mock config
     const mockConfig = apiReferenceConfigurationSchema.parse({
-      spec: { url: 'https://example.com/openapi.json' },
+      url: 'https://example.com/openapi.json',
       theme: 'default',
     })
 
@@ -43,7 +43,7 @@ describe('useConfig', () => {
     // Create a reactive source of truth
     const configSource = ref(
       apiReferenceConfigurationSchema.parse({
-        spec: { url: 'https://example.com/openapi.json' },
+        url: 'https://example.com/openapi.json',
         theme: 'default',
       }),
     )
@@ -82,7 +82,7 @@ describe('useConfig', () => {
       // Initial config
       const configSource = ref(
         apiReferenceConfigurationSchema.parse({
-          spec: { url: 'https://example.com/openapi.json' },
+          url: 'https://example.com/openapi.json',
           theme: 'default',
         }),
       )

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -1,8 +1,8 @@
 import type { ReferenceProps } from '@/types'
 import {
   type ApiReferenceConfiguration,
-  apiReferenceConfigurationSchema,
   type MultiReferenceConfiguration,
+  apiReferenceConfigurationSchema,
 } from '@scalar/types/api-reference'
 import { createHead } from '@unhead/vue'
 import { type App, createApp, h, reactive } from 'vue'
@@ -188,11 +188,11 @@ export type CreateApiReference = {
 }
 
 /**
- * Create and mount a new Scalar API Reference
+ * Create (and mount) a new Scalar API Reference
  *
- * @example createApiReference({ spec: { url: '/scalar.json' } })
- * @example createApiReference('#api-reference', { spec: { url: '/scalar.json' } })
- * @example createApiReference(document.body, { spec: { url: '/scalar.json' } })
+ * @example createApiReference({ url: '/scalar.json' }).mount('#app')
+ * @example createApiReference('#app', { url: '/scalar.json' })
+ * @example createApiReference(document.getElementById('app'), { url: '/scalar.json' })
  *
  */
 export const createApiReference: CreateApiReference = (

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,9 +20,7 @@ npm install @scalar/core
 import { getHtmlDocument } from '@scalar/core/lib/html-rendering'
 
 const html = getHtmlDocument({
-  spec: {
-    url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-  },
+  url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
 })
 ```
 

--- a/packages/types/src/api-reference/api-reference-configuration.test.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.test.ts
@@ -12,10 +12,8 @@ describe('api-reference-configuration', () => {
       const completeConfig = {
         theme: 'default',
         layout: 'modern',
-        spec: {
-          url: 'https://example.com/openapi.json',
-          content: '{"openapi": "3.1.0"}',
-        },
+        url: 'https://example.com/openapi.json',
+        content: '{"openapi": "3.1.0"}',
         proxyUrl: 'https://proxy.example.com',
         isEditable: true,
         showSidebar: true,


### PR DESCRIPTION
**Problem**

Currently, there were still a few places that had the `spec` prefix.

**Solution**

With this PR, the `spec` prefix is only in some tests that we keep to ensure the backwards compatibility.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
