### PR TITLE
fix(api-client): prevents paste event from code input

### DIFF
--- a/.changeset/few-days-matter.md
+++ b/.changeset/few-days-matter.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: prevents paste event from code mirrro instance

--- a/packages/api-client/src/components/ImportCollection/PasteEventListener.vue
+++ b/packages/api-client/src/components/ImportCollection/PasteEventListener.vue
@@ -21,11 +21,17 @@ async function handlePaste(event: ClipboardEvent) {
   // Ignore paste events in input, textarea, or contenteditable elements
   const target = event.target as HTMLElement
 
+  // Check if we're inside a CodeMirror instance
+  const isCodeMirror = Boolean(
+    document.activeElement?.classList.contains('cm-content'),
+  )
+
   if (
     target &&
     (target.tagName === 'INPUT' ||
       target.tagName === 'TEXTAREA' ||
-      target.isContentEditable)
+      target.isContentEditable ||
+      isCodeMirror)
   ) {
     return
   }


### PR DESCRIPTION
**Problem**

currently when pasting a specification within a code input, it fires the document paste event and open the import collection modal.

**Solution**

this pr updates the handle paste function to prevent event from being fired from a code mirror instance by targeting `cm-content` class.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
