### PR TITLE
fix(api-reference): title and higher level discriminator support

### DIFF
--- a/.changeset/rare-owls-look.md
+++ b/.changeset/rare-owls-look.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: increases schema property array item level support

--- a/.changeset/smooth-pumpkins-double.md
+++ b/.changeset/smooth-pumpkins-double.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates schema discriminator to include title

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -275,7 +275,7 @@ button.schema-card-title:hover {
   flex-direction: column;
 
   border: var(--scalar-border-width) solid var(--scalar-border-color);
-  border-radius: var(--scalar-radius-xl);
+  border-radius: var(--scalar-radius-lg);
   width: fit-content;
 }
 .schema-properties-name {
@@ -293,22 +293,15 @@ button.schema-card-title:hover {
 .schema-card--compact {
   align-self: flex-start;
 }
-
 .schema-card--compact.schema-card--open {
   align-self: initial;
 }
-
 .schema-card-title--compact {
   color: var(--scalar-color-2);
   padding: 6px 8px;
   height: auto;
   border-bottom: none;
 }
-.schema-card--compact > .schema-properties,
-.schema-card-title--compact {
-  border-radius: 13.5px;
-}
-
 .schema-card-title--compact > .schema-card-title-icon {
   margin: 0;
 }

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.test.ts
@@ -93,6 +93,28 @@ describe('SchemaDiscriminator', () => {
       const tab = wrapper.find('.schema-tab-label')
       expect(tab.text()).toBe('User')
     })
+
+    it('humanizes array types with item type', () => {
+      const wrapper = mount(SchemaDiscriminator, {
+        props: {
+          discriminator: 'anyOf',
+          value: {
+            anyOf: [
+              {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            ],
+          },
+          level: 0,
+        },
+      })
+
+      const tab = wrapper.find('.schema-tab-label')
+      expect(tab.text()).toBe('Array of string')
+    })
   })
 
   describe('discriminator type display', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.test.ts
@@ -1,0 +1,114 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import SchemaDiscriminator from './SchemaDiscriminator.vue'
+
+describe('SchemaDiscriminator', () => {
+  describe('getModelNameFromSchema', () => {
+    it('displays schema name when present', () => {
+      const wrapper = mount(SchemaDiscriminator, {
+        props: {
+          discriminator: 'oneOf',
+          value: {
+            oneOf: [
+              {
+                name: 'One',
+                type: 'object',
+              },
+            ],
+          },
+          level: 0,
+        },
+      })
+
+      const tab = wrapper.find('.schema-tab-label')
+      expect(tab.text()).toBe('One')
+    })
+
+    it('displays schema title when name is not present', () => {
+      const wrapper = mount(SchemaDiscriminator, {
+        props: {
+          discriminator: 'anyOf',
+          value: {
+            anyOf: [
+              {
+                title: 'Any',
+                type: 'object',
+              },
+            ],
+          },
+          level: 0,
+        },
+      })
+
+      const tab = wrapper.find('.schema-tab-label')
+      expect(tab.text()).toBe('Any')
+    })
+
+    it('displays type when name and title are not present', () => {
+      const wrapper = mount(SchemaDiscriminator, {
+        props: {
+          discriminator: 'oneOf',
+          value: {
+            oneOf: [
+              {
+                type: 'object',
+              },
+            ],
+          },
+          level: 0,
+        },
+      })
+
+      const tab = wrapper.find('.schema-tab-label')
+      expect(tab.text()).toBe('object')
+    })
+
+    it('displays schema name from components when matching schema is found', () => {
+      const wrapper = mount(SchemaDiscriminator, {
+        props: {
+          discriminator: 'oneOf',
+          schemas: {
+            User: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+              },
+            },
+          },
+          value: {
+            oneOf: [
+              {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                },
+              },
+            ],
+          },
+          level: 0,
+        },
+      })
+
+      const tab = wrapper.find('.schema-tab-label')
+      expect(tab.text()).toBe('User')
+    })
+  })
+
+  describe('discriminator type display', () => {
+    it('humanizes discriminator type', () => {
+      const wrapper = mount(SchemaDiscriminator, {
+        props: {
+          discriminator: 'oneOf',
+          value: {
+            oneOf: [{ type: 'object' }],
+          },
+          level: 0,
+        },
+      })
+
+      const typeLabel = wrapper.find('span')
+      expect(typeLabel.text()).toBe('One of')
+    })
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -59,6 +59,12 @@ const getModelNameFromSchema = (schema: any): string | null => {
     return Object.keys(schema)[0]
   }
 
+  // Handle array types with items
+  if (schema.type === 'array' && schema.items) {
+    const itemType = schema.items.type || 'any'
+    return `Array of ${itemType}`
+  }
+
   if (schema.type) {
     return schema.type
   }

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -9,7 +9,7 @@ import { mergeAllOfSchemas } from '@/components/Content/Schema/helpers/merge-all
 
 import Schema from './Schema.vue'
 
-const props = defineProps<{
+const { schemas } = defineProps<{
   discriminator: string
   schemas?:
     | OpenAPIV2.DefinitionsObject
@@ -45,15 +45,29 @@ const getModelNameFromSchema = (schema: any): string | null => {
     return schema.name
   }
 
+  if (schema.title) {
+    return schema.title
+  }
+
   // returns a matching schema name based on the schema object
-  if (props.schemas && typeof props.schemas === 'object') {
-    for (const [schemaName, schemaValue] of Object.entries(props.schemas)) {
+  if (schemas && typeof schemas === 'object') {
+    for (const [schemaName, schemaValue] of Object.entries(schemas)) {
       if (stringify(schemaValue) === stringify(schema)) {
         return schemaName
       }
     }
-
     return Object.keys(schema)[0]
+  }
+
+  if (schema.type) {
+    return schema.type
+  }
+
+  if (typeof schema === 'object') {
+    const keys = Object.keys(schema)
+    if (keys.length > 0) {
+      return keys[0]
+    }
   }
 
   return null

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -152,8 +152,12 @@ const humanizeType = (type: string) => {
 .discriminator-panel :deep(.property--compact.property--level-1) {
   padding: 8px;
 }
-.discriminator-panel :deep(.property--compact.property--level-0) {
+.discriminator-panel
+  :deep(.property--compact.property--level-0):not(:has(.property--level-1)) {
   padding: 8px;
+}
+.discriminator-panel :deep(.property--compact.property--level-0) {
+  padding: 0;
 }
 .schema-tab {
   background: none;

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -334,7 +334,7 @@ const displayPropertyHeading = (
   color: var(--scalar-color-1);
   display: flex;
   flex-direction: column;
-  padding: 12px 8px;
+  padding: 8px;
   font-size: var(--scalar-mini);
   position: relative;
 }
@@ -346,16 +346,12 @@ const displayPropertyHeading = (
 
 .property--compact.property--level-0,
 .property--compact.property--level-1 {
-  padding: 12px 0;
+  padding: 8px 0;
 }
 /*  if a property doesn't have a heading, remove the top padding */
-.property:has(> .property-rule:nth-of-type(1)) {
-  padding-top: 0;
-}
-/*  if a property doesn't have a heading but has a panel || list */
-.property:has(> .property-rule:nth-of-type(1) .discriminator-tab-list),
-.property:has(> .property-rule:nth-of-type(1) .discriminator-panel) {
-  padding: 8px;
+.property:has(> .property-rule:nth-of-type(1)):not(.property--compact) {
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 .property--deprecated {
   background: repeating-linear-gradient(

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -312,9 +312,7 @@ const displayPropertyHeading = (
           optimizedValue?.items &&
           typeof discriminator === 'string' &&
           typeof optimizedValue.items === 'object' &&
-          discriminator in optimizedValue.items &&
-          Array.isArray(optimizedValue.items[discriminator]) &&
-          level < 3
+          discriminator in optimizedValue.items
         ">
         <SchemaDiscriminator
           :compact="compact"


### PR DESCRIPTION
**Problem**

currently when any of discriminator includes a title with value, it is not retrieved within the tab.

**Solution**

this pr adds:
- support of title value that fixes #5488 
- update schema discriminator logic that fixes #5447
- dropdown for long discriminator content usage follow up #5429
- style enhancement finalizing #795

`title`
| before | after |
| -------|------|
| <img width="563" alt="image" src="https://github.com/user-attachments/assets/73aa0400-045e-453a-acbe-a1cda26ef13c" /> | <img width="563" alt="image" src="https://github.com/user-attachments/assets/738de780-b943-4bc4-984c-86dc8084da00" /> |

`deeper level`
| before | after |
| -------|------|
| <img width="563" alt="image" src="https://github.com/user-attachments/assets/4a36f424-0b2b-46b5-b45f-b60eee2f58e8" /> | <img width="563" alt="image" src="https://github.com/user-attachments/assets/76442f98-13fd-4e32-af6a-ee624dc0eb07" /> |

`long content support`
| before | after |
| -------|------|
| <img width="562" alt="image" src="https://github.com/user-attachments/assets/bd122d11-087e-40c5-9ae6-3d2aa78fd4be" /> | <img width="562" alt="image" src="https://github.com/user-attachments/assets/326a34af-48f4-40bd-a6a6-8abfbda547a1" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
