### PR TITLE
feat(api-client): add auth to the collection page

### DIFF
--- a/.changeset/hungry-crews-poke.md
+++ b/.changeset/hungry-crews-poke.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: added auth to collection page

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.ts
@@ -38,12 +38,12 @@ export const createApiClientModal = async ({
     if (configuration.url) {
       await importSpecFromUrl(configuration.url, 'default', {
         proxyUrl: configuration.proxyUrl,
-        setCollectionSecurity: true,
+        useCollectionSecurity: true,
         ...configuration,
       })
     } else if (configuration.content) {
       await importSpecFile(configuration.content, 'default', {
-        setCollectionSecurity: true,
+        useCollectionSecurity: true,
         ...configuration,
       })
     }

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -267,12 +267,10 @@ export const createApiClient = ({
         if (newConfig.url) {
           await importSpecFromUrl(newConfig.url, activeWorkspace.value?.uid ?? 'default', {
             ...newConfig,
-            setCollectionSecurity: true,
           })
         } else if (newConfig.content) {
           await importSpecFile(newConfig.content, activeWorkspace.value?.uid ?? 'default', {
             ...newConfig,
-            setCollectionSecurity: true,
           })
         } else {
           console.error(

--- a/packages/api-client/src/views/Collection/CollectionAuthentication.vue
+++ b/packages/api-client/src/views/Collection/CollectionAuthentication.vue
@@ -1,9 +1,74 @@
 <script setup lang="ts">
-import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import { ScalarToggle } from '@scalar/components'
+
+import { useActiveEntities } from '@/store/active-entities'
+import { useWorkspace } from '@/store/store'
+import { RequestAuth } from '@/views/Request/RequestSection/RequestAuth'
+
+const {
+  activeCollection,
+  activeEnvVariables,
+  activeEnvironment,
+  activeServer,
+  activeWorkspace,
+} = useActiveEntities()
+
+const { collectionMutators } = useWorkspace()
+
+/** Toggle the collection security */
+const handleToggleCollectionSecurity = () => {
+  if (!activeCollection.value?.uid) {
+    return
+  }
+
+  collectionMutators.edit(
+    activeCollection.value.uid,
+    'useCollectionSecurity',
+    !activeCollection.value.useCollectionSecurity,
+  )
+}
 </script>
 
 <template>
-  <ViewLayoutSection>
-    <template #title>Authentication</template>
-  </ViewLayoutSection>
+  <div class="flex h-full w-full flex-col gap-12 px-1.5 pt-8">
+    <div class="flex flex-col gap-4">
+      <div class="flex h-8 items-center">
+        <h3 class="font-bold">Collection Authentication</h3>
+      </div>
+
+      <div class="bg-b-1 flex items-center justify-between gap-4 text-sm">
+        <p class="text-c-2 flex flex-1 text-balance">
+          When enabled, authentication will be set at the collection level
+          instead of the request level for any requests which require
+          authentication. You can select the authentication below.
+        </p>
+        <ScalarToggle
+          class="w-4"
+          :modelValue="activeCollection?.useCollectionSecurity ?? false"
+          @update:modelValue="handleToggleCollectionSecurity" />
+      </div>
+
+      <RequestAuth
+        class="scalar-collection-auth"
+        v-if="activeCollection?.useCollectionSecurity && activeWorkspace"
+        :collection="activeCollection"
+        :envVariables="activeEnvVariables"
+        :environment="activeEnvironment"
+        layout="reference"
+        :selectedSecuritySchemeUids="
+          activeCollection?.selectedSecuritySchemeUids ?? []
+        "
+        :server="activeServer"
+        title="Authentication"
+        :workspace="activeWorkspace" />
+    </div>
+  </div>
 </template>
+
+<style scoped>
+.scalar-collection-auth {
+  border: 1px solid var(--scalar-border-color);
+  border-radius: var(--scalar-radius-lg);
+  overflow: hidden;
+}
+</style>

--- a/packages/api-client/src/views/Collection/CollectionAuthentication.vue
+++ b/packages/api-client/src/views/Collection/CollectionAuthentication.vue
@@ -33,14 +33,13 @@ const handleToggleCollectionSecurity = () => {
   <div class="flex h-full w-full flex-col gap-12 px-1.5 pt-8">
     <div class="flex flex-col gap-4">
       <div class="flex h-8 items-center">
-        <h3 class="font-bold">Collection Authentication</h3>
+        <h3 class="font-bold">Authenticate with the API once</h3>
       </div>
 
       <div class="bg-b-1 flex items-center justify-between gap-4 text-sm">
         <p class="text-c-2 flex flex-1 text-balance">
-          When enabled, authentication will be set at the collection level
-          instead of the request level for any requests which require
-          authentication. You can select the authentication below.
+          Don’t want to set up the authentication for each request? Enable this
+          option to set the authentication once for the whole collection.
         </p>
         <ScalarToggle
           class="w-4"

--- a/packages/api-client/src/views/Collection/CollectionNavigation.vue
+++ b/packages/api-client/src/views/Collection/CollectionNavigation.vue
@@ -33,20 +33,20 @@ const routes = computed<CollectionSidebarEntry[]>(() => [
     },
   },
   {
-    displayName: 'Authentication',
-    // icon: 'Lock',
+    displayName: 'Servers',
+    // icon: 'Server',
     to: {
-      name: 'collection.authentication',
+      name: 'collection.servers',
       params: {
         [PathId.Collection]: activeCollection.value?.uid,
       },
     },
   },
   {
-    displayName: 'Servers',
-    // icon: 'Server',
+    displayName: 'Authentication',
+    // icon: 'Lock',
     to: {
-      name: 'collection.servers',
+      name: 'collection.authentication',
       params: {
         [PathId.Collection]: activeCollection.value?.uid,
       },

--- a/packages/api-client/src/views/Collection/CollectionNavigation.vue
+++ b/packages/api-client/src/views/Collection/CollectionNavigation.vue
@@ -32,16 +32,16 @@ const routes = computed<CollectionSidebarEntry[]>(() => [
       },
     },
   },
-  // {
-  //   displayName: 'Authentication',
-  //   // icon: 'Lock',
-  //   to: {
-  //     name: 'collection.authentication',
-  //     params: {
-  //       [PathId.Collection]: activeCollection.value?.uid,
-  //     },
-  //   },
-  // },
+  {
+    displayName: 'Authentication',
+    // icon: 'Lock',
+    to: {
+      name: 'collection.authentication',
+      params: {
+        [PathId.Collection]: activeCollection.value?.uid,
+      },
+    },
+  },
   {
     displayName: 'Servers',
     // icon: 'Server',

--- a/packages/api-client/src/views/Collection/CollectionSettings.vue
+++ b/packages/api-client/src/views/Collection/CollectionSettings.vue
@@ -70,7 +70,7 @@ function handleDeleteCollection() {
       <!-- Watch Mode -->
       <div class="bg-b-2 rounded-lg border text-sm">
         <div
-          class="bg-b-1 -m-1/2 flex items-center justify-between gap-4 rounded-t-lg border p-3">
+          class="bg-b-1 -m-1/2 flex items-center justify-between gap-4 rounded-t-lg border-l p-3">
           <div>
             <h4>Watch Mode</h4>
             <p class="text-c-2 mt-1">
@@ -85,7 +85,7 @@ function handleDeleteCollection() {
             @update:modelValue="handleToggleWatchMode" />
         </div>
         <div
-          class="text-c-1 flex items-center overflow-x-auto whitespace-nowrap py-1.5">
+          class="text-c-1 flex items-center overflow-x-auto whitespace-nowrap border-t py-1.5">
           <div class="flex items-center">
             <template v-if="activeCollection?.documentUrl">
               <span class="bg-b-2 sticky left-0 pl-3 pr-2">Source</span>

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
 import { computed } from 'vue'
 
 import EmptyState from '@/components/EmptyState.vue'
@@ -13,13 +14,14 @@ import RequestSection from '@/views/Request/RequestSection/RequestSection.vue'
 import RequestSubpageHeader from '@/views/Request/RequestSubpageHeader.vue'
 import ResponseSection from '@/views/Request/ResponseSection/ResponseSection.vue'
 
-const { invalidParams } = defineProps<{
+const { invalidParams, selectedSecuritySchemeUids } = defineProps<{
   invalidParams: Set<string>
+  selectedSecuritySchemeUids: SelectedSecuritySchemeUids
 }>()
 defineEmits<(e: 'newTab', item: { name: string; uid: string }) => void>()
+
 const { events } = useWorkspace()
 const { isSidebarOpen } = useSidebar()
-
 const workspaceContext = useWorkspace()
 const { layout } = useLayout()
 
@@ -37,21 +39,6 @@ const { modalState, requestHistory } = workspaceContext
 
 const activeHistoryEntry = computed(() =>
   requestHistory.findLast((r) => r.request.uid === activeExample.value?.uid),
-)
-
-/**
- * Selected scheme UIDs
- *
- * In the modal we use collection.selectedSecuritySchemes and in the
- * standalone client we use request.selectedSecuritySchemeUids
- *
- * These are centralized here so they can be drilled down AND used in send-request
- */
-const selectedSecuritySchemeUids = computed(
-  () =>
-    (layout === 'modal'
-      ? activeCollection.value?.selectedSecuritySchemeUids
-      : activeRequest.value?.selectedSecuritySchemeUids) ?? [],
 )
 
 function handleCurlImport(curl: string) {

--- a/packages/api-client/src/views/Request/RequestRoot.vue
+++ b/packages/api-client/src/views/Request/RequestRoot.vue
@@ -48,7 +48,7 @@ const invalidParams = ref<Set<string>>(new Set())
  */
 const selectedSecuritySchemeUids = computed(
   () =>
-    (layout === 'modal'
+    (activeCollection.value?.useCollectionSecurity
       ? activeCollection.value?.selectedSecuritySchemeUids
       : activeRequest.value?.selectedSecuritySchemeUids) ?? [],
 )
@@ -168,7 +168,9 @@ watch(
 
       <!-- Content -->
       <div class="flex h-full flex-1 flex-col">
-        <RouterView :invalidParams="invalidParams" />
+        <RouterView
+          :invalidParams="invalidParams"
+          :selectedSecuritySchemeUids="selectedSecuritySchemeUids" />
       </div>
     </div>
   </div>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -167,7 +167,7 @@ function updateSelectedAuth(entries: SecuritySchemeOption[]) {
 
 const editSelectedSchemeUids = (uids: SelectedSecuritySchemeUids) => {
   // Set as selected on the collection for the modal
-  if (clientLayout === 'modal' || layout === 'reference') {
+  if (collection.useCollectionSecurity) {
     collectionMutators.edit(collection.uid, 'selectedSecuritySchemeUids', uids)
   }
   // Set as selected on request

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -262,7 +262,7 @@ watch(
     workspaceStore.importSpecFile(spec, 'default', {
       shouldLoad: false,
       documentUrl: configuration.value.spec?.url,
-      setCollectionSecurity: true,
+      useCollectionSecurity: true,
       ...configuration.value,
     }),
   { immediate: true },

--- a/packages/oas-utils/src/entities/spec/collection.ts
+++ b/packages/oas-utils/src/entities/spec/collection.ts
@@ -84,6 +84,12 @@ export const extendedCollectionSchema = z.object({
   /** Keeps track of which integration is associated with the specific collection */
   integration: z.string().nullable().optional(),
   /**
+   * Selected authentication will be set at the collection level instead of the request level
+   *
+   * @default false
+   */
+  useCollectionSecurity: z.boolean().optional().default(false),
+  /**
    * Status of the watcher from above
    *
    * @defaults to idle for all collections, doesn't mean that it can watch for changes

--- a/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
@@ -29,6 +29,7 @@ export const migrate_v_2_5_0 = (data: v_2_4_0.DataRecord): v_2_5_0['DataRecord']
         requests: collection.requests.map((uid) => uid as v_2_5_0['Request']['uid']),
         children: collection.children.map((uid) => uid as v_2_5_0['Request']['uid'] | v_2_5_0['Tag']['uid']),
         selectedServerUid: collection.selectedServerUid as v_2_5_0['Server']['uid'],
+        useCollectionSecurity: false,
       } satisfies v_2_5_0['Collection']
       return acc
     },

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -490,7 +490,7 @@ describe('importSpecToWorkspace', () => {
             },
           },
         },
-        setCollectionSecurity: true,
+        useCollectionSecurity: true,
       })
       if (res.error) {
         throw res.error
@@ -545,7 +545,7 @@ describe('importSpecToWorkspace', () => {
             password: 'test-password',
           },
         },
-        setCollectionSecurity: true,
+        useCollectionSecurity: true,
       })
       if (res.error) {
         throw res.error
@@ -632,7 +632,7 @@ describe('importSpecToWorkspace', () => {
       }
 
       const res = await importSpecToWorkspace(specWithEmptySecurity, {
-        setCollectionSecurity: true,
+        useCollectionSecurity: true,
         authentication: {
           preferredSecurityScheme: 'basicAuth',
         },
@@ -711,7 +711,7 @@ describe('importSpecToWorkspace', () => {
 
     it('sets collection level security when specified', async () => {
       const res = await importSpecToWorkspace(galaxy, {
-        setCollectionSecurity: true,
+        useCollectionSecurity: true,
         authentication: {
           preferredSecurityScheme: 'basicAuth',
         },
@@ -766,7 +766,7 @@ describe('importSpecToWorkspace', () => {
     it('sets the correct selectedSecuritySchemeUids when theres no collection security requirement', async () => {
       const { security, ...noSecurity } = galaxy
       const res = await importSpecToWorkspace(noSecurity, {
-        setCollectionSecurity: true,
+        useCollectionSecurity: true,
       })
       if (res.error) {
         throw res.error
@@ -801,7 +801,7 @@ describe('importSpecToWorkspace', () => {
       expect(res.requests[0]!.selectedSecuritySchemeUids).toEqual(selectedSecuritySchemeUids)
     })
 
-    it('handles AND security requirements with setCollectionSecurity', async () => {
+    it('handles AND security requirements with useCollectionSecurity', async () => {
       const specWithAndSecurity = {
         ...galaxy,
         security: [{ apiKeyHeader: [], basicAuth: [] }, { bearerAuth: [] }],
@@ -815,7 +815,7 @@ describe('importSpecToWorkspace', () => {
       }
 
       const res = await importSpecToWorkspace(specWithAndSecurity, {
-        setCollectionSecurity: true,
+        useCollectionSecurity: true,
       })
       if (res.error) {
         throw res.error

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -96,7 +96,7 @@ export const getSlugUid = (slug: string) => `slug-uid-${slug}` as Collection['ui
 export type ImportSpecToWorkspaceArgs = Pick<CollectionPayload, 'documentUrl' | 'watchMode'> &
   Pick<ApiReferenceConfiguration, 'authentication' | 'baseServerURL' | 'servers' | 'slug'> & {
     /** Sets the preferred security scheme on the collection instead of the requests */
-    setCollectionSecurity?: boolean
+    useCollectionSecurity?: boolean
     /** Call the load step from the parser */
     shouldLoad?: boolean
   }
@@ -121,7 +121,7 @@ export async function importSpecToWorkspace(
     baseServerURL,
     documentUrl,
     servers: configuredServers,
-    setCollectionSecurity = false,
+    useCollectionSecurity = false,
     slug,
     shouldLoad,
     watchMode = false,
@@ -326,7 +326,7 @@ export async function importSpecToWorkspace(
 
       // Set the initially selected security scheme
       const selectedSecuritySchemeUids =
-        securityRequirements.length && !setCollectionSecurity
+        securityRequirements.length && !useCollectionSecurity
           ? getSelectedSecuritySchemeUids(securityRequirements, preferredSecurityNames, securitySchemeMap)
           : []
 
@@ -456,7 +456,7 @@ export async function importSpecToWorkspace(
 
   // Set the initially selected security scheme
   const selectedSecuritySchemeUids =
-    (securityRequirements.length || preferredSecurityNames?.length) && setCollectionSecurity
+    (securityRequirements.length || preferredSecurityNames?.length) && useCollectionSecurity
       ? getSelectedSecuritySchemeUids(securityRequirements, preferredSecurityNames, securitySchemeMap)
       : []
 
@@ -468,6 +468,7 @@ export async function importSpecToWorkspace(
     ...schema,
     watchMode,
     documentUrl,
+    useCollectionSecurity,
     requests: requests.map((r) => r.uid),
     servers: servers.map((s) => s.uid),
     tags: tags.map((t) => t.uid),


### PR DESCRIPTION
**Problem**

Currently, in the client we can only set auth at the request level

**Solution**

With this PR we are able to set auth at the collection level. Also added a `useCollectionSecurity` flag to the collection so we can flick it on and off.

![image](https://github.com/user-attachments/assets/2051cd77-aa19-419b-98f9-9aa0317ba65a)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
