### PR TITLE
chore(prettier): add aspnetcore build directories to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,6 +20,8 @@
 **/.output/**
 **/.vite-ssg-temp/**
 **/.docusaurus/**
+**/aspnetcore/**/obj/**
+**/aspnetcore/**/bin/**
 
 **/vite.config.ts.timestamp-*.mjs
 


### PR DESCRIPTION
During `pnpm format` I noticed that prettier also formats generated files inside `bin` and `obj` folder. We already have this rule for biome, let's add it to prettier.

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
