### PR TITLE
fix(components): break words when wrapping search results

### DIFF
--- a/.changeset/tricky-jokes-lie.md
+++ b/.changeset/tricky-jokes-lie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): break words when wrapping search results

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -36,7 +36,7 @@ const { cx } = useBindCx()
     <div class="flex min-w-0 flex-1 flex-col gap-0.75">
       <div class="flex items-center gap-1">
         <div
-          class="flex-1 truncate zoomed:!whitespace-normal text-sm font-medium">
+          class="flex-1 truncate zoomed:!whitespace-normal break-words text-sm font-medium">
           <slot />
         </div>
         <div
@@ -47,7 +47,7 @@ const { cx } = useBindCx()
       </div>
       <div
         v-if="$slots.description"
-        class="truncate zoomed:!whitespace-normal text-sm text-c-2">
+        class="truncate zoomed:!whitespace-normal break-words text-sm text-c-2">
         <slot name="description" />
       </div>
     </div>


### PR DESCRIPTION
Before / After


![Google Chrome-2025-04-17-15-45-39@2x](https://github.com/user-attachments/assets/b41b34bf-c14f-4d76-940f-453b725eaa3d)
![Google Chrome-2025-04-17-15-44-06@2x](https://github.com/user-attachments/assets/e0cbb841-4576-46dd-871a-dbff5363d997)

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
