### PR TITLE
fix(api-client): mask api key value in authentication section

### DIFF
--- a/.changeset/few-dogs-brake.md
+++ b/.changeset/few-dogs-brake.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+feat: mask api key value in authentication section

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -175,6 +175,7 @@ const dataTableInputProps = {
           v-bind="dataTableInputProps"
           :modelValue="scheme.value"
           placeholder="QUxMIFlPVVIgQkFTRSBBUkUgQkVMT05HIFRPIFVT"
+          type="password"
           @update:modelValue="(v) => updateScheme(scheme.uid, 'value', v)">
           Value
         </RequestAuthDataTableInput>


### PR DESCRIPTION
**Problem**

Currently, when using [apiKey security schema ](https://swagger.io/docs/specification/v3_0/authentication/api-keys/) value of the api key is displayed as plain text. API keys are considered secrets the same way passwords are, they should not be displayed as plain text.

**Solution**

With this PR I change displayed value in api key input to password type the same way it is already handled for password in basic HTTP authentication

**Checklist**

I’ve gone through the following:

- [X] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
