### PR TITLE
fix(api-reference): config servers change

### DIFF
--- a/.changeset/sour-eels-whisper.md
+++ b/.changeset/sour-eels-whisper.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+chore: export getServersFromOpenapi function

--- a/.changeset/tame-spoons-hide.md
+++ b/.changeset/tame-spoons-hide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: remove old servers then re-add new ones on config.servers change

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -422,7 +422,9 @@ const themeStyleTag = computed(
           name="footer" />
       </div>
     </template>
-    <ApiClientModal :configuration="configuration" />
+    <ApiClientModal
+      :configuration="configuration"
+      :parsedSpec="parsedSpec" />
   </div>
   <ScalarToasts />
 </template>

--- a/packages/oas-utils/src/transforms/index.ts
+++ b/packages/oas-utils/src/transforms/index.ts
@@ -1,1 +1,7 @@
-export { getSlugUid, importSpecToWorkspace, parseSchema, type ImportSpecToWorkspaceArgs } from './import-spec'
+export {
+  getSlugUid,
+  importSpecToWorkspace,
+  getServersFromOpenApiDocument,
+  parseSchema,
+  type ImportSpecToWorkspaceArgs,
+} from './import-spec'


### PR DESCRIPTION
**Problem**

Currently, we moved to diffing on config changes. However servers is an override so we want to remove the old ones and just add the new ones.

**Solution**

With this PR we remove then re-add servers on change. (we can diff this later but need to be smarter on addition)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
