### PR TITLE
fix(api-client): response loading layer order

### DIFF
--- a/.changeset/ten-pillows-learn.md
+++ b/.changeset/ten-pillows-learn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: increases reponse loading overlay z index

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseLoadingOverlay.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseLoadingOverlay.vue
@@ -27,7 +27,7 @@ events.requestStatus.on((status) => {
   <Transition>
     <div
       v-if="loading.isLoading"
-      class="bg-b-1 absolute inset-0 flex flex-col items-center justify-center gap-6">
+      class="bg-b-1 z-overlay absolute inset-0 flex flex-col items-center justify-center gap-6">
       <ScalarLoading
         class="text-c-3"
         :loadingState="loading"


### PR DESCRIPTION
**Problem**

currently when sending a request with section open the loading layer is not at the right place.

**Solution**

this pr increases z index to position loading layer over content.

| before | after |
| -------|------|
| <img width="604" alt="image" src="https://github.com/user-attachments/assets/da5df832-18bc-482b-aed4-e4fca7a0f8eb" /> | <img width="604" alt="image" src="https://github.com/user-attachments/assets/ff5fdea2-5376-42d1-b917-73a86ab91e52" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
