### PR TITLE
fix(api-reference): stream detection code incorrect

### DIFF
--- a/.changeset/breezy-rabbits-melt.md
+++ b/.changeset/breezy-rabbits-melt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: accidental collection creation on paste in codemirror

--- a/.changeset/kind-steaks-boil.md
+++ b/.changeset/kind-steaks-boil.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: incorrect stream reader

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -1072,7 +1072,7 @@ describe('create-request-operation', () => {
         const mockResponse = new Response(mockStream, {
           status: 200,
           headers: new Headers({
-            'content-type': 'text/plain',
+            'content-type': 'text/stream',
           }),
         })
 

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -179,9 +179,12 @@ export const createRequestOperation = ({
           signal: controller.signal,
         })
 
-        // Check if response is potentially streaming
-        const contentLength = response.headers.get('content-length')
-        const isChunkedOrStreaming = !contentLength && response.body !== null && !response.bodyUsed
+        /**
+         * Checks if the response is streaming
+         * Unfortunately we cannot check the transfer-encoding header as it is not set by the browser so not quite sure how to test when
+         * content-type === 'text/plain' and transfer-encoding === 'chunked'
+         */
+        const isStreaming = response.headers.get('content-type')?.includes('stream')
 
         status?.emit('stop')
 
@@ -196,7 +199,7 @@ export const createRequestOperation = ({
             : []
 
         // We want to return the response so that it can be streamed
-        if (isChunkedOrStreaming) {
+        if (isStreaming && response.body) {
           return [
             null,
             {


### PR DESCRIPTION
**Problem**

closes #5437
closes #5440

Currently, my code for detecting a stream was wrong. Also we are listening for collections when pasting into codemirror.

**Solution**

With this PR
- we no longer check for paste on a `<br>` (go figure)
- the check for stream checks for the literal keyword stream, this will not cover all cases but it will prevent more false positives for now

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
