### PR TITLE
fix(api-reference): handle really long property titles

### DIFF
--- a/.changeset/spotty-chefs-pay.md
+++ b/.changeset/spotty-chefs-pay.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): handle really long property titles

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -243,7 +243,9 @@ const getModelNameFromSchema = (schema: OpenAPI.Document): string | null => {
   font-family: var(--scalar-font-code);
   font-weight: var(--scalar-semibold);
   font-size: var(--scalar-font-size-3);
-  display: flex;
+  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 .property-additional {


### PR DESCRIPTION
Wraps really long property titles so they don't overflow their box.

Before / After:

![Google Chrome-2025-05-12-23-44-20@2x](https://github.com/user-attachments/assets/9a6ae6a6-db96-40b8-9079-ec1287d3fa5b)

![Google Chrome-2025-05-12-23-39-48@2x](https://github.com/user-attachments/assets/4bf022de-1e5c-4a72-b9b5-0c84ead82a43)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
