### PR TITLE
docs: Add server variable example for config

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -435,6 +435,15 @@ Pass a list of servers to override the servers in your OpenAPI document.
       url: 'https://api.scalar.com',
       description: 'Production',
     },
+    {
+      url: 'https://sandbox.scalar.com:{port}',
+      description: 'Development sandboxes',
+      variables: {
+        port: {
+          default: '8080',
+        }
+      }
+    },
   ]
 }
 ```


### PR DESCRIPTION
**Problem**

There was a question on Discord about overriding servers in the config with a per-user base URL.  Server variables are a somewhat obscure feature, but Scalar supports them.

**Solution**

This change expands the the existing example to include a server using a server variable to do this sort of thing.

I’ve gone through the following:

- [X] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [X] I’ve updated the documentation.

_[**NOTE:** I don't know anything about pnpm changesets, and I didn't see an obvious package for the docs in the list of unchanged packages `pnpm changeset` prints, and I don't see anything about this in the CONTRIBUTING file.  Also, if there are docs tests I can't currently run them because of #5579 .  Happy to go back and fix anything and re-submit, with apologies for needing a bit of extra hand-holding.]_
