### PR TITLE
fix(oas-utils): `omitUndefinedValues` (for Zod schemas) doesn’t handle Arrays

### DIFF
--- a/.changeset/cuddly-swans-rest.md
+++ b/.changeset/cuddly-swans-rest.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: omitUndefinedValues (Zod helper) doesn’t handle Arrays

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -1,23 +1,6 @@
+import { omitUndefinedValues } from '@/helpers/omit-undefined-values.ts'
 import { type ENTITY_BRANDS, nanoidSchema } from '@scalar/types/utils'
 import { z } from 'zod'
-
-/**
- * Removes undefined values from an object.
- *
- * Can be used as a transform function for any Zod schema.
- */
-export const omitUndefinedValues = <T extends object>(data: T): T => {
-  return Object.fromEntries(
-    Object.entries(data)
-      .filter(([_, value]) => value !== undefined)
-      .map(([key, value]) => {
-        if (typeof value === 'object' && value !== null) {
-          return [key, omitUndefinedValues(value)]
-        }
-        return [key, value]
-      }),
-  ) as T
-}
 
 /**
  * License Object

--- a/packages/oas-utils/src/helpers/omit-undefined-values.test.ts
+++ b/packages/oas-utils/src/helpers/omit-undefined-values.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { omitUndefinedValues } from './omit-undefined-values.ts'
+
+describe('omitUndefinedValues', () => {
+  it('removes undefined values from flat objects', () => {
+    const input = {
+      name: 'test',
+      description: undefined,
+      value: 123,
+      empty: undefined,
+    }
+
+    const result = omitUndefinedValues(input)
+
+    expect(result).toEqual({
+      name: 'test',
+      value: 123,
+    })
+  })
+
+  it('preserves null values', () => {
+    const input = {
+      name: 'test',
+      description: null,
+      value: undefined,
+    }
+
+    const result = omitUndefinedValues(input)
+
+    expect(result).toEqual({
+      name: 'test',
+      description: null,
+    })
+  })
+
+  it('handles nested objects', () => {
+    const input = {
+      name: 'test',
+      metadata: {
+        description: undefined,
+        tags: ['a', 'b'],
+        settings: {
+          enabled: true,
+          config: undefined,
+        },
+      },
+    }
+
+    const result = omitUndefinedValues(input)
+
+    expect(result).toEqual({
+      name: 'test',
+      metadata: {
+        tags: ['a', 'b'],
+        settings: {
+          enabled: true,
+        },
+      },
+    })
+  })
+
+  it('handles empty objects', () => {
+    const input = {}
+
+    const result = omitUndefinedValues(input)
+
+    expect(result).toEqual({})
+  })
+
+  it('preserves arrays', () => {
+    const input = {
+      items: [
+        { id: 1, name: 'first', description: undefined },
+        { id: 2, name: 'second', value: undefined },
+      ],
+    }
+
+    const result = omitUndefinedValues(input)
+
+    expect(result).toEqual({
+      items: [
+        { id: 1, name: 'first' },
+        { id: 2, name: 'second' },
+      ],
+    })
+  })
+
+  it('preserves falsy values except undefined', () => {
+    const input = {
+      zero: 0,
+      empty: '',
+      falsy: false,
+      nullish: null,
+      notDefined: undefined,
+    }
+
+    const result = omitUndefinedValues(input)
+
+    expect(result).toEqual({
+      zero: 0,
+      empty: '',
+      falsy: false,
+      nullish: null,
+    })
+  })
+})

--- a/packages/oas-utils/src/helpers/omit-undefined-values.ts
+++ b/packages/oas-utils/src/helpers/omit-undefined-values.ts
@@ -1,0 +1,24 @@
+/**
+ * Removes undefined values from an object.
+ *
+ * Can be used as a transform function for any Zod schema.
+ */
+export const omitUndefinedValues = <T extends object>(data: T): T => {
+  // Handle arrays specially
+  if (Array.isArray(data)) {
+    return data.map((item) =>
+      typeof item === 'object' && item !== null ? omitUndefinedValues(item) : item,
+    ) as unknown as T
+  }
+
+  return Object.fromEntries(
+    Object.entries(data)
+      .filter(([_, value]) => value !== undefined)
+      .map(([key, value]) => {
+        if (typeof value === 'object' && value !== null) {
+          return [key, omitUndefinedValues(value)]
+        }
+        return [key, value]
+      }),
+  ) as T
+}


### PR DESCRIPTION
**Problem**

We have this helper we use for Zod schemas, that removes undefined values from the data. But it transforms arrays to object, that’s bad.

**Solution**

With this PR it’s all good again, because now we handle Arrays and we even have tests for it.

Got this from #5341, but need this in sooner.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
