### PR TITLE
feat(api-client): skip the import modal when the store is empty

### DIFF
--- a/.changeset/olive-numbers-roll.md
+++ b/.changeset/olive-numbers-roll.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: skip the import modal when the workspace is empty

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionListener.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionListener.vue
@@ -1,10 +1,20 @@
 <script lang="ts" setup>
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+import { useToasts } from '@scalar/use-toasts'
 import { nextTick, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { workspaceStoreIsEmpty } from '@/components/ImportCollection/utils/workspace-store-is-empty.ts'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
 
 import DropEventListener from './DropEventListener.vue'
 import ImportCollectionModal from './ImportCollectionModal.vue'
 import PasteEventListener from './PasteEventListener.vue'
 import UrlQueryParameterChecker from './UrlQueryParameterChecker.vue'
+import { importCollection } from './utils/import-collection'
+
+const store = useWorkspace()
 
 /** Source to import from */
 const source = ref<string | null>(null)
@@ -31,9 +41,78 @@ async function handleInput(
   // Reset, to trigger the modal to reopen
   await resetData()
 
+  // We skip the modal and directly import if the store is empty.
+  if (workspaceStoreIsEmpty(store)) {
+    console.info('Workspace store is empty, directly importing:', newSource)
+
+    if (await handleImportCollection(newSource)) {
+      return
+    }
+
+    console.warn('Failed to import the collection from:', newSource)
+  }
+
+  // Open the modal
   source.value = newSource
   integration.value = newIntegration
   eventType.value = newEventType
+}
+
+const router = useRouter()
+const { activeWorkspace } = useActiveEntities()
+const { toast } = useToasts()
+
+async function handleImportCollection(
+  source: string | null | undefined,
+): Promise<boolean> {
+  if (!source) {
+    return false
+  }
+
+  return new Promise<boolean>((resolve) => {
+    importCollection({
+      store,
+      workspace: activeWorkspace.value,
+      source,
+      // Use watch mode by default.
+      watchMode: true,
+      onSuccess(collection: Collection | undefined) {
+        if (collection) {
+          redirectToFirstRequestInCollection(collection)
+          toast('Import successful', 'info')
+          resolve(true)
+
+          return
+        }
+
+        // If collection is undefined, consider it a failure
+        toast('Import failed: No collection was created', 'error')
+
+        resolve(false)
+      },
+      onError(error) {
+        console.error('[importCollection]', error)
+        const errorMessage = (error as Error)?.message || 'Unknown error'
+        toast(`Import failed: ${errorMessage}`, 'error')
+
+        resolve(false)
+      },
+    })
+  })
+}
+
+function redirectToFirstRequestInCollection(collection?: Collection) {
+  if (!collection) {
+    return
+  }
+
+  router.push({
+    name: 'request',
+    params: {
+      workspace: activeWorkspace.value?.uid,
+      request: collection?.requests[0],
+    },
+  })
 }
 </script>
 

--- a/packages/api-client/src/components/ImportCollection/ImportNowButton.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportNowButton.vue
@@ -4,11 +4,12 @@ import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
 import { useRouter } from 'vue-router'
 
-import { isUrl } from '@/components/ImportCollection/utils/isUrl'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 
-const props = defineProps<{
+import { importCollection } from './utils/import-collection'
+
+const { source, watchMode = true } = defineProps<{
   source?: string | null
   variant?: 'button' | 'link'
   watchMode?: boolean
@@ -19,43 +20,30 @@ const emit = defineEmits<{
 }>()
 
 const router = useRouter()
-
+const store = useWorkspace()
 const { activeWorkspace } = useActiveEntities()
-const { importSpecFromUrl, importSpecFile } = useWorkspace()
 const { toast } = useToasts()
 
-async function importCollection() {
-  try {
-    if (props.source) {
-      if (isUrl(props.source)) {
-        const [error, entities] = await importSpecFromUrl(
-          props.source,
-          activeWorkspace.value?.uid ?? '',
-          {
-            proxyUrl: activeWorkspace.value?.proxyUrl,
-            watchMode: props.watchMode,
-          },
-        )
-        if (!error) {
-          redirectToFirstRequestInCollection(entities?.collection)
-        }
-      } else {
-        const entities = await importSpecFile(
-          props.source,
-          activeWorkspace.value?.uid ?? '',
-        )
-        redirectToFirstRequestInCollection(entities?.collection)
+async function handleImportCollection() {
+  importCollection({
+    store,
+    workspace: activeWorkspace.value,
+    source: source,
+    watchMode: watchMode,
+    onSuccess(collection: Collection | undefined) {
+      if (collection) {
+        redirectToFirstRequestInCollection(collection)
+        toast('Import successful', 'info')
+        emit('importFinished')
       }
+    },
+    onError(error) {
+      console.error('[importCollection]', error)
 
-      toast('Import successful', 'info')
-      emit('importFinished')
-    }
-  } catch (error) {
-    console.error('[importCollection]', error)
-
-    const errorMessage = (error as Error)?.message || 'Unknown error'
-    toast(`Import failed: ${errorMessage}`, 'error')
-  }
+      const errorMessage = (error as Error)?.message || 'Unknown error'
+      toast(`Import failed: ${errorMessage}`, 'error')
+    },
+  })
 }
 
 function redirectToFirstRequestInCollection(collection?: Collection) {
@@ -81,7 +69,7 @@ function redirectToFirstRequestInCollection(collection?: Collection) {
       class="mt-3 h-fit w-full rounded-lg px-6 py-2.5 font-bold"
       size="md"
       type="button"
-      @click="importCollection">
+      @click="handleImportCollection">
       Import Collection
     </ScalarButton>
     <!-- Link -->
@@ -91,7 +79,7 @@ function redirectToFirstRequestInCollection(collection?: Collection) {
       size="md"
       type="button"
       variant="ghost"
-      @click="importCollection">
+      @click="handleImportCollection">
       Try it in the browser
     </ScalarButton>
     <!-- <a

--- a/packages/api-client/src/components/ImportCollection/utils/import-collection.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/import-collection.ts
@@ -1,0 +1,44 @@
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+
+import { isUrl } from '@/components/ImportCollection/utils/isUrl'
+import type { WorkspaceStore } from '@/store'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
+
+export async function importCollection({
+  store,
+  workspace,
+  source,
+  watchMode,
+  onSuccess,
+  onError,
+}: {
+  store: WorkspaceStore
+  workspace: Workspace | undefined
+  source: string | null | undefined
+  watchMode: boolean
+  onSuccess: (collection: Collection | undefined) => void
+  onError: (error: Error) => void
+}) {
+  try {
+    if (source && workspace) {
+      if (isUrl(source)) {
+        const [error, entities] = await store.importSpecFromUrl(source, workspace.uid, {
+          proxyUrl: workspace.proxyUrl,
+          watchMode: watchMode,
+        })
+
+        if (!error) {
+          onSuccess(entities?.collection)
+        }
+
+        return
+      }
+
+      const entities = await store.importSpecFile(source, workspace.uid)
+
+      onSuccess(entities?.collection)
+    }
+  } catch (error) {
+    onError(error as Error)
+  }
+}

--- a/packages/api-client/src/components/ImportCollection/utils/workspace-store-is-empty.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/workspace-store-is-empty.ts
@@ -1,0 +1,11 @@
+import type { WorkspaceStore } from '@/store'
+
+/**
+ * Checks whether the store is empty.
+ */
+export function workspaceStoreIsEmpty(store: WorkspaceStore) {
+  const hasSingleWorkspace = Object.keys(store.workspaces).length === 1
+  const hasSingleCollection = Object.keys(store.collections).length === 1
+
+  return hasSingleWorkspace && hasSingleCollection
+}


### PR DESCRIPTION
**Problem**

We always show the import modal. That’s fine, but let’s make it even simpler.

**Solution**

With this PR we’re skipping the import modal, if the store is empty (just has one workspace, just has the “drafts” collection).

Makes importing even faster.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
