### PR TITLE
fix(api-reference): property heading null and empty value

### DIFF
--- a/.changeset/six-rice-rest.md
+++ b/.changeset/six-rice-rest.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: displays null and empty default value in property heading

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -138,4 +138,32 @@ describe('SchemaPropertyHeading', () => {
     const detailsElement = wrapper.find('.property-heading')
     expect(detailsElement.text()).toContain('array Model[]')
   })
+
+  it('renders default value: null', async () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'string',
+          default: null,
+        },
+      },
+    })
+    const defaultValueElement = wrapper.find('.property-heading')
+    expect(defaultValueElement.text()).toContain('default:')
+    expect(defaultValueElement.text()).toContain('null')
+  })
+
+  it('renders default value: empty string', async () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'string',
+          default: '',
+        },
+      },
+    })
+    const defaultValueElement = wrapper.find('.property-heading')
+    expect(defaultValueElement.text()).toContain('default:')
+    expect(defaultValueElement.text()).toContain('""')
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -46,9 +46,19 @@ const discriminatorType = discriminators.find((r) => {
 })
 
 const flattenDefaultValue = (value: Record<string, any>) => {
-  return Array.isArray(value?.default) && value.default.length === 1
-    ? value.default[0]
-    : value?.default
+  if (value?.default === null) {
+    return 'null'
+  }
+
+  if (Array.isArray(value?.default) && value.default.length === 1) {
+    return value.default[0]
+  }
+
+  if (typeof value?.default === 'string') {
+    return JSON.stringify(value.default)
+  }
+
+  return value?.default
 }
 
 // Get model name from schema


### PR DESCRIPTION
**Problem**

currently setting `null` of an empty value doesn't get displayed in api reference property heading.

**Solution**

this pr displays `null` or empty value set in property heading.

| before | after |
| -------|------|
| <img width="559" alt="image" src="https://github.com/user-attachments/assets/737cb213-1976-40ff-8a8b-4cb24e14033c" /> | <img width="559" alt="image" src="https://github.com/user-attachments/assets/52ce1090-3d6f-4479-92fd-d6116e4513a9" /> |
| null value doesn't get rendered | null value get rendered | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
