### PR TITLE
fix(api-reference): doesn’t merge deeply nested allOf schemas

### DIFF
--- a/.changeset/polite-moles-protect.md
+++ b/.changeset/polite-moles-protect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: schema doesn’t show deeply nested allOf schemas

--- a/packages/api-reference/playground/components/src/App.vue
+++ b/packages/api-reference/playground/components/src/App.vue
@@ -130,8 +130,9 @@ ul {
   font-family: monospace;
   color: #666;
   background-color: #eee;
-  padding: 0.5rem;
+  padding: 0.25rem 0.5rem;
   font-size: 0.8rem;
   display: inline-block;
+  border-radius: 0.25rem 0.25rem 0 0;
 }
 </style>

--- a/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
@@ -176,3 +176,306 @@ export const complexAllOfSchema = {
     },
   },
 }
+
+export const arrayValidationSchema = {
+  component: Schema,
+  props: {
+    name: 'ArrayValidation',
+    noncollapsible: true,
+    value: {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          description: 'A list of tags with validation constraints',
+          minItems: 1,
+          maxItems: 5,
+          uniqueItems: true,
+          items: {
+            type: 'string',
+            minLength: 2,
+            maxLength: 20,
+            pattern: '^[a-zA-Z0-9-]+$',
+          },
+        },
+        scores: {
+          type: 'array',
+          description: 'Array of numeric scores between 0 and 100',
+          items: {
+            type: 'number',
+            minimum: 0,
+            maximum: 100,
+          },
+        },
+      },
+    },
+  },
+}
+
+export const advancedStringFormatsSchema = {
+  component: Schema,
+  props: {
+    name: 'StringFormats',
+    noncollapsible: true,
+    value: {
+      type: 'object',
+      required: ['email', 'website'],
+      properties: {
+        email: {
+          type: 'string',
+          format: 'email',
+          description: 'User email address',
+          example: 'user@example.com',
+        },
+        website: {
+          type: 'string',
+          format: 'uri',
+          description: 'Website URL',
+          example: 'https://example.com',
+        },
+        dateOfBirth: {
+          type: 'string',
+          format: 'date',
+          description: 'Date of birth in ISO 8601 format',
+          example: '1990-01-01',
+        },
+        phoneNumber: {
+          type: 'string',
+          pattern: '^\\+[1-9]\\d{1,14}$',
+          description: 'Phone number in E.164 format',
+          example: '+12125551234',
+        },
+      },
+    },
+  },
+}
+
+export const oneOfCombinedSchema = {
+  component: Schema,
+  props: {
+    name: 'PaymentMethod',
+    noncollapsible: true,
+    value: {
+      type: 'object',
+      required: ['type'],
+      properties: {
+        type: {
+          type: 'string',
+          enum: ['credit_card', 'bank_transfer', 'crypto'],
+          description: 'The type of payment method',
+        },
+      },
+      oneOf: [
+        {
+          type: 'object',
+          required: ['card_number', 'expiry_date', 'cvv'],
+          properties: {
+            type: { enum: ['credit_card'] },
+            card_number: {
+              type: 'string',
+              pattern: '^[0-9]{16}$',
+              description: 'Credit card number',
+            },
+            expiry_date: {
+              type: 'string',
+              pattern: '^(0[1-9]|1[0-2])/[0-9]{2}$',
+              description: 'Card expiry date (MM/YY)',
+            },
+            cvv: {
+              type: 'string',
+              pattern: '^[0-9]{3,4}$',
+              description: 'Card verification value',
+            },
+          },
+        },
+        {
+          type: 'object',
+          required: ['account_number', 'routing_number'],
+          properties: {
+            type: { enum: ['bank_transfer'] },
+            account_number: {
+              type: 'string',
+              minLength: 8,
+              maxLength: 12,
+            },
+            routing_number: {
+              type: 'string',
+              pattern: '^[0-9]{9}$',
+            },
+          },
+        },
+        {
+          type: 'object',
+          required: ['wallet_address'],
+          properties: {
+            type: { enum: ['crypto'] },
+            wallet_address: {
+              type: 'string',
+              minLength: 26,
+              maxLength: 35,
+            },
+            network: {
+              type: 'string',
+              enum: ['bitcoin', 'ethereum'],
+            },
+          },
+        },
+      ],
+    },
+  },
+}
+
+export const conditionalFieldsSchema = {
+  component: Schema,
+  props: {
+    name: 'ShippingDetails',
+    noncollapsible: true,
+    value: {
+      type: 'object',
+      required: ['shippingType'],
+      properties: {
+        shippingType: {
+          type: 'string',
+          enum: ['domestic', 'international'],
+          description: 'Type of shipping',
+        },
+        zipCode: {
+          type: 'string',
+          pattern: '^[0-9]{5}(-[0-9]{4})?$',
+          description: 'US ZIP code',
+        },
+        countryCode: {
+          type: 'string',
+          pattern: '^[A-Z]{2}$',
+          description: 'ISO 3166-1 alpha-2 country code',
+        },
+      },
+      dependencies: {
+        shippingType: {
+          oneOf: [
+            {
+              properties: {
+                shippingType: { enum: ['domestic'] },
+                zipCode: { type: 'string' },
+              },
+              required: ['zipCode'],
+            },
+            {
+              properties: {
+                shippingType: { enum: ['international'] },
+                countryCode: { type: 'string' },
+              },
+              required: ['countryCode'],
+            },
+          ],
+        },
+      },
+    },
+  },
+}
+
+export const advancedNumberValidationSchema = {
+  component: Schema,
+  props: {
+    name: 'ProductSpecification',
+    noncollapsible: true,
+    value: {
+      type: 'object',
+      properties: {
+        weight: {
+          type: 'number',
+          minimum: 0,
+          exclusiveMinimum: true,
+          maximum: 1000,
+          multipleOf: 0.1,
+          description: 'Weight in kilograms (up to 1 decimal place)',
+        },
+        dimensions: {
+          type: 'object',
+          properties: {
+            length: {
+              type: 'number',
+              minimum: 1,
+              maximum: 100,
+              description: 'Length in centimeters',
+            },
+            width: {
+              type: 'number',
+              minimum: 1,
+              maximum: 100,
+              description: 'Width in centimeters',
+            },
+            height: {
+              type: 'number',
+              minimum: 1,
+              maximum: 100,
+              description: 'Height in centimeters',
+            },
+          },
+          required: ['length', 'width', 'height'],
+        },
+        rating: {
+          type: 'number',
+          minimum: 0,
+          maximum: 5,
+          multipleOf: 0.5,
+          description: 'Product rating (0-5 stars, in 0.5 increments)',
+        },
+      },
+    },
+  },
+}
+
+export const nestedArrayTupleSchema = {
+  component: Schema,
+  props: {
+    name: 'ChessGame',
+    noncollapsible: true,
+    value: {
+      type: 'object',
+      properties: {
+        gameId: {
+          type: 'string',
+          format: 'uuid',
+          description: 'Unique identifier for the chess game',
+        },
+        moves: {
+          type: 'array',
+          description: 'List of moves in the game',
+          items: {
+            type: 'array',
+            minItems: 3,
+            maxItems: 3,
+            description: 'Move tuple [piece, from, to]',
+            items: [
+              {
+                type: 'string',
+                enum: ['pawn', 'knight', 'bishop', 'rook', 'queen', 'king'],
+                description: 'Chess piece type',
+              },
+              {
+                type: 'string',
+                pattern: '^[a-h][1-8]$',
+                description: 'Starting position (e.g., "e2")',
+              },
+              {
+                type: 'string',
+                pattern: '^[a-h][1-8]$',
+                description: 'Ending position (e.g., "e4")',
+              },
+            ],
+          },
+        },
+        timestamps: {
+          type: 'array',
+          description: 'Timestamps for each move',
+          items: {
+            type: 'string',
+            format: 'date-time',
+          },
+        },
+      },
+      required: ['gameId', 'moves'],
+    },
+  },
+}

--- a/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
@@ -118,162 +118,47 @@ export const complexAllOfSchema = {
     name: 'ComplexAllOf',
     noncollapsible: true,
     value: {
-      'description': 'The recording session list.',
-      'allOf': [
+      allOf: [
         {
           'type': 'object',
           'properties': {
-            'from': {
+            'top-level-property': {
               'type': 'string',
-              'description': 'The start date of the query date range.',
-              'example': '2021-10-11',
-            },
-            'to': {
-              'type': 'string',
-              'description': 'The end date of the query date range.',
-              'example': '2021-11-11',
-            },
-            'page_size': {
-              'type': 'integer',
-              'description': ' The number of records returned within a single API call.',
-              'example': 30,
-            },
-            'total_records': {
-              'type': 'integer',
-              'description': 'The number of all records available across pages.',
-              'example': 100,
-            },
-            'next_page_token': {
-              'type': 'string',
-              'description': 'The next page token to paginate through large result sets.',
-              'example': 'Usse957pzxvmYwlmCZ50a6CNXFrhztxuj82',
             },
           },
         },
         {
           'type': 'object',
           'properties': {
-            'sessions': {
-              'title': 'Recording session list',
+            'top-level-array': {
               'type': 'array',
-              'description': 'List of recording sessions',
               'items': {
                 'allOf': [
                   {
                     'type': 'object',
                     'properties': {
-                      'session_id': {
+                      'all-of-schema-1': {
                         'type': 'string',
-                        'description':
-                          'Unique session identifier. Each instance of the session will have its own `session_id`.',
-                        'example': 'JZiFOknTQ4yH/tJgaUTlkg==',
-                      },
-                      'session_name': {
-                        'type': 'string',
-                        'description': 'Session name.',
-                        'example': 'session_name',
-                      },
-                      'start_time': {
-                        'type': 'string',
-                        'description': 'The time at which the session started.',
-                        'format': 'date-time',
-                        'example': '2022-03-10T02:27:24Z',
-                      },
-                      'duration': {
-                        'type': 'integer',
-                        'description': 'Session duration.',
-                        'example': 2,
-                      },
-                      'total_size': {
-                        'type': 'integer',
-                        'description':
-                          'The total file size of the recording. This includes the `recording_files` and `participant_audio_files` files.',
-                        'format': 'int64',
-                        'example': 444601,
-                      },
-                      'recording_count': {
-                        'type': 'integer',
-                        'description':
-                          'Number of recording files returned in the response of this API call. This includes the `recording_files` and  `participant_audio_files` files.',
-                        'example': 4,
-                      },
-                      'session_key': {
-                        'type': 'string',
-                        'description': 'The Video SDK custom session ID.',
-                        'example': 'ABC36jaBI145',
                       },
                     },
                   },
                   {
                     'type': 'object',
-                    'description': 'List of recording files.',
                     'allOf': [
                       {
                         'type': 'object',
                         'properties': {
-                          'recording_files': {
-                            'title': 'Recording file list',
+                          'all-of-schema-2': {
                             'type': 'array',
-                            'description': 'List of recording files.',
                             'items': {
                               'allOf': [
                                 {
                                   'type': 'object',
                                   'properties': {
-                                    'id': {
+                                    'all-of-schema-2-items-all-of-schema-1': {
                                       'type': 'string',
-                                      'description':
-                                        'The recording file ID. This is included in the general query response.',
-                                      'example': '35497738-9fef-4f8a-97db-0ec34caef065',
-                                    },
-                                    'recording_start': {
-                                      'type': 'string',
-                                      'description': 'The recording start time.',
-                                      'example': '2022-03-11T12:34:39Z',
-                                    },
-                                    'recording_end': {
-                                      'type': 'string',
-                                      'description':
-                                        'The recording end time. This is included in the the general query response.',
-                                      'example': '2022-03-11T12:34:42Z',
-                                    },
-                                    'file_type': {
-                                      'type': 'string',
-                                      'description':
-                                        "The recording file type. The value of this field could be one of the following:  \n \n`MP4`: Video file of the recording.  \n `M4A` Audio-only file of the recording.  \n `TIMELINE`: Timestamped file of the recording in JSON file format. To get a timeline file, the 'Add a timestamp to the recording'. You must enable this setting in the recording settings. See [Video SDK Account: Enable cloud recording](https://developers.zoom.us/docs/video-sdk/account/#enable-cloud-recording) for details). The time will display in the account's timezone, set in their Zoom profile.\n  \n  `TRANSCRIPT`: Transcription file of the recording in VTT format.  \n  `CHAT`: A TXT file containing in-session chat messages that were sent during the session.  \n `CC`: File containing closed captions of the recording in VTT file format.  \n `CSV`: File containing polling data in CSV format.\n\n  \n \n\nA recording file object with file type of either `CC` or `TIMELINE` **does not have** the following properties: `id`, `status`, `file_size`, and `recording_type`.",
-                                      'example': 'MP4',
-                                    },
-                                    'file_size': {
-                                      'type': 'number',
-                                      'description': 'The recording file size.',
-                                      'example': 12125,
-                                    },
-                                    'download_url': {
-                                      'type': 'string',
-                                      'description':
-                                        'The URL to download the recording. \n\nTo access a private or password-protected cloud recording of a user in your account, use your [Video SDK API JWT](https://developers.zoom.us/docs/video-sdk/auth/#generate-a-video-sdk-jwt). Set this JWT as a Bearer token in the Authorization header of your HTTP request. For example: \n\n `curl "{download_url}" --header "authorization: Bearer {JWT}" --header "content-type: application/json"`.\n\nNote: The download_url may be a redirect. In that case, use `curl --location "{download_url}"` to follow redirects or use another tool, like Postman.',
-                                      'example': 'https://example.com/download_url',
-                                    },
-                                    'status': {
-                                      'type': 'string',
-                                      'description': 'The recording status.',
-                                      'example': 'completed',
-                                      'enum': ['completed'],
-                                    },
-                                    'deleted_time': {
-                                      'type': 'string',
-                                      'description':
-                                        'The time at which the recording was deleted. Returned in the response only for the trash query.',
-                                      'example': '2022-03-28T07:22:22Z',
-                                    },
-                                    'recording_type': {
-                                      'type': 'string',
-                                      'description':
-                                        'The recording type. The value of this field can be one of the following:  \n `shared_screen_with_speaker_view(CC)`  \n `shared_screen_with_speaker_view`  \n `shared_screen_with_gallery_view`  \n `active_speaker`  \n `gallery_view`  \n `shared_screen`  \n `audio_only`  \n `audio_transcript`  \n `chat_file`  \n `poll`  \n `timeline`  \n `closed_caption`  \n `local_transcript`  \n `original_transcript`',
-                                      'example': 'audio_only',
                                     },
                                   },
-                                  'description': 'Recording file object.',
                                 },
                               ],
                             },
@@ -281,106 +166,6 @@ export const complexAllOfSchema = {
                         },
                       },
                     ],
-                  },
-                  {
-                    'type': 'object',
-                    'description': 'Return a list of recording files about individual video for each participant.',
-                    'items': {
-                      'allOf': [
-                        {
-                          'type': 'object',
-                          'properties': {
-                            'participant_video_files': {
-                              'title': 'The list of recording files for each participant.',
-                              'type': 'array',
-                              'description':
-                                'A list of recording files. The API only returns this response when the **Record a separate audio file of each participant** setting is enabled.',
-                              'items': {
-                                'allOf': [
-                                  {
-                                    'type': 'object',
-                                    'properties': {
-                                      'id': {
-                                        'type': 'string',
-                                        'description':
-                                          "The recording file's unique ID. This is included in the general query response.",
-                                        'example': '24698bd1-589e-4c33-9ba3-bc788b2a0ac2',
-                                      },
-                                      'recording_start': {
-                                        'type': 'string',
-                                        'description': "The recording file's start time.",
-                                        'format': 'date-time',
-                                        'example': '2021-12-07T05:42:13Z',
-                                      },
-                                      'recording_end': {
-                                        'type': 'string',
-                                        'description':
-                                          "The recording file's end time. This is included in the general query response.",
-                                        'format': 'date-time',
-                                        'example': '2021-12-07T05:42:28Z',
-                                      },
-                                      'file_name': {
-                                        'type': 'string',
-                                        'description': "The recording file's name.",
-                                        'example': 'recording_name',
-                                      },
-                                      'file_type': {
-                                        'type': 'string',
-                                        'description':
-                                          "The recording file's format. One of:\n\n* `MP4` - Video file.\n* `M4A` - Audio-only file.\n* `TIMELINE` - Timestamp file of the recording, in JSON file format. To get a timeline file, you must enable the **Add a timestamp to the recording** setting in the recording settings. See [Video SDK Account: Enable could recording](https://developers.zoom.us/docs/video-sdk/account/#enable-cloud-recording) for details. The time will display in the account's timezone.\n* `TRANSCRIPT` - A transcript of the recording, in VTT format.\n* `CHAT` - A text file containing chat messages sent during the session.\n* `CC` - A file containing the closed captions of the recording, in VTT file format.\n* `CSV` - A file containing polling data, in CSV format.\n\nA recording file object with file type of either `CC` or `TIMELINE` **does not have** the following properties: `id`, `status`, `file_size`, and `recording_type`.",
-                                        'example': 'MP4',
-                                      },
-                                      'file_extension': {
-                                        'type': 'string',
-                                        'description': "The archived file's file extension.",
-                                        'example': 'MP4',
-                                      },
-                                      'file_size': {
-                                        'type': 'number',
-                                        'description': "The recording file's size, in bytes.",
-                                        'example': 900452,
-                                      },
-                                      'download_url': {
-                                        'type': 'string',
-                                        'description':
-                                          'The URL to download the recording. \n\nTo access a private or password-protected cloud recording of a user in your account, use your [Video SDK API JWT](https://developers.zoom.us/docs/video-sdk/auth/#generate-a-video-sdk-jwt). Set this JWT as a Bearer token in the Authorization header of your HTTP request. For example: \n\n `curl "{download_url}" --header "authorization: Bearer {JWT}" --header "content-type: application/json"`.\n\nNote: The download_url may be a redirect. In that case, use `curl --location "{download_url}"` to follow redirects or use another tool, like Postman.',
-                                        'example': 'https://download.example.com/download_url',
-                                      },
-                                      'recording_type': {
-                                        'type': 'string',
-                                        'description':
-                                          'The type of recording file: \n* `individual_user` \n* `individual_shared_screen`.',
-                                        'example': 'individual_shared_screen',
-                                        'enum': ['individual_user', 'individual_shared_screen'],
-                                      },
-                                      'status': {
-                                        'type': 'string',
-                                        'description': "The recording file's status.",
-                                        'example': 'completed',
-                                        'enum': ['completed'],
-                                      },
-                                      'user_id': {
-                                        'type': 'string',
-                                        'description':
-                                          "The participant's session user ID. This value is assigned to a participant upon joining a session and is only valid for the duration of the session.",
-                                        'example': 'abcd1234',
-                                      },
-                                      'user_key': {
-                                        'type': 'string',
-                                        'description':
-                                          "The participant's SDK identifier. Set with the `user_identity` key in the Video SDK JWT payload. This value can be alphanumeric, up to a maximum length of 36 characters.",
-                                        'example': 'efgh5678',
-                                      },
-                                    },
-                                    'description': 'The recording file object.',
-                                  },
-                                ],
-                              },
-                            },
-                          },
-                        },
-                      ],
-                    },
                   },
                 ],
               },

--- a/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
@@ -111,3 +111,283 @@ export const discriminatorsSchema = {
     },
   },
 }
+
+export const complexAllOfSchema = {
+  component: Schema,
+  props: {
+    name: 'ComplexAllOf',
+    noncollapsible: true,
+    value: {
+      'description': 'The recording session list.',
+      'allOf': [
+        {
+          'type': 'object',
+          'properties': {
+            'from': {
+              'type': 'string',
+              'description': 'The start date of the query date range.',
+              'example': '2021-10-11',
+            },
+            'to': {
+              'type': 'string',
+              'description': 'The end date of the query date range.',
+              'example': '2021-11-11',
+            },
+            'page_size': {
+              'type': 'integer',
+              'description': ' The number of records returned within a single API call.',
+              'example': 30,
+            },
+            'total_records': {
+              'type': 'integer',
+              'description': 'The number of all records available across pages.',
+              'example': 100,
+            },
+            'next_page_token': {
+              'type': 'string',
+              'description': 'The next page token to paginate through large result sets.',
+              'example': 'Usse957pzxvmYwlmCZ50a6CNXFrhztxuj82',
+            },
+          },
+        },
+        {
+          'type': 'object',
+          'properties': {
+            'sessions': {
+              'title': 'Recording session list',
+              'type': 'array',
+              'description': 'List of recording sessions',
+              'items': {
+                'allOf': [
+                  {
+                    'type': 'object',
+                    'properties': {
+                      'session_id': {
+                        'type': 'string',
+                        'description':
+                          'Unique session identifier. Each instance of the session will have its own `session_id`.',
+                        'example': 'JZiFOknTQ4yH/tJgaUTlkg==',
+                      },
+                      'session_name': {
+                        'type': 'string',
+                        'description': 'Session name.',
+                        'example': 'session_name',
+                      },
+                      'start_time': {
+                        'type': 'string',
+                        'description': 'The time at which the session started.',
+                        'format': 'date-time',
+                        'example': '2022-03-10T02:27:24Z',
+                      },
+                      'duration': {
+                        'type': 'integer',
+                        'description': 'Session duration.',
+                        'example': 2,
+                      },
+                      'total_size': {
+                        'type': 'integer',
+                        'description':
+                          'The total file size of the recording. This includes the `recording_files` and `participant_audio_files` files.',
+                        'format': 'int64',
+                        'example': 444601,
+                      },
+                      'recording_count': {
+                        'type': 'integer',
+                        'description':
+                          'Number of recording files returned in the response of this API call. This includes the `recording_files` and  `participant_audio_files` files.',
+                        'example': 4,
+                      },
+                      'session_key': {
+                        'type': 'string',
+                        'description': 'The Video SDK custom session ID.',
+                        'example': 'ABC36jaBI145',
+                      },
+                    },
+                  },
+                  {
+                    'type': 'object',
+                    'description': 'List of recording files.',
+                    'allOf': [
+                      {
+                        'type': 'object',
+                        'properties': {
+                          'recording_files': {
+                            'title': 'Recording file list',
+                            'type': 'array',
+                            'description': 'List of recording files.',
+                            'items': {
+                              'allOf': [
+                                {
+                                  'type': 'object',
+                                  'properties': {
+                                    'id': {
+                                      'type': 'string',
+                                      'description':
+                                        'The recording file ID. This is included in the general query response.',
+                                      'example': '35497738-9fef-4f8a-97db-0ec34caef065',
+                                    },
+                                    'recording_start': {
+                                      'type': 'string',
+                                      'description': 'The recording start time.',
+                                      'example': '2022-03-11T12:34:39Z',
+                                    },
+                                    'recording_end': {
+                                      'type': 'string',
+                                      'description':
+                                        'The recording end time. This is included in the the general query response.',
+                                      'example': '2022-03-11T12:34:42Z',
+                                    },
+                                    'file_type': {
+                                      'type': 'string',
+                                      'description':
+                                        "The recording file type. The value of this field could be one of the following:  \n \n`MP4`: Video file of the recording.  \n `M4A` Audio-only file of the recording.  \n `TIMELINE`: Timestamped file of the recording in JSON file format. To get a timeline file, the 'Add a timestamp to the recording'. You must enable this setting in the recording settings. See [Video SDK Account: Enable cloud recording](https://developers.zoom.us/docs/video-sdk/account/#enable-cloud-recording) for details). The time will display in the account's timezone, set in their Zoom profile.\n  \n  `TRANSCRIPT`: Transcription file of the recording in VTT format.  \n  `CHAT`: A TXT file containing in-session chat messages that were sent during the session.  \n `CC`: File containing closed captions of the recording in VTT file format.  \n `CSV`: File containing polling data in CSV format.\n\n  \n \n\nA recording file object with file type of either `CC` or `TIMELINE` **does not have** the following properties: `id`, `status`, `file_size`, and `recording_type`.",
+                                      'example': 'MP4',
+                                    },
+                                    'file_size': {
+                                      'type': 'number',
+                                      'description': 'The recording file size.',
+                                      'example': 12125,
+                                    },
+                                    'download_url': {
+                                      'type': 'string',
+                                      'description':
+                                        'The URL to download the recording. \n\nTo access a private or password-protected cloud recording of a user in your account, use your [Video SDK API JWT](https://developers.zoom.us/docs/video-sdk/auth/#generate-a-video-sdk-jwt). Set this JWT as a Bearer token in the Authorization header of your HTTP request. For example: \n\n `curl "{download_url}" --header "authorization: Bearer {JWT}" --header "content-type: application/json"`.\n\nNote: The download_url may be a redirect. In that case, use `curl --location "{download_url}"` to follow redirects or use another tool, like Postman.',
+                                      'example': 'https://example.com/download_url',
+                                    },
+                                    'status': {
+                                      'type': 'string',
+                                      'description': 'The recording status.',
+                                      'example': 'completed',
+                                      'enum': ['completed'],
+                                    },
+                                    'deleted_time': {
+                                      'type': 'string',
+                                      'description':
+                                        'The time at which the recording was deleted. Returned in the response only for the trash query.',
+                                      'example': '2022-03-28T07:22:22Z',
+                                    },
+                                    'recording_type': {
+                                      'type': 'string',
+                                      'description':
+                                        'The recording type. The value of this field can be one of the following:  \n `shared_screen_with_speaker_view(CC)`  \n `shared_screen_with_speaker_view`  \n `shared_screen_with_gallery_view`  \n `active_speaker`  \n `gallery_view`  \n `shared_screen`  \n `audio_only`  \n `audio_transcript`  \n `chat_file`  \n `poll`  \n `timeline`  \n `closed_caption`  \n `local_transcript`  \n `original_transcript`',
+                                      'example': 'audio_only',
+                                    },
+                                  },
+                                  'description': 'Recording file object.',
+                                },
+                              ],
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    'type': 'object',
+                    'description': 'Return a list of recording files about individual video for each participant.',
+                    'items': {
+                      'allOf': [
+                        {
+                          'type': 'object',
+                          'properties': {
+                            'participant_video_files': {
+                              'title': 'The list of recording files for each participant.',
+                              'type': 'array',
+                              'description':
+                                'A list of recording files. The API only returns this response when the **Record a separate audio file of each participant** setting is enabled.',
+                              'items': {
+                                'allOf': [
+                                  {
+                                    'type': 'object',
+                                    'properties': {
+                                      'id': {
+                                        'type': 'string',
+                                        'description':
+                                          "The recording file's unique ID. This is included in the general query response.",
+                                        'example': '24698bd1-589e-4c33-9ba3-bc788b2a0ac2',
+                                      },
+                                      'recording_start': {
+                                        'type': 'string',
+                                        'description': "The recording file's start time.",
+                                        'format': 'date-time',
+                                        'example': '2021-12-07T05:42:13Z',
+                                      },
+                                      'recording_end': {
+                                        'type': 'string',
+                                        'description':
+                                          "The recording file's end time. This is included in the general query response.",
+                                        'format': 'date-time',
+                                        'example': '2021-12-07T05:42:28Z',
+                                      },
+                                      'file_name': {
+                                        'type': 'string',
+                                        'description': "The recording file's name.",
+                                        'example': 'recording_name',
+                                      },
+                                      'file_type': {
+                                        'type': 'string',
+                                        'description':
+                                          "The recording file's format. One of:\n\n* `MP4` - Video file.\n* `M4A` - Audio-only file.\n* `TIMELINE` - Timestamp file of the recording, in JSON file format. To get a timeline file, you must enable the **Add a timestamp to the recording** setting in the recording settings. See [Video SDK Account: Enable could recording](https://developers.zoom.us/docs/video-sdk/account/#enable-cloud-recording) for details. The time will display in the account's timezone.\n* `TRANSCRIPT` - A transcript of the recording, in VTT format.\n* `CHAT` - A text file containing chat messages sent during the session.\n* `CC` - A file containing the closed captions of the recording, in VTT file format.\n* `CSV` - A file containing polling data, in CSV format.\n\nA recording file object with file type of either `CC` or `TIMELINE` **does not have** the following properties: `id`, `status`, `file_size`, and `recording_type`.",
+                                        'example': 'MP4',
+                                      },
+                                      'file_extension': {
+                                        'type': 'string',
+                                        'description': "The archived file's file extension.",
+                                        'example': 'MP4',
+                                      },
+                                      'file_size': {
+                                        'type': 'number',
+                                        'description': "The recording file's size, in bytes.",
+                                        'example': 900452,
+                                      },
+                                      'download_url': {
+                                        'type': 'string',
+                                        'description':
+                                          'The URL to download the recording. \n\nTo access a private or password-protected cloud recording of a user in your account, use your [Video SDK API JWT](https://developers.zoom.us/docs/video-sdk/auth/#generate-a-video-sdk-jwt). Set this JWT as a Bearer token in the Authorization header of your HTTP request. For example: \n\n `curl "{download_url}" --header "authorization: Bearer {JWT}" --header "content-type: application/json"`.\n\nNote: The download_url may be a redirect. In that case, use `curl --location "{download_url}"` to follow redirects or use another tool, like Postman.',
+                                        'example': 'https://download.example.com/download_url',
+                                      },
+                                      'recording_type': {
+                                        'type': 'string',
+                                        'description':
+                                          'The type of recording file: \n* `individual_user` \n* `individual_shared_screen`.',
+                                        'example': 'individual_shared_screen',
+                                        'enum': ['individual_user', 'individual_shared_screen'],
+                                      },
+                                      'status': {
+                                        'type': 'string',
+                                        'description': "The recording file's status.",
+                                        'example': 'completed',
+                                        'enum': ['completed'],
+                                      },
+                                      'user_id': {
+                                        'type': 'string',
+                                        'description':
+                                          "The participant's session user ID. This value is assigned to a participant upon joining a session and is only valid for the duration of the session.",
+                                        'example': 'abcd1234',
+                                      },
+                                      'user_key': {
+                                        'type': 'string',
+                                        'description':
+                                          "The participant's SDK identifier. Set with the `user_identity` key in the Video SDK JWT payload. This value can be alphanumeric, up to a maximum length of 36 characters.",
+                                        'example': 'efgh5678',
+                                      },
+                                    },
+                                    'description': 'The recording file object.',
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+}

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -5,6 +5,8 @@ import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import { stringify } from 'flatted'
 import { ref } from 'vue'
 
+import { mergeAllOfSchemas } from '@/components/Content/Schema/helpers/merge-all-of-schemas'
+
 import Schema from './Schema.vue'
 
 const props = defineProps<{
@@ -32,52 +34,6 @@ const buttonVariants = cva({
     },
   },
 })
-
-// Function to merge allOf schemas
-const mergeAllOfSchemas = (schemas: any[]) => {
-  if (!Array.isArray(schemas) || schemas.length === 0) {
-    return {}
-  }
-
-  // Handle case where we have an array of objects with allOf properties
-  if (schemas.length > 0 && schemas[0].allOf) {
-    const allSchemas = schemas.flatMap((schema) => schema.allOf || [])
-    return mergeAllOfSchemas(allSchemas)
-  }
-
-  // Regular case - just merge the schemas directly
-  return schemas.reduce((result, schema) => {
-    if (!schema || typeof schema !== 'object') {
-      return result
-    }
-
-    const mergedResult = { ...result }
-
-    if (schema.properties) {
-      mergedResult.properties = {
-        ...mergedResult.properties,
-        ...schema.properties,
-      }
-    }
-
-    if (schema.required && Array.isArray(schema.required)) {
-      mergedResult.required = [
-        ...(mergedResult.required || []),
-        ...schema.required,
-      ]
-    }
-
-    if (schema.type && !mergedResult.type) {
-      mergedResult.type = schema.type
-    }
-
-    if (schema.description && !mergedResult.description) {
-      mergedResult.description = schema.description
-    }
-
-    return mergedResult
-  }, {})
-}
 
 // Get model name from schema
 const getModelNameFromSchema = (schema: any): string | null => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -303,18 +303,19 @@ const displayPropertyHeading = (
       v-for="discriminator in discriminators"
       :key="discriminator">
       <!-- Property discriminator -->
-      <SchemaDiscriminator
-        v-if="optimizedValue?.[discriminator]"
-        :compact="compact"
-        :discriminator="discriminator"
-        :hideHeading="hideHeading"
-        :level="level"
-        :name="name"
-        :schemas="schemas"
-        :value="optimizedValue" />
+      <template v-if="optimizedValue?.[discriminator]">
+        <SchemaDiscriminator
+          :compact="compact"
+          :discriminator="discriminator"
+          :hideHeading="hideHeading"
+          :level="level"
+          :name="name"
+          :schemas="schemas"
+          :value="optimizedValue" />
+      </template>
 
       <!-- Array item discriminator -->
-      <SchemaDiscriminator
+      <template
         v-else-if="
           optimizedValue?.items &&
           typeof discriminator === 'string' &&
@@ -322,14 +323,16 @@ const displayPropertyHeading = (
           discriminator in optimizedValue.items &&
           Array.isArray(optimizedValue.items[discriminator]) &&
           level < 3
-        "
-        :compact="compact"
-        :discriminator="discriminator"
-        :hideHeading="hideHeading"
-        :level="level"
-        :name="name"
-        :schemas="schemas"
-        :value="optimizedValue.items" />
+        ">
+        <SchemaDiscriminator
+          :compact="compact"
+          :discriminator="discriminator"
+          :hideHeading="hideHeading"
+          :level="level"
+          :name="name"
+          :schemas="schemas"
+          :value="optimizedValue.items" />
+      </template>
     </template>
   </component>
 </template>

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
@@ -293,4 +293,180 @@ describe('mergeAllOfSchemas', () => {
       },
     })
   })
+
+  it.only('merges allOf schemas within a large complex schema', () => {
+    const schema = {
+      'description': 'The big long nested list',
+      'allOf': [
+        {
+          'type': 'object',
+          'properties': {
+            'next_page_token': {
+              'type': 'string',
+              'description': 'The next page token to paginate through large result sets.',
+              'example': 'Usse957pzxvmYwlmCZ50a6CNXFrhztxuj82',
+            },
+          },
+        },
+        {
+          'type': 'object',
+          'properties': {
+            'sessions': {
+              'title': 'Recording session list',
+              'type': 'array',
+              'description': 'List of recording sessions',
+              'items': {
+                'allOf': [
+                  {
+                    'type': 'object',
+                    'properties': {
+                      'session_id': {
+                        'type': 'string',
+                        'description':
+                          'Unique session identifier. Each instance of the session will have its own `session_id`.',
+                        'example': 'JZiFOknTQ4yH/tJgaUTlkg==',
+                      },
+                    },
+                  },
+                  {
+                    'type': 'object',
+                    'description': 'List of recording files.',
+                    'allOf': [
+                      {
+                        'type': 'object',
+                        'properties': {
+                          'recording_files': {
+                            'title': 'Recording file list',
+                            'type': 'array',
+                            'description': 'List of recording files.',
+                            'items': {
+                              'allOf': [
+                                {
+                                  'type': 'object',
+                                  'properties': {
+                                    'id': {
+                                      'type': 'string',
+                                      'description':
+                                        'The recording file ID. This is included in the general query response.',
+                                      'example': '35497738-9fef-4f8a-97db-0ec34caef065',
+                                    },
+                                  },
+                                  'description': 'Recording file object.',
+                                },
+                              ],
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    'type': 'object',
+                    'description': 'Return a list of recording files about individual video for each participant.',
+                    'items': {
+                      'allOf': [
+                        {
+                          'type': 'object',
+                          'properties': {
+                            'participant_video_files': {
+                              'title': 'The list of recording files for each participant.',
+                              'type': 'array',
+                              'description':
+                                'A list of recording files. The API only returns this response when the **Record a separate audio file of each participant** setting is enabled.',
+                              'items': {
+                                'allOf': [
+                                  {
+                                    'type': 'object',
+                                    'properties': {
+                                      'id': {
+                                        'type': 'string',
+                                        'description':
+                                          "The recording file's unique ID. This is included in the general query response.",
+                                        'example': '24698bd1-589e-4c33-9ba3-bc788b2a0ac2',
+                                      },
+                                    },
+                                    'description': 'The recording file object.',
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    }
+
+    expect(mergeAllOfSchemas([schema])).toEqual({
+      'properties': {
+        'next_page_token': {
+          'type': 'string',
+          'description': 'The next page token to paginate through large result sets.',
+          'example': 'Usse957pzxvmYwlmCZ50a6CNXFrhztxuj82',
+        },
+        'sessions': {
+          'title': 'Recording session list',
+          'type': 'array',
+          'description': 'List of recording sessions',
+          'items': {
+            'properties': {
+              'session_id': {
+                'type': 'string',
+                'description':
+                  'Unique session identifier. Each instance of the session will have its own `session_id`.',
+                'example': 'JZiFOknTQ4yH/tJgaUTlkg==',
+              },
+              'recording_files': {
+                'title': 'Recording file list',
+                'type': 'array',
+                'description': 'List of recording files.',
+                'items': {
+                  'properties': {
+                    'id': {
+                      'type': 'string',
+                      'description': 'The recording file ID. This is included in the general query response.',
+                      'example': '35497738-9fef-4f8a-97db-0ec34caef065',
+                    },
+                  },
+                  'type': 'object',
+                  'description': 'Recording file object.',
+                },
+              },
+              'participant_video_files': {
+                'title': 'The list of recording files for each participant.',
+                'type': 'array',
+                'description':
+                  'A list of recording files. The API only returns this response when the **Record a separate audio file of each participant** setting is enabled.',
+                'items': {
+                  'allOf': [
+                    {
+                      'type': 'object',
+                      'properties': {
+                        'id': {
+                          'type': 'string',
+                          'description':
+                            "The recording file's unique ID. This is included in the general query response.",
+                          'example': '24698bd1-589e-4c33-9ba3-bc788b2a0ac2',
+                        },
+                      },
+                      'description': 'The recording file object.',
+                    },
+                  ],
+                },
+              },
+            },
+            'type': 'object',
+            'description': 'Return a list of recording files about individual video for each participant.',
+          },
+        },
+      },
+      'type': 'object',
+    })
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
@@ -164,6 +164,47 @@ describe('mergeAllOfSchemas', () => {
     })
   })
 
+  it('merges allOf schemas within array objects', () => {
+    const schemas = [
+      {
+        type: 'object',
+        items: {
+          allOf: [
+            {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' },
+              },
+            },
+            {
+              type: 'object',
+              properties: {
+                age: { type: 'number' },
+                email: { type: 'string' },
+              },
+              required: ['email'],
+            },
+          ],
+        },
+      },
+    ]
+
+    expect(mergeAllOfSchemas(schemas)).toEqual({
+      type: 'object',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          age: { type: 'number' },
+          email: { type: 'string' },
+        },
+        required: ['email'],
+      },
+    })
+  })
+
   it('merges allOf schemas within array items', () => {
     const schemas = [
       {
@@ -294,7 +335,7 @@ describe('mergeAllOfSchemas', () => {
     })
   })
 
-  it.only('merges allOf schemas within a large complex schema', () => {
+  it('merges allOf schemas within a large complex schema', () => {
     const schema = {
       'description': 'The big long nested list',
       'allOf': [
@@ -444,25 +485,18 @@ describe('mergeAllOfSchemas', () => {
                 'description':
                   'A list of recording files. The API only returns this response when the **Record a separate audio file of each participant** setting is enabled.',
                 'items': {
-                  'allOf': [
-                    {
-                      'type': 'object',
-                      'properties': {
-                        'id': {
-                          'type': 'string',
-                          'description':
-                            "The recording file's unique ID. This is included in the general query response.",
-                          'example': '24698bd1-589e-4c33-9ba3-bc788b2a0ac2',
-                        },
-                      },
-                      'description': 'The recording file object.',
+                  'properties': {
+                    'id': {
+                      'type': 'string',
+                      'description': "The recording file's unique ID. This is included in the general query response.",
+                      'example': '24698bd1-589e-4c33-9ba3-bc788b2a0ac2',
                     },
-                  ],
+                  },
+                  'type': 'object',
+                  'description': 'The recording file object.',
                 },
               },
             },
-            'type': 'object',
-            'description': 'Return a list of recording files about individual video for each participant.',
           },
         },
       },

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest'
+import { mergeAllOfSchemas } from './merge-all-of-schemas'
+
+describe('mergeAllOfSchemas', () => {
+  it('returns empty object for empty or invalid input', () => {
+    expect(mergeAllOfSchemas([])).toEqual({})
+    expect(mergeAllOfSchemas(null as any)).toEqual({})
+    expect(mergeAllOfSchemas(undefined as any)).toEqual({})
+    expect(mergeAllOfSchemas('not an array' as any)).toEqual({})
+  })
+
+  it('merges basic properties from multiple schemas', () => {
+    const schemas = [
+      {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      },
+      {
+        properties: {
+          age: { type: 'number' },
+        },
+      },
+    ]
+
+    expect(mergeAllOfSchemas(schemas)).toEqual({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+      },
+    })
+  })
+
+  it('handles nested allOf schemas', () => {
+    const schemas = [
+      {
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+          {
+            properties: {
+              name: { type: 'string' },
+            },
+          },
+        ],
+      },
+    ]
+
+    expect(mergeAllOfSchemas(schemas)).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+      },
+    })
+  })
+
+  it('combines required fields from multiple schemas', () => {
+    const schemas = [
+      {
+        required: ['name'],
+      },
+      {
+        required: ['age'],
+      },
+    ]
+
+    expect(mergeAllOfSchemas(schemas)).toEqual({
+      required: ['name', 'age'],
+    })
+  })
+
+  it('preserves first type and description when duplicates exist', () => {
+    const schemas = [
+      {
+        type: 'object',
+        description: 'First description',
+      },
+      {
+        type: 'array', // Should be ignored
+        description: 'Second description', // Should be ignored
+      },
+    ]
+
+    expect(mergeAllOfSchemas(schemas)).toEqual({
+      type: 'object',
+      description: 'First description',
+    })
+  })
+
+  it('merges deeply nested schema structures', () => {
+    const schemas = [
+      {
+        type: 'object',
+        properties: {
+          user: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+        },
+        required: ['user'],
+      },
+      {
+        properties: {
+          user: {
+            properties: {
+              name: { type: 'string' },
+            },
+          },
+          metadata: { type: 'object' },
+        },
+        required: ['metadata'],
+      },
+    ]
+
+    expect(mergeAllOfSchemas(schemas)).toEqual({
+      type: 'object',
+      properties: {
+        user: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+          },
+        },
+        metadata: { type: 'object' },
+      },
+      required: ['user', 'metadata'],
+    })
+  })
+
+  it('skips non-object schemas during merge', () => {
+    const schemas = [
+      null,
+      undefined,
+      {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      },
+      'invalid',
+      {
+        properties: {
+          age: { type: 'number' },
+        },
+      },
+    ] as any[]
+
+    expect(mergeAllOfSchemas(schemas)).toEqual({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+      },
+    })
+  })
+
+  it('merges allOf schemas within array items', () => {
+    const schemas = [
+      {
+        type: 'array',
+        items: {
+          allOf: [
+            {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' },
+              },
+            },
+            {
+              type: 'object',
+              properties: {
+                age: { type: 'number' },
+                email: { type: 'string' },
+              },
+              required: ['email'],
+            },
+          ],
+        },
+      },
+    ]
+
+    expect(mergeAllOfSchemas(schemas)).toEqual({
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          age: { type: 'number' },
+          email: { type: 'string' },
+        },
+        required: ['email'],
+      },
+    })
+  })
+
+  it('properly merges multiple top-level objects with array items containing allOf', () => {
+    const schemas = [
+      {
+        'type': 'object',
+        'properties': {
+          'top-level-property': {
+            'type': 'string',
+          },
+        },
+      },
+      {
+        'type': 'object',
+        'properties': {
+          'top-level-array': {
+            'type': 'array',
+            'items': {
+              'allOf': [
+                {
+                  'type': 'object',
+                  'properties': {
+                    'all-of-schema-1': {
+                      'type': 'string',
+                    },
+                  },
+                },
+                {
+                  'type': 'object',
+                  'allOf': [
+                    {
+                      'type': 'object',
+                      'properties': {
+                        'all-of-schema-2': {
+                          'type': 'array',
+                          'items': {
+                            'allOf': [
+                              {
+                                'type': 'object',
+                                'properties': {
+                                  'all-of-schema-2-items-all-of-schema-1': {
+                                    'type': 'string',
+                                  },
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]
+
+    expect(mergeAllOfSchemas(schemas)).toEqual({
+      'type': 'object',
+      'properties': {
+        'top-level-property': {
+          'type': 'string',
+        },
+        'top-level-array': {
+          'type': 'array',
+          'items': {
+            'type': 'object',
+            'properties': {
+              'all-of-schema-1': {
+                'type': 'string',
+              },
+              'all-of-schema-2': {
+                'type': 'array',
+                'items': {
+                  'type': 'object',
+                  'properties': {
+                    'all-of-schema-2-items-all-of-schema-1': {
+                      'type': 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { mergeAllOfSchemas } from './merge-all-of-schemas'
+import type { OpenAPI } from '@scalar/openapi-types'
+
+type SchemaObject = OpenAPI.SchemaObject
 
 describe('mergeAllOfSchemas', () => {
   it('returns empty object for empty or invalid input', () => {
@@ -22,7 +25,7 @@ describe('mergeAllOfSchemas', () => {
           age: { type: 'number' },
         },
       },
-    ]
+    ] as SchemaObject[]
 
     expect(mergeAllOfSchemas(schemas)).toEqual({
       type: 'object',
@@ -119,7 +122,7 @@ describe('mergeAllOfSchemas', () => {
         },
         required: ['metadata'],
       },
-    ]
+    ] as SchemaObject[]
 
     expect(mergeAllOfSchemas(schemas)).toEqual({
       type: 'object',
@@ -164,7 +167,7 @@ describe('mergeAllOfSchemas', () => {
     })
   })
 
-  it('merges allOf schemas within array objects', () => {
+  it('merges allOf schemas within object items', () => {
     const schemas = [
       {
         type: 'object',
@@ -183,24 +186,19 @@ describe('mergeAllOfSchemas', () => {
                 age: { type: 'number' },
                 email: { type: 'string' },
               },
-              required: ['email'],
             },
           ],
         },
       },
-    ]
+    ] as SchemaObject[]
 
     expect(mergeAllOfSchemas(schemas)).toEqual({
       type: 'object',
-      items: {
-        type: 'object',
-        properties: {
-          id: { type: 'string' },
-          name: { type: 'string' },
-          age: { type: 'number' },
-          email: { type: 'string' },
-        },
-        required: ['email'],
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        age: { type: 'number' },
+        email: { type: 'string' },
       },
     })
   })
@@ -229,7 +227,7 @@ describe('mergeAllOfSchemas', () => {
           ],
         },
       },
-    ]
+    ] as SchemaObject[]
 
     expect(mergeAllOfSchemas(schemas)).toEqual({
       type: 'array',
@@ -301,7 +299,7 @@ describe('mergeAllOfSchemas', () => {
           },
         },
       },
-    ]
+    ] as SchemaObject[]
 
     expect(mergeAllOfSchemas(schemas)).toEqual({
       'type': 'object',
@@ -403,7 +401,7 @@ describe('mergeAllOfSchemas', () => {
                   },
                   {
                     'type': 'object',
-                    'description': 'Return a list of recording files about individual video for each participant.',
+                    'description': 'This is the one to check',
                     'items': {
                       'allOf': [
                         {
@@ -456,6 +454,8 @@ describe('mergeAllOfSchemas', () => {
           'type': 'array',
           'description': 'List of recording sessions',
           'items': {
+            'description': 'This is the one to check',
+            'type': 'object',
             'properties': {
               'session_id': {
                 'type': 'string',

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -1,3 +1,7 @@
+import type { OpenAPI } from '@scalar/openapi-types'
+
+type SchemaObject = OpenAPI.SchemaObject
+
 /**
  * Merges multiple OpenAPI schema objects into a single schema object.
  * Handles nested allOf compositions and merges properties recursively.
@@ -36,9 +40,7 @@ export function mergeAllOfSchemas(schemas: Record<string, any>[]): Record<string
     }
 
     // Merge other schema attributes
-    mergeSchemaAttributes(mergedResult, schema)
-
-    return mergedResult
+    return mergeSchemaAttributes(mergedResult, schema)
   }, {})
 }
 
@@ -130,19 +132,23 @@ function mergeArrayItems(existing: Record<string, any>, incoming: Record<string,
 /**
  * Merges non-property schema attributes
  */
-function mergeSchemaAttributes(target: Record<string, any>, source: Record<string, any>): void {
+const mergeSchemaAttributes = (target: SchemaObject, source: SchemaObject): SchemaObject => {
+  const merged = typeof target === 'object' ? { ...target } : {}
+
   // Merge required fields
   if (source.required && Array.isArray(source.required)) {
-    target.required = [...(target.required || []), ...source.required]
+    merged.required = [...(target.required || []), ...source.required]
   }
 
   // Copy type if not already set
   if (source.type && !target.type) {
-    target.type = source.type
+    merged.type = source.type
   }
 
   // Copy description if not already set
   if (source.description && !target.description) {
-    target.description = source.description
+    merged.description = source.description
   }
+
+  return merged
 }

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -1,0 +1,149 @@
+/**
+ * Merges multiple OpenAPI schema objects into a single schema object.
+ * Handles nested allOf compositions and merges properties recursively.
+ *
+ * @param schemas - Array of OpenAPI schema objects to merge
+ * @returns Merged schema object
+ */
+export function mergeAllOfSchemas(schemas: Record<string, any>[]): Record<string, any> {
+  // Handle empty or invalid input
+  if (!Array.isArray(schemas) || schemas.length === 0) {
+    return {}
+  }
+
+  // Merge all schemas into a single object
+  return schemas.reduce((result: Record<string, any>, schema) => {
+    if (!schema || typeof schema !== 'object') {
+      return result
+    }
+
+    // Handle nested allOf case first
+    if (schema.allOf) {
+      const mergedNestedSchema: Record<string, any> = mergeAllOfSchemas(schema.allOf)
+      return mergeAllOfSchemas([result, mergedNestedSchema])
+    }
+
+    const mergedResult = { ...result }
+
+    // Merge properties if they exist
+    if (schema.properties) {
+      mergedResult.properties = mergeProperties(mergedResult.properties || {}, schema.properties)
+    }
+
+    // Handle array items
+    if (schema.type === 'array' && schema.items) {
+      mergedResult.type = 'array'
+      mergedResult.items = mergeArrayItems(mergedResult.items || {}, schema.items)
+    }
+
+    // Merge other schema attributes
+    mergeSchemaAttributes(mergedResult, schema)
+
+    return mergedResult
+  }, {})
+}
+
+/**
+ * Merges two sets of schema properties recursively
+ */
+function mergeProperties(existingProps: Record<string, any>, newProps: Record<string, any>): Record<string, any> {
+  const merged = { ...existingProps }
+
+  Object.entries(newProps).forEach(([key, value]) => {
+    if (!value || typeof value !== 'object') {
+      merged[key] = value
+      return
+    }
+
+    if (!merged[key]) {
+      // Handle array items with allOf
+      if (value.type === 'array' && value.items?.allOf) {
+        merged[key] = {
+          ...value,
+          items: mergeAllOfSchemas(value.items.allOf),
+        }
+      } else if (value.allOf) {
+        // Handle direct allOf in property
+        merged[key] = mergeAllOfSchemas(value.allOf)
+      } else {
+        merged[key] = value
+      }
+      return
+    }
+
+    // Merge existing property with new value
+    if (value.allOf) {
+      // If the new value has allOf, merge it with the existing property
+      merged[key] = mergeAllOfSchemas([merged[key], ...value.allOf])
+    } else if (value.type === 'array' && value.items) {
+      // Handle array type properties
+      merged[key] = {
+        ...merged[key],
+        type: 'array',
+        items: mergeArrayItems(merged[key].items || {}, value.items),
+      }
+    } else {
+      // For regular objects, merge properties recursively first
+      const mergedProperties =
+        merged[key].properties || value.properties
+          ? mergeProperties(merged[key].properties || {}, value.properties || {})
+          : undefined
+
+      merged[key] = {
+        ...merged[key],
+        ...value,
+      }
+
+      // Ensure properties are not overwritten by the spread
+      if (mergedProperties) {
+        merged[key].properties = mergedProperties
+      }
+    }
+  })
+
+  return merged
+}
+
+/**
+ * Merges array items schemas
+ */
+function mergeArrayItems(existing: Record<string, any>, incoming: Record<string, any>): Record<string, any> {
+  // Handle allOf in either schema
+  if (existing.allOf || incoming.allOf) {
+    const allOfSchemas = [...(existing.allOf || [existing]), ...(incoming.allOf || [incoming])]
+    return mergeAllOfSchemas(allOfSchemas)
+  }
+
+  // Regular merge for non-allOf items
+  const merged = {
+    ...existing,
+    ...incoming,
+  }
+
+  // Recursively merge properties
+  if (merged.properties || incoming.properties) {
+    merged.properties = mergeProperties(merged.properties || {}, incoming.properties || {})
+  }
+
+  return merged
+}
+
+/**
+ * Merges non-property schema attributes
+ */
+function mergeSchemaAttributes(target: Record<string, any>, source: Record<string, any>): void {
+  // Merge required fields
+  if (source.required && Array.isArray(source.required)) {
+    target.required = [...(target.required || []), ...source.required]
+  }
+
+  // Copy type if not already set
+  if (source.type && !target.type) {
+    target.type = source.type
+  }
+
+  // Copy description if not already set
+  if (source.description && !target.description) {
+    target.description = source.description
+  }
+}

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -30,9 +30,8 @@ export function mergeAllOfSchemas(schemas: Record<string, any>[]): Record<string
       mergedResult.properties = mergeProperties(mergedResult.properties || {}, schema.properties)
     }
 
-    // Handle array items
-    if (schema.type === 'array' && schema.items) {
-      mergedResult.type = 'array'
+    // Handle items property
+    if (schema.items) {
       mergedResult.items = mergeArrayItems(mergedResult.items || {}, schema.items)
     }
 


### PR DESCRIPTION
**Problem**

We introduced this new function to merge `allOf` schemas into one, but that didn't cover all cases.

**Solution**

With this PR we’re moving the function to a separate file, add tests and cover more uses cases (e.g. deeply nested `allOf` schemas).

Fixes #5325

**Preview**

<img width="443" alt="Screenshot 2025-04-08 at 14 43 17" src="https://github.com/user-attachments/assets/b38e5dc5-949f-4f23-8660-6550a90c12a1" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
