### PR TITLE
feat(api-reference): persist auth in local storage

### DIFF
--- a/.changeset/chilled-apples-work.md
+++ b/.changeset/chilled-apples-work.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/types': patch
+---
+
+feat: add auth persistance to references

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -392,6 +392,28 @@ Whether to show the dark mode toggle
 }
 ```
 
+### layout?: 'modern' | 'classic'
+
+The layout style to use for the API reference.
+
+```js
+{
+  layout: 'modern' // or 'classic'
+}
+```
+
+### isLoading?: boolean
+
+Controls whether the references show a loading state in the intro section. Useful when you want to indicate that content is being loaded.
+
+`@default false`
+
+```js
+{
+  isLoading: true
+}
+```
+
 ### customCss?: string
 
 You can pass custom CSS directly to the component. This is helpful for the integrations for Fastify, Express, Hono and others where you it's easier to add CSS to the configuration.
@@ -741,6 +763,42 @@ Customize how webhook URLs are generated. This function receives the webhook obj
 }
 ```
 
+### pathRouting?: { basePath: string }
+
+Configuration for path-based routing instead of hash-based routing. Your server must support this routing method.
+
+```js
+{
+  pathRouting: {
+    basePath: '/standalone-api-reference/:custom(.*)?'
+  }
+}
+```
+
+
+### redirect?: (path: string) => string | null | undefined
+
+Function to handle redirects in the API reference. Receives either:
+- The current path with hash if pathRouting is enabled
+- The current hash if using hashRouting (default)
+
+```js
+// Example for hashRouting (default)
+{
+  redirect: (hash) => hash.replace('#v1/old-path', '#v2/new-path')
+}
+
+// Example for pathRouting
+{
+  redirect: (pathWithHash) => {
+    if (pathWithHash.includes('#')) {
+      return pathWithHash.replace('/v1/tags/user#operation/get-user', '/v1/tags/user/operation/get-user')
+    }
+    return null
+  }
+}
+```
+
 ### onLoaded?: () => void
 
 Callback that triggers as soon as the references are lazy loaded.
@@ -752,6 +810,54 @@ Callback that triggers as soon as the references are lazy loaded.
   onLoaded: () => {
     console.log('References loaded')
   }
+}
+```
+
+### onShowMore?: (tagId: string) => void | Promise<void>
+
+Callback function that is triggered when a user clicks the "Show more" button in the references. The function receives the ID of the tag that was clicked.
+
+```js
+{
+  onShowMore: (tagId) => {
+    console.log('Show more clicked for tag:', tagId)
+  }
+}
+```
+
+### onSidebarClick?: (href: string) => void | Promise<void>
+
+Callback function that is triggered when a user clicks on any item in the sidebar. The function receives the href of the clicked item.
+
+```js
+{
+  onSidebarClick: (href) => {
+    console.log('Sidebar item clicked:', href)
+  }
+}
+```
+
+### onRequestSent?: (request: string) => void
+
+Callback function that is triggered when a request is sent through the API client. The function receives the request details as a string.
+
+```js
+{
+  onRequestSent: (request) => {
+    console.log('Request sent:', request)
+  }
+}
+```
+
+### persistAuth?: boolean
+
+Whether to persist authentication credentials in local storage. This allows the authentication state to be maintained across page reloads.
+
+`@default false`
+
+```js
+{
+  persistAuth: true
 }
 ```
 

--- a/packages/api-client/src/libs/local-storage.ts
+++ b/packages/api-client/src/libs/local-storage.ts
@@ -81,3 +81,11 @@ export const loadAllResources = (mutators: WorkspaceStore) => {
     console.error(e)
   }
 }
+
+/**
+ * localStorage keys for all client resources
+ * to ensure we do not have any conflicts
+ */
+export const CLIENT_LS_KEYS = {
+  AUTH: 'scalar-client-auth',
+} as const

--- a/packages/api-client/src/libs/local-storage.ts
+++ b/packages/api-client/src/libs/local-storage.ts
@@ -88,4 +88,5 @@ export const loadAllResources = (mutators: WorkspaceStore) => {
  */
 export const CLIENT_LS_KEYS = {
   AUTH: 'scalar-client-auth',
+  SELECTED_SECURITY_SCHEMES: 'scalar-client-selected-security-schemes',
 } as const

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
@@ -15,6 +15,7 @@ import { DataTableRow } from '@/components/DataTable'
 import type { EnvVariable } from '@/store/active-entities'
 import { useWorkspace, type UpdateScheme } from '@/store/store'
 import { authorizeOauth2 } from '@/views/Request/libs'
+import { updateScheme as _updateScheme } from '@/views/Request/RequestSection/helpers/update-scheme'
 
 import OAuthScopesInput from './OAuthScopesInput.vue'
 import RequestAuthDataTableInput from './RequestAuthDataTableInput.vue'
@@ -24,6 +25,7 @@ const {
   environment,
   envVariables,
   flow,
+  persistAuth = false,
   scheme,
   server,
   workspace,
@@ -32,6 +34,7 @@ const {
   environment: Environment
   envVariables: EnvVariable[]
   flow: Oauth2Flow
+  persistAuth: boolean
   scheme: SecuritySchemeOauth2
   server: Server | undefined
   workspace: Workspace
@@ -39,11 +42,11 @@ const {
 
 const loadingState = useLoadingState()
 const { toast } = useToasts()
-const { securitySchemeMutators } = useWorkspace()
+const storeContext = useWorkspace()
 
 /** Update the current scheme */
 const updateScheme: UpdateScheme = (path, value) =>
-  securitySchemeMutators.edit(scheme.uid, path, value)
+  _updateScheme(scheme.uid, path, value, storeContext, persistAuth)
 
 /** Authorize the user using specified flow */
 const handleAuthorize = async () => {

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon } from '@scalar/components'
+import { ScalarButton, ScalarIcon } from '@scalar/components'
 import type { Oauth2Flow } from '@scalar/oas-utils/entities/spec'
 import { computed } from 'vue'
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -40,6 +40,7 @@ const {
   envVariables,
   layout,
   operation,
+  persistAuth = false,
   selectedSecuritySchemeUids,
   server,
   title,
@@ -50,6 +51,7 @@ const {
   envVariables: EnvVariable[]
   layout: 'client' | 'reference'
   operation?: Operation | undefined
+  persistAuth?: boolean
   selectedSecuritySchemeUids: SelectedSecuritySchemeUids
   server: Server | undefined
   title: string
@@ -272,6 +274,7 @@ const schemeOptions = computed(() =>
       :envVariables="envVariables"
       :environment="environment"
       :layout="layout"
+      :persistAuth="persistAuth"
       :selectedSchemeOptions="selectedSchemeOptions"
       :server="server"
       :workspace="workspace" />

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -21,6 +21,7 @@ import { computed, ref, useId } from 'vue'
 
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useLayout } from '@/hooks/useLayout'
+import { CLIENT_LS_KEYS } from '@/libs/local-storage'
 import type { EnvVariable } from '@/store/active-entities'
 import { useWorkspace } from '@/store/store'
 import type { SecuritySchemeOption } from '@/views/Request/consts'
@@ -171,6 +172,25 @@ const editSelectedSchemeUids = (uids: SelectedSecuritySchemeUids) => {
   // Set as selected on the collection for the modal
   if (collection.useCollectionSecurity) {
     collectionMutators.edit(collection.uid, 'selectedSecuritySchemeUids', uids)
+
+    if (!persistAuth) {
+      return
+    }
+
+    // We must convert the uids to nameKeys first
+    const nameKeys = uids.map((uids) => {
+      // Handle complex auth
+      if (Array.isArray(uids)) {
+        return uids.map((uid) => securitySchemes[uid]?.nameKey)
+      }
+
+      return securitySchemes[uids]?.nameKey
+    })
+
+    localStorage.setItem(
+      CLIENT_LS_KEYS.SELECTED_SECURITY_SCHEMES,
+      JSON.stringify(nameKeys),
+    )
   }
   // Set as selected on request
   else if (operation?.uid) {

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -20,6 +20,7 @@ const {
   environment,
   envVariables,
   layout = 'client',
+  persistAuth = false,
   selectedSchemeOptions = [],
   server,
   workspace,
@@ -28,6 +29,7 @@ const {
   environment: Environment
   envVariables: EnvVariable[]
   layout: 'client' | 'reference'
+  persistAuth: boolean
   selectedSchemeOptions: { id: string; label: string }[]
   server: Server | undefined
   workspace: Workspace
@@ -95,6 +97,7 @@ watch(
         :envVariables="envVariables"
         :environment="environment"
         :layout="layout"
+        :persistAuth="persistAuth"
         :securitySchemeUids="activeScheme"
         :server="server"
         :workspace="workspace" />

--- a/packages/api-client/src/views/Request/RequestSection/helpers/update-scheme.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/helpers/update-scheme.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { updateScheme } from './update-scheme'
+import { CLIENT_LS_KEYS } from '@/libs/local-storage'
+import { securitySchemeSchema } from '@scalar/types/entities'
+import type { WorkspaceStore } from '@/store/store'
+
+describe('updateScheme', () => {
+  // Mock localStorage
+  const mockLocalStorage = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+  }
+
+  // Mock store
+  const mockSecuritySchemeMutators = {
+    edit: vi.fn(),
+  }
+
+  const scheme1 = securitySchemeSchema.parse({
+    uid: 'scheme-1',
+    nameKey: 'apiKey',
+    type: 'apiKey',
+    in: 'header',
+    name: 'X-API-Key',
+  })
+
+  const scheme2 = securitySchemeSchema.parse({
+    uid: 'scheme-2',
+    nameKey: 'bearer',
+    type: 'http',
+    scheme: 'bearer',
+  })
+
+  const mockStore = {
+    securitySchemeMutators: mockSecuritySchemeMutators,
+    securitySchemes: {
+      [scheme1.uid]: scheme1,
+      [scheme2.uid]: scheme2,
+    },
+  } as unknown as WorkspaceStore
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks()
+    // Mock localStorage
+    Object.defineProperty(window, 'localStorage', {
+      value: mockLocalStorage,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should update security scheme in store without persisting to localStorage', () => {
+    const uid = scheme1.uid
+    const path = 'name'
+    const value = 'New-API-Key'
+
+    updateScheme(uid, path, value, mockStore)
+
+    expect(mockSecuritySchemeMutators.edit).toHaveBeenCalledWith(uid, path, value)
+    expect(mockLocalStorage.setItem).not.toHaveBeenCalled()
+  })
+
+  it('should update security scheme and persist to localStorage when persistAuth is true', () => {
+    const uid = scheme1.uid
+    const path = 'name'
+    const value = 'New-API-Key'
+    const existingAuth = {
+      apiKey: {
+        name: 'Old-API-Key',
+      },
+    }
+
+    mockLocalStorage.getItem.mockReturnValue(JSON.stringify(existingAuth))
+
+    updateScheme(uid, path, value, mockStore, true)
+
+    expect(mockSecuritySchemeMutators.edit).toHaveBeenCalledWith(uid, path, value)
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      CLIENT_LS_KEYS.AUTH,
+      JSON.stringify({
+        apiKey: {
+          name: 'New-API-Key',
+        },
+      }),
+    )
+  })
+
+  it('should create new auth entry in localStorage if none exists', () => {
+    const uid = scheme1.uid
+    const path = 'name'
+    const value = 'New-API-Key'
+
+    mockLocalStorage.getItem.mockReturnValue('{}')
+
+    updateScheme(uid, path, value, mockStore, true)
+
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      CLIENT_LS_KEYS.AUTH,
+      JSON.stringify({
+        apiKey: {
+          name: 'New-API-Key',
+        },
+      }),
+    )
+  })
+
+  it('should handle different types of security schemes', () => {
+    const uid = scheme2.uid
+    const path = 'scheme'
+    const value = 'basic'
+
+    mockLocalStorage.getItem.mockReturnValue('{}')
+
+    updateScheme(uid, path, value, mockStore, true)
+
+    expect(mockSecuritySchemeMutators.edit).toHaveBeenCalledWith(uid, path, value)
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      CLIENT_LS_KEYS.AUTH,
+      JSON.stringify({
+        bearer: {
+          scheme: 'basic',
+        },
+      }),
+    )
+  })
+
+  it('should handle missing nameKey in security scheme', () => {
+    const uid = scheme1.uid
+    const path = 'name'
+    const value = 'New-API-Key'
+    const storeWithMissingNameKey = {
+      ...mockStore,
+      securitySchemes: {
+        [scheme1.uid]: {
+          ...scheme1,
+          nameKey: undefined,
+        },
+      },
+    } as unknown as WorkspaceStore
+
+    updateScheme(uid, path, value, storeWithMissingNameKey, true)
+
+    expect(mockSecuritySchemeMutators.edit).toHaveBeenCalledWith(uid, path, value)
+    expect(mockLocalStorage.setItem).not.toHaveBeenCalled()
+  })
+
+  it('should handle invalid JSON in localStorage', () => {
+    const uid = scheme1.uid
+    const path = 'name'
+    const value = 'New-API-Key'
+
+    mockLocalStorage.getItem.mockReturnValue('invalid-json')
+
+    updateScheme(uid, path, value, mockStore, true)
+
+    expect(mockSecuritySchemeMutators.edit).toHaveBeenCalledOnce()
+    expect(mockLocalStorage.setItem).not.toHaveBeenCalled()
+  })
+
+  it('should preserve existing auth data for other schemes', () => {
+    const uid = scheme1.uid
+    const path = 'name'
+    const value = 'New-API-Key'
+    const existingAuth = {
+      apiKey: {
+        name: 'Old-API-Key',
+      },
+      bearer: {
+        scheme: 'bearer',
+      },
+    }
+
+    mockLocalStorage.getItem.mockReturnValue(JSON.stringify(existingAuth))
+
+    updateScheme(uid, path, value, mockStore, true)
+
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      CLIENT_LS_KEYS.AUTH,
+      JSON.stringify({
+        apiKey: {
+          name: 'New-API-Key',
+        },
+        bearer: {
+          scheme: 'bearer',
+        },
+      }),
+    )
+  })
+})

--- a/packages/api-client/src/views/Request/RequestSection/helpers/update-scheme.ts
+++ b/packages/api-client/src/views/Request/RequestSection/helpers/update-scheme.ts
@@ -21,7 +21,6 @@ export const updateScheme = <U extends SecurityScheme['uid'], P extends Path<Sec
   }
 
   // We persist auth to local storage by name key
-
   try {
     const auth: Auth<P> = JSON.parse(localStorage.getItem(CLIENT_LS_KEYS.AUTH) ?? '{}')
     const scheme = securitySchemes[uid]

--- a/packages/api-client/src/views/Request/RequestSection/helpers/update-scheme.ts
+++ b/packages/api-client/src/views/Request/RequestSection/helpers/update-scheme.ts
@@ -1,0 +1,32 @@
+import type { SecurityScheme } from '@scalar/oas-utils/entities/spec'
+import type { Path, PathValue } from '@scalar/object-utils/nested'
+import { CLIENT_LS_KEYS } from '@/libs/local-storage'
+import type { WorkspaceStore } from '@/store/store'
+
+/** Shape of the local storage auth object */
+export type Auth<P extends Path<SecurityScheme>> = Record<
+  string,
+  { path: P; value: NonNullable<PathValue<SecurityScheme, P>> }
+>
+
+/** Update the security scheme with side effects */
+export const updateScheme = <U extends SecurityScheme['uid'], P extends Path<SecurityScheme>>(
+  uid: U,
+  path: P,
+  value: NonNullable<PathValue<SecurityScheme, P>>,
+  { securitySchemeMutators, securitySchemes }: WorkspaceStore,
+  persistAuth = false,
+) => {
+  securitySchemeMutators.edit(uid, path, value)
+
+  // We persist auth to local storage by name key
+  if (persistAuth) {
+    const auth: Auth<P> = JSON.parse(localStorage.getItem(CLIENT_LS_KEYS.AUTH) ?? '{}')
+    const scheme = securitySchemes[uid]
+
+    if (auth && scheme?.nameKey) {
+      auth[scheme.nameKey] = { path, value }
+      localStorage.setItem(CLIENT_LS_KEYS.AUTH, JSON.stringify(auth))
+    }
+  }
+}

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -30,6 +30,7 @@
             url: 'https://petstore.swagger.io/v2/swagger.json',
           },
         ],
+        persistAuth: true,
         // Avoid CORS issues
         proxyUrl: 'https://proxy.scalar.com',
       })

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -118,6 +118,7 @@ const introCardsSlot = computed(() =>
                 :envVariables="activeEnvVariables"
                 :environment="activeEnvironment"
                 layout="reference"
+                :persistAuth="config.persistAuth"
                 :selectedSecuritySchemeUids="
                   activeCollection?.selectedSecuritySchemeUids ?? []
                 "

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -212,6 +212,8 @@ export const apiClientConfigurationSchema = z.object({
   _integration: integrationEnum.optional(),
   /** onRequestSent is fired when a request is sent */
   onRequestSent: z.function().args(z.string()).returns(z.void()).optional(),
+  /** Whether to persist auth across to local storage */
+  persistAuth: z.boolean().optional().default(false).catch(false),
 })
 
 export type ApiClientConfiguration = z.infer<typeof apiClientConfigurationSchema>

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -236,7 +236,7 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
      */
     plugins: z.array(ApiReferencePluginSchema).optional(),
     /**
-     * Whether the spec input should show
+     * Allows the user to inject an editor for the spec
      * @default false
      */
     isEditable: z.boolean().optional().default(false).catch(false),

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -212,7 +212,7 @@ export const apiClientConfigurationSchema = z.object({
   _integration: integrationEnum.optional(),
   /** onRequestSent is fired when a request is sent */
   onRequestSent: z.function().args(z.string()).returns(z.void()).optional(),
-  /** Whether to persist auth across to local storage */
+  /** Whether to persist auth to local storage */
   persistAuth: z.boolean().optional().default(false).catch(false),
 })
 


### PR DESCRIPTION
**Problem**

Currently, we do not save auth in references. Users must enter it everytime if they refresh.

**Solution**
- added auth persistance for security schemes + selection
- updated docs with all missing properties including the new persist auth

closes #5320
closes #5598
closes #4704

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
