### PR TITLE
fix(api-reference): show sidebar if not set

### DIFF
--- a/.changeset/metal-experts-explode.md
+++ b/.changeset/metal-experts-explode.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): show sidebar if not set

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -46,7 +46,8 @@ watch(hash, (newHash, oldHash) => {
 <template>
   <ApiReferenceLayout
     :class="{
-      'scalar-api-references-standalone-mobile': configuration.showSidebar,
+      'scalar-api-references-standalone-mobile':
+        configuration.showSidebar ?? true,
     }"
     :configuration="configuration"
     :parsedSpec="parsedSpec"
@@ -61,7 +62,7 @@ watch(hash, (newHash, oldHash) => {
     </template>
     <template #header>
       <MobileHeader
-        v-if="props.configuration.showSidebar"
+        v-if="configuration.showSidebar ?? true"
         v-model:open="isSidebarOpen" />
     </template>
     <template #sidebar-start="{ spec }">

--- a/playwright/tests/testApiReference.ts
+++ b/playwright/tests/testApiReference.ts
@@ -11,11 +11,15 @@ export async function testApiReference(page: Page, isMobile: boolean) {
   // http client
   await expect(page.getByText('Client Libraries')).toBeVisible()
 
-  // Check for elements that are only visible on desktop
-  if (!isMobile) {
-    // Sidebar
-    await expect(page.getByRole('link', { name: 'Planets', exact: true })).toBeVisible()
+  if (isMobile) {
+    // Check for the menu button
+    await expect(page.getByRole('button', { name: 'Open Menu' })).toBeVisible()
+    // Open the mobile menu
+    await page.getByRole('button', { name: 'Open Menu' }).click()
   }
+
+  // Sidebar link
+  await expect(page.getByRole('link', { name: 'Planets', exact: true })).toBeVisible()
 }
 
 /**


### PR DESCRIPTION
It seems like at some point the defaults for the config got moved into the `ApiReferenceLayout` (which is a child of `ModernLayout`) meaning that that if `showSidebar` was undefined it didn't get defaulted to true in `ModernLayout`.

Also updated our tests so it will hopefully be harder to break it next time.

@hanspagel let me know if this seems like a good solution or if we should do something else 🫡 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
