### PR TITLE
fix(api-reference): restrict mobile header width

### DIFF
--- a/.changeset/rotten-paws-buy.md
+++ b/.changeset/rotten-paws-buy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): restrict mobile header width

--- a/packages/api-reference/src/components/MobileHeader.vue
+++ b/packages/api-reference/src/components/MobileHeader.vue
@@ -31,7 +31,7 @@ const { breadcrumb } = useSidebar()
   display: none;
   align-items: center;
   height: 100%;
-  width: 100%;
+  width: 100dvw;
   padding: 0 8px;
   background: var(--scalar-background-1);
   border-bottom: 1px solid var(--scalar-border-color);


### PR DESCRIPTION
We had the truncation set up but the mobile header width wasn't being restricted properly

Before / After:

![Google Chrome-2025-05-13-17-40-57@2x](https://github.com/user-attachments/assets/dbf28084-342b-49f5-8e3b-218b1bd7f88d)
![Google Chrome-2025-05-13-17-37-07@2x](https://github.com/user-attachments/assets/062cb883-bf3a-49d0-8bb9-c80d72abf7ab)


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
