### PR TITLE
style(api-client): add class names for targetting client

### DIFF
--- a/.changeset/neat-shrimps-arrive.md
+++ b/.changeset/neat-shrimps-arrive.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+style(api-client): add classes to target api client via CSS

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.test.ts
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.test.ts
@@ -1,0 +1,16 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import ViewLayoutSection from './ViewLayoutSection.vue'
+
+describe('ViewLayoutSection', () => {
+  it('has .request-response-header class (when title slot is used)', () => {
+    const wrapper = mount(ViewLayoutSection, {
+      slots: {
+        title: 'Hello World',
+      },
+    })
+
+    expect(wrapper.text()).toBe('Hello World')
+    expect(wrapper.find('.request-response-header').exists()).toBe(true)
+  })
+})

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -11,7 +11,7 @@ const { cx } = useBindCx()
     ">
     <div
       v-if="$slots.title"
-      class="bg-b-1 z-1 sticky top-0 flex min-h-11 items-center border-b px-2.5 text-sm font-medium xl:rounded-none">
+      class="request-response-header bg-b-1 z-1 sticky top-0 flex min-h-11 items-center border-b px-2.5 text-sm font-medium xl:rounded-none">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.test.ts
@@ -1,0 +1,76 @@
+import { WORKSPACE_SYMBOL } from '@/store/store'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import RequestSection from './RequestSection.vue'
+
+describe('RequestSection', () => {
+  it('has required classes', () => {
+    // TODO: Wow, there must be a better way to test this component, but we might need to refactor the component to get rid of the mocking.
+
+    // Mock the workspace store
+    const mockWorkspaceStore = {
+      requestMutators: {
+        edit: () => {},
+      },
+      requestExampleMutators: {
+        edit: () => {},
+      },
+      cookies: {},
+      securitySchemes: {},
+    }
+
+    const wrapper = mount(RequestSection, {
+      global: {
+        provide: {
+          [WORKSPACE_SYMBOL]: mockWorkspaceStore,
+        },
+      },
+      props: {
+        // @ts-expect-error
+        collection: {},
+        // @ts-expect-error
+        environment: {},
+        envVariables: [],
+        example: {
+          // @ts-expect-error
+          body: {},
+          parameters: {
+            path: [],
+            cookies: [],
+            headers: [],
+            query: [],
+          },
+        },
+        // @ts-expect-error
+        invalidParams: new Set(),
+        operation: {
+          // @ts-expect-error
+          uid: '1',
+          method: 'get',
+          path: '/test',
+          summary: 'Test Operation',
+        },
+        selectedSecuritySchemeUids: [],
+        server: undefined,
+        // @ts-expect-error
+        workspace: {
+          cookies: [],
+        },
+      },
+    })
+
+    const requiredClasses = [
+      'request-section-content-auth',
+      'request-section-content-path-params',
+      'request-section-content-cookies',
+      'request-section-content-headers',
+      'request-section-content-query',
+      'request-section-content-body',
+      'request-section-content-code-example',
+    ]
+
+    requiredClasses.forEach((className) => {
+      expect(wrapper.find(`.${className}`).exists()).toBe(true)
+    })
+  })
+})

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -274,7 +274,7 @@ const handleRequestNamePlaceholder = () => {
       <!-- Code Snippet -->
       <ScalarErrorBoundary>
         <RequestCodeExample
-          class="request-section-content-code-snippet"
+          class="request-section-content-code-example"
           :collection="collection"
           :example="example"
           :operation="operation"

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -174,6 +174,7 @@ const handleRequestNamePlaceholder = () => {
       class="request-section-content custom-scroll relative flex flex-1 flex-col divide-y"
       :role="selectedFilter === 'All' ? 'tabpanel' : 'none'">
       <RequestAuth
+        class="request-section-content-auth"
         v-if="
           collection &&
           workspace &&
@@ -195,6 +196,7 @@ const handleRequestNamePlaceholder = () => {
         title="Authentication"
         :workspace="workspace" />
       <RequestPathParams
+        class="request-section-content-path-params"
         v-show="
           (selectedFilter === 'All' || selectedFilter === 'Variables') &&
           example.parameters.path.length
@@ -210,6 +212,7 @@ const handleRequestNamePlaceholder = () => {
         title="Variables"
         :workspace="workspace" />
       <RequestParams
+        class="request-section-content-cookies"
         v-show="selectedFilter === 'All' || selectedFilter === 'Cookies'"
         :id="filterIds.Cookies"
         :envVariables="envVariables"
@@ -224,6 +227,7 @@ const handleRequestNamePlaceholder = () => {
         :workspace="workspace"
         workspaceParamKey="cookies" />
       <RequestParams
+        class="request-section-content-headers"
         v-show="selectedFilter === 'All' || selectedFilter === 'Headers'"
         :id="filterIds.Headers"
         :envVariables="envVariables"
@@ -236,6 +240,7 @@ const handleRequestNamePlaceholder = () => {
         title="Headers"
         :workspace="workspace" />
       <RequestParams
+        class="request-section-content-query"
         v-show="selectedFilter === 'All' || selectedFilter === 'Query'"
         :id="filterIds.Query"
         :envVariables="envVariables"
@@ -248,6 +253,7 @@ const handleRequestNamePlaceholder = () => {
         title="Query Parameters"
         :workspace="workspace" />
       <RequestBody
+        class="request-section-content-body"
         v-show="
           operation.method &&
           (selectedFilter === 'All' || selectedFilter === 'Body') &&
@@ -268,6 +274,7 @@ const handleRequestNamePlaceholder = () => {
       <!-- Code Snippet -->
       <ScalarErrorBoundary>
         <RequestCodeExample
+          class="request-section-content-code-snippet"
           :collection="collection"
           :example="example"
           :operation="operation"

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -3,7 +3,7 @@ import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
-import type { RouteLocationRaw } from 'vue-router'
+import { RouterLink, type RouteLocationRaw } from 'vue-router'
 
 import CodeInput from '@/components/CodeInput/CodeInput.vue'
 import DataTable from '@/components/DataTable/DataTable.vue'

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.test.ts
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.test.ts
@@ -1,0 +1,66 @@
+import { WORKSPACE_SYMBOL } from '@/store/store'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import ResponseSection from './ResponseSection.vue'
+
+describe('ResponseSection', () => {
+  it('has required classes', () => {
+    // TODO: Wow, there must be a better way to test this component, but we might need to refactor the component to get rid of the mocking.
+
+    // Mock the workspace store
+    const mockWorkspaceStore = {
+      requestMutators: {
+        edit: () => {},
+      },
+      requestExampleMutators: {
+        edit: () => {},
+      },
+      cookies: {},
+      securitySchemes: {},
+      events: {
+        requestStatus: {
+          on: () => {},
+          off: () => {},
+          emit: () => {},
+        },
+      },
+    }
+
+    const wrapper = mount(ResponseSection, {
+      global: {
+        provide: {
+          [WORKSPACE_SYMBOL]: mockWorkspaceStore,
+        },
+      },
+      props: {
+        numWorkspaceRequests: 0,
+        response: {
+          status: 200,
+          statusText: 'OK',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          // @ts-expect-error body should be ReadableStream but we don't need it for this test
+          body: {},
+          data: '',
+          cookies: [],
+          size: 0,
+          time: 1000,
+          duration: 1000,
+          cookieHeaderKeys: [],
+        },
+      },
+    })
+
+    const requiredClasses = [
+      'response-section-content',
+      'response-section-content-cookies',
+      'response-section-content-headers',
+      'response-section-content-body',
+    ]
+
+    requiredClasses.forEach((className) => {
+      expect(wrapper.find(`.${className}`).exists()).toBe(true)
+    })
+  })
+})

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -149,7 +149,7 @@ const shouldVirtualize = computed(() => {
     </template>
     <div
       :id="filterIds.All"
-      class="custom-scroll yooo response-section-content relative grid h-full justify-stretch"
+      class="custom-scroll response-section-content relative grid h-full justify-stretch"
       :class="{
         'content-start': response,
       }"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -149,7 +149,7 @@ const shouldVirtualize = computed(() => {
     </template>
     <div
       :id="filterIds.All"
-      class="custom-scroll relative grid h-full justify-stretch divide-y"
+      class="custom-scroll yooo response-section-content relative grid h-full justify-stretch"
       :class="{
         'content-start': response,
       }"
@@ -159,11 +159,13 @@ const shouldVirtualize = computed(() => {
       </template>
       <template v-else>
         <ResponseCookies
+          class="response-section-content-cookies"
           v-if="activeFilter === 'All' || activeFilter === 'Cookies'"
           :id="filterIds.Cookies"
           :cookies="responseCookies"
           :role="activeFilter === 'All' ? 'none' : 'tabpanel'" />
         <ResponseHeaders
+          class="response-section-content-headers"
           v-if="activeFilter === 'All' || activeFilter === 'Headers'"
           :id="filterIds.Headers"
           :headers="responseHeaders"
@@ -180,6 +182,7 @@ const shouldVirtualize = computed(() => {
             :role="activeFilter === 'All' ? 'none' : 'tabpanel'" />
 
           <ResponseBody
+            class="response-section-content-body"
             v-else
             :id="filterIds.Body"
             :active="true"


### PR DESCRIPTION
I need to target the api client via CSS classes :) 

this adds classes to everything I'll need to target 