### PR TITLE
fix(openapi-parser): migrate byte format

### DIFF
--- a/.changeset/honest-rockets-rush.md
+++ b/.changeset/honest-rockets-rush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: byte format is ignored when upgrading from OpenAPI 3.0 to OpenAPI 3.1

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
@@ -385,6 +385,40 @@ describe('upgradeFromThreeToThreeOne', () => {
     })
   })
 
+  it('migrates byte format', async () => {
+    const result = upgradeFromThreeToThreeOne({
+      openapi: '3.0.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/upload': {
+          post: {
+            requestBody: {
+              content: {
+                'image/png': {
+                  schema: {
+                    type: 'string',
+                    format: 'byte'
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.paths['/upload'].post.requestBody.content['image/png']).toEqual({
+      schema: {
+        type: 'string',
+        contentMediaType: 'image/png',
+        contentEncoding: 'base64'
+      },
+    })
+  })
+
   describe.skip('declaring $schema', () => {
     it('adds a $schema', async () => {
       const result = upgradeFromThreeToThreeOne({

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.test.ts
@@ -400,7 +400,7 @@ describe('upgradeFromThreeToThreeOne', () => {
                 'image/png': {
                   schema: {
                     type: 'string',
-                    format: 'byte'
+                    format: 'byte',
                   },
                 },
               },
@@ -414,7 +414,7 @@ describe('upgradeFromThreeToThreeOne', () => {
       schema: {
         type: 'string',
         contentMediaType: 'image/png',
-        contentEncoding: 'base64'
+        contentEncoding: 'base64',
       },
     })
   })

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -122,6 +122,22 @@ export function upgradeFromThreeToThreeOne(originalSpecification: UnknownObject)
     return schema
   })
 
+  specification = traverse(specification, (schema, path) => {
+    if (schema.type === 'string' && schema.format === 'byte') {
+      // Check if this is a multipart request body schema
+      const parentPath = path.slice(0, -1)
+      const contentMediaType = parentPath.find((_, index) => path[index - 1] === 'content')
+
+      return {
+        type: 'string',
+        contentEncoding: 'base64',
+        contentMediaType,
+      }
+    }
+
+    return schema
+  })
+
   // Declaring $schema Dialects to protect against change
   // if (typeof specification.$schema === 'undefined') {
   //   specification.$schema = 'http://json-schema.org/draft-07/schema#'

--- a/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromThreeToThreeOne.ts
@@ -124,7 +124,6 @@ export function upgradeFromThreeToThreeOne(originalSpecification: UnknownObject)
 
   specification = traverse(specification, (schema, path) => {
     if (schema.type === 'string' && schema.format === 'byte') {
-      // Check if this is a multipart request body schema
       const parentPath = path.slice(0, -1)
       const contentMediaType = parentPath.find((_, index) => path[index - 1] === 'content')
 


### PR DESCRIPTION
**Problem**

Currently, the `byte` format is ignored when upgrading from OpenAPI version `3.0.x` to `3.1.x`.

**Solution**

With this PR, the `byte` format is upgraded properly. This PR closes #5272

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
