### PR TITLE
feat(Scalar.AspNetCore): support multiple preferred security schemes

### DIFF
--- a/.changeset/blue-books-walk.md
+++ b/.changeset/blue-books-walk.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': minor
+---
+
+feat(Scalar.AspNetCore): support multiple preferred security schemes

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -208,7 +208,7 @@ To configure API key authentication:
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("ApiKey") // Optional: Sets the default security scheme
+    .AddPreferredSecuritySchemes("ApiKey") // Optional: Sets the default security scheme
     .AddApiKeyAuthentication("ApiKey", apiKey =>
     {
         apiKey.Value = "your-api-key";
@@ -222,7 +222,7 @@ Scalar supports various OAuth2 flows through specific helper methods, but all of
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth2")
+    .AddPreferredSecuritySchemes("OAuth2")
     .AddOAuth2Authentication("OAuth2", scheme => 
     {
         // Configure flows manually
@@ -256,7 +256,7 @@ app.MapScalarApiReference(options => options
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth2")
+    .AddPreferredSecuritySchemes("OAuth2")
     .AddAuthorizationCodeFlow("OAuth2", flow =>
     {
         flow.ClientId = "your-client-id";
@@ -271,7 +271,7 @@ app.MapScalarApiReference(options => options
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth2")
+    .AddPreferredSecuritySchemes("OAuth2")
     .AddClientCredentialsFlow("OAuth2", flow =>
     {
         flow.ClientId = "your-client-id";
@@ -284,7 +284,7 @@ app.MapScalarApiReference(options => options
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth2")
+    .AddPreferredSecuritySchemes("OAuth2")
     .AddImplicitFlow("OAuth2", flow =>
     {
         flow.ClientId = "your-client-id";
@@ -296,7 +296,7 @@ app.MapScalarApiReference(options => options
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth2")
+    .AddPreferredSecuritySchemes("OAuth2")
     .AddPasswordFlow("OAuth2", flow =>
     {
         flow.ClientId = "your-client-id";
@@ -312,7 +312,7 @@ You can configure multiple OAuth2 flows for a single security scheme:
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth2")
+    .AddPreferredSecuritySchemes("OAuth2")
     .AddOAuth2Flows("OAuth2", flows =>
     {
         // Authorization Code flow
@@ -343,7 +343,7 @@ app.MapScalarApiReference(options => options
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("BearerAuth")
+    .AddPreferredSecuritySchemes("BearerAuth")
     .AddHttpAuthentication("BearerAuth", auth =>
     {
         auth.Token = "ey...";
@@ -355,7 +355,7 @@ app.MapScalarApiReference(options => options
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("BasicAuth")
+    .AddPreferredSecuritySchemes("BasicAuth")
     .AddHttpAuthentication("BasicAuth", auth =>
     {
         auth.Username = "your-username";
@@ -370,8 +370,8 @@ You can configure multiple security schemes at once:
 
 ```csharp
 app.MapScalarApiReference(options => options
-    // Set the preferred (default) scheme
-    .WithPreferredScheme("OAuth2")
+    // Set the preferred (default) schemes - you can specify multiple preferred schemes
+    .AddPreferredSecuritySchemes("OAuth2", "ApiKey")
     
     // Configure OAuth2
     .AddAuthorizationCodeFlow("OAuth2", flow =>

--- a/integrations/aspnetcore/docs/authentication.md
+++ b/integrations/aspnetcore/docs/authentication.md
@@ -88,7 +88,7 @@ To make the usage of this scheme easier, you can prefill the `Token` in the `Map
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("BearerAuth")
+    .AddPreferredSecuritySchemes("BearerAuth")
     .AddHttpAuthentication("BearerAuth", auth =>
     {
         auth.Token = "ey...";
@@ -104,7 +104,7 @@ Similarly, you can set up Basic authentication using HTTP security scheme:
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("BasicAuth")
+    .AddPreferredSecuritySchemes("BasicAuth")
     .AddHttpAuthentication("BasicAuth", auth =>
     {
         auth.Username = "your-username";
@@ -158,7 +158,7 @@ For direct control over OAuth2 security schemes, you can use the core `AddOAuth2
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth")
+    .AddPreferredSecuritySchemes("OAuth")
     .AddOAuth2Authentication("OAuth", scheme =>
     {
         // Configure flows manually
@@ -192,7 +192,7 @@ To make authentication easier for users, you can prefill the OAuth2 client crede
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth")
+    .AddPreferredSecuritySchemes("OAuth")
     .AddClientCredentialsFlow("OAuth", flow =>
     {
         flow.ClientId = "your-client-id";
@@ -208,7 +208,7 @@ For the Authorization Code flow, use the following configuration:
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth")
+    .AddPreferredSecuritySchemes("OAuth")
     .AddAuthorizationCodeFlow("OAuth", flow =>
     {
         flow.ClientId = "your-client-id";
@@ -224,7 +224,7 @@ For the Implicit flow, configure it like this:
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth")
+    .AddPreferredSecuritySchemes("OAuth")
     .AddImplicitFlow("OAuth", flow =>
     {
         flow.ClientId = "your-client-id";
@@ -238,7 +238,7 @@ For the Resource Owner Password Credentials flow:
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth")
+    .AddPreferredSecuritySchemes("OAuth")
     .AddPasswordFlow("OAuth", flow =>
     {
         flow.ClientId = "your-client-id";
@@ -254,7 +254,7 @@ You can configure multiple OAuth flows for the same security scheme:
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth")
+    .AddPreferredSecuritySchemes("OAuth")
     .AddOAuth2Flows("OAuth", flows =>
     {
         // Configure Authorization Code flow
@@ -283,7 +283,7 @@ For example, you can override the TokenUrl, AuthorizationUrl, or other endpoints
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth")
+    .AddPreferredSecuritySchemes("OAuth")
     .AddOAuth2Flows("OAuth", flows =>
     {
         flows.AuthorizationCode = new AuthorizationCodeFlow
@@ -306,7 +306,7 @@ For API Key authentication, configure it as follows:
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("ApiKey")
+    .AddPreferredSecuritySchemes("ApiKey")
     .AddApiKeyAuthentication("ApiKey", apiKey =>
     {
         apiKey.Value = "your-api-key";
@@ -320,7 +320,7 @@ You can configure multiple security schemes in the same application:
 
 ```csharp
 app.MapScalarApiReference(options => options
-    .WithPreferredScheme("OAuth") // Set the preferred default scheme
+    .AddPreferredSecuritySchemes("OAuth", "ApiKey") // Set multiple preferred schemes
     .AddOAuth2Flows("OAuth", flows =>
     {
         flows.AuthorizationCode = new AuthorizationCodeFlow

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Playground/Program.cs
@@ -28,8 +28,8 @@ Action<ScalarOptions> configureOptions = options =>
         .WithJavaScriptConfiguration("./scalar/config.js")
         .WithCdnUrl("https://cdn.jsdelivr.net/npm/@scalar/api-reference")
         .WithFavicon("/favicon.png")
-        .WithPreferredScheme(AuthConstants.ApiKeyScheme)
         .AddApiKeyAuthentication(AuthConstants.ApiKeyScheme, scheme => scheme.Value = "my-api-key")
+        .AddPreferredSecuritySchemes(AuthConstants.ApiKeyScheme)
         .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient);
 
 app.MapScalarApiReference(options =>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -315,10 +315,29 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options"><see cref="ScalarOptions" />.</param>
     /// <param name="preferredScheme">The preferred authentication scheme.</param>
+    [Obsolete("This method is obsolete and will be removed in a future release. Use AddPreferredSecuritySchemes instead.")]
     public static ScalarOptions WithPreferredScheme(this ScalarOptions options, string preferredScheme)
     {
         options.Authentication ??= new ScalarAuthenticationOptions();
-        options.Authentication.PreferredSecurityScheme = preferredScheme;
+        options.Authentication.PreferredSecuritySchemes = [preferredScheme];
+        return options;
+    }
+
+    /// <summary>
+    /// Adds one or more preferred security schemes to the authentication options.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="preferredSchemes">A collection of preferred security schemes.</param>
+    public static ScalarOptions AddPreferredSecuritySchemes(this ScalarOptions options, params IEnumerable<string> preferredSchemes)
+    {
+        options.Authentication ??= new ScalarAuthenticationOptions();
+        if (options.Authentication.PreferredSecuritySchemes is null)
+        {
+            options.Authentication.PreferredSecuritySchemes = [.. preferredSchemes];
+            return options;
+        }
+
+        options.Authentication.PreferredSecuritySchemes = [.. options.Authentication.PreferredSecuritySchemes, .. preferredSchemes];
         return options;
     }
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/ScalarAuthenticationOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/ScalarAuthenticationOptions.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Scalar.AspNetCore;
 
 /// <summary>
@@ -9,7 +11,21 @@ public sealed class ScalarAuthenticationOptions
     /// Gets or sets the preferred security scheme.
     /// </summary>
     /// <value>The default value is <c>null</c>.</value>
-    public string? PreferredSecurityScheme { get; set; }
+    [JsonIgnore]
+    [Obsolete("This property is obsolete and will be removed in a future release. Use PreferredSecuritySchemes property to configure the preferred security scheme instead.")]
+    public string? PreferredSecurityScheme
+    {
+        get => PreferredSecuritySchemes?.FirstOrDefault();
+        set => PreferredSecuritySchemes = value is null ? null : [value];
+    }
+
+
+    /// <summary>
+    /// Gets or sets the preferred security schemes.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    [JsonPropertyName("preferredSecurityScheme")]
+    public IList<string>? PreferredSecuritySchemes { get; set; }
 
     /// <summary>
     /// Gets or sets the API key options.

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -58,6 +58,7 @@ public class ScalarOptionsExtensionsTests
             .AddHeaderContent("<h2>bar</h2>")
             .AddDocument("v1", "Version 1")
             .AddDocuments("v2", "v3")
+            .AddDocuments(new ScalarDocument("v4"))
             .WithBaseServerUrl("https://example.com")
             .WithDynamicBaseServerUrl()
             .WithJavaScriptConfiguration("/scalar/config.js");
@@ -103,7 +104,7 @@ public class ScalarOptionsExtensionsTests
         options.HideClientButton.Should().BeTrue();
         options.HeadContent.Should().Be("<meta name=\"foo\" content=\"bar\"/><meta name=\"bar\" content=\"foo\"/>");
         options.HeaderContent.Should().Be("<h1>foo</h1><h2>bar</h2>");
-        options.Documents.Should().HaveCount(3).And.Contain(x => x.Title == "Version 1");
+        options.Documents.Should().HaveCount(4).And.Contain(x => x.Title == "Version 1");
         options.BaseServerUrl.Should().Be("https://example.com");
         options.DynamicBaseServerUrl.Should().BeTrue();
         options.JavaScriptConfiguration.Should().Be("/scalar/config.js");

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -61,8 +61,8 @@ public class ScalarOptionsMapperTests
             HiddenClients = true,
             Authentication = new ScalarAuthenticationOptions
             {
-                PreferredSecurityScheme = "my-scheme",
 #pragma warning disable CS0618 // Type or member is obsolete
+                PreferredSecurityScheme = "my-scheme",
                 ApiKey = new ApiKeyOptions
                 {
                     Token = "my-token"
@@ -88,7 +88,6 @@ public class ScalarOptionsMapperTests
         configuration.HideDownloadButton.Should().BeTrue();
         configuration.HideTestRequestButton.Should().BeTrue();
         configuration.DarkMode.Should().BeFalse();
-        configuration.ForceDarkModeState.Should().Be("light");
         configuration.HideDarkModeToggle.Should().BeTrue();
         configuration.CustomCss.Should().Be("*{}");
         configuration.SearchHotKey.Should().Be("o");
@@ -98,8 +97,8 @@ public class ScalarOptionsMapperTests
         configuration.DefaultHttpClient!.ClientKey.Should().Be("httpclient");
         ((bool) configuration.HiddenClients!).Should().BeTrue();
         configuration.Authentication.Should().NotBeNull();
-        configuration.Authentication!.PreferredSecurityScheme.Should().Be("my-scheme");
 #pragma warning disable CS0618 // Type or member is obsolete
+        configuration.Authentication!.PreferredSecurityScheme.Should().Be("my-scheme");
         configuration.Authentication.ApiKey.Should().NotBeNull();
         configuration.Authentication.ApiKey!.Token.Should().Be("my-token");
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -203,5 +202,26 @@ public class ScalarOptionsMapperTests
                 first => first.Url.Should().Be("openapi/default.json"),
                 second => second.Url.Should().Be("external/custom.json")
             );
+    }
+
+    [Fact]
+    public void PreferredSecurityScheme_ShouldOverridePreferredSecuritySchemes_WhenSet()
+    {
+        // Arrange
+        var options = new ScalarOptions
+        {
+            // Act
+            Authentication = new ScalarAuthenticationOptions
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                PreferredSecurityScheme = "my-scheme"
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+        };
+
+        var configuration = options.ToScalarConfiguration();
+
+        // Assert
+        configuration.Authentication!.PreferredSecuritySchemes.Should().ContainSingle().Which.Should().Be("my-scheme");
     }
 }


### PR DESCRIPTION
**Problem**

Currently, it's not possible to define multiple preferred security schemes in the .NET integration.

**Solution**

This PR adds support for it! It looks like I have totally overseen the `preferredSecurityScheme` option during the authentication refactoring.

```csharp
app.MapScalarApiReference(options => options
    // before (obsolete)
    .WithPreferredScheme("ApiKey")
    // now
    .AddPreferredSecuritySchemes("ApiKey")
    // or add multiple
    .AddPreferredSecuritySchemes("ApiKey", "OAuth")
    // other config
    .AddApiKeyAuthentication("ApiKey", apiKey =>
    {
        apiKey.Value = "your-api-key";
    })
);
```

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
