### PR TITLE
feat(api-client): read response streams ⚡

### DIFF
--- a/.changeset/cool-scissors-worry.md
+++ b/.changeset/cool-scissors-worry.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: added support for streaming text response

--- a/.changeset/nasty-kangaroos-whisper.md
+++ b/.changeset/nasty-kangaroos-whisper.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': minor
+---
+
+feat: use hono logger

--- a/.changeset/tidy-deers-turn.md
+++ b/.changeset/tidy-deers-turn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+feat: add /stream for server side events

--- a/packages/api-client/src/libs/send-request/create-fetch-auth.test.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-auth.test.ts
@@ -30,6 +30,9 @@ describe('authentication', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
       'x-api-key': 'test-key',
     })
@@ -59,6 +62,9 @@ describe('authentication', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string).query).toMatchObject({
       api_key: 'test-key',
     })
@@ -88,6 +94,9 @@ describe('authentication', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string).query.api_key).toEqual('test-key')
   })
 
@@ -117,6 +126,9 @@ describe('authentication', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
       authorization: 'Basic dXNlcjpwYXNz', // base64 of "user:pass"
     })
@@ -148,6 +160,9 @@ describe('authentication', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
       authorization: 'Bearer xxxx',
     })
@@ -187,6 +202,9 @@ describe('authentication', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     const parsed = JSON.parse(result?.response.data as string)
     expect(parsed.headers.authorization).toEqual('Bearer xxxx')
     expect(parsed.query.api_key).toEqual('xxxx')
@@ -225,6 +243,9 @@ describe('authentication', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
       authorization: 'Bearer oauth-token',
     })

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -16,6 +16,7 @@ import { createRequestOperation } from './create-request-operation'
 const PROXY_PORT = 5051
 const VOID_PORT = 5052
 const PROXY_URL = `http://127.0.0.1:${PROXY_PORT}`
+// biome-ignore lint/suspicious/noExportsInTest: yolo
 export const VOID_URL = `http://127.0.0.1:${VOID_PORT}`
 
 type RequestExamplePayload = z.input<typeof requestExampleSchema>
@@ -130,6 +131,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/api/example',
@@ -151,6 +155,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/me',
@@ -172,6 +179,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/',
@@ -192,6 +202,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(result?.response.data).not.toContain('ECONNREFUSED')
     expect(requestError).toBe(null)
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
@@ -215,6 +228,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/',
@@ -254,6 +270,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/example',
@@ -284,6 +303,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       query: {
         foo: 'bar',
@@ -324,6 +346,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'POST',
     })
@@ -364,6 +389,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string).query).toMatchObject({
       foo: ['foo', 'bar'],
     })
@@ -399,6 +427,9 @@ describe('create-request-operation', () => {
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
+      if (!result || !('data' in result.response)) {
+        throw new Error('No data')
+      }
       expect(JSON.parse(result?.response.data as string).query).toStrictEqual({
         example: 'parameter',
         foo: 'bar',
@@ -435,6 +466,9 @@ describe('create-request-operation', () => {
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
+      if (!result || !('data' in result.response)) {
+        throw new Error('No data')
+      }
       expect(JSON.parse(result?.response.data as string).query).toStrictEqual({
         example: 'parameter',
         foo: 'bar',
@@ -457,6 +491,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string).query).toStrictEqual({})
   })
 
@@ -486,6 +523,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string).query).toStrictEqual({})
   })
 
@@ -515,6 +555,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string).query).toStrictEqual({
       foo: '',
     })
@@ -533,6 +576,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(result?.response.data).toBe('')
   })
 
@@ -549,6 +595,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/v1',
@@ -568,6 +617,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/v1/',
@@ -603,6 +655,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'POST',
       path: '/',
@@ -660,6 +715,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'POST',
       path: '/',
@@ -692,6 +750,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)).toMatchObject({
       method: 'GET',
       path: '/me',
@@ -743,6 +804,9 @@ describe('create-request-operation', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
     expect(JSON.parse(result?.response.data as string)?.cookies).toStrictEqual({
       'cookie': 'custom-value',
       'auth-cookie': 'super-secret-token',
@@ -775,6 +839,9 @@ describe('create-request-operation', () => {
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
+      if (!result || !('data' in result.response)) {
+        throw new Error('No data')
+      }
       expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
         'x-api-key': 'test-key',
       })
@@ -804,6 +871,9 @@ describe('create-request-operation', () => {
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
+      if (!result || !('data' in result.response)) {
+        throw new Error('No data')
+      }
       expect(JSON.parse(result?.response.data as string).query).toMatchObject({
         api_key: 'test-key',
       })
@@ -835,6 +905,9 @@ describe('create-request-operation', () => {
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
+      if (!result || !('data' in result.response)) {
+        throw new Error('No data')
+      }
       expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
         authorization: `Basic ${btoa('user:pass')}`,
       })
@@ -864,6 +937,9 @@ describe('create-request-operation', () => {
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
+      if (!result || !('data' in result.response)) {
+        throw new Error('No data')
+      }
       expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
         authorization: 'Bearer xxxx',
       })
@@ -903,6 +979,9 @@ describe('create-request-operation', () => {
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
+      if (!result || !('data' in result.response)) {
+        throw new Error('No data')
+      }
       const parsed = JSON.parse(result?.response.data as string)
       expect(parsed.headers.authorization).toEqual('Bearer xxxx')
       expect(parsed.query.api_key).toEqual('xxxx')
@@ -941,6 +1020,9 @@ describe('create-request-operation', () => {
       const [requestError, result] = await requestOperation.sendRequest()
 
       expect(requestError).toBe(null)
+      if (!result || !('data' in result.response)) {
+        throw new Error('No data')
+      }
       expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
         authorization: 'Bearer oauth-token',
       })

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyStreaming.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyStreaming.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { ScalarLoading, useLoadingState } from '@scalar/components'
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 
@@ -13,6 +13,22 @@ const loader = useLoadingState()
 const textContent = ref('')
 const errorRef = ref<Error | null>(null)
 const decoder = new TextDecoder()
+const contentContainer = ref<HTMLElement | null>(null)
+
+/**
+ * Scrolls the content container to the bottom
+ */
+const scrollToBottom = () => {
+  if (contentContainer.value) {
+    contentContainer.value.scrollTop = contentContainer.value.scrollHeight
+  }
+}
+
+// Watch for changes in textContent and scroll to bottom
+watch(textContent, () => {
+  // Use nextTick to ensure the DOM has updated
+  nextTick(scrollToBottom)
+})
 
 /**
  * Reads the stream and appends the content
@@ -71,9 +87,10 @@ onBeforeUnmount(() => {
     </template>
 
     <div
+      ref="contentContainer"
       class="text-xxs font-code leading-2 h-full overflow-auto whitespace-pre-wrap">
       <template v-if="errorRef">
-        <div class="text-red border-b p-2">
+        <div class="text-red bg-b-danger sticky top-0 border-b p-2">
           {{ errorRef.message }}
         </div>
       </template>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyStreaming.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyStreaming.vue
@@ -4,7 +4,7 @@ import { onBeforeUnmount, onMounted, ref } from 'vue'
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 
 const { reader } = defineProps<{
-  reader: ReadableStreamDefaultReader<Uint8Array<ArrayBufferLike>>
+  reader: ReadableStreamDefaultReader<Uint8Array>
 }>()
 
 const textContent = ref('')
@@ -51,7 +51,8 @@ onBeforeUnmount(() => {
     <template #title>
       Body ({{ isReading ? 'streaming...' : 'stream complete' }})
     </template>
-    <div class="text-xxs font-code leading-2 whitespace-pre-wrap p-2">
+    <div
+      class="text-xxs font-code leading-2 h-full overflow-auto whitespace-pre-wrap p-2">
       {{ textContent }}
     </div>
   </ViewLayoutCollapse>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyStreaming.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyStreaming.vue
@@ -1,0 +1,58 @@
+<script lang="ts" setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
+
+const { reader } = defineProps<{
+  reader: ReadableStreamDefaultReader<Uint8Array<ArrayBufferLike>>
+}>()
+
+const textContent = ref('')
+const isReading = ref(true)
+const decoder = new TextDecoder()
+
+// Function to read the stream
+async function readStream() {
+  try {
+    while (isReading.value) {
+      const { done, value } = await reader.read()
+
+      if (done) {
+        isReading.value = false
+        break
+      }
+
+      // Decode the Uint8Array to string and append to content
+      if (value) {
+        textContent.value += decoder.decode(value, { stream: true })
+      }
+    }
+  } catch (error) {
+    console.error('Error reading stream:', error)
+    isReading.value = false
+  } finally {
+    // Make sure to decode any remaining bytes
+    textContent.value += decoder.decode()
+  }
+}
+
+onMounted(() => {
+  readStream()
+})
+
+onBeforeUnmount(() => {
+  isReading.value = false
+  reader.cancel()
+})
+</script>
+
+<template>
+  <ViewLayoutCollapse class="max-h-content overflow-y-hidden">
+    <template #title>
+      Body ({{ isReading ? 'streaming...' : 'stream complete' }})
+    </template>
+    <div class="text-xxs font-code leading-2 whitespace-pre-wrap p-2">
+      {{ textContent }}
+    </div>
+  </ViewLayoutCollapse>
+</template>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -200,6 +200,7 @@ const requestHeaders = computed(
           <!-- Streaming response body -->
           <ResponseBodyStreaming
             v-if="'reader' in response"
+            class="response-section-content-body"
             :id="filterIds.Body"
             :reader="response.reader" />
 

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -13,6 +13,7 @@ import type { SendRequestResult } from '@/libs/send-request/create-request-opera
 
 import RequestHeaders from './RequestHeaders.vue'
 import ResponseBody from './ResponseBody.vue'
+import ResponseBodyStreaming from './ResponseBodyStreaming.vue'
 import ResponseBodyVirtual from './ResponseBodyVirtual.vue'
 import ResponseCookies from './ResponseCookies.vue'
 import ResponseEmpty from './ResponseEmpty.vue'
@@ -74,7 +75,7 @@ const filterIds = computed(
 /** Threshold for virtualizing response bodies in bytes */
 const VIRTUALIZATION_THRESHOLD = 200_000
 const shouldVirtualize = computed(() => {
-  if (!response) {
+  if (!response || !('size' in response)) {
     return false
   }
 
@@ -196,15 +197,22 @@ const requestHeaders = computed(
           :role="activeFilter === 'All' ? 'none' : 'tabpanel'" />
 
         <template v-if="activeFilter === 'All' || activeFilter === 'Body'">
+          <!-- Streaming response body -->
+          <ResponseBodyStreaming
+            v-if="'reader' in response"
+            :id="filterIds.Body"
+            :reader="response.reader" />
+
           <!-- Virtualized Text for massive responses -->
           <ResponseBodyVirtual
-            v-if="shouldVirtualize && typeof response?.data === 'string'"
+            v-else-if="shouldVirtualize && typeof response?.data === 'string'"
             :id="filterIds.Body"
             :content="response!.data"
             :data="response?.data"
             :headers="responseHeaders"
             :role="activeFilter === 'All' ? 'none' : 'tabpanel'" />
 
+          <!-- Regular response body -->
           <ResponseBody
             class="response-section-content-body"
             v-else

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -21,17 +21,24 @@ export type ResponseInstance = Omit<Response, 'headers'> & {
   cookieHeaderKeys: string[]
   /** Time in ms the request took */
   duration: number
-  /** The response data */
-  data: string | Blob
-  /** The response size in bytes */
-  size: number
   /** The response status */
   status: number
   /** The response method */
   method: RequestMethod
   /** The request path */
   path: string
-}
+} & (
+    | {
+        /** The response data */
+        data: string | Blob
+        /** The response size in bytes */
+        size: number
+      }
+    | {
+        /** A stream reader for a streamable response body */
+        reader: ReadableStreamDefaultReader<Uint8Array>
+      }
+  )
 
 /** A single request/response set to save to the history stack */
 export type RequestEvent = {

--- a/packages/void-server/src/createVoidServer.ts
+++ b/packages/void-server/src/createVoidServer.ts
@@ -58,6 +58,10 @@ export async function createVoidServer() {
     return createJsonResponse(c, requestData)
   })
 
+  app.get('/stream', async (c: Context) => {
+    return createStreamResponse(c)
+  })
+
   // All other requests just respond with a JSON containing all the request data
   app.all('/*', async (c: Context) => {
     const requestData = await getRequestData(c)

--- a/packages/void-server/src/createVoidServer.ts
+++ b/packages/void-server/src/createVoidServer.ts
@@ -1,11 +1,13 @@
 import { type Context, Hono } from 'hono'
 import { accepts } from 'hono/accepts'
 import { cors } from 'hono/cors'
+import { logger } from 'hono/logger'
 import type { StatusCode } from 'hono/utils/http-status'
 
 import { errors } from '@/utils/constants.ts'
 import { createHtmlResponse } from '@/utils/createHtmlResponse.ts'
 import { createJsonResponse } from '@/utils/createJsonResponse.ts'
+import { createStreamResponse } from '@/utils/createStreamResponse.ts'
 import { createXmlResponse } from '@/utils/createXmlResponse.ts'
 import { createZipFileResponse } from '@/utils/createZipFileResponse.ts'
 import { getRequestData } from '@/utils/getRequestData.ts'
@@ -16,13 +18,14 @@ import { getRequestData } from '@/utils/getRequestData.ts'
 export async function createVoidServer() {
   const app = new Hono()
 
+  // Logger
+  app.use(logger())
+
   // CORS headers
   app.use(cors())
 
   // HTTP errors
   app.all('/:status{[4-5][0-9][0-9]}', async (c: Context) => {
-    console.info(`${c.req.method} ${c.req.path}`)
-
     const { status: originalStatusCode } = c.req.param()
     const status = Number.parseInt(originalStatusCode ?? '0', 10) as StatusCode
 
@@ -33,15 +36,11 @@ export async function createVoidServer() {
 
   // No content
   app.all('/:status{204}', async (c: Context) => {
-    console.info(`${c.req.method} ${c.req.path}`)
-
     return c.body(null, 204)
   })
 
   // Return content based on the file extension
   app.all('/:filename{.+\\.(html|xml|json|zip)$}', async (c: Context) => {
-    console.info(`${c.req.method} ${c.req.path}`)
-
     const requestData = await getRequestData(c)
 
     const { filename } = c.req.param()
@@ -61,8 +60,6 @@ export async function createVoidServer() {
 
   // All other requests just respond with a JSON containing all the request data
   app.all('/*', async (c: Context) => {
-    console.info(`${c.req.method} ${c.req.path}`)
-
     const requestData = await getRequestData(c)
 
     const acceptedContentType = accepts(c, {

--- a/packages/void-server/src/utils/createStreamResponse.ts
+++ b/packages/void-server/src/utils/createStreamResponse.ts
@@ -1,0 +1,12 @@
+import type { Context } from 'hono'
+import { stream } from 'hono/streaming'
+
+export function createStreamResponse(c: Context) {
+  return stream(c, async (s) => {
+    while (true) {
+      s.write('data: ping\n')
+
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+    }
+  })
+}


### PR DESCRIPTION
**Problem**

Currently, we have no real support for streaming events.

closes #1928

**Solution**

With this PR we add:
- [x] text streaming support
- [x] server-sent events

Text streams:
![image](https://github.com/user-attachments/assets/5a985d13-7d6c-413e-979c-340153909b37)
![image](https://github.com/user-attachments/assets/3789610c-5cc5-481d-9c25-0e6c9c280332)

Server sent events:
![image](https://github.com/user-attachments/assets/c8097922-727f-4c94-bca9-eef855efb5bc)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
