### PR TITLE
fix(api-reference): integration links on the getting started component

### DIFF
--- a/.changeset/purple-pears-eat.md
+++ b/.changeset/purple-pears-eat.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: integration links on getting started component

--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -74,7 +74,7 @@ async function fetchExampleSpecification() {
         <div class="start-h2">INTEGRATIONS</div>
         <a
           class="start-item"
-          href="https://github.com/scalar/scalar/tree/main/packages/fastify-api-reference#readme"
+          href="https://github.com/scalar/scalar/tree/main/integrations/fastify#readme"
           target="_blank">
           <svg
             fill="currentColor"
@@ -91,7 +91,7 @@ async function fetchExampleSpecification() {
         </a>
         <a
           class="start-item"
-          href="https://github.com/scalar/scalar/tree/main#from-a-cdn"
+          href="https://github.com/scalar/scalar/blob/main/documentation/integrations/html-js.md#html"
           target="_blank">
           <svg
             fill="currentColor"
@@ -113,7 +113,7 @@ async function fetchExampleSpecification() {
         </a>
         <a
           class="start-item"
-          href="https://github.com/scalar/scalar/tree/main#with-vuejs"
+          href="https://github.com/scalar/scalar/blob/main/packages/api-reference/README.md#vuejs"
           target="_blank">
           <svg
             height="170"
@@ -133,7 +133,7 @@ async function fetchExampleSpecification() {
         </a>
         <a
           class="start-item"
-          href="https://github.com/scalar/scalar/tree/main#with-react"
+          href="https://github.com/scalar/scalar/blob/main/packages/api-reference-react/README.md#usage"
           target="_blank">
           <svg
             height="23.3"

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,5 +1,5 @@
-import { findEntryPoints } from '@scalar/build-tooling'
 import { URL, fileURLToPath } from 'node:url'
+import { findEntryPoints } from '@scalar/build-tooling'
 import { defineConfig } from 'vite'
 
 import pkg from './package.json'
@@ -20,7 +20,7 @@ export default defineConfig({
     minify: false,
     target: 'esnext',
     lib: {
-      entry: await findEntryPoints({ allowCss: true }),
+      entry: await findEntryPoints({ allowCss: false }),
       formats: ['es'],
     },
     rollupOptions: {


### PR DESCRIPTION
**Problem**

Currently, the links on getting started point to the old locations

**Solution**

With this PR we update the links for all of the integrations.

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
