### PR TITLE
refactor(Scalar.AspNetCore): compress embedded resource to reduce the Scalar.AspNetCore.dll size

### DIFF
--- a/.changeset/empty-plants-own.md
+++ b/.changeset/empty-plants-own.md
@@ -1,0 +1,5 @@
+---
+'@scalarapi/api-reference': patch
+---
+
+feat(Scalar.AspNetCore): Support GZip compression for embedded ressources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,6 +575,10 @@ jobs:
         working-directory: integrations/aspnetcore
         run: pnpm copy:standalone
 
+      - name: Compress static assets
+        working-directory: integrations/aspnetcore
+        run: pnpm compress
+
       - name: Restore dependencies
         working-directory: integrations/aspnetcore
         run: dotnet restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,6 +653,11 @@ jobs:
         run: pnpm copy:standalone
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
+        name: Compress static assets
+        working-directory: integrations/aspnetcore
+        run: pnpm compress
+
+      - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Restore dependencies
         working-directory: integrations/aspnetcore
         run: dotnet restore

--- a/integrations/aspnetcore/package.json
+++ b/integrations/aspnetcore/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "copy:standalone": "cp ../../packages/api-reference/dist/browser/standalone.js ./src/Scalar.AspNetCore/StaticAssets/scalar.js",
+    "compress": "cd ./src/Scalar.AspNetCore/StaticAssets && gzip --keep --verbose --force scalar.js scalar.aspnetcore.js",
     "format": "scalar-format",
     "format:check": "scalar-format-check",
     "lint:check": "scalar-lint-check",

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/HttpContextAcceptEncodingCheckExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/HttpContextAcceptEncodingCheckExtensions.cs
@@ -30,7 +30,7 @@ internal static partial class HttpContextAcceptEncodingCheckExtensions
         {
             0 => false,
             1 => IsGZipAccepted(acceptEncodingValues[0]),
-            _ => SlowCheckIsGZipAccepted(in acceptEncodingValues),
+            _ => SlowCheckIsGZipAccepted(in acceptEncodingValues)
         };
     }
 
@@ -44,6 +44,7 @@ internal static partial class HttpContextAcceptEncodingCheckExtensions
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/HttpContextAcceptEncodingCheckExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/HttpContextAcceptEncodingCheckExtensions.cs
@@ -10,7 +10,7 @@ namespace Scalar.AspNetCore;
 /// </summary>
 internal static partial class HttpContextAcceptEncodingCheckExtensions
 {
-    private static readonly Regex s_gzipAcceptedCheckRegex = GetGZipAcceptedCheckRegex();
+    private static readonly Regex SGzipAcceptedCheckRegex = GetGZipAcceptedCheckRegex();
 
     /// <summary>
     /// Check is the <paramref name="httpContext"/> support gzip response
@@ -23,7 +23,7 @@ internal static partial class HttpContextAcceptEncodingCheckExtensions
     private static partial Regex GetGZipAcceptedCheckRegex();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsGZipAccepted(string? acceptEncoding) => !string.IsNullOrWhiteSpace(acceptEncoding) && s_gzipAcceptedCheckRegex.IsMatch(acceptEncoding);
+    private static bool IsGZipAccepted(string? acceptEncoding) => !string.IsNullOrWhiteSpace(acceptEncoding) && SGzipAcceptedCheckRegex.IsMatch(acceptEncoding);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsGZipAccepted(in StringValues acceptEncodingValues)

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/HttpContextAcceptEncodingCheckExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/HttpContextAcceptEncodingCheckExtensions.cs
@@ -15,8 +15,6 @@ internal static partial class HttpContextAcceptEncodingCheckExtensions
     /// <summary>
     /// Check is the <paramref name="httpContext"/> support gzip response
     /// </summary>
-    /// <param name="httpContext"></param>
-    /// <returns>is gzip response accepted</returns>
     public static bool IsGZipAccepted(this HttpContext httpContext) => IsGZipAccepted(httpContext.Request.Headers.AcceptEncoding);
 
     [GeneratedRegex(@"(^|,)\s*gzip\s*(;|,|$)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/HttpContextAcceptEncodingCheckExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/HttpContextAcceptEncodingCheckExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// <see cref="HttpContext"/> Accept-Encoding check extensions
+/// </summary>
+internal static partial class HttpContextAcceptEncodingCheckExtensions
+{
+    private static readonly Regex s_gzipAcceptedCheckRegex = GetGZipAcceptedCheckRegex();
+
+    /// <summary>
+    /// Check is the <paramref name="httpContext"/> support gzip response
+    /// </summary>
+    /// <param name="httpContext"></param>
+    /// <returns>is gzip response accepted</returns>
+    public static bool IsGZipAccepted(this HttpContext httpContext) => IsGZipAccepted(httpContext.Request.Headers.AcceptEncoding);
+
+    [GeneratedRegex(@"(^|,)\s*gzip\s*(;|,|$)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex GetGZipAcceptedCheckRegex();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsGZipAccepted(string? acceptEncoding) => !string.IsNullOrWhiteSpace(acceptEncoding) && s_gzipAcceptedCheckRegex.IsMatch(acceptEncoding);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsGZipAccepted(in StringValues acceptEncodingValues)
+    {
+        return acceptEncodingValues.Count switch
+        {
+            0 => false,
+            1 => IsGZipAccepted(acceptEncodingValues[0]),
+            _ => SlowCheckIsGZipAccepted(in acceptEncodingValues),
+        };
+    }
+
+    private static bool SlowCheckIsGZipAccepted(in StringValues values)
+    {
+        var valuesCount = values.Count;
+        for (var i = 0; i < valuesCount; i++)
+        {
+            if (IsGZipAccepted(values[i]))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -213,13 +213,18 @@ public static class ScalarEndpointRouteBuilderExtensions
             return Results.StatusCode(StatusCodes.Status304NotModified);
         }
 
+#if RELEASE
         if (httpContext.IsGZipAccepted())
         {
             httpContext.Response.Headers.ContentEncoding = "gzip";
             return Results.Stream(resourceFile.CreateReadStream(), MediaTypeNames.Text.JavaScript, entityTag: new EntityTagHeaderValue(etag));
         }
+        var stream = new GZipStream(resourceFile.CreateReadStream(), CompressionMode.Decompress);
+#else
+        var stream = resourceFile.CreateReadStream();
+#endif
 
-        return Results.Stream(new GZipStream(resourceFile.CreateReadStream(), CompressionMode.Decompress), MediaTypeNames.Text.JavaScript, entityTag: new EntityTagHeaderValue(etag));
+        return Results.Stream(stream, MediaTypeNames.Text.JavaScript, entityTag: new EntityTagHeaderValue(etag));
     }
 
     private static bool ShouldRedirectToTrailingSlash(HttpContext httpContext, string? documentName, [NotNullWhen(true)] out string? redirectUrl)

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -202,7 +202,7 @@ public static class ScalarEndpointRouteBuilderExtensions
             // Return 404 if the file does not exist. This should not happen because the file is embedded.
             return Results.NotFound();
         }
-        
+
         httpContext.Response.Headers.Append(HeaderNames.Vary, HeaderNames.AcceptEncoding);
 
         var etag = $"\"{resourceFile.LastModified.Ticks}\"";
@@ -219,6 +219,7 @@ public static class ScalarEndpointRouteBuilderExtensions
             httpContext.Response.Headers.ContentEncoding = "gzip";
             return Results.Stream(resourceFile.CreateReadStream(), MediaTypeNames.Text.JavaScript, entityTag: new EntityTagHeaderValue(etag));
         }
+
         var stream = new GZipStream(resourceFile.CreateReadStream(), CompressionMode.Decompress);
 #else
         var stream = resourceFile.CreateReadStream();

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.IO.Compression;
 using System.Net.Mime;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
@@ -205,7 +206,7 @@ public static class ScalarEndpointRouteBuilderExtensions
         var etag = $"\"{resourceFile.LastModified.Ticks}\"";
 
         var ifNoneMatch = httpContext.Request.Headers.IfNoneMatch.ToString();
-        return ifNoneMatch == etag ? Results.StatusCode(StatusCodes.Status304NotModified) : Results.Stream(resourceFile.CreateReadStream(), MediaTypeNames.Text.JavaScript, entityTag: new EntityTagHeaderValue(etag));
+        return ifNoneMatch == etag ? Results.StatusCode(StatusCodes.Status304NotModified) : Results.Stream(new GZipStream(resourceFile.CreateReadStream(), CompressionMode.Decompress), MediaTypeNames.Text.JavaScript, entityTag: new EntityTagHeaderValue(etag));
     }
 
     private static bool ShouldRedirectToTrailingSlash(HttpContext httpContext, string? documentName, [NotNullWhen(true)] out string? redirectUrl)

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -202,6 +202,8 @@ public static class ScalarEndpointRouteBuilderExtensions
             // Return 404 if the file does not exist. This should not happen because the file is embedded.
             return Results.NotFound();
         }
+        
+        httpContext.Response.Headers.Append(HeaderNames.Vary, HeaderNames.AcceptEncoding);
 
         var etag = $"\"{resourceFile.LastModified.Ticks}\"";
 
@@ -216,10 +218,8 @@ public static class ScalarEndpointRouteBuilderExtensions
             httpContext.Response.Headers.ContentEncoding = "gzip";
             return Results.Stream(resourceFile.CreateReadStream(), MediaTypeNames.Text.JavaScript, entityTag: new EntityTagHeaderValue(etag));
         }
-        else
-        {
-            return Results.Stream(new GZipStream(resourceFile.CreateReadStream(), CompressionMode.Decompress), MediaTypeNames.Text.JavaScript, entityTag: new EntityTagHeaderValue(etag));
-        }
+
+        return Results.Stream(new GZipStream(resourceFile.CreateReadStream(), CompressionMode.Decompress), MediaTypeNames.Text.JavaScript, entityTag: new EntityTagHeaderValue(etag));
     }
 
     private static bool ShouldRedirectToTrailingSlash(HttpContext httpContext, string? documentName, [NotNullWhen(true)] out string? redirectUrl)

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
@@ -14,6 +14,10 @@
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated</InterceptorsPreviewNamespaces>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <StaticAssetsLogicalNamePrefix>ScalarStaticAssets</StaticAssetsLogicalNamePrefix>
+  </PropertyGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Microsoft" />
     <InternalsVisibleTo Include="$(AssemblyName).Swashbuckle" />
@@ -24,9 +28,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="StaticAssets/*.gz">
-      <!-- Import .gz files without extension so the original filename is used "scalar.js.gz" -> "scalar.js" -->
-      <LogicalName>ScalarStaticAssets.%(Filename)</LogicalName>
+    <!-- Include compressed files for Release -->
+    <!-- Import .gz files without extension so the original filename is used "scalar.js.gz" -> "scalar.js" -->
+    <EmbeddedResource Include="StaticAssets/*.gz" Condition="'$(Configuration)' == 'Release'">
+      <LogicalName>$(StaticAssetsLogicalNamePrefix).%(Filename)</LogicalName>
+    </EmbeddedResource>
+
+    <!-- Include uncompressed files for Debug -->
+    <EmbeddedResource Include="StaticAssets/*.js" Exclude="StaticAssets/*test.js" Condition="'$(Configuration)' == 'Debug'">
+      <LogicalName>$(StaticAssetsLogicalNamePrefix).%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
@@ -21,12 +21,16 @@
 
   <ItemGroup>
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta12" PrivateAssets="all" ExcludeAssets="runtime" NoWarn="NU5104" />
+    <PackageReference Include="ResourceCompressor" Version="1.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="StaticAssets/*" Exclude="StaticAssets/*test.js">
+    <CompressedEmbeddedResource Include="StaticAssets/*" Exclude="StaticAssets/*test.js">
       <LogicalName>ScalarStaticAssets.%(Filename)%(Extension)</LogicalName>
-    </EmbeddedResource>
+    </CompressedEmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
@@ -21,16 +21,13 @@
 
   <ItemGroup>
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta12" PrivateAssets="all" ExcludeAssets="runtime" NoWarn="NU5104" />
-    <PackageReference Include="ResourceCompressor" Version="1.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <CompressedEmbeddedResource Include="StaticAssets/*" Exclude="StaticAssets/*test.js">
-      <LogicalName>ScalarStaticAssets.%(Filename)%(Extension)</LogicalName>
-    </CompressedEmbeddedResource>
+    <EmbeddedResource Include="StaticAssets/*.gz">
+      <!-- Import .gz files without extension so the original filename is used "scalar.js.gz" -> "scalar.js" -->
+      <LogicalName>ScalarStaticAssets.%(Filename)</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -4,10 +4,6 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(CI) == true">
-    <DefineConstants>CI_RUN</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="8.1.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -1,4 +1,6 @@
+using System.IO.Compression;
 using System.Net;
+using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -72,7 +74,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
 #if CI_RUN
     [InlineData($"/scalar/{ScalarEndpointRouteBuilderExtensions.ScalarJavaScriptFile}", "@scalar/api-reference")]
 #endif
-    public async Task MapScalarApiReference_ShouldReturnStaticAssets_WhenRequested(string assetUrl, string expectedContent)
+    public async Task MapScalarApiReference_ShouldReturnUncompressedStaticAssets_WhenRequested(string assetUrl, string expectedContent)
     {
         // Arrange
         var client = factory.CreateClient();
@@ -87,6 +89,33 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         response.Headers.ETag.Should().NotBeNull();
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         content.Should().Contain(expectedContent);
+    }
+    
+#if CI_RUN
+    [Theory]
+    [InlineData("/scalar/scalar.aspnetcore.js", "getBasePath")]
+    [InlineData($"/scalar/{ScalarEndpointRouteBuilderExtensions.ScalarJavaScriptFile}", "@scalar/api-reference")]
+#endif
+#pragma warning disable xUnit1013
+    public async Task MapScalarApiReference_ShouldReturnCompressedStaticAssets_WhenAcceptEncodingContainsGzip(string assetUrl, string expectedContent)
+#pragma warning restore xUnit1013
+    {
+        // Arrange
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+
+        // Act
+        var response = await client.GetAsync(assetUrl, HttpCompletionOption.ResponseContentRead, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentEncoding.Should().ContainSingle(x => x == "gzip");
+        var stream = await response.Content.ReadAsStreamAsync(TestContext.Current.CancellationToken);
+        var gZipStream = new GZipStream(stream, CompressionMode.Decompress);
+        using var reader = new StreamReader(gZipStream);
+        var decompressedContent = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+        decompressedContent.Should().Contain(expectedContent);
+        response.Headers.Vary.Should().Contain("Accept-Encoding");
     }
 
     [Fact]

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -90,7 +90,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         content.Should().Contain(expectedContent);
     }
-    
+
 #if RELEASE
     [Theory]
     [InlineData("/scalar/scalar.aspnetcore.js", "getBasePath")]

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -71,7 +71,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
 
     [Theory]
     [InlineData("/scalar/scalar.aspnetcore.js", "getBasePath")]
-#if CI_RUN
+#if RELEASE
     [InlineData($"/scalar/{ScalarEndpointRouteBuilderExtensions.ScalarJavaScriptFile}", "@scalar/api-reference")]
 #endif
     public async Task MapScalarApiReference_ShouldReturnUncompressedStaticAssets_WhenRequested(string assetUrl, string expectedContent)
@@ -91,7 +91,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         content.Should().Contain(expectedContent);
     }
     
-#if CI_RUN
+#if RELEASE
     [Theory]
     [InlineData("/scalar/scalar.aspnetcore.js", "getBasePath")]
     [InlineData($"/scalar/{ScalarEndpointRouteBuilderExtensions.ScalarJavaScriptFile}", "@scalar/api-reference")]


### PR DESCRIPTION
**Problem**

Currently, the size of `Scalar.AspNetCore.dll` is about 3000KB. The reason why the file is so large is that the embedded resources are relatively large.

**Solution**

Using gzip to compress the `StaticAssets/*` at build time. And decompress it before response it.
This change can compress the size of the`Scalar.AspNetCore.dll` from 3000KB to 1000KB.

Closes #5604

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
