### PR TITLE
fix: render correct queries with form data

### DIFF
--- a/.changeset/sweet-chicken-rule.md
+++ b/.changeset/sweet-chicken-rule.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+'@scalar/types': patch
+---
+
+fix: render correct queries with form data

--- a/packages/oas-utils/src/spec-getters/get-request-body-from-operation.ts
+++ b/packages/oas-utils/src/spec-getters/get-request-body-from-operation.ts
@@ -14,16 +14,21 @@ type AnyObject = Record<string, any>
  */
 function getParamsFromObject(
   obj: AnyObject,
-  prefix = '',
+  nested = false,
+  field?: string,
 ): {
   name: string
   value: any
 }[] {
   return Object.entries(obj).flatMap(([key, value]) => {
-    const newKey = prefix ? `${prefix}[${key}]` : key
+    const newKey = field ?? key
+
+    if (Array.isArray(value) && !nested) {
+      return getParamsFromObject(value, true, key)
+    }
 
     if (typeof value === 'object' && value !== null) {
-      return getParamsFromObject(value, newKey)
+      throw new Error('Form data should not contain nested objects')
     }
 
     return [{ name: newKey, value }]

--- a/packages/types/src/snippetz/snippetz.ts
+++ b/packages/types/src/snippetz/snippetz.ts
@@ -1,6 +1,6 @@
 import type { Request as HarRequest } from 'har-format'
 
-export type { Request as HarRequest } from 'har-format'
+export type { Request as HarRequest, Param as FormDataParam } from 'har-format'
 
 /**
  * List of available clients


### PR DESCRIPTION
**Problem**

Currently, endpoints with `multipart/form-data` body (and likely `application/x-www-form-urlencoded`) are rendered incorrectly: for some reason, all requests send JSON payload.

Details are in #5553, #3316 and #4125.

**Solution**

With this PR, I used `PostDataParams` type from `har-format` when body has form data. Some `snippetz` plugins (for example, `curl`) already support this type and render it correctly:

![image](https://github.com/user-attachments/assets/b5365718-08a6-4840-b6e9-50e496c4b8a2)

Also, I fixed the way how multipart/form-data body is build:
* before this PR, when array was in the request, field names were assigned with an index, e.g. `field[0]=value0&field[1]=value1&...` (for `application/x-www-form-urlencoded`)
* after this PR, all fields should be named the same, e.g. `field=value0&field=value1`. This matches default HTML forms behavior.

There is currently no standard about expected behavior when field contains some complex object (see #4834), I think this issue should be addressed separately.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] (N/A) I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
