### PR TITLE
fix(api-client): make useResponseBody reactive

### DIFF
--- a/packages/api-client/src/hooks/useResponseBody.test.ts
+++ b/packages/api-client/src/hooks/useResponseBody.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 
 import { useResponseBody } from './useResponseBody'
 
@@ -9,8 +10,8 @@ describe('useResponseBody', () => {
 
   it('extracts the correct MimeType from headers', () => {
     const props = {
-      data: null,
-      headers: [{ name: 'Content-Type', value: 'application/json', required: true }],
+      data: ref(null),
+      headers: ref([{ name: 'Content-Type', value: 'application/json', required: true }]),
     }
     const { mimeType } = useResponseBody(props)
     expect(mimeType.value.essence).toBe('application/json')
@@ -18,14 +19,14 @@ describe('useResponseBody', () => {
 
   it('extracts the correct attachment filename from headers', () => {
     const props = {
-      data: null,
-      headers: [
+      data: ref(null),
+      headers: ref([
         {
           name: 'Content-Disposition',
           value: 'attachment; filename="test.txt"',
           required: true,
         },
-      ],
+      ]),
     }
     const { attachmentFilename } = useResponseBody(props)
     expect(attachmentFilename.value).toBe('test.txt')
@@ -34,8 +35,8 @@ describe('useResponseBody', () => {
   it('generates a data URL for a Blob', () => {
     const blob = new Blob(['test'], { type: 'text/plain' })
     const props = {
-      data: blob,
-      headers: [{ name: 'Content-Type', value: 'text/plain', required: true }],
+      data: ref(blob),
+      headers: ref([{ name: 'Content-Type', value: 'text/plain', required: true }]),
     }
     const { dataUrl } = useResponseBody(props)
     expect(dataUrl.value).toBe('mockedBlobURL')
@@ -43,8 +44,8 @@ describe('useResponseBody', () => {
 
   it('generates a data URL for a string', () => {
     const props = {
-      data: 'test string',
-      headers: [{ name: 'Content-Type', value: 'text/plain', required: true }],
+      data: ref('test string'),
+      headers: ref([{ name: 'Content-Type', value: 'text/plain', required: true }]),
     }
     const { dataUrl } = useResponseBody(props)
     expect(dataUrl.value).toBe('mockedBlobURL')
@@ -52,8 +53,8 @@ describe('useResponseBody', () => {
 
   it('generates a data URL for an object', () => {
     const props = {
-      data: { key: 'value' },
-      headers: [{ name: 'Content-Type', value: 'application/json', required: true }],
+      data: ref({ key: 'value' }),
+      headers: ref([{ name: 'Content-Type', value: 'application/json', required: true }]),
     }
     const { dataUrl } = useResponseBody(props)
     expect(dataUrl.value).toBe('mockedBlobURL')
@@ -61,8 +62,8 @@ describe('useResponseBody', () => {
 
   it('returns an empty string for unsupported data types', () => {
     const props = {
-      data: null,
-      headers: [{ name: 'Content-Type', value: 'application/json', required: true }],
+      data: ref(null),
+      headers: ref([{ name: 'Content-Type', value: 'application/json', required: true }]),
     }
     const { dataUrl } = useResponseBody(props)
     expect(dataUrl.value).toBe('')

--- a/packages/api-client/src/hooks/useResponseBody.ts
+++ b/packages/api-client/src/hooks/useResponseBody.ts
@@ -1,5 +1,5 @@
 import { extractFilename } from '@/libs/extractAttachmentFilename'
-import { computed, isRef, ref } from 'vue'
+import { computed, isRef } from 'vue'
 import MimeType from 'whatwg-mimetype'
 import type { Ref } from 'vue'
 

--- a/packages/api-client/src/hooks/useResponseBody.ts
+++ b/packages/api-client/src/hooks/useResponseBody.ts
@@ -8,10 +8,8 @@ import type { Ref } from 'vue'
  * Extracts MIME type, attachment filename, and generates a data URL.
  */
 export function useResponseBody(props: {
-  data: Ref<unknown> | unknown
-  headers:
-    | Ref<{ name: string; value: string; required: boolean }[]>
-    | { name: string; value: string; required: boolean }[]
+  data: Ref<unknown>
+  headers: Ref<{ name: string; value: string; required: boolean }[]>
 }) {
   const isBlob = (b: any): b is Blob => b instanceof Blob
 

--- a/packages/api-client/src/hooks/useResponseBody.ts
+++ b/packages/api-client/src/hooks/useResponseBody.ts
@@ -1,37 +1,45 @@
 import { extractFilename } from '@/libs/extractAttachmentFilename'
-import { computed } from 'vue'
+import { computed, isRef, ref } from 'vue'
 import MimeType from 'whatwg-mimetype'
+import type { Ref } from 'vue'
 
 /**
  * Processes the response body of an HTTP request.
  * Extracts MIME type, attachment filename, and generates a data URL.
  */
 export function useResponseBody(props: {
-  data: unknown
-  headers: { name: string; value: string; required: boolean }[]
+  data: Ref<unknown> | unknown
+  headers:
+    | Ref<{ name: string; value: string; required: boolean }[]>
+    | { name: string; value: string; required: boolean }[]
 }) {
   const isBlob = (b: any): b is Blob => b instanceof Blob
 
+  // Handle both Ref and direct values
+  const dataRef = computed(() => (isRef(props.data) ? props.data.value : props.data))
+  const headersRef = computed(() => (isRef(props.headers) ? props.headers.value : props.headers))
+
   const mimeType = computed(() => {
-    const contentType = props.headers.find((header) => header.name.toLowerCase() === 'content-type')?.value ?? ''
+    const contentType = headersRef.value.find((header) => header.name.toLowerCase() === 'content-type')?.value ?? ''
     return new MimeType(contentType)
   })
 
   const attachmentFilename = computed(() => {
-    const value = props.headers.find((header) => header.name.toLowerCase() === 'content-disposition')?.value ?? ''
+    const value = headersRef.value.find((header) => header.name.toLowerCase() === 'content-disposition')?.value ?? ''
     return extractFilename(value)
   })
 
   const dataUrl = computed<string>(() => {
-    if (isBlob(props.data)) {
-      return URL.createObjectURL(props.data)
+    console.log('new one!!')
+    if (isBlob(dataRef.value)) {
+      return URL.createObjectURL(dataRef.value)
     }
-    if (typeof props.data === 'string') {
-      return URL.createObjectURL(new Blob([props.data], { type: mimeType.value.toString() }))
+    if (typeof dataRef.value === 'string') {
+      return URL.createObjectURL(new Blob([dataRef.value], { type: mimeType.value.toString() }))
     }
-    if (props.data instanceof Object && Object.keys(props.data).length) {
+    if (dataRef.value instanceof Object && Object.keys(dataRef.value).length) {
       return URL.createObjectURL(
-        new Blob([JSON.stringify(props.data)], {
+        new Blob([JSON.stringify(dataRef.value)], {
           type: mimeType.value.toString(),
         }),
       )

--- a/packages/api-client/src/hooks/useResponseBody.ts
+++ b/packages/api-client/src/hooks/useResponseBody.ts
@@ -30,7 +30,6 @@ export function useResponseBody(props: {
   })
 
   const dataUrl = computed<string>(() => {
-    console.log('new one!!')
     if (isBlob(dataRef.value)) {
       return URL.createObjectURL(dataRef.value)
     }

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref, toRef, watch } from 'vue'
+import { computed, ref, toRef } from 'vue'
 
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useResponseBody } from '@/hooks/useResponseBody'
@@ -26,16 +26,6 @@ const showToggle = computed(
 
 const showPreview = computed(() => toggle.value || !showToggle.value)
 const showRaw = computed(() => !toggle.value || !showToggle.value)
-
-watch(
-  () => props.data,
-  (newValue) => {
-    console.log('props.data changed:', newValue)
-  },
-  { deep: true },
-)
-
-console.log(props, props.data)
 
 const { mimeType, attachmentFilename, dataUrl } = useResponseBody({
   data: toRef(props, 'data'),

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useResponseBody } from '@/hooks/useResponseBody'
@@ -27,9 +27,19 @@ const showToggle = computed(
 const showPreview = computed(() => toggle.value || !showToggle.value)
 const showRaw = computed(() => !toggle.value || !showToggle.value)
 
+watch(
+  () => props.data,
+  (newValue) => {
+    console.log('props.data changed:', newValue)
+  },
+  { deep: true },
+)
+
+console.log(props, props.data)
+
 const { mimeType, attachmentFilename, dataUrl } = useResponseBody({
-  data: props.data,
-  headers: props.headers,
+  data: toRef(props, 'data'),
+  headers: toRef(props, 'headers'),
 })
 
 const mediaConfig = computed(() => mediaTypes[mimeType.value.essence])

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyVirtual.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ScalarVirtualText } from '@scalar/components'
 import { formatJsonOrYamlString } from '@scalar/oas-utils/helpers'
-import { computed } from 'vue'
+import { computed, toRef } from 'vue'
 
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useResponseBody } from '@/hooks/useResponseBody'
@@ -17,8 +17,8 @@ const props = defineProps<{
 const textContent = computed(() => formatJsonOrYamlString(props.content))
 
 const { mimeType, attachmentFilename, dataUrl } = useResponseBody({
-  data: props.data,
-  headers: props.headers,
+  data: toRef(props, 'data'),
+  headers: toRef(props, 'headers'),
 })
 </script>
 


### PR DESCRIPTION
**Problem**

Currently useResponseBody is not reactive 🫨 

**Solution**

With this PR it is 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
