### PR TITLE
fix(nestjs): configuration requires too many attributes

### DIFF
--- a/.changeset/brown-owls-brush.md
+++ b/.changeset/brown-owls-brush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nestjs-api-reference': patch
+---
+
+fix: configuration has too many required attributes

--- a/integrations/nestjs/src/nestJSApiReference.ts
+++ b/integrations/nestjs/src/nestJSApiReference.ts
@@ -3,12 +3,12 @@ import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import type { Request, Response } from 'express'
 import type { FastifyRequest } from 'fastify'
 
-export type NestJSReferenceConfiguration = ApiReferenceConfiguration & {
+export type NestJSReferenceConfiguration = Partial<ApiReferenceConfiguration> & {
   withFastify?: boolean
   cdn?: string
 }
 
-export type ApiReferenceOptions = ApiReferenceConfiguration & {
+export type ApiReferenceOptions = Partial<ApiReferenceConfiguration> & {
   cdn?: string
 }
 


### PR DESCRIPTION
**Problem**

When using the NestJS integration, we expect too many attributes. We forgot to make the type Partial.

**Solution**

With this PR we add `Partial<>` and now you can freely pass any configuration while still having a nice auto-complete.

Fixes #5228

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
