### PR TITLE
fix(api-client): request input pill

### DIFF
--- a/.changeset/large-bobcats-do.md
+++ b/.changeset/large-bobcats-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates padding on request input with pill

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -159,7 +159,7 @@ const handleLabelClick = () => {
   padding: 6px 8px;
 }
 :deep(.cm-content):has(.cm-pill) {
-  padding: 4px 3px;
+  padding: 6px 8px;
 }
 :deep(.cm-content .cm-pill:not(:last-of-type)) {
   margin-right: 0.5px;

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -243,7 +243,7 @@ const showDeleteButton = (item: RequestExampleParameter) => {
   width: 100%;
 }
 :deep(.cm-content):has(.cm-pill) {
-  padding: 4px 3px;
+  padding: 6px 8px;
 }
 :deep(.cm-content .cm-pill:not(:last-of-type)) {
   margin-right: 0.5px;


### PR DESCRIPTION
**Problem**

currently when using pill in an input the padding is off.

**Solution**

this pr updates padding on input with pill element.

| before | after |
| -------|------|
| <img width="642" alt="image" src="https://github.com/user-attachments/assets/7e4719f6-c0a4-4b6f-af91-efd52a807ab0" /> | <img width="642" alt="image" src="https://github.com/user-attachments/assets/a8b44c70-0046-438b-8df9-e8118cf6a318" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
