### PR TITLE
fix(api-reference): references search a11y round 2 (3?)

### DIFF
--- a/.changeset/wise-dodos-chew.md
+++ b/.changeset/wise-dodos-chew.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/components': patch
+---
+
+fix(api-reference): references search a11y improvements

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -21,12 +21,13 @@
       Scalar.createApiReference('#app', {
         sources: [
           {
-            url: 'https://petstore.swagger.io/v2/swagger.json',
-          },
-          {
             title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
             slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
             url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+          },
+          {
+            title: 'Swagger Petstore',
+            url: 'https://petstore.swagger.io/v2/swagger.json',
           },
         ],
         // Avoid CORS issues

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -49,7 +49,6 @@ const isSelectedClient = (language: HttpClientState) => {
     <Tab
       v-for="client in featuredClients"
       :key="client.clientKey"
-      aria-hidden="true"
       class="client-libraries rendered-code-sdks"
       :class="{
         'client-libraries__active': isSelectedClient(client),

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -4,6 +4,8 @@ import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import { computed } from 'vue'
 
+import ScreenReader from '@/components/ScreenReader.vue'
+
 import SchemaHeading from './SchemaHeading.vue'
 import SchemaProperty from './SchemaProperty.vue'
 
@@ -82,8 +84,8 @@ const handleClick = (e: MouseEvent) =>
         <!-- Special toggle to show additional properties -->
         <div
           v-if="additionalProperties"
-          class="schema-properties"
-          v-show="!open">
+          v-show="!open"
+          class="schema-properties">
           <DisclosureButton
             as="button"
             class="schema-card-title schema-card-title--compact"
@@ -93,6 +95,7 @@ const handleClick = (e: MouseEvent) =>
               icon="Add"
               size="sm" />
             Show additional properties
+            <ScreenReader v-if="name">for {{ name }}</ScreenReader>
           </DisclosureButton>
         </div>
 
@@ -119,6 +122,7 @@ const handleClick = (e: MouseEvent) =>
             <template v-else>
               Show {{ value?.title ?? 'Child Attributes' }}
             </template>
+            <ScreenReader v-if="name">for {{ name }}</ScreenReader>
           </template>
           <template v-else>
             <ScalarIcon

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
     | Record<string, OpenAPIV3.SchemaObject>
     | Record<string, OpenAPIV3_1.SchemaObject>
     | unknown
+  name?: string
   value: Record<string, any>
   level: number
   compact?: boolean
@@ -142,6 +143,7 @@ const humanizeType = (type: string) => {
           <Schema
             :compact="compact"
             :hideHeading="hideHeading"
+            :name="name"
             :noncollapsible="true"
             :schemas="schemas"
             :value="schema" />
@@ -152,6 +154,7 @@ const humanizeType = (type: string) => {
       <Schema
         :compact="compact"
         :level="level"
+        :name="name"
         :noncollapsible="level != 0 ? false : true"
         :schemas="schemas"
         :value="mergeAllOfSchemas(value[discriminator])" />

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -2,7 +2,7 @@
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
-import { computed } from 'vue'
+import { computed, type Component } from 'vue'
 
 import {
   discriminators,
@@ -22,6 +22,7 @@ import SchemaPropertyHeading from './SchemaPropertyHeading.vue'
 
 const props = withDefaults(
   defineProps<{
+    is?: string | Component
     value?: Record<string, any>
     level?: number
     name?: string
@@ -158,7 +159,8 @@ const displayPropertyHeading = (
 }
 </script>
 <template>
-  <li
+  <component
+    :is="is ?? 'li'"
     class="property"
     :class="[
       !displayDescription(description, optimizedValue) ? '' : '',
@@ -329,7 +331,7 @@ const displayPropertyHeading = (
         :schemas="schemas"
         :value="optimizedValue.items" />
     </template>
-  </li>
+  </component>
 </template>
 
 <style scoped>

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -275,6 +275,7 @@ const displayPropertyHeading = (
       <Schema
         :compact="compact"
         :level="level + 1"
+        :name="name"
         :value="optimizedValue" />
     </div>
     <!-- Array of objects -->
@@ -291,6 +292,7 @@ const displayPropertyHeading = (
         <Schema
           :compact="compact"
           :level="level + 1"
+          :name="name"
           :value="optimizedValue.items" />
       </div>
     </template>
@@ -305,6 +307,7 @@ const displayPropertyHeading = (
         :discriminator="discriminator"
         :hideHeading="hideHeading"
         :level="level"
+        :name="name"
         :schemas="schemas"
         :value="optimizedValue" />
 
@@ -322,6 +325,7 @@ const displayPropertyHeading = (
         :discriminator="discriminator"
         :hideHeading="hideHeading"
         :level="level"
+        :name="name"
         :schemas="schemas"
         :value="optimizedValue.items" />
     </template>

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -92,6 +92,7 @@ const shouldShowParameter = computed(() => {
           v-if="parameter.headers"
           :headers="parameter.headers" />
         <SchemaProperty
+          is="div"
           compact
           :description="shouldCollapse ? '' : parameter.description"
           :name="shouldCollapse ? '' : parameter.name"

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -83,13 +83,15 @@ const partitionedSchema = computed(() => {
       class="request-body-schema">
       <Schema
         compact
+        name="Request Body"
         noncollapsible
         :schemas="schemas"
         :value="partitionedSchema.visibleProperties" />
 
       <Schema
-        compact
         additionalProperties
+        compact
+        name="Request Body"
         :schemas="schemas"
         :value="partitionedSchema.collapsedProperties" />
     </div>
@@ -100,6 +102,7 @@ const partitionedSchema = computed(() => {
       class="request-body-schema">
       <Schema
         compact
+        name="Request Body"
         noncollapsible
         :schemas="schemas"
         :value="requestBody.content?.[selectedContentType]?.schema" />

--- a/packages/api-reference/src/features/Search/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/SearchButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ScalarIcon, useModal } from '@scalar/components'
 import type { Spec } from '@scalar/types/legacy'
-import { onBeforeUnmount, onMounted } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import { isMacOs } from '../../helpers'
 import { useApiClient } from '../ApiClientModal'
@@ -17,6 +17,7 @@ const props = withDefaults(
   },
 )
 
+const button = ref<HTMLButtonElement>()
 const modalState = useModal()
 const { client } = useApiClient()
 
@@ -32,19 +33,36 @@ const handleHotKey = (e: KeyboardEvent) => {
   }
 }
 
+watch(
+  () => modalState.open,
+  (next, prev) => {
+    // Return focus to the button when the modal is closed
+    if (!next && prev) {
+      nextTick(() => {
+        button.value?.focus()
+      })
+    }
+  },
+)
+
 // Handle keyboard shortcuts
 // TODO: we can move this to the hotkey event bus but we would need to set up a custom key from the searchHotKey config
 // and make sure it works correctly inside the references first
 onMounted(() => window.addEventListener('keydown', handleHotKey))
 onBeforeUnmount(() => window.removeEventListener('keydown', handleHotKey))
+
+function handleClick() {
+  modalState.show()
+}
 </script>
 <template>
   <button
+    ref="button"
     class="sidebar-search"
     :class="$attrs.class"
     role="search"
     type="button"
-    @click="modalState.show">
+    @click="handleClick">
     <ScalarIcon
       class="scalar-search-icon"
       icon="Search"

--- a/packages/api-reference/src/features/Search/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.ts
@@ -35,7 +35,7 @@ export function useSearchIndex({
 
   const fuseDataArray = ref<FuseData[]>([])
   const searchResults = ref<FuseResult<FuseData>[]>([])
-  const selectedSearchResult = ref<number>(0)
+  const selectedSearchIndex = ref<number>()
   const searchText = ref<string>('')
 
   const fuse = new Fuse(fuseDataArray.value, {
@@ -43,7 +43,7 @@ export function useSearchIndex({
   })
 
   const fuseSearch = (): void => {
-    selectedSearchResult.value = 0
+    selectedSearchIndex.value = 0
     searchResults.value = fuse.search(searchText.value)
   }
 
@@ -57,7 +57,7 @@ export function useSearchIndex({
 
   function resetSearch(): void {
     searchText.value = ''
-    selectedSearchResult.value = 0
+    selectedSearchIndex.value = undefined
     searchResults.value = []
   }
 
@@ -75,6 +75,12 @@ export function useSearchIndex({
 
     return searchResults.value.slice(0, LIMIT)
   })
+
+  const selectedSearchResult = computed<FuseResult<FuseData> | undefined>(() =>
+    typeof selectedSearchIndex.value === 'number'
+      ? searchResultsWithPlaceholderResults.value[selectedSearchIndex.value]
+      : undefined,
+  )
 
   watch(
     specification,
@@ -201,6 +207,7 @@ export function useSearchIndex({
   return {
     resetSearch,
     fuseSearch,
+    selectedSearchIndex,
     selectedSearchResult,
     searchResultsWithPlaceholderResults,
     searchText,

--- a/packages/components/src/components/ScalarModal/ScalarModal.vue
+++ b/packages/components/src/components/ScalarModal/ScalarModal.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
-import {
-  Dialog,
-  DialogDescription,
-  DialogPanel,
-  DialogTitle,
-} from '@headlessui/vue'
+import { Dialog, DialogPanel, DialogTitle } from '@headlessui/vue'
 import type { VariantProps } from 'cva'
 import { reactive } from 'vue'
 
@@ -105,11 +100,11 @@ export function useModal() {
           :class="bodyClass">
           <slot />
         </div>
-        <DialogDescription
+        <div
           v-else
           :class="cx(body({ size, variant }), bodyClass)">
           <slot />
-        </DialogDescription>
+        </div>
       </DialogPanel>
       <div
         v-if="size === 'full'"

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -4,53 +4,51 @@ import { type Icon, ScalarIcon } from '../ScalarIcon'
 
 defineProps<{
   icon?: Icon
-  active?: boolean
+  selected?: boolean
 }>()
 
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
 </script>
 <template>
-  <li class="contents">
-    <a
-      v-bind="
-        cx(
-          'group flex cursor-pointer gap-2.5 rounded px-3 py-1.5 no-underline hover:bg-b-2',
-          {
-            'bg-b-2': active,
-          },
-        )
-      ">
-      <!-- Icon -->
-      <div
-        v-if="icon"
-        class="flex h-fit items-center text-sm font-medium text-c-3 group-hover:text-c-1">
-        <slot name="icon">
-          <ScalarIcon
-            v-if="icon"
-            :icon="icon"
-            size="sm" />
-        </slot>
-        <span>&hairsp;</span>
-      </div>
-      <!-- Content -->
-      <div class="flex min-w-0 flex-1 flex-col gap-0.75">
-        <div class="flex items-center gap-1">
-          <div class="flex-1 truncate text-sm font-medium">
-            <slot />
-          </div>
-          <div
-            v-if="$slots.addon"
-            class="text-sm text-c-2">
-            <slot name="addon" />
-          </div>
+  <li
+    :aria-selected="selected"
+    role="option"
+    v-bind="
+      cx(
+        'group flex cursor-pointer gap-2.5 rounded px-3 py-1.5 no-underline hover:bg-b-2',
+        { 'bg-b-2': selected },
+      )
+    ">
+    <!-- Icon -->
+    <div
+      v-if="icon"
+      class="flex h-fit items-center text-sm font-medium text-c-3 group-hover:text-c-1">
+      <slot name="icon">
+        <ScalarIcon
+          v-if="icon"
+          :icon="icon"
+          size="sm" />
+      </slot>
+      <span>&hairsp;</span>
+    </div>
+    <!-- Content -->
+    <div class="flex min-w-0 flex-1 flex-col gap-0.75">
+      <div class="flex items-center gap-1">
+        <div class="flex-1 truncate text-sm font-medium">
+          <slot />
         </div>
         <div
-          v-if="$slots.description"
-          class="truncate text-sm text-c-2">
-          <slot name="description" />
+          v-if="$slots.addon"
+          class="text-sm text-c-2">
+          <slot name="addon" />
         </div>
       </div>
-    </a>
+      <div
+        v-if="$slots.description"
+        class="truncate text-sm text-c-2">
+        <slot name="description" />
+      </div>
+    </div>
   </li>
 </template>

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -35,7 +35,8 @@ const { cx } = useBindCx()
     <!-- Content -->
     <div class="flex min-w-0 flex-1 flex-col gap-0.75">
       <div class="flex items-center gap-1">
-        <div class="flex-1 truncate text-sm font-medium">
+        <div
+          class="flex-1 truncate zoomed:!whitespace-normal text-sm font-medium">
           <slot />
         </div>
         <div
@@ -46,7 +47,7 @@ const { cx } = useBindCx()
       </div>
       <div
         v-if="$slots.description"
-        class="truncate text-sm text-c-2">
+        class="truncate zoomed:!whitespace-normal text-sm text-c-2">
         <slot name="description" />
       </div>
     </div>


### PR DESCRIPTION
Adds a number of a11y fixes to the references search and a few smaller fixes to the rest of the references.

- Updates the search dialog to have a label and stopped the entire dialog content being used as the description for all dialogs.
- Updates the search dialog to use a combobox / aria-activedescendent pattern (reads the number of results).
- Return to the search button if the search is opened via click
- Search results need to either wrap to another line at high zoom levels
- Fixed the tab count being incorrect for the client libraries tabs, also looked into the tab order but decided to keep the order as-is since the more button is sort of a pseudo tab.
- Add unique screen reader names for the 'Show/Hide Child Attributes' buttons.
- Swapped an `<li>` for a `<div>` in the response model since it only ever has one item (as far as I can tell).

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
