### PR TITLE
docs(hono): use /doc as the default

### DIFF
--- a/integrations/hono/README.md
+++ b/integrations/hono/README.md
@@ -25,7 +25,7 @@ import { apiReference } from '@scalar/hono-api-reference'
 app.get(
   '/reference',
   apiReference({
-    url: '/openapi.json',
+    url: '/doc',
   }),
 )
 ```
@@ -43,7 +43,7 @@ app.get(
   '/reference',
   apiReference({
     theme: 'purple',
-    url: '/openapi.json',
+    url: '/doc',
   }),
 )
 ```
@@ -59,7 +59,7 @@ app.get(
   '/reference',
   apiReference({
     pageTitle: 'Hono API Reference',
-    url: '/openapi.json',
+    url: '/doc',
   }),
 )
 ```
@@ -79,7 +79,7 @@ app.use(
   '/reference',
   apiReference({
     cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
-    url: '/openapi.json',
+    url: '/doc',
   }),
 )
 ```

--- a/integrations/hono/playground/index.ts
+++ b/integrations/hono/playground/index.ts
@@ -164,8 +164,8 @@ app.openapi(
 )
 
 // Create an OpenAPI endpoint
-app.use('/openapi.json', cors())
-app.doc('/openapi.json', {
+app.use('/doc', cors())
+app.doc('/doc', {
   openapi: '3.1.0',
   info: {
     title: 'Example',
@@ -185,7 +185,7 @@ app.get(
     sources: [
       {
         title: 'Hono',
-        url: '/openapi.json',
+        url: '/doc',
       },
       {
         title: 'Scalar Galaxy',


### PR DESCRIPTION
**Problem**

Currently, we’re using `/openapi.yaml` as the default URL in the Hono README. But the Zod OpenAPI documentation uses `/doc` as the default URL to expose the OpenAPI document.

**Solution**

With this PR we’re changing the examples in the README, so users have one thing less to think about.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
