### PR TITLE
feat(api-reference): add callback `onDocumentSelect`

### DIFF
--- a/.changeset/tall-parents-care.md
+++ b/.changeset/tall-parents-care.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: add onConfigSelect callback when switching multi configs

--- a/.changeset/tall-parents-care.md
+++ b/.changeset/tall-parents-care.md
@@ -3,4 +3,4 @@
 '@scalar/types': patch
 ---
 
-feat: add onConfigSelect callback when switching multi configs
+feat: add onDocumentSelect callback when switching multi configs

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -416,6 +416,11 @@ But you can also pass `true` to **hide all** HTTP clients. If you have any custo
 }
 ```
 
+## onDocumentSelect?: () => void
+
+Triggered when multiple documents are configured and the users switches between them.
+
+
 ### onSpecUpdate?: (spec: string) => void
 
 You can listen to changes with onSpecUpdate that runs on spec/swagger content change

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -185,8 +185,8 @@ export const useMultipleDocuments = ({
         window.scrollTo({ top: 0, behavior: 'instant' })
       }
 
-      // Fire the onConfigSelect event
-      selectedConfiguration.value.onConfigSelect?.()
+      // Fire the onDocumentSelect event
+      selectedConfiguration.value.onDocumentSelect?.()
     },
     { flush: 'sync' },
   )

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -90,45 +90,6 @@ export const useMultipleDocuments = ({
   })
 
   /**
-   * Updates the URL with the selected API definition
-   * We only want to update the URL if we have more than one document
-   */
-  const updateUrlParameter = (value: number) => {
-    // Skip URL updates during SSR
-    if (typeof window === 'undefined') {
-      return
-    }
-
-    // If there is only one document, don't add the query parameter.
-    if (availableDocuments.value.length === 1) {
-      return
-    }
-
-    const url = new URL(window.location.href)
-    const selectedDefinition = availableDocuments.value[value]
-
-    // Use slug if available, then fallback to index
-    const parameterValue = selectedDefinition?.slug ?? value.toString()
-
-    // Switch document
-    url.searchParams.set(QUERY_PARAMETER, parameterValue)
-
-    // Reset location on the page
-    url.hash = ''
-    window.history.replaceState({}, '', url.toString())
-
-    // Reset all global state
-    hash.value = ''
-    hashPrefix.value = ''
-    isIntersectionEnabled.value = false
-
-    // Scroll to the top of the page
-    if (typeof window !== 'undefined') {
-      window.scrollTo({ top: 0, behavior: 'instant' })
-    }
-  }
-
-  /**
    * Determines the initially selected API definition from the URL
    */
   const getInitialSelection = (): number => {
@@ -187,8 +148,48 @@ export const useMultipleDocuments = ({
     })
   })
 
-  // Update URL when selection changes
-  watch(selectedDocumentIndex, updateUrlParameter, { flush: 'sync' })
+  // Update URL when selection changes, also clear global state
+  watch(
+    selectedDocumentIndex,
+    (value: number) => {
+      // Skip URL updates during SSR
+      if (typeof window === 'undefined') {
+        return
+      }
+
+      // If there is only one document, don't add the query parameter.
+      if (availableDocuments.value.length === 1) {
+        return
+      }
+
+      const url = new URL(window.location.href)
+      const selectedDefinition = availableDocuments.value[value]
+
+      // Use slug if available, then fallback to index
+      const parameterValue = selectedDefinition?.slug ?? value.toString()
+
+      // Switch document
+      url.searchParams.set(QUERY_PARAMETER, parameterValue)
+
+      // Reset location on the page
+      url.hash = ''
+      window.history.replaceState({}, '', url.toString())
+
+      // Reset all global state
+      hash.value = ''
+      hashPrefix.value = ''
+      isIntersectionEnabled.value = false
+
+      // Scroll to the top of the page
+      if (typeof window !== 'undefined') {
+        window.scrollTo({ top: 0, behavior: 'instant' })
+      }
+
+      // Fire the onConfigSelect event
+      selectedConfiguration.value.onConfigSelect?.()
+    },
+    { flush: 'sync' },
+  )
 
   return {
     selectedConfiguration,

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -297,8 +297,8 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
     onSpecUpdate: z.function().args(z.string()).returns(z.void()).optional(),
     /** onServerChange is fired on selected server change */
     onServerChange: z.function().args(z.string()).returns(z.void()).optional(),
-    /** onConfigSelect is fired when the config is selected */
-    onConfigSelect: z.function().returns(z.void()).optional(),
+    /** onDocumentSelect is fired when the config is selected */
+    onDocumentSelect: z.function().returns(z.void()).optional(),
     /**
      * Route using paths instead of hashes, your server MUST support this
      * @example '/standalone-api-reference/:custom(.*)?'

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -297,6 +297,8 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
     onSpecUpdate: z.function().args(z.string()).returns(z.void()).optional(),
     /** onServerChange is fired on selected server change */
     onServerChange: z.function().args(z.string()).returns(z.void()).optional(),
+    /** onConfigSelect is fired when the config is selected */
+    onConfigSelect: z.function().returns(z.void()).optional(),
     /**
      * Route using paths instead of hashes, your server MUST support this
      * @example '/standalone-api-reference/:custom(.*)?'


### PR DESCRIPTION
**Solution**

With this PR we add a callback which gets triggered when you select a version

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
