### PR TITLE
fix(api-client): import modal transition

### DIFF
--- a/.changeset/chilled-vans-join.md
+++ b/.changeset/chilled-vans-join.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates import collection modal transition style

--- a/.changeset/violet-kiwis-mix.md
+++ b/.changeset/violet-kiwis-mix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates web layout background style target

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
@@ -351,7 +351,7 @@ function handleImportFinished() {
     overflow-x: hidden;
     contain: paint;
   }
-  .has-no-import-url {
+  .has-no-import-url .scalar-client > main {
     opacity: 1;
     background: var(--scalar-background-1);
     animation: transform-restore-layout ease-in-out 0.3s forwards;

--- a/packages/api-client/src/layouts/Web/ApiClientWeb.vue
+++ b/packages/api-client/src/layouts/Web/ApiClientWeb.vue
@@ -86,11 +86,14 @@ const themeStyleTag = computed(
 @import '@scalar/themes/style.css';
 @import '@/tailwind/tailwind.css';
 
-/** Add background for iOS and Safari scroll overflow */
 html,
 body {
-  background-color: var(--scalar-background-1);
   overscroll-behavior: none;
+}
+
+/** Add background for iOS and Safari scroll overflow */
+body {
+  background-color: var(--scalar-background-1);
 }
 
 #scalar-client {


### PR DESCRIPTION
**Problem**

color mode utility classes being currently set to the body element - while background variables are scoped to them (dark | light) - do not make background variables available at the html element level (as wrapping the body one).

this is causing some background color mismatch during the closing the import collection modal transition.

**Solution**

this pr updates the import collection modal style to target the element and maintain the background.

| before | after |
| -------|------|
| ![image](https://github.com/user-attachments/assets/b9b01683-81e5-4831-95ab-35821bcde8ad) | ![image](https://github.com/user-attachments/assets/0089643a-6780-48e4-849a-26e9aa8a3927) |
| background color is not set  | background color set according to theme | 


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
