### PR TITLE
fix(api-client): don't set html background from client

### DIFF
--- a/.changeset/forty-flowers-impress.md
+++ b/.changeset/forty-flowers-impress.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): don't set html background from client

--- a/packages/api-client/src/layouts/App/ApiClientApp.vue
+++ b/packages/api-client/src/layouts/App/ApiClientApp.vue
@@ -115,7 +115,6 @@ const themeStyleTag = computed(
 @import '@scalar/components/style.css';
 @import '@scalar/themes/style.css';
 @import '@/tailwind/tailwind.css';
-@import '@/tailwind/variables.css';
 
 #scalar-client {
   display: flex;

--- a/packages/api-client/src/layouts/Modal/ApiClientModal.vue
+++ b/packages/api-client/src/layouts/Modal/ApiClientModal.vue
@@ -98,7 +98,6 @@ onBeforeUnmount(() => {
 <style>
 @import '@scalar/components/style.css';
 @import '@/tailwind/tailwind.css';
-@import '@/tailwind/variables.css';
 </style>
 
 <style scoped>

--- a/packages/api-client/src/layouts/Web/ApiClientWeb.vue
+++ b/packages/api-client/src/layouts/Web/ApiClientWeb.vue
@@ -85,7 +85,6 @@ const themeStyleTag = computed(
 @import '@scalar/components/style.css';
 @import '@scalar/themes/style.css';
 @import '@/tailwind/tailwind.css';
-@import '@/tailwind/variables.css';
 
 /** Add background for iOS and Safari scroll overflow */
 html,

--- a/packages/api-client/src/tailwind/variables.css
+++ b/packages/api-client/src/tailwind/variables.css
@@ -1,3 +1,0 @@
-html:has(.dark-mode) {
-  --scalar-background-1: #0f0f0f;
-}


### PR DESCRIPTION
This was causing issues if `--scalar-background-1` was set to transparent (which it shouldn't be but we probably don't want to do this anyway).

It seems like this was [added along with the client import flow](https://github.com/scalar/scalar/commit/bd8e253c4126216fabd1a8d504f61026e2373690#diff-fda38c80e7cf76a6c78e3caf45248ede32f55bad34d29fb4517aa46260d40b47) at some point but I did some testing and the import flow works fine without it so I'm guessing it's just stale code. We probably don't want to do it this way anyway because we use the `.dark-mode` class for the contrast cards in the references meaning `html:has(.dark-mode)` applies even in light mode, we just didn't notice because it was hidden behind a background of `--scalar-color-1`  <sup>so<sup>cursed</sup></sup>.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
