### PR TITLE
feat(api-client): add fallback handling for +json MIME types

### DIFF
--- a/.changeset/funny-toys-peel.md
+++ b/.changeset/funny-toys-peel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: support fallback for +json MIME types

--- a/packages/api-client/src/libs/send-request/decode-buffer.ts
+++ b/packages/api-client/src/libs/send-request/decode-buffer.ts
@@ -1,4 +1,4 @@
-import { textMediaTypes } from '@/views/Request/consts'
+import { isTextMediaType } from '@/views/Request/consts'
 import MimeTypeParser from 'whatwg-mimetype'
 
 // TODO: This should return `unknown` to acknowledge we don’t know type, shouldn’t it?
@@ -6,7 +6,7 @@ import MimeTypeParser from 'whatwg-mimetype'
 export function decodeBuffer(buffer: ArrayBuffer, contentType: string) {
   const mimeType = new MimeTypeParser(contentType)
 
-  if (textMediaTypes.includes(mimeType.essence)) {
+  if (isTextMediaType(mimeType.essence)) {
     const decoder = new TextDecoder(mimeType.parameters.get('charset'))
     const string = decoder.decode(buffer)
 

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -3,7 +3,7 @@ import { computed, ref, toRef } from 'vue'
 
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import { useResponseBody } from '@/hooks/useResponseBody'
-import { mediaTypes } from '@/views/Request/consts'
+import { getMediaTypeConfig } from '@/views/Request/consts'
 
 import ResponseBodyDownload from './ResponseBodyDownload.vue'
 import ResponseBodyInfo from './ResponseBodyInfo.vue'
@@ -33,7 +33,7 @@ const { mimeType, attachmentFilename, dataUrl } = useResponseBody({
   headers: toRef(props, 'headers'),
 })
 
-const mediaConfig = computed(() => mediaTypes[mimeType.value.essence])
+const mediaConfig = computed(() => getMediaTypeConfig(mimeType.value.essence))
 </script>
 <template>
   <ViewLayoutCollapse

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
@@ -2,7 +2,7 @@
 import { ScalarIcon } from '@scalar/components'
 import { computed } from 'vue'
 
-import { mediaTypes } from '@/views/Request/consts'
+import { getMediaTypeConfig } from '@/views/Request/consts'
 
 const props = defineProps<{
   href: string
@@ -11,7 +11,8 @@ const props = defineProps<{
 }>()
 
 const filenameExtension = computed(() => {
-  const extension = mediaTypes[props.type ?? '']?.extension ?? '.unknown'
+  const extension =
+    getMediaTypeConfig(props.type ?? '')?.extension ?? '.unknown'
   return props.filename ? props.filename : `response${extension}`
 })
 </script>

--- a/packages/api-client/src/views/Request/consts/mediaTypes.test.ts
+++ b/packages/api-client/src/views/Request/consts/mediaTypes.test.ts
@@ -1,0 +1,61 @@
+import { getMediaTypeConfig, isTextMediaType } from './mediaTypes'
+import { describe, it, expect } from 'vitest'
+
+describe('mediaTypes', () => {
+  const cases = [
+    {
+      type: 'application/json',
+      config: {
+        extension: '.json',
+        raw: true,
+        language: 'json',
+      },
+    },
+    {
+      type: 'application/fhir+json',
+      config: {
+        extension: '.json',
+        raw: true,
+        language: 'json',
+      },
+    },
+    {
+      type: 'application/ld+json',
+      config: {
+        extension: '.jsonld',
+        raw: true,
+        language: 'json',
+      },
+    },
+    {
+      type: 'image/jpeg',
+      config: {
+        extension: '.jpg',
+        preview: 'image',
+      },
+    },
+    {
+      type: 'application/yaml',
+      config: {
+        extension: '.yaml',
+        raw: true,
+        language: 'yaml',
+      },
+    },
+  ]
+
+  it.each(cases)('should return the correct config for $type', ({ type, config }) => {
+    const result = getMediaTypeConfig(type)
+    expect(result).toStrictEqual(config)
+  })
+
+  it('isTextMediaType', () => {
+    expect(isTextMediaType('application/json')).toBe(true)
+    expect(isTextMediaType('application/ld+json')).toBe(true)
+    expect(isTextMediaType('application/fhir+json')).toBe(true)
+    expect(isTextMediaType('text/plain')).toBe(true)
+    expect(isTextMediaType('image/jpeg')).toBe(false)
+    expect(isTextMediaType('application/octet-stream')).toBe(false)
+    expect(isTextMediaType('application/xml')).toBe(true)
+  })
+})

--- a/packages/api-client/src/views/Request/consts/mediaTypes.ts
+++ b/packages/api-client/src/views/Request/consts/mediaTypes.ts
@@ -127,3 +127,27 @@ export const mediaTypes: { [type: string]: MediaConfig | undefined } = {
 export const textMediaTypes: string[] = Object.entries(mediaTypes)
   .filter(([, config]) => config?.raw)
   .map(([type]) => type)
+
+/** Get the config for a media type */
+export function getMediaTypeConfig(type: string): MediaConfig | undefined {
+  const config = mediaTypes[type]
+  if (config) {
+    return config
+  }
+
+  // Fallback for +json types
+  if (type.endsWith('+json')) {
+    return {
+      extension: '.json',
+      raw: true,
+      language: 'json',
+    }
+  }
+
+  return undefined
+}
+
+/** Check if a media type that can be displayed as raw text */
+export function isTextMediaType(type: string): boolean {
+  return !!getMediaTypeConfig(type)?.raw
+}


### PR DESCRIPTION
This PR introduces fallback support for MIME types that end in `+json`, which are not explicitly listed in the `mediaTypes` map. These types now correctly return a default JSON configuration via the `getMediaTypeConfig` function.

closes #5586 
