### PR TITLE
chore: don’t rely on void.scalar.com for tests

### DIFF
--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -145,7 +145,7 @@ describe('create-request-operation', () => {
     const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         requestPayload: {
-          path: 'https://void.scalar.com/me',
+          path: `${VOID_URL}/me`,
         },
       }),
     )
@@ -169,7 +169,7 @@ describe('create-request-operation', () => {
     const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         requestPayload: {
-          path: 'https://void.scalar.com',
+          path: `${VOID_URL}`,
         },
       }),
     )
@@ -740,7 +740,7 @@ describe('create-request-operation', () => {
     const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         requestPayload: {
-          path: 'void.scalar.com/me',
+          path: `${VOID_URL}/me`,
         },
       }),
     )


### PR DESCRIPTION
**Problem**

Past me used https://void.scalar.com in the tests. https://void.scalar.com is down. Main is broken. No good.

**Solution**

Present me removed https://void.scalar.com from the tests.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
