### PR TITLE
fix(components): `<ScalarTooltip />` base font size

### DIFF
--- a/.changeset/light-clouds-hide.md
+++ b/.changeset/light-clouds-hide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: adds text size variants to scalar tooltip

--- a/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
+++ b/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { cva, cx } from '@scalar/use-hooks/useBindCx'
 import {
   TooltipContent,
   TooltipProvider,
@@ -7,6 +8,17 @@ import {
 } from 'radix-vue'
 
 import { ScalarTeleport } from '../ScalarTeleport'
+
+const variants = cva({
+  base: 'scalar-app z-overlay',
+  variants: {
+    textSize: {
+      xs: 'text-xs',
+      sm: 'text-sm',
+      base: 'text-base',
+    },
+  },
+})
 
 const props = withDefaults(
   defineProps<{
@@ -21,12 +33,14 @@ const props = withDefaults(
     resize?: boolean
     as?: string
     disabled?: boolean
+    textSize?: 'xs' | 'sm' | 'base'
   }>(),
   {
     skipDelay: 1000,
     side: 'top',
     align: 'center',
     disabled: false,
+    textSize: 'xs',
   },
 )
 
@@ -51,8 +65,7 @@ defineEmits<{
         <TooltipContent
           v-if="!props.disabled"
           :align="props.align"
-          class="scalar-app z-context"
-          :class="props.class"
+          :class="cx(variants({ textSize: props.textSize }), props.class)"
           :side="props.side"
           :sideOffset="props.sideOffset">
           <slot name="content" />


### PR DESCRIPTION
**Problem**

currently the default text size used in the tooltip has broken and is now too big according to its context.

**Solution**

this pr adds a text size variant with a text size default.

| before | after |
| -------|------|
| <img width="609" alt="image" src="https://github.com/user-attachments/assets/98625a00-b7f6-44a6-beae-5281a9b8d0cd" /> | <img width="609" alt="image" src="https://github.com/user-attachments/assets/46e1aa0c-3568-4b84-a33a-70e5da0235b8" /> |
| <img width="609" alt="image" src="https://github.com/user-attachments/assets/dfa0d21f-2882-4efe-be40-99317e3785fb" /> | <img width="609" alt="image" src="https://github.com/user-attachments/assets/3e778b41-628a-4777-a3be-271c1dd0caab" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
