### PR TITLE
chore: rename @scalar/scripts to @scalar-internal/build-scripts

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@scalar-examples/*", "playwright", "client-scalar-com", "proxy-scalar-com"]
+  "ignore": ["@scalar-examples/*", "playwright", "client-scalar-com", "proxy-scalar-com", "@scalar-internal/*"]
 }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "types:check": "pnpm run -r --parallel types:check",
     "bootstrap:package": "vite-node scripts/bootstrap-package/bootstrap-package.ts",
     "markdown:check": "remark --frail .",
-    "script": "pnpm --filter @scalar/scripts start"
+    "script": "pnpm --filter @scalar-internal/build-scripts start"
   },
   "exports": {
     "./css/*.css": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scalar/scripts",
+  "name": "@scalar-internal/build-scripts",
   "version": "1.0.0",
   "description": "Scalar OSS Scripts. Packaged for easy dependency installation.",
   "scripts": {

--- a/scripts/src/cli.ts
+++ b/scripts/src/cli.ts
@@ -1,14 +1,17 @@
+import { cat } from '@/commands/cat'
+import { packages } from '@/commands/packages'
+import { run } from '@/commands/run'
+import { updateTestSnapshots } from '@/commands/update-snapshots'
+import { wait } from '@/commands/wait'
 import { Command } from 'commander'
 import { version } from '../package.json'
-import { packages } from '@/commands/packages'
-import { wait } from '@/commands/wait'
-import { cat } from '@/commands/cat'
-import { updateTestSnapshots } from '@/commands/update-snapshots'
-import { run } from '@/commands/run'
 
 const program = new Command()
 
-program.name('@scalar/scripts').description('Internal CLI to quickly run repository scripts').version(version)
+program
+  .name('@scalar-internal/build-scripts')
+  .description('Internal CLI to quickly run repository scripts')
+  .version(version)
 
 program.addCommand(packages)
 program.addCommand(wait)


### PR DESCRIPTION
**Problem**

We just recently added a private package called `@scalar/scripts`, but there’s an actual [`@scalar/scripts` coming soon](https://github.com/scalar/scalar/pull/4968).

**Solution**

To avoid conflicts, this PR renames the package to `@scalar-internal/build-scripts`.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
