### PR TITLE
Fix guides documentation url in introduction.md

### DIFF
--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -6,7 +6,7 @@ You’re working with APIs? That’s great, we’re here to make your life easie
 
 [Scalar Docs](/scalar/introduction) is our managed platform for whipping up and publishing documentation sites and API references.
 
-We’ve made it super easy to work together, and there’s an awesome free plan to get started. Plus, it plays nice with your existing setup. How cool is that? [Check out how it integrates with GitHub](/scalar/scalar-docs/github-sync).
+We’ve made it super easy to work together, and there’s an awesome free plan to get started. Plus, it plays nice with your existing setup. How cool is that? [Check out how it integrates with GitHub](/documentation/guides/docs/github-sync.md).
 
 Hop over to <https://docs.scalar.com> and take it for a spin. You don’t even need an account to play with it.
 


### PR DESCRIPTION
**Problem**

Currently the URL pointing to github-sync doc is broken

**Solution**

Update with the correct path

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
