### PR TITLE
fix(api-client): don’t send authorization header for public client

### DIFF
--- a/.changeset/proud-boats-swim.md
+++ b/.changeset/proud-boats-swim.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix: ensure we only send the authorization header when we have a secret

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -260,7 +260,9 @@ export const authorizeServers = async (
     }
 
     // Add client id + secret to headers
-    headers.Authorization = `Basic ${btoa(`${flow['x-scalar-client-id']}:${flow.clientSecret}`)}`
+    if (flow.clientSecret) {
+      headers.Authorization = `Basic ${btoa(`${flow['x-scalar-client-id']}:${flow.clientSecret}`)}`
+    }
 
     // Check if we should use the proxy
     const url = shouldUseProxy(proxyUrl, flow.tokenUrl)


### PR DESCRIPTION
AWS Cognito will return 400 when authorization header is provided.

**Problem**

When using scalar with AWS Cognito for public oauth2 client, we got 400 when exchanging the code.

**Solution**

With this PR, it won't send the Authorization header when it is a public client.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
