### PR TITLE
fix(snippetz): shell/curl with multipart/form-data JSON body doesn’t pretty print

### DIFF
--- a/.changeset/slow-cups-pull.md
+++ b/.changeset/slow-cups-pull.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+fix: multipart/form-data with JSON doesn’t pretty print

--- a/packages/snippetz/src/plugins/shell/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.test.ts
@@ -229,6 +229,32 @@ describe('shellCurl', () => {
   --form 'field=value'`)
   })
 
+  it('handles multipart form data with JSON payload', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com',
+      method: 'POST',
+      headers: [
+        {
+          name: 'Content-Type',
+          value: 'multipart/form-data',
+        },
+      ],
+      postData: {
+        mimeType: 'multipart/form-data',
+        text: JSON.stringify({
+          foo: 'bar',
+        }),
+      },
+    })
+
+    expect(result).toBe(`curl https://example.com \\
+  --request POST \\
+  --header 'Content-Type: multipart/form-data' \\
+  --data '{
+  "foo": "bar"
+}'`)
+  })
+
   it('handles url-encoded form data with special characters', () => {
     const result = shellCurl.generate({
       url: 'https://example.com',

--- a/packages/snippetz/src/plugins/shell/curl/curl.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.ts
@@ -78,9 +78,14 @@ export const shellCurl: Plugin = {
       if (normalizedRequest.postData.mimeType === 'application/json') {
         // Pretty print JSON data
         if (normalizedRequest.postData.text) {
-          const jsonData = JSON.parse(normalizedRequest.postData.text)
-          const prettyJson = JSON.stringify(jsonData, null, 2)
-          parts.push(`--data '${prettyJson}'`)
+          try {
+            const jsonData = JSON.parse(normalizedRequest.postData.text)
+            const prettyJson = JSON.stringify(jsonData, null, 2)
+            parts.push(`--data '${prettyJson}'`)
+          } catch {
+            // If JSON parsing fails, use the original text
+            parts.push(`--data '${normalizedRequest.postData.text}'`)
+          }
         }
       } else if (normalizedRequest.postData.mimeType === 'application/octet-stream') {
         parts.push(`--data-binary '${normalizedRequest.postData.text}'`)
@@ -102,7 +107,14 @@ export const shellCurl: Plugin = {
           }
         })
       } else {
-        parts.push(`--data "${normalizedRequest.postData.text}"`)
+        // Try to parse and pretty print if it's JSON, otherwise use raw text
+        try {
+          const jsonData = JSON.parse(normalizedRequest.postData.text ?? '')
+          const prettyJson = JSON.stringify(jsonData, null, 2)
+          parts.push(`--data '${prettyJson}'`)
+        } catch {
+          parts.push(`--data '${normalizedRequest.postData.text}'`)
+        }
       }
     }
 


### PR DESCRIPTION
**Problem**

See #5177

**Solution**

With this PR we’re pretty printing JSON bodies, even for multipart/form-data, because why not?

Fixes #5177

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
