### PR TITLE
feat(postman-to-openapi): import post-response scripts

### DIFF
--- a/.changeset/four-weeks-flash.md
+++ b/.changeset/four-weeks-flash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/postman-to-openapi': patch
+---
+
+feat: cleaner Postman import (no 'default' tag, no made up responses)

--- a/.changeset/nice-dots-itch.md
+++ b/.changeset/nice-dots-itch.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/postman-to-openapi': patch
+'@scalar/postman-to-openapi': minor
 ---
 
 feat: import Postman post-response scripts

--- a/.changeset/nice-dots-itch.md
+++ b/.changeset/nice-dots-itch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/postman-to-openapi': patch
+---
+
+feat: import Postman post-response scripts

--- a/.changeset/seven-laws-rhyme.md
+++ b/.changeset/seven-laws-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@scalar/postman-to-openapi': patch
+---
+
+fix: /raw and / paths are handled specifically

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -91,130 +91,129 @@ describe('convert', () => {
     }
   }, 5000)
 
-  it('should work with a basic transform', () => {
+  it('transforms basic collection', () => {
     expect(convert(JSON.parse(collections.PostmantoOpenAPI) as PostmanCollection)).toEqual(JSON.parse(expected.Basic))
   })
 
-  it('Should convert a simple postman collection to OpenAPI including servers', () => {
+  it('converts collection with servers', () => {
     expect(convert(JSON.parse(collections.SimplePost) as PostmanCollection)).toEqual(JSON.parse(expected.SimplePost))
   })
 
-  it('should use default version if not informed and not in postman variables', () => {
+  it('uses default version when not specified', () => {
     expect(convert(JSON.parse(collections.NoVersion) as PostmanCollection)).toEqual(JSON.parse(expected.NoVersion))
   })
 
-  it('should work with folders and use as tags', () => {
+  it('converts folders to tags', () => {
     expect(convert(JSON.parse(collections.Folders) as PostmanCollection)).toEqual(JSON.parse(expected.Folders))
   })
 
-  it('should parse GET methods with query string', () => {
+  it('parses GET methods with query strings', () => {
     expect(convert(JSON.parse(collections.GetMethods) as PostmanCollection)).toEqual(JSON.parse(expected.GetMethods))
   })
 
-  it.skip('should parse HEADERS parameters', () => {
+  it.skip('parses header parameters', () => {
     expect(convert(JSON.parse(collections.Headers) as PostmanCollection)).toEqual(JSON.parse(expected.Headers))
   })
 
-  it('should parse path params', () => {
+  it('parses path parameters', () => {
     expect(convert(JSON.parse(collections.PathParams) as PostmanCollection)).toEqual(JSON.parse(expected.PathParams))
   })
 
-  it('should parse servers from existing host in postman collection', () => {
+  it('parses servers from postman collection host', () => {
     expect(convert(JSON.parse(collections.MultipleServers) as PostmanCollection)).toEqual(
       JSON.parse(expected.MultipleServers),
     )
   })
 
-  it('should parse license and contact from variables', () => {
+  it('parses license and contact from variables', () => {
     expect(convert(JSON.parse(collections.LicenseContact) as PostmanCollection)).toEqual(
       JSON.parse(expected.LicenseContact),
     )
   })
 
-  it('should parse status codes from test', () => {
+  it('parses status codes from tests', () => {
     expect(convert(JSON.parse(collections.ParseStatusCode) as PostmanCollection)).toEqual(
       JSON.parse(expected.ParseStatusCode),
     )
   })
 
-  it('should parse operation when no path (only domain)', () => {
+  it('parses operations with domain only (no path)', () => {
     expect(convert(JSON.parse(collections.NoPath) as PostmanCollection)).toEqual(JSON.parse(expected.NoPath))
   })
 
-  it('should support "DELETE" operations', () => {
+  it('converts DELETE operations', () => {
     expect(convert(JSON.parse(collections.DeleteOperation) as PostmanCollection)).toEqual(
       JSON.parse(expected.DeleteOperation),
     )
   })
 
-  it('should parse global authorization (Bearer)', () => {
+  it('parses global Bearer authorization', () => {
     expect(convert(JSON.parse(collections.AuthBearer) as PostmanCollection)).toEqual(JSON.parse(expected.AuthBearer))
   })
 
-  it('should parse global authorization (Basic)', () => {
+  it('parses global Basic authorization', () => {
     expect(convert(JSON.parse(collections.AuthBasic) as PostmanCollection)).toEqual(JSON.parse(expected.AuthBasic))
   })
 
-  it('should parse url with port', () => {
+  it('parses URLs with ports', () => {
     expect(convert(JSON.parse(collections.UrlWithPort) as PostmanCollection)).toEqual(JSON.parse(expected.UrlWithPort))
   })
 
-  it('should parse external docs info from variables', () => {
+  it('parses external docs from variables', () => {
     expect(convert(JSON.parse(collections.ExternalDocs) as PostmanCollection)).toEqual(
       JSON.parse(expected.ExternalDocs),
     )
   })
 
-  it('should not transform empty url request', () => {
+  it('handles empty URL requests', () => {
     expect(convert(JSON.parse(collections.EmptyUrl) as PostmanCollection)).toEqual(JSON.parse(expected.EmptyUrl))
   })
 
-  it('should use "x-logo" from variables', () => {
+  it('uses x-logo from variables', () => {
     expect(convert(JSON.parse(collections.XLogo) as PostmanCollection)).toEqual(JSON.parse(expected.XLogoVar))
   })
 
-  it('should support auth definition at request level', () => {
+  it('supports auth at request level', () => {
     expect(convert(JSON.parse(collections.AuthMultiple) as PostmanCollection)).toEqual(
       JSON.parse(expected.AuthMultiple),
     )
   })
 
-  it('should work if auth only defined at request level', () => {
+  it('handles auth defined only at request level', () => {
     expect(convert(JSON.parse(collections.AuthRequest) as PostmanCollection)).toEqual(JSON.parse(expected.AuthRequest))
   })
 
-  it('should parse POST methods with form data', () => {
+  it('parses POST methods with form data', () => {
     expect(convert(JSON.parse(collections.FormData) as PostmanCollection)).toEqual(JSON.parse(expected.FormData))
   })
 
-  it('should parse POST methods with www form urlencoded', () => {
+  it('parses POST methods with urlencoded form data', () => {
     expect(convert(JSON.parse(collections.FormUrlencoded) as PostmanCollection)).toEqual(
       JSON.parse(expected.FormUrlencoded),
     )
   })
 
-  it('should try to parse raw body as json but fallback to text', () => {
+  it('parses raw body as JSON with text fallback', () => {
     expect(convert(JSON.parse(collections.RawBody) as PostmanCollection)).toEqual(JSON.parse(expected.RawBody))
   })
 
-  it.skip('should not fail if response body is json but empty', () => {
+  it.skip('handles empty JSON response bodies', () => {
     expect(convert(JSON.parse(collections.ResponsesEmpty) as PostmanCollection)).toEqual(
       JSON.parse(expected.ResponsesEmpty),
     )
   })
 
-  it('should include `operationId` when `brackets` is selected', () => {
+  it('includes operationId when brackets selected', () => {
     expect(convert(JSON.parse(collections.OperationIds) as PostmanCollection)).toEqual(
       JSON.parse(expected.OperationIds),
     )
   })
 
-  // fast follow with this test
-  it.skip('should add responses from postman examples', () => {
+  it.skip('adds responses from postman examples', () => {
     expect(convert(JSON.parse(collections.Responses) as PostmanCollection)).toEqual(JSON.parse(expected.Responses))
   })
 
-  it('should parse nested servers instead of leaving the server empty', () => {
+  it('parses nested servers', () => {
     expect(convert(JSON.parse(collections.NestedServers) as PostmanCollection)).toEqual(
       JSON.parse(expected.NestedServers),
     )

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -6,7 +6,7 @@ import type { PostmanCollection } from './types'
 const bucketName = 'scalar-test-fixtures'
 const BASE_URL = `https://storage.googleapis.com/${bucketName}`
 
-describe.skip('convert', () => {
+describe('convert', () => {
   // Define all file content variables
   const collections: Record<string, string> = {}
   const expected: Record<string, string> = {}

--- a/packages/postman-to-openapi/src/convert.ts
+++ b/packages/postman-to-openapi/src/convert.ts
@@ -119,19 +119,6 @@ export function convert(postmanCollection: PostmanCollection | string): OpenAPIV
             ...pathItem,
           }
         }
-
-        // Handle the /raw endpoint specifically
-        if (normalizedPathKey === '/raw' && pathItem?.post) {
-          if (pathItem.post.requestBody?.content['text/plain']) {
-            pathItem.post.requestBody.content['application/json'] = {
-              schema: {
-                type: 'object',
-                examples: [],
-              },
-            }
-            delete pathItem.post.requestBody.content['text/plain']
-          }
-        }
       }
 
       // Merge security schemes from the current item

--- a/packages/postman-to-openapi/src/convert.ts
+++ b/packages/postman-to-openapi/src/convert.ts
@@ -5,7 +5,6 @@ import { processExternalDocs } from './helpers/externalDocsHelper'
 import { processItem } from './helpers/itemHelpers'
 import { processLicenseAndContact } from './helpers/licenseContactHelper'
 import { processLogo } from './helpers/logoHelper'
-import { processPostResponseScripts } from './helpers/postResponseScripts'
 import { parseServers } from './helpers/serverHelpers'
 import { normalizePath } from './helpers/urlHelpers'
 import type { PostmanCollection } from './types'
@@ -112,6 +111,10 @@ export function convert(postmanCollection: PostmanCollection | string): OpenAPIV
         // Convert colon-style params to curly brace style
         const normalizedPathKey = normalizePath(pathKey)
 
+        if (!pathItem) {
+          continue
+        }
+
         if (!openapi.paths[normalizedPathKey]) {
           openapi.paths[normalizedPathKey] = pathItem
         } else {
@@ -195,16 +198,4 @@ export function convert(postmanCollection: PostmanCollection | string): OpenAPIV
   }
 
   return removeUndefined(openapi)
-}
-
-function processItem(item: any): { paths: any; components?: any } {
-  // ... existing code ...
-
-  // Add post-response scripts if present
-  const postResponseScript = processPostResponseScripts(item.event)
-  if (postResponseScript) {
-    method['x-post-response'] = postResponseScript
-  }
-
-  // ... rest of the function ...
 }

--- a/packages/postman-to-openapi/src/convert.ts
+++ b/packages/postman-to-openapi/src/convert.ts
@@ -111,21 +111,6 @@ export function convert(postmanCollection: PostmanCollection | string): OpenAPIV
         // Convert colon-style params to curly brace style
         const normalizedPathKey = normalizePath(pathKey)
 
-        /**
-         * this is a bit of a hack to skip empty paths only if they have no parameters
-         * because there is a test where if I remove the empty path it breaks the test
-         * but there is another test where if I leave the empty path it breaks the test
-         * so I added this check to only remove the empty path if all the methods on it have no parameters
-         */
-        if (normalizedPathKey === '/') {
-          const allMethodsHaveEmptyParams = Object.values(pathItem || {}).every(
-            (method) => !method.parameters || method.parameters.length === 0,
-          )
-          if (allMethodsHaveEmptyParams) {
-            continue
-          }
-        }
-
         if (!openapi.paths[normalizedPathKey]) {
           openapi.paths[normalizedPathKey] = pathItem
         } else {

--- a/packages/postman-to-openapi/src/convert.ts
+++ b/packages/postman-to-openapi/src/convert.ts
@@ -176,5 +176,22 @@ export function convert(postmanCollection: PostmanCollection | string): OpenAPIV
     delete openapi.components
   }
 
-  return openapi
+  // Remove undefined properties recursively
+  const removeUndefined = (obj: any): any => {
+    if (Array.isArray(obj)) {
+      return obj.map(removeUndefined).filter((item) => item !== undefined)
+    }
+
+    if (obj && typeof obj === 'object') {
+      return Object.fromEntries(
+        Object.entries(obj)
+          .map(([key, value]) => [key, removeUndefined(value)])
+          .filter(([_, value]) => value !== undefined),
+      )
+    }
+
+    return obj
+  }
+
+  return removeUndefined(openapi)
 }

--- a/packages/postman-to-openapi/src/convert.ts
+++ b/packages/postman-to-openapi/src/convert.ts
@@ -5,6 +5,7 @@ import { processExternalDocs } from './helpers/externalDocsHelper'
 import { processItem } from './helpers/itemHelpers'
 import { processLicenseAndContact } from './helpers/licenseContactHelper'
 import { processLogo } from './helpers/logoHelper'
+import { processPostResponseScripts } from './helpers/postResponseScripts'
 import { parseServers } from './helpers/serverHelpers'
 import { normalizePath } from './helpers/urlHelpers'
 import type { PostmanCollection } from './types'
@@ -194,4 +195,16 @@ export function convert(postmanCollection: PostmanCollection | string): OpenAPIV
   }
 
   return removeUndefined(openapi)
+}
+
+function processItem(item: any): { paths: any; components?: any } {
+  // ... existing code ...
+
+  // Add post-response scripts if present
+  const postResponseScript = processPostResponseScripts(item.event)
+  if (postResponseScript) {
+    method['x-post-response'] = postResponseScript
+  }
+
+  // ... rest of the function ...
 }

--- a/packages/postman-to-openapi/src/helpers/itemHelpers.ts
+++ b/packages/postman-to-openapi/src/helpers/itemHelpers.ts
@@ -82,7 +82,7 @@ export function processItem(
         : (request.description?.content ?? '')
 
   const operationObject: OpenAPIV3_1.OperationObject = {
-    tags: parentTags.length > 0 ? [parentTags.join(' > ')] : ['default'],
+    tags: parentTags.length > 0 ? [parentTags.join(' > ')] : undefined,
     summary,
     description,
     responses: extractResponses(response || [], item),

--- a/packages/postman-to-openapi/src/helpers/itemHelpers.ts
+++ b/packages/postman-to-openapi/src/helpers/itemHelpers.ts
@@ -4,6 +4,7 @@ import type { Item, ItemGroup } from '../types'
 import { processAuth } from './authHelpers'
 import { parseMdTable } from './md-utils'
 import { extractParameters } from './parameterHelpers'
+import { processPostResponseScripts } from './postResponseScripts'
 import { extractRequestBody } from './requestBodyHelpers'
 import { extractResponses } from './responseHelpers'
 import { extractPathFromUrl, extractPathParameterNames, normalizePath } from './urlHelpers'
@@ -87,6 +88,12 @@ export function processItem(
     description,
     responses: extractResponses(response || [], item),
     parameters: [],
+  }
+
+  // Add post-response scripts if present
+  const postResponseScript = processPostResponseScripts(item.event)
+  if (postResponseScript) {
+    operationObject['x-post-response'] = postResponseScript
   }
 
   // Only add operationId if it was explicitly provided

--- a/packages/postman-to-openapi/src/helpers/postResponseScripts.ts
+++ b/packages/postman-to-openapi/src/helpers/postResponseScripts.ts
@@ -1,0 +1,13 @@
+/**
+ * Processes Postman test scripts and converts them to OpenAPI x-post-response extension
+ */
+export function processPostResponseScripts(events: any[] = []): string | undefined {
+  // Find test event
+  const testEvent = events.find((event) => event.listen === 'test')
+  if (!testEvent?.script?.exec) {
+    return undefined
+  }
+
+  // Join script lines into a single string
+  return testEvent.script.exec.join('\n').trim()
+}

--- a/packages/postman-to-openapi/src/helpers/responseHelpers.ts
+++ b/packages/postman-to-openapi/src/helpers/responseHelpers.ts
@@ -9,7 +9,7 @@ import { extractStatusCodesFromTests } from './statusCodeHelpers'
  * Processes response status codes, descriptions, headers, and body content,
  * inferring schemas from example responses when possible.
  */
-export function extractResponses(responses: Response[], item?: Item): OpenAPIV3_1.ResponsesObject {
+export function extractResponses(responses: Response[], item?: Item): OpenAPIV3_1.ResponsesObject | undefined {
   // Extract status codes from tests
   const statusCodes = item ? extractStatusCodesFromTests(item) : []
 
@@ -44,14 +44,8 @@ export function extractResponses(responses: Response[], item?: Item): OpenAPIV3_
     }
   })
 
-  // If no responses and no status codes, return default 200
   if (Object.keys(responseMap).length === 0) {
-    responseMap['200'] = {
-      description: 'Successful response',
-      content: {
-        'application/json': {},
-      },
-    }
+    return undefined
   }
 
   return responseMap

--- a/packages/postman-to-openapi/test/scalar-void.json
+++ b/packages/postman-to-openapi/test/scalar-void.json
@@ -1,0 +1,95 @@
+{
+  "info": {
+    "_postman_id": "8462c354-8e17-49c3-b945-ad603a080069",
+    "name": "Scalar Void",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "41478795"
+  },
+  "item": [
+    {
+      "name": "Basic GET Request",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Body matches string\", function () {",
+              "    pm.expect(pm.response.text()).to.include(\"GET\");",
+              "});",
+              "",
+              "pm.test(\"Your test name\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData.method).to.eql(\"GET\");",
+              "});",
+              "",
+              "pm.test(\"Body is correct\", function () {",
+              "    pm.response.to.have.body(\"foobar\");",
+              "});",
+              "",
+              "pm.test(\"Content-Type is present\", function () {",
+              "    pm.response.to.have.header(\"Content-Type\");",
+              "});",
+              "",
+              "pm.test(\"Response time is less than 200ms\", function () {",
+              "    pm.expect(pm.response.responseTime).to.be.below(200);",
+              "});",
+              "",
+              "pm.test(\"Successful POST request\", function () {",
+              "    pm.expect(pm.response.code).to.be.oneOf([200, 201, 202]);",
+              "});",
+              "",
+              "pm.test(\"Status code name has string\", function () {",
+              "    pm.response.to.have.status(\"OK\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://void.scalar.com",
+          "protocol": "https",
+          "host": ["void", "scalar", "com"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "404 Error",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://void.scalar.com/404",
+          "protocol": "https",
+          "host": ["void", "scalar", "com"],
+          "path": ["404"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Download a ZIP",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://void.scalar.com/download.zip",
+          "protocol": "https",
+          "host": ["void", "scalar", "com"],
+          "path": ["download.zip"]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/packages/postman-to-openapi/test/scalar-void.test.ts
+++ b/packages/postman-to-openapi/test/scalar-void.test.ts
@@ -21,6 +21,38 @@ describe('convert', () => {
         '/': {
           'get': {
             'summary': 'Basic GET Request',
+            'x-post-response': `pm.test("Status code is 200", function () {
+    pm.response.to.have.status(200);
+});
+
+pm.test("Body matches string", function () {
+    pm.expect(pm.response.text()).to.include("GET");
+});
+
+pm.test("Your test name", function () {
+    var jsonData = pm.response.json();
+    pm.expect(jsonData.method).to.eql("GET");
+});
+
+pm.test("Body is correct", function () {
+    pm.response.to.have.body("foobar");
+});
+
+pm.test("Content-Type is present", function () {
+    pm.response.to.have.header("Content-Type");
+});
+
+pm.test("Response time is less than 200ms", function () {
+    pm.expect(pm.response.responseTime).to.be.below(200);
+});
+
+pm.test("Successful POST request", function () {
+    pm.expect(pm.response.code).to.be.oneOf([200, 201, 202]);
+});
+
+pm.test("Status code name has string", function () {
+    pm.response.to.have.status("OK");
+});`,
           },
         },
         '/404': {
@@ -35,6 +67,7 @@ describe('convert', () => {
         },
       },
     })
-    console.log(JSON.stringify(result, null, 2))
+
+    // console.log(JSON.stringify(result, null, 2))
   })
 })

--- a/packages/postman-to-openapi/test/scalar-void.test.ts
+++ b/packages/postman-to-openapi/test/scalar-void.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { convert } from '../src/convert'
+import scalarVoidCollection from './scalar-void.json'
+
+describe('convert', () => {
+  it('converts the Scalar Void Postman collection to an OpenAPI document', () => {
+    const result = convert(scalarVoidCollection)
+
+    expect(result).toMatchObject({
+      'openapi': '3.1.0',
+      'info': {
+        'title': 'Scalar Void',
+        'version': '1.0.0',
+      },
+      'servers': [
+        {
+          'url': 'https://void.scalar.com',
+        },
+      ],
+      'paths': {
+        '/': {
+          'get': {
+            'summary': 'Basic GET Request',
+          },
+        },
+        '/404': {
+          'get': {
+            'summary': '404 Error',
+          },
+        },
+        '/download.zip': {
+          'get': {
+            'summary': 'Download a ZIP',
+          },
+        },
+      },
+    })
+    console.log(JSON.stringify(result, null, 2))
+  })
+})


### PR DESCRIPTION
**Problem**

Currently, we just omit Postman scripts. But what if … we import them?

Preparation for #4968.

**Solution**

With this PR we’re importing those post-response scripts!

And I’ve noticed a few things that I wanted to change in the same PR:

* `/` paths are omitted
* `/raw` paths are handled differently
* responses are just made up
* the 'default' tag is just created as a fallback (not necessary to make something up, let’s keep the data clean)
* all the tests were skipped, let’s actually run them :eyes:

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
