### PR TITLE
fix(api-reference): fix some minor type issues with properties

### DIFF
--- a/.changeset/tidy-flowers-pump.md
+++ b/.changeset/tidy-flowers-pump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): spacing and typography issues in schema property

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -426,7 +426,6 @@ const displayPropertyHeading = (
   display: flex;
   align-items: stretch;
   position: relative;
-  font-family: var(--scalar-font-code);
 }
 .property-enum-value-label {
   display: flex;

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -236,7 +236,9 @@ const displayPropertyHeading = (
             v-for="enumValue in visibleEnumValues"
             :key="enumValue"
             class="property-enum-value">
-            {{ enumValue }}
+            <span class="property-enum-value-label">
+              {{ enumValue }}
+            </span>
           </li>
           <Disclosure
             v-if="hasLongEnumList"
@@ -246,7 +248,9 @@ const displayPropertyHeading = (
                 v-for="enumValue in remainingEnumValues"
                 :key="enumValue"
                 class="property-enum-value">
-                {{ enumValue }}
+                <span class="property-enum-value-label">
+                  {{ enumValue }}
+                </span>
               </li>
             </DisclosurePanel>
             <DisclosureButton class="enum-toggle-button">
@@ -343,7 +347,10 @@ const displayPropertyHeading = (
 .property--compact.property--level-1 {
   padding: 12px 0;
 }
-
+/*  if a property doesn't have a heading, remove the top padding */
+.property:has(> .property-rule:nth-of-type(1)) {
+  padding-top: 0;
+}
 .property--deprecated {
   background: repeating-linear-gradient(
     -45deg,
@@ -378,6 +385,9 @@ const displayPropertyHeading = (
 .property:not(:last-of-type) {
   border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
 }
+.property-description + .children {
+  margin-top: 9px;
+}
 .children {
   display: flex;
   flex-direction: column;
@@ -410,15 +420,40 @@ const displayPropertyHeading = (
   border-top-right-radius: var(--scalar-radius-lg);
 }
 .property-enum-value {
-  padding: 3px 0;
-  color: var(--scalar-color-2);
+  color: var(--scalar-color-3);
   line-height: 1.5;
   word-break: break-word;
+  display: flex;
+  align-items: stretch;
+  position: relative;
+  font-family: var(--scalar-font-code);
+}
+.property-enum-value-label {
+  display: flex;
+  padding: 3px 0;
 }
 .property-enum-value::before {
-  content: '⊢';
-  margin-right: 6px;
+  content: '';
+  margin-right: 12px;
+  width: var(--scalar-border-width);
+  display: block;
+  background: currentColor;
   color: var(--scalar-color-3);
+}
+.property-enum-value:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 8px;
+  height: var(--scalar-border-width);
+  background: currentColor;
+}
+.property-enum-value:last-of-type::after {
+  bottom: 0;
+  height: 50%;
+  background: var(--scalar-background-1);
+  border-top: var(--scalar-border-width) solid currentColor;
 }
 .property-enum-values {
   margin-top: 8px;


### PR DESCRIPTION
fixing some very minor type stuff that's been driving me crazy

1. when there's no heading on a property there's double padding 
before:
<img width="660" alt="image" src="https://github.com/user-attachments/assets/134cc0a1-c914-4871-9d3f-2c55c1f405aa" />

after:
<img width="651" alt="image" src="https://github.com/user-attachments/assets/d6ee596e-96e0-4cb9-af25-85e08ee2a201" />

2. the delineator I used in enum's can't really be used with the fonts we have so had to just do it with CSS

before
<img width="349" alt="image" src="https://github.com/user-attachments/assets/19b8b4ac-7f69-4e5d-a94c-7b6edd8545e8" />

after:
<img width="361" alt="image" src="https://github.com/user-attachments/assets/68a1502e-a775-46a5-801e-532a40e0b59e" />

Last thing is we didn't have margin a proper between description + child attribute button so added one 