### PR TITLE
feat(api-reference): add Introduction heading to the sidebar

### DIFF
--- a/.changeset/orange-pets-collect.md
+++ b/.changeset/orange-pets-collect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add Introduction heading to the sidebar

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -4,7 +4,9 @@ import type { Spec } from '@scalar/types/legacy'
 import GitHubSlugger from 'github-slugger'
 import { computed, onMounted } from 'vue'
 
+import { DEFAULT_INTRODUCTION_SLUG } from '@/hooks'
 import { useConfig } from '@/hooks/useConfig'
+import { useNavState } from '@/hooks/useNavState'
 
 import DownloadLink from '../../../features/DownloadLink/DownloadLink.vue'
 import { Badge } from '../../Badge'
@@ -25,6 +27,8 @@ const props = defineProps<{
   >
   parsedSpec: Spec
 }>()
+
+const { getHeadingId } = useNavState()
 
 /**
  * Get the OpenAPI/Swagger specification version from the API definition.
@@ -61,7 +65,15 @@ onMounted(() => config.value.onLoaded?.())
 <template>
   <SectionContainer>
     <!-- If the #after slot is used, we need to add a gap to the section. -->
-    <Section class="introduction-section gap-12">
+    <Section
+      class="introduction-section gap-12"
+      :id="
+        getHeadingId({
+          slug: DEFAULT_INTRODUCTION_SLUG,
+          depth: 1,
+          value: 'Introduction',
+        })
+      ">
       <SectionContent
         :loading="config.isLoading ?? (!info?.description && !info?.title)">
         <div class="flex gap-1">

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -396,7 +396,7 @@ export function useSidebar(options?: ParsedSpecOption & SorterOption) {
     watch(
       () => parsedSpec.value?.info?.description,
       () => {
-        const description = parsedSpec.value?.info?.description
+        const description = parsedSpec.value?.info?.description?.trim()
 
         if (!description) {
           return (headings.value = [])
@@ -405,7 +405,7 @@ export function useSidebar(options?: ParsedSpecOption & SorterOption) {
         const newHeadings = updateHeadings(description)
 
         // Add "Introduction" as the first heading
-        if (parsedSpec.value?.info?.description?.trim()) {
+        if (description && !description.startsWith('#')) {
           const introductionHeading = {
             depth: newHeadings[0]?.depth ?? 1,
             value: 'Introduction',

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -26,6 +26,8 @@ export type SidebarEntry = {
   isGroup?: boolean
 }
 
+export const DEFAULT_INTRODUCTION_SLUG = 'introduction'
+
 /**
  * This is a temp hack to get the navState outside of a setup function.
  * Sidebar will eventually be replaced by the client one so we can remove this whole hook then.
@@ -400,7 +402,20 @@ export function useSidebar(options?: ParsedSpecOption & SorterOption) {
           return (headings.value = [])
         }
 
-        return (headings.value = updateHeadings(description))
+        const newHeadings = updateHeadings(description)
+
+        // Add "Introduction" as the first heading
+        if (parsedSpec.value?.info?.description?.trim()) {
+          const introductionHeading = {
+            depth: newHeadings[0]?.depth ?? 1,
+            value: 'Introduction',
+            slug: DEFAULT_INTRODUCTION_SLUG,
+          }
+
+          newHeadings.unshift(introductionHeading)
+        }
+
+        return (headings.value = newHeadings)
       },
       {
         immediate: true,


### PR DESCRIPTION
**Problem**

I think we had this already, but there’s no more "Introduction” heading in the sidebar anymore. An entry that lets you jump to the top of the page.

**Solution**

With this PR we’re adding an Introduction heading (if we have a description) to the sidebar.

**Preview**

<img width="876" alt="Screenshot 2025-04-09 at 16 34 48" src="https://github.com/user-attachments/assets/3b8a1da3-98ad-4697-bd97-30ce8b25973b" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
