### PR TITLE
fix(api-reference): client selector and sidebar scroll listener

### DIFF
--- a/.changeset/short-hats-grow.md
+++ b/.changeset/short-hats-grow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: enable sidebar scroll listener

--- a/.changeset/thirty-boats-stare.md
+++ b/.changeset/thirty-boats-stare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: references client selector not working with custom client selected

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -24,7 +24,7 @@ const {
   hashPrefix,
 } = useMultipleDocuments({
   configuration: toRef(props, 'configuration'),
-  isIntersectionEnabled: ref(false),
+  isIntersectionEnabled: ref(true),
   hash: ref(''),
   hashPrefix: ref(''),
 })

--- a/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
+++ b/packages/api-reference/src/features/ExampleRequest/ExampleRequest.vue
@@ -245,9 +245,20 @@ function updateHttpClient(value: string) {
     }, 300)
   }
 
+  // Update to the local example
   if (data.targetKey === 'customExamples') {
     localHttpClient.value = data
-  } else {
+  }
+  // Here we need to handle a special case when we have custom selected and the global doesn't change
+  else if (
+    localHttpClient.value.targetKey === 'customExamples' &&
+    data.targetKey === httpClient.targetKey &&
+    data.clientKey === httpClient.clientKey
+  ) {
+    localHttpClient.value = data
+  }
+  // Update the global example
+  else {
     setHttpClient(data)
   }
 }


### PR DESCRIPTION
**Problem**

Currently, the sidebar scroll listener is disabled by default. Also when we have a custom client selected, we cannot switch to the globally selected client (shell + curl by default).

**Solution**

With this PR we enable the scroll listener by default.
We also toss in a quick fix for the custom client selector.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
