### PR TITLE
feat(api-client): add new callback for request sent

### DIFF
--- a/.changeset/quiet-pans-study.md
+++ b/.changeset/quiet-pans-study.md
@@ -1,0 +1,5 @@
+---
+'@scalar/types': patch
+---
+
+feat: added new callback for execution request

--- a/packages/api-client/src/hooks/useClientConfig.ts
+++ b/packages/api-client/src/hooks/useClientConfig.ts
@@ -1,0 +1,7 @@
+import { apiClientConfigurationSchema, type ApiClientConfiguration } from '@scalar/types/api-reference'
+import { type InjectionKey, type Ref, inject, ref } from 'vue'
+
+export const CLIENT_CONFIGURATION_SYMBOL = Symbol() as InjectionKey<Ref<ApiClientConfiguration>>
+
+/** Hook for easy access to the reference configuration */
+export const useClientConfig = () => inject(CLIENT_CONFIGURATION_SYMBOL, ref(apiClientConfigurationSchema.parse({})))

--- a/packages/api-client/src/libs/create-client.test.ts
+++ b/packages/api-client/src/libs/create-client.test.ts
@@ -71,6 +71,7 @@ vi.mock('vue', () => ({
     provide: vi.fn(),
     mount: vi.fn(),
   })),
+  ref: vi.fn((value) => ({ value })),
   watch: vi.fn((getter, callback) => {
     // Store the callback for testing
     watchCallbacks.push({ getter, callback })

--- a/packages/api-client/src/views/Request/RequestRoot.vue
+++ b/packages/api-client/src/views/Request/RequestRoot.vue
@@ -7,6 +7,7 @@ import { RouterView } from 'vue-router'
 
 import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
 import { useLayout } from '@/hooks'
+import { useClientConfig } from '@/hooks/useClientConfig'
 import { useSidebar } from '@/hooks/useSidebar'
 import { ERRORS } from '@/libs'
 import { createRequestOperation } from '@/libs/send-request'
@@ -22,6 +23,9 @@ defineEmits<(e: 'newTab', item: { name: string; uid: string }) => void>()
 const workspaceContext = useWorkspace()
 const { toast } = useToasts()
 const { layout } = useLayout()
+const config = useClientConfig()
+const { isSidebarOpen } = useSidebar()
+
 const {
   activeCollection,
   activeExample,
@@ -32,7 +36,6 @@ const {
 } = useActiveEntities()
 const { cookies, requestHistory, showSidebar, securitySchemes, events } =
   workspaceContext
-const { isSidebarOpen } = useSidebar()
 
 const element = ref<HTMLDivElement>()
 
@@ -97,6 +100,9 @@ const executeRequest = async () => {
     securitySchemes: securitySchemes,
     server,
   })
+
+  // Call the onRequestSent callback if it exists
+  config.value?.onRequestSent?.(activeRequest.value.path ?? '')
 
   // Error from createRequestOperation
   if (error) {

--- a/packages/api-reference/src/hooks/useConfig.ts
+++ b/packages/api-reference/src/hooks/useConfig.ts
@@ -3,7 +3,10 @@ import { type ComputedRef, type InjectionKey, computed, inject } from 'vue'
 
 export const CONFIGURATION_SYMBOL = Symbol() as InjectionKey<ComputedRef<ApiReferenceConfiguration>>
 
-/** Hook for easy access to the reference configuration */
+/**
+ * New hook for reactive access to the client config
+ * TODO: we need to move some properties from the store this way so that they are reactive
+ */
 export const useConfig = () => {
   const config = inject(
     CONFIGURATION_SYMBOL,

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -208,6 +208,8 @@ export const apiClientConfigurationSchema = z.object({
   theme: themeIdEnum.optional().default('default').catch('default'),
   /** Integration type identifier */
   _integration: integrationEnum.optional(),
+  /** onRequestSent is fired when a request is sent */
+  onRequestSent: z.function().args(z.string()).returns(z.void()).optional(),
 })
 
 export type ApiClientConfiguration = z.infer<typeof apiClientConfigurationSchema>


### PR DESCRIPTION
**Solution**

With this PR we add a new client config hook for reactive config, as well as a callback on request sent.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
