### PR TITLE
feat(api-client): collection environment page

### DIFF
--- a/.changeset/dull-glasses-fix.md
+++ b/.changeset/dull-glasses-fix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: adds collection environment page

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -237,6 +237,14 @@ const defaultType = computed(() => {
       props.type
 })
 
+const displayVariablesDropdown = computed(
+  () =>
+    showDropdown.value &&
+    props.withVariables &&
+    layout !== 'modal' &&
+    props.environment,
+)
+
 defineExpose({
   /** Expose focus method */
   focus: () => {
@@ -334,7 +342,7 @@ export default {
   </div>
   <div
     v-if="$slots.icon"
-    class="centered-y group-has-[.cm-focused]:z-1 absolute right-0 flex h-full items-center p-1.5">
+    class="centered-y group-has-[.cm-focused]:z-1 -right-0.25 absolute flex h-full items-center p-1.5">
     <slot name="icon" />
   </div>
   <div
@@ -343,7 +351,7 @@ export default {
     Required
   </div>
   <EnvironmentVariableDropdown
-    v-if="showDropdown && withVariables && layout !== 'modal' && environment"
+    v-if="displayVariablesDropdown"
     ref="dropdownRef"
     :dropdownPosition="dropdownPosition"
     :envVariables="envVariables"

--- a/packages/api-client/src/components/DataTable/DataTable.vue
+++ b/packages/api-client/src/components/DataTable/DataTable.vue
@@ -15,7 +15,7 @@ const { cx } = useBindCx()
     v-bind="
       cx(
         scroll ? 'overflow-x-auto custom-scroll' : 'overflow-visible',
-        'scalar-data-table bg-b-1',
+        'scalar-data-table',
       )
     ">
     <table

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -65,6 +65,25 @@ const availableEnvironments = computed(() => {
     : []
 })
 
+const selectLatestEnvironment = () => {
+  const environments = availableEnvironments.value
+  if (environments.length > 0) {
+    // Get the latest created collection environment
+    const latestEnvironment = environments[environments.length - 1]
+
+    if (latestEnvironment?.uid) {
+      updateSelected(latestEnvironment.uid)
+    }
+  }
+}
+
+// Select for the collection its latest environment on creation
+watch(availableEnvironments, (newEnvs, oldEnvs) => {
+  if (newEnvs.length > oldEnvs.length) {
+    selectLatestEnvironment()
+  }
+})
+
 const setInitialEnvironment = (collection: Collection) => {
   const activeEnv = collection['x-scalar-active-environment']
   if (activeEnv && activeCollection.value && activeWorkspace.value) {

--- a/packages/api-client/src/views/Collection/CollectionAuthentication.vue
+++ b/packages/api-client/src/views/Collection/CollectionAuthentication.vue
@@ -32,19 +32,18 @@ const handleToggleCollectionSecurity = () => {
 <template>
   <div class="flex h-full w-full flex-col gap-12 px-1.5 pt-8">
     <div class="flex flex-col gap-4">
-      <div class="flex h-8 items-center">
-        <h3 class="font-bold">Authenticate with the API once</h3>
-      </div>
-
-      <div class="bg-b-1 flex items-center justify-between gap-4 text-sm">
-        <p class="text-c-2 flex flex-1 text-balance">
-          Don’t want to set up the authentication for each request? Enable this
-          option to set the authentication once for the whole collection.
+      <div class="flex flex-col gap-2">
+        <div class="flex h-8 items-center justify-between">
+          <h3 class="font-bold">Authentication</h3>
+          <ScalarToggle
+            class="w-4"
+            :modelValue="activeCollection?.useCollectionSecurity ?? false"
+            @update:modelValue="handleToggleCollectionSecurity" />
+        </div>
+        <p class="pr-6 text-sm">
+          Added authentication will apply to all requests under this collection.
+          You can override this by specifying another one in the request.
         </p>
-        <ScalarToggle
-          class="w-4"
-          :modelValue="activeCollection?.useCollectionSecurity ?? false"
-          @update:modelValue="handleToggleCollectionSecurity" />
       </div>
 
       <RequestAuth

--- a/packages/api-client/src/views/Collection/CollectionEnvironment.vue
+++ b/packages/api-client/src/views/Collection/CollectionEnvironment.vue
@@ -1,9 +1,207 @@
 <script setup lang="ts">
+import {
+  ScalarButton,
+  ScalarIcon,
+  ScalarModal,
+  useModal,
+} from '@scalar/components'
+import { ScalarIconTrash } from '@scalar/icons'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
+import { computed, ref } from 'vue'
+
+import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
 import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import { useActiveEntities, useWorkspace } from '@/store'
+import EnvironmentColorModal from '@/views/Environment/EnvironmentColorModal.vue'
+import EnvironmentModal from '@/views/Environment/EnvironmentModal.vue'
+
+import EnvironmentForm from './components/EnvironmentForm.vue'
+
+const { activeCollection, activeWorkspace, activeEnvVariables } =
+  useActiveEntities()
+const { collectionMutators } = useWorkspace()
+
+const colorModal = useModal()
+const deleteModal = useModal()
+const environmentModal = useModal()
+const selectedColor = ref('')
+const selectedEnvironmentName = ref<string | null>(null)
+
+const collectionEnvironments = computed(() => {
+  if (!activeCollection.value?.['x-scalar-environments']) {
+    return []
+  }
+  return Object.entries(activeCollection.value['x-scalar-environments']).map(
+    ([name, environment]) => ({
+      uid: name as Environment['uid'],
+      name,
+      value: JSON.stringify(environment.variables || {}),
+      color: environment.color || '#FFFFFF',
+    }),
+  )
+})
+
+const deleteEnvironment = () => {
+  if (!activeCollection.value?.uid || !selectedEnvironmentName.value) {
+    return
+  }
+
+  collectionMutators.removeEnvironment(
+    selectedEnvironmentName.value,
+    activeCollection.value.uid,
+  )
+  deleteModal.hide()
+}
+
+const openDeleteModal = (environmentName: string) => {
+  selectedEnvironmentName.value = environmentName
+  deleteModal.show()
+}
+
+const handleEnvironmentSubmit = (environment: {
+  name: string
+  color: string
+  collectionId: string | undefined
+}) => {
+  if (!activeCollection.value?.uid) {
+    return
+  }
+
+  collectionMutators.addEnvironment(
+    environment.name,
+    {
+      variables: {},
+      color: environment.color,
+    },
+    activeCollection.value.uid,
+  )
+  environmentModal.hide()
+}
+
+const handleOpenColorModal = (environment: {
+  name: string
+  color?: string | undefined
+}) => {
+  selectedEnvironmentName.value = environment.name
+  selectedColor.value = environment.color || '#FFFFFF'
+  colorModal.show()
+}
+
+const submitColorChange = (color: string) => {
+  if (!activeCollection.value?.uid || !selectedEnvironmentName.value) {
+    return
+  }
+
+  const environments = {
+    ...activeCollection.value['x-scalar-environments'],
+    [selectedEnvironmentName.value]: {
+      variables:
+        activeCollection.value['x-scalar-environments']?.[
+          selectedEnvironmentName.value
+        ]?.variables || {},
+      color,
+    },
+  }
+
+  collectionMutators.edit(
+    activeCollection.value.uid,
+    'x-scalar-environments',
+    environments,
+  )
+  colorModal.hide()
+}
 </script>
 
 <template>
   <ViewLayoutSection>
-    <template #title>Environments</template>
+    <div class="flex h-full w-full flex-col gap-12 px-1.5 pt-8">
+      <div class="flex flex-col gap-4">
+        <div class="flex items-start justify-between gap-2">
+          <div class="flex flex-col gap-2">
+            <div class="flex h-8 items-center">
+              <h3 class="font-bold">Environment Variables</h3>
+            </div>
+            <p class="text-sm">
+              Set environment variables at your collection level. Use
+              <code
+                class="font-code text-c-2"
+                v-pre
+                >{{ variable }}</code
+              >
+              to add / search among the selected environment's variables in your
+              request inputs.
+            </p>
+          </div>
+        </div>
+        <div
+          v-for="environment in collectionEnvironments"
+          :key="environment.name">
+          <div class="rounded-lg border">
+            <div
+              class="bg-b-2 flex items-center justify-between rounded-t-lg px-1 py-1 text-sm">
+              <div class="flex items-center gap-1">
+                <ScalarButton
+                  class="hover:bg-b-3 flex h-6 w-6 p-1"
+                  @click="handleOpenColorModal(environment)"
+                  variant="ghost">
+                  <span
+                    :style="{ backgroundColor: environment.color || '#FFFFFF' }"
+                    class="h-2.5 w-2.5 rounded-full"></span>
+                </ScalarButton>
+                <span class="text-sm">{{ environment.name }}</span>
+              </div>
+              <ScalarButton
+                class="hover:bg-b-3 hover:text-c-1 p-1.25 h-fit"
+                variant="ghost"
+                @click="openDeleteModal(environment.name)">
+                <ScalarIconTrash class="size-3.5" />
+              </ScalarButton>
+            </div>
+            <EnvironmentForm
+              v-if="activeCollection && activeWorkspace"
+              :collection="activeCollection"
+              :environment="environment"
+              :envVariables="activeEnvVariables"
+              :workspace="activeWorkspace" />
+          </div>
+        </div>
+        <div
+          class="text-c-3 flex h-full items-center justify-center rounded-lg border p-4">
+          <ScalarButton
+            class="hover:bg-b-2 hover:text-c-1 flex items-center gap-2"
+            size="sm"
+            variant="ghost"
+            @click="environmentModal.show()">
+            <ScalarIcon
+              class="inline-flex"
+              icon="Add"
+              size="sm"
+              thickness="1.5" />
+            <span>Add Environment</span>
+          </ScalarButton>
+        </div>
+      </div>
+      <ScalarModal
+        :size="'xxs'"
+        :state="deleteModal"
+        :title="`Delete ${selectedEnvironmentName || 'Environment'}`">
+        <DeleteSidebarListElement
+          :variableName="'Environment'"
+          :warningMessage="'Are you sure you want to delete this environment? This action cannot be undone.'"
+          @close="deleteModal.hide()"
+          @delete="deleteEnvironment" />
+      </ScalarModal>
+      <EnvironmentModal
+        :activeWorkspaceCollections="activeCollection ? [activeCollection] : []"
+        :collectionId="activeCollection?.uid"
+        :state="environmentModal"
+        @cancel="environmentModal.hide()"
+        @submit="handleEnvironmentSubmit" />
+      <EnvironmentColorModal
+        :selectedColor="selectedColor"
+        :state="colorModal"
+        @cancel="colorModal.hide()"
+        @submit="submitColorChange" />
+    </div>
   </ViewLayoutSection>
 </template>

--- a/packages/api-client/src/views/Collection/CollectionNavigation.vue
+++ b/packages/api-client/src/views/Collection/CollectionNavigation.vue
@@ -52,16 +52,16 @@ const routes = computed<CollectionSidebarEntry[]>(() => [
       },
     },
   },
-  // {
-  //   displayName: 'Environments',
-  //   // icon: 'Brackets',
-  //   to: {
-  //     name: 'collection.environment',
-  //     params: {
-  //       [PathId.Collection]: activeCollection.value?.uid,
-  //     },
-  //   },
-  // },
+  {
+    displayName: 'Environment',
+    // icon: 'Brackets',
+    to: {
+      name: 'collection.environment',
+      params: {
+        [PathId.Collection]: activeCollection.value?.uid,
+      },
+    },
+  },
   // {
   //   displayName: 'Cookies',
   //   // icon: 'Cookie',

--- a/packages/api-client/src/views/Collection/CollectionServers.vue
+++ b/packages/api-client/src/views/Collection/CollectionServers.vue
@@ -57,7 +57,7 @@ const openDeleteModal = (serverUid: Server['uid']) => {
   <div class="flex h-full w-full flex-col gap-12 px-1.5 pt-8">
     <div class="flex flex-col gap-4">
       <div class="flex items-start justify-between gap-2">
-        <div class="flex flex-col">
+        <div class="flex flex-col gap-2">
           <div class="flex h-8 items-center">
             <h3 class="font-bold">Servers</h3>
           </div>
@@ -71,9 +71,9 @@ const openDeleteModal = (serverUid: Server['uid']) => {
       <div
         v-for="(server, index) in collectionServers"
         :key="server.uid">
-        <div class="bg-b-2 rounded-lg border">
+        <div class="rounded-lg border">
           <div
-            class="flex items-start justify-between rounded-t-lg py-1 pl-3 pr-1 text-sm">
+            class="bg-b-2 flex items-start justify-between rounded-t-lg py-1 pl-3 pr-1 text-sm">
             <ScalarMarkdown
               v-if="server.description"
               :value="server.description"

--- a/packages/api-client/src/views/Collection/components/EnvironmentForm.vue
+++ b/packages/api-client/src/views/Collection/components/EnvironmentForm.vue
@@ -1,0 +1,400 @@
+<script setup lang="ts">
+import { ScalarButton } from '@scalar/components'
+import { ScalarIconTrash, ScalarIconWarning } from '@scalar/icons'
+import type { Environment } from '@scalar/oas-utils/entities/environment'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+import type { Workspace } from '@scalar/oas-utils/entities/workspace'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
+
+import CodeInput from '@/components/CodeInput/CodeInput.vue'
+import DataTable from '@/components/DataTable/DataTable.vue'
+import DataTableCell from '@/components/DataTable/DataTableCell.vue'
+import DataTableHeader from '@/components/DataTable/DataTableHeader.vue'
+import DataTableRow from '@/components/DataTable/DataTableRow.vue'
+import { useWorkspace } from '@/store'
+import type { EnvVariable } from '@/store/active-entities'
+
+const { collection, environment, workspace, envVariables } = defineProps<{
+  collection: Collection
+  environment: Environment
+  workspace: Workspace
+  envVariables: EnvVariable[]
+}>()
+
+const { collectionMutators } = useWorkspace()
+
+//
+const localVariables = ref<Array<{ key: string; value: string }>>([])
+
+// Set of existing keys from the collection
+const collectionKeys = ref<Set<string>>(new Set())
+
+// Map of key typed by the user
+const tempKeys = ref<Map<number, string>>(new Map())
+
+// Prevent multiple updates to the collection
+const isUpdating = ref(false)
+
+const variables = computed(() => {
+  if (!environment?.value) {
+    return [{ key: '', value: '' }]
+  }
+  try {
+    const parsedObject = JSON.parse(environment.value)
+    const entries = Object.entries(parsedObject).map(([key, val]) => ({
+      key,
+      value: String(val),
+    }))
+    if (entries.length === 0) {
+      return [{ key: '', value: '' }]
+    }
+    return entries
+  } catch (_) {
+    return [{ key: '', value: '' }]
+  }
+})
+
+const environmentVariables = computed(() => {
+  const lastRow = localVariables.value[localVariables.value.length - 1]
+  if (!lastRow) {
+    return [{ key: '', value: '' }]
+  }
+  if (lastRow.key || lastRow.value) {
+    return [...localVariables.value, { key: '', value: '' }]
+  }
+  return localVariables.value
+})
+
+const getDuplicateKeyIndexes = computed(() => {
+  const keyCounts = new Map<string, number[]>()
+
+  // Add existing keys from the collection
+  localVariables.value.forEach((v, index) => {
+    if (v.key) {
+      const indexes = keyCounts.get(v.key) || []
+      indexes.push(index)
+      keyCounts.set(v.key, indexes)
+    }
+  })
+
+  // Add typed keys that are being edited
+  tempKeys.value.forEach((key, index) => {
+    if (key) {
+      const indexes = keyCounts.get(key) || []
+      indexes.push(index)
+      keyCounts.set(key, indexes)
+    }
+  })
+
+  return Array.from(keyCounts.values())
+    .filter((indexes) => indexes.length > 1)
+    .flat()
+})
+
+// Update originalKeys when variables change
+watch(
+  variables,
+  (newVars) => {
+    localVariables.value = [...newVars]
+    collectionKeys.value = new Set(newVars.map((v) => v.key).filter(Boolean))
+  },
+  { immediate: true },
+)
+
+const handleUpdateRow = async (
+  index: number,
+  field: 'key' | 'value',
+  value: string,
+) => {
+  if (isUpdating.value) {
+    return
+  }
+
+  if (field === 'key') {
+    // Store the typed key
+    tempKeys.value.set(index, value)
+
+    // Check for duplicates
+    const otherKeys = new Set(collectionKeys.value)
+    const currentItem = localVariables.value[index]
+
+    // Remove the current item from the set of original keys
+    if (currentItem) {
+      otherKeys.delete(currentItem.key)
+    }
+
+    // If it's a duplicate, don't proceed with mutation
+    if (otherKeys.has(value)) {
+      return
+    }
+  }
+
+  isUpdating.value = true
+
+  try {
+    const newVariables = [...localVariables.value]
+    const currentItem = newVariables[index]
+    if (!currentItem) {
+      return
+    }
+
+    newVariables[index] = {
+      key: field === 'key' ? value : currentItem.key,
+      value: field === 'value' ? value : currentItem.value,
+    }
+
+    if (
+      !newVariables[index].key &&
+      !newVariables[index].value &&
+      index !== newVariables.length - 1
+    ) {
+      newVariables.splice(index, 1)
+    }
+
+    const updatedValue = newVariables.reduce(
+      (acc, { key, value }) => {
+        if (key || value) {
+          acc[key] = value
+        }
+        return acc
+      },
+      {} as Record<string, string>,
+    )
+
+    if (collection) {
+      const environments = {
+        ...collection['x-scalar-environments'],
+        [environment.name]: {
+          ...collection['x-scalar-environments']?.[environment.name],
+          variables: updatedValue,
+        },
+      }
+      await collectionMutators.edit(
+        collection.uid,
+        'x-scalar-environments',
+        environments,
+      )
+    }
+
+    if (index === localVariables.value.length - 1) {
+      const lastRow = newVariables[newVariables.length - 1]
+      if (lastRow && (lastRow.key || lastRow.value)) {
+        await addRow()
+      }
+    }
+
+    await nextTick()
+    localVariables.value = newVariables
+
+    // Update collection keys after successful update
+    if (field === 'key') {
+      collectionKeys.value = new Set(
+        newVariables.map((v) => v.key).filter(Boolean),
+      )
+      // Clear the typed key after successful update
+      tempKeys.value.delete(index)
+    }
+  } finally {
+    isUpdating.value = false
+  }
+}
+
+const addRow = async () => {
+  if (isUpdating.value) {
+    return
+  }
+  isUpdating.value = true
+
+  try {
+    const newVariables = [...localVariables.value, { key: '', value: '' }]
+    const updatedValue = newVariables.reduce(
+      (acc, { key, value }) => {
+        if (key || value) {
+          acc[key] = value
+        }
+        return acc
+      },
+      {} as Record<string, string>,
+    )
+
+    if (collection) {
+      const environments = {
+        ...collection['x-scalar-environments'],
+        [environment.name]: {
+          ...collection['x-scalar-environments']?.[environment.name],
+          variables: updatedValue,
+        },
+      }
+      await collectionMutators.edit(
+        collection.uid,
+        'x-scalar-environments',
+        environments,
+      )
+    }
+
+    await nextTick()
+    localVariables.value = newVariables
+  } finally {
+    isUpdating.value = false
+  }
+}
+
+const handleDeleteRow = async (index: number) => {
+  if (isUpdating.value) {
+    return
+  }
+  isUpdating.value = true
+
+  try {
+    const newVariables = [...localVariables.value]
+    newVariables.splice(index, 1)
+    const updatedValue = newVariables.reduce(
+      (acc, { key, value }) => {
+        if (key || value) {
+          acc[key] = value
+        }
+        return acc
+      },
+      {} as Record<string, string>,
+    )
+
+    if (collection) {
+      const environments = {
+        ...collection['x-scalar-environments'],
+        [environment.name]: {
+          ...collection['x-scalar-environments']?.[environment.name],
+          variables: updatedValue,
+        },
+      }
+      await collectionMutators.edit(
+        collection.uid,
+        'x-scalar-environments',
+        environments,
+      )
+    }
+
+    await nextTick()
+    localVariables.value = newVariables
+  } finally {
+    isUpdating.value = false
+  }
+}
+
+// Keep an empty row at the end of the table
+const defaultRow = async () => {
+  if (localVariables.value.length === 0) {
+    await addRow()
+  } else if (localVariables.value.length >= 1) {
+    const lastRow = localVariables.value[localVariables.value.length - 1]
+    if (lastRow && (lastRow.key || lastRow.value)) {
+      await addRow()
+    }
+  }
+}
+
+onMounted(() => {
+  defaultRow()
+})
+
+// Update the collection on local variables changes
+watch(
+  () => localVariables.value,
+  () => {
+    defaultRow()
+  },
+)
+</script>
+
+<template>
+  <DataTable
+    class="group/table flex-1"
+    :columns="['', '']">
+    <DataTableRow class="sr-only !block">
+      <DataTableHeader>Key</DataTableHeader>
+      <DataTableHeader>Value</DataTableHeader>
+    </DataTableRow>
+    <DataTableRow
+      v-for="(variable, index) in environmentVariables"
+      :key="index"
+      :class="{
+        error: getDuplicateKeyIndexes.includes(index),
+      }">
+      <DataTableCell>
+        <CodeInput
+          disableCloseBrackets
+          disableEnter
+          disableTabIndent
+          lineWrapping
+          :environment="environment"
+          :envVariables="envVariables"
+          :modelValue="variable.key"
+          placeholder="Key"
+          :workspace="workspace"
+          @update:modelValue="(v: string) => handleUpdateRow(index, 'key', v)">
+          <template
+            #icon
+            v-if="getDuplicateKeyIndexes.includes(index)">
+            <ScalarIconWarning
+              class="text-red mr-0.75 size-3.5 brightness-[.9]" />
+          </template>
+        </CodeInput>
+      </DataTableCell>
+      <DataTableCell>
+        <CodeInput
+          class="pr-6 group-hover:pr-10 group-has-[.cm-focused]:pr-10"
+          disableCloseBrackets
+          disableEnter
+          disableTabIndent
+          lineWrapping
+          :environment="environment"
+          :envVariables="envVariables"
+          :modelValue="variable.value"
+          placeholder="Value"
+          :workspace="workspace"
+          @update:modelValue="
+            (v: string) => handleUpdateRow(index, 'value', v)
+          ">
+          <template #icon>
+            <ScalarButton
+              v-if="variable.key || variable.value"
+              class="text-c-2 hover:text-c-1 hover:bg-b-2 z-context hidden h-fit rounded p-1 group-hover:flex group-has-[.cm-focused]:flex"
+              size="sm"
+              variant="ghost"
+              @click.stop="handleDeleteRow(index)">
+              <ScalarIconTrash class="size-3.5" />
+            </ScalarButton>
+          </template>
+        </CodeInput>
+      </DataTableCell>
+    </DataTableRow>
+  </DataTable>
+</template>
+
+<style scoped>
+:deep(.cm-editor) {
+  padding: 0;
+}
+:deep(.cm-content) {
+  align-items: center;
+  background-color: transparent;
+  display: flex;
+  font-family: var(--scalar-font);
+  font-size: var(--scalar-mini);
+  padding: 6px 8px;
+  width: 100%;
+}
+:deep(.cm-content):has(.cm-pill) {
+  padding: 6px 8px;
+}
+:deep(.cm-content .cm-pill:not(:last-of-type)) {
+  margin-right: 0.5px;
+}
+:deep(.cm-content .cm-pill:not(:first-of-type)) {
+  margin-left: 0.5px;
+}
+:deep(.cm-line) {
+  overflow: hidden;
+  padding: 0;
+  text-overflow: ellipsis;
+}
+</style>

--- a/packages/api-client/src/views/Environment/EnvironmentModal.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentModal.vue
@@ -78,6 +78,10 @@ watch(
 )
 
 const handleSubmit = () => {
+  if (!environmentName.value.trim()) {
+    toast('Please enter a name before adding an environment.', 'error')
+    return
+  }
   if (!selectedEnvironment.value?.id) {
     toast('Please select a collection before adding an environment.', 'error')
     return
@@ -105,7 +109,7 @@ const redirectToCreateCollection = () => {
     size="xs"
     :state="state">
     <CommandActionForm
-      :disabled="!selectedEnvironment"
+      :disabled="!selectedEnvironment || !environmentName.trim()"
       @cancel="emit('cancel')"
       @submit="handleSubmit">
       <div class="flex items-start gap-2">


### PR DESCRIPTION
**Solution**

this pr adds the collection environment page in order to allow user to set their environment variables directly from at the collection level.

| after |
|------|
| <img width="1465" alt="image" src="https://github.com/user-attachments/assets/3f95cb92-939a-4950-97ba-25b0833aa313" /> |

**Test**

<table>
<tbody>
<tr>
<td>
#
</td>
<td>
description
</td>
<td>preview</td>
</tr>
<tr>
<td valign="top">1</td>
<td valign="top" width="40%">Import <a href="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml">Scalar Galaxy Document</a></td>
<td ><img width="520" alt="image" src="https://github.com/user-attachments/assets/2395f7b3-4a54-4bf4-b725-c77aaf1b84be" /></td>
</tr>
<tr>
<td valign="top">2</td>
<td valign="top" width="40%">Select <code>Environment</code></td>
<td><img width="520" alt="image" src="https://github.com/user-attachments/assets/31073564-56c7-4ea8-b9d9-d9ea78eed13c" /></td>
</tr>
<tr>
<td valign="top">3</td>
<td valign="top" width="40%">Create an <code>Environment</code></td>
<td><img width="520" alt="image" src="https://github.com/user-attachments/assets/355b4712-753d-4e35-a466-a3b8728cb2a4" /></td>
</tr>
</tbody>
</table>

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
