### PR TITLE
fix(api-reference): improve handling of schema discriminators

### DIFF
--- a/.changeset/fast-feet-occur.md
+++ b/.changeset/fast-feet-occur.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): improve handling of schema discriminators

--- a/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
@@ -112,6 +112,55 @@ export const discriminatorsSchema = {
   },
 }
 
+export const complexArrayDiscriminatorSchema = {
+  component: Schema,
+  props: {
+    name: 'ComplexArrayDiscriminator',
+    noncollapsible: true,
+    value: {
+      allOf: [
+        {
+          'type': 'object',
+          'properties': {
+            'top-level-property': {
+              'type': 'string',
+            },
+          },
+        },
+        {
+          'type': 'object',
+          'properties': {
+            'top-level-array': {
+              'type': 'array',
+              'items': {
+                'type': 'object',
+                oneOf: [
+                  {
+                    name: 'Foo',
+                    type: 'object',
+                    properties: {
+                      type: { type: 'string', enum: ['foo'] },
+                      fooProperty: { type: 'string' },
+                    },
+                  },
+                  {
+                    name: 'Bar',
+                    type: 'object',
+                    properties: {
+                      type: { type: 'string', enum: ['bar'] },
+                      barProperty: { type: 'number' },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+}
+
 export const complexAllOfSchema = {
   component: Schema,
   props: {

--- a/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.preview.ts
@@ -90,24 +90,30 @@ export const discriminatorsSchema = {
     name: 'CustomDiscriminator',
     noncollapsible: true,
     value: {
-      anyOf: [
-        {
-          name: 'Foo',
+      type: 'object',
+      properties: {
+        foobar: {
           type: 'object',
-          properties: {
-            type: { type: 'string', enum: ['foo'] },
-            fooProperty: { type: 'string' },
-          },
+          anyOf: [
+            {
+              name: 'Foo',
+              type: 'object',
+              properties: {
+                type: { type: 'string', enum: ['foo'] },
+                fooProperty: { type: 'string' },
+              },
+            },
+            {
+              name: 'Bar',
+              type: 'object',
+              properties: {
+                type: { type: 'string', enum: ['bar'] },
+                barProperty: { type: 'number' },
+              },
+            },
+          ],
         },
-        {
-          name: 'Bar',
-          type: 'object',
-          properties: {
-            type: { type: 'string', enum: ['bar'] },
-            barProperty: { type: 'number' },
-          },
-        },
-      ],
+      },
     },
   },
 }

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -317,6 +317,11 @@ button.schema-card-title:hover {
   > .schema-properties {
   border: none;
 }
+.discriminator-panel
+  > .schema-card--level-0:not(.schema-card--compact)
+  > .schema-properties {
+  border: none;
+}
 :deep(.schema-card-description) p {
   font-size: var(--scalar-mini, var(--scalar-paragraph));
   color: var(--scalar-color-2);

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -210,6 +210,7 @@ const handleClick = (e: MouseEvent) =>
             <SchemaProperty
               :compact="compact"
               :hideHeading="hideHeading"
+              :level="level"
               :name="(value as OpenAPIV2.SchemaObject).name"
               :schemas="schemas"
               :value="value" />

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -312,7 +312,9 @@ button.schema-card-title:hover {
 .schema-properties-open > .schema-card-title--compact {
   position: static;
 }
-.schema-card--compact.schema-card--level-0 > .schema-properties {
+:not(.discriminator-panel)
+  > .schema-card--compact.schema-card--level-0
+  > .schema-properties {
   border: none;
 }
 :deep(.schema-card-description) p {

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.test.ts
@@ -21,7 +21,7 @@ describe('SchemaDiscriminator', () => {
         },
       })
 
-      const tab = wrapper.find('.schema-tab-label')
+      const tab = wrapper.find('.discriminator-selector-label')
       expect(tab.text()).toBe('One')
     })
 
@@ -41,7 +41,7 @@ describe('SchemaDiscriminator', () => {
         },
       })
 
-      const tab = wrapper.find('.schema-tab-label')
+      const tab = wrapper.find('.discriminator-selector-label')
       expect(tab.text()).toBe('Any')
     })
 
@@ -60,7 +60,7 @@ describe('SchemaDiscriminator', () => {
         },
       })
 
-      const tab = wrapper.find('.schema-tab-label')
+      const tab = wrapper.find('.discriminator-selector-label')
       expect(tab.text()).toBe('object')
     })
 
@@ -90,7 +90,7 @@ describe('SchemaDiscriminator', () => {
         },
       })
 
-      const tab = wrapper.find('.schema-tab-label')
+      const tab = wrapper.find('.discriminator-selector-label')
       expect(tab.text()).toBe('User')
     })
 
@@ -112,7 +112,7 @@ describe('SchemaDiscriminator', () => {
         },
       })
 
-      const tab = wrapper.find('.schema-tab-label')
+      const tab = wrapper.find('.discriminator-selector-label')
       expect(tab.text()).toBe('Array of string')
     })
   })

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -30,27 +30,6 @@ const { schemas, value, discriminator } = defineProps<{
 }>()
 
 const selectedIndex = ref(0)
-const tabsContainer = ref<HTMLElement | null>(null)
-const isOverflowing = ref(false)
-
-onMounted(async () => {
-  await nextTick()
-  // Check if the tabs container is overflowing
-  if (tabsContainer.value) {
-    const container = tabsContainer.value
-    isOverflowing.value = container.scrollWidth > container.clientWidth
-  }
-})
-
-const buttonVariants = cva({
-  base: 'schema-tab',
-  variants: {
-    selected: {
-      true: 'schema-tab-selected',
-      false: 'text-c-3',
-    },
-  },
-})
 
 const listboxOptions = computed(() =>
   value[discriminator].map((schema: any, index: number) => ({
@@ -125,71 +104,30 @@ const humanizeType = (type: string) => {
   <div class="property-rule">
     <template v-if="discriminator === 'oneOf' || discriminator === 'anyOf'">
       <!-- Tabs -->
-      <TabGroup
-        v-model="selectedIndex"
-        as="div">
-        <TabList
-          class="discriminator-tab-list py-1.25 flex flex-col gap-1 rounded-t-lg border border-b-0 px-2 pr-3">
-          <span class="text-c-3">{{ humanizeType(discriminator) }}</span>
-          <div
-            ref="tabsContainer"
-            class="flex items-center gap-1.5">
-            <template v-if="!isOverflowing">
-              <Tab
-                v-for="(schema, index) in value[discriminator]"
-                :key="index"
-                :class="
-                  cx(buttonVariants({ selected: selectedIndex === index }))
-                "
-                @click="selectedIndex = index">
-                <span class="schema-tab-label z-1 relative">
-                  {{ getModelNameFromSchema(schema) || 'Schema' }}
-                </span>
-              </Tab>
-            </template>
-            <template v-else>
-              <ScalarListbox
-                v-model="selectedOption"
-                :options="listboxOptions"
-                resize>
-                <div
-                  class="flex cursor-pointer items-center gap-1"
-                  :class="cx(buttonVariants({ selected: true }))">
-                  <span class="schema-tab-label z-1 text-c-1 relative">
-                    {{ selectedOption?.label || 'Schema' }}
-                  </span>
-                  <ScalarIconCaretDown class="z-1" />
-                </div>
-              </ScalarListbox>
-            </template>
-          </div>
-        </TabList>
-        <template v-if="!isOverflowing">
-          <TabPanel
-            v-for="(schema, index) in value[discriminator]"
-            :key="index"
-            class="discriminator-panel">
-            <Schema
-              :compact="compact"
-              :hideHeading="hideHeading"
-              :name="name"
-              :noncollapsible="true"
-              :schemas="schemas"
-              :value="schema" />
-          </TabPanel>
-        </template>
-        <template v-else>
-          <TabPanel class="discriminator-panel">
-            <Schema
-              :compact="compact"
-              :hideHeading="hideHeading"
-              :name="name"
-              :noncollapsible="true"
-              :schemas="schemas"
-              :value="value[discriminator][selectedIndex]" />
-          </TabPanel>
-        </template>
-      </TabGroup>
+      <ScalarListbox
+        v-model="selectedOption"
+        :options="listboxOptions"
+        resize>
+        <button
+          class="discriminator-selector bg-b-1.5 hover:bg-b-2 py-1.25 flex cursor-pointer gap-1 rounded-t-lg border border-b-0 px-2 pr-3 text-left"
+          type="button">
+          <span class="text-c-2">{{ humanizeType(discriminator) }}</span>
+          <span class="schema-tab-label text-c-1 relative">
+            {{ selectedOption?.label || 'Schema' }}
+          </span>
+          <ScalarIconCaretDown class="z-1" />
+        </button>
+      </ScalarListbox>
+      <div class="discriminator-panel">
+        <Schema
+          :compact="compact"
+          :level="level"
+          :hideHeading="hideHeading"
+          :name="name"
+          :noncollapsible="true"
+          :schemas="schemas"
+          :value="value[discriminator][selectedIndex]" />
+      </div>
     </template>
     <template v-else>
       <Schema
@@ -203,11 +141,6 @@ const humanizeType = (type: string) => {
   </div>
 </template>
 <style scoped>
-.discriminator-panel:has(.property--compact) {
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
-  border-bottom-left-radius: var(--scalar-radius-lg);
-  border-bottom-right-radius: var(--scalar-radius-lg);
-}
 .discriminator-panel :deep(.schema-properties .schema-properties-open) {
   border-top-left-radius: 0;
   border-top-right-radius: 0;

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -112,7 +112,7 @@ const humanizeType = (type: string) => {
           class="discriminator-selector bg-b-1.5 hover:bg-b-2 py-1.25 flex cursor-pointer gap-1 rounded-t-lg border border-b-0 px-2 pr-3 text-left"
           type="button">
           <span class="text-c-2">{{ humanizeType(discriminator) }}</span>
-          <span class="schema-tab-label text-c-1 relative">
+          <span class="discriminator-selector-label text-c-1 relative">
             {{ selectedOption?.label || 'Schema' }}
           </span>
           <ScalarIconCaretDown class="z-1" />
@@ -140,55 +140,3 @@ const humanizeType = (type: string) => {
     </template>
   </div>
 </template>
-<style scoped>
-.discriminator-panel :deep(.schema-properties .schema-properties-open) {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-.discriminator-panel :deep(.property--level-0),
-.discriminator-panel :deep(.property--compact.property--level-1) {
-  padding: 8px;
-}
-.discriminator-panel
-  :deep(.property--compact.property--level-0):not(:has(.property--level-1)) {
-  padding: 8px;
-}
-.discriminator-panel :deep(.property--compact.property--level-0) {
-  padding: 0;
-}
-.schema-tab {
-  background: none;
-  border: none;
-  font-size: var(--scalar-mini);
-  font-family: var(--scalar-font);
-  color: var(--scalar-color-2);
-  font-weight: var(--scalar-semibold);
-  line-height: calc(var(--scalar-mini) + 2px);
-  white-space: nowrap;
-  cursor: pointer;
-  padding: 0;
-  position: relative;
-  line-height: 1.35;
-  position: relative;
-}
-.schema-tab:before {
-  content: '';
-  position: absolute;
-  z-index: 0;
-  left: -4px;
-  top: -4px;
-  width: calc(100% + 8px);
-  height: calc(100% + 8px);
-  border-radius: var(--scalar-radius);
-  background: var(--scalar-background-2);
-  opacity: 0;
-}
-.schema-tab:hover:before {
-  opacity: 1;
-}
-.schema-tab-selected:not([aria-haspopup='listbox']) {
-  color: var(--scalar-color-1);
-  text-decoration: underline;
-  text-underline-offset: 8px;
-}
-</style>

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -300,4 +300,34 @@ describe('SchemaProperty sub-schema', () => {
     const foobar = wrapper.html().match(/foobar/g)
     expect(foobar).toHaveLength(1)
   })
+
+  it('renders discriminators for object of array items', async () => {
+    const wrapper = mount(SchemaProperty, {
+      props: {
+        value: {
+          type: 'array',
+          items: {
+            type: 'object',
+            oneOf: [
+              {
+                description: 'foobar',
+                properties: { test: { type: 'string' } },
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    // Check that the discriminator is not rendered
+    expect(wrapper.html().match(/foobar/g)).toBeNull()
+    expect(wrapper.find('button[aria-expanded="false"]').exists()).toBe(true)
+
+    // Open the schema card
+    await wrapper.find('.schema-card-title').trigger('click')
+
+    // Find 'foobar' only once
+    const foobar = wrapper.html().match(/foobar/g)
+    expect(foobar).toHaveLength(1)
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -312,7 +312,8 @@ const displayPropertyHeading = (
         v-else-if="
           optimizedValue?.items &&
           typeof discriminator === 'string' &&
-          typeof optimizedValue.items !== 'object' &&
+          typeof optimizedValue.items === 'object' &&
+          !('type' in optimizedValue.items) &&
           discriminator in optimizedValue.items
         ">
         <SchemaDiscriminator

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -406,18 +406,18 @@ const displayPropertyHeading = (
   border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 .property-rule,
-.property-rule:has(> .discriminator-tab-list)
+.property-rule:has(> .discriminator-selector)
   :deep(.property-rule .schema-properties.schema-properties-open) {
   border-radius: var(--scalar-radius-lg);
   display: flex;
   flex-direction: column;
 }
-.property-rule:has(.discriminator-tab-list)
+.property-rule:has(.discriminator-selector)
   :deep(.schema-card .schema-properties.schema-properties-open) {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
-.property-rule:has(.discriminator-tab-list)
+.property-rule:has(.discriminator-selector)
   :deep(.children .schema-card .schema-properties.schema-properties-open) {
   border-top-left-radius: var(--scalar-radius-lg);
   border-top-right-radius: var(--scalar-radius-lg);

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -312,7 +312,7 @@ const displayPropertyHeading = (
         v-else-if="
           optimizedValue?.items &&
           typeof discriminator === 'string' &&
-          typeof optimizedValue.items === 'object' &&
+          typeof optimizedValue.items !== 'object' &&
           discriminator in optimizedValue.items
         ">
         <SchemaDiscriminator
@@ -405,22 +405,17 @@ const displayPropertyHeading = (
   padding: 6px;
   border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
-.property-rule,
-.property-rule:has(> .discriminator-selector)
-  :deep(.property-rule .schema-properties.schema-properties-open) {
+.property-rule {
   border-radius: var(--scalar-radius-lg);
   display: flex;
   flex-direction: column;
 }
-.property-rule:has(.discriminator-selector)
-  :deep(.schema-card .schema-properties.schema-properties-open) {
+.property-rule
+  :deep(
+    .discriminator-panel .schema-card .schema-properties.schema-properties-open
+  ) {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
-}
-.property-rule:has(.discriminator-selector)
-  :deep(.children .schema-card .schema-properties.schema-properties-open) {
-  border-top-left-radius: var(--scalar-radius-lg);
-  border-top-right-radius: var(--scalar-radius-lg);
 }
 .property-enum-value {
   color: var(--scalar-color-3);

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -350,11 +350,15 @@ const displayPropertyHeading = (
 .property--compact.property--level-1 {
   padding: 8px 0;
 }
+.discriminator-panel .property.property.property.property--level-0 {
+  padding: 0px;
+}
 .property--compact.property--level-0
   .discriminator-panel
   .property--compact.property--level-1 {
   padding: 8px;
 }
+
 /*  if a property doesn't have a heading, remove the top padding */
 .property:has(> .property-rule:nth-of-type(1)):not(.property--compact) {
   padding-top: 8px;

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -350,6 +350,11 @@ const displayPropertyHeading = (
 .property--compact.property--level-1 {
   padding: 8px 0;
 }
+.property--compact.property--level-0
+  .discriminator-panel
+  .property--compact.property--level-1 {
+  padding: 8px;
+}
 /*  if a property doesn't have a heading, remove the top padding */
 .property:has(> .property-rule:nth-of-type(1)):not(.property--compact) {
   padding-top: 8px;


### PR DESCRIPTION
Fixes some issues with the schema discriminators and updates the UX to always render a dropdown (based on @cameronrohani's suggestion).

Most of the issues seem to be coming from whether or not a `type` is set at the top level for a `oneOf` (or similar) discriminator. I did my best to do what I considered a reasonable job of rendering the content with or without a type set but it's very possible we'll want to tweak it in the future based on folks actual usage.

## Before / After with a mock schema

(Renders the discriminator block twice)

![Google Chrome-2025-05-09-17-03-17@2x](https://github.com/user-attachments/assets/98263295-cd31-4d9a-b29b-3be3f57f1bfb)

![Google Chrome-2025-05-09-17-18-33@2x](https://github.com/user-attachments/assets/6aecef40-fe72-46b8-8237-10d82d6af9bc)

## Before / After with a complex real world schema

https://github.com/user-attachments/assets/21858e3f-44ee-4855-abfa-027881fe2d42

https://github.com/user-attachments/assets/b34b1332-be75-4fb2-ad4d-5b662b002474


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
