### PR TITLE
fix(api-client): response border style

### DIFF
--- a/.changeset/famous-apricots-attack.md
+++ b/.changeset/famous-apricots-attack.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates duplicated border and alignment style"

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -64,7 +64,7 @@ watch(
   <form @submit.prevent>
     <div
       v-if="selectedSchemeOptions.length > 1"
-      class="flex flex-wrap gap-x-2.5 overflow-hidden border-t px-3">
+      class="box-content flex h-8 flex-wrap gap-x-2.5 overflow-hidden border-t px-3">
       <div
         v-for="(option, index) in selectedSchemeOptions"
         :key="option.id"
@@ -78,8 +78,6 @@ watch(
             option.label
           }}</span>
         </button>
-        <div
-          class="bg-border absolute -inset-x-96 bottom-0 z-0 h-[var(--scalar-border-width)]" />
         <div
           v-if="activeAuthIndex === index"
           class="z-1 absolute inset-x-1 bottom-[var(--scalar-border-width)] left-1/2 h-px w-full -translate-x-1/2 bg-current" />
@@ -104,7 +102,7 @@ watch(
 
     <div
       v-else
-      class="text-c-3 bg-b-1 flex min-h-16 items-center justify-center border-t px-4 text-sm">
+      class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border-t px-4 text-sm">
       No authentication selected
     </div>
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -224,7 +224,7 @@ const dataTableInputProps = {
     <!-- Open ID Connect -->
     <template v-else-if="scheme?.type === 'openIdConnect'">
       <div
-        class="text-c-3 bg-b-1 flex min-h-16 items-center justify-center border-t px-4 text-sm">
+        class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border-t px-4 text-sm">
         Coming soon
       </div>
     </template>

--- a/packages/api-client/src/views/Request/ResponseSection/RequestHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/RequestHeaders.vue
@@ -27,7 +27,7 @@ const findHeaderInfo = (name: string) => {
     <template #title>Request Headers</template>
     <div
       v-if="headers.length"
-      class="max-h-[calc(100%-32px)] overflow-y-auto border-t">
+      class="max-h-[calc(100%-32px)] overflow-y-auto">
       <DataTable
         :columns="['minmax(auto, min-content)', 'minmax(50%, 1fr)']"
         scroll>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -49,7 +49,7 @@ const mediaConfig = computed(() => mediaTypes[mimeType.value.essence])
       v-if="data"
       class="bg-b-1 flex max-h-[calc(100%-32px)] flex-col overflow-hidden">
       <div
-        class="flex min-h-8 items-center justify-between border-y px-3 py-1.5">
+        class="box-content flex min-h-8 items-center justify-between border-y px-3">
         <span class="text-xxs font-code leading-3">
           {{ mimeType.essence }}
         </span>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -27,7 +27,7 @@ const findHeaderInfo = (name: string) => {
     <template #title>Response Headers</template>
     <div
       v-if="headers.length"
-      class="max-h-[calc(100%-32px)] overflow-y-auto border-t">
+      class="max-h-[calc(100%-32px)] overflow-y-auto">
       <DataTable
         :columns="['minmax(auto, min-content)', 'minmax(50%, 1fr)']"
         scroll>


### PR DESCRIPTION
**Problem**

currently some border are duplicated and misaligned.

**Solution**

this pr removes duplicated border and aligns request/response borders.

| before | after |
| -------|------|
| <img width="418" alt="image" src="https://github.com/user-attachments/assets/0ff33510-09bc-4d12-b13a-f63263ca6506" /> | <img width="418" alt="image" src="https://github.com/user-attachments/assets/138b95f2-4174-49a7-bd1a-bedbb89fe2a4" /> |
| duplicated and misaligned section borders | single aligned section borders | 

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
