### PR TITLE
feat(api-reference): omit deprecated fields from generated examples

### DIFF
--- a/.changeset/neat-fireants-breathe.md
+++ b/.changeset/neat-fireants-breathe.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: omit deprecated fields from examples

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.test.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.test.ts
@@ -1139,4 +1139,25 @@ describe('getExampleFromSchema', () => {
       expect(Object.keys(example).length).toBe(26)
     })
   })
+
+  it('omits deprecated properties', () => {
+    expect(
+      getExampleFromSchema({
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            example: 'test',
+          },
+          oldField: {
+            type: 'string',
+            example: 'should not appear',
+            deprecated: true,
+          },
+        },
+      }),
+    ).toStrictEqual({
+      name: 'test',
+    })
+  })
 })

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
@@ -111,6 +111,11 @@ export const getExampleFromSchema = (
   // But if `emptyString` is  set, we do want to see some values.
   const makeUpRandomData = !!options?.emptyString
 
+  // If the property is deprecated anyway, we don’t want to show it.
+  if (schema.deprecated) {
+    return undefined
+  }
+
   // Check if the property is read-only/write-only
   if ((options?.mode === 'write' && schema.readOnly) || (options?.mode === 'read' && schema.writeOnly)) {
     return undefined


### PR DESCRIPTION
**Problem**

If a schema/property is flagged as deprecated, it’s still in the generated examples.

**Solution**

We can omit it from the generated examples. I’ve found this great addition here: https://github.com/GitbookIO/gitbook/pull/3085

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
