### PR TITLE
fix(api-client): request sidebar search visual hint

### DIFF
--- a/.changeset/ten-stingrays-exercise.md
+++ b/.changeset/ten-stingrays-exercise.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates border style on request section

--- a/.changeset/wise-pans-run.md
+++ b/.changeset/wise-pans-run.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sidebar search visual indicator on navigation

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -13,7 +13,7 @@ const { cx } = useBindCx()
     ">
     <div
       v-if="$slots.title"
-      class="request-response-header bg-b-1 z-1 sticky top-0 flex min-h-11 items-center border-b px-2.5 text-sm font-medium xl:rounded-none">
+      class="request-response-header bg-b-1 z-1 -mb-1/2 sticky top-0 flex min-h-11 items-center border-b px-2.5 text-sm font-medium xl:rounded-none">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -105,7 +105,7 @@ watch(
 
     <div
       v-else
-      class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border border-b-0 px-4 text-sm">
+      class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border-t px-4 text-sm">
       No authentication selected
     </div>
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -297,7 +297,8 @@ const dataTableInputProps = {
     <!-- Open ID Connect -->
     <template v-else-if="scheme?.type === 'openIdConnect'">
       <div
-        class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border border-b-0 px-4 text-sm">
+        class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border-b-0 border-t px-4 text-sm"
+        :class="{ 'rounded-b-lg': layout === 'reference' }">
         Coming soon
       </div>
     </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -173,7 +173,7 @@ const labelRequestNameId = useId()
     </template>
     <div
       :id="filterIds.All"
-      class="request-section-content custom-scroll relative flex flex-1 flex-col divide-y"
+      class="request-section-content custom-scroll relative flex flex-1 flex-col"
       :role="selectedFilter === 'All' ? 'tabpanel' : 'none'">
       <RequestAuth
         v-if="
@@ -186,7 +186,7 @@ const labelRequestNameId = useId()
           (selectedFilter === 'All' || selectedFilter === 'Auth')
         "
         :id="filterIds.Auth"
-        class="request-section-content-auth border-b-0"
+        class="request-section-content-auth"
         :collection="collection"
         :envVariables="envVariables"
         :environment="environment"
@@ -273,12 +273,12 @@ const labelRequestNameId = useId()
         :workspace="workspace" />
 
       <!-- Spacer -->
-      <div class="-my-0.25 flex flex-grow" />
+      <div class="flex flex-grow" />
 
       <!-- Code Snippet -->
       <ScalarErrorBoundary>
         <RequestCodeExample
-          class="request-section-content-code-example"
+          class="request-section-content-code-example -mt-1/2 border-t"
           :collection="collection"
           :example="example"
           :operation="operation"

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -352,7 +352,7 @@ const blurSearch = () => {
               :id="`#search-input-${entry.item.id}`"
               :key="entry.refIndex"
               :ref="(el) => (searchResultRefs[index] = el as HTMLElement)"
-              :active="selectedSearchResult === index"
+              :selected="selectedSearchResult === index"
               class="px-2"
               :href="entry.item.link"
               @click.prevent="onSearchResultClick(entry)"

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -272,6 +272,13 @@ const collections = computed(() => {
   }
   return activeWorkspaceCollections.value
 })
+
+/** Blur the search input if the text is empty */
+const blurSearch = () => {
+  if (!searchText.value) {
+    isSearchVisible.value = false
+  }
+}
 </script>
 <template>
   <Sidebar
@@ -319,7 +326,8 @@ const collections = computed(() => {
           @input="fuseSearch"
           @keydown.down.stop="navigateSearchResults('down')"
           @keydown.enter.stop="selectSearchResult()"
-          @keydown.up.stop="navigateSearchResults('up')" />
+          @keydown.up.stop="navigateSearchResults('up')"
+          @blur="blurSearch" />
       </div>
       <div
         class="gap-1/2 flex flex-1 flex-col overflow-visible overflow-y-auto px-3 pb-3 pt-0"


### PR DESCRIPTION
**Problem**

currently when searching and navigating through the request navigation search, no visual hint is provided while the navigation is working.

**Solution**

this pr updates the prop usage for the component + enhances the border on the request section (for one last time).

`sidebar search`
| before | after |
| -------|------|
| <img width="612" alt="image" src="https://github.com/user-attachments/assets/6029c5aa-b1ae-49ed-8b62-6420ed8840a7" /> | <img width="612" alt="image" src="https://github.com/user-attachments/assets/00a50686-b63e-4229-ab74-3209b8b62b3b" /> |
| missing visual hint on selected item | selected item is highlighted | 


`request section`
| before | after |
| -------|------|
| <img width="612" alt="image" src="https://github.com/user-attachments/assets/325156b9-c19b-4ddd-9391-21a7d26dde40" /> | <img width="612" alt="image" src="https://github.com/user-attachments/assets/57dde80b-6338-4cdd-bc14-adfcb9ec79d8" /> |
| double top border on filtered section | single top border on filtered section | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
