### PR TITLE
fix(nuxt): don’t use default layout

### DIFF
--- a/.changeset/dull-tigers-count.md
+++ b/.changeset/dull-tigers-count.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nuxt': patch
+---
+
+don't inherit the default layout

--- a/integrations/nuxt/playground/layouts/default.vue
+++ b/integrations/nuxt/playground/layouts/default.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <header>
+      <p>This is an example header</p>
+    </header>
+    <NuxtPage />
+  </div>
+</template>
+
+<style>
+header {
+  width: 100%;
+  height: 50px;
+  color: white;
+  background-color: black;
+  font-family: sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: hotpink 1px solid;
+  p {
+    margin: 0;
+  }
+}
+</style>

--- a/integrations/nuxt/playground/nuxt.config.ts
+++ b/integrations/nuxt/playground/nuxt.config.ts
@@ -1,0 +1,14 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  compatibilityDate: '2025-05-11',
+
+  devtools: { enabled: false },
+
+  modules: ['@scalar/nuxt'],
+
+  nitro: {
+    experimental: {
+      openAPI: true,
+    },
+  },
+})

--- a/integrations/nuxt/playground/pages/index.vue
+++ b/integrations/nuxt/playground/pages/index.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <NuxtLink to="/_scalar">Checkout the docs</NuxtLink>
+    <NuxtLink
+      external
+      to="/_scalar">
+      Checkout the docs
+    </NuxtLink>
   </div>
 </template>
 

--- a/integrations/nuxt/playground/pages/index.vue
+++ b/integrations/nuxt/playground/pages/index.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <NuxtLink to="/_scalar">Checkout the docs</NuxtLink>
+  </div>
+</template>
+
+<style scoped>
+a[href] {
+  font-family: sans-serif;
+  font-size: 200%;
+}
+</style>

--- a/integrations/nuxt/src/module.ts
+++ b/integrations/nuxt/src/module.ts
@@ -95,6 +95,7 @@ export default defineNuxtModule<ModuleOptions>({
             name: 'scalar-' + index,
             path: configuration.pathRouting?.basePath + ':pathMatch(.*)*',
             meta: {
+              layout: false,
               configuration,
               isOpenApiEnabled,
             },
@@ -108,6 +109,7 @@ export default defineNuxtModule<ModuleOptions>({
           name: 'scalar',
           path: _options.pathRouting?.basePath + ':pathMatch(.*)*',
           meta: {
+            layout: false,
             configuration: _options,
             isOpenApiEnabled,
           },

--- a/integrations/nuxt/src/module.ts
+++ b/integrations/nuxt/src/module.ts
@@ -9,6 +9,7 @@ export type ModuleOptions = {
    * configurations. These configurations will extend over the base config
    */
   configurations: Omit<Configuration, 'devtools'>[]
+  layout: string | false
 } & Configuration
 
 export default defineNuxtModule<ModuleOptions>({
@@ -28,6 +29,7 @@ export default defineNuxtModule<ModuleOptions>({
     showSidebar: true,
     devtools: true,
     configurations: [],
+    layout: false,
   },
   setup(_options, _nuxt) {
     const resolver = createResolver(import.meta.url)
@@ -95,7 +97,7 @@ export default defineNuxtModule<ModuleOptions>({
             name: 'scalar-' + index,
             path: configuration.pathRouting?.basePath + ':pathMatch(.*)*',
             meta: {
-              layout: false,
+              layout: _options.layout,
               configuration,
               isOpenApiEnabled,
             },
@@ -109,7 +111,7 @@ export default defineNuxtModule<ModuleOptions>({
           name: 'scalar',
           path: _options.pathRouting?.basePath + ':pathMatch(.*)*',
           meta: {
-            layout: false,
+            layout: _options.layout,
             configuration: _options,
             isOpenApiEnabled,
           },

--- a/integrations/nuxt/src/runtime/pages/ScalarPage.vue
+++ b/integrations/nuxt/src/runtime/pages/ScalarPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import {  useRoute } from '#imports'
+import { useRoute } from '#imports'
 import type { Meta } from '~/src/types'
 
 const route = useRoute()

--- a/integrations/nuxt/src/runtime/pages/ScalarPage.vue
+++ b/integrations/nuxt/src/runtime/pages/ScalarPage.vue
@@ -1,13 +1,9 @@
 <script lang="ts" setup>
-import { definePageMeta, useRoute } from '#imports'
+import { useRoute } from '#imports'
 import type { Meta } from '~/src/types'
 
 const route = useRoute()
 const meta = route.meta as Meta
-
-definePageMeta({
-  layout: false,
-})
 
 // Ensure we have a spec
 if (

--- a/integrations/nuxt/src/runtime/pages/ScalarPage.vue
+++ b/integrations/nuxt/src/runtime/pages/ScalarPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { useRoute } from '#imports'
+import { definePageMeta, useRoute } from '@nuxt/kit'
 import type { Meta } from '~/src/types'
 
 const route = useRoute()

--- a/integrations/nuxt/src/runtime/pages/ScalarPage.vue
+++ b/integrations/nuxt/src/runtime/pages/ScalarPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { useRoute } from '#imports'
+import { definePageMeta, useRoute } from '#imports'
 import type { Meta } from '~/src/types'
 
 const route = useRoute()

--- a/integrations/nuxt/src/runtime/pages/ScalarPage.vue
+++ b/integrations/nuxt/src/runtime/pages/ScalarPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { definePageMeta, useRoute } from '@nuxt/kit'
+import { useRoute } from '#imports'
 import type { Meta } from '~/src/types'
 
 const route = useRoute()

--- a/integrations/nuxt/src/runtime/pages/ScalarPage.vue
+++ b/integrations/nuxt/src/runtime/pages/ScalarPage.vue
@@ -1,9 +1,13 @@
 <script lang="ts" setup>
-import { useRoute } from '#imports'
+import { definePageMeta, useRoute } from '#imports'
 import type { Meta } from '~/src/types'
 
 const route = useRoute()
 const meta = route.meta as Meta
+
+definePageMeta({
+  layout: false,
+})
 
 // Ensure we have a spec
 if (

--- a/integrations/nuxt/src/runtime/pages/ScalarPage.vue
+++ b/integrations/nuxt/src/runtime/pages/ScalarPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { definePageMeta, useRoute } from '#imports'
+import {  useRoute } from '#imports'
 import type { Meta } from '~/src/types'
 
 const route = useRoute()


### PR DESCRIPTION
Fixes #5018

**Problem**

Currently, the Scalar page inherits the default Nuxt layout.

**Solution**

This PR turns off the layout, leaving all the styling to Scalar.

Reference: https://nuxt.com/docs/api/utils/define-page-meta#defining-layout

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
