### PR TITLE
fix(api-client): sidenav active state

### DIFF
--- a/.changeset/early-guests-turn.md
+++ b/.changeset/early-guests-turn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates sidenav active state logic

--- a/packages/api-client/src/components/SideNav/SideNav.vue
+++ b/packages/api-client/src/components/SideNav/SideNav.vue
@@ -44,11 +44,7 @@ const { activeWorkspace } = useActiveEntities()
         )"
         :key="i">
         <SideNavRouterLink
-          :active="
-            Boolean(
-              (currentRoute.name as string | undefined)?.startsWith(to.name),
-            )
-          "
+          :active="Boolean(currentRoute.name === displayName.toLowerCase())"
           :icon="icon"
           :to="{
             ...to,
@@ -64,7 +60,7 @@ const { activeWorkspace } = useActiveEntities()
     <SideNavGroup class="app-no-drag-region">
       <li class="flex items-center">
         <SideNavRouterLink
-          :active="currentRoute.name === 'settings.default'"
+          :active="currentRoute.name === 'settings'"
           icon="Settings"
           :to="{
             name: `settings.default`,


### PR DESCRIPTION
**Problem**

currently the sidenav doesn't get an active state when on any pages.

**Solution**

this pr updates the sidenav active state logic. late night hotfix which might be done better.

| before | after |
| -------|------|
| <img width="505" alt="image" src="https://github.com/user-attachments/assets/3a4793ac-2745-49d4-b443-ea76ea70fb47" /> | <img width="505" alt="image" src="https://github.com/user-attachments/assets/23e18985-7383-43cd-922c-f42fdfb091f2" /> |
| request sidenav state is not active | request sidenav state is active | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
