### PR TITLE
chore: ensure consistent order of package.json exports keys

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -43,30 +43,120 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./views/Request/types": {
-      "import": "./dist/views/Request/types/index.js",
-      "types": "./dist/views/Request/types/index.d.ts",
-      "default": "./dist/views/Request/types/index.js"
+    "./*.css": {
+      "import": "./dist/*.css",
+      "require": "./dist/*.css",
+      "default": "./dist/*.css"
     },
-    "./views/Request/libs": {
-      "import": "./dist/views/Request/libs/index.js",
-      "types": "./dist/views/Request/libs/index.d.ts",
-      "default": "./dist/views/Request/libs/index.js"
+    "./components": {
+      "import": "./dist/components/index.js",
+      "types": "./dist/components/index.d.ts",
+      "default": "./dist/components/index.js"
     },
-    "./views/Request/consts": {
-      "import": "./dist/views/Request/consts/index.js",
-      "types": "./dist/views/Request/consts/index.d.ts",
-      "default": "./dist/views/Request/consts/index.js"
+    "./components/AddressBar": {
+      "import": "./dist/components/AddressBar/index.js",
+      "types": "./dist/components/AddressBar/index.d.ts",
+      "default": "./dist/components/AddressBar/index.js"
+    },
+    "./components/CommandPalette": {
+      "import": "./dist/components/CommandPalette/index.js",
+      "types": "./dist/components/CommandPalette/index.d.ts",
+      "default": "./dist/components/CommandPalette/index.js"
+    },
+    "./components/DataTable": {
+      "import": "./dist/components/DataTable/index.js",
+      "types": "./dist/components/DataTable/index.d.ts",
+      "default": "./dist/components/DataTable/index.js"
+    },
+    "./components/HttpMethod": {
+      "import": "./dist/components/HttpMethod/index.js",
+      "types": "./dist/components/HttpMethod/index.d.ts",
+      "default": "./dist/components/HttpMethod/index.js"
+    },
+    "./components/ImportCollection": {
+      "import": "./dist/components/ImportCollection/index.js",
+      "types": "./dist/components/ImportCollection/index.d.ts",
+      "default": "./dist/components/ImportCollection/index.js"
+    },
+    "./components/Server": {
+      "import": "./dist/components/Server/index.js",
+      "types": "./dist/components/Server/index.d.ts",
+      "default": "./dist/components/Server/index.js"
+    },
+    "./components/Sidebar": {
+      "import": "./dist/components/Sidebar/index.js",
+      "types": "./dist/components/Sidebar/index.d.ts",
+      "default": "./dist/components/Sidebar/index.js"
+    },
+    "./css/*.css": {
+      "import": "./dist/css/*.css",
+      "require": "./dist/css/*.css",
+      "default": "./dist/css/*.css"
+    },
+    "./hooks": {
+      "import": "./dist/hooks/index.js",
+      "types": "./dist/hooks/index.d.ts",
+      "default": "./dist/hooks/index.js"
+    },
+    "./layouts/App": {
+      "import": "./dist/layouts/App/index.js",
+      "types": "./dist/layouts/App/index.d.ts",
+      "default": "./dist/layouts/App/index.js"
+    },
+    "./layouts/Modal": {
+      "import": "./dist/layouts/Modal/index.js",
+      "types": "./dist/layouts/Modal/index.d.ts",
+      "default": "./dist/layouts/Modal/index.js"
+    },
+    "./layouts/Web": {
+      "import": "./dist/layouts/Web/index.js",
+      "types": "./dist/layouts/Web/index.d.ts",
+      "default": "./dist/layouts/Web/index.js"
+    },
+    "./libs": {
+      "import": "./dist/libs/index.js",
+      "types": "./dist/libs/index.d.ts",
+      "default": "./dist/libs/index.js"
+    },
+    "./libs/importers": {
+      "import": "./dist/libs/importers/index.js",
+      "types": "./dist/libs/importers/index.d.ts",
+      "default": "./dist/libs/importers/index.js"
+    },
+    "./libs/send-request": {
+      "import": "./dist/libs/send-request/index.js",
+      "types": "./dist/libs/send-request/index.d.ts",
+      "default": "./dist/libs/send-request/index.js"
+    },
+    "./store": {
+      "import": "./dist/store/index.js",
+      "types": "./dist/store/index.d.ts",
+      "default": "./dist/store/index.js"
+    },
+    "./types": {
+      "import": "./dist/types/index.js",
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/types/index.js"
+    },
+    "./views/Components/CodeSnippet": {
+      "import": "./dist/views/Components/CodeSnippet/index.js",
+      "types": "./dist/views/Components/CodeSnippet/index.d.ts",
+      "default": "./dist/views/Components/CodeSnippet/index.js"
     },
     "./views/Request/components": {
       "import": "./dist/views/Request/components/index.js",
       "types": "./dist/views/Request/components/index.d.ts",
       "default": "./dist/views/Request/components/index.js"
     },
-    "./views/Request/ResponseSection": {
-      "import": "./dist/views/Request/ResponseSection/index.js",
-      "types": "./dist/views/Request/ResponseSection/index.d.ts",
-      "default": "./dist/views/Request/ResponseSection/index.js"
+    "./views/Request/consts": {
+      "import": "./dist/views/Request/consts/index.js",
+      "types": "./dist/views/Request/consts/index.d.ts",
+      "default": "./dist/views/Request/consts/index.js"
+    },
+    "./views/Request/libs": {
+      "import": "./dist/views/Request/libs/index.js",
+      "types": "./dist/views/Request/libs/index.d.ts",
+      "default": "./dist/views/Request/libs/index.js"
     },
     "./views/Request/RequestSection": {
       "import": "./dist/views/Request/RequestSection/index.js",
@@ -78,105 +168,15 @@
       "types": "./dist/views/Request/RequestSection/RequestAuth/index.d.ts",
       "default": "./dist/views/Request/RequestSection/RequestAuth/index.js"
     },
-    "./views/Components/CodeSnippet": {
-      "import": "./dist/views/Components/CodeSnippet/index.js",
-      "types": "./dist/views/Components/CodeSnippet/index.d.ts",
-      "default": "./dist/views/Components/CodeSnippet/index.js"
+    "./views/Request/ResponseSection": {
+      "import": "./dist/views/Request/ResponseSection/index.js",
+      "types": "./dist/views/Request/ResponseSection/index.d.ts",
+      "default": "./dist/views/Request/ResponseSection/index.js"
     },
-    "./types": {
-      "import": "./dist/types/index.js",
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/types/index.js"
-    },
-    "./store": {
-      "import": "./dist/store/index.js",
-      "types": "./dist/store/index.d.ts",
-      "default": "./dist/store/index.js"
-    },
-    "./libs": {
-      "import": "./dist/libs/index.js",
-      "types": "./dist/libs/index.d.ts",
-      "default": "./dist/libs/index.js"
-    },
-    "./libs/send-request": {
-      "import": "./dist/libs/send-request/index.js",
-      "types": "./dist/libs/send-request/index.d.ts",
-      "default": "./dist/libs/send-request/index.js"
-    },
-    "./libs/importers": {
-      "import": "./dist/libs/importers/index.js",
-      "types": "./dist/libs/importers/index.d.ts",
-      "default": "./dist/libs/importers/index.js"
-    },
-    "./layouts/Web": {
-      "import": "./dist/layouts/Web/index.js",
-      "types": "./dist/layouts/Web/index.d.ts",
-      "default": "./dist/layouts/Web/index.js"
-    },
-    "./layouts/Modal": {
-      "import": "./dist/layouts/Modal/index.js",
-      "types": "./dist/layouts/Modal/index.d.ts",
-      "default": "./dist/layouts/Modal/index.js"
-    },
-    "./layouts/App": {
-      "import": "./dist/layouts/App/index.js",
-      "types": "./dist/layouts/App/index.d.ts",
-      "default": "./dist/layouts/App/index.js"
-    },
-    "./hooks": {
-      "import": "./dist/hooks/index.js",
-      "types": "./dist/hooks/index.d.ts",
-      "default": "./dist/hooks/index.js"
-    },
-    "./components": {
-      "import": "./dist/components/index.js",
-      "types": "./dist/components/index.d.ts",
-      "default": "./dist/components/index.js"
-    },
-    "./components/Sidebar": {
-      "import": "./dist/components/Sidebar/index.js",
-      "types": "./dist/components/Sidebar/index.d.ts",
-      "default": "./dist/components/Sidebar/index.js"
-    },
-    "./components/Server": {
-      "import": "./dist/components/Server/index.js",
-      "types": "./dist/components/Server/index.d.ts",
-      "default": "./dist/components/Server/index.js"
-    },
-    "./components/ImportCollection": {
-      "import": "./dist/components/ImportCollection/index.js",
-      "types": "./dist/components/ImportCollection/index.d.ts",
-      "default": "./dist/components/ImportCollection/index.js"
-    },
-    "./components/HttpMethod": {
-      "import": "./dist/components/HttpMethod/index.js",
-      "types": "./dist/components/HttpMethod/index.d.ts",
-      "default": "./dist/components/HttpMethod/index.js"
-    },
-    "./components/DataTable": {
-      "import": "./dist/components/DataTable/index.js",
-      "types": "./dist/components/DataTable/index.d.ts",
-      "default": "./dist/components/DataTable/index.js"
-    },
-    "./components/CommandPalette": {
-      "import": "./dist/components/CommandPalette/index.js",
-      "types": "./dist/components/CommandPalette/index.d.ts",
-      "default": "./dist/components/CommandPalette/index.js"
-    },
-    "./components/AddressBar": {
-      "import": "./dist/components/AddressBar/index.js",
-      "types": "./dist/components/AddressBar/index.d.ts",
-      "default": "./dist/components/AddressBar/index.js"
-    },
-    "./css/*.css": {
-      "import": "./dist/css/*.css",
-      "require": "./dist/css/*.css",
-      "default": "./dist/css/*.css"
-    },
-    "./*.css": {
-      "import": "./dist/*.css",
-      "require": "./dist/*.css",
-      "default": "./dist/*.css"
+    "./views/Request/types": {
+      "import": "./dist/views/Request/types/index.js",
+      "types": "./dist/views/Request/types/index.d.ts",
+      "default": "./dist/views/Request/types/index.js"
     }
   },
   "files": [

--- a/packages/build-tooling/src/entry.ts
+++ b/packages/build-tooling/src/entry.ts
@@ -87,10 +87,12 @@ export async function addPackageFileExports({
 
   // Update the package file with the new exports
   const packageFile = JSON.parse(await fs.readFile('./package.json', 'utf-8'))
-  packageFile.exports = {
-    ...packageExports,
-    ...(allowCss ? cssExports : {}),
-  }
+  packageFile.exports = allowCss ? { ...packageExports, ...cssExports } : { ...packageExports }
+
+  // Sort the keys in the exports object to ensure consistent order across OS
+  packageFile.exports = Object.fromEntries(
+    Object.entries(packageFile.exports).sort(([keyA], [keyB]) => keyA.localeCompare(keyB)),
+  )
 
   // Green text
   console.log('\x1b[32m%s\x1b[0m', 'Updating package.json exports field…')

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -38,25 +38,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./rehype-highlight": {
-      "import": "./dist/rehype-highlight/index.js",
-      "types": "./dist/rehype-highlight/index.d.ts",
-      "default": "./dist/rehype-highlight/index.js"
-    },
-    "./rehype-alert": {
-      "import": "./dist/rehype-alert/index.js",
-      "types": "./dist/rehype-alert/index.d.ts",
-      "default": "./dist/rehype-alert/index.js"
-    },
-    "./markdown": {
-      "import": "./dist/markdown/index.js",
-      "types": "./dist/markdown/index.d.ts",
-      "default": "./dist/markdown/index.js"
-    },
-    "./languages": {
-      "import": "./dist/languages/index.js",
-      "types": "./dist/languages/index.d.ts",
-      "default": "./dist/languages/index.js"
+    "./*.css": {
+      "import": "./dist/*.css",
+      "require": "./dist/*.css",
+      "default": "./dist/*.css"
     },
     "./code": {
       "import": "./dist/code/index.js",
@@ -68,10 +53,25 @@
       "require": "./dist/css/*.css",
       "default": "./dist/css/*.css"
     },
-    "./*.css": {
-      "import": "./dist/*.css",
-      "require": "./dist/*.css",
-      "default": "./dist/*.css"
+    "./languages": {
+      "import": "./dist/languages/index.js",
+      "types": "./dist/languages/index.d.ts",
+      "default": "./dist/languages/index.js"
+    },
+    "./markdown": {
+      "import": "./dist/markdown/index.js",
+      "types": "./dist/markdown/index.d.ts",
+      "default": "./dist/markdown/index.js"
+    },
+    "./rehype-alert": {
+      "import": "./dist/rehype-alert/index.js",
+      "types": "./dist/rehype-alert/index.d.ts",
+      "default": "./dist/rehype-alert/index.js"
+    },
+    "./rehype-highlight": {
+      "import": "./dist/rehype-highlight/index.js",
+      "types": "./dist/rehype-highlight/index.d.ts",
+      "default": "./dist/rehype-highlight/index.js"
     }
   },
   "files": [

--- a/packages/components/src/scripts/typegen.ts
+++ b/packages/components/src/scripts/typegen.ts
@@ -9,7 +9,9 @@ function generateTypes(folder: string, name: 'LOGOS' | 'ICONS') {
   const indexFile = join(folder, 'index.ts')
 
   const svgRegex = /\.svg$/
-  const fileNames = readdirSync(folder).filter((fileName) => svgRegex.test(fileName))
+  const fileNames = readdirSync(folder)
+    .filter((fileName) => svgRegex.test(fileName))
+    .sort() // Sort filenames to ensure consistent order across OS
 
   // Write icons to a typescript file for exporting
   let writeStr = `export const ${name} = [\n`

--- a/packages/draggable/package.json
+++ b/packages/draggable/package.json
@@ -37,15 +37,15 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./css/*.css": {
-      "import": "./dist/css/*.css",
-      "require": "./dist/css/*.css",
-      "default": "./dist/css/*.css"
-    },
     "./*.css": {
       "import": "./dist/*.css",
       "require": "./dist/*.css",
       "default": "./dist/*.css"
+    },
+    "./css/*.css": {
+      "import": "./dist/css/*.css",
+      "require": "./dist/css/*.css",
+      "default": "./dist/css/*.css"
     }
   },
   "files": [

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -33,55 +33,55 @@
   "type": "module",
   "main": "dist/index.js",
   "exports": {
-    "./transforms": {
-      "import": "./dist/transforms/index.js",
-      "types": "./dist/transforms/index.d.ts",
-      "default": "./dist/transforms/index.js"
-    },
-    "./spec-getters": {
-      "import": "./dist/spec-getters/index.js",
-      "types": "./dist/spec-getters/index.d.ts",
-      "default": "./dist/spec-getters/index.js"
-    },
-    "./migrations": {
-      "import": "./dist/migrations/index.js",
-      "types": "./dist/migrations/index.d.ts",
-      "default": "./dist/migrations/index.js"
-    },
-    "./helpers": {
-      "import": "./dist/helpers/index.js",
-      "types": "./dist/helpers/index.d.ts",
-      "default": "./dist/helpers/index.js"
-    },
-    "./entities/workspace": {
-      "import": "./dist/entities/workspace/index.js",
-      "types": "./dist/entities/workspace/index.d.ts",
-      "default": "./dist/entities/workspace/index.js"
-    },
-    "./entities/spec": {
-      "import": "./dist/entities/spec/index.js",
-      "types": "./dist/entities/spec/index.d.ts",
-      "default": "./dist/entities/spec/index.js"
-    },
-    "./entities/shared": {
-      "import": "./dist/entities/shared/index.js",
-      "types": "./dist/entities/shared/index.d.ts",
-      "default": "./dist/entities/shared/index.js"
-    },
-    "./entities/hotkeys": {
-      "import": "./dist/entities/hotkeys/index.js",
-      "types": "./dist/entities/hotkeys/index.d.ts",
-      "default": "./dist/entities/hotkeys/index.js"
+    "./entities/cookie": {
+      "import": "./dist/entities/cookie/index.js",
+      "types": "./dist/entities/cookie/index.d.ts",
+      "default": "./dist/entities/cookie/index.js"
     },
     "./entities/environment": {
       "import": "./dist/entities/environment/index.js",
       "types": "./dist/entities/environment/index.d.ts",
       "default": "./dist/entities/environment/index.js"
     },
-    "./entities/cookie": {
-      "import": "./dist/entities/cookie/index.js",
-      "types": "./dist/entities/cookie/index.d.ts",
-      "default": "./dist/entities/cookie/index.js"
+    "./entities/hotkeys": {
+      "import": "./dist/entities/hotkeys/index.js",
+      "types": "./dist/entities/hotkeys/index.d.ts",
+      "default": "./dist/entities/hotkeys/index.js"
+    },
+    "./entities/shared": {
+      "import": "./dist/entities/shared/index.js",
+      "types": "./dist/entities/shared/index.d.ts",
+      "default": "./dist/entities/shared/index.js"
+    },
+    "./entities/spec": {
+      "import": "./dist/entities/spec/index.js",
+      "types": "./dist/entities/spec/index.d.ts",
+      "default": "./dist/entities/spec/index.js"
+    },
+    "./entities/workspace": {
+      "import": "./dist/entities/workspace/index.js",
+      "types": "./dist/entities/workspace/index.d.ts",
+      "default": "./dist/entities/workspace/index.js"
+    },
+    "./helpers": {
+      "import": "./dist/helpers/index.js",
+      "types": "./dist/helpers/index.d.ts",
+      "default": "./dist/helpers/index.js"
+    },
+    "./migrations": {
+      "import": "./dist/migrations/index.js",
+      "types": "./dist/migrations/index.d.ts",
+      "default": "./dist/migrations/index.js"
+    },
+    "./spec-getters": {
+      "import": "./dist/spec-getters/index.js",
+      "types": "./dist/spec-getters/index.d.ts",
+      "default": "./dist/spec-getters/index.js"
+    },
+    "./transforms": {
+      "import": "./dist/transforms/index.js",
+      "types": "./dist/transforms/index.d.ts",
+      "default": "./dist/transforms/index.js"
     }
   },
   "files": [

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -37,40 +37,40 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./transforms": {
-      "import": "./dist/transforms/index.js",
-      "types": "./dist/transforms/index.d.ts",
-      "default": "./dist/transforms/index.js"
-    },
-    "./parse": {
-      "import": "./dist/parse/index.js",
-      "types": "./dist/parse/index.d.ts",
-      "default": "./dist/parse/index.js"
-    },
-    "./nested": {
-      "import": "./dist/nested/index.js",
-      "types": "./dist/nested/index.d.ts",
-      "default": "./dist/nested/index.js"
-    },
-    "./mutator-record": {
-      "import": "./dist/mutator-record/index.js",
-      "types": "./dist/mutator-record/index.d.ts",
-      "default": "./dist/mutator-record/index.js"
-    },
-    "./merge": {
-      "import": "./dist/merge/index.js",
-      "types": "./dist/merge/index.d.ts",
-      "default": "./dist/merge/index.js"
+    "./arrays": {
+      "import": "./dist/arrays/index.js",
+      "types": "./dist/arrays/index.d.ts",
+      "default": "./dist/arrays/index.js"
     },
     "./clone": {
       "import": "./dist/clone/index.js",
       "types": "./dist/clone/index.d.ts",
       "default": "./dist/clone/index.js"
     },
-    "./arrays": {
-      "import": "./dist/arrays/index.js",
-      "types": "./dist/arrays/index.d.ts",
-      "default": "./dist/arrays/index.js"
+    "./merge": {
+      "import": "./dist/merge/index.js",
+      "types": "./dist/merge/index.d.ts",
+      "default": "./dist/merge/index.js"
+    },
+    "./mutator-record": {
+      "import": "./dist/mutator-record/index.js",
+      "types": "./dist/mutator-record/index.d.ts",
+      "default": "./dist/mutator-record/index.js"
+    },
+    "./nested": {
+      "import": "./dist/nested/index.js",
+      "types": "./dist/nested/index.d.ts",
+      "default": "./dist/nested/index.js"
+    },
+    "./parse": {
+      "import": "./dist/parse/index.js",
+      "types": "./dist/parse/index.d.ts",
+      "default": "./dist/parse/index.js"
+    },
+    "./transforms": {
+      "import": "./dist/transforms/index.js",
+      "types": "./dist/transforms/index.d.ts",
+      "default": "./dist/transforms/index.js"
     }
   },
   "files": [

--- a/packages/openapi-types/package.json
+++ b/packages/openapi-types/package.json
@@ -37,20 +37,20 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./schemas/extensions": {
-      "import": "./dist/schemas/extensions/index.js",
-      "types": "./dist/schemas/extensions/index.d.ts",
-      "default": "./dist/schemas/extensions/index.js"
+    "./schemas/3.1/processed": {
+      "import": "./dist/schemas/3.1/processed/index.js",
+      "types": "./dist/schemas/3.1/processed/index.d.ts",
+      "default": "./dist/schemas/3.1/processed/index.js"
     },
     "./schemas/3.1/unprocessed": {
       "import": "./dist/schemas/3.1/unprocessed/index.js",
       "types": "./dist/schemas/3.1/unprocessed/index.d.ts",
       "default": "./dist/schemas/3.1/unprocessed/index.js"
     },
-    "./schemas/3.1/processed": {
-      "import": "./dist/schemas/3.1/processed/index.js",
-      "types": "./dist/schemas/3.1/processed/index.d.ts",
-      "default": "./dist/schemas/3.1/processed/index.js"
+    "./schemas/extensions": {
+      "import": "./dist/schemas/extensions/index.js",
+      "types": "./dist/schemas/extensions/index.d.ts",
+      "default": "./dist/schemas/extensions/index.js"
     }
   },
   "files": [

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -33,185 +33,185 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./utils": {
-      "import": "./dist/utils/index.js",
-      "types": "./dist/utils/index.d.ts",
-      "default": "./dist/utils/index.js"
-    },
-    "./plugins/swift/nsurlsession": {
-      "import": "./dist/plugins/swift/nsurlsession/index.js",
-      "types": "./dist/plugins/swift/nsurlsession/index.d.ts",
-      "default": "./dist/plugins/swift/nsurlsession/index.js"
-    },
-    "./plugins/shell/wget": {
-      "import": "./dist/plugins/shell/wget/index.js",
-      "types": "./dist/plugins/shell/wget/index.d.ts",
-      "default": "./dist/plugins/shell/wget/index.js"
-    },
-    "./plugins/shell/httpie": {
-      "import": "./dist/plugins/shell/httpie/index.js",
-      "types": "./dist/plugins/shell/httpie/index.d.ts",
-      "default": "./dist/plugins/shell/httpie/index.js"
-    },
-    "./plugins/shell/curl": {
-      "import": "./dist/plugins/shell/curl/index.js",
-      "types": "./dist/plugins/shell/curl/index.d.ts",
-      "default": "./dist/plugins/shell/curl/index.js"
-    },
-    "./plugins/ruby/native": {
-      "import": "./dist/plugins/ruby/native/index.js",
-      "types": "./dist/plugins/ruby/native/index.d.ts",
-      "default": "./dist/plugins/ruby/native/index.js"
-    },
-    "./plugins/r/httr": {
-      "import": "./dist/plugins/r/httr/index.js",
-      "types": "./dist/plugins/r/httr/index.d.ts",
-      "default": "./dist/plugins/r/httr/index.js"
-    },
-    "./plugins/python/requests": {
-      "import": "./dist/plugins/python/requests/index.js",
-      "types": "./dist/plugins/python/requests/index.d.ts",
-      "default": "./dist/plugins/python/requests/index.js"
-    },
-    "./plugins/python/python3": {
-      "import": "./dist/plugins/python/python3/index.js",
-      "types": "./dist/plugins/python/python3/index.d.ts",
-      "default": "./dist/plugins/python/python3/index.js"
-    },
-    "./plugins/powershell/webrequest": {
-      "import": "./dist/plugins/powershell/webrequest/index.js",
-      "types": "./dist/plugins/powershell/webrequest/index.d.ts",
-      "default": "./dist/plugins/powershell/webrequest/index.js"
-    },
-    "./plugins/powershell/restmethod": {
-      "import": "./dist/plugins/powershell/restmethod/index.js",
-      "types": "./dist/plugins/powershell/restmethod/index.d.ts",
-      "default": "./dist/plugins/powershell/restmethod/index.js"
-    },
-    "./plugins/php/guzzle": {
-      "import": "./dist/plugins/php/guzzle/index.js",
-      "types": "./dist/plugins/php/guzzle/index.d.ts",
-      "default": "./dist/plugins/php/guzzle/index.js"
-    },
-    "./plugins/php/curl": {
-      "import": "./dist/plugins/php/curl/index.js",
-      "types": "./dist/plugins/php/curl/index.d.ts",
-      "default": "./dist/plugins/php/curl/index.js"
-    },
-    "./plugins/ocaml/cohttp": {
-      "import": "./dist/plugins/ocaml/cohttp/index.js",
-      "types": "./dist/plugins/ocaml/cohttp/index.d.ts",
-      "default": "./dist/plugins/ocaml/cohttp/index.js"
-    },
-    "./plugins/objc/nsurlsession": {
-      "import": "./dist/plugins/objc/nsurlsession/index.js",
-      "types": "./dist/plugins/objc/nsurlsession/index.d.ts",
-      "default": "./dist/plugins/objc/nsurlsession/index.js"
-    },
-    "./plugins/node/undici": {
-      "import": "./dist/plugins/node/undici/index.js",
-      "types": "./dist/plugins/node/undici/index.d.ts",
-      "default": "./dist/plugins/node/undici/index.js"
-    },
-    "./plugins/node/ofetch": {
-      "import": "./dist/plugins/node/ofetch/index.js",
-      "types": "./dist/plugins/node/ofetch/index.d.ts",
-      "default": "./dist/plugins/node/ofetch/index.js"
-    },
-    "./plugins/node/fetch": {
-      "import": "./dist/plugins/node/fetch/index.js",
-      "types": "./dist/plugins/node/fetch/index.d.ts",
-      "default": "./dist/plugins/node/fetch/index.js"
-    },
-    "./plugins/node/axios": {
-      "import": "./dist/plugins/node/axios/index.js",
-      "types": "./dist/plugins/node/axios/index.d.ts",
-      "default": "./dist/plugins/node/axios/index.js"
-    },
-    "./plugins/kotlin/okhttp": {
-      "import": "./dist/plugins/kotlin/okhttp/index.js",
-      "types": "./dist/plugins/kotlin/okhttp/index.d.ts",
-      "default": "./dist/plugins/kotlin/okhttp/index.js"
-    },
-    "./plugins/js/xhr": {
-      "import": "./dist/plugins/js/xhr/index.js",
-      "types": "./dist/plugins/js/xhr/index.d.ts",
-      "default": "./dist/plugins/js/xhr/index.js"
-    },
-    "./plugins/js/ofetch": {
-      "import": "./dist/plugins/js/ofetch/index.js",
-      "types": "./dist/plugins/js/ofetch/index.d.ts",
-      "default": "./dist/plugins/js/ofetch/index.js"
-    },
-    "./plugins/js/jquery": {
-      "import": "./dist/plugins/js/jquery/index.js",
-      "types": "./dist/plugins/js/jquery/index.d.ts",
-      "default": "./dist/plugins/js/jquery/index.js"
-    },
-    "./plugins/js/fetch": {
-      "import": "./dist/plugins/js/fetch/index.js",
-      "types": "./dist/plugins/js/fetch/index.d.ts",
-      "default": "./dist/plugins/js/fetch/index.js"
-    },
-    "./plugins/js/axios": {
-      "import": "./dist/plugins/js/axios/index.js",
-      "types": "./dist/plugins/js/axios/index.d.ts",
-      "default": "./dist/plugins/js/axios/index.js"
-    },
-    "./plugins/java/unirest": {
-      "import": "./dist/plugins/java/unirest/index.js",
-      "types": "./dist/plugins/java/unirest/index.d.ts",
-      "default": "./dist/plugins/java/unirest/index.js"
-    },
-    "./plugins/java/okhttp": {
-      "import": "./dist/plugins/java/okhttp/index.js",
-      "types": "./dist/plugins/java/okhttp/index.d.ts",
-      "default": "./dist/plugins/java/okhttp/index.js"
-    },
-    "./plugins/java/nethttp": {
-      "import": "./dist/plugins/java/nethttp/index.js",
-      "types": "./dist/plugins/java/nethttp/index.d.ts",
-      "default": "./dist/plugins/java/nethttp/index.js"
-    },
-    "./plugins/java/asynchttp": {
-      "import": "./dist/plugins/java/asynchttp/index.js",
-      "types": "./dist/plugins/java/asynchttp/index.d.ts",
-      "default": "./dist/plugins/java/asynchttp/index.js"
-    },
-    "./plugins/http/http11": {
-      "import": "./dist/plugins/http/http11/index.js",
-      "types": "./dist/plugins/http/http11/index.d.ts",
-      "default": "./dist/plugins/http/http11/index.js"
-    },
-    "./plugins/go/native": {
-      "import": "./dist/plugins/go/native/index.js",
-      "types": "./dist/plugins/go/native/index.d.ts",
-      "default": "./dist/plugins/go/native/index.js"
-    },
-    "./plugins/dart/http": {
-      "import": "./dist/plugins/dart/http/index.js",
-      "types": "./dist/plugins/dart/http/index.d.ts",
-      "default": "./dist/plugins/dart/http/index.js"
-    },
-    "./plugins/csharp/restsharp": {
-      "import": "./dist/plugins/csharp/restsharp/index.js",
-      "types": "./dist/plugins/csharp/restsharp/index.d.ts",
-      "default": "./dist/plugins/csharp/restsharp/index.js"
-    },
-    "./plugins/csharp/httpclient": {
-      "import": "./dist/plugins/csharp/httpclient/index.js",
-      "types": "./dist/plugins/csharp/httpclient/index.d.ts",
-      "default": "./dist/plugins/csharp/httpclient/index.js"
+    "./plugins/c/libcurl": {
+      "import": "./dist/plugins/c/libcurl/index.js",
+      "types": "./dist/plugins/c/libcurl/index.d.ts",
+      "default": "./dist/plugins/c/libcurl/index.js"
     },
     "./plugins/clojure/clj_http": {
       "import": "./dist/plugins/clojure/clj_http/index.js",
       "types": "./dist/plugins/clojure/clj_http/index.d.ts",
       "default": "./dist/plugins/clojure/clj_http/index.js"
     },
-    "./plugins/c/libcurl": {
-      "import": "./dist/plugins/c/libcurl/index.js",
-      "types": "./dist/plugins/c/libcurl/index.d.ts",
-      "default": "./dist/plugins/c/libcurl/index.js"
+    "./plugins/csharp/httpclient": {
+      "import": "./dist/plugins/csharp/httpclient/index.js",
+      "types": "./dist/plugins/csharp/httpclient/index.d.ts",
+      "default": "./dist/plugins/csharp/httpclient/index.js"
+    },
+    "./plugins/csharp/restsharp": {
+      "import": "./dist/plugins/csharp/restsharp/index.js",
+      "types": "./dist/plugins/csharp/restsharp/index.d.ts",
+      "default": "./dist/plugins/csharp/restsharp/index.js"
+    },
+    "./plugins/dart/http": {
+      "import": "./dist/plugins/dart/http/index.js",
+      "types": "./dist/plugins/dart/http/index.d.ts",
+      "default": "./dist/plugins/dart/http/index.js"
+    },
+    "./plugins/go/native": {
+      "import": "./dist/plugins/go/native/index.js",
+      "types": "./dist/plugins/go/native/index.d.ts",
+      "default": "./dist/plugins/go/native/index.js"
+    },
+    "./plugins/http/http11": {
+      "import": "./dist/plugins/http/http11/index.js",
+      "types": "./dist/plugins/http/http11/index.d.ts",
+      "default": "./dist/plugins/http/http11/index.js"
+    },
+    "./plugins/java/asynchttp": {
+      "import": "./dist/plugins/java/asynchttp/index.js",
+      "types": "./dist/plugins/java/asynchttp/index.d.ts",
+      "default": "./dist/plugins/java/asynchttp/index.js"
+    },
+    "./plugins/java/nethttp": {
+      "import": "./dist/plugins/java/nethttp/index.js",
+      "types": "./dist/plugins/java/nethttp/index.d.ts",
+      "default": "./dist/plugins/java/nethttp/index.js"
+    },
+    "./plugins/java/okhttp": {
+      "import": "./dist/plugins/java/okhttp/index.js",
+      "types": "./dist/plugins/java/okhttp/index.d.ts",
+      "default": "./dist/plugins/java/okhttp/index.js"
+    },
+    "./plugins/java/unirest": {
+      "import": "./dist/plugins/java/unirest/index.js",
+      "types": "./dist/plugins/java/unirest/index.d.ts",
+      "default": "./dist/plugins/java/unirest/index.js"
+    },
+    "./plugins/js/axios": {
+      "import": "./dist/plugins/js/axios/index.js",
+      "types": "./dist/plugins/js/axios/index.d.ts",
+      "default": "./dist/plugins/js/axios/index.js"
+    },
+    "./plugins/js/fetch": {
+      "import": "./dist/plugins/js/fetch/index.js",
+      "types": "./dist/plugins/js/fetch/index.d.ts",
+      "default": "./dist/plugins/js/fetch/index.js"
+    },
+    "./plugins/js/jquery": {
+      "import": "./dist/plugins/js/jquery/index.js",
+      "types": "./dist/plugins/js/jquery/index.d.ts",
+      "default": "./dist/plugins/js/jquery/index.js"
+    },
+    "./plugins/js/ofetch": {
+      "import": "./dist/plugins/js/ofetch/index.js",
+      "types": "./dist/plugins/js/ofetch/index.d.ts",
+      "default": "./dist/plugins/js/ofetch/index.js"
+    },
+    "./plugins/js/xhr": {
+      "import": "./dist/plugins/js/xhr/index.js",
+      "types": "./dist/plugins/js/xhr/index.d.ts",
+      "default": "./dist/plugins/js/xhr/index.js"
+    },
+    "./plugins/kotlin/okhttp": {
+      "import": "./dist/plugins/kotlin/okhttp/index.js",
+      "types": "./dist/plugins/kotlin/okhttp/index.d.ts",
+      "default": "./dist/plugins/kotlin/okhttp/index.js"
+    },
+    "./plugins/node/axios": {
+      "import": "./dist/plugins/node/axios/index.js",
+      "types": "./dist/plugins/node/axios/index.d.ts",
+      "default": "./dist/plugins/node/axios/index.js"
+    },
+    "./plugins/node/fetch": {
+      "import": "./dist/plugins/node/fetch/index.js",
+      "types": "./dist/plugins/node/fetch/index.d.ts",
+      "default": "./dist/plugins/node/fetch/index.js"
+    },
+    "./plugins/node/ofetch": {
+      "import": "./dist/plugins/node/ofetch/index.js",
+      "types": "./dist/plugins/node/ofetch/index.d.ts",
+      "default": "./dist/plugins/node/ofetch/index.js"
+    },
+    "./plugins/node/undici": {
+      "import": "./dist/plugins/node/undici/index.js",
+      "types": "./dist/plugins/node/undici/index.d.ts",
+      "default": "./dist/plugins/node/undici/index.js"
+    },
+    "./plugins/objc/nsurlsession": {
+      "import": "./dist/plugins/objc/nsurlsession/index.js",
+      "types": "./dist/plugins/objc/nsurlsession/index.d.ts",
+      "default": "./dist/plugins/objc/nsurlsession/index.js"
+    },
+    "./plugins/ocaml/cohttp": {
+      "import": "./dist/plugins/ocaml/cohttp/index.js",
+      "types": "./dist/plugins/ocaml/cohttp/index.d.ts",
+      "default": "./dist/plugins/ocaml/cohttp/index.js"
+    },
+    "./plugins/php/curl": {
+      "import": "./dist/plugins/php/curl/index.js",
+      "types": "./dist/plugins/php/curl/index.d.ts",
+      "default": "./dist/plugins/php/curl/index.js"
+    },
+    "./plugins/php/guzzle": {
+      "import": "./dist/plugins/php/guzzle/index.js",
+      "types": "./dist/plugins/php/guzzle/index.d.ts",
+      "default": "./dist/plugins/php/guzzle/index.js"
+    },
+    "./plugins/powershell/restmethod": {
+      "import": "./dist/plugins/powershell/restmethod/index.js",
+      "types": "./dist/plugins/powershell/restmethod/index.d.ts",
+      "default": "./dist/plugins/powershell/restmethod/index.js"
+    },
+    "./plugins/powershell/webrequest": {
+      "import": "./dist/plugins/powershell/webrequest/index.js",
+      "types": "./dist/plugins/powershell/webrequest/index.d.ts",
+      "default": "./dist/plugins/powershell/webrequest/index.js"
+    },
+    "./plugins/python/python3": {
+      "import": "./dist/plugins/python/python3/index.js",
+      "types": "./dist/plugins/python/python3/index.d.ts",
+      "default": "./dist/plugins/python/python3/index.js"
+    },
+    "./plugins/python/requests": {
+      "import": "./dist/plugins/python/requests/index.js",
+      "types": "./dist/plugins/python/requests/index.d.ts",
+      "default": "./dist/plugins/python/requests/index.js"
+    },
+    "./plugins/r/httr": {
+      "import": "./dist/plugins/r/httr/index.js",
+      "types": "./dist/plugins/r/httr/index.d.ts",
+      "default": "./dist/plugins/r/httr/index.js"
+    },
+    "./plugins/ruby/native": {
+      "import": "./dist/plugins/ruby/native/index.js",
+      "types": "./dist/plugins/ruby/native/index.d.ts",
+      "default": "./dist/plugins/ruby/native/index.js"
+    },
+    "./plugins/shell/curl": {
+      "import": "./dist/plugins/shell/curl/index.js",
+      "types": "./dist/plugins/shell/curl/index.d.ts",
+      "default": "./dist/plugins/shell/curl/index.js"
+    },
+    "./plugins/shell/httpie": {
+      "import": "./dist/plugins/shell/httpie/index.js",
+      "types": "./dist/plugins/shell/httpie/index.d.ts",
+      "default": "./dist/plugins/shell/httpie/index.js"
+    },
+    "./plugins/shell/wget": {
+      "import": "./dist/plugins/shell/wget/index.js",
+      "types": "./dist/plugins/shell/wget/index.d.ts",
+      "default": "./dist/plugins/shell/wget/index.js"
+    },
+    "./plugins/swift/nsurlsession": {
+      "import": "./dist/plugins/swift/nsurlsession/index.js",
+      "types": "./dist/plugins/swift/nsurlsession/index.d.ts",
+      "default": "./dist/plugins/swift/nsurlsession/index.js"
+    },
+    "./utils": {
+      "import": "./dist/utils/index.js",
+      "types": "./dist/utils/index.d.ts",
+      "default": "./dist/utils/index.js"
     }
   },
   "files": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -38,30 +38,30 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./utils": {
-      "import": "./dist/utils/index.js",
-      "types": "./dist/utils/index.d.ts",
-      "default": "./dist/utils/index.js"
-    },
-    "./snippetz": {
-      "import": "./dist/snippetz/index.js",
-      "types": "./dist/snippetz/index.d.ts",
-      "default": "./dist/snippetz/index.js"
-    },
-    "./legacy": {
-      "import": "./dist/legacy/index.js",
-      "types": "./dist/legacy/index.d.ts",
-      "default": "./dist/legacy/index.js"
+    "./api-reference": {
+      "import": "./dist/api-reference/index.js",
+      "types": "./dist/api-reference/index.d.ts",
+      "default": "./dist/api-reference/index.js"
     },
     "./entities": {
       "import": "./dist/entities/index.js",
       "types": "./dist/entities/index.d.ts",
       "default": "./dist/entities/index.js"
     },
-    "./api-reference": {
-      "import": "./dist/api-reference/index.js",
-      "types": "./dist/api-reference/index.d.ts",
-      "default": "./dist/api-reference/index.js"
+    "./legacy": {
+      "import": "./dist/legacy/index.js",
+      "types": "./dist/legacy/index.d.ts",
+      "default": "./dist/legacy/index.js"
+    },
+    "./snippetz": {
+      "import": "./dist/snippetz/index.js",
+      "types": "./dist/snippetz/index.d.ts",
+      "default": "./dist/snippetz/index.js"
+    },
+    "./utils": {
+      "import": "./dist/utils/index.js",
+      "types": "./dist/utils/index.d.ts",
+      "default": "./dist/utils/index.js"
     }
   },
   "files": [

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -40,15 +40,15 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./themes": {
-      "import": "./dist/themes/index.js",
-      "types": "./dist/themes/index.d.ts",
-      "default": "./dist/themes/index.js"
-    },
     "./hooks": {
       "import": "./dist/hooks/index.js",
       "types": "./dist/hooks/index.d.ts",
       "default": "./dist/hooks/index.js"
+    },
+    "./themes": {
+      "import": "./dist/themes/index.js",
+      "types": "./dist/themes/index.d.ts",
+      "default": "./dist/themes/index.js"
     }
   },
   "files": [

--- a/packages/use-hooks/package.json
+++ b/packages/use-hooks/package.json
@@ -28,20 +28,20 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./useColorMode": {
-      "import": "./dist/useColorMode/index.js",
-      "types": "./dist/useColorMode/index.d.ts",
-      "default": "./dist/useColorMode/index.js"
+    "./useBreakpoints": {
+      "import": "./dist/useBreakpoints/index.js",
+      "types": "./dist/useBreakpoints/index.d.ts",
+      "default": "./dist/useBreakpoints/index.js"
     },
     "./useClipboard": {
       "import": "./dist/useClipboard/index.js",
       "types": "./dist/useClipboard/index.d.ts",
       "default": "./dist/useClipboard/index.js"
     },
-    "./useBreakpoints": {
-      "import": "./dist/useBreakpoints/index.js",
-      "types": "./dist/useBreakpoints/index.d.ts",
-      "default": "./dist/useBreakpoints/index.js"
+    "./useColorMode": {
+      "import": "./dist/useColorMode/index.js",
+      "types": "./dist/useColorMode/index.d.ts",
+      "default": "./dist/useColorMode/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
**Problem**

Currently, the generated order of the export entries is different on Windows. This could be annoying as it would always generate a gitt diff.

**Solution**

With this PR the keys are sorted, so its always the same order.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
