### PR TITLE
feat(components): scalar button loading update

### DIFF
--- a/.changeset/small-buses-draw.md
+++ b/.changeset/small-buses-draw.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: updates scalar loading component style

--- a/packages/components/src/components/ScalarButton/ScalarButton.vue
+++ b/packages/components/src/components/ScalarButton/ScalarButton.vue
@@ -53,7 +53,7 @@ const { cx } = useBindCx()
       class="centered-x absolute">
       <ScalarLoading
         :loadingState="loading"
-        size="xs" />
+        size="xl" />
     </div>
   </button>
 </template>

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.vue
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.vue
@@ -127,7 +127,7 @@ export function useLoadingState() {
           cy="50"
           fill="none"
           r="20"
-          stroke-width="2" />
+          stroke-width="3" />
       </g>
     </svg>
   </div>
@@ -157,7 +157,7 @@ export function useLoadingState() {
 }
 
 .svg-path {
-  stroke-width: 14;
+  stroke-width: 12;
   fill: none;
   transition: 0.3s;
 }
@@ -190,7 +190,7 @@ export function useLoadingState() {
     fade-in 0.4s;
 
   transform-origin: center center;
-  transform: scale(5);
+  transform: scale(3.5);
 
   background: transparent;
 }
@@ -222,10 +222,10 @@ export function useLoadingState() {
 
 @keyframes rotate {
   from {
-    transform: scale(5) rotate(0deg);
+    transform: scale(3.5) rotate(0deg);
   }
   to {
-    transform: scale(5) rotate(360deg);
+    transform: scale(3.5) rotate(360deg);
   }
 }
 </style>


### PR DESCRIPTION
**Problem**

currently the loading state within a button is too small to be properly noticeable.

**Solution**

this pr updates the scalar loading style and increase the size used in the scalar button component:

| before | after |
| -------|------|
| <img width="127" alt="image" src="https://github.com/user-attachments/assets/f8a5357e-2d62-4c63-9f23-8fe9bea29250" /> | <img width="127" alt="image" src="https://github.com/user-attachments/assets/e697f01a-4a16-4f3a-ad2f-9623bd5ae6d9" /> |
|  <img width="127" alt="image" src="https://github.com/user-attachments/assets/200e963b-bd83-4b6e-8029-a646c1016344" /> |  <img width="127" alt="image" src="https://github.com/user-attachments/assets/a1381131-7786-4878-b0af-b5e4f831ebee" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
