### PR TITLE
style(schema-discriminator): update padding in discriminator panel

### DIFF
--- a/.changeset/brave-feet-know.md
+++ b/.changeset/brave-feet-know.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+style: Update padding in discriminator panel

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -133,7 +133,7 @@ const humanizeType = (type: string) => {
   padding: 8px;
 }
 .discriminator-panel :deep(.property--compact.property--level-0) {
-  padding: 0;
+  padding: 8px;
 }
 .schema-tab {
   background: none;


### PR DESCRIPTION
**Problem**

- resolved #5428

Currently:

The discriminator panel has zero padding, which doesn't look like an intentional style. 

![image](https://github.com/user-attachments/assets/30b63a17-7eab-4c7e-a131-c78b6b9e9c6e)


**Solution**

In this PR, I have set the padding for level 0 to `8px`.

After:

![image](https://github.com/user-attachments/assets/f727aac9-0bda-4683-8fe5-793ec8d7f3c7)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
