### PR TITLE
feat(api-client): show actual request headers

### DIFF
--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -30,6 +30,8 @@ type SendRequestResponse = Promise<
   }>
 >
 
+export type SendRequestResult = Awaited<SendRequestResponse>[1]
+
 /** Execute the request */
 export const createRequestOperation = ({
   environment,

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -8,6 +8,7 @@ import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import { useLayout } from '@/hooks'
 import { useSidebar } from '@/hooks/useSidebar'
 import { importCurlCommand } from '@/libs/importers/curl'
+import type { SendRequestResult } from '@/libs/send-request/create-request-operation'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 import RequestSection from '@/views/Request/RequestSection/RequestSection.vue'
@@ -17,6 +18,7 @@ import ResponseSection from '@/views/Request/ResponseSection/ResponseSection.vue
 const { invalidParams, selectedSecuritySchemeUids } = defineProps<{
   invalidParams: Set<string>
   selectedSecuritySchemeUids: SelectedSecuritySchemeUids
+  requestResult?: SendRequestResult | null
 }>()
 defineEmits<(e: 'newTab', item: { name: string; uid: string }) => void>()
 
@@ -91,6 +93,7 @@ function handleCurlImport(curl: string) {
               :server="activeServer"
               :workspace="activeWorkspace" />
             <ResponseSection
+              :requestResult="requestResult"
               :numWorkspaceRequests="activeWorkspaceRequests.length"
               :response="activeHistoryEntry?.response" />
           </ViewLayoutContent>

--- a/packages/api-client/src/views/Request/RequestRoot.vue
+++ b/packages/api-client/src/views/Request/RequestRoot.vue
@@ -10,6 +10,7 @@ import { useLayout } from '@/hooks'
 import { useSidebar } from '@/hooks/useSidebar'
 import { ERRORS } from '@/libs'
 import { createRequestOperation } from '@/libs/send-request'
+import type { SendRequestResult } from '@/libs/send-request/create-request-operation'
 import { validateParameters } from '@/libs/validate-parameters'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
@@ -37,6 +38,7 @@ const element = ref<HTMLDivElement>()
 
 const requestAbortController = ref<AbortController>()
 const invalidParams = ref<Set<string>>(new Set())
+const requestResult = ref<SendRequestResult | null>(null)
 
 /**
  * Selected scheme UIDs
@@ -105,6 +107,9 @@ const executeRequest = async () => {
   requestAbortController.value = requestOperation.controller
   const [sendRequestError, result] = await requestOperation.sendRequest()
 
+  // Store the result to share it with child components
+  requestResult.value = result
+
   // Send error toast
   if (sendRequestError) {
     toast(sendRequestError.message, 'error')
@@ -170,7 +175,8 @@ watch(
       <div class="flex h-full flex-1 flex-col">
         <RouterView
           :invalidParams="invalidParams"
-          :selectedSecuritySchemeUids="selectedSecuritySchemeUids" />
+          :selectedSecuritySchemeUids="selectedSecuritySchemeUids"
+          :requestResult="requestResult" />
       </div>
     </div>
   </div>

--- a/packages/api-client/src/views/Request/ResponseSection/RequestHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/RequestHeaders.vue
@@ -23,7 +23,7 @@ const findHeaderInfo = (name: string) => {
     class="overflow-auto"
     :defaultOpen="false"
     :itemCount="headers.length">
-    <template #title>Response Headers</template>
+    <template #title>Request Headers</template>
     <div
       v-if="headers.length"
       class="max-h-[calc(100%-32px)] overflow-y-auto border-t">

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -4,18 +4,21 @@ import { computed, ref, useId } from 'vue'
 
 import SectionFilter from '@/components/SectionFilter.vue'
 import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
-import ResponseBody from '@/views/Request/ResponseSection/ResponseBody.vue'
-import ResponseEmpty from '@/views/Request/ResponseSection/ResponseEmpty.vue'
-import ResponseLoadingOverlay from '@/views/Request/ResponseSection/ResponseLoadingOverlay.vue'
-import ResponseMetaInformation from '@/views/Request/ResponseSection/ResponseMetaInformation.vue'
+import type { SendRequestResult } from '@/libs/send-request/create-request-operation'
 
+import RequestHeaders from './RequestHeaders.vue'
+import ResponseBody from './ResponseBody.vue'
 import ResponseBodyVirtual from './ResponseBodyVirtual.vue'
 import ResponseCookies from './ResponseCookies.vue'
+import ResponseEmpty from './ResponseEmpty.vue'
 import ResponseHeaders from './ResponseHeaders.vue'
+import ResponseLoadingOverlay from './ResponseLoadingOverlay.vue'
+import ResponseMetaInformation from './ResponseMetaInformation.vue'
 
-const { numWorkspaceRequests, response } = defineProps<{
+const { numWorkspaceRequests, response, requestResult } = defineProps<{
   numWorkspaceRequests: number
   response: ResponseInstance | undefined
+  requestResult: SendRequestResult | null | undefined
 }>()
 
 // Headers
@@ -155,6 +158,20 @@ const shouldVirtualize = computed(() => {
           v-if="activeFilter === 'All' || activeFilter === 'Cookies'"
           :id="filterIds.Cookies"
           :cookies="responseCookies"
+          :role="activeFilter === 'All' ? 'none' : 'tabpanel'" />
+        <RequestHeaders
+          class="response-section-content-headers"
+          v-if="activeFilter === 'All' || activeFilter === 'Headers'"
+          :id="filterIds.Headers"
+          :headers="
+            requestResult?.request.parameters.headers
+              .filter((h) => h.enabled)
+              .map((h) => ({
+                name: h.key,
+                value: h.value,
+                required: h.required,
+              })) ?? []
+          "
           :role="activeFilter === 'All' ? 'none' : 'tabpanel'" />
         <ResponseHeaders
           class="response-section-content-headers"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -23,19 +23,11 @@ const responseHeaders = computed(() => {
   const headers = response?.headers
 
   return headers
-    ? Object.keys(headers)
-        .map((key) => ({
-          name: key,
-          value: headers[key] ?? '',
-          required: false,
-        }))
-        .filter(
-          (item) =>
-            ![
-              'rest-api-client-content-length',
-              'X-API-Client-Content-Length',
-            ].includes(item.name),
-        )
+    ? Object.keys(headers).map((key) => ({
+        name: key,
+        value: headers[key] ?? '',
+        required: false,
+      }))
     : []
 })
 


### PR DESCRIPTION
**Problem**

Sometimes, I’d wish to see the actual request headers that were sent, or even the whole request (see #5273). But it’s only in the browser console (as of now).

**Solution**

With this PR we’re adding a “Request Headers” section to the response pane, so you can see the headers that are sent.

Just two things to note:

1. It’s just the headers, not the whole HTTP request yet.
2. It’s not showing the headers that the browser adds (we can’t access those).

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
