### PR TITLE
fix(api-client): mask password input but don't define it as a password

### DIFF
--- a/.changeset/tasty-bats-care.md
+++ b/.changeset/tasty-bats-care.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): make password fields not trigger browser autofill

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -59,11 +59,7 @@ const handleBlur = () => {
 }
 
 const inputType = computed(() =>
-  props.type === 'password'
-    ? mask.value
-      ? 'password'
-      : 'text'
-    : (props.type ?? 'text'),
+  props.type === 'password' ? 'text' : (props.type ?? 'text'),
 )
 
 // If not an enum nor read only, focus the code input
@@ -98,6 +94,7 @@ const handleLabelClick = () => {
           v-bind="id ? { ...$attrs, id: id } : $attrs"
           autocomplete="off"
           class="text-c-1 disabled:text-c-2 py-1.25 peer w-full min-w-0 border-none px-2 -outline-offset-1"
+          :class="{ 'scalar-password-input': type === 'password' }"
           data-1p-ignore
           :readOnly="readOnly"
           spellcheck="false"
@@ -118,6 +115,7 @@ const handleLabelClick = () => {
           :class="[
             type === 'password' && description && 'pr-12',
             description && 'pr-8',
+            type === 'password' && 'scalar-password-input',
           ]"
           :description="description"
           disableCloseBrackets
@@ -186,5 +184,11 @@ const handleLabelClick = () => {
 /* Tailwind placeholder is busted */
 input::placeholder {
   color: var(--scalar-color-3);
+}
+/* we want our inputs to look like a password input but not be one */
+.scalar-password-input {
+  text-security: disc;
+  -webkit-text-security: disc;
+  -moz-text-security: disc;
 }
 </style>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTableInput.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTableInput.vue
@@ -38,6 +38,7 @@ const id = useId()
     v-bind="$attrs"
     :envVariables="props.envVariables"
     :environment="props.environment"
+    lineWrapping
     :modelValue="props.modelValue"
     :readOnly="props.readOnly"
     :required="props.required"


### PR DESCRIPTION
currently we use input type="password" to mask password credentials 

this causes browsers to trigger their password autofill's which is _generally_ intended for user passwords and not quite intended for our use cases of passwords in our data tables.

now when someone uses type="password" on password inputs it will apply change the type to text and apply the  class `scalar-password-input` which overrides the characters to be discs, giving it the effect of a password input. 

there's a better way to go about doing this that maybe @hwkr or @antlio can help me with in the future :) but we need to get this in for now 

before: 
<img width="752" alt="image" src="https://github.com/user-attachments/assets/9695b8de-3b42-489b-a684-826581e0487a" />

after:
<img width="854" alt="image" src="https://github.com/user-attachments/assets/44b05f80-77c5-4213-a293-5b2614e904f8" />
