### PR TITLE
fix(api-reference): ensure pathRouting works on initial load

### DIFF
--- a/.changeset/new-baboons-cry.md
+++ b/.changeset/new-baboons-cry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: ensure pathRouting works on first load

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -101,7 +101,7 @@ const {
 } = useSidebar()
 
 const {
-  getReferenceHash,
+  getReferenceId,
   getPathRoutingId,
   getSectionId,
   getTagId,
@@ -109,7 +109,7 @@ const {
   isIntersectionEnabled,
   updateHash,
   replaceUrlState,
-} = useNavState()
+} = useNavState(configuration)
 
 // Front-end redirect
 if (configuration.value.redirect && typeof window !== 'undefined') {
@@ -167,7 +167,7 @@ onMounted(() => {
 
   // This is what updates the hash ref from hash changes
   window.onhashchange = () => {
-    scrollToSection(getReferenceHash())
+    scrollToSection(getReferenceId())
   }
   // Handle back for path routing
   window.onpopstate = () =>


### PR DESCRIPTION
**Problem**

Currently, if you refresh the page while using pathRouting it does not route to the correct spot.

**Solution**

It turns out config was undefined as it is provided in `ApiReferenceLayout` so if we use `useNavState` in that component we don't get config. So we pass in config here as we are computing it above.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
