### PR TITLE
fix(api-client): displays authentication description on hover

### DIFF
--- a/.changeset/hot-forks-carry.md
+++ b/.changeset/hot-forks-carry.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: displays wrapped auth description on hover

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -26,7 +26,9 @@ const id = useId()
     <section
       :aria-labelledby="id"
       class="contents">
-      <div class="bg-b-2 flex items-center">
+      <div
+        class="bg-b-2 flex items-center"
+        :class="layout === 'reference' && 'rounded-t-lg border border-b-0'">
         <DisclosureButton
           :class="[
             'hover:text-c-1 group box-content flex max-h-8 flex-1 items-center gap-2.5 overflow-hidden px-1 py-1.5 text-sm font-medium outline-none md:px-1.5 xl:pl-2 xl:pr-0.5',

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -64,7 +64,7 @@ watch(
   <form @submit.prevent>
     <div
       v-if="selectedSchemeOptions.length > 1"
-      class="box-content flex h-8 flex-wrap gap-x-2.5 overflow-hidden border-t px-3">
+      class="box-content flex h-8 flex-wrap gap-x-2.5 overflow-hidden border border-b-0 px-3">
       <div
         v-for="(option, index) in selectedSchemeOptions"
         :key="option.id"
@@ -87,7 +87,7 @@ watch(
     <DataTable
       v-if="activeScheme.length"
       class="flex-1"
-      :class="layout === 'reference' && 'border-0'"
+      :class="layout === 'reference' && 'rounded-b-lg border border-t-0'"
       :columns="['']"
       presentational>
       <RequestAuthTab
@@ -102,7 +102,7 @@ watch(
 
     <div
       v-else
-      class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border-t px-4 text-sm">
+      class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border border-b-0 px-4 text-sm">
       No authentication selected
     </div>
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -109,8 +109,12 @@ const dataTableInputProps = {
     <!-- Description -->
     <DataTableRow v-if="scheme?.description && security.length <= 1">
       <DataTableCell
-        class="text-c-2 flex items-center overflow-auto whitespace-nowrap pl-3">
-        {{ scheme.description }}
+        :aria-label="scheme.description"
+        class="text-c-2 auth-description-container -mb-0.25 flex items-center whitespace-nowrap outline-none hover:whitespace-normal">
+        <span
+          class="auth-description z-1 bg-b-1 outline-b-3 top-0 w-full overflow-hidden text-ellipsis px-3 py-1.5">
+          {{ scheme.description }}
+        </span>
       </DataTableCell>
     </DataTableRow>
 
@@ -225,7 +229,7 @@ const dataTableInputProps = {
     <!-- Open ID Connect -->
     <template v-else-if="scheme?.type === 'openIdConnect'">
       <div
-        class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border-t px-4 text-sm">
+        class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border border-b-0 px-4 text-sm">
         Coming soon
       </div>
     </template>
@@ -244,5 +248,13 @@ const dataTableInputProps = {
   border-top: 0;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
+}
+
+.scalar-data-table .auth-description-container .auth-description {
+  outline: 0.5px solid var(--scalar-border-color);
+}
+
+.scalar-data-table .auth-description-container:hover .auth-description {
+  position: absolute;
 }
 </style>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ScalarMarkdown } from '@scalar/components'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type {
   Collection,
@@ -110,11 +111,10 @@ const dataTableInputProps = {
     <DataTableRow v-if="scheme?.description && security.length <= 1">
       <DataTableCell
         :aria-label="scheme.description"
-        class="text-c-2 auth-description-container -mb-0.25 flex items-center whitespace-nowrap outline-none hover:whitespace-normal">
-        <span
-          class="auth-description z-1 bg-b-1 outline-b-3 top-0 w-full overflow-hidden text-ellipsis px-3 py-1.5">
-          {{ scheme.description }}
-        </span>
+        class="text-c-2 auth-description-container group/auth -mb-0.25 flex items-center whitespace-nowrap outline-none hover:whitespace-normal">
+        <ScalarMarkdown
+          :value="scheme.description"
+          class="auth-description z-1 bg-b-1 text-c-2 outline-b-3 top-0 line-clamp-1 h-full w-full px-3 py-1.5 group-hover/auth:line-clamp-none" />
       </DataTableCell>
     </DataTableRow>
 
@@ -256,5 +256,6 @@ const dataTableInputProps = {
 
 .scalar-data-table .auth-description-container:hover .auth-description {
   position: absolute;
+  height: auto;
 }
 </style>

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -156,7 +156,9 @@ const installationInstructions = computed(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   background: var(--scalar-background-1);
-  border-top: var(--scalar-border-width) solid var(--scalar-border-color);
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-bottom-left-radius: var(--scalar-radius-lg);
+  border-bottom-right-radius: var(--scalar-radius-lg);
   min-height: fit-content;
 }
 .client-libraries-heading {
@@ -168,5 +170,8 @@ const installationInstructions = computed(() => {
   display: flex;
   align-items: center;
   max-height: 32px;
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-top-left-radius: var(--scalar-radius-lg);
+  border-top-right-radius: var(--scalar-radius-lg);
 }
 </style>

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -143,7 +143,8 @@ const isSelectedClient = (language: HttpClientState) => {
   overflow: hidden;
   padding: 0 12px;
   background-color: var(--scalar-background-1);
-  border-top: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-left: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-right: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 .client-libraries {
   display: flex;

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -101,7 +101,7 @@ const introCardsSlot = computed(() =>
             :class="{ 'introduction-card-row': layout === 'classic' }">
             <div
               v-if="activeCollection?.servers?.length"
-              class="scalar-reference-intro-server scalar-client introduction-card-item divide-y text-sm [--scalar-address-bar-height:0px]">
+              class="scalar-reference-intro-server scalar-client introduction-card-item text-sm [--scalar-address-bar-height:0px]">
               <BaseUrl
                 :collection="activeCollection"
                 :server="activeServer" />
@@ -194,9 +194,6 @@ const introCardsSlot = computed(() =>
 }
 .introduction-card-item {
   display: flex;
-  overflow: hidden;
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
-  border-radius: var(--scalar-radius-lg);
   margin-bottom: 12px;
   flex-direction: column;
   justify-content: start;

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -36,10 +36,13 @@ const updateServer = (newServer: string) => {
 }
 </script>
 <template>
-  <label class="bg-b-2 flex h-8 items-center px-3 py-2.5 text-sm font-medium">
+  <label
+    class="bg-b-2 flex h-8 items-center rounded-t-lg border border-b-0 px-3 py-2.5 text-sm font-medium">
     Server
   </label>
-  <div :id="id">
+  <div
+    :id="id"
+    class="rounded-b-lg border">
     <ServerSelector
       v-if="collection?.servers?.length"
       :collection="collection"

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -42,7 +42,10 @@ const updateServer = (newServer: string) => {
   </label>
   <div
     :id="id"
-    class="rounded-b-lg border">
+    class="border"
+    :class="{
+      'rounded-b-lg': !server?.description,
+    }">
     <ServerSelector
       v-if="collection?.servers?.length"
       :collection="collection"
@@ -56,6 +59,6 @@ const updateServer = (newServer: string) => {
   <!-- Description -->
   <ScalarMarkdown
     v-if="server?.description"
-    class="text-c-3 px-3 py-1.5"
+    class="text-c-3 rounded-b-lg border border-t-0 px-3 py-1.5"
     :value="server.description" />
 </template>

--- a/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.vue
+++ b/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { htmlFromMarkdown } from '@scalar/code-highlight'
+import { cx } from '@scalar/use-hooks/useBindCx'
 import { computed, onServerPrefetch } from 'vue'
 
 import { sleep } from '../../helpers/oas-utils'
@@ -11,6 +12,7 @@ const props = withDefaults(
     transform?: (node: Record<string, any>) => Record<string, any>
     transformType?: string
     clamp?: string | boolean
+    class?: string
   }>(),
   {
     withImages: false,
@@ -30,8 +32,9 @@ onServerPrefetch(async () => await sleep(1))
 </script>
 <template>
   <div
-    class="markdown text-ellipsis"
-    :class="{ 'line-clamp-4': clamp }"
+    :class="
+      cx('markdown text-ellipsis', { 'line-clamp-4': clamp }, props.class)
+    "
     :style="{
       '-webkit-line-clamp': typeof clamp === 'string' ? clamp : undefined,
     }"


### PR DESCRIPTION
**Problem**

currently the long authentication description are not easy to read through scroll usage.

**Solution**

this pr wraps the authentication description and displays it fully on hover.

| before | after |
| -------|------|
| <img width="553" alt="image" src="https://github.com/user-attachments/assets/76963d7e-43d5-415f-bb62-d39e2e092bed" /> | <img width="537" alt="image" src="https://github.com/user-attachments/assets/50eed9be-636e-4d4b-ae77-43ea4954ae96" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
