### PR TITLE
fix(api-client): vendor specific content type examples

### DIFF
--- a/.changeset/bright-mirrors-build.md
+++ b/.changeset/bright-mirrors-build.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates example handling in example request for any content type

--- a/.changeset/itchy-months-mate.md
+++ b/.changeset/itchy-months-mate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates request body vendor specific json type support

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
@@ -231,4 +231,38 @@ describe('RequestBody.vue', () => {
 
     wrapper.unmount()
   })
+
+  it('uses vendor-specific JSON content type when available', async () => {
+    mockOperation.requestBody = {
+      content: {
+        'application/vnd.api+json': {},
+      },
+    }
+
+    mockActiveExample.body = {
+      activeBody: 'formData',
+      formData: {
+        encoding: 'form-data',
+        value: [],
+      },
+    }
+
+    mockActiveExample.parameters = {
+      headers: [{ key: 'Content-Type', value: 'multipart/form-data', enabled: true }],
+      path: [],
+      cookies: [],
+      query: [],
+    }
+
+    const wrapper = mount(RequestBody, props)
+
+    const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+    await listbox.vm.$emit('update:modelValue', { id: 'json', label: 'JSON' })
+
+    expect(mockRequestExampleMutators.edit).toHaveBeenCalledWith('mockExampleUid', 'parameters.headers', [
+      { key: 'Content-Type', value: 'application/vnd.api+json', enabled: true },
+    ])
+
+    wrapper.unmount()
+  })
 })

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -249,13 +249,18 @@ const getBodyType = (type: Content) => {
       header: 'application/octet-stream',
     } as const
   }
-  if (type === 'json' || type.endsWith('+json')) {
+  if (type === 'json') {
+    const contentTypes = Object.keys(operation.requestBody?.content ?? {})
+
+    // Gets json content types including vendor specific ones
+    const jsonContentType =
+      contentTypes.find((t) => t.includes('json') || t.endsWith('+json')) ||
+      'application/json'
+
     return {
       activeBody: 'raw',
       encoding: 'json',
-      header: type.endsWith('+json')
-        ? `application/${type}`
-        : 'application/json',
+      header: jsonContentType,
     } as const
   }
   if (type === 'xml') {


### PR DESCRIPTION
**Problem**

currently when using vendor specific content type (e.g. `application/vnd.api+json`), the type gets changed to `application/json` + the examples selector is not getting displayed as seen in #5399.

**Solution**

this pr updates the request body logic to avoid updating the content type and bring back the example selector + fix the body update on change.

| before | after |
| -------|------|
| <img width="1113" alt="image" src="https://github.com/user-attachments/assets/bfcc3eaf-239a-4bc9-af32-98ed5a25395e" /> | <img width="1113" alt="image" src="https://github.com/user-attachments/assets/024fb332-125c-482f-af10-ff69e0a1def5" /> |
| unsupported vendor specific content type + no examples | vendor specific content type support + examples | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
