### PR TITLE
fix(api-reference): this should fix the unselectable auth bug

### DIFF
--- a/.changeset/metal-lemons-tease.md
+++ b/.changeset/metal-lemons-tease.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updating the client store with isReadOnly

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -264,14 +264,16 @@ export const createApiClient = ({
         store.tagMutators.reset()
         workspaceMutators.edit(activeWorkspace.value?.uid, 'collections', [])
 
+        /** Add any extra properties to the config */
+        const config = {
+          ...newConfig,
+          useCollectionSecurity: isReadOnly,
+        }
+
         if (newConfig.url) {
-          await importSpecFromUrl(newConfig.url, activeWorkspace.value?.uid ?? 'default', {
-            ...newConfig,
-          })
+          await importSpecFromUrl(newConfig.url, activeWorkspace.value?.uid ?? 'default', config)
         } else if (newConfig.content) {
-          await importSpecFile(newConfig.content, activeWorkspace.value?.uid ?? 'default', {
-            ...newConfig,
-          })
+          await importSpecFile(newConfig.content, activeWorkspace.value?.uid ?? 'default', config)
         } else {
           console.error(
             '[@scalar/api-client-modal] Could not create the API client.',


### PR DESCRIPTION
**Problem**

Currently, auth is unselectable if we use `updateConfiguration` from the htmlApi

**Solution**

With this PR this is another bandaid, we may need that new store sooner rather than later.

A fully reactive store makes me 🤤 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
