### PR TITLE
feat(api-reference): multiple configurations with multiple sources

### DIFF
--- a/.changeset/serious-ways-tickle.md
+++ b/.changeset/serious-ways-tickle.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+---
+
+feat: multiple configurations with multiple sources

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -167,6 +167,44 @@ Scalar.createApiReference('#app', [
 ])
 ```
 
+
+### Multiple Configurations with Sources (Advanced)
+
+You can even combine multiple configurations that each have their own set of sources. This gives you maximum flexibility in organizing and configuring your API documents:
+
+```ts
+Scalar.createApiReference('#app', [
+  // Configuration #1
+  {
+    // With sources! 🤯
+    sources: [
+      // API #1
+      {
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+      },
+      // API #2
+      {
+        url: 'https://example.com/openapi.json',
+        // This will make it the default OpenAPI document:
+        default: true,
+      }
+    ]
+  },
+  // Configuration #2
+  {
+    url: 'https://example.com/openapi.json',
+  },
+  // Configuration #3
+  {
+    sources: [
+      {
+        content: '{ "openapi": "3.1.1", … }',
+      }
+    ]
+  }
+])
+```
+
 ### JSON or YAML
 
 It is completely up to you whether you want to pass JSON or YAML. None of the differences make really a big difference,

--- a/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
@@ -366,6 +366,59 @@ describe('useMultipleDocuments', () => {
       expect(availableDocuments.value).toHaveLength(1)
       expect(availableDocuments.value[0].slug).toBe('valid-api')
     })
+
+    it('handles multiple configurations with multiple sources', () => {
+      // Set up the URL with the query parameter we want to test
+      mockUrl = new URL('http://example.com?api=second-api-2')
+      vi.spyOn(window, 'location', 'get').mockReturnValue(mockUrl as any)
+
+      const multipleConfigurations = {
+        configuration: ref([
+          {
+            sources: [
+              {
+                url: '/openapi-1.yaml',
+                slug: 'first-api-1',
+                title: 'First API 1',
+              },
+              {
+                url: '/openapi-2.yaml',
+                slug: 'first-api-2',
+                title: 'First API 2',
+              },
+            ],
+          },
+          {
+            sources: [
+              {
+                url: '/openapi-3.yaml',
+                slug: 'second-api-1',
+                title: 'Second API 1',
+              },
+              {
+                url: '/openapi-4.yaml',
+                slug: 'second-api-2',
+                title: 'Second API 2',
+              },
+            ],
+          },
+        ]),
+      }
+
+      const { selectedDocumentIndex, selectedConfiguration, availableDocuments } =
+        useMultipleDocuments(multipleConfigurations)
+
+      // Check that all documents are available
+      expect(availableDocuments.value).toHaveLength(4)
+
+      // Verify the selected document matches the query parameter
+      expect(selectedDocumentIndex.value).toBe(3)
+      expect(selectedConfiguration.value).toMatchObject({
+        url: '/openapi-4.yaml',
+        slug: 'second-api-2',
+        title: 'Second API 2',
+      })
+    })
   })
 
   describe('title and slug handling', () => {

--- a/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
@@ -1,4 +1,4 @@
-import { useMultipleDocuments } from '@/hooks/useMultipleDocuments'
+import { normalizeConfigurations, useMultipleDocuments } from '@/hooks/useMultipleDocuments'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
@@ -647,6 +647,122 @@ describe('useMultipleDocuments', () => {
 
       // Restore window object
       global.window = originalWindow
+    })
+  })
+})
+
+describe('normalizeConfigurations', () => {
+  it('returns empty array for undefined configuration', () => {
+    expect(normalizeConfigurations(undefined)).toEqual([])
+  })
+
+  it('handles single configuration without sources', () => {
+    const config = {
+      url: '/openapi.json',
+      title: 'Single API',
+    }
+    const result = normalizeConfigurations(config)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      url: '/openapi.json',
+      title: 'Single API',
+      slug: 'single-api',
+    })
+  })
+
+  it('handles array of configurations without sources', () => {
+    const configs = [
+      { url: '/api1.json', title: 'API 1' },
+      { url: '/api2.json', title: 'API 2' },
+    ]
+    const result = normalizeConfigurations(configs)
+    expect(result).toHaveLength(2)
+    expect(result[0].slug).toBe('api-1')
+    expect(result[1].slug).toBe('api-2')
+  })
+
+  it('flattens configurations with sources', () => {
+    const config = {
+      hideClientButton: true,
+      sources: [
+        { url: '/api1.json', title: 'API 1' },
+        { url: '/api2.json', title: 'API 2' },
+      ],
+    }
+    const result = normalizeConfigurations(config)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({
+      hideClientButton: true,
+      url: '/api1.json',
+      title: 'API 1',
+    })
+    expect(result[1]).toMatchObject({
+      hideClientButton: true,
+      url: '/api2.json',
+      title: 'API 2',
+    })
+  })
+
+  it('filters out invalid sources without url or content', () => {
+    const config = {
+      sources: [{ title: 'Invalid API' }, { url: '/valid.json', title: 'Valid API' }],
+    }
+    const result = normalizeConfigurations(config)
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('Valid API')
+  })
+
+  it('generates slugs from titles when missing', () => {
+    const config = {
+      sources: [{ url: '/api.json', title: 'My Cool API!' }],
+    }
+    const result = normalizeConfigurations(config)
+    expect(result[0].slug).toBe('my-cool-api')
+  })
+
+  it('generates numeric slugs when no title or slug provided', () => {
+    const config = {
+      sources: [{ url: '/api1.json' }, { url: '/api2.json' }],
+    }
+    const result = normalizeConfigurations(config)
+    expect(result[0].slug).toBe('api-1')
+    expect(result[1].slug).toBe('api-2')
+  })
+
+  it('preserves existing slugs', () => {
+    const config = {
+      sources: [{ url: '/api.json', title: 'My API', slug: 'custom-slug' }],
+    }
+    const result = normalizeConfigurations(config)
+    expect(result[0].slug).toBe('custom-slug')
+  })
+
+  it('handles mixed configuration types', () => {
+    const configs = [
+      { url: '/api1.json', title: 'Direct API' },
+      {
+        sources: [{ url: '/api2.json', title: 'Source API' }],
+      },
+    ]
+    const result = normalizeConfigurations(configs)
+    expect(result).toHaveLength(2)
+    expect(result[0].title).toBe('Direct API')
+    expect(result[1].title).toBe('Source API')
+  })
+
+  it('merges spec properties from old format', () => {
+    const config = {
+      spec: {
+        customField: 'value',
+      },
+      url: '/api.json',
+      title: 'API',
+    }
+    const result = normalizeConfigurations(config)
+    expect(result[0]).toMatchObject({
+      customField: 'value',
+      url: '/api.json',
+      title: 'API',
     })
   })
 })

--- a/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
@@ -378,13 +378,13 @@ describe('useMultipleDocuments', () => {
             sources: [
               {
                 url: '/openapi-1.yaml',
-                slug: 'first-api-1',
-                title: 'First API 1',
+                slug: 'first-api',
+                title: 'First API ',
               },
               {
                 url: '/openapi-2.yaml',
-                slug: 'first-api-2',
-                title: 'First API 2',
+                slug: 'second-api',
+                title: 'Second API',
               },
             ],
           },
@@ -392,17 +392,20 @@ describe('useMultipleDocuments', () => {
             sources: [
               {
                 url: '/openapi-3.yaml',
-                slug: 'second-api-1',
-                title: 'Second API 1',
+                slug: 'third-api',
+                title: 'Third API',
               },
               {
                 url: '/openapi-4.yaml',
-                slug: 'second-api-2',
-                title: 'Second API 2',
+                slug: 'fourth-api',
+                title: 'Fourth API',
               },
             ],
           },
         ]),
+        hash: ref(''),
+        hashPrefix: ref(''),
+        isIntersectionEnabled: ref(false),
       }
 
       const { selectedDocumentIndex, selectedConfiguration, availableDocuments } =
@@ -414,9 +417,67 @@ describe('useMultipleDocuments', () => {
       // Verify the selected document matches the query parameter
       expect(selectedDocumentIndex.value).toBe(3)
       expect(selectedConfiguration.value).toMatchObject({
-        url: '/openapi-4.yaml',
-        slug: 'second-api-2',
-        title: 'Second API 2',
+        url: '/openapi-3.yaml',
+        slug: 'third-api',
+        title: 'Third API',
+      })
+    })
+
+    it('handles multiple configurations with multiple sources and a default source', () => {
+      // Set up the URL with the query parameter we want to test
+      mockUrl = new URL('http://example.com?api=second-api-2')
+      vi.spyOn(window, 'location', 'get').mockReturnValue(mockUrl as any)
+
+      const multipleConfigurations = {
+        configuration: ref([
+          {
+            sources: [
+              {
+                url: '/openapi-1.yaml',
+                slug: 'first-api',
+                title: 'First API ',
+              },
+              {
+                url: '/openapi-2.yaml',
+                slug: 'second-api',
+                title: 'Second API',
+              },
+            ],
+          },
+          {
+            sources: [
+              {
+                url: '/openapi-3.yaml',
+                slug: 'third-api',
+                title: 'Third API',
+                // Setting the default source to the third AP
+                default: true,
+              },
+              {
+                url: '/openapi-4.yaml',
+                slug: 'fourth-api',
+                title: 'Fourth API',
+              },
+            ],
+          },
+        ]),
+        hash: ref(''),
+        hashPrefix: ref(''),
+        isIntersectionEnabled: ref(false),
+      }
+
+      const { selectedDocumentIndex, selectedConfiguration, availableDocuments } =
+        useMultipleDocuments(multipleConfigurations)
+
+      // Check that all documents are available
+      expect(availableDocuments.value).toHaveLength(4)
+
+      // Verify the selected document matches the query parameter
+      expect(selectedDocumentIndex.value).toBe(3)
+      expect(selectedConfiguration.value).toMatchObject({
+        url: '/openapi-3.yaml',
+        slug: 'third-api',
+        title: 'Third API',
       })
     })
   })

--- a/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.test.ts
@@ -379,7 +379,7 @@ describe('useMultipleDocuments', () => {
               {
                 url: '/openapi-1.yaml',
                 slug: 'first-api',
-                title: 'First API ',
+                title: 'First API',
               },
               {
                 url: '/openapi-2.yaml',
@@ -415,12 +415,12 @@ describe('useMultipleDocuments', () => {
       expect(availableDocuments.value).toHaveLength(4)
 
       // Verify the selected document matches the query parameter
-      expect(selectedDocumentIndex.value).toBe(3)
       expect(selectedConfiguration.value).toMatchObject({
-        url: '/openapi-3.yaml',
-        slug: 'third-api',
-        title: 'Third API',
+        url: '/openapi-1.yaml',
+        slug: 'first-api',
+        title: 'First API',
       })
+      expect(selectedDocumentIndex.value).toBe(0)
     })
 
     it('handles multiple configurations with multiple sources and a default source', () => {
@@ -473,12 +473,12 @@ describe('useMultipleDocuments', () => {
       expect(availableDocuments.value).toHaveLength(4)
 
       // Verify the selected document matches the query parameter
-      expect(selectedDocumentIndex.value).toBe(3)
       expect(selectedConfiguration.value).toMatchObject({
         url: '/openapi-3.yaml',
         slug: 'third-api',
         title: 'Third API',
       })
+      expect(selectedDocumentIndex.value).toBe(2)
     })
   })
 

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -79,14 +79,18 @@ export const useMultipleDocuments = ({
       return []
     }
 
-    // Map the sources down to an array of specs
-    const sources = isConfigurationWithSources(configuration.value)
-      ? // This IFFE is needed for the type guard as it doens't persist into the callback scope
-        (() => {
-          const { sources, ...rest } = configuration.value
-          return sources?.map((source) => ({ ...rest, ...source })) ?? []
-        })()
-      : [configuration.value].flat()
+    // Handle array of configurations
+    const configs = Array.isArray(configuration.value) ? configuration.value : [configuration.value]
+
+    // Flatten all configurations and their sources into a single array
+    const sources = configs.flatMap((config) => {
+      if (isConfigurationWithSources(config)) {
+        // Spread the config properties (except sources) into each source
+        const { sources: configSources, ...rest } = config
+        return configSources?.map((source) => ({ ...rest, ...source })) ?? []
+      }
+      return [config]
+    })
 
     // Process them
     return sources.map((source, index) => source && addSlugAndTitle(source, index)).filter(isDefined)

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -72,23 +72,32 @@ export const useMultipleDocuments = ({
   hashPrefix,
 }: UseMultipleDocumentsProps) => {
   /**
-   * All available API definitions that can be selected
+   * All available documents that can be selected
    */
   const availableDocuments = computed((): SpecConfiguration[] => {
     if (!configuration.value) {
       return []
     }
 
-    // Handle array of configurations
+    // Make it an array, even if it’s a single configuration
     const configs = Array.isArray(configuration.value) ? configuration.value : [configuration.value]
 
     // Flatten all configurations and their sources into a single array
+
+    // Process each configuration to extract and normalize sources
     const sources = configs.flatMap((config) => {
+      // Check if this config has a 'sources' array property
       if (isConfigurationWithSources(config)) {
-        // Spread the config properties (except sources) into each source
+        // Destructure to separate sources array from other config properties
         const { sources: configSources, ...rest } = config
+
+        // For each source in the array:
+        // - Merge the source with the parent config properties
+        // - Handle undefined sources by returning empty array via ?? []
         return configSources?.map((source) => ({ ...rest, ...source })) ?? []
       }
+
+      // If config doesn’t have sources array, treat the config itself as a source
       return [config]
     })
 

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -501,6 +501,7 @@ export type AnyApiReferenceConfiguration =
   | Partial<ApiReferenceConfiguration>
   | Partial<ApiReferenceConfigurationWithSources>
   | Partial<ApiReferenceConfigurationWithDefault>[]
+  | Partial<ApiReferenceConfigurationWithSources>[]
 
 /** Typeguard to check to narrow the configs to the one with sources */
 export const isConfigurationWithSources = (


### PR DESCRIPTION
**Problem**

We support multiple configurations and a single configuration with multiple sources, but can you image: we don’t support multiple configurations *with* multiple sources. Let’s tackle this.

**Solution**

This PR adds support for multiple configurations with multiple sources. 💥 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
