### PR TITLE
chore(api-client): add layout prop to ResponseBody

### DIFF
--- a/.changeset/young-sloths-listen.md
+++ b/.changeset/young-sloths-listen.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+chore: propogogate layout prop outside response body

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -13,6 +13,7 @@ import ResponseBodyToggle from './ResponseBodyToggle.vue'
 
 const props = defineProps<{
   title: string
+  layout: 'client' | 'reference'
   data: unknown
   headers: { name: string; value: string; required: boolean }[]
 }>()
@@ -35,7 +36,9 @@ const { mimeType, attachmentFilename, dataUrl } = useResponseBody({
 const mediaConfig = computed(() => mediaTypes[mimeType.value.essence])
 </script>
 <template>
-  <ViewLayoutCollapse class="max-h-content overflow-y-hidden">
+  <ViewLayoutCollapse
+    class="max-h-content overflow-y-hidden"
+    :layout="layout">
     <template #title>{{ title }}</template>
     <template
       v-if="data && dataUrl"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseSection.vue
@@ -218,6 +218,7 @@ const requestHeaders = computed(
             class="response-section-content-body"
             v-else
             :id="filterIds.Body"
+            layout="client"
             :active="true"
             :data="response?.data"
             :headers="responseHeaders"


### PR DESCRIPTION


**Solution**

With this PR we just expose the layout prop, pretty standard across our external components in client.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
