### PR TITLE
feat(api-reference): "Freeze" elements on page when switching clients

### DIFF
--- a/.changeset/cool-points-love.md
+++ b/.changeset/cool-points-love.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: freeze element in window when switching clients

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -11,11 +11,19 @@ import type {
 import type { ClientId, TargetId } from '@scalar/snippetz'
 import type { TransformedOperation } from '@scalar/types/legacy'
 import { useExampleStore } from '#legacy'
-import { computed, ref, useId, watch } from 'vue'
+import {
+  computed,
+  ref,
+  useId,
+  VueElement,
+  watch,
+  type ComponentPublicInstance,
+} from 'vue'
 
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/Card'
 import { HttpMethod } from '@/components/HttpMethod'
 import ScreenReader from '@/components/ScreenReader.vue'
+import { freezeElement } from '@/helpers/freeze-element'
 import { useConfig } from '@/hooks/useConfig'
 import { useHttpClientStore, type HttpClientState } from '@/stores'
 
@@ -223,9 +231,19 @@ const options = computed<TextSelectOptions>(() => {
   return entries
 })
 
+const elem = ref<ComponentPublicInstance | null>(null)
+
 /** Set custom example, or update the selected HTTP client globally */
 function updateHttpClient(value: string) {
   const data = JSON.parse(value)
+
+  // We need to freeze the ui to prevent scrolling as the clients change
+  if (elem.value) {
+    const unfreeze = freezeElement(elem.value.$el)
+    setTimeout(() => {
+      unfreeze()
+    }, 300)
+  }
 
   if (data.targetKey === 'customExamples') {
     localHttpClient.value = data
@@ -239,6 +257,7 @@ function updateHttpClient(value: string) {
     v-if="availableTargets.length || customRequestExamples.length"
     :aria-labelledby="`${id}-header`"
     class="dark-mode"
+    ref="elem"
     role="region">
     <CardHeader muted>
       <div

--- a/packages/api-reference/src/helpers/freeze-element.test.ts
+++ b/packages/api-reference/src/helpers/freeze-element.test.ts
@@ -1,0 +1,106 @@
+import { flushPromises } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { freezeElement } from './freeze-element'
+
+describe('freezeElement', () => {
+  let element: HTMLDivElement
+
+  beforeEach(() => {
+    // Setup test DOM element
+    element = document.createElement('div')
+    document.body.appendChild(element)
+    vi.useFakeTimers()
+
+    // Mock window.scrollBy more robustly
+    Object.defineProperty(window, 'scrollBy', {
+      value: vi.fn(),
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('returns a cleanup function', () => {
+    const unfreeze = freezeElement(element)
+    expect(typeof unfreeze).toBe('function')
+  })
+
+  it('returns a no-op function when element is null', () => {
+    const unfreeze = freezeElement(null as unknown as HTMLElement)
+    expect(unfreeze()).toBeNull()
+  })
+
+  it('maintains element position when content changes', async () => {
+    // Mock initial position
+    const initialRect = { top: 100 } as DOMRect
+    const movedRect = { top: 200 } as DOMRect
+
+    let rectCallCount = 0
+    element.getBoundingClientRect = vi.fn(() => {
+      rectCallCount++
+      return rectCallCount === 1 ? initialRect : movedRect
+    })
+
+    const unfreeze = freezeElement(element)
+
+    // Simulate content change that would move the element
+    const newElement = document.createElement('div')
+    newElement.style.height = '100px'
+    document.body.insertBefore(newElement, element)
+
+    // Let MutationObserver process the change
+    await flushPromises()
+
+    // Verify window.scrollBy was called to adjust position
+    expect(window.scrollBy).toHaveBeenCalledWith(0, 100)
+
+    unfreeze()
+  })
+
+  it('stops maintaining position after unfreeze is called', () => {
+    const unfreeze = freezeElement(element)
+
+    // Important: Call unfreeze before making changes
+    unfreeze()
+
+    // Clear any previous calls to scrollBy
+    vi.mocked(window.scrollBy).mockClear()
+
+    // Simulate content change
+    const newElement = document.createElement('div')
+    document.body.insertBefore(newElement, element)
+
+    // Let MutationObserver process the change
+    vi.runAllTimers()
+
+    // Verify window.scrollBy was not called after unfreezing
+    expect(window.scrollBy).not.toHaveBeenCalled()
+  })
+
+  it('adjusts scroll by the correct amount', async () => {
+    // Mock getBoundingClientRect to simulate element movement
+    const initialRect = { top: 100 } as DOMRect
+    const movedRect = { top: 200 } as DOMRect
+
+    let rectCallCount = 0
+    element.getBoundingClientRect = vi.fn(() => {
+      rectCallCount++
+      return rectCallCount === 1 ? initialRect : movedRect
+    })
+
+    freezeElement(element)
+
+    // Simulate content change
+    const newElement = document.createElement('div')
+    document.body.insertBefore(newElement, element)
+
+    await flushPromises()
+
+    // Should scroll by the difference (200 - 100 = 100)
+    expect(window.scrollBy).toHaveBeenCalledWith(0, 100)
+  })
+})

--- a/packages/api-reference/src/helpers/freeze-element.ts
+++ b/packages/api-reference/src/helpers/freeze-element.ts
@@ -1,0 +1,43 @@
+/**
+ * Scroll Freezing Utility
+ * "Freezes" the scroll position of an element, so that it doesn't move when the rest of the content changes
+ *
+ * @example
+ * const unfreeze = freezeElement(document.querySelector('#your-element'))
+ * ... content changes ...
+ * unfreeze()
+ */
+export const freezeElement = (element: HTMLElement) => {
+  if (!element) {
+    return () => null
+  }
+
+  // Get initial position relative to viewport
+  const rect = element.getBoundingClientRect()
+  const initialViewportTop = rect.top
+
+  // Create mutation observer to watch for DOM changes
+  const observer = new MutationObserver(() => {
+    const newRect = element.getBoundingClientRect()
+    const currentViewportTop = newRect.top
+
+    // If element has moved from its initial viewport position
+    if (currentViewportTop !== initialViewportTop) {
+      // Calculate how far it moved
+      const diff = currentViewportTop - initialViewportTop
+      // Adjust scroll to maintain position
+      window.scrollBy(0, diff)
+    }
+  })
+
+  // Start observing
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    characterData: true,
+  })
+
+  // Return function to stop maintaining position
+  return () => observer.disconnect()
+}


### PR DESCRIPTION
**Problem**

Currently, when you change clients, all of snippets change size and the content shifts

closes #5196

**Solution**

With this PR we "Freeze" the current element such that it doesn't move when you switch clients.

We can use this tech to improve lazy loading as well!

TO test:
- change clients and the content should not move!

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
