### PR TITLE
fix(api-client): command palette arrow navigation

### DIFF
--- a/.changeset/many-pugs-study.md
+++ b/.changeset/many-pugs-study.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates arrow key handler function


### PR DESCRIPTION
**Problem**

currently when navigating using arrow key through the command palette, some item are not visible or skipped.

**Solution**

this pr updates the arrow key handler to take into consideration the command grouping + the sticky command menu / viewport to handle focused item display.

| before | after |
| -------|------|
| <video src="https://github.com/user-attachments/assets/6612747c-7157-410f-9116-b881b2b06b32"/> | <video src="https://github.com/user-attachments/assets/9718a501-234f-4626-b1b2-fe8924ebfe8a"/> |
| description of the issue in image | description of the change in image | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
