### PR TITLE
fix(api-reference): schema property heading prop defaults

### DIFF
--- a/.changeset/sour-laws-draw.md
+++ b/.changeset/sour-laws-draw.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates prop destructuring defaults in schema property heading

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -14,26 +14,24 @@ import ScreenReader from '@/components/ScreenReader.vue'
 import { Badge } from '../../Badge'
 import SchemaPropertyDetail from './SchemaPropertyDetail.vue'
 
-const { value, schemas } = withDefaults(
-  defineProps<{
-    value?: Record<string, any>
-    enum?: boolean
-    required?: boolean
-    additional?: boolean
-    pattern?: boolean
-    withExamples?: boolean
-    schemas?:
-      | OpenAPIV2.DefinitionsObject
-      | Record<string, OpenAPIV3.SchemaObject>
-      | Record<string, OpenAPIV3_1.SchemaObject>
-      | unknown
-  }>(),
-  {
-    level: 0,
-    required: false,
-    withExamples: true,
-  },
-)
+const {
+  value,
+  schemas,
+  required = false,
+  withExamples = true,
+} = defineProps<{
+  value?: Record<string, any>
+  enum?: boolean
+  required?: boolean
+  additional?: boolean
+  pattern?: boolean
+  withExamples?: boolean
+  schemas?:
+    | OpenAPIV2.DefinitionsObject
+    | Record<string, OpenAPIV3.SchemaObject>
+    | Record<string, OpenAPIV3_1.SchemaObject>
+    | unknown
+}>()
 
 const discriminatorType = discriminators.find((r) => {
   if (!value || typeof value !== 'object') {


### PR DESCRIPTION
**Problem**

current usage of destructture along  `withDefaults` is unnecessary and won't apply and fire an error on build.

**Solution**

this pr updates the way default is set along destructure and remove one unused prop.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
