### PR TITLE
fix(api-client): layout modal

### DIFF
--- a/.changeset/olive-pens-dance.md
+++ b/.changeset/olive-pens-dance.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: adds missing api client layout layout value

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
@@ -72,4 +72,5 @@ export const createApiClientModalSync = ({
     mountOnInitialize,
     store,
     router: createModalRouter(),
+    layout: 'modal',
   })

--- a/packages/api-client/src/layouts/Modal/index.ts
+++ b/packages/api-client/src/layouts/Modal/index.ts
@@ -1,2 +1,2 @@
 export { default as ApiClientModal } from './ApiClientModal.vue'
-export * from './create-api-client-modal'
+export { createApiClientModal, createApiClientModalSync } from './create-api-client-modal'


### PR DESCRIPTION
**Problem**

Currently the create api client modal function usage is not retrieving the layout value, resulting in desktop action accessible from the modal.

**Solution**

this pr adds the missing layout value in the create api client function.

| before | after |
| -------|------|
| <img width="1386" alt="image" src="https://github.com/user-attachments/assets/1021a157-57ef-4cd9-9f8c-bc57e14cecae" /> | <img width="1386" alt="image" src="https://github.com/user-attachments/assets/e6568f75-8926-4871-a0df-d53a434e61d6" /> |
| desktop action are available in the modal (add item, shortcut, etc) | desktop actions are not available in the modal | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
