### PR TITLE
feat(api-client): add support for json api mime type

### DIFF
--- a/.changeset/rude-suits-roll.md
+++ b/.changeset/rude-suits-roll.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Adds support for JSON:API media type on responses

--- a/packages/api-client/src/views/Request/consts/mediaTypes.ts
+++ b/packages/api-client/src/views/Request/consts/mediaTypes.ts
@@ -23,6 +23,7 @@ export const mediaTypes: { [type: string]: MediaConfig | undefined } = {
     raw: true,
     language: 'json',
   },
+  'application/vnd.api+json': { extension: '.json', raw: true, language: 'json' },
   'application/msword': { extension: '.doc' },
   'application/octet-stream': { extension: '.bin' },
   'application/ogg': { extension: '.ogx' },


### PR DESCRIPTION
**Problem**

Currently, any response of `Content-Type: application/vnd.api+json` will be parsed as a Binary file, when it should be treated as a plain text json response.

See https://sandbox.scalar.com/e/bKl1f to reproduce.

**Solution**

With this PR, we map the json api content type to the right format.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
