### PR TITLE
feat(api-reference): CSS class for HTTP methods

### DIFF
--- a/.changeset/poor-apricots-chew.md
+++ b/.changeset/poor-apricots-chew.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: CSS class for HTTP methods

--- a/packages/api-reference/src/components/Sidebar/SidebarHttpBadge.test.ts
+++ b/packages/api-reference/src/components/Sidebar/SidebarHttpBadge.test.ts
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import SidebarHttpBadge from './SidebarHttpBadge.vue'
+
+describe('SidebarHttpBadge', () => {
+  it('adds the correct method class', () => {
+    const wrapper = mount(SidebarHttpBadge, {
+      props: {
+        method: 'GET',
+      },
+    })
+
+    expect(wrapper.classes()).toContain('sidebar-heading-type--get')
+  })
+
+  it('handles different HTTP methods', () => {
+    const methods = ['POST', 'PUT', 'DELETE', 'PATCH']
+
+    methods.forEach((method) => {
+      const wrapper = mount(SidebarHttpBadge, {
+        props: {
+          method,
+        },
+      })
+
+      expect(wrapper.classes()).toContain(`sidebar-heading-type--${method.toLowerCase()}`)
+    })
+  })
+
+  it('adds active class when active prop is true', () => {
+    const wrapper = mount(SidebarHttpBadge, {
+      props: {
+        method: 'GET',
+        active: true,
+      },
+    })
+
+    expect(wrapper.classes()).toContain('sidebar-heading-type-active')
+  })
+})

--- a/packages/api-reference/src/components/Sidebar/SidebarHttpBadge.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarHttpBadge.vue
@@ -8,8 +8,11 @@ defineProps<{
 </script>
 <template>
   <HttpMethod
-    class="sidebar-heading-type"
-    :class="{ 'sidebar-heading-type-active': active }"
+    :class="[
+      'sidebar-heading-type',
+      'sidebar-heading-type--' + method.toLowerCase(),
+      { 'sidebar-heading-type-active': active }
+    ]"
     :method="method"
     property="--method-color"
     short />

--- a/packages/api-reference/src/components/Sidebar/SidebarHttpBadge.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarHttpBadge.vue
@@ -2,16 +2,16 @@
 import { HttpMethod } from '../HttpMethod'
 
 defineProps<{
-  active?: boolean
   method: string
+  active?: boolean
 }>()
 </script>
 <template>
   <HttpMethod
     :class="[
       'sidebar-heading-type',
-      'sidebar-heading-type--' + method.toLowerCase(),
-      { 'sidebar-heading-type-active': active }
+      `sidebar-heading-type--${method.toLowerCase()}`,
+      { 'sidebar-heading-type-active': active },
     ]"
     :method="method"
     property="--method-color"


### PR DESCRIPTION
Added HTTP method-specific CSS classes for custom styling

**Problem**

Currently, there's no possibility to customize http methods of endpoints in the sidebar. They all have to same css class.

**Solution**

With this PR I added a specific css class per http method so that they can be customized.

**Checklist**

I’ve gone through the following:

- [X] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
