### PR TITLE
fix(api-client): remove instances of useActiveEntities

### DIFF
--- a/.changeset/curly-tips-kick.md
+++ b/.changeset/curly-tips-kick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: remove useActiveEntity useage in response

--- a/packages/api-client/src/views/Request/Request.vue
+++ b/packages/api-client/src/views/Request/Request.vue
@@ -93,6 +93,9 @@ function handleCurlImport(curl: string) {
               :server="activeServer"
               :workspace="activeWorkspace" />
             <ResponseSection
+              :collection="activeCollection"
+              :operation="activeRequest"
+              :workspace="activeWorkspace"
               :requestResult="requestResult"
               :numWorkspaceRequests="activeWorkspaceRequests.length"
               :response="activeHistoryEntry?.response" />

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -141,6 +141,8 @@ const handleRequestNamePlaceholder = () => {
       ? operation.path.replace(REGEX.PROTOCOL, '')
       : 'Request Name'
 }
+
+const labelRequestNameId = useId()
 </script>
 <template>
   <ViewLayoutSection :aria-label="`Request: ${operation.summary}`">
@@ -150,10 +152,10 @@ const handleRequestNamePlaceholder = () => {
         <label
           v-if="layout !== 'modal'"
           class="pointer-events-auto absolute left-0 top-0 h-full w-full cursor-text opacity-0"
-          for="requestname" />
+          :for="labelRequestNameId" />
         <input
           v-if="layout !== 'modal'"
-          id="requestname"
+          :id="labelRequestNameId"
           class="text-c-1 group-hover-input pl-1.25 md:-ml-1.25 pointer-events-auto relative z-10 -ml-0.5 h-8 w-full rounded has-[:focus-visible]:outline"
           :placeholder="handleRequestNamePlaceholder()"
           :value="operation.summary"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseEmpty.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { Collection, Operation } from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { nextTick, onBeforeUnmount, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -9,9 +11,11 @@ import ScalarHotkey from '@/components/ScalarHotkey.vue'
 import { useLayout } from '@/hooks'
 import type { HotKeyEvent } from '@/libs'
 import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
 
-const { numWorkspaceRequests } = defineProps<{
+const { numWorkspaceRequests, collection, operation, workspace } = defineProps<{
+  collection: Collection
+  operation: Operation
+  workspace: Workspace
   numWorkspaceRequests: number
 }>()
 
@@ -19,28 +23,20 @@ const { events, requestMutators } = useWorkspace()
 const route = useRoute()
 const router = useRouter()
 const { layout } = useLayout()
-const { activeWorkspace, activeCollection, activeRequest } = useActiveEntities()
 
 const addRequest = () => {
-  if (!activeCollection.value?.uid) {
-    return
-  }
-
   // If the request has tags, add the first tag to the new request
-  const requestData = activeRequest.value?.tags?.length
-    ? { tags: activeRequest.value.tags[0] ? [activeRequest.value.tags[0]] : [] }
+  const requestData = operation.tags?.length
+    ? { tags: operation.tags[0] ? [operation.tags[0]] : [] }
     : {}
 
-  const newRequest = requestMutators.add(
-    requestData,
-    activeCollection.value?.uid,
-  )
+  const newRequest = requestMutators.add(requestData, collection.uid)
 
   if (newRequest) {
     router.push({
       name: 'request',
       params: {
-        workspace: activeWorkspace.value?.uid,
+        workspace: workspace.uid,
         request: newRequest.uid,
       },
     })

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import type { ResponseInstance } from '@scalar/oas-utils/entities/spec'
+import type {
+  Collection,
+  Operation,
+  ResponseInstance,
+} from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { computed, ref, useId } from 'vue'
 
 import SectionFilter from '@/components/SectionFilter.vue'
@@ -16,6 +21,9 @@ import ResponseLoadingOverlay from './ResponseLoadingOverlay.vue'
 import ResponseMetaInformation from './ResponseMetaInformation.vue'
 
 const { numWorkspaceRequests, response, requestResult } = defineProps<{
+  collection: Collection
+  operation: Operation
+  workspace: Workspace
   numWorkspaceRequests: number
   response: ResponseInstance | undefined
   requestResult: SendRequestResult | null | undefined
@@ -161,7 +169,11 @@ const requestHeaders = computed(
       }"
       :role="activeFilter === 'All' && response ? 'tabpanel' : 'none'">
       <template v-if="!response">
-        <ResponseEmpty :numWorkspaceRequests="numWorkspaceRequests" />
+        <ResponseEmpty
+          :collection="collection"
+          :operation="operation"
+          :workspace="workspace"
+          :numWorkspaceRequests="numWorkspaceRequests" />
       </template>
       <template v-else>
         <ResponseCookies


### PR DESCRIPTION
This hook is no good and deprecated, incorrect useage

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
