### PR TITLE
feat(api-reference): parameter examples improvements

### DIFF
--- a/.changeset/fresh-falcons-build.md
+++ b/.changeset/fresh-falcons-build.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates parameter list item passed value

--- a/.changeset/long-needles-drop.md
+++ b/.changeset/long-needles-drop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: sets scalar tooltip content word break to all

--- a/.changeset/sour-ligers-confess.md
+++ b/.changeset/sour-ligers-confess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: adds external and object value format example

--- a/.changeset/stupid-needles-sort.md
+++ b/.changeset/stupid-needles-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+feat: improves request examples entity example defaulting

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -89,7 +89,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
 
 <template>
   <div
-    class="group-[.alert]:outline-orange group-[.error]:outline-red w-full pr-4 -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline">
+    class="group-[.alert]:outline-orange group-[.error]:outline-red w-full pr-10 -outline-offset-1 has-[:focus-visible]:rounded-[4px] has-[:focus-visible]:outline">
     <template v-if="type === 'array'">
       <ScalarComboboxMultiselect
         :modelValue="selectedArrayOptions"
@@ -106,7 +106,8 @@ const updateSelectedOptions = (selectedOptions: any) => {
           }}</span>
           <ScalarIcon
             icon="ChevronDown"
-            size="md" />
+            size="md"
+            class="min-w-4" />
         </ScalarButton>
       </ScalarComboboxMultiselect>
     </template>
@@ -128,7 +129,9 @@ const updateSelectedOptions = (selectedOptions: any) => {
           class="h-full justify-start gap-1.5 overflow-auto whitespace-nowrap px-2 py-1.5 font-normal outline-none"
           fullWidth
           variant="ghost">
-          <span class="text-c-1">{{ initialValue || 'Select a value' }}</span>
+          <span class="text-c-1 overflow-hidden text-ellipsis">{{
+            initialValue || 'Select a value'
+          }}</span>
           <ScalarIcon
             icon="ChevronDown"
             size="md" />
@@ -152,7 +155,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
                 icon="Checkmark"
                 thickness="3" />
             </div>
-            {{ option }}
+            <span class="overflow-hidden text-ellipsis">{{ option }}</span>
           </ScalarDropdownItem>
           <template v-if="canAddCustomValue">
             <ScalarDropdownDivider v-if="options.length" />

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -98,6 +98,7 @@ const { copyToClipboard } = useClipboard()
 .property-example-value {
   font-family: var(--scalar-font-code);
   display: flex;
+  gap: 8px;
   align-items: center;
   width: 100%;
   padding: 6px;

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.test.ts
@@ -79,4 +79,20 @@ describe('formatExample', () => {
     const result = formatExample(input)
     expect(result).toBe('123.456')
   })
+
+  it('handles external value', () => {
+    const input = {
+      externalValue: 'https://example.com',
+    }
+    const result = formatExample(input)
+    expect(result).toBe('https://example.com')
+  })
+
+  it('handles object value', () => {
+    const input = {
+      value: '123',
+    }
+    const result = formatExample(input)
+    expect(result).toBe('123')
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/formatExample.ts
@@ -26,12 +26,20 @@ export function formatExample(example: unknown): string | number {
       .join(', ')}]`
   }
 
-  if (typeof example === 'object') {
-    return JSON.stringify(example)
-  }
-
   if (example === null) {
     return 'null'
+  }
+
+  if (typeof example === 'object') {
+    if ('value' in example) {
+      return example.value as string | number
+    }
+
+    if ('externalValue' in example) {
+      return example.externalValue as string | number
+    }
+
+    return JSON.stringify(example)
   }
 
   if (example === undefined) {

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -2,6 +2,7 @@
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
+import { isDefined } from '@scalar/oas-utils/helpers'
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { ContentType } from '@scalar/types/legacy'
 import { computed, ref } from 'vue'
@@ -103,10 +104,17 @@ const shouldShowParameter = computed(() => {
           :required="parameter.required"
           :schemas="schemas"
           :value="{
-            deprecated: parameter.deprecated,
             ...(parameter.content
               ? parameter.content?.[selectedContentType]?.schema
               : parameter.schema),
+            deprecated: parameter.deprecated,
+            ...(isDefined(parameter.example) && { example: parameter.example }),
+            examples: parameter.content
+              ? {
+                  ...parameter.examples,
+                  ...parameter.content?.[selectedContentType]?.examples,
+                }
+              : parameter.examples || parameter.schema?.examples,
           }"
           :withExamples="withExamples" />
       </DisclosurePanel>

--- a/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
+++ b/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
@@ -10,7 +10,7 @@ import {
 import { ScalarTeleport } from '../ScalarTeleport'
 
 const variants = cva({
-  base: 'scalar-app z-overlay',
+  base: 'scalar-app z-overlay break-all',
   variants: {
     textSize: {
       xs: 'text-xs',

--- a/packages/oas-utils/src/entities/spec/parameters.ts
+++ b/packages/oas-utils/src/entities/spec/parameters.ts
@@ -36,8 +36,9 @@ export const oasParameterSchema = z.object({
       z.record(
         z.string(),
         z.object({
-          value: z.unknown(),
+          value: z.unknown().optional(),
           summary: z.string().optional(),
+          externalValue: z.string().optional(),
         }),
       ),
       z.array(z.unknown()),

--- a/packages/oas-utils/src/entities/spec/parameters.ts
+++ b/packages/oas-utils/src/entities/spec/parameters.ts
@@ -1,5 +1,7 @@
 import type { OpenAPI } from '@scalar/openapi-types'
 import { type ZodSchema, z } from 'zod'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { RequestExampleParameter } from './request-examples.ts'
 
 export const parameterTypeSchema = z.enum(['path', 'query', 'header', 'cookie'])
 export type ParamType = z.infer<typeof parameterTypeSchema>
@@ -14,6 +16,15 @@ export const parameterStyleSchema = z.enum([
   'deepObject',
 ])
 export type ParameterStyle = z.infer<typeof parameterStyleSchema>
+export type ParameterContent = Record<
+  string,
+  {
+    schema?: OpenAPIV3_1.Document
+    examples?: Record<string, RequestExampleParameter>
+    example?: RequestExampleParameter
+  }
+>
+export const parameterExampleSchema = z.unknown()
 
 /**
  * OpenAPI compliant parameters object

--- a/packages/oas-utils/src/entities/spec/request-example.test.ts
+++ b/packages/oas-utils/src/entities/spec/request-example.test.ts
@@ -233,6 +233,78 @@ describe('createParamInstance', () => {
       value: '',
     })
   })
+
+  it('works with content examples', () => {
+    const result = createParamInstance({
+      in: 'query',
+      name: 'foo',
+      required: false,
+      deprecated: false,
+      content: {
+        'application/json': {
+          schema: { type: 'integer', maximum: 50 },
+          examples: {
+            zero: { value: 0 },
+            max: { value: 50 },
+          },
+        },
+      },
+    })
+
+    expect(result).toEqual({
+      key: 'foo',
+      value: '0',
+      enabled: false,
+      description: undefined,
+      required: false,
+    })
+  })
+
+  it('works with content example', () => {
+    const result = createParamInstance({
+      in: 'query',
+      name: 'foo',
+      required: false,
+      deprecated: false,
+      content: {
+        'application/json': {
+          schema: { type: 'integer' },
+          example: 42,
+        },
+      },
+    })
+
+    expect(result).toEqual({
+      key: 'foo',
+      value: '42',
+      enabled: false,
+      description: undefined,
+      required: false,
+    })
+  })
+
+  it('works with parameter example', () => {
+    const result = createParamInstance({
+      in: 'query',
+      name: 'foo',
+      required: false,
+      deprecated: false,
+      example: 42,
+      schema: {
+        type: 'integer',
+        example: 1,
+      },
+    })
+
+    expect(result).toEqual({
+      key: 'foo',
+      value: '42',
+      enabled: false,
+      description: undefined,
+      required: false,
+      type: 'integer',
+    })
+  })
 })
 
 describe('parameterArrayToObject', () => {

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -4,8 +4,11 @@ import { keysOf } from '@scalar/object-utils/arrays'
 import { type ENTITY_BRANDS, nanoidSchema } from '@scalar/types/utils'
 import { z } from 'zod'
 
+import { isDefined } from '@/helpers/is-defined.ts'
+import { getObjectKeys } from '@/helpers/object.ts'
+
 import { getRequestBodyFromOperation } from '@/spec-getters/get-request-body-from-operation.ts'
-import type { RequestParameter } from './parameters.ts'
+import type { RequestParameter, ParameterContent } from './parameters.ts'
 import type { Request } from './requests.ts'
 import type { Server } from './server.ts'
 
@@ -27,7 +30,7 @@ export const requestExampleParametersSchema = z
     description: z.string().optional(),
     required: z.boolean().optional(),
     enum: z.array(z.string()).optional(),
-    examples: z.array(z.string()).optional(),
+    examples: z.array(z.any()).optional(),
     type: z
       .union([
         // 'string'
@@ -51,7 +54,7 @@ export const requestExampleParametersSchema = z
       data.nullable = true
     }
 
-    // Hey, if it’s just one value and 'null', we can make it a string and ditch the 'null'.
+    // Hey, if it's just one value and 'null', we can make it a string and ditch the 'null'.
     if (Array.isArray(data.type) && data.type.length === 2 && data.type.includes('null')) {
       data.type = data.type.find((item) => item !== 'null')
     }
@@ -287,19 +290,72 @@ export function convertExampleToXScalar(example: RequestExample) {
 /** Create new instance parameter from a request parameter */
 export function createParamInstance(param: RequestParameter) {
   const schema = param.schema as any
-  const keys = Object.keys(param?.examples ?? {})
 
   const firstExample = (() => {
-    if (keys.length && !Array.isArray(param.examples)) {
-      return param.examples?.[keys[0]!]
+    if (param.examples && !Array.isArray(param.examples) && getObjectKeys(param.examples).length > 0) {
+      const exampleValues = Object.entries(param.examples).map(([_, example]) => {
+        // returns the external value if it exists
+        if (example.externalValue) {
+          return example.externalValue
+        }
+
+        // returns the value if it exists and is defined
+        // e.g. { examples: { foo: { value: 'bar' } } } would return ['bar']
+        return example.value
+      })
+
+      // returns the first example as selected value along other examples
+      return { value: exampleValues[0], examples: exampleValues }
     }
 
+    // param example e.g. { example: 'foo' }
+    if (isDefined(param.example)) {
+      return { value: param.example }
+    }
+
+    // param examples e.g. { examples: ['foo', 'bar'] }
     if (Array.isArray(param.examples) && param.examples.length > 0) {
       return { value: param.examples[0] }
     }
 
+    // schema example e.g. { example: 'foo' } while being discouraged
+    // see https://spec.openapis.org/oas/v3.1.1.html#fixed-fields-20
+    if (isDefined(schema?.example)) {
+      return { value: schema.example }
+    }
+
+    // schema examples e.g. { examples: ['foo', 'bar'] }
+    if (Array.isArray(schema?.examples) && schema.examples.length > 0) {
+      // For boolean type, default to false when using schema examples
+      if (schema?.type === 'boolean') {
+        return { value: schema.default ?? false }
+      }
+      return { value: schema.examples[0] }
+    }
+
+    // content examples e.g. { content: { 'application/json': { examples: { foo: { value: 'bar' } } } } }
+    if (param.content) {
+      const firstContentType = getObjectKeys(param.content)[0]
+      if (firstContentType) {
+        const content = (param.content as ParameterContent)[firstContentType]
+        if (content?.examples) {
+          const firstExampleKey = Object.keys(content.examples)[0]
+          if (firstExampleKey) {
+            const example = content.examples[firstExampleKey]
+            if (isDefined(example?.value)) {
+              return { value: example.value }
+            }
+          }
+        }
+        // content example e.g. { example: 'foo' }
+        if (isDefined(content?.example)) {
+          return { value: content.example }
+        }
+      }
+    }
+
     return null
-  })()
+  })() as null | { value: any; examples?: string[] }
 
   /**
    * TODO:
@@ -307,9 +363,7 @@ export function createParamInstance(param: RequestParameter) {
    * - Need to handle non-string parameters much better
    * - Need to handle unions/array values for schema
    */
-  const value = String(
-    schema?.default ?? schema?.examples?.[0] ?? schema?.example ?? firstExample?.value ?? param.example ?? '',
-  )
+  const value = String(firstExample?.value ?? schema?.default ?? '')
 
   // Handle non-string enums and enums within items for array types
   const parseEnum = (() => {
@@ -324,8 +378,10 @@ export function createParamInstance(param: RequestParameter) {
     return schema?.enum
   })()
 
-  // Handle non-string examples
-  const parseExamples = schema?.examples && schema?.type !== 'string' ? schema.examples?.map(String) : schema?.examples
+  // Handle parameter examples
+  const examples =
+    firstExample?.examples ||
+    (schema?.examples && schema?.type !== 'string' ? schema.examples?.map(String) : schema?.examples)
 
   // safe parse the example
   const example = schemaModel(
@@ -338,7 +394,7 @@ export function createParamInstance(param: RequestParameter) {
       /** Initialized all required properties to enabled */
       enabled: !!param.required,
       enum: parseEnum,
-      examples: parseExamples,
+      examples,
     },
     requestExampleParametersSchema,
     false,


### PR DESCRIPTION
**Problem**

as highlighted in #5518, parameter object example / examples is not currently displayed within the reference and well supported in the client along content example support.

**Solution**

this pr fixes UI glitches and improves overall examples support.

`example support`
| before | after |
| -------|------|
| <img width="604" alt="image" src="https://github.com/user-attachments/assets/a38d69f6-54fd-4df0-9e3b-ac01767552b9" /> | <img width="604" alt="image" src="https://github.com/user-attachments/assets/ffd8d3c2-75e0-4bcb-b271-1d5d2c0e74a7" /> |

tested with
<details>
<summary>OAI specification document</summary>

```yaml
openapi: 3.1.1
info:
  title: Examples
  version: 1.0.0
paths:
  '/not-working':
    get:
      description: |
        Demonstrates examples on the parameter object isn't shown as examples.
        Specification, see https://spec.openapis.org/oas/v3.1.1.html#fixed-fields-for-use-with-schema and https://spec.openapis.org/oas/v3.1.1.html#example-object
      parameters:
      - in: query
        name: examples
        description: Examples in `examples` property isn't shown or available in API Client
        schema:
          type: integer
          maximum: 50
        examples:
          zero:
            value: 0
            summary: A sample limit value
            description: A longer description
          max:
            value: 50
            summary: A sample limit value 
          externalValue:
            summary: This is an external value
            externalValue: https://example.org/examples/external-value
      - in: query
        name: example
        description: Example `example` property is used in API Client, but not shown in doc
        schema:
          type: integer
          maximum: 50
        example: 42
      - in: query
        name: example-override-bug
        description: |
            BUG: Example `example: 42` isn't shown and isn't overriding `schema.example: 1`  in API Client
            > Because examples using these fields represent the final serialized form of the data, they SHALL override any example in the corresponding Schema Object.<br/>
            > https://spec.openapis.org/oas/v3.1.1.html#working-with-examples
        schema:
          type: integer
          maximum: 50
          example: 1
        example: 42
      - in: query
        name: example-media-object
        description: Examples in `content.application/json.examples` property isn't shown or available in API Client
        content:
          "application/json":
            schema:
              type: integer
              maximum: 50
            examples:
              zero:
                value: 0
              max:
                value: 50
  '/working':
    get:
      description: Examples given in schema is supported
      parameters:
      - in: query
        name: schema-example
        description: Using `schema.example` works, but Deprecated, see https://spec.openapis.org/oas/v3.1.1.html#fixed-fields-20
        schema:
          type: integer
          maximum: 50
          example: 42 # Deprecated
      - in: query
        name: schema-examples
        description: Using `schema.examples` works
        schema:
          type: integer
          examples: 
          - 42
          - 4711
```

</details>

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
