### PR TITLE
fix(api-reference): some jumpiness on config "changes" and multi doc select

### DIFF
--- a/.changeset/rich-mails-fetch.md
+++ b/.changeset/rich-mails-fetch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: some jumpiness when switching specs or any config changing

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -197,6 +197,9 @@ export const useMultipleDocuments = ({
       const url = new URL(window.location.href)
       const selectedDefinition = availableDocuments.value[value]
 
+      // Clear path as well
+      url.pathname = selectedConfiguration.value.pathRouting?.basePath ?? ''
+
       // Use slug if available, then fallback to index
       const parameterValue = selectedDefinition?.slug ?? value.toString()
 

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -197,8 +197,10 @@ export const useMultipleDocuments = ({
       const url = new URL(window.location.href)
       const selectedDefinition = availableDocuments.value[value]
 
-      // Clear path as well
-      url.pathname = selectedConfiguration.value.pathRouting?.basePath ?? ''
+      // Clear path if pathRouting is enabled
+      if (selectedConfiguration.value.pathRouting) {
+        url.pathname = selectedConfiguration.value.pathRouting?.basePath ?? ''
+      }
 
       // Use slug if available, then fallback to index
       const parameterValue = selectedDefinition?.slug ?? value.toString()


### PR DESCRIPTION
**Problem**
- we weren't clearing path on multi doc change when using pathRouting
- our config watcher was triggering when nothing changed, re-creating the store for no reason

**Solution**

With this PR 
- we clear the path if path routing
- added a hacky json.stringify check for diff checking

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
