### PR TITLE
feat(api-reference): use live sync mutator for config changes to store

### DIFF
--- a/.changeset/smooth-suns-wink.md
+++ b/.changeset/smooth-suns-wink.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+feat: use live sync mutator for changes to config (do not blindly re-create state)

--- a/packages/api-client/src/views/Request/libs/index.ts
+++ b/packages/api-client/src/views/Request/libs/index.ts
@@ -1,2 +1,3 @@
 export * from './auth'
 export * from './oauth2'
+export * from './watch-mode'

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -84,6 +84,7 @@
     "flatted": "^3.3.1",
     "fuse.js": "^7.0.0",
     "github-slugger": "^2.0.0",
+    "microdiff": "^1.4.0",
     "nanoid": "catalog:",
     "vue": "catalog:",
     "zod": "catalog:"

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
-import { useWorkspace } from '@scalar/api-client/store'
-import { getObjectKeys } from '@scalar/oas-utils/helpers'
+import { useActiveEntities, useWorkspace } from '@scalar/api-client/store'
+import {
+  mutateSecuritySchemeDiff,
+  mutateServerDiff,
+  parseDiff,
+} from '@scalar/api-client/views/Request/libs'
+import { serverSchema } from '@scalar/oas-utils/entities/spec'
 import type { ApiClientConfiguration } from '@scalar/types/api-reference'
 import { watchDebounced } from '@vueuse/core'
 import { useExampleStore } from '#legacy'
+import microdiff, { type Difference } from 'microdiff'
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import { useNavState } from '@/hooks'
@@ -18,6 +24,7 @@ const el = ref<HTMLDivElement | null>(null)
 
 const { client, init } = useApiClient()
 const { selectedExampleKey, operationId } = useExampleStore()
+const activeEntities = useActiveEntities()
 const store = useWorkspace()
 const { isIntersectionEnabled } = useNavState()
 
@@ -35,27 +42,44 @@ onMounted(() => {
 })
 
 // Update the config on change
-// We temporarily just debounce this but we should switch to the diff from watch mode for updates
 watchDebounced(
   () => configuration,
   (newConfig, oldConfig) => {
-    /** Hacky way to ensure something actually changed in this watcher. This won't cover everything so we default to true */
-    let hasChanged = true
-    try {
-      hasChanged = JSON.stringify(newConfig) !== JSON.stringify(oldConfig)
-    } catch (error) {
-      // If we can't compare the configs, we default to true
-    }
+    const diff = microdiff(oldConfig, newConfig)
+    const hasContentChanged = diff.some(
+      (d) =>
+        d.path[0] === 'url' ||
+        d.path[0] === 'content' ||
+        d.path[1] === 'url' ||
+        d.path[1] === 'content',
+    )
 
-    if (newConfig && hasChanged) {
-      // Disable intersection observer in case there's some jumpiness
-      isIntersectionEnabled.value = false
+    // If the content changes then we re-create the whole store
+    if (hasContentChanged) {
       client.value?.updateConfig(newConfig)
-
-      setTimeout(() => {
-        isIntersectionEnabled.value = true
-      }, 1000)
     }
+    // Or we handle the specific diff changes, just auth and servers for now
+    // TODO: move to lib and add tests
+    else {
+      diff.forEach((diff) => {
+        // Servers
+        if (diff.path[0] === 'servers') {
+          mutateServerDiff(diff, activeEntities, store)
+        }
+        // Auth - TODO preferredSecurityScheme
+        else if (diff.path[0] === 'authentication') {
+          console.log('security', diff.path.slice(1))
+          mutateSecuritySchemeDiff(diff, activeEntities, store)
+        }
+        // TODO: baseServerURL
+      })
+    }
+
+    // Disable intersection observer in case there's some jumpiness
+    isIntersectionEnabled.value = false
+    setTimeout(() => {
+      isIntersectionEnabled.value = true
+    }, 1000)
   },
   { deep: true, debounce: 300 },
 )

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -45,6 +45,10 @@ onMounted(() => {
 watchDebounced(
   () => configuration,
   (newConfig, oldConfig) => {
+    if (!oldConfig) {
+      return
+    }
+
     const diff = microdiff(oldConfig, newConfig)
     const hasContentChanged = diff.some(
       (d) =>

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -63,7 +63,6 @@ watchDebounced(
       client.value?.updateConfig(newConfig)
     }
     // Or we handle the specific diff changes, just auth and servers for now
-    // TODO: move to lib and add tests
     else {
       diff.forEach((diff) => {
         // Servers

--- a/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/ApiClientModal/ApiClientModal.vue
@@ -59,6 +59,7 @@ watchDebounced(
     )
 
     // If the content changes then we re-create the whole store
+    // TODO: we can easily use live sync for this as well
     if (hasContentChanged) {
       client.value?.updateConfig(newConfig)
     }
@@ -71,7 +72,6 @@ watchDebounced(
         }
         // Auth - TODO preferredSecurityScheme
         else if (diff.path[0] === 'authentication') {
-          console.log('security', diff.path.slice(1))
           mutateSecuritySchemeDiff(diff, activeEntities, store)
         }
         // TODO: baseServerURL

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1094,6 +1094,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      microdiff:
+        specifier: ^1.4.0
+        version: 1.4.0
       nanoid:
         specifier: 'catalog:'
         version: 5.1.5
@@ -11387,6 +11390,7 @@ packages:
 
   formidable@2.1.2:
     resolution: {integrity: sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==}
+    deprecated: 'ACTION REQUIRED: SWITCH TO v3 - v1 and v2 are VULNERABLE! v1 is DEPRECATED FOR OVER 2 YEARS! Use formidable@latest or try formidable-mini for fresh projects'
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -18008,6 +18012,9 @@ packages:
 
   vue-component-type-helpers@2.0.21:
     resolution: {integrity: sha512-3NaicyZ7N4B6cft4bfb7dOnPbE9CjLcx+6wZWAg5zwszfO4qXRh+U52dN5r5ZZfc6iMaxKCEcoH9CmxxoFZHLg==}
+
+  vue-component-type-helpers@2.2.10:
+    resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
 
   vue-component-type-helpers@2.2.8:
     resolution: {integrity: sha512-4bjIsC284coDO9om4HPA62M7wfsTvcmZyzdfR0aUlFXqq4tXxM1APyXpNVxPC8QazKw9OhmZNHBVDA6ODaZsrA==}
@@ -25841,7 +25848,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.12(typescript@5.6.2)
-      vue-component-type-helpers: 2.2.8
+      vue-component-type-helpers: 2.2.10
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -39208,6 +39215,8 @@ snapshots:
       typescript: 5.6.2
 
   vue-component-type-helpers@2.0.21: {}
+
+  vue-component-type-helpers@2.2.10: {}
 
   vue-component-type-helpers@2.2.8: {}
 


### PR DESCRIPTION
**Problem**

Currently, we just blindly re-create the store on any config change.

**Solution**

With this PR we only re-create the whole store when content or url changes (spec related). Otherwise we use the tools from live sync to update the store accordingly.

TODO: we can also use live sync on the spec too but just requires a bit of time which is scarce right now

**To test**
plop this into api-reference/index.html
```html
    <!-- Initialize the Scalar API Reference -->
    <script type="module">
      const reference = Scalar.createApiReference('#app', {
        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
        servers: [
          {
            url: 'https://excited-glider-18.clerk.accountsstage.dev/',
          },
        ],
        authentication: {
          securitySchemes: {
            bearerAuth: {
              token:
                'xxww',
            },
          },
        },
      })
      setTimeout(() => {
        reference.updateConfiguration({
          url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
          servers: [
            {
              url: 'https://mature-muskox-27.clerk.accountsstage.dev/',
            },
          ],
          authentication: {
            securitySchemes: {
              bearerAuth: {
                token: 'haaaay whats up',
              },
            },
          },
        })
      }, 2_000)
    </script>
```
You should see both the server and the auth change.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
