### PR TITLE
fix(api-reference): align document selector chevron

### DIFF
--- a/.changeset/chilly-trainers-judge.md
+++ b/.changeset/chilly-trainers-judge.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): align document selector chevron

--- a/packages/api-reference/src/components/DocumentSelector/DocumentSelector.vue
+++ b/packages/api-reference/src/components/DocumentSelector/DocumentSelector.vue
@@ -54,7 +54,7 @@ const selectedOption = computed({
             {{ selectedOption?.label || 'Select API' }}
           </span>
           <ScalarIcon
-            class="group-hover/dropdown-label:text-c-1 ml-auto"
+            class="group-hover/dropdown-label:text-c-1 ml-auto mr-2"
             icon="ChevronDown"
             size="sm"
             thickness="2" />


### PR DESCRIPTION
Before / After

![Google Chrome-2025-04-15-16-53-48@2x](https://github.com/user-attachments/assets/d6058a33-7be4-4a1d-b169-3cef285e3233)

![Google Chrome-2025-04-15-16-53-34@2x](https://github.com/user-attachments/assets/65605e1e-1871-4767-91a4-48ccd39fdcc1)
