### PR TITLE
fix(api-reference): displays schema name in property heading

### DIFF
--- a/.changeset/fuzzy-poems-grin.md
+++ b/.changeset/fuzzy-poems-grin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: displays schema name in property heading

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -173,7 +173,8 @@ const displayPropertyHeading = (
       :enum="getEnumFromValue(optimizedValue).length > 0"
       :pattern="pattern"
       :required="required"
-      :value="optimizedValue">
+      :value="optimizedValue"
+      :schemas="schemas">
       <template
         v-if="name"
         #name>

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -70,4 +70,21 @@ describe('SchemaPropertyHeading', () => {
     const constElement = wrapper.find('.property-pattern')
     expect(constElement.text()).toContain('pattern')
   })
+
+  it('renders schema name', async () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'array',
+          items: { type: 'object', name: 'Model' },
+        },
+        schemas: {
+          Model: { type: 'object', name: 'Model' },
+        },
+      },
+    })
+
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('array Model[]')
+  })
 })


### PR DESCRIPTION
**Problem**

currently only the type is displayed as property heading over schema name.

**Solution**

this pr displays schema name when available over type and fixes #5377.

| before | after |
| -------|------|
| <img width="570" alt="image" src="https://github.com/user-attachments/assets/ad3c8ef6-7e43-4d0e-af18-9ed256a3aa96" /> | <img width="570" alt="image" src="https://github.com/user-attachments/assets/5d9d8684-666f-42c2-8b66-aff2b5e2ae39" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
