### PR TITLE
fix(api-reference): types + reactivity for auth config

### DIFF
--- a/.changeset/cuddly-seahorses-heal.md
+++ b/.changeset/cuddly-seahorses-heal.md
@@ -1,0 +1,5 @@
+---
+'@scalar/types': patch
+---
+
+fix: types of authentication config

--- a/.changeset/two-eagles-kiss.md
+++ b/.changeset/two-eagles-kiss.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: falsy values in auth config reactivity

--- a/packages/api-client/src/views/Request/libs/watch-mode.test.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.test.ts
@@ -8,6 +8,7 @@ import {
   type Tag,
   collectionSchema,
   operationSchema,
+  securityHttpSchema,
   securitySchemeSchema,
   serverSchema,
   tagSchema,
@@ -1346,6 +1347,11 @@ describe('narrowUnionSchema', () => {
     const result = narrowUnionSchema(discriminatedUnion, 'type', 'two')
     expect(result).equal(schema2)
   })
+
+  it('returns the correct schema from auth discriminated by type', () => {
+    const result = narrowUnionSchema(securitySchemeSchema, 'type', 'http')
+    expect(result).equal(securityHttpSchema)
+  })
 })
 
 describe('traverseZodSchema', () => {
@@ -1540,5 +1546,16 @@ describe('parseDiff', () => {
     }
     const result = parseDiff(testSchema, diff)
     expect(result).toBeNull()
+  })
+
+  it('handles a CHANGE diff on an http security scheme with an empty string value', () => {
+    const diff: Difference = {
+      oldValue: 'oldVal',
+      type: 'CHANGE',
+      path: ['token'],
+      value: '',
+    }
+    const result = parseDiff(securityHttpSchema, diff)
+    expect(result).not.toBeNull()
   })
 })

--- a/packages/api-client/src/views/Request/libs/watch-mode.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.ts
@@ -232,7 +232,7 @@ export const parseDiff = <T>(
 
   // Safe parse the value as well
   const parsedValue = schemaModel<T>(diff.value, parsedSchema, false)
-  if (!parsedValue) {
+  if (typeof parsedValue === 'undefined' || parsedValue === null) {
     return null
   }
 

--- a/packages/api-reference/src/hooks/useMultipleDocuments.ts
+++ b/packages/api-reference/src/hooks/useMultipleDocuments.ts
@@ -235,5 +235,17 @@ export const useMultipleDocuments = ({
     isIntersectionEnabled,
     hash,
     hashPrefix,
-  }
+  } as
+    /**
+     * This was needed for a the bug: The inferred type of 'useMultipleDocuments' cannot be named without a reference to
+     * A limitation of typescript
+     */
+    {
+      selectedConfiguration: Ref<SpecConfiguration>
+      availableDocuments: Ref<SpecConfiguration[]>
+      selectedDocumentIndex: Ref<number>
+      isIntersectionEnabled: Ref<boolean>
+      hash: Ref<string>
+      hashPrefix: Ref<string>
+    }
 }

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -546,7 +546,7 @@ describe('importSpecToWorkspace', () => {
           },
         },
         useCollectionSecurity: true,
-      })
+      } as any)
       if (res.error) {
         throw res.error
       }
@@ -733,7 +733,7 @@ describe('importSpecToWorkspace', () => {
             scopes: ['read:account'],
           },
         },
-      })
+      } as any)
       if (res.error) {
         throw res.error
       }

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -3,7 +3,8 @@ import { z } from 'zod'
 import { ApiReferencePluginSchema } from '@/api-reference/api-reference-plugin.ts'
 import type { TargetId } from '@/snippetz/index.ts'
 import type { AuthenticationConfiguration } from './authentication-configuration.ts'
-import { migrateThemeVariables } from './helpers/migrate-theme-variables.ts'
+import { migrateThemeVariables } from '@/api-reference/helpers/migrate-theme-variables.ts'
+
 /** Available theme presets for the API reference */
 const themeIdEnum = z.enum([
   'alternate',
@@ -214,9 +215,6 @@ export const apiClientConfigurationSchema = z.object({
 })
 
 export type ApiClientConfiguration = z.infer<typeof apiClientConfigurationSchema>
-
-const OLD_PROXY_URL = 'https://api.scalar.com/request-proxy'
-const NEW_PROXY_URL = 'https://proxy.scalar.com'
 
 /** Configuration for the Api Client without the transform since it cannot be merged */
 const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
@@ -448,6 +446,9 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
   }),
 )
 
+const OLD_PROXY_URL = 'https://api.scalar.com/request-proxy'
+const NEW_PROXY_URL = 'https://proxy.scalar.com'
+
 /** Migrate the configuration through a transform */
 const migrateConfiguration = <T extends z.infer<typeof _apiReferenceConfigurationSchema>>(_configuration: T): T => {
   const configuration = { ..._configuration }
@@ -509,7 +510,7 @@ export const apiReferenceConfigurationSchema = _apiReferenceConfigurationSchema.
 export type ApiReferenceConfiguration = Omit<
   z.infer<typeof _apiReferenceConfigurationSchema>,
   // Remove deprecated attributes
-  'proxy' | 'spec'
+  'proxy' | 'spec' | 'authentication'
 > & {
   authentication?: AuthenticationConfiguration
 }

--- a/packages/types/src/entities/security-scheme.ts
+++ b/packages/types/src/entities/security-scheme.ts
@@ -209,7 +209,7 @@ export const oasSecuritySchemeSchema = z.union([
 
 /** Extended security schemes for workspace usage */
 export const securitySchemeSchema = z
-  .union([securityApiKeySchema, securityHttpSchema, securityOpenIdSchema, securityOauthSchema])
+  .discriminatedUnion('type', [securityApiKeySchema, securityHttpSchema, securityOpenIdSchema, securityOauthSchema])
   .transform((data) => {
     // Set selected scopes from x-default-scopes
     if (data.type === 'oauth2' && data['x-default-scopes']?.length) {


### PR DESCRIPTION
**Problem**

Currently, authentication config was typed to any and didn't work for empty string values (falsy).

**Solution**

With this PR we add an explicit check for defined and null and fixed types.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
