### PR TITLE
fix(api-reference): disable intersection on update

### DIFF
--- a/.changeset/olive-rocks-film.md
+++ b/.changeset/olive-rocks-film.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: disable intersection observer on config update


### PR DESCRIPTION
**Problem**

Currently, we may have some jumpiness on config update.

**Solution**

With this PR we disable the intersection observer in case it was causing the jumpiness.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
