### PR TITLE
feat(api-reference): register scalar instances globally

### DIFF
--- a/.changeset/few-items-decide.md
+++ b/.changeset/few-items-decide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: register html api apps globally

--- a/packages/api-reference-react/src/ApiReferenceReact.tsx
+++ b/packages/api-reference-react/src/ApiReferenceReact.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { type ApiReferenceInstance, createApiReference } from '@scalar/api-reference'
-import type { AnyApiReferenceConfiguration } from '@scalar/types/api-reference'
+import { createApiReference } from '@scalar/api-reference'
+import type { AnyApiReferenceConfiguration, ApiReferenceInstance } from '@scalar/types/api-reference'
 import { useEffect, useRef, useState } from 'react'
 
 import './style.css'

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -6,7 +6,7 @@ export { SearchButton, SearchModal } from '@/features/Search'
 export { default as GettingStarted } from '@/components/GettingStarted.vue'
 
 export { useReactiveSpec } from '@/hooks/useReactiveSpec'
-export { type ApiReferenceInstance, createApiReference } from '@/standalone/lib/html-api'
+export { createApiReference } from '@/standalone/lib/html-api'
 
 export { Sidebar } from '@/components/Sidebar'
 export { Card, CardHeader, CardContent, CardFooter, CardTabHeader, CardTab } from '@/components/Card'

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -63,7 +63,7 @@ describe('html-api', () => {
 
       expect(consoleWarnSpy).toHaveBeenCalledOnce()
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'scalar:reload-references event has been deprecated, please use the window.Scalar.app.mount method instead',
+        "scalar:reload-references event has been deprecated, please use the window.Scalar.apps['default'].app.mount method instead",
       )
     })
 
@@ -75,7 +75,7 @@ describe('html-api', () => {
 
       document.dispatchEvent(new Event('scalar:destroy-references'))
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'scalar:destroy-references event has been deprecated, please use window.Scalar.destroy instead',
+        "scalar:destroy-references event has been deprecated, please use window.Scalar.apps['default'].destroy instead",
       )
     })
 
@@ -91,7 +91,7 @@ describe('html-api', () => {
       document.dispatchEvent(updateEvent)
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'scalar:update-references-config event has been deprecated, please use window.Scalar.updateConfiguration instead',
+        "scalar:destroy-references event has been deprecated, please use window.Scalar.apps['default'].destroy instead",
       )
     })
 

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -3,9 +3,10 @@ import {
   type AnyApiReferenceConfiguration,
   type ApiReferenceConfiguration,
   apiReferenceConfigurationSchema,
+  type CreateApiReference,
 } from '@scalar/types/api-reference'
 import { createHead } from '@unhead/vue'
-import { type App, createApp, h, reactive } from 'vue'
+import { createApp, h, reactive } from 'vue'
 
 import { default as ApiReference } from '@/components/ApiReference.vue'
 
@@ -165,28 +166,6 @@ export const createContainer = (doc: Document, element?: Element | null) => {
   }
 
   return _container
-}
-
-// Add a type for our enhanced app
-export type ApiReferenceInstance = {
-  /** The vue app instance */
-  app: App<Element>
-  /** Destroy the current API Reference instance */
-  destroy: () => void
-  /** Get the current configuration[s] */
-  getConfiguration: () => AnyApiReferenceConfiguration
-  /** Update all configuration[s] */
-  updateConfiguration: (newConfig: AnyApiReferenceConfiguration) => void
-}
-
-/** Function overload for createApiReference to allow multiple different signatures */
-export type CreateApiReference = {
-  /** Pass in the configuration only */
-  (configuration: AnyApiReferenceConfiguration): ApiReferenceInstance
-  /** Pass in the element or selector and configuration */
-  (elementOrSelector: Element | string, configuration: AnyApiReferenceConfiguration): ApiReferenceInstance
-  /** Pass in the element or selector, configuration and name for global registration, name is required when you have more than one page with a reference */
-  (elementOrSelector: Element | string, configuration: AnyApiReferenceConfiguration, name: string): ApiReferenceInstance
 }
 
 /**

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -185,6 +185,8 @@ export type CreateApiReference = {
   (configuration: AnyApiReferenceConfiguration): ApiReferenceInstance
   /** Pass in the element or selector and configuration */
   (elementOrSelector: Element | string, configuration: AnyApiReferenceConfiguration): ApiReferenceInstance
+  /** Pass in the element or selector, configuration and name for global registration, name is required when you have more than one page with a reference */
+  (elementOrSelector: Element | string, configuration: AnyApiReferenceConfiguration, name: string): ApiReferenceInstance
 }
 
 /**
@@ -193,11 +195,12 @@ export type CreateApiReference = {
  * @example createApiReference({ url: '/scalar.json' }).mount('#app')
  * @example createApiReference('#app', { url: '/scalar.json' })
  * @example createApiReference(document.getElementById('app'), { url: '/scalar.json' })
- *
+ * @example createApiReference(document.getElementById('app'), { url: '/scalar.json' }, 'my-api-reference')
  */
 export const createApiReference: CreateApiReference = (
   elementOrSelectorOrConfig,
   optionalConfiguration?: AnyApiReferenceConfiguration,
+  name?: string,
 ) => {
   const props = reactive<ReferenceProps>({
     // Either the configuration will be the second arugment or it MUST be the first (configuration only)
@@ -233,7 +236,7 @@ export const createApiReference: CreateApiReference = (
     'scalar:reload-references',
     () => {
       console.warn(
-        'scalar:reload-references event has been deprecated, please use the window.Scalar.app.mount method instead',
+        'scalar:reload-references event has been deprecated, please use the window.Scalar.[default | name].app.mount method instead',
       )
       if (!props.configuration) {
         return
@@ -276,7 +279,9 @@ export const createApiReference: CreateApiReference = (
   document.addEventListener(
     'scalar:destroy-references',
     () => {
-      console.warn('scalar:destroy-references event has been deprecated, please use window.Scalar.destroy instead')
+      console.warn(
+        'scalar:destroy-references event has been deprecated, please use window.Scalar.[default | name].destroy instead',
+      )
       destroy()
     },
     false,
@@ -290,7 +295,7 @@ export const createApiReference: CreateApiReference = (
     'scalar:update-references-config',
     (ev) => {
       console.warn(
-        'scalar:update-references-config event has been deprecated, please use window.Scalar.updateConfiguration instead',
+        'scalar:update-references-config event has been deprecated, please use window.Scalar.[default | name].updateConfiguration instead',
       )
       if ('detail' in ev) {
         Object.assign(props, ev.detail)
@@ -299,7 +304,7 @@ export const createApiReference: CreateApiReference = (
     false,
   )
 
-  return {
+  const instance = {
     app,
     getConfiguration: () => props.configuration ?? {},
     updateConfiguration: (newConfig: AnyApiReferenceConfiguration) => {
@@ -307,4 +312,11 @@ export const createApiReference: CreateApiReference = (
     },
     destroy,
   }
+
+  // Register the instance globally
+  if (typeof window !== 'undefined' && window.Scalar) {
+    window.Scalar.apps[name ?? 'default'] = instance
+  }
+
+  return instance
 }

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -215,7 +215,7 @@ export const createApiReference: CreateApiReference = (
     'scalar:reload-references',
     () => {
       console.warn(
-        'scalar:reload-references event has been deprecated, please use the window.Scalar.[default | name].app.mount method instead',
+        "scalar:reload-references event has been deprecated, please use the window.Scalar.apps['default'].app.mount method instead",
       )
       if (!props.configuration) {
         return
@@ -259,7 +259,7 @@ export const createApiReference: CreateApiReference = (
     'scalar:destroy-references',
     () => {
       console.warn(
-        'scalar:destroy-references event has been deprecated, please use window.Scalar.[default | name].destroy instead',
+        "scalar:destroy-references event has been deprecated, please use window.Scalar.apps['default'].destroy instead",
       )
       destroy()
     },
@@ -274,7 +274,7 @@ export const createApiReference: CreateApiReference = (
     'scalar:update-references-config',
     (ev) => {
       console.warn(
-        'scalar:update-references-config event has been deprecated, please use window.Scalar.[default | name].updateConfiguration instead',
+        "scalar:update-references-config event has been deprecated, please use window.Scalar.apps['default'].updateConfiguration instead",
       )
       if ('detail' in ev) {
         Object.assign(props, ev.detail)

--- a/packages/api-reference/src/standalone/lib/register-globals.test.ts
+++ b/packages/api-reference/src/standalone/lib/register-globals.test.ts
@@ -11,4 +11,28 @@ describe('registerGlobals', () => {
     expect(window.Scalar.createApiReference).toStrictEqual(createApiReference)
     expect(window.Scalar.createApiReference('#something', {})).toBeDefined()
   })
+
+  it('registers a default app instance globally', () => {
+    registerGlobals()
+
+    expect(window.Scalar.createApiReference('#something', {})).toBeDefined()
+    expect(window.Scalar.apps['default']).toMatchObject({
+      app: expect.any(Object),
+      destroy: expect.any(Function),
+      getConfiguration: expect.any(Function),
+      updateConfiguration: expect.any(Function),
+    })
+  })
+
+  it('registers a named app instance globally', () => {
+    registerGlobals()
+
+    expect(window.Scalar.createApiReference('#something', {}, 'my-app')).toBeDefined()
+    expect(window.Scalar.apps['my-app']).toMatchObject({
+      app: expect.any(Object),
+      destroy: expect.any(Function),
+      getConfiguration: expect.any(Function),
+      updateConfiguration: expect.any(Function),
+    })
+  })
 })

--- a/packages/api-reference/src/standalone/lib/register-globals.ts
+++ b/packages/api-reference/src/standalone/lib/register-globals.ts
@@ -1,10 +1,12 @@
-import { createApiReference, type CreateApiReference } from '@/standalone/lib/html-api'
+import { createApiReference, type ApiReferenceInstance, type CreateApiReference } from '@/standalone/lib/html-api'
 
 // Register the createApiReference function in the global Scalar object (new)
 declare global {
   interface Window {
     Scalar: {
       createApiReference: CreateApiReference
+      /** Globally registered API Reference instances */
+      apps: Record<string, ApiReferenceInstance>
     }
   }
 }
@@ -20,5 +22,6 @@ export const registerGlobals = () => {
   // Initialize the global Scalar object
   globalWindow.Scalar = {
     createApiReference,
+    apps: {},
   }
 }

--- a/packages/api-reference/src/standalone/lib/register-globals.ts
+++ b/packages/api-reference/src/standalone/lib/register-globals.ts
@@ -1,13 +1,11 @@
-import { createApiReference, type ApiReferenceInstance, type CreateApiReference } from '@/standalone/lib/html-api'
+import type { ScalarGlobal } from '@scalar/types/api-reference'
+
+import { createApiReference } from '@/standalone/lib/html-api'
 
 // Register the createApiReference function in the global Scalar object (new)
 declare global {
   interface Window {
-    Scalar: {
-      createApiReference: CreateApiReference
-      /** Globally registered API Reference instances */
-      apps: Record<string, ApiReferenceInstance>
-    }
+    Scalar: ScalarGlobal
   }
 }
 

--- a/packages/types/src/api-reference/html-api.ts
+++ b/packages/types/src/api-reference/html-api.ts
@@ -1,0 +1,41 @@
+import type { AnyApiReferenceConfiguration } from '@/api-reference/api-reference-configuration.ts'
+
+/**
+ * This is a subset of the vue app type
+ * Didn't want to add vue as a dependency just for this type so we stub whatever we need for the html api
+ */
+type App<HostElement = any> = {
+  mount(rootContainer: HostElement | string): unknown
+  unmount(): void
+  onUnmount(cb: () => void): void
+}
+
+/** Enhanced ApiReferenceInstance with subset vue app */
+export type ApiReferenceInstance = {
+  /** The vue app instance */
+  app: App<Element>
+  /** Destroy the current API Reference instance */
+  destroy: () => void
+  /** Get the current configuration[s] */
+  getConfiguration: () => AnyApiReferenceConfiguration
+  /** Update all configuration[s] */
+  updateConfiguration: (newConfig: AnyApiReferenceConfiguration) => void
+}
+
+/** Function overload for createApiReference to allow multiple different signatures */
+export type CreateApiReference = {
+  /** Pass in the configuration only */
+  (configuration: AnyApiReferenceConfiguration): ApiReferenceInstance
+  /** Pass in the element or selector and configuration */
+  (elementOrSelector: Element | string, configuration: AnyApiReferenceConfiguration): ApiReferenceInstance
+  /** Pass in the element or selector, configuration and name for global registration, name is required when you have more than one page with a reference */
+  (elementOrSelector: Element | string, configuration: AnyApiReferenceConfiguration, name: string): ApiReferenceInstance
+}
+
+/** Scalar global object which lives at window.Scalar */
+export type ScalarGlobal = {
+  /** Create a new API Reference instance */
+  createApiReference: CreateApiReference
+  /** Globally registered API Reference instances */
+  apps: Record<string, ApiReferenceInstance>
+}

--- a/packages/types/src/api-reference/index.ts
+++ b/packages/types/src/api-reference/index.ts
@@ -21,3 +21,5 @@ export type {
   SpecificationExtension,
   ApiReferencePlugin,
 } from './api-reference-plugin.ts'
+
+export type { ApiReferenceInstance, CreateApiReference, ScalarGlobal } from './html-api.ts'


### PR DESCRIPTION
**Problem**

Currently, we register a window.Scalar object but all it can do is create instances

**Solution**

With this PR we save a reference to the instance globally so we can perform actions on it. Also updated the deprecation message as it did nothing before.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
