### PR TITLE
fix(api-reference): prevent the store from crashing when we have exponential body properties

### DIFF
--- a/.changeset/yellow-ladybugs-rhyme.md
+++ b/.changeset/yellow-ladybugs-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: add cap on horizontal expententially expanding bodys

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -26,13 +26,15 @@ const props = withDefaults(
     /** Shows a toggle to hide/show children */
     noncollapsible?: boolean
     hideHeading?: boolean
+    /** Show a special one way toggle for additional properties, also has a top border when open */
+    additionalProperties?: boolean
     schemas?:
       | OpenAPIV2.DefinitionsObject
       | Record<string, OpenAPIV3.SchemaObject>
       | Record<string, OpenAPIV3_1.SchemaObject>
       | unknown
   }>(),
-  { level: 0 },
+  { level: 0, showAdditionalProperties: false },
 )
 
 const shouldShowToggle = computed(() => {
@@ -56,6 +58,7 @@ const handleClick = (e: MouseEvent) =>
       :class="[
         `schema-card--level-${level}`,
         { 'schema-card--compact': compact, 'schema-card--open': open },
+        { 'border-t-1/2': additionalProperties && open },
       ]">
       <div
         v-if="
@@ -74,7 +77,25 @@ const handleClick = (e: MouseEvent) =>
         :class="{
           'schema-properties-open': open,
         }">
+        <!-- Special toggle to show additional properties -->
+        <div
+          v-if="additionalProperties"
+          class="schema-properties"
+          v-show="!open">
+          <DisclosureButton
+            as="button"
+            class="schema-card-title schema-card-title--compact"
+            @click.capture="handleClick">
+            <ScalarIcon
+              class="schema-card-title-icon"
+              icon="Add"
+              size="sm" />
+            Show additional properties
+          </DisclosureButton>
+        </div>
+
         <DisclosureButton
+          v-else
           v-show="!hideHeading && !(noncollapsible && compact)"
           :as="noncollapsible ? 'div' : 'button'"
           class="schema-card-title"

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -27,6 +27,8 @@ if (requestBody?.content) {
     selectedContentType.value = availableContentTypes.value[0] as ContentType
   }
 }
+
+console.log(requestBody?.content?.[selectedContentType.value])
 </script>
 <template>
   <div v-if="requestBody">
@@ -49,7 +51,10 @@ if (requestBody?.content) {
       class="request-body-schema">
       <Schema
         compact
-        noncollapsible
+        :noncollapsible="
+          Object.keys(requestBody.content?.[selectedContentType] ?? {}).length >
+          10
+        "
         :schemas="schemas"
         :value="requestBody.content?.[selectedContentType]?.schema" />
     </div>

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -27,8 +27,6 @@ if (requestBody?.content) {
     selectedContentType.value = availableContentTypes.value[0] as ContentType
   }
 }
-
-console.log(requestBody?.content?.[selectedContentType.value])
 </script>
 <template>
   <div v-if="requestBody">

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.test.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.test.ts
@@ -1009,33 +1009,6 @@ describe('getExampleFromSchema', () => {
     })
   })
 
-  it('deals with circular references', () => {
-    const schema = {
-      type: 'object',
-      properties: {
-        foobar: {},
-      },
-    }
-
-    // Create a circular reference
-    schema.properties.foobar = schema
-
-    // 10 levels deep, that’s enough. It should return null then.
-    expect(getExampleFromSchema(schema)).toStrictEqual({
-      foobar: {
-        foobar: {
-          foobar: {
-            foobar: {
-              foobar: {
-                foobar: '[Circular Reference]',
-              },
-            },
-          },
-        },
-      },
-    })
-  })
-
   it('handles patternProperties', () => {
     expect(
       getExampleFromSchema({
@@ -1069,6 +1042,101 @@ describe('getExampleFromSchema', () => {
         dataId: '',
         link: 'https://example.com',
       },
+    })
+  })
+
+  describe('circular references', () => {
+    it('deals with circular references', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          foobar: {},
+        },
+      }
+
+      // Create a circular reference
+      schema.properties.foobar = schema
+
+      // 10 levels deep, that’s enough. It should return null then.
+      expect(getExampleFromSchema(schema)).toStrictEqual({
+        foobar: {
+          foobar: {
+            foobar: {
+              foobar: {
+                foobar: {
+                  foobar: '[Circular Reference]',
+                },
+              },
+            },
+          },
+        },
+      })
+    })
+
+    it('deals with circular references that expand horizontally', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          a: {},
+          b: {},
+          c: {},
+          d: {},
+          e: {},
+          f: {},
+          g: {},
+          h: {},
+          i: {},
+          j: {},
+          k: {},
+          l: {},
+          m: {},
+          n: {},
+          o: {},
+          p: {},
+          q: {},
+          r: {},
+          s: {},
+          t: {},
+          u: {},
+          v: {},
+          w: {},
+          x: {},
+          y: {},
+          z: {},
+        },
+      }
+
+      // Create a circular reference for each property
+      schema.properties.a = schema
+      schema.properties.b = schema
+      schema.properties.c = schema
+      schema.properties.d = schema
+      schema.properties.e = schema
+      schema.properties.f = schema
+      schema.properties.g = schema
+      schema.properties.h = schema
+      schema.properties.i = schema
+      schema.properties.j = schema
+      schema.properties.k = schema
+      schema.properties.l = schema
+      schema.properties.m = schema
+      schema.properties.n = schema
+      schema.properties.o = schema
+      schema.properties.p = schema
+      schema.properties.q = schema
+      schema.properties.r = schema
+      schema.properties.s = schema
+      schema.properties.t = schema
+      schema.properties.u = schema
+      schema.properties.v = schema
+      schema.properties.w = schema
+      schema.properties.x = schema
+      schema.properties.y = schema
+      schema.properties.z = schema
+
+      const example = getExampleFromSchema(schema)
+      expect(example).toBeInstanceOf(Object)
+      expect(Object.keys(example).length).toBe(26)
     })
   })
 })

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
@@ -174,6 +174,7 @@ export const getExampleFromSchema = (
     const response: Record<string, any> = {}
     let propertyCount = 0
 
+    // Regular properties
     if (schema.properties !== undefined) {
       for (const propertyName in schema.properties) {
         if (Object.prototype.hasOwnProperty.call(schema.properties, propertyName)) {

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
@@ -1,5 +1,7 @@
 /** Hard limit for rendering circular references */
 const MAX_LEVELS_DEEP = 5
+/** Sets the max number of properties after the third level to prevent exponential horizontal growth */
+const MAX_PROPERTIES = 5
 
 const genericExampleValues: Record<string, string> = {
   // 'date-time': '1970-01-01T00:00:00Z',
@@ -89,6 +91,8 @@ export const getExampleFromSchema = (
   level: number = 0,
   parentSchema?: Record<string, any>,
   name?: string,
+  seenPaths: Set<string> = new Set(),
+  currentPath: string = '',
 ): any => {
   // Check if the result is already cached
   if (resultCache.has(schema)) {
@@ -170,24 +174,26 @@ export const getExampleFromSchema = (
   // Object
   if (schema.type === 'object' || schema.properties !== undefined) {
     const response: Record<string, any> = {}
+    let propertyCount = 0
 
-    // Regular properties
     if (schema.properties !== undefined) {
       for (const propertyName in schema.properties) {
         if (Object.prototype.hasOwnProperty.call(schema.properties, propertyName)) {
+          // Only apply property limit for nested levels (level > 0)
+          if (level > 3 && propertyCount >= MAX_PROPERTIES) {
+            response['...'] = '[Additional Properties Truncated]'
+            break
+          }
+
           const property = schema.properties[propertyName]
           const propertyXmlTagName = options?.xml ? property.xml?.name : undefined
+          const newPath = currentPath ? `${currentPath}.${propertyName}` : propertyName
 
-          response[propertyXmlTagName ?? propertyName] = getExampleFromSchema(
-            property,
-            options,
-            level + 1,
-            schema,
-            propertyName,
-          )
+          const value = getExampleFromSchema(property, options, level + 1, schema, propertyName, seenPaths, newPath)
 
-          if (typeof response[propertyXmlTagName ?? propertyName] === 'undefined') {
-            delete response[propertyXmlTagName ?? propertyName]
+          if (typeof value !== 'undefined') {
+            response[propertyXmlTagName ?? propertyName] = value
+            propertyCount++
           }
         }
       }

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
@@ -1,7 +1,7 @@
 /** Hard limit for rendering circular references */
 const MAX_LEVELS_DEEP = 5
 /** Sets the max number of properties after the third level to prevent exponential horizontal growth */
-const MAX_PROPERTIES = 5
+const MAX_PROPERTIES = 10
 
 const genericExampleValues: Record<string, string> = {
   // 'date-time': '1970-01-01T00:00:00Z',

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
@@ -91,7 +91,6 @@ export const getExampleFromSchema = (
   level: number = 0,
   parentSchema?: Record<string, any>,
   name?: string,
-  currentPath: string = '',
 ): any => {
   // Check if the result is already cached
   if (resultCache.has(schema)) {
@@ -186,9 +185,8 @@ export const getExampleFromSchema = (
 
           const property = schema.properties[propertyName]
           const propertyXmlTagName = options?.xml ? property.xml?.name : undefined
-          const newPath = currentPath ? `${currentPath}.${propertyName}` : propertyName
 
-          const value = getExampleFromSchema(property, options, level + 1, schema, propertyName, newPath)
+          const value = getExampleFromSchema(property, options, level + 1, schema, propertyName)
 
           if (typeof value !== 'undefined') {
             response[propertyXmlTagName ?? propertyName] = value

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
@@ -91,7 +91,6 @@ export const getExampleFromSchema = (
   level: number = 0,
   parentSchema?: Record<string, any>,
   name?: string,
-  seenPaths: Set<string> = new Set(),
   currentPath: string = '',
 ): any => {
   // Check if the result is already cached
@@ -189,7 +188,7 @@ export const getExampleFromSchema = (
           const propertyXmlTagName = options?.xml ? property.xml?.name : undefined
           const newPath = currentPath ? `${currentPath}.${propertyName}` : propertyName
 
-          const value = getExampleFromSchema(property, options, level + 1, schema, propertyName, seenPaths, newPath)
+          const value = getExampleFromSchema(property, options, level + 1, schema, propertyName, newPath)
 
           if (typeof value !== 'undefined') {
             response[propertyXmlTagName ?? propertyName] = value


### PR DESCRIPTION
**Problem**

Currently, we have a hard limit on depth for circular bodies, however nothing stops it from expanding horizontally.

**Solution**

With this PR we add a cap on properties after 3 levels deep to 10 (can be adjusted as we go) in the client request body.
![image](https://github.com/user-attachments/assets/4d37d004-3831-4039-81fb-3ff0af6cebae)

Added a show additional properties button as well when it has 12 properties
![image](https://github.com/user-attachments/assets/57d4c2c8-f51e-4750-9a4d-e43bc1a66c7b)



**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
