### PR TITLE
fix(api-client): sidebar empty getting started rendering

### DIFF
--- a/.changeset/angry-goats-rush.md
+++ b/.changeset/angry-goats-rush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: displays request sidebar ascii art if getting started only

--- a/.changeset/cuddly-cups-pull.md
+++ b/.changeset/cuddly-cups-pull.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: adds inert attribute to ascii art

--- a/packages/api-client/src/components/ScalarAsciiArt.vue
+++ b/packages/api-client/src/components/ScalarAsciiArt.vue
@@ -20,7 +20,8 @@ const getLineAnimation = (chars: number, row: number): StyleValue => ({
     aria-hidden="true"
     class="ascii-art font-code flex flex-col items-start text-[6px] leading-[7px]"
     :class="{ 'ascii-art-animate': animate }"
-    role="presentation">
+    role="presentation"
+    inert>
     <span
       v-for="(line, i) in lines"
       :key="i"

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -407,7 +407,9 @@ const collections = computed(() => {
         :class="{
           'empty-sidebar-item': showGettingStarted,
         }">
-        <div class="empty-sidebar-item-content px-2.5 py-2.5">
+        <div
+          v-if="showGettingStarted"
+          class="empty-sidebar-item-content px-2.5 py-2.5">
           <div class="rabbit-ascii relative m-auto mt-2 h-[68px] w-[60px]">
             <ScalarAsciiArt
               :art="Rabbit"


### PR DESCRIPTION
**Problem**

currently the getting started ascii art is rendered all the time while being hidden + gets crawled by search engines as seen below:

| currently |
| -------|
| <img width="598" alt="image" src="https://github.com/user-attachments/assets/e5ee91d9-d3dc-49bb-a409-094ec4fdf52e" /> |
| search meta description result is showing ascii |

**Solution**

this pr adds the following updates:
- displays ascii if getting started only
- adds inert html attribute to prevent content from being crawled ([see reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert)).

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
