### PR TITLE
feat(api-client): request table row deletion and input wrapping

### DIFF
--- a/.changeset/afraid-turtles-pull.md
+++ b/.changeset/afraid-turtles-pull.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds request table row deletion

--- a/.changeset/two-fireants-know.md
+++ b/.changeset/two-fireants-know.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds request table input wrapping

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -49,6 +49,7 @@ const props = withDefaults(
     environment: Environment
     envVariables: EnvVariable[]
     workspace: Workspace
+    lineWrapping?: boolean
   }>(),
   {
     disableCloseBrackets: false,
@@ -60,6 +61,7 @@ const props = withDefaults(
     withVariables: true,
     isCopyable: false,
     disabled: false,
+    lineWrapping: false,
   },
 )
 const emit = defineEmits<{
@@ -282,6 +284,8 @@ export default {
       ref="codeMirrorRef"
       class="group/input group-[.alert]:outline-orange group-[.error]:outline-red font-code peer relative w-full overflow-hidden whitespace-nowrap text-xs leading-[1.44] -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline"
       :class="{
+        'line-wrapping has-[:focus-visible]:bg-b-1 has-[:focus-visible]:z-1 has-[:focus-visible]:absolute':
+          lineWrapping,
         'flow-code-input--error': error,
       }"
       @keydown.down.stop="handleKeyDown('down', $event)"
@@ -317,7 +321,11 @@ export default {
     class="centered-y text-orange absolute right-7 text-xs">
     <slot name="warning" />
   </div>
-  <slot name="icon" />
+  <div
+    v-if="$slots.icon"
+    class="centered-y group-has-[.cm-focused]:z-1 absolute right-0 flex h-full items-center p-1.5">
+    <slot name="icon" />
+  </div>
   <div
     v-if="required"
     class="required centered-y text-xxs text-c-3 group-[.error]:text-red bg-b-1 pointer-events-none absolute right-0 mr-0.5 pr-2 pt-px opacity-100 shadow-[-8px_0_4px_var(--scalar-background-1)] transition-opacity duration-150 group-[.alert]:bg-transparent group-[.error]:bg-transparent group-[.alert]:shadow-none group-[.error]:shadow-none peer-has-[.cm-focused]:opacity-0">
@@ -472,6 +480,11 @@ export default {
 }
 .copy-button svg {
   stroke-width: 1.5;
+}
+.line-wrapping:focus-within :deep(.cm-content) {
+  min-height: fit-content;
+  white-space: break-spaces;
+  word-break: break-all;
 }
 </style>
 <style>

--- a/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestParams.vue
@@ -133,6 +133,20 @@ const deleteAllRows = () => {
   nextTick(() => addRow())
 }
 
+const deleteRow = (rowIdx: number) => {
+  const currentParams = params.value
+  if (currentParams.length > rowIdx) {
+    const updatedParams = [...currentParams]
+    updatedParams.splice(rowIdx, 1)
+
+    requestExampleMutators.edit(
+      example.uid,
+      `parameters.${paramKey}`,
+      updatedParams,
+    )
+  }
+}
+
 function defaultRow() {
   /** ensure one empty row by default */
   if (params.value.length === 0) {
@@ -225,7 +239,8 @@ const hasReadOnlyEntries = computed(() => (readOnlyEntries ?? []).length > 0)
         :label
         :workspace="workspace"
         @toggleRow="toggleRow"
-        @updateRow="updateRow" />
+        @updateRow="updateRow"
+        @deleteRow="deleteRow" />
     </div>
   </ViewLayoutCollapse>
 </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestPathParams.vue
@@ -76,6 +76,20 @@ const updateRow = (rowIdx: number, field: 'key' | 'value', value: string) => {
   )
 }
 
+const deleteRow = (rowIdx: number) => {
+  const currentParams = params.value
+  if (currentParams.length > rowIdx) {
+    const updatedParams = [...currentParams]
+    updatedParams.splice(rowIdx, 1)
+
+    requestExampleMutators.edit(
+      example.uid,
+      `parameters.${paramKey}`,
+      updatedParams,
+    )
+  }
+}
+
 const setPathVariable = (url: string) => {
   const pathVariables = url.match(REGEX.PATH)?.map((v) => v.slice(1, -1)) || []
   const parameters = example.parameters[paramKey]
@@ -126,6 +140,7 @@ watch(
       :invalidParams="invalidParams"
       :items="params"
       :workspace="workspace"
-      @updateRow="updateRow" />
+      @updateRow="updateRow"
+      @deleteRow="deleteRow" />
   </ViewLayoutCollapse>
 </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -132,6 +132,7 @@ const showDeleteButton = (item: RequestExampleParameter) => {
           :disabled="props.isReadOnly"
           disableEnter
           disableTabIndent
+          lineWrapping
           :envVariables="envVariables"
           :environment="environment"
           :modelValue="item.key"
@@ -157,6 +158,7 @@ const showDeleteButton = (item: RequestExampleParameter) => {
           :disabled="props.isReadOnly"
           disableEnter
           disableTabIndent
+          lineWrapping
           :enum="item.enum ?? []"
           :envVariables="envVariables"
           :environment="environment"
@@ -250,7 +252,9 @@ const showDeleteButton = (item: RequestExampleParameter) => {
   margin-left: 0.5px;
 }
 :deep(.cm-line) {
+  overflow: hidden;
   padding: 0;
+  text-overflow: ellipsis;
 }
 .filemask {
   mask-image: linear-gradient(

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
+import { ScalarIconTrash } from '@scalar/icons'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
@@ -42,7 +43,7 @@ const emit = defineEmits<{
   (e: 'updateRow', idx: number, field: 'key' | 'value', value: string): void
   (e: 'toggleRow', idx: number, enabled: boolean): void
   (e: 'addRow'): void
-  (e: 'deleteRow'): void
+  (e: 'deleteRow', idx: number): void
   (e: 'inputFocus'): void
   (e: 'inputBlur'): void
   (e: 'uploadFile', idx: number): void
@@ -67,6 +68,11 @@ const flattenValue = (item: RequestExampleParameter) => {
   return Array.isArray(item.default) && item.default.length === 1
     ? item.default[0]
     : item.default
+}
+
+// Shows delete button if the item has key or value filled
+const showDeleteButton = (item: RequestExampleParameter) => {
+  return Boolean(item.key || item.value)
 }
 </script>
 <template>
@@ -141,9 +147,11 @@ const flattenValue = (item: RequestExampleParameter) => {
       </DataTableCell>
       <DataTableCell>
         <CodeInput
-          :class="{
-            'pr-6': hasItemProperties(item),
-          }"
+          :class="
+            hasItemProperties(item)
+              ? 'pr-5 group-hover:pr-10 group-has-[.cm-focused]:pr-10'
+              : 'group-hover:pr-5 group-has-[.cm-focused]:pr-5'
+          "
           :default="item.default"
           disableCloseBrackets
           :disabled="props.isReadOnly"
@@ -167,6 +175,17 @@ const flattenValue = (item: RequestExampleParameter) => {
             (v: string) => emit('updateRow', idx, 'value', v)
           ">
           <template #icon>
+            <ScalarButton
+              v-if="showDeleteButton(item) && !item.required"
+              :class="{
+                '-mr-0.5': hasItemProperties(item),
+              }"
+              class="text-c-2 hover:text-c-1 hover:bg-b-2 z-context hidden h-fit rounded p-1 group-hover:flex group-has-[.cm-focused]:flex"
+              size="sm"
+              variant="ghost"
+              @click="emit('deleteRow', idx)">
+              <ScalarIconTrash class="size-3.5" />
+            </ScalarButton>
             <RequestTableTooltip
               v-if="hasItemProperties(item)"
               :item="{ ...item, default: flattenValue(item) }" />
@@ -219,6 +238,7 @@ const flattenValue = (item: RequestExampleParameter) => {
   font-family: var(--scalar-font);
   font-size: var(--scalar-mini);
   padding: 6px 8px;
+  width: 100%;
 }
 :deep(.cm-content):has(.cm-pill) {
   padding: 4px 3px;

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -149,8 +149,8 @@ const showDeleteButton = (item: RequestExampleParameter) => {
         <CodeInput
           :class="
             hasItemProperties(item)
-              ? 'pr-5 group-hover:pr-10 group-has-[.cm-focused]:pr-10'
-              : 'group-hover:pr-5 group-has-[.cm-focused]:pr-5'
+              ? 'pr-6 group-hover:pr-10 group-has-[.cm-focused]:pr-10'
+              : 'group-hover:pr-6 group-has-[.cm-focused]:pr-6'
           "
           :default="item.default"
           disableCloseBrackets

--- a/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTableTooltip.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarIcon, ScalarTooltip } from '@scalar/components'
+import { ScalarTooltip } from '@scalar/components'
+import { ScalarIconInfo, ScalarIconWarning } from '@scalar/icons'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
 import { computed } from 'vue'
 
@@ -15,21 +16,18 @@ const isInvalid = computed(() => !!parameterIsInvalid(item).value)
     class="w-full pr-px"
     :delay="0"
     side="left"
-    triggerClass="before:absolute before:content-[''] before:bg-gradient-to-r before:from-transparent before:to-b-1 group-[.alert]:before:to-b-alert group-[.error]:before:to-b-danger before:min-h-[calc(100%-4px)] before:pointer-events-none before:right-[23px] before:top-0.5 before:w-3 absolute h-full right-0 -outline-offset-1">
+    triggerClass="py-1">
     <template #trigger>
       <div
         :aria-label="isInvalid ? 'Input is invalid' : 'More Information'"
-        class="bg-b-1 mr-1 pl-1 pr-1.5 group-[.alert]:bg-transparent group-[.error]:bg-transparent"
+        class="bg-b-1 px-1 group-[.alert]:bg-transparent group-[.error]:bg-transparent"
         :role="isInvalid ? 'alert' : 'none'">
-        <ScalarIcon
-          :class="
-            isInvalid
-              ? 'text-orange brightness-[.9]'
-              : 'text-c-3 group-hover/info:text-c-1'
-          "
-          :icon="isInvalid ? 'Alert' : 'Info'"
-          size="sm"
-          thickness="1.5" />
+        <ScalarIconWarning
+          v-if="isInvalid"
+          class="text-orange size-3.5 brightness-[.9]" />
+        <ScalarIconInfo
+          v-else
+          class="text-c-2 hover:text-c-1 size-3.5" />
       </div>
     </template>
     <template #content>


### PR DESCRIPTION
**Problem**

currently it is not possible to quickly remove a key and value at the request table row level + long content get stripped out through scroll.

**Solution**

this pr introduces:
- row deletion capability fixes #3788
- line wrapping on long content

| before | after |
| -------|------|
| <video src="https://github.com/user-attachments/assets/726381da-f9f3-44e9-9fc6-02eb0efc4252" /> | <video src="https://github.com/user-attachments/assets/f5ad15d5-e089-4287-88bd-7f2ebd448484"/>  |
| row non deletable and long content is hard to reach | row is deletable and wrapped if long content | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
