### PR TITLE
fix(components): set search result item to use an anchor tag

### DIFF
--- a/.changeset/quick-wombats-fly.md
+++ b/.changeset/quick-wombats-fly.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): set search result item to use an anchor tag

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -12,9 +12,10 @@ defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
 </script>
 <template>
-  <li
+  <a
     :aria-selected="selected"
     role="option"
+    tabindex="-1"
     v-bind="
       cx(
         'group flex cursor-pointer gap-2.5 rounded px-3 py-1.5 no-underline hover:bg-b-2',
@@ -52,5 +53,5 @@ const { cx } = useBindCx()
         <slot name="description" />
       </div>
     </div>
-  </li>
+  </a>
 </template>

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultList.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultList.vue
@@ -9,7 +9,7 @@ defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
 </script>
 <template>
-  <ul
+  <div
     role="listbox"
     v-bind="cx('flex flex-col')">
     <slot
@@ -25,5 +25,5 @@ const { cx } = useBindCx()
       </div>
     </slot>
     <slot />
-  </ul>
+  </div>
 </template>


### PR DESCRIPTION
Semantically it makes more sense for this to be an `<a>` tag and we're managing the aria semantics already with the `role="option"`.

Fixes #5589

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
