### PR TITLE
fix(express): @types/express@5 TypeScript error

### DIFF
--- a/.changeset/green-panthers-change.md
+++ b/.changeset/green-panthers-change.md
@@ -1,0 +1,5 @@
+---
+'@scalar/express-api-reference': patch
+---
+
+fix(express): restore express middleware return value type

--- a/integrations/express/src/apiReference.ts
+++ b/integrations/express/src/apiReference.ts
@@ -120,5 +120,7 @@ export function apiReference(givenConfiguration: Partial<ApiReferenceConfigurati
   }
 
   // Respond with the HTML document
-  return (_: Request, res: Response) => res.type('text/html').send(getHtmlDocument(configuration, customTheme))
+  return (_: Request, res: Response) => {
+    res.type('text/html').send(getHtmlDocument(configuration, customTheme))
+  }
 }


### PR DESCRIPTION
fixes https://github.com/scalar/scalar/issues/5199.

Commit 89d8b7504759c5bb3eae687c49b3363e8890828b as part of [1], incorrectly changed the return value type for express middleware function returned by apiReference(). Removing braces from the arrow function implementation turned its body type from "block" to "expression". In an expression body, only a single expression is specified, which becomes the implicit return value.

This commit reverts that change to restore the original return type which was consistent with express's guidelines.

Although the above change did not impact runtime execution of the middleware (express does not care about the return value type at all), it did trigger a build error on Typescript projects using @types/express 5.x for type validation.

[1] https://github.com/scalar/scalar/pull/4795

**Problem**

Currently, …

**Solution**

With this PR …

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
