### PR TITLE
feat(api-reference): single `text-base` wrap for specification extensions

### DIFF
--- a/.changeset/strong-starfishes-wait.md
+++ b/.changeset/strong-starfishes-wait.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: single text-base wrapper for multiple specification extensions

--- a/packages/api-reference/src/components/SpecificationExtension/SpecificationExtension.vue
+++ b/packages/api-reference/src/components/SpecificationExtension/SpecificationExtension.vue
@@ -45,15 +45,15 @@ const customExtensions =
 </script>
 
 <template>
-  <template v-if="typeof value === 'object'">
-    <template v-for="extension in customExtensions">
-      <ScalarErrorBoundary>
-        <div class="text-base">
+  <template v-if="typeof value === 'object' && customExtensions.length">
+    <div class="text-base">
+      <template v-for="extension in customExtensions">
+        <ScalarErrorBoundary>
           <component
             :is="extension.component"
             v-bind="{ [extension.name]: value?.[extension.name] }" />
-        </div>
-      </ScalarErrorBoundary>
-    </template>
+        </ScalarErrorBoundary>
+      </template>
+    </div>
   </template>
 </template>


### PR DESCRIPTION
**Problem**

When registering two (or more) specification extensions (through the plugin API), each component is wrapped in a `div.text-base` wrapper to reset the CSS `font-size`. This can lead to problems, when styling the group of rendered elements.

<img width="575" alt="Screenshot 2025-04-23 at 13 44 55" src="https://github.com/user-attachments/assets/16f0273f-7623-41dd-b2ea-ad6428f70b61" />

**Solution**

With this PR we’re rendering only one `div.text-base` around all components.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
