### PR TITLE
fix(scalar-app): toDesktop can’t install pnpm catalog dependencies

### DIFF
--- a/.changeset/tricky-pots-cry.md
+++ b/.changeset/tricky-pots-cry.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: ignore pnpm catalog dependencies

--- a/projects/scalar-app/todesktop.json
+++ b/projects/scalar-app/todesktop.json
@@ -19,6 +19,12 @@
       "@scalar/themes": null,
       "@scalar/components": null,
       "@scalar/import": null
+    },
+    "devDependencies": {
+      "@types/node": null,
+      "@vitejs/plugin-vue": null,
+      "vite": null,
+      "vue": null
     }
   }
 }


### PR DESCRIPTION
**Problem**

We moved a few dependencies to the pnpm workspace catalog, and while we use pnpm@10 in the toDesktop cloud, we don’t push the whole monorepository there, but only the scalar-app/ folder. This breaks the build.

**Solution**

With this PR we’re ignoring the pnpm catalog dependencies in the toDesktop build cloud.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
