### PR TITLE
feat(api-reference): new string fallback for schema examples

### DIFF
--- a/.changeset/proud-forks-fly.md
+++ b/.changeset/proud-forks-fly.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/mock-server': patch
+---
+
+feat: use `"string"` as the fallback for string examples (not `"…"`)

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponse.vue
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponse.vue
@@ -21,7 +21,7 @@ defineProps<{
     class="bg-b-2 -outline-offset-2"
     :content="
       getExampleFromSchema(response?.schema, {
-        emptyString: '…',
+        emptyString: 'string',
         mode: 'read',
       })
     "

--- a/packages/mock-server/src/routes/mockAnyResponse.ts
+++ b/packages/mock-server/src/routes/mockAnyResponse.ts
@@ -61,7 +61,7 @@ export function mockAnyResponse(c: Context, operation: OpenAPI.Operation, option
     ? acceptedResponse.example
     : acceptedResponse?.schema
       ? getExampleFromSchema(acceptedResponse.schema, {
-          emptyString: '…',
+          emptyString: 'string',
           variables: c.req.param(),
           mode: 'read',
         })


### PR DESCRIPTION
**Problem**

Currently, we’re using `"…"` as the fallbacks for strings when we generate examples from schemas.

 <img width="528" alt="Screenshot 2025-04-17 at 15 40 28" src="https://github.com/user-attachments/assets/9921122e-ba31-4e76-8d43-a9118f3b7dff" />

**Solution**

I thought I’d be smart when I built that, but a few people are confused by it, and actually, just using `"string"` seems easier to understand (it’s also what Swagger UI does).

<img width="531" alt="Screenshot 2025-04-17 at 15 38 17" src="https://github.com/user-attachments/assets/e087ae62-1f2b-41d5-9a15-a42acf271483" />

Note: We can’t really do this for numbers, booleans and others, because we’d need to make them a string then.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
