### PR TITLE
fix(api-client): import collection modal font size

### DIFF
--- a/.changeset/rude-days-fetch.md
+++ b/.changeset/rude-days-fetch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: decreases import collection modal preview font size

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
@@ -210,7 +210,9 @@ const handleInput = (value: string) => {
     <template v-else>
       <!-- OpenAPI document preview -->
       <div class="flex justify-between">
-        <div class="text-c-2 min-h-8 py-2 pl-8 text-xs">Preview</div>
+        <div class="text-c-2 min-h-8 w-full py-2 pl-12 text-center text-xs">
+          Preview
+        </div>
         <ScalarButton
           class="hover:bg-b-2 relative ml-auto max-h-8 gap-1.5 p-2 text-xs"
           variant="ghost"
@@ -220,7 +222,7 @@ const handleInput = (value: string) => {
       </div>
       <ScalarCodeBlock
         v-if="documentDetails && !isUrl(inputContent)"
-        class="bg-b-2 mt-1 max-h-[40dvh] rounded border [--scalar-small:--scalar-font-size-4]"
+        class="bg-b-2 mt-1 max-h-[40dvh] rounded border px-2 py-1 text-sm"
         :content="inputContent"
         :copy="false"
         :lang="documentType" />


### PR DESCRIPTION
**Problem**

following scalar block package update the font size used in the import collection preview is off.

**Solution**

this pr updates the import collection preview font size and style.

| before | after |
| -------|------|
| <img width="727" alt="image" src="https://github.com/user-attachments/assets/dd25e388-f8db-43bb-acbb-14b56a1865a2" /> | <img width="727" alt="image" src="https://github.com/user-attachments/assets/2d41c62a-114a-4fea-89fb-00f7601a0c61" /> |

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
