### PR TITLE
fix(Scalar.AspNetCore): make Pkce property nullable

### DIFF
--- a/.changeset/selfish-lemons-learn.md
+++ b/.changeset/selfish-lemons-learn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+fix: make Pkce property nullable

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/AuthorizationCodeFlow.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/AuthorizationCodeFlow.cs
@@ -27,7 +27,7 @@ public sealed class AuthorizationCodeFlow : OAuthFlow
     /// </summary>
     [JsonPropertyName("x-usePkce")]
     [JsonConverter(typeof(PkceJsonConverter))]
-    public Pkce Pkce { get; set; }
+    public Pkce? Pkce { get; set; }
 
     /// <summary>
     /// Gets or sets the redirect URI for the authorization code flow.


### PR DESCRIPTION
**Problem**

With the recent PR https://github.com/scalar/scalar/pull/5451 we migrated to the new authentication. I forgot to make the `Pkce` entry nullable. So the default value was set to `no`. This overwrites the extensions set in the OpenAPI document itself.


**Solution**

Now the `Pkce` property is nullable, as every auth related property should be!

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
