### PR TITLE
fix: make code snippet default closed

### DIFF
--- a/.changeset/blue-starfishes-hope.md
+++ b/.changeset/blue-starfishes-hope.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: make code snippet default closed

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -215,7 +215,7 @@ const customCodeContent = computed(() => {
   <div class="w-full">
     <ViewLayoutCollapse
       class="group/preview w-full border-b-0"
-      :defaultOpen="true">
+      :defaultOpen="false">
       <template #title>Code Snippet</template>
       <template #actions>
         <div class="-mx-1 flex flex-1">


### PR DESCRIPTION
**Problem**

Currently we hit some large codemirror perf bugs on api client cause we load BODY + SNIPPET

<img width="862" alt="image" src="https://github.com/user-attachments/assets/0f44d9b1-f8e3-40aa-b4b6-c90bd86c32b3" />


**Solution**

Lets not overwhelm the user and have code snippets hidden by default

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
