### PR TITLE
feat(hono): rename export from `apiReference` to `Scalar`

### DIFF
--- a/.changeset/flat-ladybugs-explain.md
+++ b/.changeset/flat-ladybugs-explain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/hono-api-reference': patch
+---
+
+chore: deprecated apiReference export

--- a/.changeset/slow-icons-share.md
+++ b/.changeset/slow-icons-share.md
@@ -1,0 +1,5 @@
+---
+'@scalar/hono-api-reference': minor
+---
+
+feat: rename apiReference to scalar (please update your import)

--- a/integrations/hono/README.md
+++ b/integrations/hono/README.md
@@ -17,46 +17,33 @@ npm install @scalar/hono-api-reference
 
 ## Usage
 
-Set up [Zod OpenAPI Hono](https://github.com/honojs/middleware/tree/main/packages/zod-openapi) and pass the configured URL to the `apiReference` middleware:
+Set up [Zod OpenAPI Hono](https://github.com/honojs/middleware/tree/main/packages/zod-openapi) and pass the configured URL to the `scalar` middleware:
 
 ```ts
-import { apiReference } from '@scalar/hono-api-reference'
+import { scalar } from '@scalar/hono-api-reference'
 
 app.get(
-  '/reference',
-  apiReference({
-    url: '/doc',
+  '/scalar',
+  scalar({
+    url: '/openapi.json',
   }),
 )
 ```
 
 The Hono middleware takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/blob/main/documentation/configuration.md) in the core package README.
 
-### CORS middleware
-
-We recommend to allow requests from other domains to your API definition. That makes it easier to use your API with [our free web client](https://client.scalar.com/) for example.
-
-You just need to add the official Hono CORS middleware to the route of your OpenAPI document:
-
-```ts
-import { cors } from 'hono/cors'
-
-// Recommended: Allows cross-origin requests (from other domains) to your OpenAPI document
-app.use('/doc', cors())
-```
-
 ### Themes
 
 The middleware comes with a custom theme for Hono. You can use one of [the other predefined themes](https://github.com/scalar/scalar/blob/main/packages/themes/src/index.ts#L15) (`alternate`, `default`, `moon`, `purple`, `solarized`) or overwrite it with `none`. All themes come with a light and dark color scheme.
 
 ```ts
-import { apiReference } from '@scalar/hono-api-reference'
+import { scalar } from '@scalar/hono-api-reference'
 
 app.get(
-  '/reference',
-  apiReference({
+  '/scalar',
+  scalar({
     theme: 'purple',
-    url: '/doc',
+    url: '/openapi.json',
   }),
 )
 ```
@@ -66,13 +53,13 @@ app.get(
 There’s one additional option to set the page title:
 
 ```ts
-import { apiReference } from '@scalar/hono-api-reference'
+import { scalar } from '@scalar/hono-api-reference'
 
 app.get(
-  '/reference',
-  apiReference({
+  '/scalar',
+  scalar({
     pageTitle: 'Hono API Reference',
-    url: '/doc',
+    url: '/openapi.json',
   }),
 )
 ```
@@ -86,13 +73,13 @@ You can also pin the CDN to a specific version by specifying it in the CDN strin
 You can find all available CDN versions [here](https://www.jsdelivr.com/package/npm/@scalar/api-reference?tab=files)
 
 ```ts
-import { apiReference } from '@scalar/hono-api-reference'
+import { scalar } from '@scalar/hono-api-reference'
 
 app.use(
-  '/reference',
-  apiReference({
+  '/scalar',
+  scalar({
     cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
-    url: '/doc',
+    url: '/openapi.json',
   }),
 )
 ```

--- a/integrations/hono/README.md
+++ b/integrations/hono/README.md
@@ -20,14 +20,15 @@ npm install @scalar/hono-api-reference
 Set up [Zod OpenAPI Hono](https://github.com/honojs/middleware/tree/main/packages/zod-openapi) and pass the configured URL to the `scalar` middleware:
 
 ```ts
-import { scalar } from '@scalar/hono-api-reference'
+import { Hono } from 'hono'
+import { Scalar } from '@scalar/hono-api-reference'
 
-app.get(
-  '/scalar',
-  scalar({
-    url: '/openapi.json',
-  }),
-)
+const app = new Hono()
+
+// Use the middleware to serve the Scalar API Reference at /scalar
+app.get('/scalar', Scalar({ url: '/doc' }))
+
+export default app
 ```
 
 The Hono middleware takes our universal configuration object, [read more about configuration](https://github.com/scalar/scalar/blob/main/documentation/configuration.md) in the core package README.
@@ -39,13 +40,11 @@ The middleware comes with a custom theme for Hono. You can use one of [the other
 ```ts
 import { scalar } from '@scalar/hono-api-reference'
 
-app.get(
-  '/scalar',
-  scalar({
-    theme: 'purple',
-    url: '/openapi.json',
-  }),
-)
+// Switch the theme (or pass other options)
+app.get('/scalar', Scalar({
+  url: '/doc',
+  theme: 'purple',
+}))
 ```
 
 ### Custom page title
@@ -55,13 +54,11 @@ There’s one additional option to set the page title:
 ```ts
 import { scalar } from '@scalar/hono-api-reference'
 
-app.get(
-  '/scalar',
-  scalar({
-    pageTitle: 'Hono API Reference',
-    url: '/openapi.json',
-  }),
-)
+// Set a page title
+app.get('/scalar', Scalar({
+  url: '/doc',
+  pageTitle: 'Awesome API',
+}))
 ```
 
 ### Custom CDN
@@ -75,13 +72,12 @@ You can find all available CDN versions [here](https://www.jsdelivr.com/package/
 ```ts
 import { scalar } from '@scalar/hono-api-reference'
 
-app.use(
-  '/scalar',
-  scalar({
-    cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
-    url: '/openapi.json',
-  }),
-)
+app.get('/scalar', Scalar({ url: '/doc', pageTitle: 'Awesome API' }))
+
+app.get('/scalar', Scalar({
+  url: '/doc',
+  cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
+}))
 ```
 
 ## Community

--- a/integrations/hono/README.md
+++ b/integrations/hono/README.md
@@ -17,7 +17,7 @@ npm install @scalar/hono-api-reference
 
 ## Usage
 
-Set up [Zod OpenAPI Hono](https://github.com/honojs/middleware/tree/main/packages/zod-openapi) and pass the configured URL to the `scalar` middleware:
+Set up [Zod OpenAPI Hono](https://github.com/honojs/middleware/tree/main/packages/zod-openapi) and pass the configured URL to the `Scalar` middleware:
 
 ```ts
 import { Hono } from 'hono'
@@ -38,7 +38,7 @@ The Hono middleware takes our universal configuration object, [read more about c
 The middleware comes with a custom theme for Hono. You can use one of [the other predefined themes](https://github.com/scalar/scalar/blob/main/packages/themes/src/index.ts#L15) (`alternate`, `default`, `moon`, `purple`, `solarized`) or overwrite it with `none`. All themes come with a light and dark color scheme.
 
 ```ts
-import { scalar } from '@scalar/hono-api-reference'
+import { Scalar } from '@scalar/hono-api-reference'
 
 // Switch the theme (or pass other options)
 app.get('/scalar', Scalar({
@@ -52,7 +52,7 @@ app.get('/scalar', Scalar({
 There’s one additional option to set the page title:
 
 ```ts
-import { scalar } from '@scalar/hono-api-reference'
+import { Scalar } from '@scalar/hono-api-reference'
 
 // Set a page title
 app.get('/scalar', Scalar({
@@ -70,7 +70,7 @@ You can also pin the CDN to a specific version by specifying it in the CDN strin
 You can find all available CDN versions [here](https://www.jsdelivr.com/package/npm/@scalar/api-reference?tab=files)
 
 ```ts
-import { scalar } from '@scalar/hono-api-reference'
+import { Scalar } from '@scalar/hono-api-reference'
 
 app.get('/scalar', Scalar({ url: '/doc', pageTitle: 'Awesome API' }))
 

--- a/integrations/hono/playground/index.ts
+++ b/integrations/hono/playground/index.ts
@@ -1,8 +1,7 @@
 import { serve } from '@hono/node-server'
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'
 import { cors } from 'hono/cors'
-
-import { apiReference } from '../src/index.ts'
+import { Scalar } from '../src/index.ts'
 
 const PORT = Number(process.env.PORT) || 5054
 const HOST = process.env.HOST || '0.0.0.0'
@@ -178,7 +177,7 @@ app.doc('/doc', {
 // Load the middleware
 app.get(
   '/',
-  apiReference({
+  Scalar({
     onLoaded: () => {
       console.log('ready')
     },

--- a/integrations/hono/src/index.ts
+++ b/integrations/hono/src/index.ts
@@ -1,2 +1,2 @@
-export { apiReference, scalar } from './scalar.ts'
+export { apiReference, Scalar } from './scalar.ts'
 export type { ApiReferenceConfiguration } from './types.ts'

--- a/integrations/hono/src/index.ts
+++ b/integrations/hono/src/index.ts
@@ -1,2 +1,2 @@
-export { apiReference } from './honoApiReference.ts'
+export { apiReference, scalar } from './scalar.ts'
 export type { ApiReferenceConfiguration } from './types.ts'

--- a/integrations/hono/src/scalar.test.ts
+++ b/integrations/hono/src/scalar.test.ts
@@ -1,4 +1,4 @@
-import { apiReference, scalar } from '@/scalar.ts'
+import { Scalar, apiReference } from '@/scalar.ts'
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 
@@ -10,7 +10,7 @@ describe('apiReference', () => {
       content: { info: { title: 'Test API' } },
     }
 
-    app.get('/', scalar(config))
+    app.get('/', Scalar(config))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
@@ -26,7 +26,7 @@ describe('apiReference', () => {
     const app = new Hono()
     app.get(
       '/',
-      scalar({
+      Scalar({
         content: { info: { title: 'Test API' } },
         theme: 'kepler',
         cdn: 'https://cdn.example.com',
@@ -49,7 +49,7 @@ describe('apiReference', () => {
     const options = {
       cdn: 'https://cdn.example.com',
     }
-    app.get('/', scalar(options))
+    app.get('/', Scalar(options))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
@@ -66,7 +66,7 @@ describe('apiReference', () => {
     const options = {
       content: { info: { title: 'Test API' } },
     }
-    app.get('/', scalar(options))
+    app.get('/', Scalar(options))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
@@ -78,7 +78,7 @@ describe('apiReference', () => {
 
   it('includes content only once', async () => {
     const app = new Hono()
-    app.get('/', scalar({ content: { info: { title: 'Test API' } } }))
+    app.get('/', Scalar({ content: { info: { title: 'Test API' } } }))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
@@ -96,7 +96,7 @@ describe('apiReference', () => {
     const app = new Hono()
     app.get(
       '/',
-      scalar({
+      Scalar({
         url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       }),
     )
@@ -110,7 +110,7 @@ describe('apiReference', () => {
 
   it('applies custom theme CSS without theme specified', async () => {
     const app = new Hono()
-    app.get('/', scalar({}))
+    app.get('/', Scalar({}))
 
     const response = await app.request('/')
     const text = await response.text()
@@ -120,7 +120,7 @@ describe('apiReference', () => {
 
   it('excludes custom theme CSS when theme is specified', async () => {
     const app = new Hono()
-    app.get('/', scalar({ theme: 'none' }))
+    app.get('/', Scalar({ theme: 'none' }))
 
     const response = await app.request('/')
     const text = await response.text()
@@ -129,7 +129,7 @@ describe('apiReference', () => {
 
   it('includes hono integration in configuration', async () => {
     const app = new Hono()
-    app.get('/', scalar({}))
+    app.get('/', Scalar({}))
 
     const response = await app.request('/')
     const text = await response.text()
@@ -139,7 +139,7 @@ describe('apiReference', () => {
   it('handles content as function', async () => {
     const app = new Hono()
     const contentFn = () => ({ info: { title: 'Function API' } })
-    app.get('/', scalar({ content: contentFn }))
+    app.get('/', Scalar({ content: contentFn }))
 
     const response = await app.request('/')
     const text = await response.text()
@@ -150,7 +150,7 @@ describe('apiReference', () => {
     const app = new Hono()
     app.get(
       '/',
-      scalar({
+      Scalar({
         url: 'https://example.com/api.json',
         content: { info: { title: 'Test API' } },
       }),
@@ -164,7 +164,7 @@ describe('apiReference', () => {
 
   it('sets HTML content type and 200 status', async () => {
     const app = new Hono()
-    app.get('/', scalar({}))
+    app.get('/', Scalar({}))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)

--- a/integrations/hono/src/scalar.test.ts
+++ b/integrations/hono/src/scalar.test.ts
@@ -1,16 +1,16 @@
+import { apiReference, scalar } from '@/scalar.ts'
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
-import { apiReference } from './honoApiReference.ts'
 
 describe('apiReference', () => {
-  it('should return HTML with default theme CSS when no theme is provided', async () => {
+  it('returns HTML with default theme CSS when theme is not provided', async () => {
     const app = new Hono()
     const config = {
       cdn: 'https://cdn.example.com',
       content: { info: { title: 'Test API' } },
     }
 
-    app.get('/', apiReference(config))
+    app.get('/', scalar(config))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
@@ -22,11 +22,11 @@ describe('apiReference', () => {
     expect(text).toContain('--scalar-color-1: #2a2f45;')
   })
 
-  it('should not include default theme CSS when a theme is provided', async () => {
+  it('excludes default theme CSS when theme is provided', async () => {
     const app = new Hono()
     app.get(
       '/',
-      apiReference({
+      scalar({
         content: { info: { title: 'Test API' } },
         theme: 'kepler',
         cdn: 'https://cdn.example.com',
@@ -44,12 +44,12 @@ describe('apiReference', () => {
     expect(text).not.toContain('--scalar-color-1')
   })
 
-  it('should handle missing spec content gracefully', async () => {
+  it('handles missing spec content gracefully', async () => {
     const app = new Hono()
     const options = {
       cdn: 'https://cdn.example.com',
     }
-    app.get('/', apiReference(options))
+    app.get('/', scalar(options))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
@@ -61,12 +61,12 @@ describe('apiReference', () => {
     expect(text).not.toContain('undefined')
   })
 
-  it('should use default CDN when no CDN is provided', async () => {
+  it('uses default CDN when CDN is not provided', async () => {
     const app = new Hono()
     const options = {
       content: { info: { title: 'Test API' } },
     }
-    app.get('/', apiReference(options))
+    app.get('/', scalar(options))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
@@ -76,9 +76,9 @@ describe('apiReference', () => {
     expect(text).toContain('https://cdn.jsdelivr.net/npm/@scalar/api-reference')
   })
 
-  it("doesn't have the content twice", async () => {
+  it('includes content only once', async () => {
     const app = new Hono()
-    app.get('/', apiReference({ content: { info: { title: 'Test API' } } }))
+    app.get('/', scalar({ content: { info: { title: 'Test API' } } }))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
@@ -92,11 +92,11 @@ describe('apiReference', () => {
     expect(titleCount).toBe(1)
   })
 
-  it('keeps the URL in the configuration', async () => {
+  it('preserves URL in configuration', async () => {
     const app = new Hono()
     app.get(
       '/',
-      apiReference({
+      scalar({
         url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
       }),
     )
@@ -108,9 +108,9 @@ describe('apiReference', () => {
     expect(text).toContain('https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json')
   })
 
-  it('applies custom theme CSS when no theme is provided', async () => {
+  it('applies custom theme CSS without theme specified', async () => {
     const app = new Hono()
-    app.get('/', apiReference({}))
+    app.get('/', scalar({}))
 
     const response = await app.request('/')
     const text = await response.text()
@@ -118,18 +118,18 @@ describe('apiReference', () => {
     expect(text).toContain('--scalar-color-accent: #0099ff')
   })
 
-  it('does not include custom theme CSS when theme is provided', async () => {
+  it('excludes custom theme CSS when theme is specified', async () => {
     const app = new Hono()
-    app.get('/', apiReference({ theme: 'none' }))
+    app.get('/', scalar({ theme: 'none' }))
 
     const response = await app.request('/')
     const text = await response.text()
     expect(text).not.toContain('--scalar-color-1: #2a2f45;')
   })
 
-  it('includes _integration: "hono" in configuration', async () => {
+  it('includes hono integration in configuration', async () => {
     const app = new Hono()
-    app.get('/', apiReference({}))
+    app.get('/', scalar({}))
 
     const response = await app.request('/')
     const text = await response.text()
@@ -139,18 +139,18 @@ describe('apiReference', () => {
   it('handles content as function', async () => {
     const app = new Hono()
     const contentFn = () => ({ info: { title: 'Function API' } })
-    app.get('/', apiReference({ content: contentFn }))
+    app.get('/', scalar({ content: contentFn }))
 
     const response = await app.request('/')
     const text = await response.text()
     expect(text).toContain('Function API')
   })
 
-  it('removes spec.content when spec.url is provided', async () => {
+  it('removes content when URL is provided', async () => {
     const app = new Hono()
     app.get(
       '/',
-      apiReference({
+      scalar({
         url: 'https://example.com/api.json',
         content: { info: { title: 'Test API' } },
       }),
@@ -162,12 +162,31 @@ describe('apiReference', () => {
     expect(text).not.toContain('Test API')
   })
 
-  it('sets correct content type and status', async () => {
+  it('sets HTML content type and 200 status', async () => {
     const app = new Hono()
-    app.get('/', apiReference({}))
+    app.get('/', scalar({}))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
     expect(response.headers.get('content-type')).toContain('text/html')
+  })
+
+  it('works with the deprecated export', async () => {
+    const app = new Hono()
+    const config = {
+      cdn: 'https://cdn.example.com',
+      content: { info: { title: 'Test API' } },
+    }
+
+    app.get('/', apiReference(config))
+
+    const response = await app.request('/')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/html')
+    const text = await response.text()
+    expect(text).toContain('<title>Scalar API Reference</title>')
+    expect(text).toContain('https://cdn.example.com')
+    expect(text).toContain('Test API')
+    expect(text).toContain('--scalar-color-1: #2a2f45;')
   })
 })

--- a/integrations/hono/src/scalar.ts
+++ b/integrations/hono/src/scalar.ts
@@ -118,7 +118,7 @@ export const customTheme = `
 /**
  * The Hono middleware for the Scalar API Reference.
  */
-export const scalar = <E extends Env>(givenConfiguration: Partial<ApiReferenceConfiguration>): MiddlewareHandler<E> => {
+export const Scalar = <E extends Env>(givenConfiguration: Partial<ApiReferenceConfiguration>): MiddlewareHandler<E> => {
   // Merge the defaults
   const configuration = {
     ...DEFAULT_CONFIGURATION,

--- a/integrations/hono/src/scalar.ts
+++ b/integrations/hono/src/scalar.ts
@@ -118,9 +118,7 @@ export const customTheme = `
 /**
  * The Hono middleware for the Scalar API Reference.
  */
-export const apiReference = <E extends Env>(
-  givenConfiguration: Partial<ApiReferenceConfiguration>,
-): MiddlewareHandler<E> => {
+export const scalar = <E extends Env>(givenConfiguration: Partial<ApiReferenceConfiguration>): MiddlewareHandler<E> => {
   // Merge the defaults
   const configuration = {
     ...DEFAULT_CONFIGURATION,
@@ -130,3 +128,8 @@ export const apiReference = <E extends Env>(
   // Respond with the HTML document
   return async (c) => c.html(/* html */ `${getHtmlDocument(configuration, customTheme)}`)
 }
+
+/**
+ * @deprecated Use `scalar` instead.
+ */
+export const apiReference = scalar

--- a/integrations/hono/src/scalar.ts
+++ b/integrations/hono/src/scalar.ts
@@ -130,6 +130,6 @@ export const Scalar = <E extends Env>(givenConfiguration: Partial<ApiReferenceCo
 }
 
 /**
- * @deprecated Use `scalar` instead.
+ * @deprecated Use `Scalar` instead.
  */
-export const apiReference = scalar
+export const apiReference = Scalar

--- a/integrations/hono/vite.config.ts
+++ b/integrations/hono/vite.config.ts
@@ -1,0 +1,9 @@
+import { alias } from '@scalar/build-tooling'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [],
+  resolve: {
+    alias: alias(import.meta.url),
+  },
+})


### PR DESCRIPTION
**Problem**

Currently, we’re exporting `apiReference` as the middleware for Hono.

But people refer to our solution as Scalar and when they [come from Swagger UI](https://hono.dev/examples/swagger-ui) it might be more familiar to replace swaggerUI with Scalar in your code.

**Solution**

With this PR we deprecate the ~~`apiReference`~~ export and add a `Scalar` export.

```ts
import { Hono } from 'hono'
import { Scalar } from '@scalar/hono-api-reference'

const app = new Hono()

// Use the middleware to serve the Scalar API Reference at /scalar
app.get('/scalar', Scalar({ url: '/doc' }))

export default app
```

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
