### PR TITLE
fix(api-reference): Open in API Client button is missing

### DIFF
--- a/.changeset/brown-glasses-marry.md
+++ b/.changeset/brown-glasses-marry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: open in api client button

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -261,7 +261,7 @@ watch(
     spec &&
     workspaceStore.importSpecFile(spec, 'default', {
       shouldLoad: false,
-      documentUrl: configuration.value.url,
+      documentUrl: configuration.value.spec?.url ?? configuration.value.url,
       useCollectionSecurity: true,
       ...configuration.value,
     }),

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -261,7 +261,7 @@ watch(
     spec &&
     workspaceStore.importSpecFile(spec, 'default', {
       shouldLoad: false,
-      documentUrl: configuration.value.spec?.url,
+      documentUrl: configuration.value.url,
       useCollectionSecurity: true,
       ...configuration.value,
     }),


### PR DESCRIPTION
**Problem**

Currently, the open in api client button is missing because we were still looking at the old spec.url

**Solution**

With this PR we also check for config.url for the `documentUrl` which brings the button back!

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
