### PR TITLE
feat(code-highlight): allow ScalarCodeblock to support different font sizes

### DIFF
--- a/.changeset/shiny-impalas-share.md
+++ b/.changeset/shiny-impalas-share.md
@@ -1,0 +1,7 @@
+---
+'@scalar/code-highlight': patch
+'@scalar/api-reference': patch
+'@scalar/components': patch
+---
+
+feat(components): allow ScalarCodeblock to support different font sizes

--- a/packages/api-reference/src/components/Card/Card.vue
+++ b/packages/api-reference/src/components/Card/Card.vue
@@ -7,6 +7,7 @@
 .scalar-card {
   all: unset;
   font-family: var(--scalar-font);
+  font-size: var(--scalar-font-size-3);
   border-radius: var(--scalar-radius-lg);
   overflow: hidden;
   border: var(--scalar-border-width) solid var(--scalar-border-color);

--- a/packages/code-highlight/src/code/highlight.test.ts
+++ b/packages/code-highlight/src/code/highlight.test.ts
@@ -47,7 +47,7 @@ describe('syntaxHighlight', () => {
     }
 
     const result = syntaxHighlight(codeWithCredentials, options)
-    expect(result).toContain('<span class="credentials">secret</span>')
+    expect(result).toContain('<span class="credential"><span class="credential-value">secret</span></span>')
   })
 
   it('should handle line numbers if option is enabled', () => {
@@ -70,6 +70,6 @@ describe('syntaxHighlight', () => {
     }
 
     const result = syntaxHighlight(codeExampleWithSpecialChar, options)
-    expect(result).toContain('<span class="credentials">(secret</span>')
+    expect(result).toContain('<span class="credential"><span class="credential-value">(secret</span></span>')
   })
 })

--- a/packages/code-highlight/src/code/highlight.ts
+++ b/packages/code-highlight/src/code/highlight.ts
@@ -60,7 +60,10 @@ export function syntaxHighlight(
   // Replace any credentials with a wrapper element
   return credentials.length
     ? credentials.reduce(
-        (acc, credential) => acc.split(credential).join(`<span class="credentials">${credential}</span>`),
+        (acc, credential) =>
+          acc
+            .split(credential)
+            .join(`<span class="credential"><span class="credential-value">${credential}</span></span>`),
         htmlString,
       )
     : htmlString

--- a/packages/code-highlight/src/css/code.css
+++ b/packages/code-highlight/src/css/code.css
@@ -1,6 +1,6 @@
 .scalar-app {
-  code.hljs * {
-    font-size: var(--scalar-small);
+  :where(code.hljs) * {
+    font-size: inherit;
     font-family: var(--scalar-font-code);
     text-align: left;
     white-space: pre;
@@ -12,7 +12,7 @@
   }
   code.hljs {
     all: unset;
-    font-size: var(--scalar-small);
+    font-size: inherit;
     color: var(--scalar-color-2);
     font-family: var(--scalar-font-code);
     display: inline-block;
@@ -139,15 +139,14 @@
   }
 
   /** Hide credentials */
-  .credentials {
-    font-size: 0 !important;
+  .credential .credential-value {
+    font-size: 0;
     color: transparent;
   }
 
   /** Show a few dots instead */
-  .credentials::after {
+  .credential::after {
     content: "·····";
-    font-size: var(--scalar-small);
     color: var(--scalar-color-3);
     user-select: none;
   }

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.stories.ts
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.stories.ts
@@ -59,6 +59,9 @@ const contentJson = JSON.stringify([
  */
 const meta = {
   component: ScalarCodeBlock,
+  argTypes: {
+    class: { control: 'text' },
+  },
   tags: ['autodocs'],
   render: (args) => ({
     components: { ScalarCodeBlock },


### PR DESCRIPTION
Updates `ScalarCodeBlock` to inherit it's font size from it's parent allowing it to use different font sizes. Had to tweak how we do credentials a little bit to get it working.

## Before

https://github.com/user-attachments/assets/7f1b943f-ac51-4a0c-aa3a-4ebc7147104d

## After

https://github.com/user-attachments/assets/267f80cf-1c75-432c-8182-b04709423582

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
