### PR TITLE
feat(galaxy): use `default` theme for playground

### DIFF
--- a/packages/galaxy/playground/src/index.ts
+++ b/packages/galaxy/playground/src/index.ts
@@ -28,6 +28,7 @@ app.get(
   Scalar({
     // Served by createMockServer
     url: '/openapi.yaml',
+    theme: 'default',
     pageTitle: 'Scalar Galaxy',
   }),
 )

--- a/packages/galaxy/playground/src/index.ts
+++ b/packages/galaxy/playground/src/index.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises'
 import { serve } from '@hono/node-server'
-import { apiReference } from '@scalar/hono-api-reference'
+import { Scalar } from '@scalar/hono-api-reference'
 import { createMockServer } from '@scalar/mock-server'
 
 const specification = await readOpenApiDocumentFromDisk()
@@ -25,7 +25,7 @@ const app = await createMockServer({
 // Load the middleware
 app.get(
   '/',
-  apiReference({
+  Scalar({
     // Served by createMockServer
     url: '/openapi.yaml',
     pageTitle: 'Scalar Galaxy',


### PR DESCRIPTION
**Problem**

Currently, https://galaxy.scalar.com/ shows the Hono custom theme. But this is our default example, that’s not really related to Hono.

**Solution**

Let’s just use the default theme.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
