### PR TITLE
fix(api-reference): remove bad timeout code and replace with mutation observer

### DIFF
--- a/.changeset/three-doors-breathe.md
+++ b/.changeset/three-doors-breathe.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: remove bad timeout code and replace with mutation observer

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Spec } from '@scalar/types/legacy'
-import { onMounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { sleep } from '../../helpers'
 import { useNavState, useSidebar, type SorterOption } from '../../hooks'
@@ -65,10 +65,33 @@ const scrollSidebar = (id: string) => {
   scrollerEl.value.scrollTo({ top, behavior: 'smooth' })
 }
 
-// TODO timeout is due to sidebar section opening time
+/** Adds an observer to watch for elements */
+const observeSidebarElement = (id: string) => {
+  const observer = new MutationObserver((mutations, obs) => {
+    const el = document.getElementById(`sidebar-${id}`)
+    if (el) {
+      scrollSidebar(id)
+      disableScroll.value = false
+      obs.disconnect() // Stop observing once we find the element
+    }
+  })
+
+  // Start observing the document with the configured parameters
+  observer.observe(scrollerEl.value, {
+    childList: true,
+    subtree: true,
+  })
+
+  return observer
+}
+
 onMounted(() => {
-  setTimeout(() => scrollSidebar(hash.value), 500)
-  disableScroll.value = false
+  const observer = observeSidebarElement(hash.value)
+
+  // Cleanup the observer when component is unmounted
+  onUnmounted(() => {
+    observer.disconnect()
+  })
 })
 </script>
 <template>

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -67,6 +67,10 @@ const scrollSidebar = (id: string) => {
 
 /** Adds an observer to watch for elements */
 const observeSidebarElement = (id: string) => {
+  if (!scrollerEl.value) {
+    return
+  }
+
   const observer = new MutationObserver((mutations, obs) => {
     const el = document.getElementById(`sidebar-${id}`)
     if (el) {

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -94,7 +94,7 @@ onMounted(() => {
 
   // Cleanup the observer when component is unmounted
   onUnmounted(() => {
-    observer.disconnect()
+    observer?.disconnect()
   })
 })
 </script>


### PR DESCRIPTION
**Problem**

Currently, we had some hacky old timeout code which broke tests randomly but frequently enough to be annoying.

closes #5088

**Solution**

With this PR we get rid of it and hopefully it wont break any more tests

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
