### PR TITLE
feat(api-reference): directly show responses in the list

### DIFF
--- a/.changeset/forty-ducks-admire.md
+++ b/.changeset/forty-ducks-admire.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: directly show responses in the list

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -36,13 +36,14 @@ const props = withDefaults(
       | Record<string, OpenAPIV3_1.SchemaObject>
       | unknown
   }>(),
-  { level: 0, showAdditionalProperties: false },
+  { level: 0, showAdditionalProperties: false, noncollapsible: false },
 )
 
 const shouldShowToggle = computed(() => {
   if (props.noncollapsible || props.level === 0) {
     return false
   }
+
   return true
 })
 
@@ -100,7 +101,7 @@ const handleClick = (e: MouseEvent) =>
         </div>
 
         <DisclosureButton
-          v-else
+          v-else-if="shouldShowToggle"
           v-show="!hideHeading && !(noncollapsible && compact)"
           :as="noncollapsible ? 'div' : 'button'"
           class="schema-card-title"
@@ -111,7 +112,6 @@ const handleClick = (e: MouseEvent) =>
           @click.capture="handleClick">
           <template v-if="compact">
             <ScalarIcon
-              v-if="shouldShowToggle"
               class="schema-card-title-icon"
               :class="{ 'schema-card-title-icon--open': open }"
               icon="Add"
@@ -126,7 +126,6 @@ const handleClick = (e: MouseEvent) =>
           </template>
           <template v-else>
             <ScalarIcon
-              v-if="shouldShowToggle"
               class="schema-card-title-icon"
               :class="{ 'schema-card-title-icon--open': open }"
               icon="Add"
@@ -138,7 +137,7 @@ const handleClick = (e: MouseEvent) =>
         </DisclosureButton>
         <DisclosurePanel
           as="ul"
-          :static="noncollapsible">
+          :static="!shouldShowToggle">
           <template
             v-if="
               value.properties ||

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -24,6 +24,7 @@ const props = withDefaults(
   defineProps<{
     is?: string | Component
     value?: Record<string, any>
+    noncollapsible?: boolean
     level?: number
     name?: string
     required?: boolean
@@ -278,6 +279,7 @@ const displayPropertyHeading = (
         :compact="compact"
         :level="level + 1"
         :name="name"
+        :noncollapsible="noncollapsible"
         :value="optimizedValue" />
     </div>
     <!-- Array of objects -->
@@ -295,6 +297,7 @@ const displayPropertyHeading = (
           :compact="compact"
           :level="level + 1"
           :name="name"
+          :noncollapsible="noncollapsible"
           :value="optimizedValue.items" />
       </div>
     </template>
@@ -310,6 +313,7 @@ const displayPropertyHeading = (
           :hideHeading="hideHeading"
           :level="level"
           :name="name"
+          :noncollapsible="noncollapsible"
           :schemas="schemas"
           :value="optimizedValue" />
       </template>
@@ -330,6 +334,7 @@ const displayPropertyHeading = (
           :hideHeading="hideHeading"
           :level="level"
           :name="name"
+          :noncollapsible="noncollapsible"
           :schemas="schemas"
           :value="optimizedValue.items" />
       </template>

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -96,7 +96,7 @@ const shouldShowParameter = computed(() => {
           compact
           :description="shouldCollapse ? '' : parameter.description"
           :name="shouldCollapse ? '' : parameter.name"
-          :noncollapsible="showChildren"
+          :noncollapsible="true"
           :required="parameter.required"
           :schemas="schemas"
           :value="{


### PR DESCRIPTION
**Problem**

We collapse responses in the list, super annoying.

**Solution**

With this PR we’re expanding them by default. No need to click the additional toggle to see them anymore.

**Before**

![image](https://github.com/user-attachments/assets/6efea57a-8ed9-4148-8c32-1896f6d231e9)

**After**

<img width="586" alt="Screenshot 2025-04-09 at 14 54 18" src="https://github.com/user-attachments/assets/c9fa906a-148d-4370-8049-2e0ce6e02f71" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
