### PR TITLE
docs(nuxt): fix typos in README

### DIFF
--- a/integrations/nuxt/README.md
+++ b/integrations/nuxt/README.md
@@ -46,7 +46,7 @@ export default defineNuxtConfig({
 })
 ```
 
-By default the docs will be hosted at `/docs` but you an easily customize that, here's a more in
+By default the docs will be hosted at `/docs` but you can easily customize that, here's a more in
 depth config example.
 
 ```ts
@@ -54,7 +54,7 @@ export default defineNuxtConfig({
   modules: ['@scalar/nuxt'],
   scalar: {
     darkMode: true,
-    hideModals: false,
+    hideModels: false,
     hideDownloadButton: false,
     metaData: {
       title: 'API Documentation by Scalar',


### PR DESCRIPTION
Caught a couple of typos while reading the readme