### PR TITLE
fix(api-reference): syntax highlighting doesn’t work for Dart

### DIFF
--- a/.changeset/slow-points-exercise.md
+++ b/.changeset/slow-points-exercise.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+feat: add dart to standard languages

--- a/packages/code-highlight/src/languages/basic.ts
+++ b/packages/code-highlight/src/languages/basic.ts
@@ -16,9 +16,9 @@ import yaml from 'highlight.js/lib/languages/yaml'
 const basicLanguages: Record<string, LanguageFn> = {
   bash,
   css,
+  html: xml,
   javascript,
   json,
-  html: xml,
   less,
   markdown,
   plaintext,
@@ -26,8 +26,8 @@ const basicLanguages: Record<string, LanguageFn> = {
   scss,
   shell,
   typescript,
-  yaml,
   xml,
+  yaml,
 }
 
 export { basicLanguages }

--- a/packages/code-highlight/src/languages/standard.ts
+++ b/packages/code-highlight/src/languages/standard.ts
@@ -5,6 +5,7 @@ import clojure from 'highlight.js/lib/languages/clojure'
 import cpp from 'highlight.js/lib/languages/cpp'
 import csharp from 'highlight.js/lib/languages/csharp'
 import css from 'highlight.js/lib/languages/css'
+import dart from 'highlight.js/lib/languages/dart'
 import elixir from 'highlight.js/lib/languages/elixir'
 import go from 'highlight.js/lib/languages/go'
 import graphql from 'highlight.js/lib/languages/graphql'
@@ -41,9 +42,10 @@ const standardLanguages: Record<string, LanguageFn> = {
   c,
   clojure,
   cpp,
+  csharp,
   css,
   curl,
-  csharp,
+  dart,
   elixir,
   go,
   graphql,


### PR DESCRIPTION
**Problem**

Currently, we don’t have any syntax highlighting for the (new) Dart code examples.

**Solution**

This PR adds it to the set of standard languages, that we use in @scalar/api-reference and @scalar/api-client.

Fixes #4913

**Preview**

<img width="532" alt="Screenshot 2025-04-07 at 11 07 13" src="https://github.com/user-attachments/assets/8119b751-f57e-4631-a54a-62b8495f53a7" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
