### PR TITLE
fix(api-reference): proxy is skipped for localhost, even if the proxy is local

### DIFF
--- a/.changeset/nervous-penguins-bake.md
+++ b/.changeset/nervous-penguins-bake.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference-editor': patch
+'@scalar/api-reference': patch
+---
+
+fix: can’t fetch OpenAPI documents from local URLs with a port

--- a/.changeset/olive-mangos-serve.md
+++ b/.changeset/olive-mangos-serve.md
@@ -1,0 +1,8 @@
+---
+'@scalar/api-reference-editor': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+refactor: use central helper fetchDocument to fetch OpenAPI documents

--- a/.changeset/proud-flowers-smile.md
+++ b/.changeset/proud-flowers-smile.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: use proxy when it’s relative (even for local domains)

--- a/packages/api-client/src/components/ImportCollection/hooks/useUrlPrefetcher.ts
+++ b/packages/api-client/src/components/ImportCollection/hooks/useUrlPrefetcher.ts
@@ -33,7 +33,7 @@ export function useUrlPrefetcher() {
     })
   }
 
-  async function prefetchUrl(input: string | null, proxy?: string) {
+  async function prefetchUrl(input: string | null, proxyUrl?: string) {
     if (!input) {
       return {
         state: 'idle',
@@ -48,7 +48,7 @@ export function useUrlPrefetcher() {
       // If we try hard enough, we might find the actual OpenAPI document URL even if the input isn't one directly.
       const urlOrDocument = await resolve(input, {
         fetch: (url) => {
-          return fetch(proxy ? redirectToProxy(proxy, url) : url, {
+          return fetch(proxyUrl ? redirectToProxy(proxyUrl, url) : url, {
             cache: 'no-cache',
           })
         },
@@ -91,7 +91,7 @@ export function useUrlPrefetcher() {
 
       // Okay, we've got an URL. Let's fetch it:
       const result = await fetchWithProxyFallback(url, {
-        proxy,
+        proxyUrl,
         cache: 'no-cache',
       })
 
@@ -126,7 +126,7 @@ export function useUrlPrefetcher() {
     }
   }
 
-  async function prefetchUrlAndUpdateState(input: string | null, proxy?: string) {
+  async function prefetchUrlAndUpdateState(input: string | null, proxyUrl?: string) {
     Object.assign(prefetchResult, {
       state: 'loading',
       content: null,
@@ -135,7 +135,7 @@ export function useUrlPrefetcher() {
       error: null,
     })
 
-    const result = await prefetchUrl(input, proxy)
+    const result = await prefetchUrl(input, proxyUrl)
     Object.assign(prefetchResult, result)
     return result
   }

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -10,13 +10,13 @@ import {
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import type { z } from 'zod'
 
-import { createRequestOperation } from './create-request-operation'
 import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
+import { createRequestOperation } from './create-request-operation'
 
 const PROXY_PORT = 5051
 const VOID_PORT = 5052
 const PROXY_URL = `http://127.0.0.1:${PROXY_PORT}`
-export const VOID_URL = `http://127.0.0.1:${VOID_PORT}`
+const VOID_URL = `http://127.0.0.1:${VOID_PORT}`
 
 type RequestExamplePayload = z.input<typeof requestExampleSchema>
 
@@ -703,7 +703,6 @@ describe('create-request-operation', () => {
     const [error, requestOperation] = createRequestOperation({
       ...createRequestPayload({
         serverPayload: { url: VOID_URL },
-        proxyUrl: PROXY_URL,
         requestExamplePayload: {
           parameters: {
             cookies: [

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -16,7 +16,7 @@ import { createRequestOperation } from './create-request-operation'
 const PROXY_PORT = 5051
 const VOID_PORT = 5052
 const PROXY_URL = `http://127.0.0.1:${PROXY_PORT}`
-const VOID_URL = `http://127.0.0.1:${VOID_PORT}`
+export const VOID_URL = `http://127.0.0.1:${VOID_PORT}`
 
 type RequestExamplePayload = z.input<typeof requestExampleSchema>
 

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -15,7 +15,7 @@ import type {
   SecurityScheme,
   Server,
 } from '@scalar/oas-utils/entities/spec'
-import { isDefined, mergeUrls, shouldUseProxy } from '@scalar/oas-utils/helpers'
+import { isDefined, mergeUrls, redirectToProxy, shouldUseProxy } from '@scalar/oas-utils/helpers'
 
 import { buildRequestSecurity } from './build-request-security'
 
@@ -154,8 +154,7 @@ export const createRequestOperation = ({
       }
     }
 
-    const proxyPath = new URLSearchParams([['scalar_url', url.toString()]])
-    const proxiedUrl = shouldUseProxy(proxyUrl, url) ? `${proxyUrl}?${proxyPath.toString()}` : url
+    const proxiedUrl = redirectToProxy(proxyUrl, url)
 
     const proxiedRequest = new Request(proxiedUrl, {
       method: request.method.toUpperCase(),

--- a/packages/api-client/src/store/import-spec.ts
+++ b/packages/api-client/src/store/import-spec.ts
@@ -1,7 +1,7 @@
 import { type ErrorResponse, normalizeError } from '@/libs'
 import type { StoreContext } from '@/store/store-context'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
-import { createHash, fetchSpecFromUrl } from '@scalar/oas-utils/helpers'
+import { createHash, fetchDocument } from '@scalar/oas-utils/helpers'
 import { type ImportSpecToWorkspaceArgs, importSpecToWorkspace } from '@scalar/oas-utils/transforms'
 import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
@@ -79,7 +79,7 @@ export function importSpecFileFactory({
     }: Omit<ImportSpecFileArgs, 'documentUrl'> & Pick<ApiReferenceConfiguration, 'proxyUrl'> = {},
   ): Promise<ErrorResponse<Awaited<ReturnType<typeof importSpecFile>>>> {
     try {
-      const spec = await fetchSpecFromUrl(url, proxyUrl)
+      const spec = await fetchDocument(url, proxyUrl)
 
       return [
         null,

--- a/packages/api-client/src/views/Request/hooks/useOpenApiWatcher.ts
+++ b/packages/api-client/src/views/Request/hooks/useOpenApiWatcher.ts
@@ -9,7 +9,7 @@ import {
   mutateServerDiff,
   mutateTagDiff,
 } from '@/views/Request/libs/watch-mode'
-import { createHash, fetchSpecFromUrl } from '@scalar/oas-utils/helpers'
+import { createHash, fetchDocument } from '@scalar/oas-utils/helpers'
 import { parseSchema } from '@scalar/oas-utils/transforms'
 import { useToasts } from '@scalar/use-toasts'
 import { useTimeoutPoll } from '@vueuse/core'
@@ -89,7 +89,7 @@ export const useOpenApiWatcher = () => {
 
     try {
       // Grab the new spec
-      const spec = await fetchSpecFromUrl(url, activeWorkspace.value?.proxyUrl, false)
+      const spec = await fetchDocument(url, activeWorkspace.value?.proxyUrl, false)
       const hash = createHash(spec)
 
       collectionMutators.edit(activeCollection.value.uid, 'watchModeStatus', 'WATCHING')

--- a/packages/api-reference-editor/src/components/ApiReferenceEditor.vue
+++ b/packages/api-reference-editor/src/components/ApiReferenceEditor.vue
@@ -7,7 +7,7 @@ import {
 
 import '@scalar/api-reference/style.css'
 
-import { fetchSpecFromUrl } from '@scalar/oas-utils/helpers'
+import { fetchDocument } from '@scalar/oas-utils/helpers'
 import {
   apiReferenceConfigurationSchema,
   type ApiReferenceConfiguration,
@@ -42,7 +42,7 @@ function setSpec({ url, content }: SpecConfiguration) {
   if (url) {
     // For URLs we just set the value to fetched string
     try {
-      fetchSpecFromUrl(url).then((val) => {
+      fetchDocument(url).then((val) => {
         editorContent.value = val
       })
     } catch (error) {

--- a/packages/api-reference/src/hooks/useReactiveSpec.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.ts
@@ -1,4 +1,4 @@
-import { fetchSpecFromUrl, isValidUrl, prettyPrintJson } from '@scalar/oas-utils/helpers'
+import { fetchSpecFromUrl, prettyPrintJson } from '@scalar/oas-utils/helpers'
 import type { SpecConfiguration } from '@scalar/types/api-reference'
 import { type MaybeRefOrGetter, ref, toValue, watch } from 'vue'
 
@@ -6,7 +6,7 @@ import { createEmptySpecification } from '../helpers'
 import { parse } from '../helpers/parse'
 
 /**
- * Get the spec content from the provided configuration:
+ * Get the content from the provided configuration:
  *
  * 1. If the URL is provided, fetch the spec from the URL.
  * 2. If the content is a string, return it.
@@ -14,17 +14,13 @@ import { parse } from '../helpers/parse'
  * 4. If the content is a function, call it and get the content.
  * 5. Otherwise, return an empty string.
  */
-const getSpecContent = async ({ url, content }: SpecConfiguration, proxyUrl?: string): Promise<string | undefined> => {
-  // If the URL is provided, fetch the API definition from the URL
+const getContent = async ({ url, content }: SpecConfiguration, proxyUrl?: string): Promise<string | undefined> => {
+  // Fetch from URL
   if (url) {
     const start = performance.now()
 
     try {
-      // TODO: Use the resolve URL, not the given URL for the download link
-
-      // If the url is not valid, we can assume its a path and
-      // if it’s a path we can skip the proxy.
-      const result = !isValidUrl(url) ? await fetchSpecFromUrl(url) : await fetchSpecFromUrl(url, proxyUrl)
+      const result = await fetchSpecFromUrl(url, proxyUrl)
 
       const end = performance.now()
       console.log(`fetch: ${Math.round(end - start)} ms (${url})`)
@@ -32,11 +28,11 @@ const getSpecContent = async ({ url, content }: SpecConfiguration, proxyUrl?: st
 
       return result
     } catch (error) {
-      console.error('Failed to fetch spec from URL:', error)
+      console.error('Failed to fetch OpenAPI document from URL:', error)
     }
   }
 
-  // Callback
+  // Use a callback
   const activeContent = typeof content === 'function' ? content() : content
 
   // Strings are fine
@@ -99,7 +95,7 @@ export function useReactiveSpec({
     () => toValue(specConfig),
     async (newConfig) => {
       if (newConfig) {
-        const specContent = (await getSpecContent(newConfig, toValue(proxyUrl)))?.trim()
+        const specContent = (await getContent(newConfig, toValue(proxyUrl)))?.trim()
         if (typeof specContent === 'string') {
           rawSpec.value = specContent
         }

--- a/packages/api-reference/src/hooks/useReactiveSpec.ts
+++ b/packages/api-reference/src/hooks/useReactiveSpec.ts
@@ -1,4 +1,4 @@
-import { fetchSpecFromUrl, prettyPrintJson } from '@scalar/oas-utils/helpers'
+import { fetchDocument, prettyPrintJson } from '@scalar/oas-utils/helpers'
 import type { SpecConfiguration } from '@scalar/types/api-reference'
 import { type MaybeRefOrGetter, ref, toValue, watch } from 'vue'
 
@@ -20,7 +20,7 @@ const getContent = async ({ url, content }: SpecConfiguration, proxyUrl?: string
     const start = performance.now()
 
     try {
-      const result = await fetchSpecFromUrl(url, proxyUrl)
+      const result = await fetchDocument(url, proxyUrl)
 
       const end = performance.now()
       console.log(`fetch: ${Math.round(end - start)} ms (${url})`)

--- a/packages/oas-utils/src/helpers/fetch-document.test.ts
+++ b/packages/oas-utils/src/helpers/fetch-document.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
-import { fetchSpecFromUrl } from './fetch-spec-from-url.ts'
+import { fetchDocument } from './fetch-document.ts'
 
 const PROXY_PORT = 5051
 
@@ -25,16 +25,16 @@ $ pnpm dev:proxy-server
   }
 })
 
-describe('fetchSpecFromUrl', () => {
+describe('fetchDocument', () => {
   it('fetches specifications (without a proxy)', async () => {
-    const spec = await fetchSpecFromUrl('https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml')
+    const spec = await fetchDocument('https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml')
 
     expect(typeof spec).toEqual('string')
     expect(spec.length).toBeGreaterThan(100)
   })
 
   it('fetches specifications (through proxy.scalar.com)', async () => {
-    const spec = await fetchSpecFromUrl(
+    const spec = await fetchDocument(
       'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
       'https://proxy.scalar.com',
     )
@@ -44,7 +44,7 @@ describe('fetchSpecFromUrl', () => {
   })
 
   it(`fetches specifications (through 127.0.0.1:${PROXY_PORT})`, async () => {
-    const spec = await fetchSpecFromUrl(
+    const spec = await fetchDocument(
       'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml',
       `http://127.0.0.1:${PROXY_PORT}`,
     )
@@ -65,7 +65,7 @@ describe('fetchSpecFromUrl', () => {
       }),
     )
 
-    const spec = await fetchSpecFromUrl(`http://127.0.0.1:${PROXY_PORT}/test`)
+    const spec = await fetchDocument(`http://127.0.0.1:${PROXY_PORT}/test`)
 
     expect(typeof spec).toEqual('string')
 
@@ -74,10 +74,10 @@ describe('fetchSpecFromUrl', () => {
   })
 
   it('throws error for invalid URLs', async () => {
-    await expect(fetchSpecFromUrl('not-a-valid-url')).rejects.toThrow()
+    await expect(fetchDocument('not-a-valid-url')).rejects.toThrow()
   })
 
   it('throws error when fetch fails', async () => {
-    await expect(fetchSpecFromUrl('https://does-not-exist.scalar.com/spec.yaml')).rejects.toThrow('fetch failed')
+    await expect(fetchDocument('https://does-not-exist.scalar.com/spec.yaml')).rejects.toThrow('fetch failed')
   })
 })

--- a/packages/oas-utils/src/helpers/fetch-document.ts
+++ b/packages/oas-utils/src/helpers/fetch-document.ts
@@ -18,8 +18,6 @@ export async function fetchDocument(url: string, proxyUrl?: string, prettyPrint 
     proxyUrl = NEW_PROXY_URL
   }
 
-  console.log('fetchDocument', url, proxyUrl)
-
   const response = await fetch(redirectToProxy(proxyUrl, url))
 
   // Looks like the request failed

--- a/packages/oas-utils/src/helpers/fetch-document.ts
+++ b/packages/oas-utils/src/helpers/fetch-document.ts
@@ -11,24 +11,24 @@ const NEW_PROXY_URL = 'https://proxy.scalar.com'
  *
  * @throws an error if the fetch fails
  */
-export async function fetchSpecFromUrl(url: string, proxyUrl?: string, prettyPrint = true): Promise<string> {
+export async function fetchDocument(url: string, proxyUrl?: string, prettyPrint = true): Promise<string> {
   // This replaces the OLD_PROXY_URL with the NEW_PROXY_URL on the fly.
   if (proxyUrl === OLD_PROXY_URL) {
     // biome-ignore lint/style/noParameterAssign: It’s ok, let’s make an exception here.
     proxyUrl = NEW_PROXY_URL
   }
 
-  console.log('fetchSpecFromUrl', url, proxyUrl)
+  console.log('fetchDocument', url, proxyUrl)
 
   const response = await fetch(redirectToProxy(proxyUrl, url))
 
   // Looks like the request failed
   if (response.status !== 200) {
-    console.error(`[fetchSpecFromUrl] Failed to fetch the OpenAPI document from ${url} (Status: ${response.status})`)
+    console.error(`[fetchDocument] Failed to fetch the OpenAPI document from ${url} (Status: ${response.status})`)
 
     if (!proxyUrl) {
       console.warn(
-        `[fetchSpecFromUrl] Tried to fetch the OpenAPI document from ${url} without a proxy. Are the CORS headers configured to allow cross-domain requests? https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS`,
+        `[fetchDocument] Tried to fetch the OpenAPI document from ${url} without a proxy. Are the CORS headers configured to allow cross-domain requests? https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS`,
       )
     }
 

--- a/packages/oas-utils/src/helpers/fetch-spec-from-url.ts
+++ b/packages/oas-utils/src/helpers/fetch-spec-from-url.ts
@@ -1,5 +1,5 @@
-import { formatJsonOrYamlString } from '@/helpers/parse.ts'
-import { redirectToProxy } from '@/helpers/redirect-to-proxy.ts'
+import { formatJsonOrYamlString } from './parse.ts'
+import { redirectToProxy } from './redirect-to-proxy.ts'
 
 // Doesn’t work
 const OLD_PROXY_URL = 'https://api.scalar.com/request-proxy'
@@ -7,36 +7,38 @@ const OLD_PROXY_URL = 'https://api.scalar.com/request-proxy'
 const NEW_PROXY_URL = 'https://proxy.scalar.com'
 
 /**
- * Fetches an OpenAPI/Swagger specification from a given URL.
+ * Fetches an OpenAPI/Swagger document from a given URL
  *
  * @throws an error if the fetch fails
  */
-export async function fetchSpecFromUrl(url: string, proxy?: string, beautify = true): Promise<string> {
+export async function fetchSpecFromUrl(url: string, proxyUrl?: string, prettyPrint = true): Promise<string> {
   // This replaces the OLD_PROXY_URL with the NEW_PROXY_URL on the fly.
-  if (proxy === OLD_PROXY_URL) {
+  if (proxyUrl === OLD_PROXY_URL) {
     // biome-ignore lint/style/noParameterAssign: It’s ok, let’s make an exception here.
-    proxy = NEW_PROXY_URL
+    proxyUrl = NEW_PROXY_URL
   }
 
-  // To use a proxy or not to use a proxy
-  const response = await fetch(proxy ? redirectToProxy(proxy, url) : url)
+  console.log('fetchSpecFromUrl', url, proxyUrl)
+
+  const response = await fetch(redirectToProxy(proxyUrl, url))
 
   // Looks like the request failed
   if (response.status !== 200) {
-    console.error(`[fetchSpecFromUrl] Failed to fetch the specification at ${url} (Status: ${response.status})`)
+    console.error(`[fetchSpecFromUrl] Failed to fetch the OpenAPI document from ${url} (Status: ${response.status})`)
 
-    if (!proxy) {
+    if (!proxyUrl) {
       console.warn(
-        `[fetchSpecFromUrl] Tried to fetch the specification (url: ${url}) without a proxy. Are the CORS headers configured to allow cross-domain requests? https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS`,
+        `[fetchSpecFromUrl] Tried to fetch the OpenAPI document from ${url} without a proxy. Are the CORS headers configured to allow cross-domain requests? https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS`,
       )
     }
 
-    throw new Error(`Failed to fetch the specification (Status: ${response.status})`)
+    throw new Error(`Failed to fetch the OpenAPI document from ${url} (Status: ${response.status})`)
   }
 
   // If it’s JSON, make it pretty
-  if (beautify) {
+  if (prettyPrint) {
     return formatJsonOrYamlString(await response.text())
   }
+
   return await response.text()
 }

--- a/packages/oas-utils/src/helpers/fetch-with-proxy-fallback.ts
+++ b/packages/oas-utils/src/helpers/fetch-with-proxy-fallback.ts
@@ -1,7 +1,7 @@
 import { redirectToProxy, shouldUseProxy } from './redirect-to-proxy.ts'
 
 export type FetchWithProxyFallbackOptions = {
-  proxy: string | undefined
+  proxyUrl: string | undefined
   /**
    * @see https://developer.mozilla.org/en-US/docs/Web/API/Request/cache
    */
@@ -9,17 +9,17 @@ export type FetchWithProxyFallbackOptions = {
 }
 
 /**
- * Fetches an OpenAPI document with a proxy fallback mechanism.
+ * Fetches an OpenAPI document with a proxyUrl fallback mechanism.
  *
  * If a proxy is provided and the URL requires it, it will first attempt to fetch using the proxy.
  * If the proxy fetch fails or is not used, it will fall back to a direct fetch.
  */
-export async function fetchWithProxyFallback(url: string, { proxy, cache }: FetchWithProxyFallbackOptions) {
+export async function fetchWithProxyFallback(url: string, { proxyUrl, cache }: FetchWithProxyFallbackOptions) {
   const fetchOptions = {
     cache: cache || 'default',
   }
-  const shouldTryProxy = shouldUseProxy(proxy, url)
-  const initialUrl = shouldTryProxy ? redirectToProxy(proxy, url) : url
+  const shouldTryProxy = shouldUseProxy(proxyUrl, url)
+  const initialUrl = shouldTryProxy ? redirectToProxy(proxyUrl, url) : url
 
   try {
     const result = await fetch(initialUrl, fetchOptions)
@@ -28,11 +28,11 @@ export async function fetchWithProxyFallback(url: string, { proxy, cache }: Fetc
       return result
     }
 
-    // Retry without proxy if the initial request failed
+    // Retry without proxyUrl if the initial request failed
     return await fetch(url, fetchOptions)
   } catch (error) {
     if (shouldTryProxy) {
-      // If proxy failed, try without it
+      // If proxyUrl failed, try without it
       return await fetch(url, fetchOptions)
     }
     throw error

--- a/packages/oas-utils/src/helpers/index.ts
+++ b/packages/oas-utils/src/helpers/index.ts
@@ -1,6 +1,6 @@
 export { createHash } from './create-hash.ts'
 export { ensureProtocol } from './ensure-protocol.ts'
-export { fetchSpecFromUrl } from './fetch-spec-from-url.ts'
+export { fetchDocument } from './fetch-document.ts'
 export { type FetchWithProxyFallbackOptions, fetchWithProxyFallback } from './fetch-with-proxy-fallback.ts'
 export { findVariables } from './find-variables.ts'
 export { canMethodHaveBody, getHttpMethodInfo, isHttpMethod, REQUEST_METHODS } from './http-methods.ts'

--- a/packages/oas-utils/src/helpers/redirect-to-proxy.test.ts
+++ b/packages/oas-utils/src/helpers/redirect-to-proxy.test.ts
@@ -3,32 +3,36 @@ import { describe, expect, it } from 'vitest'
 import { isRelativePath, redirectToProxy } from './redirect-to-proxy.ts'
 
 describe('redirectToProxy', () => {
-  it('rewrites URLs', async () => {
+  it('rewrites URLs', () => {
     expect(redirectToProxy('https://proxy.scalar.com', 'https://example.com')).toBe(
       'https://proxy.scalar.com/?scalar_url=https%3A%2F%2Fexample.com',
     )
   })
 
-  it('keeps query parameters', async () => {
+  it('keeps query parameters', () => {
     expect(redirectToProxy('https://proxy.scalar.com?foo=bar', 'https://example.com')).toBe(
       'https://proxy.scalar.com/?foo=bar&scalar_url=https%3A%2F%2Fexample.com',
     )
   })
 
-  it('skips the proxy if no proxy url is passed', async () => {
+  it('skips the proxy if no proxy url is passed', () => {
     expect(redirectToProxy('', 'https://example.com')).toBe('https://example.com')
   })
 
-  it('skips the proxy for relative URLs starting with a slash', async () => {
+  it('skips the proxy for relative URLs starting with a slash', () => {
     expect(redirectToProxy('https://proxy.scalar.com', '/api')).toBe('/api')
   })
 
-  it('skips the proxy for relative URLs not starting with a slash', async () => {
+  it('skips the proxy for relative URLs not starting with a slash', () => {
     expect(redirectToProxy('https://proxy.scalar.com', 'api')).toBe('api')
   })
 
-  it('skips the proxy for relative URLs not starting with a slash, but containing a dot', async () => {
+  it('skips the proxy for relative URLs not starting with a slash, but containing a dot', () => {
     expect(redirectToProxy('https://proxy.scalar.com', 'openapi.json')).toBe('openapi.json')
+  })
+
+  it('skips the proxy when the proxyUrl is relative', () => {
+    expect(redirectToProxy('/proxy', 'https://example.com')).toBe('https://example.com')
   })
 })
 

--- a/packages/oas-utils/src/helpers/redirect-to-proxy.test.ts
+++ b/packages/oas-utils/src/helpers/redirect-to-proxy.test.ts
@@ -36,6 +36,12 @@ describe('redirectToProxy', () => {
   it('skips the proxy for relative URLs not starting with a slash, but containing a dot', () => {
     expect(redirectToProxy('https://proxy.scalar.com', 'openapi.json')).toBe('openapi.json')
   })
+
+  it('uses the proxy when it’s local', () => {
+    expect(redirectToProxy('http://localhost:3000/proxy', 'http://localhost:3000/api')).toBe(
+      'http://localhost:3000/proxy?scalar_url=http%3A%2F%2Flocalhost%3A3000%2Fapi',
+    )
+  })
 })
 
 describe('isRelativePath', () => {

--- a/packages/oas-utils/src/helpers/redirect-to-proxy.test.ts
+++ b/packages/oas-utils/src/helpers/redirect-to-proxy.test.ts
@@ -15,6 +15,12 @@ describe('redirectToProxy', () => {
     )
   })
 
+  it('uses the proxy when the proxyUrl is relative', () => {
+    expect(redirectToProxy('/proxy', 'http://localhost:3000/api')).toBe(
+      '/proxy?scalar_url=http%3A%2F%2Flocalhost%3A3000%2Fapi',
+    )
+  })
+
   it('skips the proxy if no proxy url is passed', () => {
     expect(redirectToProxy('', 'https://example.com')).toBe('https://example.com')
   })
@@ -29,10 +35,6 @@ describe('redirectToProxy', () => {
 
   it('skips the proxy for relative URLs not starting with a slash, but containing a dot', () => {
     expect(redirectToProxy('https://proxy.scalar.com', 'openapi.json')).toBe('openapi.json')
-  })
-
-  it('skips the proxy when the proxyUrl is relative', () => {
-    expect(redirectToProxy('/proxy', 'https://example.com')).toBe('https://example.com')
   })
 })
 

--- a/packages/oas-utils/src/helpers/redirect-to-proxy.ts
+++ b/packages/oas-utils/src/helpers/redirect-to-proxy.ts
@@ -84,6 +84,11 @@ export function shouldUseProxy(proxyUrl?: string, url?: string): url is string {
       return true
     }
 
+    // ✅ Proxy URL is local
+    if (isLocalUrl(proxyUrl)) {
+      return true
+    }
+
     // ❌ Requests to localhost
     // We won’t reach them from a (likely remote) proxy.
     if (isLocalUrl(url)) {

--- a/packages/oas-utils/src/helpers/redirect-to-proxy.ts
+++ b/packages/oas-utils/src/helpers/redirect-to-proxy.ts
@@ -5,25 +5,41 @@ import { REGEX } from './regex-helpers.ts'
  * Redirects the request to a proxy server with a given URL. But not for:
  *
  * - Relative URLs
- * - URLs that seem to point to a local IP
- * - URLs that don't look like a domain
+ * - URLs that seem to point to a local IP (except the proxy is on the same domain)
+ * - URLs that don’t look like a domain
  **/
-export function redirectToProxy(proxy?: string, url?: string): string {
+export function redirectToProxy(proxyUrl?: string, url?: string): string {
   try {
-    if (!shouldUseProxy(proxy, url)) {
+    if (!shouldUseProxy(proxyUrl, url)) {
+      console.log('should not use proxy', proxyUrl, url)
       return url ?? ''
     }
 
     // Create new URL object from url
-    const newUrl = new URL(url as string)
+    const newUrl = new URL(url)
+
+    // Add temporary domain for relative proxy URLs
+    //
+    // Q: Why isn’t proxyUrl type guarded?
+    // A: Type guarding works for one parameter only (as of now).
+    //
+    // Q: Why do we need to add http://localhost to relative proxy URLs?
+    // A: Because the `new URL()` would otherwise fail.
+    //
+    const temporaryProxyUrl = isRelativePath(proxyUrl as string) ? `http://localhost${proxyUrl}` : (proxyUrl as string)
 
     // Rewrite the URL with the proxy
-    newUrl.href = proxy as string
+    newUrl.href = temporaryProxyUrl
 
     // Add the original URL as a query parameter
-    newUrl.searchParams.append('scalar_url', url as string)
+    newUrl.searchParams.append('scalar_url', url)
 
-    return newUrl.toString()
+    // Remove the temporary domain if we added it, but only from the start of the URL
+    const result = isRelativePath(proxyUrl as string)
+      ? newUrl.toString().replace(/^http:\/\/localhost/, '')
+      : newUrl.toString()
+
+    return result
   } catch {
     return url ?? ''
   }
@@ -50,23 +66,31 @@ export const isRelativePath = (url: string) => {
 /**
  * Returns false for requests to localhost, relative URLs, if no proxy is defined …
  **/
-export function shouldUseProxy(proxyUrl?: string, url?: string): boolean {
+export function shouldUseProxy(proxyUrl?: string, url?: string): url is string {
   try {
-    // No proxy or url
+    // ❌ We don’t have a proxy URL or the URL
     if (!proxyUrl || !url) {
       return false
     }
 
-    // Relative URLs
+    // ❌ Request to relative URLs (won’t be blocked by CORS anyway)
     if (isRelativePath(url)) {
       return false
     }
 
-    // Requests to localhost
+    // ✅ Proxy URL is on the same domain (e.g. /proxy)
+    // It’s more likely (not guaranteed, though) that the proxy has access to local domains.
+    if (isRelativePath(proxyUrl)) {
+      return true
+    }
+
+    // ❌ Requests to localhost
+    // We won’t reach them from a (likely remote) proxy.
     if (isLocalUrl(url)) {
       return false
     }
 
+    // ✅ Seems fine (e.g. remote proxy + remote URL)
     return true
   } catch {
     return false

--- a/packages/oas-utils/src/helpers/redirect-to-proxy.ts
+++ b/packages/oas-utils/src/helpers/redirect-to-proxy.ts
@@ -50,10 +50,10 @@ export const isRelativePath = (url: string) => {
 /**
  * Returns false for requests to localhost, relative URLs, if no proxy is defined …
  **/
-export function shouldUseProxy(proxy?: string, url?: string): boolean {
+export function shouldUseProxy(proxyUrl?: string, url?: string): boolean {
   try {
     // No proxy or url
-    if (!proxy || !url) {
+    if (!proxyUrl || !url) {
       return false
     }
 


### PR DESCRIPTION
**Problem**

Our API reference can’t fetch OpenAPI documents from other (local) domains, if CORS isn’t set up properly (because we can’t use the remote proxy then).

**Solution**

Initially, I thought we’re just missing something in the fetching logic, turns out: Not really.  BUT two changes:

* The @scalar/api-reference fetching logic is closer to what we do for API requests.
* If the proxyUrl is relative, we’ll use it even for local domains (fixes #5258)

I used the opportunity to streamline the fetching a bit, though:

* Renamed `fetchSpecFromUrl` to `fetchDocument` (we’re talking about documents, not about the standard/specification)
* Updated comments
* Removed the isValidUrl/isRelativeUrl/whatever logic from `useReactiveSpec` and just used `fetchDocument` (to make it work the same in all places)
* Added a few more tests
* Catched a few more exceptions to simplify the usage of the related helpers

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
