### PR TITLE
fix(api-reference): allow promise returns in onDocumentSelect

### DIFF
--- a/.changeset/khaki-wolves-study.md
+++ b/.changeset/khaki-wolves-study.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: reduce section opening jank and ensure spec is changed correctly

--- a/.changeset/neat-maps-relate.md
+++ b/.changeset/neat-maps-relate.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+fix: allow async functions in onDocumentSelect

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -40,17 +40,17 @@ const config = useConfig()
 
 // We disable intersection observer on click
 const handleClick = async () => {
+  // wait for a short delay before enabling intersection observer
+  isIntersectionEnabled.value = false
+
   if (props.hasChildren) {
     emit('toggleOpen')
   }
   props.item?.select?.()
 
-  // If the section was open, wait for a short delay before enabling intersection observer
-  if (props.open) {
-    isIntersectionEnabled.value = false
-    await sleep(100)
-    isIntersectionEnabled.value = true
-  }
+  // Re-enable intersection observer
+  await sleep(100)
+  isIntersectionEnabled.value = true
 }
 
 // Build relative URL and add hash

--- a/packages/api-reference/src/hooks/useReactiveSpec.test.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.test.ts
@@ -208,7 +208,7 @@ describe('useReactiveSpec', () => {
     // Sleep for 10ms to wait for the parser to finish
     await new Promise((resolve) => setTimeout(resolve, 50))
 
-    expect(parsedSpec.info?.title).toBe('Example')
+    expect(parsedSpec.value.info?.title).toBe('Example')
   })
 
   it('works with refs', async () => {
@@ -223,7 +223,7 @@ describe('useReactiveSpec', () => {
     // Sleep for 300ms to wait for the debouncer and the parser
     await new Promise((resolve) => setTimeout(resolve, 300))
 
-    expect(parsedSpec.info?.title).toBe('Example')
+    expect(parsedSpec.value.info?.title).toBe('Example')
   })
 
   it('watches the ref', async () => {
@@ -238,7 +238,7 @@ describe('useReactiveSpec', () => {
     // Sleep for 300ms to wait for the debouncer and the parser
     await new Promise((resolve) => setTimeout(resolve, 300))
 
-    expect(parsedSpec.info?.title).toBe('Example')
+    expect(parsedSpec.value.info?.title).toBe('Example')
 
     rawSpecConfig.value = {
       content: JSON.stringify(basicSpecString.replace('Example', 'Foobar')),
@@ -247,7 +247,7 @@ describe('useReactiveSpec', () => {
     // Sleep for 300ms to wait for the debouncer and the parser
     await new Promise((resolve) => setTimeout(resolve, 300))
 
-    expect(parsedSpec.info?.title).toBe('Foobar')
+    expect(parsedSpec.value.info?.title).toBe('Foobar')
   })
 
   it('deals with undefined input', async () => {
@@ -256,7 +256,7 @@ describe('useReactiveSpec', () => {
     // Sleep for 10ms to wait for the parser to finish
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(parsedSpec.info?.title).toBe('')
+    expect(parsedSpec.value.info?.title).toBe('')
   })
 
   it('deals with empty input', async () => {
@@ -269,7 +269,7 @@ describe('useReactiveSpec', () => {
     // Sleep for 10ms to wait for the parser to finish
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(parsedSpec.info?.title).toBe('')
+    expect(parsedSpec.value.info?.title).toBe('')
   })
 
   it('returns errors', async () => {
@@ -306,9 +306,9 @@ describe('useReactiveSpec', () => {
     // Sleep for 10ms to wait for the parser to finish
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(parsedSpec.info?.title).toBe('API #1')
-    expect(parsedSpec.components?.schemas).toBeDefined()
-    expect(Object.keys(parsedSpec.components?.schemas ?? {})).toStrictEqual(['Planet'])
+    expect(parsedSpec.value.info?.title).toBe('API #1')
+    expect(parsedSpec.value.components?.schemas).toBeDefined()
+    expect(Object.keys(parsedSpec.value.components?.schemas ?? {})).toStrictEqual(['Planet'])
 
     // Change the configuration …
     Object.assign(specConfig.value, {
@@ -322,7 +322,7 @@ describe('useReactiveSpec', () => {
     // Sleep for 10ms to wait for the parser to finish
     await new Promise((resolve) => setTimeout(resolve, 100))
 
-    expect(parsedSpec.info?.title).toBe('API #2')
-    expect(Object.keys(parsedSpec.components?.schemas ?? {})).toStrictEqual([])
+    expect(parsedSpec.value.info?.title).toBe('API #2')
+    expect(Object.keys(parsedSpec.value.components?.schemas ?? {})).toStrictEqual([])
   })
 })

--- a/packages/api-reference/src/hooks/useReactiveSpec.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.ts
@@ -1,6 +1,6 @@
 import { fetchSpecFromUrl, isValidUrl, prettyPrintJson } from '@scalar/oas-utils/helpers'
 import type { SpecConfiguration } from '@scalar/types/api-reference'
-import { type MaybeRefOrGetter, reactive, ref, toValue, watch } from 'vue'
+import { type MaybeRefOrGetter, ref, toValue, watch } from 'vue'
 
 import { createEmptySpecification } from '../helpers'
 import { parse } from '../helpers/parse'
@@ -65,7 +65,7 @@ export function useReactiveSpec({
   /** OAS spec as a string */
   const rawSpec = ref<string>('')
   /** Fully parsed and resolved OAS object */
-  const parsedSpec = reactive(createEmptySpecification())
+  const parsedSpec = ref(createEmptySpecification())
   /** Parser error messages when parsing fails */
   const specErrors = ref<string | null>(null)
 
@@ -76,19 +76,18 @@ export function useReactiveSpec({
    */
   function parseInput(value?: string) {
     if (!value) {
-      return Object.assign(parsedSpec, createEmptySpecification())
+      parsedSpec.value = createEmptySpecification()
+      return
     }
 
-    return parse(value, {
+    parse(value, {
       proxyUrl: proxyUrl ? toValue(proxyUrl) : undefined,
     })
       .then((validSpec) => {
         specErrors.value = null
 
         // Some specs don’t have servers, make sure they are defined
-        Object.assign(parsedSpec, {
-          ...validSpec,
-        })
+        parsedSpec.value = validSpec
       })
       .catch((error) => {
         // Save the parse error message to display

--- a/packages/types/src/api-reference/api-reference-configuration.test.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { apiReferenceConfigurationSchema } from './api-reference-configuration.ts'
+import { type ApiReferenceConfiguration, apiReferenceConfigurationSchema } from './api-reference-configuration.ts'
 
 describe('api-reference-configuration', () => {
   describe('schema', () => {
@@ -245,6 +245,31 @@ describe('api-reference-configuration', () => {
 
       expect(migratedConfig.spec).toBeUndefined()
       expect(migratedConfig.content).toBe('{"openapi": "3.1.0"}')
+    })
+
+    it('allows a function as onDocumentSelect', () => {
+      const config = {
+        onDocumentSelect: () => console.log('selected'),
+      }
+      const migratedConfig = apiReferenceConfigurationSchema.parse(config)
+      expect(migratedConfig.onDocumentSelect).toBeInstanceOf(Function)
+    })
+
+    it('allows a function as onDocumentSelect', () => {
+      const config = {
+        onDocumentSelect: () => console.log('selected'),
+      } satisfies Partial<ApiReferenceConfiguration>
+      const migratedConfig = apiReferenceConfigurationSchema.parse(config)
+      expect(migratedConfig.onDocumentSelect).toBeInstanceOf(Function)
+    })
+
+    it('allows an async function as onDocumentSelect', async () => {
+      const config = {
+        onDocumentSelect: async () => console.log('selected'),
+      } satisfies Partial<ApiReferenceConfiguration>
+      const migratedConfig = apiReferenceConfigurationSchema.parse(config)
+
+      expect(migratedConfig.onDocumentSelect?.()).toBeInstanceOf(Promise)
     })
   })
 })

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -298,7 +298,7 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
     /** onServerChange is fired on selected server change */
     onServerChange: z.function().args(z.string()).returns(z.void()).optional(),
     /** onDocumentSelect is fired when the config is selected */
-    onDocumentSelect: z.function().returns(z.void()).optional(),
+    onDocumentSelect: z.function().returns(z.void().or(z.void().promise())).optional(),
     /**
      * Route using paths instead of hashes, your server MUST support this
      * @example '/standalone-api-reference/:custom(.*)?'


### PR DESCRIPTION
**Problem**

Currently, we can only use sync functions as `onDocumentSelect`

**Solution**

- allow using async functions aka returning promises
- useReactiveSpec not clearing spec between document changes, switched to a ref from reactive for this
- ensure interaction observer is always disabled before opening up sections

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
