### PR TITLE
fix(api-reference-react): only lazyload once

### DIFF
--- a/.changeset/weak-spies-invite.md
+++ b/.changeset/weak-spies-invite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: only lazyload once

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -1,3 +1,7 @@
+<script lang="ts">
+/** We use this global var to ensure that we only show loading once on config change */
+const hasLoaded = ref(false)
+</script>
 <script lang="ts" setup>
 import type { Collection, Server } from '@scalar/oas-utils/entities/spec'
 import type { OpenAPIV3 } from '@scalar/openapi-types'
@@ -55,7 +59,9 @@ const models = ref<string[]>([])
 const { getModelId, getSectionId, getTagId, hash, isIntersectionEnabled } =
   useNavState()
 
-const isLoading = ref(props.layout !== 'classic' && hash.value)
+const isLoading = ref(
+  !hasLoaded.value && props.layout !== 'classic' && hash.value,
+)
 
 // Ensure we have a spec loaded
 watch(
@@ -154,14 +160,22 @@ const unsubscribe = lazyBus.on(({ id }) => {
       scrollToId(hashStr)
     }
     isLoading.value = false
-    setTimeout(() => (isIntersectionEnabled.value = true), 1000)
+    hasLoaded.value = true
+
+    setTimeout(() => {
+      isIntersectionEnabled.value = true
+    }, 1000)
   }, 300)
 })
 
 // Enable intersection observer withb timeout when not deep linking
 onMounted(() => {
   if (!hash.value) {
-    setTimeout(() => (isIntersectionEnabled.value = true), 1000)
+    hasLoaded.value = true
+
+    setTimeout(() => {
+      isIntersectionEnabled.value = true
+    }, 1000)
   }
 })
 </script>


### PR DESCRIPTION
**Problem**

Currently, we show the lazy loading fake container on every config change, we don't need to do that.

**Solution**

With this PR we only show the lazy loading on initial load.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
