### PR TITLE
fix(api-reference): support server url definition per individual endpoint

### DIFF
--- a/.changeset/tall-falcons-train.md
+++ b/.changeset/tall-falcons-train.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: distinguishes collection and operation servers in import spec

--- a/.changeset/thick-parrots-heal.md
+++ b/.changeset/thick-parrots-heal.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates server dropdown item selected server logic

--- a/.changeset/witty-singers-jog.md
+++ b/.changeset/witty-singers-jog.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: returns operation server at the operation level

--- a/packages/api-client/src/components/Server/ServerDropdownItem.vue
+++ b/packages/api-client/src/components/Server/ServerDropdownItem.vue
@@ -74,7 +74,11 @@ const updateSelectedServer = (serverUid: Server['uid'], event?: Event) => {
 /** Set server checkbox in the dropdown */
 const isSelectedServer = computed(() => {
   if (props.type === 'collection') {
-    return props.collection.selectedServerUid === props.serverOption.id
+    // Check selected collection unless operation level server is selected
+    return (
+      props.collection.selectedServerUid === props.serverOption.id &&
+      !props.operation?.selectedServerUid
+    )
   }
 
   if (props.type === 'request' && props.operation) {

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -3,6 +3,7 @@ import { useWorkspace } from '@scalar/api-client/store'
 import type { Collection, Server } from '@scalar/oas-utils/entities/spec'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { TransformedOperation } from '@scalar/types/legacy'
+import { computed } from 'vue'
 
 import { getPointer } from '@/blocks/helpers/getPointer'
 import { useBlockProps } from '@/blocks/hooks/useBlockProps'
@@ -48,6 +49,23 @@ const { operation } = useBlockProps({
     transformedOperation.httpVerb.toLowerCase(),
   ]),
 })
+
+/** Return operation server if available or fallback to the collection server */
+const operationServer = computed(() => {
+  if (!operation.value) {
+    return server
+  }
+
+  if (operation.value?.selectedServerUid) {
+    const operationServer = store.servers[operation.value.selectedServerUid]
+    if (operationServer) {
+      return operationServer
+    }
+  }
+
+  // Fallback to the provided server
+  return server
+})
 </script>
 
 <template>
@@ -58,7 +76,7 @@ const { operation } = useBlockProps({
         :collection="collection"
         :operation="operation"
         :schemas="schemas"
-        :server="server"
+        :server="operationServer"
         :transformedOperation="transformedOperation" />
     </template>
     <template v-else>
@@ -67,7 +85,7 @@ const { operation } = useBlockProps({
         :collection="collection"
         :operation="operation"
         :schemas="schemas"
-        :server="server"
+        :server="operationServer"
         :transformedOperation="transformedOperation" />
     </template>
   </template>

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -934,6 +934,27 @@ describe('importSpecToWorkspace', () => {
       // Restore the original window.location
       vi.stubGlobal('location', originalLocation)
     })
+
+    it('returns both collection and operation servers when present', async () => {
+      const result = await importSpecToWorkspace({
+        servers: [{ url: 'https://collection-server.com' }],
+        paths: {
+          '/test': {
+            get: {
+              servers: [{ url: 'https://operation-server.com' }],
+            },
+          },
+        },
+      })
+
+      if (result.error) {
+        throw result.error
+      }
+
+      expect(result.servers).toHaveLength(2)
+      expect(result.servers.map((s) => s.url)).toContain('https://collection-server.com')
+      expect(result.servers.map((s) => s.url)).toContain('https://operation-server.com')
+    })
   })
 })
 


### PR DESCRIPTION
**Problem**

Currently when an OpenApi document has an operation server:
- server gets displayed at the collection selector level
- server is accessible amongst any other endpoints
- operation in questions is not displaying the server by default

**Solution**

this pr is a proposal to distinguish operation from collection servers at the import level while setting an operation server when available to get displayed.

⊢ api reference server selector
| before | after |
| -------|------|
| <img width="1145" alt="image" src="https://github.com/user-attachments/assets/4d23c12f-ef76-4f1c-ad04-a1f680b2c967" /> | <img width="1145" alt="image" src="https://github.com/user-attachments/assets/e993a7e3-3da5-4d48-a7ca-e396e06eae35" /> |
| any api document server displayed | only collection servers displayed | 

⊢ api reference operation with server
| before | after |
| -------|------|
| <img width="1145" alt="image" src="https://github.com/user-attachments/assets/b5448ad8-3c08-4be7-862b-df8dbc7f1ccc" /> | <img width="1145" alt="image" src="https://github.com/user-attachments/assets/f80823ec-0f59-40bc-901e-66e804b29abf" /> |
| collection server is used in operation | operation server is used in operation | 

<details>
<summary>OpenAPI specification testing document</summary>

```yaml
openapi: 3.0.3
info:
  title: Petstore API
  version: 1.0.0
servers:
  - url: https://staging.collection-server.com
    description: Collection staging server
  - url: https://api.collection-server.com
    description: Collection production server
tags:
  - name: pets
    description: Operations related to pets
paths:
  /pets:
    get:
      summary: Get pets
      tags:
        - pets
      servers:
        - url: https://api.operation-server.com
          description: Operation production server
      responses:
        '200':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'
    post:
      summary: Create a pet
      tags:
        - pets
      requestBody:
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Pet'
      responses:
        '201':
          description: Pet created successfully
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'

components:
  schemas:
    BasePet:
      description: The following types will eventually be exported by a more relevant package.
      type: object
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
```
</details>

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
