### PR TITLE
fix(api-client): view layout section duplicated classes

### DIFF
--- a/.changeset/wet-snakes-sing.md
+++ b/.changeset/wet-snakes-sing.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: disables view layout section attribute inheritance

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { useBindCx } from '@scalar/components'
 
+defineOptions({ inheritAttrs: false })
+
 const { cx } = useBindCx()
 </script>
 


### PR DESCRIPTION
**Problem**

currently attribute inheritance is creating class duplication along cx usage in view layout section component.

**Solution**

this pr disables attribute inheritance to fix class duplication.

| before | after |
| -------|------|
| <img width="504" alt="image" src="https://github.com/user-attachments/assets/94418232-e9d5-4e00-b8f1-6638748d00ca" /> | <img width="504" alt="image" src="https://github.com/user-attachments/assets/ae17ee8c-ab43-4e81-9e2d-877150018524" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
