### PR TITLE
feat(api-reference): show responses schema in the list

### DIFF
--- a/.changeset/fifty-ducks-carry.md
+++ b/.changeset/fifty-ducks-carry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: show response schema in the response list

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -51,7 +51,9 @@ if (props.parameter.content) {
 const shouldCollapse = computed<boolean>(() => {
   return !!(
     props.collapsableItems &&
-    (props.parameter.content || props.parameter.headers)
+    (props.parameter.content ||
+      props.parameter.headers ||
+      props.parameter.schema)
   )
 })
 

--- a/packages/api-reference/src/features/Operation/hooks/useResponses.ts
+++ b/packages/api-reference/src/features/Operation/hooks/useResponses.ts
@@ -18,6 +18,7 @@ export function useResponses(operation: TransformedOperation) {
       description: string
       content: RequestBodyMimeTypes
       headers?: { [key: string]: OpenAPI.HeaderObject }
+      schema?: OpenAPI.SchemaObject
     }[] = []
 
     if (!responses) {
@@ -30,6 +31,7 @@ export function useResponses(operation: TransformedOperation) {
         description: response.description,
         content: response.content,
         headers: response.headers,
+        schema: response.schema,
       })
     })
 


### PR DESCRIPTION
**Problem**

If a Swagger 2.0 document has a schema attached to a response, it’s not rendered in the response list:

<img width="576" alt="Screenshot 2025-05-13 at 13 55 23" src="https://github.com/user-attachments/assets/0dac686a-42b6-4145-a932-fe21989b2529" />

**Solution**

Note: OpenAPI 3.x document have a different structure, but until we have an upgraded document here, we can just pass the schema attribute. Easy patch.

With this PR, we’re showing the schema in the list:

<img width="574" alt="Screenshot 2025-05-13 at 13 56 00" src="https://github.com/user-attachments/assets/c0e18cf0-5085-43c9-a55a-a61fa8cc806a" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
