### PR TITLE
feat(themes): heading variables update

### DIFF
--- a/.changeset/friendly-monkeys-double.md
+++ b/.changeset/friendly-monkeys-double.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/themes': patch
+---
+
+feat: updates heading variables

--- a/packages/api-reference/src/components/Section/SectionHeader.vue
+++ b/packages/api-reference/src/components/Section/SectionHeader.vue
@@ -32,7 +32,7 @@ defineProps<{
 }
 
 .section-header {
-  font-size: var(--font-size, var(--scalar-heading-2));
+  font-size: var(--font-size, var(--scalar-heading-1));
   font-weight: var(--font-weight, var(--scalar-bold));
   /* prettier-ignore */
   color: var(--scalar-color-1);

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -14,9 +14,9 @@
     "Courier New", monospace;
 
   /** Font sizes for rendered text content (editor styles or static content) */
-  --scalar-heading-1: 40px; /* Editor Page heading */
-  --scalar-page-description: 24px;
-  --scalar-heading-2: 24px; /* Editor section headings */
+  --scalar-heading-1: 24px; /* Editor Page heading */
+  --scalar-page-description: 16px;
+  --scalar-heading-2: 20px; /* Editor section headings */
   --scalar-heading-3: 20px;
   --scalar-heading-4: 16px;
   --scalar-heading-5: 16px;

--- a/packages/themes/src/presets/custom-theme-starter.css
+++ b/packages/themes/src/presets/custom-theme-starter.css
@@ -17,9 +17,9 @@
   --scalar-font-code: "JetBrains Mono";
 
   /* Font sizes */
-  --scalar-heading-1: 40px; /* Page headings */
-  --scalar-page-description: 24px;
-  --scalar-heading-2: 24px; /* Section headings */
+  --scalar-heading-1: 24px; /* Page headings */
+  --scalar-page-description: 16px;
+  --scalar-heading-2: 20px; /* Section headings */
   --scalar-heading-3: 20px;
   --scalar-heading-4: 16px;
   --scalar-heading-5: 16px;


### PR DESCRIPTION
**Solution**

this pr is updating the heading variable values in our theme package to match incoming dashboard updates. it shouldn't affect the style or make any changes to the current state of reference.

| before | after |
| -------|------|
| <img width="1464" alt="image" src="https://github.com/user-attachments/assets/c2a66bb6-1bde-4cf0-af08-e30ebc502467" /> | <img width="1464" alt="image" src="https://github.com/user-attachments/assets/09569c60-0e1b-48ad-aa2b-92ab0557e034" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
