### PR TITLE
fix(api-client): remove incorrect stream header check

### DIFF
--- a/.changeset/unlucky-owls-collect.md
+++ b/.changeset/unlucky-owls-collect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: remove streaming header check as it was incorrect

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -1072,7 +1072,7 @@ describe('create-request-operation', () => {
         const mockResponse = new Response(mockStream, {
           status: 200,
           headers: new Headers({
-            'content-type': 'text/stream',
+            'content-type': 'text/event-stream',
           }),
         })
 

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -185,8 +185,7 @@ export const createRequestOperation = ({
          * Unfortunately we cannot check the transfer-encoding header as it is not set by the browser so not quite sure how to test when
          * content-type === 'text/plain' and transfer-encoding === 'chunked'
          *
-         * Currently we are only checking for server sent events. In the future we should let the user select if its a stream in the UI as there's no
-         * way to reliably test for it in the browser.
+         * Currently we are only checking for server sent events. In OpenApi 3.2.0 streams will be added to the spec
          */
         const isStreaming = response.headers.get('content-type')?.startsWith('text/event-stream')
         status?.emit('stop')

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -184,9 +184,11 @@ export const createRequestOperation = ({
          * Checks if the response is streaming
          * Unfortunately we cannot check the transfer-encoding header as it is not set by the browser so not quite sure how to test when
          * content-type === 'text/plain' and transfer-encoding === 'chunked'
+         *
+         * Currently we are only checking for server sent events. In the future we should let the user select if its a stream in the UI as there's no
+         * way to reliably test for it in the browser.
          */
-        const isStreaming = response.headers.get('content-type')?.includes('stream')
-
+        const isStreaming = response.headers.get('content-type')?.startsWith('text/event-stream')
         status?.emit('stop')
 
         const responseHeaders = normalizeHeaders(response.headers, shouldUseProxy(proxyUrl, url))


### PR DESCRIPTION
**Problem**

Currently, we just checked for stream in the header to stream a response.

**Solution**

With this PR we only check for server sent events this way (with `text/event-stream`) as there's no way to reliably check for stream in the browser. ~We will add this to the [UI later.](https://github.com/scalar/scalar/issues/5574).~ [Apparently it is being added to the spec](https://github.com/OAI/OpenAPI-Specification/pull/4554)

closes #5519
closes  #2684

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
