### PR TITLE
fix(docs): added hono-openapi in hono integration package

### DIFF
--- a/integrations/hono/README.md
+++ b/integrations/hono/README.md
@@ -17,7 +17,7 @@ npm install @scalar/hono-api-reference
 
 ## Usage
 
-Set up [Zod OpenAPI Hono](https://github.com/honojs/middleware/tree/main/packages/zod-openapi) and pass the configured URL to the `Scalar` middleware:
+Set up [Zod OpenAPI Hono](https://github.com/honojs/middleware/tree/main/packages/zod-openapi) or [Hono OpenAPI](https://github.com/rhinobase/hono-openapi) and pass the configured URL to the `Scalar` middleware:
 
 ```ts
 import { Hono } from 'hono'


### PR DESCRIPTION
**Problem**

Just added [hono-openapi](https://github.com/rhinobase/hono-openapi) as a option in the hono package for setting up OpenAPI
