### PR TITLE
feat(api-client): export viewLayoutCollapse and add some helpers

### DIFF
--- a/.changeset/dirty-clocks-exist.md
+++ b/.changeset/dirty-clocks-exist.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+chore: export view layout collapse component

--- a/.changeset/forty-months-hug.md
+++ b/.changeset/forty-months-hug.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: add a few security scheme helpers

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -4,6 +4,11 @@
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",
   "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scalar/scalar.git",
+    "directory": "examples/nuxt"
+  },
   "private": true,
   "engines": {
     "node": ">=20"
@@ -21,10 +26,5 @@
   "devDependencies": {
     "@scalar/api-client": "workspace:*",
     "@scalar/nuxt": "workspace:*"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/scalar/scalar.git",
-    "directory": "examples/nuxt"
   }
 }

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -58,6 +58,11 @@
       "types": "./dist/components/AddressBar/index.d.ts",
       "default": "./dist/components/AddressBar/index.js"
     },
+    "./components/CodeInput": {
+      "import": "./dist/components/CodeInput/index.js",
+      "types": "./dist/components/CodeInput/index.d.ts",
+      "default": "./dist/components/CodeInput/index.js"
+    },
     "./components/CommandPalette": {
       "import": "./dist/components/CommandPalette/index.js",
       "types": "./dist/components/CommandPalette/index.d.ts",
@@ -87,6 +92,11 @@
       "import": "./dist/components/Sidebar/index.js",
       "types": "./dist/components/Sidebar/index.d.ts",
       "default": "./dist/components/Sidebar/index.js"
+    },
+    "./components/ViewLayout": {
+      "import": "./dist/components/ViewLayout/index.js",
+      "types": "./dist/components/ViewLayout/index.d.ts",
+      "default": "./dist/components/ViewLayout/index.js"
     },
     "./css/*.css": {
       "import": "./dist/css/*.css",

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -28,6 +28,7 @@ const props = withDefaults(
     modelValue: string | number
     error?: boolean
     emitOnBlur?: boolean
+    extensions?: Extension[]
     lineNumbers?: boolean
     lint?: boolean
     disableTabIndent?: boolean
@@ -54,6 +55,7 @@ const props = withDefaults(
   {
     disableCloseBrackets: false,
     disableEnter: false,
+    extensions: () => [],
     disableTabIndent: false,
     emitOnBlur: true,
     colorPicker: false,
@@ -137,7 +139,7 @@ function handleBlur(value: string) {
 
 // WARNING: Extensions are non-reactive! If props change nothing will happen
 
-const extensions: Extension[] = []
+const extensions: Extension[] = [...props.extensions]
 if (props.colorPicker) {
   extensions.push(colorPickerExtension)
 }

--- a/packages/api-client/src/components/CodeInput/index.ts
+++ b/packages/api-client/src/components/CodeInput/index.ts
@@ -1,0 +1,1 @@
+export { default as CodeInput } from './CodeInput.vue'

--- a/packages/api-client/src/components/ViewLayout/index.ts
+++ b/packages/api-client/src/components/ViewLayout/index.ts
@@ -1,0 +1,1 @@
+export { default as ViewLayoutCollapse } from './ViewLayoutCollapse.vue'

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
@@ -50,12 +50,11 @@ const handleAuthorize = async () => {
   if (loadingState.isLoading || !collection?.uid) {
     return
   }
-  loadingState.startLoading()
-
   if (!server) {
     toast('No server selected', 'error')
     return
   }
+  loadingState.startLoading()
 
   const [error, accessToken] = await authorizeOauth2(
     flow,
@@ -94,7 +93,7 @@ const dataTableInputProps = {
       </RequestAuthDataTableInput>
     </DataTableRow>
     <DataTableRow class="min-w-full">
-      <div class="flex h-8 items-center justify-self-end">
+      <div class="border-t-1/2 flex h-8 items-center justify-end gap-2">
         <ScalarButton
           class="mr-1 p-0 px-2 py-0.5"
           :loading="loadingState"

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -68,6 +68,11 @@
       "types": "./dist/helpers/index.d.ts",
       "default": "./dist/helpers/index.js"
     },
+    "./helpers/security": {
+      "import": "./dist/helpers/security/index.js",
+      "types": "./dist/helpers/security/index.d.ts",
+      "default": "./dist/helpers/security/index.js"
+    },
     "./migrations": {
       "import": "./dist/migrations/index.js",
       "types": "./dist/migrations/index.d.ts",

--- a/packages/oas-utils/src/helpers/security/get-schemes.test.ts
+++ b/packages/oas-utils/src/helpers/security/get-schemes.test.ts
@@ -1,0 +1,80 @@
+import { securitySchemeSchema, type SecurityScheme } from '@scalar/types/entities'
+import { describe, it, expect } from 'vitest'
+
+import { getSchemes } from './get-schemes.ts'
+import type { Operation } from '@/entities/spec/operation.ts'
+
+describe('getSchemes', () => {
+  // Setup some mock security schemes for testing
+  const mockSecuritySchemes: Record<string, SecurityScheme> = {
+    'auth1-uid': securitySchemeSchema.parse({
+      uid: 'auth1-uid',
+      type: 'http',
+      scheme: 'bearer',
+    }),
+    'auth2-uid': securitySchemeSchema.parse({
+      uid: 'auth2-uid',
+      type: 'apiKey',
+      in: 'header',
+    }),
+    'auth3-uid': securitySchemeSchema.parse({
+      uid: 'auth3-uid',
+      type: 'oauth2',
+      flows: {},
+    }),
+  }
+
+  it('should return empty array for empty input', () => {
+    const result = getSchemes([], mockSecuritySchemes)
+    expect(result).toEqual([])
+  })
+
+  it('should handle single-level array of UIDs', () => {
+    const result = getSchemes(
+      ['auth1-uid', 'auth2-uid'] as Operation['selectedSecuritySchemeUids'],
+      mockSecuritySchemes,
+    )
+    expect(result).toHaveLength(2)
+    expect(result).toEqual([mockSecuritySchemes['auth1-uid'], mockSecuritySchemes['auth2-uid']])
+  })
+
+  it('should handle nested arrays of UIDs', () => {
+    const result = getSchemes(
+      [['auth1-uid'], ['auth2-uid', 'auth3-uid']] as Operation['selectedSecuritySchemeUids'],
+      mockSecuritySchemes,
+    )
+    expect(result).toHaveLength(3)
+    expect(result).toEqual([
+      mockSecuritySchemes['auth1-uid'],
+      mockSecuritySchemes['auth2-uid'],
+      mockSecuritySchemes['auth3-uid'],
+    ])
+  })
+
+  it('should deduplicate UIDs', () => {
+    const result = getSchemes(
+      [
+        ['auth1-uid', 'auth1-uid'],
+        ['auth1-uid', 'auth2-uid'],
+      ] as Operation['selectedSecuritySchemeUids'],
+      mockSecuritySchemes,
+    )
+    expect(result).toHaveLength(2)
+    expect(result).toEqual([mockSecuritySchemes['auth1-uid'], mockSecuritySchemes['auth2-uid']])
+  })
+
+  it('should filter out undefined schemes', () => {
+    const result = getSchemes(
+      ['auth1-uid', 'nonexistent-uid', 'auth2-uid'] as Operation['selectedSecuritySchemeUids'],
+      mockSecuritySchemes,
+    )
+    expect(result).toHaveLength(2)
+    expect(result).toEqual([mockSecuritySchemes['auth1-uid'], mockSecuritySchemes['auth2-uid']])
+  })
+
+  it('should handle empty nested arrays', () => {
+    const result = getSchemes([[], ['auth1-uid'], []] as Operation['selectedSecuritySchemeUids'], mockSecuritySchemes)
+    expect(result).toHaveLength(1)
+    expect(result).toEqual([mockSecuritySchemes['auth1-uid']])
+  })
+})

--- a/packages/oas-utils/src/helpers/security/get-schemes.ts
+++ b/packages/oas-utils/src/helpers/security/get-schemes.ts
@@ -1,0 +1,15 @@
+import type { SecurityScheme } from '@scalar/types/entities'
+
+import type { Operation } from '@/entities/spec/operation.ts'
+import { isDefined } from '@/helpers/is-defined.ts'
+
+/** Parses a list of selected security scheme uids which may be an array or single uid and returns a flattened array of security schemes */
+export const getSchemes = (
+  selectedSecuritySchemes: Operation['selectedSecuritySchemeUids'],
+  securitySchemes: Record<SecurityScheme['uid'], SecurityScheme>,
+) => {
+  const uids = new Set(selectedSecuritySchemes.flat())
+  return Array.from(uids)
+    .map((uid) => securitySchemes[uid])
+    .filter(isDefined)
+}

--- a/packages/oas-utils/src/helpers/security/has-token.test.ts
+++ b/packages/oas-utils/src/helpers/security/has-token.test.ts
@@ -1,0 +1,172 @@
+import { securitySchemeSchema } from '@scalar/types/entities'
+import { describe, it, expect } from 'vitest'
+
+import { hasToken } from './has-token.ts'
+
+describe('hasToken', () => {
+  describe('apiKey scheme', () => {
+    it('returns true when value is present', () => {
+      const scheme = securitySchemeSchema.parse({
+        type: 'apiKey',
+        value: 'my-api-key',
+        in: 'header',
+        name: 'x-api-key',
+      })
+      expect(hasToken(scheme)).toBe(true)
+    })
+
+    it('returns false when value is empty', () => {
+      const scheme = securitySchemeSchema.parse({
+        type: 'apiKey',
+        value: '',
+        in: 'header',
+        name: 'x-api-key',
+      })
+      expect(hasToken(scheme)).toBe(false)
+    })
+  })
+
+  describe('http scheme', () => {
+    describe('bearer', () => {
+      it('returns true when token is present', () => {
+        const scheme = securitySchemeSchema.parse({
+          type: 'http',
+          scheme: 'bearer',
+          token: 'my-bearer-token',
+        })
+        expect(hasToken(scheme)).toBe(true)
+      })
+
+      it('returns false when token is empty', () => {
+        const scheme = securitySchemeSchema.parse({
+          type: 'http',
+          scheme: 'bearer',
+          token: '',
+        })
+        expect(hasToken(scheme)).toBe(false)
+      })
+    })
+
+    describe('basic', () => {
+      it('returns true when both username and password are present', () => {
+        const scheme = securitySchemeSchema.parse({
+          type: 'http',
+          scheme: 'basic',
+          username: 'user',
+          password: 'pass',
+        })
+        expect(hasToken(scheme)).toBe(true)
+      })
+
+      it('returns false when username is missing', () => {
+        const scheme = securitySchemeSchema.parse({
+          type: 'http',
+          scheme: 'basic',
+          username: '',
+          password: 'pass',
+        })
+        expect(hasToken(scheme)).toBe(false)
+      })
+
+      it('returns false when password is missing', () => {
+        const scheme = securitySchemeSchema.parse({
+          type: 'http',
+          scheme: 'basic',
+          username: 'user',
+          password: '',
+        })
+        expect(hasToken(scheme)).toBe(false)
+      })
+    })
+  })
+
+  describe('oauth2 scheme', () => {
+    it('returns true when authorization code flow has token', () => {
+      const scheme = securitySchemeSchema.parse({
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            token: 'auth-code-token',
+            authorizationUrl: 'https://auth.example.com',
+            tokenUrl: 'https://token.example.com',
+            scopes: {},
+          },
+        },
+      })
+      expect(hasToken(scheme)).toBe(true)
+    })
+
+    it('returns true when client credentials flow has token', () => {
+      const scheme = securitySchemeSchema.parse({
+        type: 'oauth2',
+        flows: {
+          clientCredentials: {
+            token: 'client-creds-token',
+            tokenUrl: 'https://token.example.com',
+            scopes: {},
+          },
+        },
+      })
+      expect(hasToken(scheme)).toBe(true)
+    })
+
+    it('returns true when password flow has token', () => {
+      const scheme = securitySchemeSchema.parse({
+        type: 'oauth2',
+        flows: {
+          password: {
+            token: 'password-token',
+            tokenUrl: 'https://token.example.com',
+            scopes: {},
+          },
+        },
+      })
+      expect(hasToken(scheme)).toBe(true)
+    })
+
+    it('returns true when implicit flow has token', () => {
+      const scheme = securitySchemeSchema.parse({
+        type: 'oauth2',
+        flows: {
+          implicit: {
+            token: 'implicit-token',
+            authorizationUrl: 'https://auth.example.com',
+            scopes: {},
+          },
+        },
+      })
+      expect(hasToken(scheme)).toBe(true)
+    })
+
+    it('returns false when no flows have tokens', () => {
+      const scheme = securitySchemeSchema.parse({
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            token: '',
+            authorizationUrl: 'https://auth.example.com',
+            tokenUrl: 'https://token.example.com',
+            scopes: {},
+          },
+          clientCredentials: {
+            token: '',
+            tokenUrl: 'https://token.example.com',
+            scopes: {},
+          },
+        },
+      })
+      expect(hasToken(scheme)).toBe(false)
+    })
+  })
+
+  describe('unknown scheme type', () => {
+    it('returns false for unknown scheme types', () => {
+      // Note: For unknown types, we can't use parse as it would fail validation
+      // This is testing the edge case of an invalid type
+      const scheme = {
+        type: 'unknown',
+      } as any
+      expect(hasToken(scheme)).toBe(false)
+    })
+  })
+})

--- a/packages/oas-utils/src/helpers/security/has-token.ts
+++ b/packages/oas-utils/src/helpers/security/has-token.ts
@@ -1,0 +1,28 @@
+import type { SecurityScheme } from '@scalar/types/entities'
+
+/** Pass in a security scheme and it will return true if it has a token or value depending on the scheme type */
+export const hasToken = (scheme: SecurityScheme): Boolean => {
+  // ApiKey
+  if (scheme.type === 'apiKey') {
+    return Boolean(scheme.value)
+  }
+
+  // Http
+  if (scheme.type === 'http') {
+    return Boolean(
+      (scheme.scheme === 'bearer' && scheme.token) || (scheme.scheme === 'basic' && scheme.username && scheme.password),
+    )
+  }
+
+  // OAuth2 just check for A token
+  if (scheme.type === 'oauth2') {
+    return Boolean(
+      scheme.flows.authorizationCode?.token ||
+        scheme.flows.clientCredentials?.token ||
+        scheme.flows.password?.token ||
+        scheme.flows.implicit?.token,
+    )
+  }
+
+  return false
+}

--- a/packages/oas-utils/src/helpers/security/index.ts
+++ b/packages/oas-utils/src/helpers/security/index.ts
@@ -1,0 +1,2 @@
+export { getSchemes } from './get-schemes.ts'
+export { hasToken } from './has-token.ts'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ catalogs:
       specifier: ^2.4.5
       version: 2.6.0
     zod:
-      specifier: ^3.23.8
-      version: 3.23.8
+      specifier: 3.24.1
+      version: 3.24.1
 
 importers:
 
@@ -464,7 +464,7 @@ importers:
         version: link:../../integrations/nuxt
       nuxt:
         specifier: ^3.12.4
-        version: 3.14.159(@biomejs/biome@1.9.4)(@parcel/watcher@2.4.1)(@types/node@20.17.10)(encoding@0.1.13)(eslint@9.20.1(jiti@2.4.0))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.36.0)(terser@5.31.2)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))
+        version: 3.14.159(@biomejs/biome@1.9.4)(@parcel/watcher@2.4.1)(@types/node@20.17.10)(encoding@0.1.13)(eslint@9.20.1(jiti@2.4.0))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.24.4)(terser@5.31.2)(typescript@5.6.2)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vue-tsc@2.1.10(typescript@5.6.2))
     devDependencies:
       '@scalar/api-client':
         specifier: workspace:*
@@ -740,7 +740,7 @@ importers:
         version: 1.11.3
       '@hono/zod-openapi':
         specifier: ^0.8.6
-        version: 0.8.6(hono@4.6.5)(zod@3.23.8)
+        version: 0.8.6(hono@4.6.5)(zod@3.24.1)
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../../packages/build-tooling
@@ -826,7 +826,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: ^3.12.3
-        version: 3.12.3(magicast@0.3.5)(rollup@4.24.4)
+        version: 3.12.3(magicast@0.3.5)(rollup@3.29.4)
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client
@@ -839,19 +839,19 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: ^1.3.9
-        version: 1.3.9(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))
+        version: 1.3.9(rollup@3.29.4)
       '@nuxt/eslint-config':
         specifier: ^0.7.3
         version: 0.7.6(@vue/compiler-sfc@3.5.12)(eslint@9.20.1(jiti@2.4.0))(typescript@5.6.2)
       '@nuxt/module-builder':
         specifier: ^0.8.1
-        version: 0.8.1(@nuxt/kit@3.12.3(magicast@0.3.5)(rollup@4.24.4))(nuxi@3.15.0)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))
+        version: 0.8.1(@nuxt/kit@3.12.3(magicast@0.3.5)(rollup@3.29.4))(nuxi@3.15.0)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))
       '@nuxt/schema':
         specifier: ^3.12.3
-        version: 3.12.3(rollup@4.24.4)
+        version: 3.12.3(rollup@3.29.4)
       '@nuxt/test-utils':
         specifier: ^3.13.1
-        version: 3.13.1(@jest/globals@29.7.0)(@playwright/test@1.49.1)(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@24.1.0)(magicast@0.3.5)(nitropack@2.10.4(encoding@0.1.13)(typescript@5.6.2))(playwright-core@1.49.1)(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vitest@1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))
+        version: 3.13.1(@jest/globals@29.7.0)(@playwright/test@1.49.1)(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@24.1.0)(magicast@0.3.5)(nitropack@2.10.4(encoding@0.1.13)(typescript@5.6.2))(playwright-core@1.49.1)(rollup@3.29.4)(vitest@1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))
       '@types/node':
         specifier: 'catalog:'
         version: 20.17.10
@@ -860,7 +860,7 @@ importers:
         version: 0.5.5(magicast@0.3.5)
       nuxt:
         specifier: ^3.12.4
-        version: 3.14.159(@biomejs/biome@1.9.4)(@parcel/watcher@2.4.1)(@types/node@20.17.10)(encoding@0.1.13)(eslint@9.20.1(jiti@2.4.0))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.24.4)(terser@5.31.2)(typescript@5.6.2)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vue-tsc@2.1.10(typescript@5.6.2))
+        version: 3.14.159(@biomejs/biome@1.9.4)(@parcel/watcher@2.4.1)(@types/node@20.17.10)(encoding@0.1.13)(eslint@9.20.1(jiti@2.4.0))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@3.29.4)(terser@5.31.2)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))
       vitest:
         specifier: 'catalog:'
         version: 1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2)
@@ -1018,7 +1018,7 @@ importers:
         version: 2.6.0
       zod:
         specifier: 'catalog:'
-        version: 3.23.8
+        version: 3.24.1
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -1173,7 +1173,7 @@ importers:
         version: 3.5.12(typescript@5.6.2)
       zod:
         specifier: 'catalog:'
-        version: 3.23.8
+        version: 3.24.1
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -1741,7 +1741,7 @@ importers:
     dependencies:
       zod:
         specifier: 'catalog:'
-        version: 3.23.8
+        version: 3.24.1
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -1950,7 +1950,7 @@ importers:
         version: 2.6.0
       zod:
         specifier: 'catalog:'
-        version: 3.23.8
+        version: 3.24.1
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -1969,7 +1969,7 @@ importers:
         version: 1.6.0(@types/node@20.17.10)(jsdom@25.0.1)(terser@5.31.2)
       zod-to-ts:
         specifier: github:amritk/zod-to-ts#build
-        version: https://codeload.github.com/amritk/zod-to-ts/tar.gz/1f956fe246b5b3e70bbeb9e3a928396f9c22e400(typescript@5.6.2)(zod@3.23.8)
+        version: https://codeload.github.com/amritk/zod-to-ts/tar.gz/1f956fe246b5b3e70bbeb9e3a928396f9c22e400(typescript@5.6.2)(zod@3.24.1)
 
   packages/object-utils:
     dependencies:
@@ -2052,7 +2052,7 @@ importers:
     dependencies:
       zod:
         specifier: 'catalog:'
-        version: 3.23.8
+        version: 3.24.1
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -2202,7 +2202,7 @@ importers:
         version: 4.26.1
       zod:
         specifier: 'catalog:'
-        version: 3.23.8
+        version: 3.24.1
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -2318,7 +2318,7 @@ importers:
         version: 3.5.12(typescript@5.6.2)
       zod:
         specifier: 'catalog:'
-        version: 3.23.8
+        version: 3.24.1
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -2334,7 +2334,7 @@ importers:
         version: 5.4.10(@types/node@20.17.10)(terser@5.31.2)
       zod-to-ts:
         specifier: ^1.2.0
-        version: 1.2.0(typescript@5.6.2)(zod@3.23.8)
+        version: 1.2.0(typescript@5.6.2)(zod@3.24.1)
 
   packages/use-toasts:
     dependencies:
@@ -18976,6 +18976,9 @@ packages:
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -19173,10 +19176,10 @@ snapshots:
       call-me-maybe: 1.0.2
       openapi-types: 12.1.3
 
-  '@asteasolutions/zod-to-openapi@5.5.0(zod@3.23.8)':
+  '@asteasolutions/zod-to-openapi@5.5.0(zod@3.24.1)':
     dependencies:
       openapi3-ts: 4.3.3
-      zod: 3.23.8
+      zod: 3.24.1
 
   '@aw-web-design/x-default-browser@1.4.126':
     dependencies:
@@ -23124,17 +23127,17 @@ snapshots:
 
   '@hono/node-server@1.11.3': {}
 
-  '@hono/zod-openapi@0.8.6(hono@4.6.5)(zod@3.23.8)':
+  '@hono/zod-openapi@0.8.6(hono@4.6.5)(zod@3.24.1)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 5.5.0(zod@3.23.8)
-      '@hono/zod-validator': 0.1.11(hono@4.6.5)(zod@3.23.8)
+      '@asteasolutions/zod-to-openapi': 5.5.0(zod@3.24.1)
+      '@hono/zod-validator': 0.1.11(hono@4.6.5)(zod@3.24.1)
       hono: 4.6.5
-      zod: 3.23.8
+      zod: 3.24.1
 
-  '@hono/zod-validator@0.1.11(hono@4.6.5)(zod@3.23.8)':
+  '@hono/zod-validator@0.1.11(hono@4.6.5)(zod@3.24.1)':
     dependencies:
       hono: 4.6.5
-      zod: 3.23.8
+      zod: 3.24.1
 
   '@humanfs/core@0.19.1': {}
 
@@ -23961,12 +23964,21 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.3.9(magicast@0.3.4)(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))':
+  '@nuxt/devtools-kit@1.3.9(magicast@0.3.4)(rollup@3.29.4)':
     dependencies:
-      '@nuxt/kit': 3.12.3(magicast@0.3.4)(rollup@4.24.4)
-      '@nuxt/schema': 3.12.3(rollup@4.24.4)
+      '@nuxt/kit': 3.12.3(magicast@0.3.4)(rollup@3.29.4)
+      '@nuxt/schema': 3.12.3(rollup@3.29.4)
       execa: 7.2.0
-      vite: 5.4.10(@types/node@20.17.10)(terser@5.31.2)
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
+
+  '@nuxt/devtools-kit@1.6.0(magicast@0.3.5)(rollup@3.29.4)':
+    dependencies:
+      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@3.29.4)
+      '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@3.29.4)
+      execa: 7.2.0
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -23978,16 +23990,6 @@ snapshots:
       '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@4.24.4)
       execa: 7.2.0
       vite: 5.4.10(@types/node@20.17.10)(terser@5.31.2)
-    transitivePeerDependencies:
-      - magicast
-      - rollup
-      - supports-color
-
-  '@nuxt/devtools-kit@1.6.0(magicast@0.3.5)(rollup@4.36.0)':
-    dependencies:
-      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.36.0)
-      '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@4.36.0)
-      execa: 7.2.0
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -24019,13 +24021,13 @@ snapshots:
       rc9: 2.1.2
       semver: 7.6.3
 
-  '@nuxt/devtools@1.3.9(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))':
+  '@nuxt/devtools@1.3.9(rollup@3.29.4)':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.3.9(magicast@0.3.4)(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))
+      '@nuxt/devtools-kit': 1.3.9(magicast@0.3.4)(rollup@3.29.4)
       '@nuxt/devtools-wizard': 1.3.9
-      '@nuxt/kit': 3.12.3(magicast@0.3.4)(rollup@4.24.4)
-      '@vue/devtools-core': 7.3.3(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))
+      '@nuxt/kit': 3.12.3(magicast@0.3.4)(rollup@3.29.4)
+      '@vue/devtools-core': 7.3.3
       '@vue/devtools-kit': 7.3.3
       birpc: 0.2.17
       consola: 3.2.3
@@ -24053,9 +24055,8 @@ snapshots:
       semver: 7.6.2
       simple-git: 3.25.0
       sirv: 2.0.4
-      unimport: 3.13.2(rollup@4.24.4)
-      vite: 5.4.10(@types/node@20.17.10)(terser@5.31.2)
-      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.12.3(magicast@0.3.5)(rollup@4.24.4))(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))
+      unimport: 3.13.2(rollup@3.29.4)
+      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.12.3(magicast@0.3.5)(rollup@3.29.4))(rollup@3.29.4)
       vite-plugin-vue-inspector: 5.1.3(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))
       which: 3.0.1
       ws: 8.18.0
@@ -24064,6 +24065,52 @@ snapshots:
       - rollup
       - supports-color
       - utf-8-validate
+
+  '@nuxt/devtools@1.6.0(rollup@3.29.4)(vue@3.5.12(typescript@5.6.2))':
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@nuxt/devtools-kit': 1.6.0(magicast@0.3.5)(rollup@3.29.4)
+      '@nuxt/devtools-wizard': 1.6.0
+      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@3.29.4)
+      '@vue/devtools-core': 7.4.4(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vue@3.5.12(typescript@5.6.2))
+      '@vue/devtools-kit': 7.4.4
+      birpc: 0.2.17
+      consola: 3.2.3
+      cronstrue: 2.50.0
+      destr: 2.0.3
+      error-stack-parser-es: 0.1.5
+      execa: 7.2.0
+      fast-npm-meta: 0.2.2
+      flatted: 3.3.1
+      get-port-please: 3.1.2
+      hookable: 5.5.3
+      image-meta: 0.2.1
+      is-installed-globally: 1.0.0
+      launch-editor: 2.9.1
+      local-pkg: 0.5.0
+      magicast: 0.3.5
+      nypm: 0.3.12
+      ohash: 1.1.4
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.2.1
+      rc9: 2.1.2
+      scule: 1.3.0
+      semver: 7.6.3
+      simple-git: 3.27.0
+      sirv: 2.0.4
+      tinyglobby: 0.2.10
+      unimport: 3.13.2(rollup@3.29.4)
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.14.159(magicast@0.3.5)(rollup@3.29.4))(rollup@3.29.4)
+      vite-plugin-vue-inspector: 5.1.3(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))
+      which: 3.0.1
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - rollup
+      - supports-color
+      - utf-8-validate
+      - vue
 
   '@nuxt/devtools@1.6.0(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vue@3.5.12(typescript@5.6.2))':
     dependencies:
@@ -24112,52 +24159,6 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/devtools@1.6.0(rollup@4.36.0)(vue@3.5.12(typescript@5.6.2))':
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.6.0(magicast@0.3.5)(rollup@4.36.0)
-      '@nuxt/devtools-wizard': 1.6.0
-      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.36.0)
-      '@vue/devtools-core': 7.4.4(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vue@3.5.12(typescript@5.6.2))
-      '@vue/devtools-kit': 7.4.4
-      birpc: 0.2.17
-      consola: 3.2.3
-      cronstrue: 2.50.0
-      destr: 2.0.3
-      error-stack-parser-es: 0.1.5
-      execa: 7.2.0
-      fast-npm-meta: 0.2.2
-      flatted: 3.3.1
-      get-port-please: 3.1.2
-      hookable: 5.5.3
-      image-meta: 0.2.1
-      is-installed-globally: 1.0.0
-      launch-editor: 2.9.1
-      local-pkg: 0.5.0
-      magicast: 0.3.5
-      nypm: 0.3.12
-      ohash: 1.1.4
-      pathe: 1.1.2
-      perfect-debounce: 1.0.0
-      pkg-types: 1.2.1
-      rc9: 2.1.2
-      scule: 1.3.0
-      semver: 7.6.3
-      simple-git: 3.27.0
-      sirv: 2.0.4
-      tinyglobby: 0.2.10
-      unimport: 3.13.2(rollup@4.36.0)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.14.159(magicast@0.3.5)(rollup@4.36.0))(rollup@4.36.0)
-      vite-plugin-vue-inspector: 5.1.3(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))
-      which: 3.0.1
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - rollup
-      - supports-color
-      - utf-8-validate
-      - vue
-
   '@nuxt/eslint-config@0.7.6(@vue/compiler-sfc@3.5.12)(eslint@9.20.1(jiti@2.4.0))(typescript@5.6.2)':
     dependencies:
       '@antfu/install-pkg': 1.0.0
@@ -24195,9 +24196,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/kit@3.12.3(magicast@0.3.4)(rollup@4.24.4)':
+  '@nuxt/kit@3.12.3(magicast@0.3.4)(rollup@3.29.4)':
     dependencies:
-      '@nuxt/schema': 3.12.3(rollup@4.24.4)
+      '@nuxt/schema': 3.12.3(rollup@3.29.4)
       c12: 1.11.1(magicast@0.3.4)
       consola: 3.2.3
       defu: 6.1.4
@@ -24215,16 +24216,16 @@ snapshots:
       semver: 7.6.2
       ufo: 1.5.3
       unctx: 2.3.1
-      unimport: 3.7.2(rollup@4.24.4)
+      unimport: 3.7.2(rollup@3.29.4)
       untyped: 1.4.2
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.12.3(magicast@0.3.5)(rollup@4.24.4)':
+  '@nuxt/kit@3.12.3(magicast@0.3.5)(rollup@3.29.4)':
     dependencies:
-      '@nuxt/schema': 3.12.3(rollup@4.24.4)
+      '@nuxt/schema': 3.12.3(rollup@3.29.4)
       c12: 1.11.1(magicast@0.3.5)
       consola: 3.2.3
       defu: 6.1.4
@@ -24242,8 +24243,35 @@ snapshots:
       semver: 7.6.2
       ufo: 1.5.3
       unctx: 2.3.1
-      unimport: 3.7.2(rollup@4.24.4)
+      unimport: 3.7.2(rollup@3.29.4)
       untyped: 1.4.2
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
+
+  '@nuxt/kit@3.14.159(magicast@0.3.5)(rollup@3.29.4)':
+    dependencies:
+      '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@3.29.4)
+      c12: 2.0.1(magicast@0.3.5)
+      consola: 3.2.3
+      defu: 6.1.4
+      destr: 2.0.3
+      globby: 14.0.2
+      hash-sum: 2.0.0
+      ignore: 6.0.2
+      jiti: 2.4.0
+      klona: 2.0.6
+      knitwork: 1.1.0
+      mlly: 1.7.3
+      pathe: 1.1.2
+      pkg-types: 1.2.1
+      scule: 1.3.0
+      semver: 7.6.3
+      ufo: 1.5.4
+      unctx: 2.3.1
+      unimport: 3.13.2(rollup@3.29.4)
+      untyped: 1.5.1
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -24276,36 +24304,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.14.159(magicast@0.3.5)(rollup@4.36.0)':
+  '@nuxt/module-builder@0.8.1(@nuxt/kit@3.12.3(magicast@0.3.5)(rollup@3.29.4))(nuxi@3.15.0)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))':
     dependencies:
-      '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@4.36.0)
-      c12: 2.0.1(magicast@0.3.5)
-      consola: 3.2.3
-      defu: 6.1.4
-      destr: 2.0.3
-      globby: 14.0.2
-      hash-sum: 2.0.0
-      ignore: 6.0.2
-      jiti: 2.4.0
-      klona: 2.0.6
-      knitwork: 1.1.0
-      mlly: 1.7.3
-      pathe: 1.1.2
-      pkg-types: 1.2.1
-      scule: 1.3.0
-      semver: 7.6.3
-      ufo: 1.5.4
-      unctx: 2.3.1
-      unimport: 3.13.2(rollup@4.36.0)
-      untyped: 1.5.1
-    transitivePeerDependencies:
-      - magicast
-      - rollup
-      - supports-color
-
-  '@nuxt/module-builder@0.8.1(@nuxt/kit@3.12.3(magicast@0.3.5)(rollup@4.24.4))(nuxi@3.15.0)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))':
-    dependencies:
-      '@nuxt/kit': 3.12.3(magicast@0.3.5)(rollup@4.24.4)
+      '@nuxt/kit': 3.12.3(magicast@0.3.5)(rollup@3.29.4)
       citty: 0.1.6
       consola: 3.2.3
       defu: 6.1.4
@@ -24322,7 +24323,7 @@ snapshots:
       - typescript
       - vue-tsc
 
-  '@nuxt/schema@3.12.3(rollup@4.24.4)':
+  '@nuxt/schema@3.12.3(rollup@3.29.4)':
     dependencies:
       compatx: 0.1.8
       consola: 3.2.3
@@ -24334,9 +24335,29 @@ snapshots:
       std-env: 3.7.0
       ufo: 1.5.3
       uncrypto: 0.1.3
-      unimport: 3.7.2(rollup@4.24.4)
+      unimport: 3.7.2(rollup@3.29.4)
       untyped: 1.4.2
     transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  '@nuxt/schema@3.14.159(magicast@0.3.5)(rollup@3.29.4)':
+    dependencies:
+      c12: 2.0.1(magicast@0.3.5)
+      compatx: 0.1.8
+      consola: 3.2.3
+      defu: 6.1.4
+      hookable: 5.5.3
+      pathe: 1.1.2
+      pkg-types: 1.2.1
+      scule: 1.3.0
+      std-env: 3.7.0
+      ufo: 1.5.4
+      uncrypto: 0.1.3
+      unimport: 3.13.2(rollup@3.29.4)
+      untyped: 1.5.1
+    transitivePeerDependencies:
+      - magicast
       - rollup
       - supports-color
 
@@ -24360,21 +24381,26 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/schema@3.14.159(magicast@0.3.5)(rollup@4.36.0)':
+  '@nuxt/telemetry@2.6.0(magicast@0.3.5)(rollup@3.29.4)':
     dependencies:
-      c12: 2.0.1(magicast@0.3.5)
-      compatx: 0.1.8
+      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@3.29.4)
+      ci-info: 4.0.0
       consola: 3.2.3
+      create-require: 1.1.1
       defu: 6.1.4
-      hookable: 5.5.3
+      destr: 2.0.3
+      dotenv: 16.4.5
+      git-url-parse: 15.0.0
+      is-docker: 3.0.0
+      jiti: 1.21.6
+      mri: 1.2.0
+      nanoid: 5.1.5
+      ofetch: 1.4.1
+      package-manager-detector: 0.2.0
+      parse-git-config: 3.0.0
       pathe: 1.1.2
-      pkg-types: 1.2.1
-      scule: 1.3.0
+      rc9: 2.1.2
       std-env: 3.7.0
-      ufo: 1.5.4
-      uncrypto: 0.1.3
-      unimport: 3.13.2(rollup@4.36.0)
-      untyped: 1.5.1
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -24405,35 +24431,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/telemetry@2.6.0(magicast@0.3.5)(rollup@4.36.0)':
+  '@nuxt/test-utils@3.13.1(@jest/globals@29.7.0)(@playwright/test@1.49.1)(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@24.1.0)(magicast@0.3.5)(nitropack@2.10.4(encoding@0.1.13)(typescript@5.6.2))(playwright-core@1.49.1)(rollup@3.29.4)(vitest@1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))':
     dependencies:
-      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.36.0)
-      ci-info: 4.0.0
-      consola: 3.2.3
-      create-require: 1.1.1
-      defu: 6.1.4
-      destr: 2.0.3
-      dotenv: 16.4.5
-      git-url-parse: 15.0.0
-      is-docker: 3.0.0
-      jiti: 1.21.6
-      mri: 1.2.0
-      nanoid: 5.1.5
-      ofetch: 1.4.1
-      package-manager-detector: 0.2.0
-      parse-git-config: 3.0.0
-      pathe: 1.1.2
-      rc9: 2.1.2
-      std-env: 3.7.0
-    transitivePeerDependencies:
-      - magicast
-      - rollup
-      - supports-color
-
-  '@nuxt/test-utils@3.13.1(@jest/globals@29.7.0)(@playwright/test@1.49.1)(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@24.1.0)(magicast@0.3.5)(nitropack@2.10.4(encoding@0.1.13)(typescript@5.6.2))(playwright-core@1.49.1)(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vitest@1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))':
-    dependencies:
-      '@nuxt/kit': 3.12.3(magicast@0.3.5)(rollup@4.24.4)
-      '@nuxt/schema': 3.12.3(rollup@4.24.4)
+      '@nuxt/kit': 3.12.3(magicast@0.3.5)(rollup@3.29.4)
+      '@nuxt/schema': 3.12.3(rollup@3.29.4)
       c12: 1.11.1(magicast@0.3.5)
       consola: 3.2.3
       defu: 6.1.4
@@ -24456,8 +24457,7 @@ snapshots:
       ufo: 1.5.3
       unenv: 1.9.0
       unplugin: 1.11.0
-      vite: 5.4.10(@types/node@20.17.10)(terser@5.31.2)
-      vitest-environment-nuxt: 1.0.0(@jest/globals@29.7.0)(@playwright/test@1.49.1)(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@24.1.0)(magicast@0.3.5)(nitropack@2.10.4(encoding@0.1.13)(typescript@5.6.2))(playwright-core@1.49.1)(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vitest@1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))
+      vitest-environment-nuxt: 1.0.0(@jest/globals@29.7.0)(@playwright/test@1.49.1)(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@24.1.0)(magicast@0.3.5)(nitropack@2.10.4(encoding@0.1.13)(typescript@5.6.2))(playwright-core@1.49.1)(rollup@3.29.4)(vitest@1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))
       vue: 3.5.12(typescript@5.6.2)
       vue-router: 4.4.5(vue@3.5.12(typescript@5.6.2))
     optionalDependencies:
@@ -24472,10 +24472,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/vite-builder@3.14.159(@biomejs/biome@1.9.4)(@types/node@20.17.10)(eslint@9.20.1(jiti@2.4.0))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.24.4)(terser@5.31.2)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))(vue@3.5.12(typescript@5.6.2))':
+  '@nuxt/vite-builder@3.14.159(@biomejs/biome@1.9.4)(@types/node@20.17.10)(eslint@9.20.1(jiti@2.4.0))(magicast@0.3.5)(optionator@0.9.4)(rollup@3.29.4)(terser@5.31.2)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))(vue@3.5.12(typescript@5.6.2))':
     dependencies:
-      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.24.4)
-      '@rollup/plugin-replace': 6.0.1(rollup@4.24.4)
+      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@3.29.4)
+      '@rollup/plugin-replace': 6.0.1(rollup@3.29.4)
       '@vitejs/plugin-vue': 5.2.0(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vue@3.5.12(typescript@5.6.2))
       '@vitejs/plugin-vue-jsx': 4.1.0(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vue@3.5.12(typescript@5.6.2))
       autoprefixer: 10.4.20(postcss@8.4.47)
@@ -24498,7 +24498,7 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 1.2.1
       postcss: 8.4.47
-      rollup-plugin-visualizer: 5.12.0(rollup@4.24.4)
+      rollup-plugin-visualizer: 5.12.0(rollup@3.29.4)
       std-env: 3.7.0
       strip-literal: 2.1.0
       ufo: 1.5.4
@@ -24532,10 +24532,10 @@ snapshots:
       - vti
       - vue-tsc
 
-  '@nuxt/vite-builder@3.14.159(@biomejs/biome@1.9.4)(@types/node@20.17.10)(eslint@9.20.1(jiti@2.4.0))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.36.0)(terser@5.31.2)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))(vue@3.5.12(typescript@5.6.2))':
+  '@nuxt/vite-builder@3.14.159(@biomejs/biome@1.9.4)(@types/node@20.17.10)(eslint@9.20.1(jiti@2.4.0))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.24.4)(terser@5.31.2)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))(vue@3.5.12(typescript@5.6.2))':
     dependencies:
-      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.36.0)
-      '@rollup/plugin-replace': 6.0.1(rollup@4.36.0)
+      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.24.4)
+      '@rollup/plugin-replace': 6.0.1(rollup@4.24.4)
       '@vitejs/plugin-vue': 5.2.0(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vue@3.5.12(typescript@5.6.2))
       '@vitejs/plugin-vue-jsx': 4.1.0(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vue@3.5.12(typescript@5.6.2))
       autoprefixer: 10.4.20(postcss@8.4.47)
@@ -24558,7 +24558,7 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 1.2.1
       postcss: 8.4.47
-      rollup-plugin-visualizer: 5.12.0(rollup@4.36.0)
+      rollup-plugin-visualizer: 5.12.0(rollup@4.24.4)
       std-env: 3.7.0
       strip-literal: 2.1.0
       ufo: 1.5.4
@@ -25372,19 +25372,19 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
+  '@rollup/plugin-replace@6.0.1(rollup@3.29.4)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.3(rollup@3.29.4)
+      magic-string: 0.30.17
+    optionalDependencies:
+      rollup: 3.29.4
+
   '@rollup/plugin-replace@6.0.1(rollup@4.24.4)':
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.24.4)
       magic-string: 0.30.17
     optionalDependencies:
       rollup: 4.24.4
-
-  '@rollup/plugin-replace@6.0.1(rollup@4.36.0)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.36.0)
-      magic-string: 0.30.17
-    optionalDependencies:
-      rollup: 4.36.0
 
   '@rollup/plugin-swc@0.4.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(rollup@4.24.4)':
     dependencies:
@@ -27462,10 +27462,10 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.0.8
 
-  '@vue-macros/common@1.15.0(rollup@4.24.4)(vue@3.5.12(typescript@5.6.2))':
+  '@vue-macros/common@1.15.0(rollup@3.29.4)(vue@3.5.12(typescript@5.6.2))':
     dependencies:
       '@babel/types': 7.26.9
-      '@rollup/pluginutils': 5.1.3(rollup@4.24.4)
+      '@rollup/pluginutils': 5.1.3(rollup@3.29.4)
       '@vue/compiler-sfc': 3.5.12
       ast-kit: 1.3.1
       local-pkg: 0.5.0
@@ -27475,10 +27475,10 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/common@1.15.0(rollup@4.36.0)(vue@3.5.12(typescript@5.6.2))':
+  '@vue-macros/common@1.15.0(rollup@4.24.4)(vue@3.5.12(typescript@5.6.2))':
     dependencies:
       '@babel/types': 7.26.9
-      '@rollup/pluginutils': 5.1.3(rollup@4.36.0)
+      '@rollup/pluginutils': 5.1.3(rollup@4.24.4)
       '@vue/compiler-sfc': 3.5.12
       ast-kit: 1.3.1
       local-pkg: 0.5.0
@@ -27612,7 +27612,7 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@7.3.3(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))':
+  '@vue/devtools-core@7.3.3':
     dependencies:
       '@vue/devtools-kit': 7.3.3
       '@vue/devtools-shared': 7.3.5
@@ -32384,9 +32384,9 @@ snapshots:
 
   import-meta-resolve@4.1.0: {}
 
-  impound@0.2.0(rollup@4.24.4):
+  impound@0.2.0(rollup@3.29.4):
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.24.4)
+      '@rollup/pluginutils': 5.1.3(rollup@3.29.4)
       mlly: 1.7.3
       pathe: 1.1.2
       unenv: 1.10.0
@@ -32394,9 +32394,9 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  impound@0.2.0(rollup@4.36.0):
+  impound@0.2.0(rollup@4.24.4):
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.36.0)
+      '@rollup/pluginutils': 5.1.3(rollup@4.24.4)
       mlly: 1.7.3
       pathe: 1.1.2
       unenv: 1.10.0
@@ -35042,6 +35042,120 @@ snapshots:
 
   nuxi@3.15.0: {}
 
+  nuxt@3.14.159(@biomejs/biome@1.9.4)(@parcel/watcher@2.4.1)(@types/node@20.17.10)(encoding@0.1.13)(eslint@9.20.1(jiti@2.4.0))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@3.29.4)(terser@5.31.2)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2)):
+    dependencies:
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/devtools': 1.6.0(rollup@3.29.4)(vue@3.5.12(typescript@5.6.2))
+      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@3.29.4)
+      '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@3.29.4)
+      '@nuxt/telemetry': 2.6.0(magicast@0.3.5)(rollup@3.29.4)
+      '@nuxt/vite-builder': 3.14.159(@biomejs/biome@1.9.4)(@types/node@20.17.10)(eslint@9.20.1(jiti@2.4.0))(magicast@0.3.5)(optionator@0.9.4)(rollup@3.29.4)(terser@5.31.2)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))(vue@3.5.12(typescript@5.6.2))
+      '@unhead/dom': 1.11.11
+      '@unhead/shared': 1.11.11
+      '@unhead/ssr': 1.11.11
+      '@unhead/vue': 1.11.11(vue@3.5.12(typescript@5.6.2))
+      '@vue/shared': 3.5.12
+      acorn: 8.14.0
+      c12: 2.0.1(magicast@0.3.5)
+      chokidar: 4.0.1
+      compatx: 0.1.8
+      consola: 3.2.3
+      cookie-es: 1.2.2
+      defu: 6.1.4
+      destr: 2.0.3
+      devalue: 5.1.1
+      errx: 0.1.0
+      esbuild: 0.24.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      globby: 14.0.2
+      h3: 1.13.0
+      hookable: 5.5.3
+      ignore: 6.0.2
+      impound: 0.2.0(rollup@3.29.4)
+      jiti: 2.4.0
+      klona: 2.0.6
+      knitwork: 1.1.0
+      magic-string: 0.30.12
+      mlly: 1.7.3
+      nanotar: 0.1.1
+      nitropack: 2.10.4(encoding@0.1.13)(typescript@5.6.2)
+      nuxi: 3.15.0
+      nypm: 0.3.12
+      ofetch: 1.4.1
+      ohash: 1.1.4
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.2.1
+      radix3: 1.1.2
+      scule: 1.3.0
+      semver: 7.6.3
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      tinyglobby: 0.2.10
+      ufo: 1.5.4
+      ultrahtml: 1.5.3
+      uncrypto: 0.1.3
+      unctx: 2.3.1
+      unenv: 1.10.0
+      unhead: 1.11.11
+      unimport: 3.13.2(rollup@3.29.4)
+      unplugin: 1.16.0
+      unplugin-vue-router: 0.10.8(rollup@3.29.4)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))
+      unstorage: 1.13.1(ioredis@5.4.1)
+      untyped: 1.5.1
+      vue: 3.5.12(typescript@5.6.2)
+      vue-bundle-renderer: 2.1.1
+      vue-devtools-stub: 0.1.0
+      vue-router: 4.4.5(vue@3.5.12(typescript@5.6.2))
+    optionalDependencies:
+      '@parcel/watcher': 2.4.1
+      '@types/node': 20.17.10
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - better-sqlite3
+      - bufferutil
+      - drizzle-orm
+      - encoding
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - uWebSockets.js
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - xml2js
+
   nuxt@3.14.159(@biomejs/biome@1.9.4)(@parcel/watcher@2.4.1)(@types/node@20.17.10)(encoding@0.1.13)(eslint@9.20.1(jiti@2.4.0))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.24.4)(terser@5.31.2)(typescript@5.6.2)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vue-tsc@2.1.10(typescript@5.6.2)):
     dependencies:
       '@nuxt/devalue': 2.0.2
@@ -35102,120 +35216,6 @@ snapshots:
       unimport: 3.13.2(rollup@4.24.4)
       unplugin: 1.16.0
       unplugin-vue-router: 0.10.8(rollup@4.24.4)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))
-      unstorage: 1.13.1(ioredis@5.4.1)
-      untyped: 1.5.1
-      vue: 3.5.12(typescript@5.6.2)
-      vue-bundle-renderer: 2.1.1
-      vue-devtools-stub: 0.1.0
-      vue-router: 4.4.5(vue@3.5.12(typescript@5.6.2))
-    optionalDependencies:
-      '@parcel/watcher': 2.4.1
-      '@types/node': 20.17.10
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/kv'
-      - better-sqlite3
-      - bufferutil
-      - drizzle-orm
-      - encoding
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - typescript
-      - uWebSockets.js
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - xml2js
-
-  nuxt@3.14.159(@biomejs/biome@1.9.4)(@parcel/watcher@2.4.1)(@types/node@20.17.10)(encoding@0.1.13)(eslint@9.20.1(jiti@2.4.0))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.36.0)(terser@5.31.2)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2)):
-    dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.6.0(rollup@4.36.0)(vue@3.5.12(typescript@5.6.2))
-      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.36.0)
-      '@nuxt/schema': 3.14.159(magicast@0.3.5)(rollup@4.36.0)
-      '@nuxt/telemetry': 2.6.0(magicast@0.3.5)(rollup@4.36.0)
-      '@nuxt/vite-builder': 3.14.159(@biomejs/biome@1.9.4)(@types/node@20.17.10)(eslint@9.20.1(jiti@2.4.0))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.36.0)(terser@5.31.2)(typescript@5.6.2)(vue-tsc@2.1.10(typescript@5.6.2))(vue@3.5.12(typescript@5.6.2))
-      '@unhead/dom': 1.11.11
-      '@unhead/shared': 1.11.11
-      '@unhead/ssr': 1.11.11
-      '@unhead/vue': 1.11.11(vue@3.5.12(typescript@5.6.2))
-      '@vue/shared': 3.5.12
-      acorn: 8.14.0
-      c12: 2.0.1(magicast@0.3.5)
-      chokidar: 4.0.1
-      compatx: 0.1.8
-      consola: 3.2.3
-      cookie-es: 1.2.2
-      defu: 6.1.4
-      destr: 2.0.3
-      devalue: 5.1.1
-      errx: 0.1.0
-      esbuild: 0.24.0
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      globby: 14.0.2
-      h3: 1.13.0
-      hookable: 5.5.3
-      ignore: 6.0.2
-      impound: 0.2.0(rollup@4.36.0)
-      jiti: 2.4.0
-      klona: 2.0.6
-      knitwork: 1.1.0
-      magic-string: 0.30.12
-      mlly: 1.7.3
-      nanotar: 0.1.1
-      nitropack: 2.10.4(encoding@0.1.13)(typescript@5.6.2)
-      nuxi: 3.15.0
-      nypm: 0.3.12
-      ofetch: 1.4.1
-      ohash: 1.1.4
-      pathe: 1.1.2
-      perfect-debounce: 1.0.0
-      pkg-types: 1.2.1
-      radix3: 1.1.2
-      scule: 1.3.0
-      semver: 7.6.3
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinyglobby: 0.2.10
-      ufo: 1.5.4
-      ultrahtml: 1.5.3
-      uncrypto: 0.1.3
-      unctx: 2.3.1
-      unenv: 1.10.0
-      unhead: 1.11.11
-      unimport: 3.13.2(rollup@4.36.0)
-      unplugin: 1.16.0
-      unplugin-vue-router: 0.10.8(rollup@4.36.0)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))
       unstorage: 1.13.1(ioredis@5.4.1)
       untyped: 1.5.1
       vue: 3.5.12(typescript@5.6.2)
@@ -37564,6 +37564,15 @@ snapshots:
     dependencies:
       rollup-plugin-inject: 3.0.2
 
+  rollup-plugin-visualizer@5.12.0(rollup@3.29.4):
+    dependencies:
+      open: 8.4.2
+      picomatch: 2.3.1
+      source-map: 0.7.4
+      yargs: 17.7.2
+    optionalDependencies:
+      rollup: 3.29.4
+
   rollup-plugin-visualizer@5.12.0(rollup@4.24.4):
     dependencies:
       open: 8.4.2
@@ -37572,15 +37581,6 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       rollup: 4.24.4
-
-  rollup-plugin-visualizer@5.12.0(rollup@4.36.0):
-    dependencies:
-      open: 8.4.2
-      picomatch: 2.3.1
-      source-map: 0.7.4
-      yargs: 17.7.2
-    optionalDependencies:
-      rollup: 4.36.0
 
   rollup-plugin-webpack-stats@0.2.6(rollup@4.36.0):
     dependencies:
@@ -39376,6 +39376,24 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.1
 
+  unimport@3.13.2(rollup@3.29.4):
+    dependencies:
+      '@rollup/pluginutils': 5.1.3(rollup@3.29.4)
+      acorn: 8.14.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      fast-glob: 3.3.3
+      local-pkg: 0.5.0
+      magic-string: 0.30.12
+      mlly: 1.7.3
+      pathe: 1.1.2
+      pkg-types: 1.2.1
+      scule: 1.3.0
+      strip-literal: 2.1.0
+      unplugin: 1.16.0
+    transitivePeerDependencies:
+      - rollup
+
   unimport@3.13.2(rollup@4.24.4):
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.24.4)
@@ -39394,27 +39412,9 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  unimport@3.13.2(rollup@4.36.0):
+  unimport@3.7.2(rollup@3.29.4):
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.36.0)
-      acorn: 8.14.0
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.3
-      local-pkg: 0.5.0
-      magic-string: 0.30.12
-      mlly: 1.7.3
-      pathe: 1.1.2
-      pkg-types: 1.2.1
-      scule: 1.3.0
-      strip-literal: 2.1.0
-      unplugin: 1.16.0
-    transitivePeerDependencies:
-      - rollup
-
-  unimport@3.7.2(rollup@4.24.4):
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.24.4)
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       acorn: 8.14.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -39498,11 +39498,11 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-router@0.10.8(rollup@4.24.4)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2)):
+  unplugin-vue-router@0.10.8(rollup@3.29.4)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2)):
     dependencies:
       '@babel/types': 7.26.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.24.4)
-      '@vue-macros/common': 1.15.0(rollup@4.24.4)(vue@3.5.12(typescript@5.6.2))
+      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@vue-macros/common': 1.15.0(rollup@3.29.4)(vue@3.5.12(typescript@5.6.2))
       ast-walker-scope: 0.6.2
       chokidar: 3.6.0
       fast-glob: 3.3.3
@@ -39520,11 +39520,11 @@ snapshots:
       - rollup
       - vue
 
-  unplugin-vue-router@0.10.8(rollup@4.36.0)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2)):
+  unplugin-vue-router@0.10.8(rollup@4.24.4)(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2)):
     dependencies:
       '@babel/types': 7.26.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.36.0)
-      '@vue-macros/common': 1.15.0(rollup@4.36.0)(vue@3.5.12(typescript@5.6.2))
+      '@rollup/pluginutils': 5.1.0(rollup@4.24.4)
+      '@vue-macros/common': 1.15.0(rollup@4.24.4)(vue@3.5.12(typescript@5.6.2))
       ast-walker-scope: 0.6.2
       chokidar: 3.6.0
       fast-glob: 3.3.3
@@ -39884,10 +39884,10 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.4(@nuxt/kit@3.12.3(magicast@0.3.5)(rollup@4.24.4))(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2)):
+  vite-plugin-inspect@0.8.4(@nuxt/kit@3.12.3(magicast@0.3.5)(rollup@3.29.4))(rollup@3.29.4):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.3(rollup@4.24.4)
+      '@rollup/pluginutils': 5.1.3(rollup@3.29.4)
       debug: 4.4.0(supports-color@9.4.0)
       error-stack-parser-es: 0.1.4
       fs-extra: 11.2.0
@@ -39895,9 +39895,25 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 2.0.4
-      vite: 5.4.10(@types/node@20.17.10)(terser@5.31.2)
     optionalDependencies:
-      '@nuxt/kit': 3.12.3(magicast@0.3.5)(rollup@4.24.4)
+      '@nuxt/kit': 3.12.3(magicast@0.3.5)(rollup@3.29.4)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.14.159(magicast@0.3.5)(rollup@3.29.4))(rollup@3.29.4):
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@rollup/pluginutils': 5.1.3(rollup@3.29.4)
+      debug: 4.4.0(supports-color@9.4.0)
+      error-stack-parser-es: 0.1.5
+      fs-extra: 11.2.0
+      open: 10.1.0
+      perfect-debounce: 1.0.0
+      picocolors: 1.1.1
+      sirv: 2.0.4
+    optionalDependencies:
+      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@3.29.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -39916,23 +39932,6 @@ snapshots:
       vite: 5.4.10(@types/node@20.17.10)(terser@5.31.2)
     optionalDependencies:
       '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.24.4)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.14.159(magicast@0.3.5)(rollup@4.36.0))(rollup@4.36.0):
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.3(rollup@4.36.0)
-      debug: 4.4.0(supports-color@9.4.0)
-      error-stack-parser-es: 0.1.5
-      fs-extra: 11.2.0
-      open: 10.1.0
-      perfect-debounce: 1.0.0
-      picocolors: 1.1.1
-      sirv: 2.0.4
-    optionalDependencies:
-      '@nuxt/kit': 3.14.159(magicast@0.3.5)(rollup@4.36.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -40013,9 +40012,9 @@ snapshots:
     optionalDependencies:
       vite: 6.2.5(@types/node@20.17.10)(jiti@2.4.0)(terser@5.31.2)(tsx@4.19.1)(yaml@2.6.0)
 
-  vitest-environment-nuxt@1.0.0(@jest/globals@29.7.0)(@playwright/test@1.49.1)(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@24.1.0)(magicast@0.3.5)(nitropack@2.10.4(encoding@0.1.13)(typescript@5.6.2))(playwright-core@1.49.1)(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vitest@1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2)):
+  vitest-environment-nuxt@1.0.0(@jest/globals@29.7.0)(@playwright/test@1.49.1)(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@24.1.0)(magicast@0.3.5)(nitropack@2.10.4(encoding@0.1.13)(typescript@5.6.2))(playwright-core@1.49.1)(rollup@3.29.4)(vitest@1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2)):
     dependencies:
-      '@nuxt/test-utils': 3.13.1(@jest/globals@29.7.0)(@playwright/test@1.49.1)(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@24.1.0)(magicast@0.3.5)(nitropack@2.10.4(encoding@0.1.13)(typescript@5.6.2))(playwright-core@1.49.1)(rollup@4.24.4)(vite@5.4.10(@types/node@20.17.10)(terser@5.31.2))(vitest@1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))
+      '@nuxt/test-utils': 3.13.1(@jest/globals@29.7.0)(@playwright/test@1.49.1)(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@24.1.0)(magicast@0.3.5)(nitropack@2.10.4(encoding@0.1.13)(typescript@5.6.2))(playwright-core@1.49.1)(rollup@3.29.4)(vitest@1.6.0(@types/node@20.17.10)(jsdom@24.1.0)(terser@5.31.2))(vue-router@4.4.5(vue@3.5.12(typescript@5.6.2)))(vue@3.5.12(typescript@5.6.2))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -40760,16 +40759,18 @@ snapshots:
     dependencies:
       zod: 3.23.8
 
-  zod-to-ts@1.2.0(typescript@5.6.2)(zod@3.23.8):
+  zod-to-ts@1.2.0(typescript@5.6.2)(zod@3.24.1):
     dependencies:
       typescript: 5.6.2
-      zod: 3.23.8
+      zod: 3.24.1
 
-  zod-to-ts@https://codeload.github.com/amritk/zod-to-ts/tar.gz/1f956fe246b5b3e70bbeb9e3a928396f9c22e400(typescript@5.6.2)(zod@3.23.8):
+  zod-to-ts@https://codeload.github.com/amritk/zod-to-ts/tar.gz/1f956fe246b5b3e70bbeb9e3a928396f9c22e400(typescript@5.6.2)(zod@3.24.1):
     dependencies:
       typescript: 5.6.2
-      zod: 3.23.8
+      zod: 3.24.1
 
   zod@3.23.8: {}
+
+  zod@3.24.1: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,4 +41,4 @@ catalog:
   vitest: ^1.6.0
   vue: ^3.5.12
   yaml: ^2.4.5
-  zod: ^3.23.8
+  zod: 3.24.1


### PR DESCRIPTION
**Solution**

With this PR
- export viewLayoutCollapse from api-client. I know we want to add it to components but I have another PR open for that
- export codeInput and allow additional languages
- bump zod version to match org
- add a few security scheme helpers to oas-utils

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
