### PR TITLE
fix(api-reference): response body not showing

### DIFF
--- a/.changeset/new-phones-search.md
+++ b/.changeset/new-phones-search.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: missing body in references responses

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
@@ -1,7 +1,10 @@
 <script lang="ts" setup>
 import { ScalarCodeBlock, ScalarIcon, ScalarMarkdown } from '@scalar/components'
 import type { Operation } from '@scalar/oas-utils/entities/spec'
-import { normalizeMimeTypeObject } from '@scalar/oas-utils/helpers'
+import {
+  getObjectKeys,
+  normalizeMimeTypeObject,
+} from '@scalar/oas-utils/helpers'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { computed, ref, useId } from 'vue'
 
@@ -52,6 +55,9 @@ const currentJsonResponse = computed(() => {
     currentResponse.value?.content,
   )
 
+  /** All the keys of the normalized content */
+  const keys = getObjectKeys(normalizedContent ?? {})
+
   return (
     // OpenAPI 3.x
     normalizedContent?.['application/json'] ??
@@ -59,6 +65,8 @@ const currentJsonResponse = computed(() => {
     normalizedContent?.['text/plain'] ??
     normalizedContent?.['text/html'] ??
     normalizedContent?.['*/*'] ??
+    // Take the first key - in the future we may want to use the selected content type
+    normalizedContent?.[keys[0]] ??
     // Swagger 2.0
     currentResponse.value
   )


### PR DESCRIPTION
**Problem**

Currently, the response body in the references was only showing a select number of content types.

**Solution**

With this PR we will show any content type! In the future we can also extend this to use the one selected in the body dropdown.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
