### PR TITLE
fix(api-client): doesn't show a download button anymore

### DIFF
--- a/.changeset/red-pans-battle.md
+++ b/.changeset/red-pans-battle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: download doesn’t appear anymore

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -8,10 +8,8 @@ import {
 import type { Operation, RequestEvent } from '@scalar/oas-utils/entities/spec'
 import { httpStatusCodes } from '@scalar/oas-utils/helpers'
 import { computed } from 'vue'
-import { useRouter } from 'vue-router'
 
 import { formatMs } from '@/libs/formatters'
-import { PathId } from '@/routes'
 import { useWorkspace } from '@/store'
 
 import HttpMethod from '../HttpMethod/HttpMethod.vue'
@@ -23,9 +21,7 @@ const { operation, target } = defineProps<{
   target: string
 }>()
 
-const { requestHistory, requestExampleMutators } = useWorkspace()
-
-const router = useRouter()
+const { requestHistory } = useWorkspace()
 
 /** Use a local copy to prevent mutation of the reactive object */
 const history = computed(() =>
@@ -35,40 +31,13 @@ const history = computed(() =>
     .reverse(),
 )
 
-// To be added back in later according to url management
-
-// /** Generate a user readable URL */
-// function getPrettyResponseUrl(rawUrl: string) {
-//   const url = new URL(rawUrl)
-//   const params = new URLSearchParams(url.search)
-
-//   const scalarUrl = params.get('scalar_url')
-//   if (!scalarUrl) return url.href
-
-//   const scalarUrlParsed = new URL(scalarUrl)
-
-//   return scalarUrlParsed.href
-// }
-
-function handleHistoryClick(historicalRequest: RequestEvent) {
-  const workspaceId = router.currentRoute.value.params.workspace
-
-  // see if we need to update the topnav
-  // todo potentially search and find a previous open request id of this maybe
-  // or we can open it in a draft state if the request is already open :)
-  if (operation.uid !== historicalRequest.request.requestUid) {
-    // TODO: This is not working. We don't want to just redirect to the same request, but restore the state.
-
-    router.push({
-      name: 'request',
-      params: {
-        [PathId.Workspace]: workspaceId,
-        [PathId.Request]: historicalRequest.request.requestUid,
-      },
-    })
-  }
-
-  requestExampleMutators.set({ ...historicalRequest.request })
+function handleHistoryClick(requestHistoryItem: RequestEvent) {
+  console.warn(
+    'Restoring from the request history doesn’t work yet. Request History Item:',
+    requestHistoryItem,
+  )
+  // TODO: Restore the request data with the history item
+  // TODO: Restore the response data with the history item
 }
 </script>
 <template>

--- a/packages/api-client/src/views/Request/RequestRoot.vue
+++ b/packages/api-client/src/views/Request/RequestRoot.vue
@@ -113,10 +113,9 @@ const executeRequest = async () => {
   // Send error toast
   if (sendRequestError) {
     toast(sendRequestError.message, 'error')
-  }
-  // we need to deep clone the result because it's a ref and updates will break the history
-  else {
-    requestHistory.push(JSON.parse(JSON.stringify(result)))
+  } else {
+    // We need to deep clone the result because it's a ref and updates will break the history
+    requestHistory.push(cloneRequestResult(result))
   }
 }
 
@@ -146,6 +145,33 @@ watch(
   },
   { deep: true },
 )
+
+const cloneRequestResult = (result: any) => {
+  // Create a structured clone that can handle Blobs, ArrayBuffers, etc.
+  try {
+    return structuredClone(result)
+  } catch (error) {
+    // Fallback to a custom cloning approach if structuredClone fails
+    // or isn't available in the environment
+    const clone = { ...result }
+
+    // Handle response data specifically
+    if (result.response?.data) {
+      // If it's a Blob/File/ArrayBuffer, store a reference
+      if (
+        result.response.data instanceof Blob ||
+        result.response.data instanceof ArrayBuffer
+      ) {
+        clone.response.data = result.response.data
+      } else {
+        // For regular objects, do a deep clone
+        clone.response.data = JSON.parse(JSON.stringify(result.response.data))
+      }
+    }
+
+    return clone
+  }
+}
 </script>
 
 <template>


### PR DESCRIPTION
**Problem**

In #4864 we started to clone the request result, but we lost the `Blob` for binary responses. And then we couldn’t and didn't show a Download button anymore.

**Solution**

With this PR we’re improving the cloning of the request result, so we keep the `Blob`.

Fixes #5208 

Note: Restoring from the request history doesn’t work at all (and never did). We need to fix that in a separate PR.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
