### PR TITLE
feat(api-reference): add classes to intro cards

### DIFF
--- a/.changeset/dirty-seals-invite.md
+++ b/.changeset/dirty-seals-invite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: add unique classes to intro cards

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -101,7 +101,7 @@ const introCardsSlot = computed(() =>
             :class="{ 'introduction-card-row': layout === 'classic' }">
             <div
               v-if="activeCollection?.servers?.length"
-              class="scalar-client introduction-card-item divide-y text-sm [--scalar-address-bar-height:0px]">
+              class="scalar-reference-intro-server scalar-client introduction-card-item divide-y text-sm [--scalar-address-bar-height:0px]">
               <BaseUrl
                 :collection="activeCollection"
                 :server="activeServer" />
@@ -112,7 +112,7 @@ const introCardsSlot = computed(() =>
                 activeWorkspace &&
                 Object.keys(securitySchemes ?? {}).length
               "
-              class="scalar-client introduction-card-item">
+              class="scalar-reference-intro-auth scalar-client introduction-card-item">
               <RequestAuth
                 :collection="activeCollection"
                 :envVariables="activeEnvVariables"
@@ -125,7 +125,8 @@ const introCardsSlot = computed(() =>
                 title="Authentication"
                 :workspace="activeWorkspace" />
             </div>
-            <ClientLibraries class="introduction-card-item" />
+            <ClientLibraries
+              class="introduction-card-item scalar-reference-intro-clients" />
           </div>
         </ScalarErrorBoundary>
       </template>


### PR DESCRIPTION
**Problem**

Currently, we cannot target the intro cards with css in case we want to hide them.

**Solution**

With this PR we add a unique class to each of the intro cards.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
