### PR TITLE
fix(openapi-parser): Swagger 2.0 `basePath` is ignored when there’s no `host`

### DIFF
--- a/.changeset/swift-mirrors-battle.md
+++ b/.changeset/swift-mirrors-battle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: swagger 2.0 basePath is ignored, if there’s no host

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.test.ts
@@ -36,6 +36,23 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.host).toBeUndefined()
   })
 
+  it('upgrades basePath to new server syntax', async () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      basePath: '/v2',
+    })
+
+    expect(result.servers).toStrictEqual([
+      {
+        url: '/v2',
+      },
+    ])
+
+    expect(result.basePath).toBeUndefined()
+    expect(result.schemes).toBeUndefined()
+    expect(result.host).toBeUndefined()
+  })
+
   it('upgrades host to new server syntax', async () => {
     const result = upgradeFromTwoToThree({
       swagger: '2.0',

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -32,6 +32,9 @@ export function upgradeFromTwoToThree(originalSpecification: UnknownObject) {
     delete specification.basePath
     delete specification.schemes
     delete specification.host
+  } else if (specification.basePath) {
+    specification.servers = [{ url: specification.basePath }]
+    delete specification.basePath
   }
 
   // Schemas


### PR DESCRIPTION
**Problem**

Currently, we just ditch the `basePath` of a Swagger 2.0 document when there’s no `host`. That’s so wrong.

**Solution**

We’re keeping the lovely `basePath` with this PR here, isn’t it wonderful?

Fixes #5126 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
