### PR TITLE
feat(Scalar.AspNetCore): migrate to new authentication

### DIFF
--- a/.changeset/fluffy-wombats-cover.md
+++ b/.changeset/fluffy-wombats-cover.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': minor
+---
+
+feat: support for new authentication

--- a/.changeset/fluffy-wombats-cover.md
+++ b/.changeset/fluffy-wombats-cover.md
@@ -2,4 +2,4 @@
 '@scalar/aspnetcore': minor
 ---
 
-feat: support for new authentication
+feat: support for new authentication please checkout the [migration guide](https://github.com/scalar/scalar/discussions/5468)

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -583,11 +583,51 @@ To make authentication easier you can prefill the credentials for your users:
       oauth2: {
         flows: {
           authorizationCode: {
+            // Provide a token that is used instead of calling the auth provider
             token: 'auth code token',
+            // Prefill client id or secret
+            'x-scalar-client-id': 'your-client-id',
+            clientSecret: 'your-client-secret',
+            // Overwrite values from the OpenAPI document
+            authorizationUrl: 'https://auth.example.com/oauth2/authorize',
+            tokenUrl: 'https://auth.example.com/oauth2/token',
+            'x-scalar-redirect-uri': 'https://your-app.com/callback',
+            // Use PKCE for additional security: 'SHA-256', 'plain', or 'no'
+            'x-usePkce': 'SHA-256',
+            // Preselected scopes
+            selectedScopes: ['profile', 'email']
+          },
+          clientCredentials: {
+            token: 'client credentials token',
+            'x-scalar-client-id': 'your-client-id',
+            clientSecret: 'your-client-secret',
+            tokenUrl: 'https://auth.example.com/oauth2/token',
+            // Preselected scopes
+            selectedScopes: ['profile', 'api:read']
+          },
+          implicit: {
+            token: 'implicit flow token',
+            'x-scalar-client-id': 'your-client-id',
+            authorizationUrl: 'https://auth.example.com/oauth2/authorize',
+            'x-scalar-redirect-uri': 'https://your-app.com/callback',
+            // Preselected scopes
+            selectedScopes: ['openid', 'profile']
+          },
+          password: {
+            token: 'password flow token',
+            'x-scalar-client-id': 'your-client-id',
+            clientSecret: 'your-client-secret',
+            tokenUrl: 'https://auth.example.com/oauth2/token',
+            username: 'default-username',
+            password: 'default-password',
+            selectedScopes: ['profile', 'email']
           },
         },
-      },
+        // Set default scopes for all flows
+        'x-default-scopes': ['profile', 'email']
+      }
     },
+  }
 }
 ```
 

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -4,6 +4,7 @@ The `Scalar.AspNetCore` package provides a simple way to integrate the Scalar AP
 
 ## Migration Guide
 
+If you are upgrading from `2.1.x` to `2.2.x`, please refer to the [migration guide](https://github.com/scalar/scalar/discussions/5468).
 If you are upgrading from `1.x.x` to `2.x.x`, please refer to the [migration guide](https://github.com/scalar/scalar/issues/4362).
 
 ## Basic Setup

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -217,7 +217,39 @@ app.MapScalarApiReference(options => options
 
 #### OAuth2 Authentication
 
-Scalar supports all OAuth2 flows: Authorization Code, Implicit, Password, and Client Credentials. You can configure one or multiple flows for each security scheme.
+Scalar supports various OAuth2 flows through specific helper methods, but all of these methods are built on top of a core configuration method called `AddOAuth2Authentication`. This method gives you direct control over the OAuth2 security scheme configuration:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("OAuth2")
+    .AddOAuth2Authentication("OAuth2", scheme => 
+    {
+        // Configure flows manually
+        scheme.Flows = new ScalarFlows
+        {
+            AuthorizationCode = new AuthorizationCodeFlow
+            {
+                ClientId = "your-client-id",
+                RedirectUri = "https://your-app.com/callback"
+            },
+            ClientCredentials = new ClientCredentialsFlow
+            {
+                ClientId = "your-client-id",
+                ClientSecret = "your-client-secret"
+            }
+        };
+        
+        // Set default scopes
+        scheme.DefaultScopes = ["profile", "email"];
+    })
+);
+```
+
+> [!NOTE]
+> All the OAuth2 convenience methods (`AddClientCredentialsFlow`, `AddAuthorizationCodeFlow`, 
+> `AddImplicitFlow`, `AddPasswordFlow`, and `AddOAuth2Flows`) are wrappers around this core 
+> `AddOAuth2Authentication` method. These convenience methods make it easier to configure specific 
+> flows without having to set up the entire structure manually.
 
 ##### Authorization Code Flow
 
@@ -280,7 +312,7 @@ You can configure multiple OAuth2 flows for a single security scheme:
 ```csharp
 app.MapScalarApiReference(options => options
     .WithPreferredScheme("OAuth2")
-    .AddOAuth2Authentication("OAuth2", flows =>
+    .AddOAuth2Flows("OAuth2", flows =>
     {
         // Authorization Code flow
         flows.AuthorizationCode = new AuthorizationCodeFlow

--- a/integrations/aspnetcore/README.md
+++ b/integrations/aspnetcore/README.md
@@ -19,6 +19,7 @@ Made possible by the wonderful work of [@captainsafia](https://github.com/captai
 
 ## Migration Guide
 
+If you are upgrading from `2.1.x` to `2.2.x`, please refer to the [migration guide](https://github.com/scalar/scalar/discussions/5468).
 If you are upgrading from `1.x.x` to `2.x.x`, please refer to the [migration guide](https://github.com/scalar/scalar/issues/4362).
 
 ## Usage

--- a/integrations/aspnetcore/docs/authentication.md
+++ b/integrations/aspnetcore/docs/authentication.md
@@ -87,24 +87,35 @@ This addition ensures that the security scheme is applied globally to all operat
 To make the usage of this scheme easier, you can prefill the `Token` in the `MapScalarApiReference()` method:
 
 ```csharp
-app.MapScalarApiReference(options => options.Authentication = new ScalarAuthenticationOptions
-{
-    PreferredSecurityScheme = JwtBearerDefaults.AuthenticationScheme,
-    Http = new HttpOptions
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("BearerAuth")
+    .AddHttpAuthentication("BearerAuth", auth =>
     {
-        Bearer = new HttpBearerOptions
-        {
-            Token = "my JWT token"
-        }
-    }
-});
+        auth.Token = "ey...";
+    });
+);
 ```
 
 This configuration preselects the `Bearer` authentication scheme in the API Reference and pre-fills the token with a given value.
 
-## OAuth Authentication
+### HTTP Basic Authentication
 
-OAuth is a widely used authorization standard that typically uses a Bearer Token to authenticate users. It supports various flows, including Authorization Code, Implicit, and Client Credentials.
+Similarly, you can set up Basic authentication using HTTP security scheme:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("BasicAuth")
+    .AddHttpAuthentication("BasicAuth", auth =>
+    {
+        auth.Username = "your-username";
+        auth.Password = "your-password";
+    })
+);
+```
+
+## OAuth2 Authentication
+
+OAuth is a widely used authorization standard that typically uses a Bearer Token to authenticate users. It supports various flows, including Authorization Code, Implicit, Client Credentials, and Password.
 
 When integrating OAuth with your API, you need to configure the appropriate OAuth flow as a security scheme in your OpenAPI document. This ensures that `Scalar.AspNetCore` can recognize and display the necessary authentication options based on the selected OAuth flow. It is possible to provide multiple flows for a security scheme.
 
@@ -141,61 +152,156 @@ options.AddDocumentTransformer((document, _, _) =>
 });
 ```
 
-This transformer ensures that the required security scheme is included in the generated OpenAPI document. Once you start your project, you will see an option in the authentication dropdown.
+### Prefilling Client Credentials Flow
 
-### Adding a Global Security Requirement for OAuth
-
-Optionally, add a security requirement to the entire OpenAPI document:
+To make authentication easier for users, you can prefill the OAuth2 client credentials flow using the new authentication approach:
 
 ```csharp
-options.AddDocumentTransformer((document, _, _) =>
-{
-    var securityScheme = new OpenApiSecurityScheme
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("OAuth")
+    .AddClientCredentialsFlow("OAuth", flow =>
     {
-        Type = SecuritySchemeType.OAuth2,
-        Flows = new OpenApiOAuthFlows
-        {
-            ClientCredentials = new OpenApiOAuthFlow
-            {
-                TokenUrl = new Uri("https://your-authorization-server.com/connect/token")
-            }
-        }
-    };
-    document.Components ??= new OpenApiComponents();
-    document.Components.SecuritySchemes.Add("OAuth", securityScheme);
-
-    // Adds a global security requirement
-    var referenceScheme = new OpenApiSecurityScheme
-    {
-        Reference = new OpenApiReference
-        {
-            Id = "OAuth",
-            Type = ReferenceType.SecurityScheme
-        }
-    };
-    
-    document.SecurityRequirements.Add(new OpenApiSecurityRequirement
-    {
-        [referenceScheme] = []
+        flow.ClientId = "your-client-id";
+        flow.ClientSecret = "your-client-secret";
+        flow.SelectedScopes = ["profile", "email"];
     });
-
-    return Task.CompletedTask;
-});
+);
 ```
 
-### Prefilling Credentials for OAuth
+This configuration preselects the `OAuth` authentication scheme in the API Reference, pre-fills the client ID and secret, and sets the default scopes.
 
-To make the usage of this scheme easier, you can prefill the `ClientId` in the `MapScalarApiReference()` method:
+### Authorization Code Flow
+
+For the Authorization Code flow, use the following configuration:
 
 ```csharp
-app.MapScalarApiReference(options => options.Authentication = new ScalarAuthenticationOptions
-{
-    PreferredSecurityScheme = "OAuth",
-    OAuth2 = new OAuth2Options
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("OAuth")
+    .AddAuthorizationCodeFlow("OAuth", flow =>
     {
-        ClientId = "your-client-id"
-    }
-});
+        flow.ClientId = "your-client-id";
+        flow.ClientSecret = "your-client-secret";
+        flow.Pkce = Pkce.Sha256; // Use PKCE for additional security
+    });
+);
 ```
 
-This configuration preselects the `OAuth` authentication scheme in the API Reference and pre-fills the token with a given value.
+### Implicit Flow
+
+For the Implicit flow, configure it like this:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("OAuth")
+    .AddImplicitFlow("OAuth", flow =>
+    {
+        flow.ClientId = "your-client-id";
+    });
+);
+```
+
+### Password Flow
+
+For the Resource Owner Password Credentials flow:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("OAuth")
+    .AddPasswordFlow("OAuth", flow =>
+    {
+        flow.ClientId = "your-client-id";
+        flow.Username = "default-username";
+        flow.Password = "default-password";
+    });
+);
+```
+
+### Multiple OAuth Flows
+
+You can configure multiple OAuth flows for the same security scheme:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("OAuth")
+    .AddOAuth2Authentication("OAuth", flows =>
+    {
+        // Configure Authorization Code flow
+        flows.AuthorizationCode = new AuthorizationCodeFlow
+        {
+            ClientId = "your-client-id"
+        };
+
+        // Configure Client Credentials flow
+        flows.ClientCredentials = new ClientCredentialsFlow
+        {
+            ClientId = "your-client-id",
+            ClientSecret = "your-client-secret"
+        };
+    })
+    // All OAuth flows will have preselected scopes
+    .AddDefaultScopes("OAuth", ["profile", "email"])
+);
+```
+
+### Overriding OpenAPI Document Values
+
+When configuring authentication, you can also override values that are defined in the OpenAPI document. This is particularly useful when you need to change URLs or other properties without modifying the OpenAPI document itself.
+
+For example, you can override the TokenUrl, AuthorizationUrl, or other endpoints defined in the OpenAPI document:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("OAuth")
+    .AddOAuth2Authentication("OAuth", flows =>
+    {
+        flows.AuthorizationCode = new AuthorizationCodeFlow
+        {
+            ClientId = "your-client-id",
+            // Override AuthorizationUrl from OpenAPI document
+            AuthorizationUrl = "https://your-custom-auth-server.com/authorize",
+            // Override TokenUrl from OpenAPI document
+            TokenUrl = "https://your-custom-auth-server.com/token",
+            // Override RedirectUri from OpenAPI document
+            RedirectUri = "https://your-app.com/custom-callback"
+        };
+    })
+);
+```
+
+## API Key Authentication
+
+For API Key authentication, configure it as follows:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("ApiKey")
+    .AddApiKeyAuthentication("ApiKey", apiKey =>
+    {
+        apiKey.Value = "your-api-key";
+    })
+);
+```
+
+## Multiple Security Schemes
+
+You can configure multiple security schemes in the same application:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("OAuth") // Set the preferred default scheme
+    .AddOAuth2Authentication("OAuth", flows =>
+    {
+        flows.AuthorizationCode = new AuthorizationCodeFlow
+        {
+            ClientId = "your-client-id"
+        };
+    })
+    .AddApiKeyAuthentication("ApiKey", apiKey =>
+    {
+        apiKey.Value = "your-api-key";
+    });
+);
+```
+
+> [!WARNING]
+> Sensitive Information: Pre-filled authentication details are exposed to the client/browser and may pose a security risk. Do not use this feature in production environments.

--- a/integrations/aspnetcore/docs/authentication.md
+++ b/integrations/aspnetcore/docs/authentication.md
@@ -152,6 +152,40 @@ options.AddDocumentTransformer((document, _, _) =>
 });
 ```
 
+### Using the Core OAuth2 Configuration Method
+
+For direct control over OAuth2 security schemes, you can use the core `AddOAuth2Authentication` method. This is the foundation that all other OAuth2 configuration methods build on:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .WithPreferredScheme("OAuth")
+    .AddOAuth2Authentication("OAuth", scheme =>
+    {
+        // Configure flows manually
+        scheme.Flows = new ScalarFlows
+        {
+            AuthorizationCode = new AuthorizationCodeFlow
+            {
+                ClientId = "your-client-id"
+            },
+            ClientCredentials = new ClientCredentialsFlow
+            {
+                ClientId = "your-client-id",
+                ClientSecret = "your-client-secret"
+            }
+        };
+        
+        // Set default scopes
+        scheme.DefaultScopes = ["profile", "email"];
+    });
+);
+```
+
+> [!NOTE]
+> All the OAuth2 convenience methods (`AddClientCredentialsFlow`, `AddAuthorizationCodeFlow`, 
+> `AddImplicitFlow`, `AddPasswordFlow`, and `AddOAuth2Flows`) are wrappers around this core method 
+> that make it easier to configure specific flows.
+
 ### Prefilling Client Credentials Flow
 
 To make authentication easier for users, you can prefill the OAuth2 client credentials flow using the new authentication approach:
@@ -167,8 +201,6 @@ app.MapScalarApiReference(options => options
     });
 );
 ```
-
-This configuration preselects the `OAuth` authentication scheme in the API Reference, pre-fills the client ID and secret, and sets the default scopes.
 
 ### Authorization Code Flow
 
@@ -223,7 +255,7 @@ You can configure multiple OAuth flows for the same security scheme:
 ```csharp
 app.MapScalarApiReference(options => options
     .WithPreferredScheme("OAuth")
-    .AddOAuth2Authentication("OAuth", flows =>
+    .AddOAuth2Flows("OAuth", flows =>
     {
         // Configure Authorization Code flow
         flows.AuthorizationCode = new AuthorizationCodeFlow
@@ -252,7 +284,7 @@ For example, you can override the TokenUrl, AuthorizationUrl, or other endpoints
 ```csharp
 app.MapScalarApiReference(options => options
     .WithPreferredScheme("OAuth")
-    .AddOAuth2Authentication("OAuth", flows =>
+    .AddOAuth2Flows("OAuth", flows =>
     {
         flows.AuthorizationCode = new AuthorizationCodeFlow
         {
@@ -289,7 +321,7 @@ You can configure multiple security schemes in the same application:
 ```csharp
 app.MapScalarApiReference(options => options
     .WithPreferredScheme("OAuth") // Set the preferred default scheme
-    .AddOAuth2Authentication("OAuth", flows =>
+    .AddOAuth2Flows("OAuth", flows =>
     {
         flows.AuthorizationCode = new AuthorizationCodeFlow
         {

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/AuthConstants.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/AuthConstants.cs
@@ -2,5 +2,5 @@ namespace Scalar.AspNetCore.Playground;
 
 internal struct AuthConstants
 {
-    internal const string ApiKey = "ApiKey";
+    internal const string ApiKeyScheme = "ApiKey";
 }

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Extensions/ServiceCollectionExtensions.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Extensions/ServiceCollectionExtensions.cs
@@ -9,8 +9,8 @@ internal static class ServiceCollectionExtensions
 {
     internal static void AddAuthenticationScheme(this IServiceCollection services)
     {
-        services.AddAuthentication(AuthConstants.ApiKey)
-            .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationSchemeHandler>(AuthConstants.ApiKey, null);
+        services.AddAuthentication(AuthConstants.ApiKeyScheme)
+            .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationSchemeHandler>(AuthConstants.ApiKeyScheme, null);
         services.AddAuthorization();
     }
 
@@ -30,7 +30,7 @@ internal static class ServiceCollectionExtensions
             services.AddOpenApi(version, options =>
             {
                 // Adds api key security scheme to the api
-                options.AddSecurityScheme(AuthConstants.ApiKey, scheme =>
+                options.AddSecurityScheme(AuthConstants.ApiKeyScheme, scheme =>
                 {
                     scheme.Type = SecuritySchemeType.ApiKey;
                     scheme.In = ParameterLocation.Header;

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
@@ -39,14 +39,13 @@ Action<ScalarOptions> configureOptions = options =>
     options
         .WithCdnUrl("https://cdn.jsdelivr.net/npm/@scalar/api-reference")
         .WithFavicon("/favicon.png")
-        .WithPreferredScheme(AuthConstants.ApiKey)
-        .WithApiKeyAuthentication(x => x.Token = "my-api-key")
+        .WithPreferredScheme(AuthConstants.ApiKeyScheme)
+        .AddApiKeyAuthentication(AuthConstants.ApiKeyScheme, scheme => scheme.Value = "my-api-key")
         .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient);
 
-app.MapScalarApiReference((options, context) =>
+app.MapScalarApiReference(options =>
 {
     configureOptions.Invoke(options);
-    options.Title = context.Request.Path;
     options.WithTheme(ScalarTheme.Mars);
 });
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Converters/PkceJsonConverter.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Converters/PkceJsonConverter.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Scalar.AspNetCore;
+
+internal sealed class PkceJsonConverter : JsonConverter<Pkce>
+{
+    public override Pkce Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        // We don't have to implement this method because we don't need to deserialize the Pkce enum.
+        return default;
+    }
+
+    public override void Write(Utf8JsonWriter writer, Pkce value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToStringFast(true));
+    }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/Pkce.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/Pkce.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel;
+using NetEscapades.EnumGenerators;
+
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents the Proof Key for Code Exchange (PKCE) method types used in the OAuth 2 authorization code flow.
+/// </summary>
+[EnumExtensions]
+public enum Pkce
+{
+    /// <summary>
+    /// Disables PKCE.
+    /// </summary>
+    [Description("no")]
+    No,
+
+    /// <summary>
+    /// Uses plain code challenge method.
+    /// </summary>
+    [Description("plain")]
+    Plain,
+
+    /// <summary>
+    /// Uses SHA-256 code challenge method.
+    /// </summary>
+    [Description("SHA-256")]
+    Sha256
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTheme.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTheme.cs
@@ -73,5 +73,11 @@ public enum ScalarTheme
     /// Deep Space theme.
     /// </summary>
     [Description("deepSpace")]
-    DeepSpace
+    DeepSpace,
+    
+    /// <summary>
+    /// Laserwave theme.
+    /// </summary>
+    [Description("laserwave")]
+    Laserwave
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -327,6 +327,10 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="apiKeyOptions">The API key options to set.</param>
+    /// <remarks>
+    /// This method is obsolete and will be removed in a future release. Use <see cref="AddApiKeyAuthentication" /> instead.
+    /// </remarks>
+    [Obsolete("This method is obsolete and will be removed in a future release. Use AddApiKeyAuthentication instead.")]
     public static ScalarOptions WithApiKeyAuthentication(this ScalarOptions options, ApiKeyOptions apiKeyOptions)
     {
         options.Authentication ??= new ScalarAuthenticationOptions();
@@ -339,6 +343,10 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="configureApiKeyOptions">The action to configure the API key options.</param>
+    /// <remarks>
+    /// This method is obsolete and will be removed in a future release. Use <see cref="AddApiKeyAuthentication" /> instead.
+    /// </remarks>
+    [Obsolete("This method is obsolete and will be removed in a future release. Use AddApiKeyAuthentication instead.")]
     public static ScalarOptions WithApiKeyAuthentication(this ScalarOptions options, Action<ApiKeyOptions> configureApiKeyOptions)
     {
         var apiKeyOptions = new ApiKeyOptions();
@@ -351,6 +359,10 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="oauth2Options">The OAuth2 options to set.</param>
+    /// <remarks>
+    /// This method is obsolete and will be removed in a future release. Use <see cref="AddClientCredentialsFlow" /> or <see cref="AddAuthorizationCodeFlow" /> instead.
+    /// </remarks>
+    [Obsolete("This method is obsolete and will be removed in a future release. Use AddClientCredentialsAuthentication or AddAuthorizationCodeAuthentication instead.")]
     public static ScalarOptions WithOAuth2Authentication(this ScalarOptions options, OAuth2Options oauth2Options)
     {
         options.Authentication ??= new ScalarAuthenticationOptions();
@@ -363,6 +375,10 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="configureOAuth2Options">The action to configure the OAuth2 options.</param>
+    /// <remarks>
+    /// This method is obsolete and will be removed in a future release. Use <see cref="AddClientCredentialsFlow" /> or <see cref="AddAuthorizationCodeFlow" /> instead.
+    /// </remarks>
+    [Obsolete("This method is obsolete and will be removed in a future release. Use AddClientCredentialsAuthentication or AddAuthorizationCodeAuthentication instead.")]
     public static ScalarOptions WithOAuth2Authentication(this ScalarOptions options, Action<OAuth2Options> configureOAuth2Options)
     {
         var oauth2Options = new OAuth2Options();
@@ -375,6 +391,10 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="httpBasicOptions">The HTTP basic options to set.</param>
+    /// <remarks>
+    /// This method is obsolete and will be removed in a future release. Use <see cref="AddHttpAuthentication" /> instead.
+    /// </remarks>
+    [Obsolete("This method is obsolete and will be removed in a future release. Use AddHttpBasicAuthentication instead.")]
     public static ScalarOptions WithHttpBasicAuthentication(this ScalarOptions options, HttpBasicOptions httpBasicOptions)
     {
         options.Authentication ??= new ScalarAuthenticationOptions();
@@ -388,6 +408,10 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="configureHttpBasicOptions">The action to configure the HTTP basic options.</param>
+    /// <remarks>
+    /// This method is obsolete and will be removed in a future release. Use <see cref="AddHttpAuthentication" /> instead.
+    /// </remarks>
+    [Obsolete("This method is obsolete and will be removed in a future release. Use AddHttpBasicAuthentication instead.")]
     public static ScalarOptions WithHttpBasicAuthentication(this ScalarOptions options, Action<HttpBasicOptions> configureHttpBasicOptions)
     {
         var httpBasicOptions = new HttpBasicOptions();
@@ -400,6 +424,10 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="httpBearerOptions">The HTTP bearer options to set.</param>
+    /// <remarks>
+    /// This method is obsolete and will be removed in a future release. Use <see cref="AddHttpAuthentication" /> instead.
+    /// </remarks>
+    [Obsolete("This method is obsolete and will be removed in a future release. Use AddHttpAuthentication instead.")]
     public static ScalarOptions WithHttpBearerAuthentication(this ScalarOptions options, HttpBearerOptions httpBearerOptions)
     {
         options.Authentication ??= new ScalarAuthenticationOptions();
@@ -413,11 +441,194 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="configureHttpBearerOptions">The action to configure the HTTP bearer options.</param>
+    /// <remarks>
+    /// This method is obsolete and will be removed in a future release. Use <see cref="AddHttpAuthentication" /> instead.
+    /// </remarks>
+    [Obsolete("This method is obsolete and will be removed in a future release. Use AddHttpAuthentication instead.")]
     public static ScalarOptions WithHttpBearerAuthentication(this ScalarOptions options, Action<HttpBearerOptions> configureHttpBearerOptions)
     {
         var httpBearerOptions = new HttpBearerOptions();
         configureHttpBearerOptions(httpBearerOptions);
         return options.WithHttpBearerAuthentication(httpBearerOptions);
+    }
+
+    /// <summary>
+    /// Sets default scopes to be requested for a specific OAuth2 security scheme during authentication.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="securitySchemeName">The name of the security scheme as defined in the OpenAPI document.</param>
+    /// <param name="scopes">A collection of scopes to request by default.</param>
+    /// <remarks>
+    /// Default scopes are pre-selected in the UI when the user initiates an OAuth2 authentication flow.
+    /// If the specified security scheme does not exist, a new one will be created.
+    /// </remarks>
+    public static ScalarOptions AddDefaultScopes(this ScalarOptions options, string securitySchemeName, params IEnumerable<string> scopes)
+    {
+        options.Authentication ??= new ScalarAuthenticationOptions();
+        options.Authentication.SecuritySchemes ??= new Dictionary<string, ScalarSecurityScheme>();
+
+        if (options.Authentication.SecuritySchemes.TryGetValue(securitySchemeName, out var existingScheme) && existingScheme is ScalarOAuth2SecurityScheme existingOAuth2Scheme)
+        {
+            existingOAuth2Scheme.DefaultScopes = scopes;
+            return options;
+        }
+
+        options.Authentication.SecuritySchemes[securitySchemeName] = new ScalarOAuth2SecurityScheme
+        {
+            DefaultScopes = scopes
+        };
+
+        return options;
+    }
+
+    /// <summary>
+    /// Adds OAuth2 authentication configuration for a specific security scheme.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="securitySchemeName">The name of the security scheme as defined in the OpenAPI document.</param>
+    /// <param name="configureFlows">An action to configure the OAuth2 flows.</param>
+    /// <remarks>
+    /// This method allows you to configure different OAuth2 flows for the specified security scheme.
+    /// If the security scheme already exists and is an OAuth2 scheme, the existing configuration will be updated.
+    /// </remarks>
+    public static ScalarOptions AddOAuth2Authentication(this ScalarOptions options, string securitySchemeName, Action<ScalarFlows> configureFlows)
+    {
+        options.Authentication ??= new ScalarAuthenticationOptions();
+        options.Authentication.SecuritySchemes ??= new Dictionary<string, ScalarSecurityScheme>();
+
+
+        // Check if the security scheme already exists
+        if (options.Authentication.SecuritySchemes.TryGetValue(securitySchemeName, out var existingScheme) &&
+            existingScheme is ScalarOAuth2SecurityScheme existingOAuth2Scheme)
+        {
+            // If it exists and is an OAuth2 scheme, configure the existing flows
+            existingOAuth2Scheme.Flows ??= new ScalarFlows();
+            configureFlows(existingOAuth2Scheme.Flows);
+            return options;
+        }
+
+        // If it doesn't exist or is not an OAuth2 scheme, create a new one
+        var flows = new ScalarFlows();
+        configureFlows(flows);
+
+        options.Authentication.SecuritySchemes[securitySchemeName] = new ScalarOAuth2SecurityScheme
+        {
+            Flows = flows
+        };
+
+        return options;
+    }
+
+    /// <summary>
+    /// Adds OAuth2 client credentials authentication configuration for a specific security scheme.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="securitySchemeName">The name of the security scheme as defined in the OpenAPI document.</param>
+    /// <param name="configureFlow">An action to configure the flow.</param>
+    public static ScalarOptions AddClientCredentialsFlow(this ScalarOptions options, string securitySchemeName, Action<ClientCredentialsFlow> configureFlow)
+    {
+        return options.AddOAuth2Authentication(securitySchemeName, flows =>
+        {
+            flows.ClientCredentials ??= new ClientCredentialsFlow();
+            configureFlow(flows.ClientCredentials);
+        });
+    }
+
+
+    /// <summary>
+    /// Adds OAuth2 authorization code authentication configuration for a specific security scheme.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="securitySchemeName">The name of the security scheme as defined in the OpenAPI document.</param>
+    /// <param name="configureFlow">An action to configure the flow.</param>
+    public static ScalarOptions AddAuthorizationCodeFlow(this ScalarOptions options, string securitySchemeName, Action<AuthorizationCodeFlow> configureFlow)
+    {
+        return options.AddOAuth2Authentication(securitySchemeName, flows =>
+        {
+            flows.AuthorizationCode ??= new AuthorizationCodeFlow();
+            configureFlow(flows.AuthorizationCode);
+        });
+    }
+
+    /// <summary>
+    /// Adds OAuth2 implicit flow authentication configuration for a specific security scheme.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="securitySchemeName">The name of the security scheme as defined in the OpenAPI document.</param>
+    /// <param name="configureFlow">An action to configure the implicit flow.</param>
+    public static ScalarOptions AddImplicitFlow(this ScalarOptions options, string securitySchemeName, Action<ImplicitFlow> configureFlow)
+    {
+        return options.AddOAuth2Authentication(securitySchemeName, flows =>
+        {
+            flows.Implicit ??= new ImplicitFlow();
+            configureFlow(flows.Implicit);
+        });
+    }
+
+    /// <summary>
+    /// Adds OAuth2 password flow authentication configuration for a specific security scheme.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="securitySchemeName">The name of the security scheme as defined in the OpenAPI document.</param>
+    /// <param name="configureFlow">An action to configure the password flow.</param>
+    public static ScalarOptions AddPasswordFlow(this ScalarOptions options, string securitySchemeName, Action<PasswordFlow> configureFlow)
+    {
+        return options.AddOAuth2Authentication(securitySchemeName, flows =>
+        {
+            flows.Password ??= new PasswordFlow();
+            configureFlow(flows.Password);
+        });
+    }
+
+    /// <summary>
+    /// Adds API key authentication configuration for a specific security scheme.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="securitySchemeName">The name of the security scheme as defined in the OpenAPI document.</param>
+    /// <param name="configureAuth">An action to configure the API key authentication.</param>
+    public static ScalarOptions AddApiKeyAuthentication(this ScalarOptions options, string securitySchemeName, Action<ScalarApiKeySecurityScheme> configureAuth)
+    {
+        options.Authentication ??= new ScalarAuthenticationOptions();
+        options.Authentication.SecuritySchemes ??= new Dictionary<string, ScalarSecurityScheme>();
+
+        if (options.Authentication.SecuritySchemes.TryGetValue(securitySchemeName, out var existingScheme) && existingScheme is ScalarApiKeySecurityScheme existingHttpScheme)
+        {
+            configureAuth(existingHttpScheme);
+            return options;
+        }
+        
+        var headerScheme = new ScalarApiKeySecurityScheme();
+        configureAuth(headerScheme);
+
+        options.Authentication.SecuritySchemes[securitySchemeName] = headerScheme;
+
+        return options;
+    }
+
+    /// <summary>
+    /// Adds HTTP basic authentication configuration for a specific security scheme.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="securitySchemeName">The name of the security scheme as defined in the OpenAPI document.</param>
+    /// <param name="configureAuth">An action to configure the HTTP authentication.</param>
+    public static ScalarOptions AddHttpAuthentication(this ScalarOptions options, string securitySchemeName, Action<ScalarHttpSecurityScheme> configureAuth)
+    {
+        options.Authentication ??= new ScalarAuthenticationOptions();
+        options.Authentication.SecuritySchemes ??= new Dictionary<string, ScalarSecurityScheme>();
+
+
+        if (options.Authentication.SecuritySchemes.TryGetValue(securitySchemeName, out var existingScheme) && existingScheme is ScalarHttpSecurityScheme existingHttpScheme)
+        {
+            configureAuth(existingHttpScheme);
+            return options;
+        }
+
+        var httpScheme = new ScalarHttpSecurityScheme();
+        configureAuth(httpScheme);
+
+        options.Authentication.SecuritySchemes[securitySchemeName] = httpScheme;
+
+        return options;
     }
 
     /// <summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/ApiKeyOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/ApiKeyOptions.cs
@@ -3,6 +3,7 @@ namespace Scalar.AspNetCore;
 /// <summary>
 /// Represents the options for API key authentication.
 /// </summary>
+[Obsolete("This class is obsolete and will be removed in a future release. Use AddApiKeyAuthentication with ScalarApiKeySecurityScheme instead.")]
 public sealed class ApiKeyOptions
 {
     /// <summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/AuthorizationCodeFlow.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/AuthorizationCodeFlow.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents the OAuth2 Authorization Code flow configuration.
+/// </summary>
+public sealed class AuthorizationCodeFlow : OAuthFlow
+{
+    /// <summary>
+    /// Gets or sets the authorization URL to be used for this flow.
+    /// </summary>
+    public string? AuthorizationUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the token URL to be used for this flow.
+    /// </summary>
+    public string? TokenUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client secret used for authentication.
+    /// </summary>
+    public string? ClientSecret { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to use PKCE (Proof Key for Code Exchange) for the authorization code flow.
+    /// </summary>
+    [JsonPropertyName("x-usePkce")]
+    [JsonConverter(typeof(PkceJsonConverter))]
+    public Pkce Pkce { get; set; }
+
+    /// <summary>
+    /// Gets or sets the redirect URI for the authorization code flow.
+    /// </summary>
+    [JsonPropertyName("x-scalar-redirect-uri")]
+    public string? RedirectUri { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/ClientCredentialsFlow.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/ClientCredentialsFlow.cs
@@ -1,0 +1,17 @@
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents the OAuth2 Client Credentials flow configuration.
+/// </summary>
+public sealed class ClientCredentialsFlow : OAuthFlow
+{
+    /// <summary>
+    /// Gets or sets the token URL to be used for this flow.
+    /// </summary>
+    public string? TokenUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client secret used for authentication.
+    /// </summary>
+    public string? ClientSecret { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/ImplicitFlow.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/ImplicitFlow.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents the OAuth2 Implicit flow configuration.
+/// </summary>
+public sealed class ImplicitFlow : OAuthFlow
+{
+    /// <summary>
+    /// Gets or sets the authorization URL to be used for this flow.
+    /// </summary>
+    public string? AuthorizationUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the redirect URI for the implicit flow.
+    /// </summary>
+    [JsonPropertyName("x-scalar-redirect-uri")]
+    public string? RedirectUri { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/OAuthFlow.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/OAuthFlow.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Base class containing common properties for all OAuth2 flows.
+/// </summary>
+public abstract class OAuthFlow
+{
+    /// <summary>
+    /// Gets or sets the URL to be used for obtaining refresh tokens.
+    /// </summary>
+    public string? RefreshUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the preselected scopes for the request.
+    /// </summary>
+    public IEnumerable<string>? SelectedScopes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client ID associated with the OAuth flow.
+    /// </summary>
+    [JsonPropertyName("x-scalar-client-id")]
+    public string? ClientId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authentication token.
+    /// </summary>
+    public string? Token { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/PasswordFlow.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/PasswordFlow.cs
@@ -1,0 +1,27 @@
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents the OAuth2 Resource Owner Password flow configuration.
+/// </summary>
+public sealed class PasswordFlow : OAuthFlow
+{
+    /// <summary>
+    /// Gets or sets the token URL to be used for this flow.
+    /// </summary>
+    public string? TokenUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client secret used for authentication.
+    /// </summary>
+    public string? ClientSecret { get; set; }
+
+    /// <summary>
+    /// Gets or sets the username used for authentication.
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Gets or sets the password used for authentication.
+    /// </summary>
+    public string? Password { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/ScalarFlows.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/ScalarFlows.cs
@@ -1,0 +1,32 @@
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents the available OAuth 2.0 flows for authentication.
+/// </summary>
+/// <remarks>
+/// This class defines the different OAuth 2.0 flow types that can be used for authentication.
+/// Each flow type has its own configuration properties that are used to prefill or overwrite
+/// values during the authentication process.
+/// </remarks>
+public sealed class ScalarFlows
+{
+    /// <summary>
+    /// Gets or sets the implicit flow configuration.
+    /// </summary>
+    public ImplicitFlow? Implicit { get; set; }
+
+    /// <summary>
+    /// Gets or sets the password flow configuration.
+    /// </summary>
+    public PasswordFlow? Password { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client credentials flow configuration.
+    /// </summary>
+    public ClientCredentialsFlow? ClientCredentials { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authorization code flow configuration.
+    /// </summary>
+    public AuthorizationCodeFlow? AuthorizationCode { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpBasicOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpBasicOptions.cs
@@ -3,6 +3,7 @@ namespace Scalar.AspNetCore;
 /// <summary>
 /// Represents the options for HTTP basic authentication.
 /// </summary>
+[Obsolete("This class is obsolete and will be removed in a future release. Use AddHttpBasicAuthentication with ScalarHttpSecurityScheme instead.")]
 public sealed class HttpBasicOptions
 {
     /// <summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpBearerOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpBearerOptions.cs
@@ -3,6 +3,7 @@ namespace Scalar.AspNetCore;
 /// <summary>
 /// Represents the options for HTTP bearer authentication.
 /// </summary>
+[Obsolete("This class is obsolete and will be removed in a future release. Use AddHttpBasicAuthentication with ScalarHttpSecurityScheme instead.")]
 public sealed class HttpBearerOptions
 {
     /// <summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/HttpOptions.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Represents the options for HTTP authentication.
 /// </summary>
+[Obsolete("This class is obsolete and will be removed in a future release. Use AddHttpBasicAuthentication with ScalarHttpSecurityScheme instead.")]
 public sealed class HttpOptions
 {
     /// <summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/OAuth2Options.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/OAuth2Options.cs
@@ -3,6 +3,18 @@ namespace Scalar.AspNetCore;
 /// <summary>
 /// Represents the options for OAuth2 authentication.
 /// </summary>
+/// <remarks>
+/// This class is obsolete and will be removed in a future release.
+/// Instead of using this class, consider using one of the following extension methods:
+/// <list type="bullet">
+/// <item><description><see cref="ScalarOptionsExtensions.AddClientCredentialsFlow"/></description></item>
+/// <item><description><see cref="ScalarOptionsExtensions.AddAuthorizationCodeFlow"/></description></item>
+/// <item><description><see cref="ScalarOptionsExtensions.AddImplicitFlow"/></description></item>
+/// <item><description><see cref="ScalarOptionsExtensions.AddPasswordFlow"/></description></item>
+/// <item><description><see cref="ScalarOptionsExtensions.AddOAuth2Authentication"/></description></item>
+/// </list>
+/// </remarks>
+[Obsolete("This class is obsolete and will be removed in a future release. Use AddClientCredentialsFlow, AddAuthorizationCodeFlow, AddImplicitFlow, AddPasswordFlow or AddOAuth2Authentication instead.")]
 public sealed class OAuth2Options
 {
     /// <summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/OAuth2Options.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/OAuth2Options.cs
@@ -11,10 +11,11 @@ namespace Scalar.AspNetCore;
 /// <item><description><see cref="ScalarOptionsExtensions.AddAuthorizationCodeFlow"/></description></item>
 /// <item><description><see cref="ScalarOptionsExtensions.AddImplicitFlow"/></description></item>
 /// <item><description><see cref="ScalarOptionsExtensions.AddPasswordFlow"/></description></item>
+/// <item><description><see cref="ScalarOptionsExtensions.AddOAuth2Flows"/></description></item>
 /// <item><description><see cref="ScalarOptionsExtensions.AddOAuth2Authentication"/></description></item>
 /// </list>
 /// </remarks>
-[Obsolete("This class is obsolete and will be removed in a future release. Use AddClientCredentialsFlow, AddAuthorizationCodeFlow, AddImplicitFlow, AddPasswordFlow or AddOAuth2Authentication instead.")]
+[Obsolete("This class is obsolete and will be removed in a future release. Use AddClientCredentialsFlow, AddAuthorizationCodeFlow, AddImplicitFlow, AddPasswordFlow, AddOAuth2Flows or AddOAuth2Authentication instead.")]
 public sealed class OAuth2Options
 {
     /// <summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/ScalarAuthenticationOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/ScalarAuthenticationOptions.cs
@@ -16,6 +16,7 @@ public sealed class ScalarAuthenticationOptions
     /// This can be used if the OpenApi document has a API key security scheme.
     /// </summary>
     /// <value>The default value is <c>null</c>.</value>
+    [Obsolete("This property is obsolete and will be removed in a future release. Use SecuritySchemes property to configure API key authentication instead.")]
     public ApiKeyOptions? ApiKey { get; set; }
 
     /// <summary>
@@ -23,6 +24,7 @@ public sealed class ScalarAuthenticationOptions
     /// This can be used if the OpenApi document has a OAuth2 security scheme.
     /// </summary>
     /// <value>The default value is <c>null</c>.</value>
+    [Obsolete("This property is obsolete and will be removed in a future release. Use SecuritySchemes property to configure OAuth2 authentication instead.")]
     public OAuth2Options? OAuth2 { get; set; }
 
     /// <summary>
@@ -30,5 +32,16 @@ public sealed class ScalarAuthenticationOptions
     /// This can be used if the OpenApi document has a HTTP security scheme.
     /// </summary>
     /// <value>The default value is <c>null</c>.</value>
+    [Obsolete("This property is obsolete and will be removed in a future release. Use SecuritySchemes property to configure HTTP authentication instead.")]
     public HttpOptions? Http { get; set; }
+
+    /// <summary>
+    /// Gets or sets the security schemes dictionary.
+    /// This dictionary allows configuring multiple security schemes by name,
+    /// enabling more flexible authentication configuration for OpenAPI operations.
+    /// The key represents the security scheme name as defined in the OpenAPI document,
+    /// and the value contains the configuration for that specific security scheme.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public IDictionary<string, ScalarSecurityScheme>? SecuritySchemes { get; set; }
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Schemes/ScalarApiKeySecurityScheme.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Schemes/ScalarApiKeySecurityScheme.cs
@@ -1,0 +1,27 @@
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents a security scheme that uses HTTP header authentication.
+/// </summary>
+/// <remarks>
+/// This scheme is used to prefill or overwrite HTTP header values for authentication purposes
+/// when making API requests. It allows specifying a custom header name and value pair.
+/// </remarks>
+public sealed class ScalarApiKeySecurityScheme : ScalarSecurityScheme
+{
+    /// <summary>
+    /// Gets or sets the name of the HTTP header to be used for authentication.
+    /// </summary>
+    /// <remarks>
+    /// Common examples include "Authorization", "X-API-Key", or custom header names.
+    /// </remarks>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of the HTTP header to be used for authentication.
+    /// </summary>
+    /// <remarks>
+    /// This value will be sent as-is in the specified header. For example, "Bearer token123" or "ApiKey abc123".
+    /// </remarks>
+    public string? Value { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Schemes/ScalarHttpSecurityScheme.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Schemes/ScalarHttpSecurityScheme.cs
@@ -1,0 +1,41 @@
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents a security scheme that uses HTTP authentication mechanisms like Basic or Bearer.
+/// </summary>
+/// <remarks>
+/// This scheme is used to prefill or overwrite authentication values.
+/// It supports both Basic authentication (username/password) and Bearer authentication (token).
+/// </remarks>
+public sealed class ScalarHttpSecurityScheme : ScalarSecurityScheme
+{
+    /// <summary>
+    /// Gets or sets the username used for HTTP basic authentication.
+    /// </summary>
+    /// <remarks>
+    /// When provided, this value will be used to prefill or overwrite the username
+    /// for Basic authentication requests.
+    /// </remarks>
+    /// <value>The default value is <c>null</c>.</value>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Gets or sets the password used for HTTP basic authentication.
+    /// </summary>
+    /// <remarks>
+    /// When provided, this value will be used to prefill or overwrite the password
+    /// for Basic authentication requests.
+    /// </remarks>
+    /// <value>The default value is <c>null</c>.</value>
+    public string? Password { get; set; }
+
+    /// <summary>
+    /// Gets or sets the token used for HTTP bearer authentication.
+    /// </summary>
+    /// <remarks>
+    /// When provided, this value will be used to prefill or overwrite the token
+    /// for Bearer authentication requests.
+    /// </remarks>
+    /// <value>The default value is <c>null</c>.</value>
+    public string? Token { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Schemes/ScalarOAuth2SecurityScheme.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Schemes/ScalarOAuth2SecurityScheme.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents a security scheme that uses OAuth 2.0 authentication.
+/// </summary>
+/// <remarks>
+/// This scheme is used to prefill or overwrite OAuth 2.0 authentication values
+/// when making API requests. It specifies flows and default scopes to be used
+/// during the authorization process.
+/// </remarks>
+public sealed class ScalarOAuth2SecurityScheme : ScalarSecurityScheme
+{
+    /// <summary>
+    /// Gets or sets the OAuth 2.0 flows configuration for this security scheme.
+    /// </summary>
+    /// <remarks>
+    /// Contains configuration for different OAuth flow types like implicit, password,
+    /// client credentials, or authorization code. The configured flows determine how
+    /// the authentication process is handled.
+    /// </remarks>
+    public ScalarFlows? Flows { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default OAuth 2.0 scopes to request during authorization.
+    /// </summary>
+    /// <remarks>
+    /// These scopes are prefilled or used to overwrite the requested scopes when initiating
+    /// the OAuth flow.
+    /// </remarks>
+    [JsonPropertyName("x-default-scopes")]
+    public IEnumerable<string>? DefaultScopes { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Schemes/ScalarSecurityScheme.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Schemes/ScalarSecurityScheme.cs
@@ -8,4 +8,10 @@ namespace Scalar.AspNetCore;
 [JsonDerivedType(typeof(ScalarHttpSecurityScheme))]
 [JsonDerivedType(typeof(ScalarApiKeySecurityScheme))]
 [JsonDerivedType(typeof(ScalarOAuth2SecurityScheme))]
-public abstract class ScalarSecurityScheme;
+public abstract class ScalarSecurityScheme
+{
+    /// <summary>
+    /// Gets or sets the description of this security scheme.
+    /// </summary>
+    public string? Description { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Schemes/ScalarSecurityScheme.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Schemes/ScalarSecurityScheme.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Represents the base class for security schemes in Scalar.
+/// </summary>
+[JsonDerivedType(typeof(ScalarHttpSecurityScheme))]
+[JsonDerivedType(typeof(ScalarApiKeySecurityScheme))]
+[JsonDerivedType(typeof(ScalarOAuth2SecurityScheme))]
+public abstract class ScalarSecurityScheme;

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/PkceConverterTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/PkceConverterTests.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+
+namespace Scalar.AspNetCore.Tests;
+
+public class PkceConverterTests
+{
+    [Fact]
+    public void Converter_ShouldSerializeToStringFast()
+    {
+        // Arrange
+        var authorizationCodeFlow = new AuthorizationCodeFlow
+        {
+            Pkce = Pkce.Sha256
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(authorizationCodeFlow, typeof(AuthorizationCodeFlow), ScalarConfigurationSerializerContext.Default);
+
+        // Assert
+        json.Should().Contain("\"SHA-256\"");
+    }
+}

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -64,7 +64,7 @@ public class ScalarOptionsExtensionsTests
         // Assert
         options.Title.Should().Be("My title");
         options.EndpointPathPrefix.Should().Be("/docs/{documentName}");
-#pragma warning restore CS0618 // Type or member is obsolete
+
         options.HideModels.Should().BeTrue();
         options.HideDownloadButton.Should().BeTrue();
         options.HideTestRequestButton.Should().BeTrue();
@@ -105,5 +105,297 @@ public class ScalarOptionsExtensionsTests
         options.Documents.Should().HaveCount(3).And.Contain(x => x.Title == "Version 1");
         options.BaseServerUrl.Should().Be("https://example.com");
         options.DynamicBaseServerUrl.Should().BeTrue();
+
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    [Fact]
+    public void AddDefaultScopes_ShouldAddScopesToScheme()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+        string[] scopes = ["scope1", "scope2"];
+
+        // Act
+        options.AddDefaultScopes("oauth2Scheme", scopes);
+
+        // Assert
+        options.Authentication.Should().NotBeNull();
+        options.Authentication!.SecuritySchemes.Should().NotBeNull();
+        options.Authentication!.SecuritySchemes.Should().ContainKey("oauth2Scheme");
+        var scheme = options.Authentication!.SecuritySchemes["oauth2Scheme"];
+        scheme.Should().BeOfType<ScalarOAuth2SecurityScheme>();
+        var oauth2Scheme = scheme as ScalarOAuth2SecurityScheme;
+        oauth2Scheme!.DefaultScopes.Should().BeEquivalentTo(scopes);
+    }
+
+    [Fact]
+    public void AddDefaultScopes_ShouldUpdateExistingScheme()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+        string[] initialScopes = ["scope1"];
+        string[] updatedScopes = ["scope2", "scope3"];
+        options.AddDefaultScopes("oauth2Scheme", initialScopes);
+
+        // Act
+        options.AddDefaultScopes("oauth2Scheme", updatedScopes);
+
+        // Assert
+        var oauth2Scheme = options.Authentication!.SecuritySchemes!["oauth2Scheme"] as ScalarOAuth2SecurityScheme;
+        oauth2Scheme!.DefaultScopes.Should().BeEquivalentTo(updatedScopes);
+    }
+
+    [Fact]
+    public void AddOAuth2Authentication_ShouldConfigureFlows()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.AddOAuth2Authentication("oauth2Scheme", flows =>
+        {
+            flows.AuthorizationCode = new AuthorizationCodeFlow
+            {
+                AuthorizationUrl = "https://auth.example.com/authorize",
+                TokenUrl = "https://auth.example.com/token",
+                ClientId = "clientId",
+                ClientSecret = "clientSecret",
+                RedirectUri = "https://auth.example.com/callback",
+                SelectedScopes = ["foo"],
+                Token = "token"
+            };
+        });
+
+        // Assert
+        options.Authentication.Should().NotBeNull();
+        options.Authentication!.SecuritySchemes.Should().ContainKey("oauth2Scheme");
+        var scheme = options.Authentication!.SecuritySchemes["oauth2Scheme"];
+        scheme.Should().BeOfType<ScalarOAuth2SecurityScheme>();
+        var oauth2Scheme = scheme as ScalarOAuth2SecurityScheme;
+        oauth2Scheme!.Flows.Should().NotBeNull();
+        oauth2Scheme.Flows!.AuthorizationCode.Should().NotBeNull();
+        oauth2Scheme.Flows!.AuthorizationCode!.AuthorizationUrl.Should().Be("https://auth.example.com/authorize");
+        oauth2Scheme.Flows!.AuthorizationCode!.TokenUrl.Should().Be("https://auth.example.com/token");
+        oauth2Scheme.Flows!.AuthorizationCode!.ClientId.Should().Be("clientId");
+        oauth2Scheme.Flows!.AuthorizationCode!.ClientSecret.Should().Be("clientSecret");
+        oauth2Scheme.Flows!.AuthorizationCode!.RedirectUri.Should().Be("https://auth.example.com/callback");
+        oauth2Scheme.Flows!.AuthorizationCode!.SelectedScopes.Should().Contain("foo");
+        oauth2Scheme.Flows!.AuthorizationCode!.Token.Should().Be("token");
+    }
+
+    [Fact]
+    public void AddClientCredentialsFlow_ShouldConfigureClientCredentialsFlow()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.AddClientCredentialsFlow("oauth2Scheme", flow =>
+        {
+            flow.TokenUrl = "https://auth.example.com/token";
+            flow.RefreshUrl = "https://auth.example.com/refresh";
+            flow.ClientId = "clientId";
+            flow.ClientSecret = "clientSecret";
+        });
+
+        // Assert
+        options.Authentication.Should().NotBeNull();
+        options.Authentication!.SecuritySchemes.Should().ContainKey("oauth2Scheme");
+        var scheme = options.Authentication!.SecuritySchemes["oauth2Scheme"];
+        scheme.Should().BeOfType<ScalarOAuth2SecurityScheme>();
+        var oauth2Scheme = scheme as ScalarOAuth2SecurityScheme;
+        oauth2Scheme!.Flows.Should().NotBeNull();
+        oauth2Scheme.Flows!.ClientCredentials.Should().NotBeNull();
+        oauth2Scheme.Flows!.ClientCredentials!.TokenUrl.Should().Be("https://auth.example.com/token");
+        oauth2Scheme.Flows!.ClientCredentials!.RefreshUrl.Should().Be("https://auth.example.com/refresh");
+        oauth2Scheme.Flows!.ClientCredentials!.ClientId.Should().Be("clientId");
+        oauth2Scheme.Flows!.ClientCredentials!.ClientSecret.Should().Be("clientSecret");
+    }
+
+    [Fact]
+    public void AddAuthorizationCodeFlow_ShouldConfigureAuthorizationCodeFlow()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.AddAuthorizationCodeFlow("oauth2Scheme", flow =>
+        {
+            flow.AuthorizationUrl = "https://auth.example.com/authorize";
+            flow.TokenUrl = "https://auth.example.com/token";
+            flow.RefreshUrl = "https://auth.example.com/refresh";
+        });
+
+        // Assert
+        options.Authentication.Should().NotBeNull();
+        options.Authentication!.SecuritySchemes.Should().ContainKey("oauth2Scheme");
+        var scheme = options.Authentication!.SecuritySchemes["oauth2Scheme"];
+        scheme.Should().BeOfType<ScalarOAuth2SecurityScheme>();
+        var oauth2Scheme = scheme as ScalarOAuth2SecurityScheme;
+        oauth2Scheme!.Flows.Should().NotBeNull();
+        oauth2Scheme.Flows!.AuthorizationCode.Should().NotBeNull();
+        oauth2Scheme.Flows!.AuthorizationCode!.AuthorizationUrl.Should().Be("https://auth.example.com/authorize");
+        oauth2Scheme.Flows!.AuthorizationCode!.TokenUrl.Should().Be("https://auth.example.com/token");
+        oauth2Scheme.Flows!.AuthorizationCode!.RefreshUrl.Should().Be("https://auth.example.com/refresh");
+    }
+
+    [Fact]
+    public void AddImplicitFlow_ShouldConfigureImplicitFlow()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.AddImplicitFlow("oauth2Scheme", flow =>
+        {
+            flow.AuthorizationUrl = "https://auth.example.com/authorize";
+            flow.RefreshUrl = "https://auth.example.com/refresh";
+            flow.RedirectUri = "https://auth.example.com/callback";
+        });
+
+        // Assert
+        options.Authentication.Should().NotBeNull();
+        options.Authentication!.SecuritySchemes.Should().ContainKey("oauth2Scheme");
+        var scheme = options.Authentication!.SecuritySchemes["oauth2Scheme"];
+        scheme.Should().BeOfType<ScalarOAuth2SecurityScheme>();
+        var oauth2Scheme = scheme as ScalarOAuth2SecurityScheme;
+        oauth2Scheme!.Flows.Should().NotBeNull();
+        oauth2Scheme.Flows!.Implicit.Should().NotBeNull();
+        oauth2Scheme.Flows!.Implicit!.AuthorizationUrl.Should().Be("https://auth.example.com/authorize");
+        oauth2Scheme.Flows!.Implicit!.RefreshUrl.Should().Be("https://auth.example.com/refresh");
+        oauth2Scheme.Flows!.Implicit!.RedirectUri.Should().Be("https://auth.example.com/callback");
+    }
+
+    [Fact]
+    public void AddPasswordFlow_ShouldConfigurePasswordFlow()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.AddPasswordFlow("oauth2Scheme", flow =>
+        {
+            flow.TokenUrl = "https://auth.example.com/token";
+            flow.RefreshUrl = "https://auth.example.com/refresh";
+            flow.ClientId = "clientId";
+            flow.ClientSecret = "clientSecret";
+            flow.Username = "username";
+            flow.Password = "password";
+        });
+
+        // Assert
+        options.Authentication.Should().NotBeNull();
+        options.Authentication!.SecuritySchemes.Should().ContainKey("oauth2Scheme");
+        var scheme = options.Authentication!.SecuritySchemes["oauth2Scheme"];
+        scheme.Should().BeOfType<ScalarOAuth2SecurityScheme>();
+        var oauth2Scheme = scheme as ScalarOAuth2SecurityScheme;
+        oauth2Scheme!.Flows.Should().NotBeNull();
+        oauth2Scheme.Flows!.Password.Should().NotBeNull();
+        oauth2Scheme.Flows!.Password!.TokenUrl.Should().Be("https://auth.example.com/token");
+        oauth2Scheme.Flows!.Password!.RefreshUrl.Should().Be("https://auth.example.com/refresh");
+        oauth2Scheme.Flows!.Password!.ClientId.Should().Be("clientId");
+        oauth2Scheme.Flows!.Password!.ClientSecret.Should().Be("clientSecret");
+        oauth2Scheme.Flows!.Password!.Username.Should().Be("username");
+        oauth2Scheme.Flows!.Password!.Password.Should().Be("password");
+    }
+
+    [Fact]
+    public void AddApiKeyAuthentication_ShouldConfigureApiKeyAuthentication()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.AddApiKeyAuthentication("apiKeyScheme", header =>
+        {
+            header.Name = "X-API-KEY";
+            header.Value = "my-api-key";
+        });
+
+        // Assert
+        options.Authentication.Should().NotBeNull();
+        options.Authentication!.SecuritySchemes.Should().ContainKey("apiKeyScheme");
+        var scheme = options.Authentication!.SecuritySchemes["apiKeyScheme"];
+        scheme.Should().BeOfType<ScalarApiKeySecurityScheme>();
+        var apiKeyScheme = scheme as ScalarApiKeySecurityScheme;
+        apiKeyScheme!.Name.Should().Be("X-API-KEY");
+        apiKeyScheme.Value.Should().Be("my-api-key");
+    }
+
+    [Fact]
+    public void AddHttpAuthentication_ShouldConfigureHttpAuthentication()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.AddHttpAuthentication("httpScheme", http =>
+        {
+            http.Username = "testuser";
+            http.Password = "testpassword";
+            http.Token = "testtoken";
+        });
+
+        // Assert
+        options.Authentication.Should().NotBeNull();
+        options.Authentication!.SecuritySchemes.Should().ContainKey("httpScheme");
+        var scheme = options.Authentication!.SecuritySchemes["httpScheme"];
+        scheme.Should().BeOfType<ScalarHttpSecurityScheme>();
+        var httpScheme = scheme as ScalarHttpSecurityScheme;
+        httpScheme!.Username.Should().Be("testuser");
+        httpScheme.Password.Should().Be("testpassword");
+        httpScheme.Token.Should().Be("testtoken");
+    }
+
+    [Fact]
+    public void AddHttpAuthentication_ShouldUpdateExistingHttpScheme()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+        options.AddHttpAuthentication("httpScheme", http =>
+        {
+            http.Username = "olduser";
+            http.Password = "oldpassword";
+        });
+
+        // Act
+        options.AddHttpAuthentication("httpScheme", http =>
+        {
+            http.Username = "newuser";
+            http.Password = "newpassword";
+        });
+
+        // Assert
+        var httpScheme = options.Authentication!.SecuritySchemes!["httpScheme"] as ScalarHttpSecurityScheme;
+        httpScheme!.Username.Should().Be("newuser");
+        httpScheme.Password.Should().Be("newpassword");
+    }
+
+    [Fact]
+    public void MultipleAuthMethods_ShouldAllWork()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options
+            .AddApiKeyAuthentication("apiKey", config => config.Name = "X-API-KEY")
+            .AddHttpAuthentication("basicAuth", config =>
+            {
+                config.Username = "testuser";
+            })
+            .AddClientCredentialsFlow("oauth2", config => config.TokenUrl = "https://example.com/token")
+            .AddDefaultScopes("oauth2", "read", "write");
+
+        // Assert
+        options.Authentication!.SecuritySchemes.Should().ContainKeys("apiKey", "basicAuth", "oauth2");
+        options.Authentication!.SecuritySchemes["apiKey"].Should().BeOfType<ScalarApiKeySecurityScheme>();
+        options.Authentication!.SecuritySchemes["basicAuth"].Should().BeOfType<ScalarHttpSecurityScheme>();
+        options.Authentication!.SecuritySchemes["oauth2"].Should().BeOfType<ScalarOAuth2SecurityScheme>();
+
+        var oauth2Scheme = options.Authentication!.SecuritySchemes["oauth2"] as ScalarOAuth2SecurityScheme;
+        oauth2Scheme!.DefaultScopes.Should().BeEquivalentTo("read", "write");
+        oauth2Scheme.Flows!.ClientCredentials!.TokenUrl.Should().Be("https://example.com/token");
     }
 }

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -62,10 +62,12 @@ public class ScalarOptionsMapperTests
             Authentication = new ScalarAuthenticationOptions
             {
                 PreferredSecurityScheme = "my-scheme",
+#pragma warning disable CS0618 // Type or member is obsolete
                 ApiKey = new ApiKeyOptions
                 {
                     Token = "my-token"
                 }
+#pragma warning restore CS0618 // Type or member is obsolete
             },
             DefaultFonts = false,
             DefaultOpenAllTags = true,
@@ -97,8 +99,10 @@ public class ScalarOptionsMapperTests
         ((bool) configuration.HiddenClients!).Should().BeTrue();
         configuration.Authentication.Should().NotBeNull();
         configuration.Authentication!.PreferredSecurityScheme.Should().Be("my-scheme");
+#pragma warning disable CS0618 // Type or member is obsolete
         configuration.Authentication.ApiKey.Should().NotBeNull();
         configuration.Authentication.ApiKey!.Token.Should().Be("my-token");
+#pragma warning restore CS0618 // Type or member is obsolete
         configuration.WithDefaultFonts.Should().BeFalse();
         configuration.DefaultOpenAllTags.Should().BeTrue();
         configuration.TagsSorter.Should().Be("alpha");

--- a/packages/types/src/entities/security-scheme.ts
+++ b/packages/types/src/entities/security-scheme.ts
@@ -157,11 +157,6 @@ const oasSecuritySchemeOauth2 = commonProps.extend({
       authorizationCode: flowsCommon.extend({
         'type': z.literal('authorizationCode').default('authorizationCode'),
         authorizationUrl,
-        /**
-         * Whether to use PKCE for the authorization code flow.
-         *
-         * TODO: add docs
-         */
         'x-usePkce': z.enum(pkceOptions).optional().default('no'),
         'x-scalar-redirect-uri': z.string().optional().default(defaultRedirectUri),
         tokenUrl,


### PR DESCRIPTION
This PR migrates the .NET Integration to the new authentication. I added new methods that allow the user to use the new authentication:

**Example**

```c#
app.MapScalarApiReference(options => options
    // Set the preferred (default) scheme
    .WithPreferredScheme("OAuth2")
    
    // Configure OAuth2
   .AddOAuth2Flows("OAuth2", flows =>
    {
        // Authorization Code flow
        flows.AuthorizationCode = new AuthorizationCodeFlow
        {
            ClientId = "your-client-id",
            AuthorizationUrl = "https://auth.example.com/oauth2/authorize",
            TokenUrl = "https://auth.example.com/oauth2/token",
            RedirectUri = "https://your-app.com/callback"
        };
        
        // Client Credentials flow
        flows.ClientCredentials = new ClientCredentialsFlow
        {
            ClientId = "your-client-id",
            ClientSecret = "your-client-secret",
            TokenUrl = "https://auth.example.com/oauth2/token"
        };
    })

    // All OAuth flows will have preselected scopes
    .AddDefaultScopes("OAuth2", ["profile", "email"])
    
    // Configure API Key
    .AddApiKeyAuthentication("ApiKey", apiKey =>
    {
        apiKey.Value = "your-api-key";
    })
    
    // Configure HTTP Basic
    .AddHttpAuthentication("BasicAuth", auth =>
    {
        auth.Username = "your-username";
        auth.Password = "your-password";
    });
);
```

What do you think about the extension method names? Is `AddHttpAuthentication` ok, or should it rather be `AddHttpScheme` or `AddHttpSecurityScheme`?


This PR also deprecates all existing extension methods and properties that relate to the old authentication.
I updated the docs for the dotnet integration, the `configuration.md` and added some more examples to the authentication docs.

**Other**
I also added the new awesome laserwave theme.

Closes #4935

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
