### PR TITLE
feat(api-reference): copy example/examples  to clipboard

### DIFF
--- a/.changeset/quick-scissors-press.md
+++ b/.changeset/quick-scissors-press.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/galaxy': patch
+---
+
+feat(api-reference): add copy button to examples and redesign them

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -109,4 +109,8 @@ const models = computed(() => {
   margin-top: 32px;
   top: 0px;
 }
+/* increase z-index for hover of examples */
+.models-list-item:hover {
+  z-index: 10;
+}
 </style>

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -202,7 +202,6 @@ const handleClick = (e: MouseEvent) =>
   font-size: var(--scalar-font-size-4);
   color: var(--scalar-color-1);
 }
-
 .schema-card-title {
   height: var(--schema-title-height);
 

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -199,7 +199,6 @@ const handleClick = (e: MouseEvent) =>
 }
 .schema-card {
   z-index: 0;
-  position: relative;
   font-size: var(--scalar-font-size-4);
   color: var(--scalar-color-1);
 }

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -425,18 +425,18 @@ const displayPropertyHeading = (
   list-style: none;
 }
 
-.property--compact .property-example {
+.property-example {
   background: transparent;
   border: none;
   display: flex;
   flex-direction: row;
   gap: 8px;
 }
-.property--compact .property-example-label,
-.property--compact .property-example-value {
+.property-example-label,
+.property-example-value {
   padding: 3px 0 0 0;
 }
-.property--compact .property-example-value {
+.property-example-value {
   background: var(--scalar-background-2);
   border-top: 0;
   border-radius: var(--scalar-radius);

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -4,7 +4,6 @@ import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import { computed } from 'vue'
 
-import { formatExample } from '@/components/Content/Schema/helpers/formatExample'
 import {
   discriminators,
   optimizeValueForDisplay,
@@ -15,9 +14,9 @@ import SchemaDiscriminator from './SchemaDiscriminator.vue'
 import SchemaPropertyHeading from './SchemaPropertyHeading.vue'
 
 /**
- * Note: We’re taking in a prop called `value` which should be a JSON Schema.
+ * Note: We're taking in a prop called `value` which should be a JSON Schema.
  *
- * We’re using `optimizeValueForDisplay` to merge null types in discriminators (anyOf, allOf, oneOf, not).
+ * We're using `optimizeValueForDisplay` to merge null types in discriminators (anyOf, allOf, oneOf, not).
  * So you should basically use the optimizedValue everywhere in the component.
  */
 
@@ -106,7 +105,7 @@ const getEnumFromValue = (value?: Record<string, any>): any[] | [] =>
 //
 // - For enums with 9 or fewer values, all values are shown.
 // - For enums with more than 9 values, only first 5 are shown initially.
-// - A “Show more” button reveals the remaining values.
+// - A "Show more" button reveals the remaining values.
 const hasLongEnumList = computed(
   () => getEnumFromValue(optimizedValue.value).length > 9,
 )
@@ -209,46 +208,6 @@ const displayPropertyHeading = (
       <ScalarMarkdown
         :value="generatePropertyDescription(optimizedValue) || ''" />
     </div>
-    <!-- Example -->
-    <div
-      v-if="
-        withExamples &&
-        (optimizedValue?.example || optimizedValue?.items?.example)
-      "
-      class="property-example custom-scroll">
-      <span class="property-example-label">Example</span>
-      <code class="property-example-value">{{
-        formatExample(
-          optimizedValue?.example ||
-            (discriminatorType &&
-              optimizedValue?.items &&
-              typeof optimizedValue.items === 'object' &&
-              optimizedValue.items[discriminatorType]),
-        )
-      }}</code>
-    </div>
-    <template
-      v-if="
-        optimizedValue?.examples &&
-        typeof optimizedValue.examples === 'object' &&
-        Object.keys(optimizedValue.examples).length > 0
-      ">
-      <div class="property-example custom-scroll">
-        <span class="property-example-label">
-          {{
-            Object.keys(optimizedValue.examples).length === 1
-              ? 'Example'
-              : 'Examples'
-          }}
-        </span>
-        <code
-          v-for="(example, key) in optimizedValue.examples"
-          :key="key"
-          class="property-example-value">
-          {{ example }}
-        </code>
-      </div>
-    </template>
     <!-- Enum -->
     <div
       v-if="getEnumFromValue(optimizedValue)?.length > 0"
@@ -372,6 +331,12 @@ const displayPropertyHeading = (
   flex-direction: column;
   padding: 12px 8px;
   font-size: var(--scalar-mini);
+  position: relative;
+}
+
+/* increase z-index for example hovers */
+.property:hover {
+  z-index: 1;
 }
 
 .property--compact.property--level-0,
@@ -421,26 +386,6 @@ const displayPropertyHeading = (
   padding: 12px;
 }
 
-.property-example {
-  display: flex;
-  flex-direction: column;
-
-  margin-top: 6px;
-
-  max-height: calc(((var(--full-height) - var(--refs-header-height))) / 2);
-
-  font-size: var(--scalar-micro);
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
-  background: var(--scalar-background-2);
-  border-radius: var(--scalar-radius-lg);
-}
-
-.property-example-label {
-  font-weight: var(--scalar-semibold);
-  color: var(--scalar-color-3);
-
-  padding: 6px;
-}
 .property-example-value {
   all: unset;
   font-family: var(--scalar-font-code);

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -14,9 +14,9 @@ import SchemaDiscriminator from './SchemaDiscriminator.vue'
 import SchemaPropertyHeading from './SchemaPropertyHeading.vue'
 
 /**
- * Note: We're taking in a prop called `value` which should be a JSON Schema.
+ * Note: We’re taking in a prop called `value` which should be a JSON Schema.
  *
- * We're using `optimizeValueForDisplay` to merge null types in discriminators (anyOf, allOf, oneOf, not).
+ * We’re using `optimizeValueForDisplay` to merge null types in discriminators (anyOf, allOf, oneOf, not).
  * So you should basically use the optimizedValue everywhere in the component.
  */
 
@@ -105,7 +105,7 @@ const getEnumFromValue = (value?: Record<string, any>): any[] | [] =>
 //
 // - For enums with 9 or fewer values, all values are shown.
 // - For enums with more than 9 values, only first 5 are shown initially.
-// - A "Show more" button reveals the remaining values.
+// - A “Show more” button reveals the remaining values.
 const hasLongEnumList = computed(
   () => getEnumFromValue(optimizedValue.value).length > 9,
 )

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+import { ScalarIcon } from '@scalar/components'
+import { useClipboard } from '@scalar/use-hooks/useClipboard'
+
+import { formatExample } from '@/components/Content/Schema/helpers/formatExample'
+
+defineProps<{
+  examples?: Record<string, unknown>
+  example?: unknown
+  discriminatorType?: string
+}>()
+
+const { copyToClipboard } = useClipboard()
+</script>
+<template>
+  <!-- single example (deprecated) -->
+  <div
+    v-if="example"
+    class="property-example">
+    <button
+      type="button"
+      class="property-example-label">
+      <span>Example</span>
+    </button>
+    <div class="property-example-value-list">
+      <button
+        type="button"
+        class="property-example-value group"
+        @click="copyToClipboard(String(formatExample(example)))">
+        <span>
+          {{ formatExample(example) }}
+        </span>
+        <ScalarIcon
+          icon="Clipboard"
+          size="xs"
+          class="group-hover:text-c-1 text-c-3 ml-auto min-h-3 min-w-3" />
+      </button>
+    </div>
+  </div>
+
+  <!-- multiple examples -->
+  <template
+    v-if="
+      examples &&
+      typeof examples === 'object' &&
+      Object.keys(examples).length > 0
+    ">
+    <div class="property-example">
+      <button
+        type="button"
+        class="property-example-label">
+        <span>
+          {{ Object.keys(examples).length === 1 ? 'Example' : 'Examples' }}
+        </span>
+      </button>
+      <div class="property-example-value-list">
+        <button
+          type="button"
+          v-for="(example, key) in examples"
+          :key="key"
+          class="property-example-value group"
+          @click="copyToClipboard(String(formatExample(example)))">
+          <span>{{ formatExample(example) }} </span>
+          <ScalarIcon
+            icon="Clipboard"
+            size="xs"
+            class="text-c-3 group-hover:text-c-1 ml-auto min-h-3 min-w-3" />
+        </button>
+      </div>
+    </div>
+  </template>
+</template>
+
+<style scoped>
+.property-example {
+  display: flex;
+  flex-direction: column;
+  font-size: var(--scalar-micro);
+  position: relative;
+}
+.property-example:hover:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 20px;
+  border-radius: var(--scalar-radius);
+}
+.property-example:hover .property-example-label span {
+  color: var(--scalar-color-1);
+}
+.property-example-label span {
+  color: var(--scalar-color-3);
+  position: relative;
+  border-bottom: var(--scalar-border-width) dotted currentColor;
+}
+.property-example-value {
+  font-family: var(--scalar-font-code);
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 6px;
+}
+.property-example-value span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.property-example-value :deep(svg) {
+  color: var(--scalar-color-3);
+}
+
+.property-example-value:hover :deep(svg) {
+  color: var(--scalar-color-1);
+}
+
+.property--compact .property-example {
+  background: transparent;
+}
+
+.property--compact .property-example-value {
+  background: var(--scalar-background-2);
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-radius: var(--scalar-radius);
+}
+.property-example-value-list {
+  position: absolute;
+  top: 18px;
+  left: 50%;
+  transform: translate3d(-50%, 0, 0);
+  overflow: auto;
+  background-color: var(--scalar-background-1);
+  box-shadow: var(--scalar-shadow-1);
+  border-radius: var(--scalar-radius-lg);
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  padding: 9px;
+  min-width: 200px;
+  max-width: 300px;
+  flex-direction: column;
+  gap: 3px;
+  display: none;
+  z-index: 10;
+}
+.property-example:hover .property-example-value-list,
+.property-example:focus-within .property-example-value-list {
+  display: flex;
+}
+</style>

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -116,11 +116,7 @@ const { copyToClipboard } = useClipboard()
   color: var(--scalar-color-1);
 }
 
-.property--compact .property-example {
-  background: transparent;
-}
-
-.property--compact .property-example-value {
+.property-example-value {
   background: var(--scalar-background-2);
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   border-radius: var(--scalar-radius);

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -14,29 +14,29 @@ const { copyToClipboard } = useClipboard()
 </script>
 <template>
   <!-- single example (deprecated) -->
-  <div
-    v-if="example"
-    class="property-example">
-    <button
-      type="button"
-      class="property-example-label">
-      <span>Example</span>
-    </button>
-    <div class="property-example-value-list">
+  <template v-if="example">
+    <div class="property-example">
       <button
         type="button"
-        class="property-example-value group"
-        @click="copyToClipboard(String(formatExample(example)))">
-        <span>
-          {{ formatExample(example) }}
-        </span>
-        <ScalarIcon
-          icon="Clipboard"
-          size="xs"
-          class="group-hover:text-c-1 text-c-3 ml-auto min-h-3 min-w-3" />
+        class="property-example-label">
+        <span>Example</span>
       </button>
+      <div class="property-example-value-list">
+        <button
+          type="button"
+          class="property-example-value group"
+          @click="copyToClipboard(String(formatExample(example)))">
+          <span>
+            {{ formatExample(example) }}
+          </span>
+          <ScalarIcon
+            icon="Clipboard"
+            size="xs"
+            class="group-hover:text-c-1 text-c-3 ml-auto min-h-3 min-w-3" />
+        </button>
+      </div>
     </div>
-  </div>
+  </template>
 
   <!-- multiple examples -->
   <template

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -184,12 +184,14 @@ const { copyToClipboard } = useClipboard()
           class="property-example-value group"
           @click="
             copyToClipboard(
-              formatExample(
-                value?.example ||
-                  (discriminatorType &&
-                    value?.items &&
-                    typeof value.items === 'object' &&
-                    value.items[discriminatorType]),
+              String(
+                formatExample(
+                  value?.example ||
+                    (discriminatorType &&
+                      value?.items &&
+                      typeof value.items === 'object' &&
+                      value.items[discriminatorType]),
+                ),
               ),
             )
           ">

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -1,9 +1,6 @@
 <script lang="ts" setup>
-import { ScalarIcon } from '@scalar/components'
-import { useClipboard } from '@scalar/use-hooks/useClipboard'
-
-import { formatExample } from '@/components/Content/Schema/helpers/formatExample'
 import { discriminators } from '@/components/Content/Schema/helpers/optimizeValueForDisplay'
+import SchemaPropertyExamples from '@/components/Content/Schema/SchemaPropertyExamples.vue'
 import ScreenReader from '@/components/ScreenReader.vue'
 
 import { Badge } from '../../Badge'
@@ -43,8 +40,6 @@ const flattenDefaultValue = (value: Record<string, any>) => {
     ? value.default[0]
     : value?.default
 }
-
-const { copyToClipboard } = useClipboard()
 </script>
 <template>
   <div class="property-heading">
@@ -169,84 +164,12 @@ const { copyToClipboard } = useClipboard()
       class="property-required">
       required
     </div>
-    <!-- example -->
-    <div
-      v-if="withExamples && (value?.example || value?.items?.example)"
-      class="property-example">
-      <button
-        type="button"
-        class="property-example-label">
-        <span> Example </span>
-      </button>
-      <div class="property-example-value-list">
-        <button
-          type="button"
-          class="property-example-value group"
-          @click="
-            copyToClipboard(
-              String(
-                formatExample(
-                  value?.example ||
-                    (discriminatorType &&
-                      value?.items &&
-                      typeof value.items === 'object' &&
-                      value.items[discriminatorType]),
-                ),
-              ),
-            )
-          ">
-          <span>
-            {{
-              formatExample(
-                value?.example ||
-                  (discriminatorType &&
-                    value?.items &&
-                    typeof value.items === 'object' &&
-                    value.items[discriminatorType]),
-              )
-            }}
-          </span>
-          <ScalarIcon
-            icon="Clipboard"
-            size="xs"
-            class="group-hover:text-c-1 text-c-3 ml-auto min-h-3 min-w-3" />
-        </button>
-      </div>
-    </div>
-    <template
-      v-if="
-        value?.examples &&
-        typeof value.examples === 'object' &&
-        Object.keys(value.examples).length > 0
-      ">
-      <div class="property-example">
-        <button
-          type="button"
-          class="property-example-label">
-          <span>
-            {{
-              Object.keys(value.examples).length === 1 ? 'Example' : 'Examples'
-            }}
-          </span>
-        </button>
-        <div class="property-example-value-list">
-          <button
-            type="button"
-            v-for="(example, key) in value.examples"
-            :key="key"
-            class="property-example-value group"
-            @click="copyToClipboard(example)">
-            <span>
-              {{ example }}
-            </span>
-            <ScalarIcon
-              icon="Clipboard"
-              size="xs"
-              class="text-c-3 group-hover:text-c-1 ml-auto min-h-3 min-w-3" />
-          </button>
-        </div>
-      </div>
-    </template>
+    <!-- examples -->
+    <SchemaPropertyExamples
+      v-if="withExamples"
+      :examples="value?.examples"
+      :example="value?.example || value?.items?.example"
+      :discriminator-type="discriminatorType" />
   </div>
 </template>
 <style scoped>
@@ -320,82 +243,5 @@ const { copyToClipboard } = useClipboard()
 
 .deprecated {
   text-decoration: line-through;
-}
-
-.property-example {
-  display: flex;
-  flex-direction: column;
-  font-size: var(--scalar-micro);
-  position: relative;
-}
-.property-example:hover:before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 20px;
-  border-radius: var(--scalar-radius);
-}
-.property-example:hover .property-example-label span {
-  color: var(--scalar-color-1);
-}
-.property-example-label span {
-  color: var(--scalar-color-3);
-  position: relative;
-  border-bottom: var(--scalar-border-width) dotted currentColor;
-}
-.property-example-value {
-  font-family: var(--scalar-font-code);
-  display: flex;
-  align-items: center;
-  width: 100%;
-  padding: 6px;
-}
-.property-example-value span {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.property-example-value :deep(svg) {
-  color: var(--scalar-color-3);
-}
-
-.property-example-value:hover :deep(svg) {
-  color: var(--scalar-color-1);
-}
-
-.property--compact .property-example {
-  background: transparent;
-}
-
-.property--compact .property-example-value {
-  background: var(--scalar-background-2);
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
-  border-radius: var(--scalar-radius);
-}
-.property-example-value-list {
-  position: absolute;
-  z-index: 1;
-  top: 18px;
-  left: 50%;
-  transform: translate3d(-50%, 0, 0);
-  overflow: auto;
-  background-color: var(--scalar-background-1);
-  box-shadow: var(--scalar-shadow-1);
-  border-radius: var(--scalar-radius-lg);
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
-  padding: 9px;
-  min-width: 200px;
-  max-width: 300px;
-  flex-direction: column;
-  gap: 3px;
-  display: none;
-  z-index: 10;
-}
-.property-example:hover .property-example-value-list,
-.property-example:focus-within .property-example-value-list {
-  display: flex;
 }
 </style>

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -605,6 +605,8 @@ components:
           writeOnly: true
           examples:
             - i-love-scalar
+            - i-love-OSS
+            - i-love-code
     Token:
       description: A token to authenticate a user
       type: object


### PR DESCRIPTION
we currently don't have a copy to clipboard button for examples + it gets overwhelming when you have too many examples, so this aims to fix that :) 

I also updated an example in scalar galaxy that have multiple examples

before:
<img width="472" alt="image" src="https://github.com/user-attachments/assets/84efbfaf-ba60-470c-aaf3-38c65d789def" />

after:
<img width="843" alt="image" src="https://github.com/user-attachments/assets/b9f71076-973c-4a11-a009-49218997ecfa" />
