### PR TITLE
docs(Scalar.AspNetCore): add docs for legacy .NET versions and FastEndpoints

### DIFF
--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -71,6 +71,21 @@ if (app.Environment.IsDevelopment())
 }
 ```
 
+For `FastEndpoints`:
+
+```csharp
+builder.Services.SwaggerDocument();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwaggerGen(options =>
+    {
+        options.Path = "/openapi/{documentName}.json";
+    });
+    app.MapScalarApiReference();
+}
+```
+
 That's it! 🎉 You can now access the Scalar API Reference at `/scalar`. By default, the API Reference uses the `v1` document. You can add documents by calling the `AddDocument` method. Alternatively, you can navigate to `/scalar/{documentName}` (e.g., `/scalar/v1`) to view the API reference for a specific document.
 
 ## Configuration Options

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -309,3 +309,115 @@ app
 ```
 
 For all available configuration properties and their default values, check out the [`ScalarOptions`](https://github.com/scalar/scalar/blob/main/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs) and the [`ScalarOptionsExtensions`](https://github.com/scalar/scalar/blob/main/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs).
+
+## Legacy .NET Integration
+
+This guide explains how to integrate Scalar API Reference into .NET Framework and .NET Core projects using static assets.
+
+### Prerequisites
+
+- An ASP.NET or ASP.NET Core application with OpenAPI/Swagger support (using Swashbuckle or NSwag)
+
+
+### Step 1: Enable Swagger/OpenAPI in your project
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddControllers();
+    
+    // Using Swashbuckle
+    services.AddSwaggerGen(c =>
+    {
+        c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+    });
+    
+    // OR using NSwag
+    services.AddOpenApiDocument();
+}
+
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
+    // Enable the endpoint for generating the OpenAPI documents
+    app.UseSwagger();
+    
+    // Required for serving static scalar files
+    app.UseStaticFiles();
+    
+    // Other middleware
+    app.UseRouting();
+    app.UseEndpoints(endpoints =>
+    {
+        endpoints.MapControllers();
+    });
+}
+```
+
+### Step 2: Create the directory structure
+
+Create the following folder structure:
+
+```
+wwwroot/ (or your static files directory)
+└── scalar/
+    ├── index.html
+    └── scalar.config.js
+```
+
+### Step 3: Create the HTML file for Scalar
+
+Create `index.html` in the `wwwroot/scalar` directory with:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scalar API Reference</title>
+</head>
+<body>
+    <div id="app"></div>
+    
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script src="./scalar.config.js"></script>
+</body>
+</html>
+```
+
+### Step 4: Create the configuration file
+
+Create `scalar.config.js` in the same directory:
+
+```javascript
+Scalar.initialize({
+    selector: "#app",
+    url: "/swagger/v1/swagger.json", // Adjust this URL to match your OpenAPI document path
+    theme: "moon" // Other configuration
+});
+```
+
+### Step 5: Accessing your API Reference
+
+After starting your application, the Scalar API Reference will be available at:
+
+```
+http://localhost:<port>/scalar/index.html
+```
+
+#### Using a specific Scalar version
+
+To use a specific version instead of the latest, specify the version in your HTML:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.28.23"></script>
+```
+
+### Troubleshooting
+
+- **Swagger JSON not loading**: Verify the URL path to your Swagger JSON in the configuration
+- **CORS issues**: Ensure your API allows CORS if hosted on a different domain
+- **Static files not serving**: Check that `app.UseStaticFiles()` is present in your middleware pipeline
+- **404 errors**: Confirm the directory structure and that the files are correctly named
+
+For more configuration options, refer to the [official Scalar configuration documentation](https://github.com/scalar/scalar/blob/main/documentation/configuration.md).

--- a/integrations/aspnetcore/README.md
+++ b/integrations/aspnetcore/README.md
@@ -86,6 +86,21 @@ if (app.Environment.IsDevelopment())
 }
 ```
 
+For `FastEndpoints`:
+
+```csharp
+builder.Services.SwaggerDocument();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwaggerGen(options =>
+    {
+        options.Path = "/openapi/{documentName}.json";
+    });
+    app.MapScalarApiReference();
+}
+```
+
 That's it! 🎉 You can now access the Scalar API Reference at `/scalar`. By default, the API Reference uses the `v1` document. You can add documents by calling the `AddDocument` method. Alternatively, you can navigate to `/scalar/{documentName}` (e.g., `/scalar/v1`) to view the API Reference for a specific document. Please check out the [dotnet integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md#multiple-openapi-documents) for more details.
 
 ## Configuration


### PR DESCRIPTION
This PR adds documentation for legacy .NET versions that are not supported by our official `Scalar.AspNetCore` package. Specifically, I included a simple guide in the integration docs explaining how to use the HTML integration in existing .NET applications.

Additionally, I’ve added `FastEndpoints` to the list of supported OpenAPI document providers. While it uses `NSwag` under the hood, its setup differs slightly from the standard configuration.

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
