### PR TITLE
feat(api-reference): render top-level specification extensions

### DIFF
--- a/.changeset/giant-boxes-drop.md
+++ b/.changeset/giant-boxes-drop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: render top-level specification extensions

--- a/packages/api-reference/playground/vue/src/components/DebugBar.vue
+++ b/packages/api-reference/playground/vue/src/components/DebugBar.vue
@@ -57,8 +57,9 @@ const sources = [
   {
     title: 'Specification Extensions',
     content: JSON.stringify({
-      openapi: '3.1.0',
-      info: {
+      'x-custom-extension': 'root.x-custom-extension',
+      'openapi': '3.1.0',
+      'info': {
         'title': 'Specification Extensions',
         'description':
           'An OpenAPI document with specification extensions where the specification allows them.',
@@ -76,17 +77,17 @@ const sources = [
           'x-custom-extension': 'info.license.x-custom-extension',
         },
       },
-      tags: [
+      'tags': [
         {
           'name': 'Foobar',
           'x-custom-extension': 'tags.Foobar.x-custom-extension',
         },
       ],
-      externalDocumentation: {
+      'externalDocumentation': {
         'url': 'https://www.example.com/docs',
         'x-custom-extension': 'externalDocumentation.x-custom-extension',
       },
-      servers: [
+      'servers': [
         {
           'url': 'https://example.com/{version}',
           'x-custom-extension': 'servers.x-custom-extension',
@@ -99,7 +100,7 @@ const sources = [
           },
         },
       ],
-      paths: {
+      'paths': {
         '/': {
           'x-custom-extension': 'paths./.x-custom-extension',
           'post': {
@@ -240,7 +241,7 @@ const sources = [
           },
         },
       },
-      components: {
+      'components': {
         'securitySchemes': {
           apiKey: {
             'type': 'apiKey',

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -99,6 +99,7 @@ onMounted(() => config.value.onLoaded?.())
             </div>
           </SectionColumn>
         </SectionColumns>
+        <SpecificationExtension :value="parsedSpec" />
         <SpecificationExtension :value="info" />
       </SectionContent>
       <slot name="after" />

--- a/packages/api-reference/src/components/SpecificationExtension/SpecificationExtension.vue
+++ b/packages/api-reference/src/components/SpecificationExtension/SpecificationExtension.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ScalarErrorBoundary } from '@scalar/components'
+import { computed } from 'vue'
 
 import { usePluginManager } from '@/plugins'
 
@@ -35,13 +36,14 @@ function getCustomOpenApiExtensionComponents(extensionNames: `x-${string}`[]) {
 /**
  * Get the names of custom extensions from the provided value.
  */
-const customExtensionNames = getCustomExtensionNames(value)
+const customExtensionNames = computed(() => getCustomExtensionNames(value))
 
 /**
  * Get the components for the custom extensions.
  */
-const customExtensions =
-  getCustomOpenApiExtensionComponents(customExtensionNames)
+const customExtensions = computed(() =>
+  getCustomOpenApiExtensionComponents(customExtensionNames.value),
+)
 </script>
 
 <template>


### PR DESCRIPTION
**Problem**

Currently, we render specification extensions (`x-custom-property`) already, but we ignore them in the root (because the specification doesn’t explicitly allows them). But a lot of people actually have top-level specification extensions (`x-logo` is a super popular one).

**Solution**

With this PR we allow to register custom components for those top-level specification extensions, too.

Turns out, the rendering wasn’t reactive, so I fixed that, too. (They didn’t show up when the content changed.)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
