### PR TITLE
fix(Scalar.AspNetCore): improve module script loading

### DIFF
--- a/.changeset/pink-dolphins-rhyme.md
+++ b/.changeset/pink-dolphins-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+fix(Scalar.AspNetCore): improve script module loading

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -167,8 +167,8 @@ public static class ScalarEndpointRouteBuilderExtensions
                   <body>
                       {{options.HeaderContent}}
                       <div id="app"></div>
+                      <script src="{{standaloneResourceUrl}}"></script>
                       <script type="module" src="{{ScalarJavaScriptHelperFile}}"></script>
-                      <script type="module" src="{{standaloneResourceUrl}}"></script>
                       <script type="module">
                           import { initialize } from './{{ScalarJavaScriptHelperFile}}'
                           initialize(

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.js
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.js
@@ -60,5 +60,5 @@ export const initialize = (path, useDynamicBaseServerUrl, configuration = { sour
     normalizedConfig.baseServerURL = `${window.location.origin}${basePath}`
   }
 
-  Scalar.createApiReference('#app', normalizedConfig)
+  window.Scalar.createApiReference('#app', normalizedConfig)
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.test.js
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.test.js
@@ -41,22 +41,19 @@ describe('scalar.aspnetcore', () => {
     let mockScalar
 
     beforeEach(() => {
+      mockScalar = {
+        createApiReference: vi.fn(),
+      }
       // Create a mock window object
       global.window = {
         location: new URL('https://example.com/api/docs'),
+        Scalar: mockScalar,
       }
     })
 
     afterEach(() => {
       // Clean up after each test
       delete global.window
-    })
-
-    beforeEach(() => {
-      mockScalar = {
-        createApiReference: vi.fn(),
-      }
-      global.Scalar = mockScalar
     })
 
     it('transforms URLs to absolute paths when using relative URLs', () => {

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -32,8 +32,8 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
                                 <body>
                                     
                                     <div id="app"></div>
+                                    <script src="scalar.js"></script>
                                     <script type="module" src="scalar.aspnetcore.js"></script>
-                                    <script type="module" src="scalar.js"></script>
                                     <script type="module">
                                         import { initialize } from './scalar.aspnetcore.js'
                                         initialize(
@@ -161,7 +161,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         // Assert
         index.StatusCode.Should().Be(HttpStatusCode.OK);
         var indexContent = await index.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        indexContent.Should().Contain($"<script type=\"module\" src=\"{cdnUrl}\"></script>");
+        indexContent.Should().Contain($"<script src=\"{cdnUrl}\"></script>");
     }
 
     [Fact]


### PR DESCRIPTION
**Problem**

Currently, the API Reference script is loaded as `type=module` even if we don't use any module feature here. This _may_ cause some issues in browsers. 

**Now**

This PR removes the `type=module` attribute, so the script is loaded like a default JS script.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
