### PR TITLE
fix(api-reference): overflow scrolling on anyOf discriminator

### DIFF
--- a/.changeset/eight-eyes-sort.md
+++ b/.changeset/eight-eyes-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: overflow scrolling on any of discriminator

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -77,7 +77,8 @@ const humanizeType = (type: string) => {
         <TabList
           class="discriminator-tab-list py-1.25 flex flex-col gap-1 rounded-t-lg border border-b-0 px-2 pr-3">
           <span class="text-c-3">{{ humanizeType(discriminator) }}</span>
-          <div class="flex items-center gap-1.5">
+          <div
+            class="custom-scroll flex items-center gap-1.5 !overflow-y-hidden">
             <Tab
               v-for="(schema, index) in value[discriminator]"
               :key="index"


### PR DESCRIPTION
**Problem**

![image](https://github.com/user-attachments/assets/2c14b6a6-128e-4f25-b9a2-a6321b9fc14b)


**Solution**

![image](https://github.com/user-attachments/assets/83ac44c6-c70c-4af3-bb8b-06704716ac0a)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
