### PR TITLE
fix(api-reference): render required for request body

### DIFF
--- a/.changeset/sweet-kings-sort.md
+++ b/.changeset/sweet-kings-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): render required for request body

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -62,8 +62,15 @@ const partitionedSchema = computed(() => {
 </script>
 <template>
   <div v-if="requestBody">
-    <div class="request-body-title">
-      <slot name="title" />
+    <div class="request-body-header">
+      <span class="request-body-title">
+        <slot name="title" />
+        <div
+          v-if="requestBody.required"
+          class="request-body-required">
+          required
+        </div>
+      </span>
       <ContentTypeSelect
         :defaultValue="selectedContentType"
         :requestBody="requestBody"
@@ -111,74 +118,27 @@ const partitionedSchema = computed(() => {
 </template>
 
 <style scoped>
-.request-body-title {
+.request-body-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: var(--scalar-font-size-2);
-  font-weight: var(--scalar-semibold);
-  color: var(--scalar-color-1);
   margin-top: 24px;
   padding-bottom: 12px;
   border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
   flex-flow: wrap;
 }
-.request-body-title-select {
-  position: relative;
-  height: fit-content;
-  margin-left: auto;
-  font-weight: var(--scalar-regular);
+.request-body-title {
   display: flex;
   align-items: center;
-  color: var(--scalar-color-3);
-  font-size: var(--scalar-micro);
-  background: var(--scalar-background-2);
-  padding: 2px 6px;
-  border-radius: 12px;
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
-}
-
-.request-body-title-no-select.request-body-title-select {
-  pointer-events: none;
-}
-.request-body-title-no-select {
-  border: none;
-}
-.request-body-title-no-select.request-body-title-select:after {
-  display: none;
-}
-.request-body-title-select span {
-  display: flex;
-  align-items: center;
-}
-.request-body-title-select:after {
-  content: '';
-  width: 6px;
-  height: 6px;
-  transform: rotate(45deg) translate3d(0, -3px, 0);
-  display: block;
-  margin-left: 6px;
-  box-shadow: 1px 1px 0 currentColor;
-  margin-right: 5px;
-}
-.request-body-title-select select {
-  border: none;
-  outline: none;
-  cursor: pointer;
-  background: var(--scalar-background-3);
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  appearance: none;
-}
-.request-body-title-select:hover {
+  gap: 8px;
+  font-size: var(--scalar-font-size-2);
+  font-weight: var(--scalar-semibold);
   color: var(--scalar-color-1);
 }
-.request-body-title-select:has(select:focus-visible) {
-  outline: 1px solid var(--scalar-color-accent);
+.request-body-required {
+  font-size: var(--scalar-micro);
+  color: var(--scalar-color-orange);
+  font-weight: normal;
 }
 .request-body-description {
   margin-top: 6px;
@@ -187,11 +147,5 @@ const partitionedSchema = computed(() => {
 }
 .request-body-description :deep(.markdown) * {
   color: var(--scalar-color-2) !important;
-}
-@media (max-width: 460px) {
-  .request-body-title-select {
-    margin-left: auto;
-    padding-right: 3px;
-  }
 }
 </style>

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -306,9 +306,4 @@ const title = computed(() => operation.summary || operation.path)
   padding: 9px;
   margin: 0;
 }
-.operation-details-card :deep(.request-body-title-select) {
-  text-transform: initial;
-  font-weight: initial;
-  margin-left: auto;
-}
 </style>


### PR DESCRIPTION
Turns out you can make the [entire request body required](https://swagger.io/docs/specification/v3_0/describing-request-body/describing-request-body/#:~:text=Request%20bodies%20are%20optional,1) but we weren't rendering that info in the docs.

Before / After:

![Google Chrome-2025-05-12-22-27-08@2x](https://github.com/user-attachments/assets/203306ae-59ea-493c-b9e5-a68457423693)
![Google Chrome-2025-05-12-22-23-04@2x](https://github.com/user-attachments/assets/a797877b-c6be-45a1-ac29-3b5a699e7ea3)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
