### PR TITLE
fix(api-client): environment collection

### DIFF
--- a/.changeset/chilly-donuts-mate.md
+++ b/.changeset/chilly-donuts-mate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: makes collection environment draggable

--- a/.changeset/hip-geckos-call.md
+++ b/.changeset/hip-geckos-call.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates string template replacement value for operation

--- a/.changeset/sour-shirts-reflect.md
+++ b/.changeset/sour-shirts-reflect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: environment collection management

--- a/packages/api-client/src/components/CodeInput/CodeInput.test.ts
+++ b/packages/api-client/src/components/CodeInput/CodeInput.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import CodeInput from './CodeInput.vue'
-import { useCodeMirror, type Extension } from '@scalar/use-codemirror'
+import { useCodeMirror } from '@scalar/use-codemirror'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { enableConsoleError, enableConsoleWarn } from '@/vitest.setup'
-import { ref } from 'vue'
+import { ref, toValue } from 'vue'
 import { environmentSchema } from '@scalar/oas-utils/entities/environment'
 import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
+import { nanoid } from 'nanoid'
 
 // Mock dependencies
 vi.mock('@scalar/use-codemirror', async (importOriginal) => {
@@ -53,13 +54,24 @@ describe('CodeInput', () => {
     }
   })
 
+  const defaultProps = {
+    modelValue: 'test value',
+    environment: environmentSchema.parse({
+      uid: nanoid(),
+      name: 'Test Environment',
+      value: 'test',
+      color: '#000000',
+    }),
+    envVariables: [],
+    workspace: workspaceSchema.parse({
+      name: 'Test Workspace',
+    }),
+  }
+
   const createWrapper = (props = {}, attrs = {}) => {
     return mount(CodeInput, {
       props: {
-        modelValue: 'test value',
-        environment: environmentSchema.parse({}),
-        envVariables: [],
-        workspace: workspaceSchema.parse({}),
+        ...defaultProps,
         ...props,
       },
       attrs,
@@ -170,7 +182,7 @@ describe('CodeInput', () => {
     })
 
     // Check that extensions are set up correctly
-    const extensions = vi.mocked(useCodeMirror).mock.calls[0]?.[0].extensions as Extension[]
-    expect(extensions.length).toBeGreaterThan(0)
+    const extensions = toValue(vi.mocked(useCodeMirror).mock.calls[0]?.[0].extensions)
+    expect(extensions?.length).toBeGreaterThan(0)
   })
 })

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -141,15 +141,24 @@ const extensions: Extension[] = []
 if (props.colorPicker) {
   extensions.push(colorPickerExtension)
 }
-extensions.push(
+
+// Create a reactive pill plugin that updates when environment changes
+const pillPluginExtension = computed(() =>
   pillPlugin({
     environment: props.environment,
     envVariables: props.envVariables,
     workspace: props.workspace,
     isReadOnly: layout === 'modal',
   }),
-  backspaceCommand,
 )
+
+// Base extensions that will be used for the editor
+const baseExtensions = computed(() => [
+  ...extensions,
+  pillPluginExtension.value,
+  backspaceCommand,
+])
+
 const codeMirrorRef: Ref<HTMLDivElement | null> = ref(null)
 
 const { codeMirror } = useCodeMirror({
@@ -169,7 +178,7 @@ const { codeMirror } = useCodeMirror({
   lineNumbers: toRef(() => props.lineNumbers),
   language: toRef(() => props.language),
   lint: toRef(() => props.lint),
-  extensions,
+  extensions: baseExtensions,
   placeholder: toRef(() => props.placeholder),
 })
 
@@ -502,7 +511,7 @@ export default {
   background: var(--scalar-background-3) !important;
 }
 .dark-mode .cm-pill {
-  background: color-mix(in srgb, var(--tw-bg-base), transparent 80%) !important;
+  background: color-mix(in srgb, var(--tw-bg-base), transparent 90%) !important;
 }
 .cm-pill:first-of-type {
   margin-left: 0;

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -12,6 +12,7 @@ import { computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { useLayout } from '@/hooks'
+import { PathId } from '@/routes'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
 
@@ -33,11 +34,12 @@ const updateSelected = (uid: string) => {
     activeWorkspace.value.activeEnvironmentId = uid
   }
 }
-const createNewEnvironment = () =>
+
+const redirectToEnvironments = () =>
   router.push({
-    name: 'environment',
+    name: 'environment.default',
     params: {
-      environment: activeWorkspace.value?.uid,
+      [PathId.Workspace]: activeWorkspace.value?.uid,
     },
   })
 
@@ -45,7 +47,7 @@ const selectedEnvironment = computed(() => {
   const { value: environment } = activeEnvironment
   const { value: collection } = activeCollection
   return (
-    environment?.uid ||
+    environment?.name ||
     collection?.['x-scalar-active-environment'] ||
     'No Environment'
   )
@@ -83,62 +85,53 @@ onMounted(() => {
 })
 </script>
 <template>
-  <div>
-    <ScalarDropdown placement="bottom-end">
-      <ScalarButton
-        class="text-c-1 hover:bg-b-2 h-auto w-fit justify-start px-1.5 py-1.5 pl-2 font-normal"
-        fullWidth
-        variant="ghost">
-        <h2 class="m-0 flex items-center gap-1.5 whitespace-nowrap font-medium">
-          {{ selectedEnvironment }}
-        </h2>
-      </ScalarButton>
-      <!-- Workspace list -->
-      <template #items>
-        <ScalarDropdownItem
-          v-for="environment in availableEnvironments"
-          :key="environment.uid"
-          class="group/item flex items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap"
-          @click.stop="updateSelected(environment.uid)">
-          <ScalarListboxCheckbox
-            :selected="
-              activeCollection?.['x-scalar-active-environment'] ===
-              environment.uid
-            " />
-          {{ environment.name }}
-        </ScalarDropdownItem>
-        <ScalarDropdownItem
-          class="group/item flex items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap"
-          @click.stop="updateSelected('')">
-          <div
-            class="flex h-4 w-4 items-center justify-center rounded-full p-[3px]"
-            :class="
-              activeEnvironment?.uid === '' &&
-              activeCollection?.['x-scalar-active-environment'] === ''
-                ? 'bg-c-accent text-b-1'
-                : 'shadow-border text-transparent'
-            ">
-            <ScalarIcon
-              class="size-2.5"
-              icon="Checkmark"
-              thickness="3" />
-          </div>
-          No Environment
-        </ScalarDropdownItem>
-        <ScalarDropdownDivider />
-        <!-- Manage environments -->
-        <ScalarDropdownItem
-          v-if="layout !== 'modal'"
-          class="flex items-center gap-1.5"
-          @click="createNewEnvironment">
-          <div class="flex h-4 w-4 items-center justify-center">
-            <ScalarIcon
-              icon="Brackets"
-              size="sm" />
-          </div>
-          <span class="leading-none">Manage Environments</span>
-        </ScalarDropdownItem>
-      </template>
-    </ScalarDropdown>
-  </div>
+  <ScalarDropdown teleport>
+    <ScalarButton
+      class="text-c-1 hover:bg-b-2 line-clamp-1 h-auto w-fit justify-start px-1.5 py-1.5 font-normal"
+      fullWidth
+      variant="ghost">
+      <h2 class="m-0 flex items-center gap-1.5 whitespace-nowrap font-medium">
+        {{ selectedEnvironment }}
+      </h2>
+    </ScalarButton>
+    <!-- Workspace list -->
+    <template #items>
+      <ScalarDropdownItem
+        v-for="environment in availableEnvironments"
+        :key="environment.uid"
+        class="group/item flex items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap"
+        @click.stop="updateSelected(environment.uid)">
+        <ScalarListboxCheckbox
+          :selected="
+            activeCollection?.['x-scalar-active-environment'] ===
+            environment.uid
+          " />
+        {{ environment.name }}
+      </ScalarDropdownItem>
+      <ScalarDropdownItem
+        class="group/item flex items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap"
+        @click.stop="updateSelected('')">
+        <ScalarListboxCheckbox
+          :selected="
+            (activeEnvironment?.uid === '' &&
+              activeCollection?.['x-scalar-active-environment'] === '') ||
+            activeEnvironment?.name === 'No Environment'
+          " />
+        No Environment
+      </ScalarDropdownItem>
+      <ScalarDropdownDivider />
+      <!-- Manage environments -->
+      <ScalarDropdownItem
+        v-if="layout !== 'modal'"
+        class="flex items-center gap-1.5"
+        @click="redirectToEnvironments">
+        <div class="flex h-4 w-4 items-center justify-center">
+          <ScalarIcon
+            icon="Brackets"
+            size="sm" />
+        </div>
+        <span class="leading-none">Manage Environments</span>
+      </ScalarDropdownItem>
+    </template>
+  </ScalarDropdown>
 </template>

--- a/packages/api-client/src/components/SideNav/SideNav.vue
+++ b/packages/api-client/src/components/SideNav/SideNav.vue
@@ -44,7 +44,13 @@ const { activeWorkspace } = useActiveEntities()
         )"
         :key="i">
         <SideNavRouterLink
-          :active="Boolean(currentRoute.name === displayName.toLowerCase())"
+          :active="
+            Boolean(
+              currentRoute.name === displayName.toLowerCase() ||
+                (displayName.toLowerCase() === 'environment' &&
+                  currentRoute.name === 'environment.collection'),
+            )
+          "
           :icon="icon"
           :to="{
             ...to,

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -1,10 +1,21 @@
 <script setup lang="ts">
 import { ScalarIcon, type Icon } from '@scalar/components'
+import {
+  Draggable,
+  type DraggableProps,
+  type DraggingItem,
+  type HoveredItem,
+} from '@scalar/draggable'
+import { computed, ref } from 'vue'
 import { useRouter, type RouteLocationRaw } from 'vue-router'
 
 import SidebarListElementActions from '@/components/Sidebar/SidebarListElementActions.vue'
 
-const props = defineProps<{
+const {
+  isDraggable = false,
+  isDroppable = false,
+  to,
+} = defineProps<{
   variable: {
     uid: string
     name: string
@@ -17,21 +28,35 @@ const props = defineProps<{
   isDeletable?: boolean
   isCopyable?: boolean
   isRenameable?: boolean
+  /**
+   * Toggle dragging on and off
+   *
+   * @default false
+   */
+  isDraggable?: boolean
+  /**
+   * Prevents items from being hovered and dropped into
+   *
+   * @default false
+   */
+  isDroppable?: DraggableProps['isDroppable']
+  collectionId?: string
 }>()
 
 const emit = defineEmits<{
   (e: 'delete', id: string): void
   (e: 'colorModal', id: string): void
   (e: 'rename', id: string): void
+  (e: 'onDragEnd', draggingItem: DraggingItem, hoveredItem: HoveredItem): void
 }>()
 
 const router = useRouter()
 
 const handleNavigation = (event: MouseEvent) => {
   if (event.metaKey) {
-    window.open(router.resolve(props.to).href, '_blank')
+    window.open(router.resolve(to).href, '_blank')
   } else {
-    router.push(props.to)
+    router.push(to)
   }
 }
 
@@ -46,45 +71,71 @@ const handleColorClick = (uid: string) => {
 const handleRename = (id: string) => {
   emit('rename', id)
 }
+
+/** The draggable component */
+const draggableRef = ref<{
+  draggingItem: DraggingItem
+  hoveredItem: HoveredItem
+} | null>(null)
+
+/** Calculate offsets for drag and drop */
+const getDraggableOffsets = computed(() => ({
+  ceiling: 0.5,
+  floor: 0.5,
+}))
 </script>
 
 <template>
   <li>
-    <router-link
-      class="text-c-2 hover:bg-b-2 group relative flex h-8 items-center gap-1.5 rounded py-1 pr-1.5 font-medium no-underline"
-      :class="[variable.color ? 'pl-1' : 'pl-1.5']"
-      exactActiveClass="bg-b-2 !text-c-1"
-      role="button"
-      :to="to"
-      @click.prevent="handleNavigation($event)">
-      <button
-        v-if="variable.color"
-        class="hover:bg-b-3 rounded p-1.5"
-        type="button"
-        @click="handleColorClick(variable.uid)">
-        <div
-          class="h-2.5 w-2.5 rounded-xl"
-          :style="{ backgroundColor: variable.color }"></div>
-      </button>
-      <ScalarIcon
-        v-if="variable.icon"
-        class="text-sidebar-c-2 size-3.5 stroke-[2.25]"
-        :icon="variable.icon" />
-      <span
-        class="empty-variable-name line-clamp-1 break-all text-sm group-hover:pr-5">
-        {{ variable.name }}
-      </span>
-      <SidebarListElementActions
-        :isCopyable="Boolean(isCopyable)"
-        :isDeletable="Boolean(isDeletable)"
-        :isRenameable="Boolean(isRenameable)"
-        :variable="{ ...variable, isDefault: variable.isDefault ?? false }"
-        :warningMessage="warningMessage"
-        @delete="handleDelete"
-        @rename="handleRename" />
-    </router-link>
+    <Draggable
+      :id="variable.uid"
+      ref="draggableRef"
+      :ceiling="getDraggableOffsets.ceiling"
+      :floor="getDraggableOffsets.floor"
+      :isDraggable="isDraggable"
+      :isDroppable="isDroppable"
+      :parentIds="collectionId ? [collectionId] : []"
+      @onDragEnd="(...args) => $emit('onDragEnd', ...args)">
+      <router-link
+        class="text-c-2 hover:bg-b-2 group relative flex h-8 items-center gap-1.5 rounded py-1 pr-1.5 font-medium no-underline"
+        :class="[variable.color ? 'pl-5' : 'pl-1.5']"
+        exactActiveClass="bg-b-2 !text-c-1"
+        role="button"
+        :to="to"
+        @click.prevent="handleNavigation($event)">
+        <button
+          v-if="variable.color"
+          class="hover:bg-b-3 rounded p-1.5"
+          type="button"
+          @click="handleColorClick(variable.uid)">
+          <div
+            class="h-2.5 w-2.5 rounded-xl"
+            :style="{ backgroundColor: variable.color }"></div>
+        </button>
+        <ScalarIcon
+          v-if="variable.icon"
+          class="text-sidebar-c-2 size-3.5 stroke-[2.25]"
+          :icon="variable.icon" />
+        <span
+          class="empty-variable-name line-clamp-1 break-all text-sm group-hover:pr-5">
+          {{ variable.name }}
+        </span>
+        <SidebarListElementActions
+          :isCopyable="Boolean(isCopyable)"
+          :isDeletable="Boolean(isDeletable)"
+          :isRenameable="Boolean(isRenameable)"
+          :variable="{ ...variable, isDefault: variable.isDefault ?? false }"
+          :warningMessage="warningMessage"
+          @delete="handleDelete"
+          @rename="handleRename" />
+      </router-link>
+    </Draggable>
   </li>
 </template>
+
+<style>
+@import '@scalar/draggable/style.css';
+</style>
 
 <style scoped>
 .empty-variable-name:empty:before {

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -53,7 +53,7 @@ const handleRename = (id: string) => {
     <router-link
       class="text-c-2 hover:bg-b-2 group relative flex h-8 items-center gap-1.5 rounded py-1 pr-1.5 font-medium no-underline"
       :class="[variable.color ? 'pl-1' : 'pl-1.5']"
-      exactActiveClass="bg-b-2 text-c-1"
+      exactActiveClass="bg-b-2 !text-c-1"
       role="button"
       :to="to"
       @click.prevent="handleNavigation($event)">

--- a/packages/api-client/src/libs/env-helpers.test.ts
+++ b/packages/api-client/src/libs/env-helpers.test.ts
@@ -1,11 +1,13 @@
 import { environmentSchema } from '@scalar/oas-utils/entities/environment'
 import { describe, expect, it } from 'vitest'
+import { nanoid } from 'nanoid'
 
 import { getEnvColor } from './env-helpers'
 
 describe('getEnvColor', () => {
   it('returns the environment color when provided', () => {
     const env = environmentSchema.parse({
+      uid: nanoid(),
       color: '#FF0000',
       name: 'Production',
       value: 'production',
@@ -16,11 +18,11 @@ describe('getEnvColor', () => {
 
   it('returns default color when environment is undefined', () => {
     // @ts-expect-error testing undefined
-    expect(getEnvColor(undefined)).toBe('#8E8E8E')
+    expect(getEnvColor(undefined)).toBe('#FFFFFF')
   })
 
   it('returns default color when environment is null', () => {
     // @ts-expect-error testing null
-    expect(getEnvColor(null)).toBe('#8E8E8E')
+    expect(getEnvColor(null)).toBe('#FFFFFF')
   })
 })

--- a/packages/api-client/src/libs/env-helpers.ts
+++ b/packages/api-client/src/libs/env-helpers.ts
@@ -1,6 +1,8 @@
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 
-export type EnvVariables = { key: string; value: string; source: string }[]
+export type EnvVariables = { key: string; value: string; source: 'global' | 'collection' }[]
 
 /** Gets the color of an environment with default fallback */
-export const getEnvColor = (environment: Environment) => (environment ? environment.color : '#8E8E8E')
+export function getEnvColor(environment: Environment): string {
+  return environment?.color || '#FFFFFF'
+}

--- a/packages/api-client/src/libs/env-helpers.ts
+++ b/packages/api-client/src/libs/env-helpers.ts
@@ -2,6 +2,12 @@ import type { Environment } from '@scalar/oas-utils/entities/environment'
 
 export type EnvVariables = { key: string; value: string; source: 'global' | 'collection' }[]
 
+export type EnvConfig = {
+  variables: Record<string, string | { default: string; description?: string | undefined }>
+  color?: string | undefined
+  description?: string | undefined
+}
+
 /** Gets the color of an environment with default fallback */
 export function getEnvColor(environment: Environment): string {
   return environment?.color || '#FFFFFF'

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -72,7 +72,8 @@ export const createRequestOperation = ({
     }, {})
 
     const serverString = replaceTemplateVariables(server?.url ?? '', env)
-    const pathString = replaceTemplateVariables(request.path, pathVariables)
+    // Replace environment variables, then path variables
+    const pathString = replaceTemplateVariables(replaceTemplateVariables(request.path, env), pathVariables)
 
     /**
      * Start building the main URL, we cannot use the URL class yet as it does not work with relative servers

--- a/packages/api-client/src/libs/string-template.test.ts
+++ b/packages/api-client/src/libs/string-template.test.ts
@@ -33,23 +33,35 @@ describe('Replaces template vars with context values', () => {
       city: 'Peel',
       country: 'Bananaland',
     },
+    single: {
+      name: 'Nolan',
+      age: '1 month',
+    },
   }
+
   it('Handles double curly variable substitution', () => {
     const res = replaceTemplateVariables('My name is {{name}} from {{address.city}}', ctx)
     expect(res).toEqual('My name is Dave from Peel')
   })
+
   it('Handles single curly variable substitution', () => {
     const res = replaceTemplateVariables('My name is {name} from { address.city }', ctx)
     expect(res).toEqual('My name is Dave from Peel')
   })
+
   it('Handles colon variable substitution', () => {
     const res = replaceTemplateVariables('My name is :name from :address.city', ctx)
     expect(res).toEqual('My name is Dave from Peel')
   })
+
   it('Handles object conversion to string', () => {
     const res = replaceTemplateVariables('My name is {{name}} from {{address}}', ctx)
-
     expect(res).toEqual(`My name is Dave from ${JSON.stringify(ctx.address)}`)
+  })
+
+  it('Handles mixed double and single curly braces independently', () => {
+    const res = replaceTemplateVariables('{{name}} and {single.name} which is {single.age}', ctx)
+    expect(res).toEqual('Dave and Nolan which is 1 month')
   })
 })
 

--- a/packages/api-client/src/store/active-entities.ts
+++ b/packages/api-client/src/store/active-entities.ts
@@ -79,7 +79,7 @@ export const createActiveEntitiesStore = ({
     if (!activeWorkspace.value?.activeEnvironmentId) {
       return environmentSchema.parse({
         uid: 'default',
-        color: '#0082D0',
+        color: '#FFFFFF',
         name: 'No Environment',
         value: JSON.stringify(activeWorkspace.value?.environments, null, 2),
       })
@@ -100,14 +100,14 @@ export const createActiveEntitiesStore = ({
         ),
         color:
           activeEnvironmentCollection['x-scalar-environments']?.[activeWorkspace.value?.activeEnvironmentId]?.color ||
-          '#0082D0',
+          '#FFFFFF',
         isDefault: false,
       })
     }
 
     return environmentSchema.parse({
       uid: 'default',
-      color: '#0082D0',
+      color: '#FFFFFF',
       name: 'No Environment',
       value: JSON.stringify(activeWorkspace.value.environments, null, 2),
     })

--- a/packages/api-client/src/store/environment.ts
+++ b/packages/api-client/src/store/environment.ts
@@ -15,7 +15,7 @@ export function createStoreEnvironments(useLocalStorage: boolean) {
     environmentSchema.parse({
       uid: 'default',
       name: 'Default Environment',
-      color: '#0082D0',
+      color: '#FFFFFF',
       value: JSON.stringify({ exampleKey: 'exampleValue' }, null, 2),
       isDefault: true,
     }),

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -29,6 +29,7 @@ import { useActiveEntities } from '@/store/active-entities'
 
 import EnvironmentColorModal from './EnvironmentColorModal.vue'
 import EnvironmentModal from './EnvironmentModal.vue'
+import { environmentDragHandlerFactory } from './handle-drag'
 
 const router = useRouter()
 const route = useRoute()
@@ -399,6 +400,12 @@ function handleRename(newName: string) {
   tempEnvironmentName.value = undefined
   editModal.hide()
 }
+
+// Replace handleEnvironmentDragEnd with the factory
+const { handleDragEnd, isDroppable } = environmentDragHandlerFactory(
+  activeWorkspaceCollections,
+  collectionMutators,
+)
 </script>
 <template>
   <ViewLayout>
@@ -461,11 +468,13 @@ function handleRename(newName: string) {
                     'x-scalar-environments'
                   ]"
                   :key="environmentName"
-                  class="text-xs [&>a]:pl-5"
+                  class="text-xs"
                   :collectionId="collection.uid"
                   :isCopyable="false"
                   :isDeletable="true"
                   :isRenameable="true"
+                  :isDraggable="true"
+                  :isDroppable="isDroppable"
                   :to="{
                     name: 'environment.collection',
                     params: {
@@ -486,7 +495,8 @@ function handleRename(newName: string) {
                   "
                   @colorModal="handleOpenColorModal(environmentName)"
                   @delete="removeCollectionEnvironment(environmentName)"
-                  @rename="openRenameModal(environmentName, collection.uid)" />
+                  @rename="openRenameModal(environmentName, collection.uid)"
+                  @onDragEnd="handleDragEnd" />
                 <ScalarButton
                   v-if="
                     Object.keys(collection['x-scalar-environments'] || {})

--- a/packages/api-client/src/views/Environment/EnvironmentColors.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentColors.vue
@@ -22,7 +22,7 @@ const showCustomInput = ref(false)
 const showSelector = ref(false)
 
 const colorOptions = [
-  { color: '#8E8E8E' },
+  { color: '#FFFFFF' },
   { color: '#EF0006' },
   { color: '#EDBE20' },
   { color: '#069061' },

--- a/packages/api-client/src/views/Environment/EnvironmentModal.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentModal.vue
@@ -38,7 +38,7 @@ const emit = defineEmits<{
 const { events } = useWorkspace()
 
 const environmentName = ref('')
-const selectedColor = ref('#8E8E8E')
+const selectedColor = ref('#FFFFFF')
 
 const collections = computed(() => [
   ...props.activeWorkspaceCollections
@@ -65,7 +65,7 @@ watch(
   (isOpen) => {
     if (isOpen) {
       environmentName.value = ''
-      selectedColor.value = '#8E8E8E'
+      selectedColor.value = '#FFFFFF'
       if (props.collectionId) {
         selectedEnvironment.value = collections.value.find(
           (collection) => collection.id === props.collectionId,

--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -137,16 +137,16 @@ onClickOutside(
             class="font-code text-xxs hover:bg-b-2 flex h-8 cursor-pointer items-center justify-between gap-1.5 rounded p-1.5 transition-colors duration-150"
             :class="{ 'bg-b-2': index === selectedVariableIndex }"
             @click="selectVariable(item.key)">
-            <div class="flex items-center gap-1.5 whitespace-nowrap">
+            <div class="flex items-center gap-2 whitespace-nowrap">
               <span
                 v-if="item.source === 'collection'"
-                class="h-2.5 w-2.5 min-w-2.5 rounded-full"
+                class="h-2.25 w-2.25 min-w-2.25 rounded-full"
                 :style="{
                   backgroundColor: getEnvColor(environment),
                 }"></span>
               <ScalarIcon
                 v-else
-                class="w-2.5"
+                class="-ml-1/2 h-2.5 w-2.5"
                 icon="Globe" />
               {{ item.key }}
             </div>

--- a/packages/api-client/src/views/Environment/handle-drag.ts
+++ b/packages/api-client/src/views/Environment/handle-drag.ts
@@ -1,0 +1,72 @@
+import type { ActiveEntitiesStore } from '@/store/active-entities'
+import type { DraggingItem, HoveredItem } from '@scalar/draggable'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+
+type CollectionMutator = {
+  edit: (uid: Collection['uid'], path: 'x-scalar-environments', value: Collection['x-scalar-environments']) => void
+}
+
+/** Create environment DnD handlers */
+export function environmentDragHandlerFactory(
+  activeWorkspaceCollections: ActiveEntitiesStore['activeWorkspaceCollections'],
+  collectionMutator: CollectionMutator,
+) {
+  /** Drag handler that mutates the collection's environments order */
+  const handleDragEnd = (draggingItem: DraggingItem, hoveredItem: HoveredItem) => {
+    if (!draggingItem || !hoveredItem) {
+      return
+    }
+
+    const { id: draggingUid, parentId: draggingParentUid } = draggingItem
+    const { id: hoveredUid, parentId: hoveredParentUid, offset } = hoveredItem
+
+    // Only allow reordering within the same collection
+    if (draggingParentUid !== hoveredParentUid) {
+      return
+    }
+
+    const collection = activeWorkspaceCollections.value.find((c) => c.uid === draggingParentUid)
+
+    if (!collection || !collection['x-scalar-environments']) {
+      return
+    }
+
+    const environments = collection['x-scalar-environments']
+    const envKeys = Object.keys(environments)
+    const orderedEnvs = { ...environments }
+
+    // Remove dragged item from its position
+    const draggedIndex = envKeys.findIndex((key) => key === draggingUid)
+    envKeys.splice(draggedIndex, 1)
+
+    // Insert at new position
+    const hoveredIndex = envKeys.findIndex((key) => key === hoveredUid)
+    const targetIndex = hoveredIndex + (offset === 1 ? 1 : 0)
+    envKeys.splice(targetIndex, 0, draggingUid)
+
+    // Rebuild ordered environments object
+    const reorderedEnvs = envKeys.reduce(
+      (acc, key) => {
+        const env = environments[key]
+        if (env) {
+          acc[key] = env
+        }
+        return acc
+      },
+      {} as typeof orderedEnvs,
+    )
+
+    collection['x-scalar-environments'] = reorderedEnvs
+    collectionMutator.edit(collection.uid, 'x-scalar-environments', collection['x-scalar-environments'])
+  }
+
+  /** Ensure only environments within the same collection can be dropped */
+  const isDroppable = (draggingItem: DraggingItem, hoveredItem: HoveredItem) => {
+    return draggingItem.parentId === hoveredItem.parentId
+  }
+
+  return {
+    handleDragEnd,
+    isDroppable,
+  }
+}

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -40,10 +40,17 @@ const {
 }>()
 
 const { requestExampleMutators } = useWorkspace()
+const isTooltipReady = ref(false)
 
 const params = computed(() => example.parameters[paramKey] ?? [])
 
-onMounted(() => defaultRow())
+onMounted(() => {
+  nextTick(() => {
+    // TODO: currently waiting for the tooltip to be ready otherwise error is thrown on mount
+    isTooltipReady.value = true
+    defaultRow()
+  })
+})
 
 /** Add a new row to a given parameter list */
 const addRow = () => {
@@ -164,7 +171,9 @@ const itemCount = computed(
   () => params.value.filter((param) => param.key || param.value).length,
 )
 
-const showTooltip = computed(() => params.value.length > 1)
+const showTooltip = computed(
+  () => isTooltipReady.value && params.value.length > 1,
+)
 
 watch(
   () => example,

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.test.ts
@@ -46,7 +46,7 @@ describe('RequestSection', () => {
         operation: {
           // @ts-expect-error
           uid: '1',
-          method: 'get',
+          method: 'post',
           path: '/test',
           summary: 'Test Operation',
         },

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -257,7 +257,7 @@ const labelRequestNameId = useId()
         title="Query Parameters"
         :workspace="workspace" />
       <RequestBody
-        v-show="
+        v-if="
           operation.method &&
           (selectedFilter === 'All' || selectedFilter === 'Body') &&
           canMethodHaveBody(operation.method)

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -227,8 +227,7 @@ const labelRequestNameId = useId()
         :readOnlyEntries="activeWorkspaceCookies"
         :role="selectedFilter === 'All' ? 'none' : 'tabpanel'"
         title="Cookies"
-        :workspace="workspace"
-        workspaceParamKey="cookies" />
+        :workspace="workspace" />
       <RequestParams
         v-show="selectedFilter === 'All' || selectedFilter === 'Headers'"
         :id="filterIds.Headers"

--- a/packages/oas-utils/src/entities/environment/environment.ts
+++ b/packages/oas-utils/src/entities/environment/environment.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod'
 
-import { type ENTITY_BRANDS, nanoidSchema } from '@scalar/types/utils'
+import type { ENTITY_BRANDS } from '@scalar/types/utils'
 
 export const environmentSchema = z.object({
-  uid: nanoidSchema.brand<ENTITY_BRANDS['ENVIRONMENT']>(),
+  uid: z.string().brand<ENTITY_BRANDS['ENVIRONMENT']>(),
   name: z.string().optional().default('Default Environment'),
-  color: z.string().optional().default('#0082D0'),
+  color: z.string().optional().default('#FFFFFF'),
   value: z.string().default(''),
   isDefault: z.boolean().optional(),
 })


### PR DESCRIPTION
**Problem**

currently collection environment usage is not properly usable due to issues:
- environment selector position is overflowing once selected
- environment collection routes needs to be updated
- pill plugin lacks reactivity on environment change
- draft collection if shown in environment page
- environment selector is displaying uid instead of name
- environment collection name cannot be updated
- zod schema prevent short name usage for environment

**Solution**

this pr fixes #5384 #4349 + listed above issues +:
- updates default environment variable pill color for better accessibility
- adds icon on global variable pill

`environment selector`
| before | after |
| -------|------|
| <img width="334" alt="image" src="https://github.com/user-attachments/assets/d10061de-eaba-4168-b01b-ac5bcd9b36e2" /> | <img width="334" alt="image" src="https://github.com/user-attachments/assets/34a3ed0c-7694-4ad9-a24f-f7b61d38797f" /> |
| selector overflowing once selected | selector is teleported | 

`environment active state`
| before | after |
| -------|------|
| <img width="334" alt="image" src="https://github.com/user-attachments/assets/63cc4b8b-f601-4e8d-997d-7a82890a4398" /> | <img width="334" alt="image" src="https://github.com/user-attachments/assets/3b176950-6513-4ff4-81e1-358267cb67fb" /> |
| lacks active state and shows draft | active state shown and draft filtered out | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
