### PR TITLE
chore: configure turborepo output dirs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,16 @@
   "tasks": {
     "lint:fix": {},
     "build": {
-      "outputs": ["dist/**", "storybook-static/**"],
+      "outputs": [
+        "dist/**",
+        "storybook-static/**",
+        ".next/**",
+        "build/**",
+        ".nuxt/**",
+        ".output/**",
+        "public/build/**",
+        "projects/proxy-scalar-com/main"
+      ],
       "dependsOn": ["^build"]
     },
     "dev": {


### PR DESCRIPTION
**Problem**

Currently, turborepo is warning that the outputs of a few packages aren’t correctly configured.

> WARNING  no output files found for task @scalar-examples/docusaurus#build. Please check your `outputs` key in `turbo.json`
> WARNING  no output files found for task @scalar-examples/nextjs-api-reference#build. Please check your `outputs` key in `turbo.json`
> WARNING  no output files found for task @scalar-examples/nuxt-playground#build. Please check your `outputs` key in `turbo.json`
> WARNING  no output files found for task @scalar-examples/sveltekit#build. Please check your `outputs` key in `turbo.json`
> WARNING  no output files found for task @scalarapi/api-reference#build. Please check your `outputs` key in `turbo.json`
> WARNING  no output files found for task proxy-scalar-com#build. Please check your `outputs` key in `turbo.json`

**Solution**

With this PR, we’re adding all the build dirs.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
