### PR TITLE
feat(api-reference): show schema title in heading when available

### DIFF
--- a/.changeset/two-dots-sneeze.md
+++ b/.changeset/two-dots-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: show schema title in heading when available

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -77,7 +77,7 @@ const models = computed(() => {
             <template #heading>
               <SectionHeaderTag :level="3">
                 <SchemaHeading
-                  :name="name"
+                  :name="(schemas as any)[name].title ?? name"
                   :value="(schemas as any)[name]" />
               </SectionHeaderTag>
             </template>

--- a/packages/api-reference/src/components/Content/Models/ModelsAccordion.vue
+++ b/packages/api-reference/src/components/Content/Models/ModelsAccordion.vue
@@ -52,7 +52,7 @@ const { getModelId } = useNavState()
           <SectionHeaderTag :level="3">
             <SchemaHeading
               class="reference-models-label"
-              :name="name"
+              :name="schema.title ?? name"
               :value="schema" />
           </SectionHeaderTag>
         </Anchor>


### PR DESCRIPTION
**Problem**

Currently, in the Sidebar, the model schema displays the schema title first, but the main model view does not.

**Solution**

This PR updates the model view to display the schema title in the heading when available.

before:
<img width="657" alt="Screenshot 2568-04-10 at 20 01 09" src="https://github.com/user-attachments/assets/1497e4ea-8036-4088-b915-ecfcd7271215" />
after:
<img width="657" alt="Screenshot 2568-04-10 at 19 59 13" src="https://github.com/user-attachments/assets/1686238e-add9-4930-827d-96108d2ce151" />


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
