### PR TITLE
fix(api-reference): empty search results on references

### DIFF
--- a/.changeset/heavy-tables-smoke.md
+++ b/.changeset/heavy-tables-smoke.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: empty search on references

--- a/packages/api-reference/src/features/Search/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.ts
@@ -77,20 +77,20 @@ export function useSearchIndex({
   })
 
   watch(
-    specification.value,
-    async () => {
+    specification,
+    (newSpec) => {
       fuseDataArray.value = []
 
       // Likely an incomplete/invalid spec
       // TODO: Or just an OpenAPI document without tags and webhooks?
-      if (!specification.value?.tags?.length && !specification.value?.webhooks?.length) {
+      if (!newSpec?.tags?.length && !newSpec?.webhooks?.length) {
         fuse.setCollection([])
         return
       }
 
       // Headings from the description
       const headingsData: FuseData[] = []
-      const headings = getHeadingsFromMarkdown(specification.value?.info?.description ?? '')
+      const headings = getHeadingsFromMarkdown(newSpec?.info?.description ?? '')
 
       if (headings.length) {
         headings.forEach((heading) => {
@@ -108,7 +108,7 @@ export function useSearchIndex({
       }
 
       // Tags
-      specification.value?.tags?.forEach((tag) => {
+      newSpec?.tags?.forEach((tag) => {
         const tagData: FuseData = {
           title: tag['x-displayName'] ?? tag.name,
           href: `#${getTagId(tag)}`,
@@ -151,7 +151,7 @@ export function useSearchIndex({
       })
 
       // Adding webhooks
-      const webhooks = specification.value?.webhooks
+      const webhooks = newSpec?.webhooks
       const webhookData: FuseData[] = []
 
       if (webhooks) {
@@ -175,7 +175,7 @@ export function useSearchIndex({
       }
 
       // Adding models as well
-      const schemas = hideModels.value ? {} : getModels(specification.value)
+      const schemas = hideModels.value ? {} : getModels(newSpec)
       const modelData: FuseData[] = []
 
       if (schemas) {


### PR DESCRIPTION
**Problem**

Currently, we had a watcher on a value to generate search results. .value is not responsive.

**Solution**

With this PR we move the watcher to the ref instead so its reactive.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
