### PR TITLE
docs: Link to changeset info in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,10 @@ Here are all the prefixes you need to know:
 | chore    | Other changes that don't modify src or test files                                                           |
 | revert   | Reverts a previous commit                                                                                   |
 
+### Changesets
+
+If your PR will cause a version bump for any package, you will need to include a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) by running `pnpm changeset`.
+
 ## Styles and CSS Layers
 
 The Scalar packages use CSS cascade layers extensively to manage the priority of exported styles and to make it easy to override themes and component styles in projects consuming those packages.


### PR DESCRIPTION
**Problem**

As a first-time contributor whose JavaScript knowledge is very out-of-date, I was puzzled by the PR template's mention of changesets.

**Solution**

Then a bot added a helpful link, which I thought would be even more helpful in the PR section of CONTRIBUTING.md.

**Checklist**

I’ve gone through the following:

- [X] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [X] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
