### PR TITLE
feat(api-client): updates collection server page style

### DIFF
--- a/.changeset/sharp-coats-matter.md
+++ b/.changeset/sharp-coats-matter.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: updates collection server page style

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -29,8 +29,14 @@ const props = withDefaults(
     envVariables: EnvVariable[]
     workspace: Workspace
     description?: string | undefined
+    lineWrapping?: boolean
   }>(),
-  { canAddCustomEnumValue: true, required: false, readOnly: false },
+  {
+    canAddCustomEnumValue: true,
+    required: false,
+    readOnly: false,
+    lineWrapping: false,
+  },
 )
 
 const emit = defineEmits<{
@@ -78,7 +84,7 @@ const handleLabelClick = () => {
       @click="handleLabelClick">
       <slot />:
     </div>
-    <div class="row-1 overflow-x-auto">
+    <div class="row-1 relative min-w-0">
       <template v-if="props.enum && props.enum.length">
         <DataTableInputSelect
           :canAddCustomValue="props.canAddCustomEnumValue"
@@ -118,6 +124,7 @@ const handleLabelClick = () => {
           disableTabIndent
           :envVariables="envVariables"
           :environment="environment"
+          :lineWrapping="Boolean(lineWrapping)"
           :max="max"
           :min="min"
           :modelValue="modelValue ?? ''"
@@ -157,6 +164,7 @@ const handleLabelClick = () => {
   font-family: var(--scalar-font);
   font-size: var(--scalar-mini);
   padding: 6px 8px;
+  width: 100%;
 }
 :deep(.cm-content):has(.cm-pill) {
   padding: 4px 3px;
@@ -168,7 +176,9 @@ const handleLabelClick = () => {
   margin-left: 0.5px;
 }
 :deep(.cm-line) {
+  overflow: hidden;
   padding: 0;
+  text-overflow: ellipsis;
 }
 .required::after {
   content: 'Required';

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -29,7 +29,7 @@ const { activeEnvVariables, activeEnvironment, activeWorkspace } =
 const id = useId()
 </script>
 <template>
-  <ViewLayoutSection>
+  <ViewLayoutSection class="rounded-b-lg">
     <template
       v-if="title || $slots.title"
       #title>
@@ -38,15 +38,18 @@ const id = useId()
         v-else
         name="title" />
     </template>
-    <div class="custom-scroll flex flex-1 flex-col gap-1.5">
+    <div class="flex flex-1 flex-col gap-1.5">
       <DataTable
         v-if="Object.keys(data).length > 0 && activeWorkspace"
-        :columns="['']">
+        :columns="['']"
+        class="rounded-b-lg">
         <DataTableRow
           v-for="(option, index) in options"
           :key="index"
           :class="{ 'border-t': index === 0 }">
           <DataTableInput
+            class="pr-9"
+            lineWrapping
             :id="id"
             :envVariables="activeEnvVariables"
             :environment="activeEnvironment"
@@ -62,7 +65,8 @@ const id = useId()
             <template
               v-if="option.key === 'description'"
               #icon>
-              <div class="bg-b-2 flex-center border-l px-2">
+              <div
+                class="centered-y bg-b-2 flex-center z-1 absolute right-1 rounded px-1 py-0.5">
                 <ScalarIcon
                   icon="Markdown"
                   size="lg" />

--- a/packages/api-client/src/views/Collection/CollectionServerForm.vue
+++ b/packages/api-client/src/views/Collection/CollectionServerForm.vue
@@ -110,7 +110,9 @@ const updateServerVariable = (key: string, value: string) => {
 </script>
 
 <template>
-  <div class="bg-b-1 divide-0.5 flex w-full flex-col divide-y text-sm">
+  <div
+    class="divide-0.5 flex w-full flex-col divide-y rounded-b-lg text-sm"
+    :class="activeServer?.variables && 'bg-b-1'">
     <template v-if="activeServer">
       <Form
         :data="activeServer"

--- a/packages/api-client/src/views/Collection/CollectionServers.vue
+++ b/packages/api-client/src/views/Collection/CollectionServers.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarDropdown,
-  ScalarDropdownItem,
   ScalarIcon,
   ScalarMarkdown,
   ScalarModal,
   useModal,
 } from '@scalar/components'
+import { ScalarIconTrash } from '@scalar/icons'
 import type { Server } from '@scalar/oas-utils/entities/spec'
 import { computed, ref } from 'vue'
 
@@ -78,28 +77,12 @@ const openDeleteModal = (serverUid: Server['uid']) => {
               v-if="server.description"
               :value="server.description" />
             <span v-else>Server {{ index + 1 }}</span>
-            <ScalarDropdown placement="bottom-end">
-              <ScalarButton
-                class="hover:bg-b-3 h-full max-h-8 gap-1 p-1 text-xs"
-                variant="ghost">
-                <ScalarIcon
-                  class="text-c-3"
-                  icon="Ellipses"
-                  size="md" />
-              </ScalarButton>
-              <template #items>
-                <ScalarDropdownItem
-                  class="flex gap-2 font-normal"
-                  @click="openDeleteModal(server.uid)">
-                  <ScalarIcon
-                    class="inline-flex"
-                    icon="Delete"
-                    size="sm"
-                    thickness="1.5" />
-                  <span>Delete</span>
-                </ScalarDropdownItem>
-              </template>
-            </ScalarDropdown>
+            <ScalarButton
+              class="hover:bg-b-3 hover:text-c-1 p-1.25 h-fit"
+              variant="ghost"
+              @click="openDeleteModal(server.uid)">
+              <ScalarIconTrash class="size-3.5" />
+            </ScalarButton>
           </div>
           <CollectionServerForm
             v-if="activeCollection"

--- a/packages/api-client/src/views/Collection/CollectionServers.vue
+++ b/packages/api-client/src/views/Collection/CollectionServers.vue
@@ -71,12 +71,18 @@ const openDeleteModal = (serverUid: Server['uid']) => {
       <div
         v-for="(server, index) in collectionServers"
         :key="server.uid">
-        <div class="bg-b-2 overflow-hidden rounded-lg border">
-          <div class="flex items-center justify-between py-1 pl-3 pr-1 text-sm">
+        <div class="bg-b-2 rounded-lg border">
+          <div
+            class="flex items-start justify-between rounded-t-lg py-1 pl-3 pr-1 text-sm">
             <ScalarMarkdown
               v-if="server.description"
-              :value="server.description" />
-            <span v-else>Server {{ index + 1 }}</span>
+              :value="server.description"
+              class="self-center" />
+            <span
+              class="self-center"
+              v-else
+              >Server {{ index + 1 }}</span
+            >
             <ScalarButton
               class="hover:bg-b-3 hover:text-c-1 p-1.25 h-fit"
               variant="ghost"


### PR DESCRIPTION
**Problem**

currently server removal button is within a dropdown of one and long description content are not easily readable.

**Solution**

this pr extracts the deletion cta from the dropdown and update form to better handle long content.

| before | after |
| -------|------|
| <img width="1100" alt="image" src="https://github.com/user-attachments/assets/b9e29902-cc53-4967-8be2-b58d262c337f" /> | <img width="1100" alt="image" src="https://github.com/user-attachments/assets/b6057855-936f-4aa0-8ee2-0685d05a9c79" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
