### PR TITLE
feat(api-reference): better schema rendering

### DIFF
--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -37,6 +37,7 @@
     "playground:esm": "vite ./playground/esm -c ./playground/esm/vite.config.ts",
     "playground:ssr": "cd ./playground/ssr && pnpm dev",
     "playground:vue": "vite ./playground/vue -c ./playground/vue/vite.config.ts",
+    "playground:components": "vite ./playground/components -c ./playground/components/vite.config.ts",
     "preview": "vite preview",
     "test": "vitest",
     "types:build": "vue-tsc -p tsconfig.build.json",

--- a/packages/api-reference/playground/components/index.html
+++ b/packages/api-reference/playground/components/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/vite.svg" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0" />
+    <title>Scalar API Reference (Components)</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/api-reference/playground/components/src/App.vue
+++ b/packages/api-reference/playground/components/src/App.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import '@scalar/themes/style.css'
+import '@scalar/components/style.css'
+import '../../../dist/style.css'
+
+import { ScalarErrorBoundary } from '@scalar/components'
+import { computed, type Component } from 'vue'
+
+// This will be populated by the file search in agent mode
+type Preview = {
+  component: Component
+  props: Record<string, any>
+}
+
+// Use Vite's glob import to find all preview files
+const previewModules = import.meta.glob<{ preview: Preview }>(
+  '../../../**/*.preview.ts',
+  {
+    eager: true,
+  },
+)
+
+// Transform the modules into a cleaner structure
+const files = computed(() => {
+  const result: Record<
+    string,
+    (Preview & {
+      _key: string
+      _name: string
+      _path: string
+      _exportKey: string
+      _position: number
+    })[]
+  > = {}
+
+  console.log(previewModules)
+
+  for (const path in previewModules) {
+    if (path) {
+      const name = getNameFromPath(path)
+
+      if (!result[path]) {
+        result[path] = []
+      }
+
+      // Convert exports to array and preserve their order
+      const entries = Object.entries(previewModules[path])
+        .filter(([key]) => key !== 'default') // Skip default export if present
+        .map(([exportKey, value], index) => ({
+          ...value,
+          _key: `${path}.${exportKey}`,
+          _path: path,
+          _exportKey: exportKey,
+          _position: index,
+        }))
+        .sort((a, b) => b._position - a._position)
+
+      result[path].push(...entries)
+    }
+  }
+
+  return result
+})
+
+function getNameFromPath(path: string) {
+  return path.split('/').pop()?.replace('.preview.ts', '') || ('' as string)
+}
+</script>
+
+<template>
+  <div
+    class="light-mode scalar-app scalar-api-reference references-layout references-sidebar app">
+    <template
+      v-for="(previews, _path) in files"
+      :key="_path">
+      <h1>{{ getNameFromPath(_path) }}.vue</h1>
+      <div class="components">
+        <ul>
+          <li
+            v-for="preview in previews"
+            class="preview"
+            :key="preview._key">
+            <div class="preview-badge">
+              {{ preview._exportKey }}
+            </div>
+            <div class="preview-component">
+              <ScalarErrorBoundary>
+                <component
+                  :is="preview.component"
+                  v-bind="preview.props ?? {}" />
+              </ScalarErrorBoundary>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+h1 {
+  font-weight: bold;
+  margin: 1rem 0;
+}
+
+.app {
+  padding: 0 1rem;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.preview {
+  list-style: none;
+
+  position: relative;
+}
+
+.preview-component {
+  border: 1px solid #eee;
+  padding: 1rem;
+}
+
+.preview-badge {
+  font-family: monospace;
+  color: #666;
+  background-color: #eee;
+  padding: 0.5rem;
+  font-size: 0.8rem;
+  display: inline-block;
+}
+</style>

--- a/packages/api-reference/playground/components/src/main.ts
+++ b/packages/api-reference/playground/components/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/packages/api-reference/playground/components/vite.config.ts
+++ b/packages/api-reference/playground/components/vite.config.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from 'node:url'
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('../../src', import.meta.url)),
+    },
+    dedupe: ['vue'],
+  },
+  server: {
+    fs: {
+      allow: [
+        fileURLToPath(new URL('./', import.meta.url)),
+        '../../**/*.preview.ts',
+        '../../**/*.ts',
+        '../../**/*.js',
+        '../../**/*.vue',
+      ],
+    },
+  },
+})

--- a/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
@@ -1,0 +1,113 @@
+import Schema from './Schema.vue'
+
+export const stringSchema = {
+  component: Schema,
+  noncollapsible: true,
+  props: {
+    name: 'CustomString',
+    noncollapsible: true,
+    value: {
+      type: 'string',
+      example: 'Hello, world!',
+    },
+  },
+}
+
+export const objectSchema = {
+  component: Schema,
+  noncollapsible: true,
+  props: {
+    name: 'CustomObject',
+    noncollapsible: true,
+    value: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          example: 'John Doe',
+        },
+        age: {
+          type: 'number',
+          example: 30,
+        },
+      },
+    },
+  },
+}
+
+const objectWithCircularReference = {
+  type: 'object',
+  properties: {
+    circularReference: {},
+  },
+}
+
+objectWithCircularReference.properties.circularReference = objectWithCircularReference
+
+export const recursiveSchema = {
+  component: Schema,
+  props: {
+    name: 'CustomRecursive',
+    noncollapsible: true,
+    value: objectWithCircularReference,
+  },
+}
+
+export const enumSchema = {
+  component: Schema,
+  props: {
+    name: 'CustomEnum',
+    noncollapsible: true,
+    value: {
+      type: 'string',
+      enum: ['foo', 'bar'],
+      description: 'The enum value',
+    },
+  },
+}
+
+export const objectWithEnumSchema = {
+  component: Schema,
+  props: {
+    name: 'ObjectWithEnum',
+    noncollapsible: true,
+    value: {
+      type: 'object',
+      properties: {
+        enumValue: {
+          type: 'string',
+          enum: ['foo', 'bar'],
+          description: 'The enum value',
+        },
+      },
+    },
+  },
+}
+
+export const discriminatorsSchema = {
+  component: Schema,
+  props: {
+    name: 'CustomDiscriminator',
+    noncollapsible: true,
+    value: {
+      anyOf: [
+        {
+          name: 'Foo',
+          type: 'object',
+          properties: {
+            type: { type: 'string', enum: ['foo'] },
+            fooProperty: { type: 'string' },
+          },
+        },
+        {
+          name: 'Bar',
+          type: 'object',
+          properties: {
+            type: { type: 'string', enum: ['bar'] },
+            barProperty: { type: 'number' },
+          },
+        },
+      ],
+    },
+  },
+}

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -70,7 +70,9 @@ const handleClick = (e: MouseEvent) =>
           !compact
         "
         class="schema-card-description">
-        <ScalarMarkdown :value="value.description" />
+        <template v-if="!value.enum">
+          <ScalarMarkdown :value="value.description" />
+        </template>
       </div>
       <div
         class="schema-properties"

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -84,6 +84,10 @@ const getModelNameFromSchema = (schema: any): string | null => {
     return null
   }
 
+  if (schema.name) {
+    return schema.name
+  }
+
   // returns a matching schema name based on the schema object
   if (props.schemas && typeof props.schemas === 'object') {
     for (const [schemaName, schemaValue] of Object.entries(props.schemas)) {
@@ -91,6 +95,7 @@ const getModelNameFromSchema = (schema: any): string | null => {
         return schemaName
       }
     }
+
     return Object.keys(schema)[0]
   }
 


### PR DESCRIPTION
**Problem**

Every time we fix something for the schema rendering, we break something else. The tests we have aren’t very visual, it’s hard to miss bugs, and the Scalar Galaxy example only covers a few schema use cases.

**Solution**

This PR reinvents storybook (just a Vue component that looks for a `*.preview.ts` files and renders what it exports). This makes it easier to add examples and quickly check whether they are rendered nicely.

* Fixes #5251
* It’s showing the schema name for discriminators, when there’s one defined.

You’re wondering why we don’t use Storybook? I never got HMR working in `@scalar/api-reference`. Even after I copied the exact same setup from `@scalar/components`.

**Preview**

<img width="735" alt="Screenshot 2025-04-01 at 13 32 11" src="https://github.com/user-attachments/assets/c2cb37e5-ed25-4451-9026-ae0c4582e4ef" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
