### PR TITLE
feat(mock-server): add another document to galaxy.scalar.com

### DIFF
--- a/packages/mock-server/playground/index.ts
+++ b/packages/mock-server/playground/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 
 import { serve } from '@hono/node-server'
-import { apiReference } from '@scalar/hono-api-reference'
+import { Scalar } from '@scalar/hono-api-reference'
 
 import { createMockServer } from '../src/createMockServer'
 
@@ -28,9 +28,19 @@ const app = await createMockServer({
 // Render the API reference
 app.get(
   '/',
-  apiReference({
+  Scalar({
     pageTitle: 'Scalar Galaxy',
-    url: '/openapi.yaml',
+    sources: [
+      {
+        title: 'Scalar Galaxy',
+        url: '/openapi.yaml',
+      },
+      {
+        title: 'Petstore (OpenAPI 3.1)',
+        url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+      },
+    ],
+    proxyUrl: 'https://proxy.scalar.com',
     baseServerURL: `http://localhost:${port}`,
   }),
 )


### PR DESCRIPTION
**Problem**

Currently, https://galaxy.scalar.com only shows the Scalar Galaxy reference. This is a great demo, but doesn’t show multi document support.

**Solution**

This PR adds a second document to show multi document support on https://galaxy.scalar.com. :)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
