### PR TITLE
fix(api-reference): all of schema max depth merging

### DIFF
--- a/.changeset/violet-pets-work.md
+++ b/.changeset/violet-pets-work.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: adds max depth to merge all of schemas

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -3,15 +3,21 @@ import type { OpenAPI } from '@scalar/openapi-types'
 type SchemaObject = OpenAPI.SchemaObject
 
 /**
+ * This is a temporary limit to prevent infinite recursion
+ * Incoming new store will replace that approach
+ */
+const MAX_DEPTH = 20
+
+/**
  * Merges multiple OpenAPI schema objects into a single schema object.
  * Handles nested allOf compositions and merges properties recursively.
  *
  * @param schemas - Array of OpenAPI schema objects to merge
  * @returns Merged schema object
  */
-export function mergeAllOfSchemas(schemas: SchemaObject[]): SchemaObject {
-  // Handle empty or invalid input
-  if (!Array.isArray(schemas) || schemas.length === 0) {
+export function mergeAllOfSchemas(schemas: SchemaObject[], depth = 0): SchemaObject {
+  // Handle max depth, empty or invalid input
+  if (depth >= MAX_DEPTH || !Array.isArray(schemas) || schemas.length === 0) {
     return {}
   }
 
@@ -23,38 +29,46 @@ export function mergeAllOfSchemas(schemas: SchemaObject[]): SchemaObject {
 
     // Handle nested allOf case first
     if (schema.allOf) {
-      const mergedNestedSchema = mergeAllOfSchemas(schema.allOf as SchemaObject[])
-      return mergeAllOfSchemas([result, mergedNestedSchema])
+      const mergedNestedSchema = mergeAllOfSchemas(schema.allOf as SchemaObject[], depth + 1)
+      return mergeAllOfSchemas([result, mergedNestedSchema], depth + 1)
     }
 
     const mergedResult = typeof result === 'object' ? { ...result } : {}
 
     // Merge properties if they exist
     if (schema.properties) {
-      mergedResult.properties = mergeProperties(mergedResult.properties || {}, schema.properties)
+      mergedResult.properties = mergeProperties(mergedResult.properties || {}, schema.properties, depth + 1)
     }
 
     // Handle items property
     if (schema.items) {
       if (schema.type === 'array') {
-        mergedResult.items = mergeArrayItems(mergedResult.items || {}, schema.items)
+        mergedResult.items = mergeArrayItems(mergedResult.items || {}, schema.items, depth + 1)
       }
       // Special case for objects with items.allOf
       else if (schema.type === 'object' && schema.items.allOf) {
-        const mergedItems = mergeAllOfSchemas(schema.items.allOf)
-        mergedResult.properties = mergeProperties(mergedResult.properties || {}, mergedItems.properties || {})
+        const mergedItems = mergeAllOfSchemas(schema.items.allOf, depth + 1)
+        mergedResult.properties = mergeProperties(
+          mergedResult.properties || {},
+          mergedItems.properties || {},
+          depth + 1,
+        )
       }
     }
 
     // Merge other schema attributes
-    return mergeSchemaAttributes(mergedResult, schema)
+    return mergeSchemaAttributes(mergedResult, schema, depth + 1)
   }, {})
 }
 
 /**
  * Merges two sets of schema properties recursively
  */
-function mergeProperties(existingProps: SchemaObject, newProps: SchemaObject): SchemaObject {
+function mergeProperties(existingProps: SchemaObject, newProps: SchemaObject, depth = 0): SchemaObject {
+  if (depth >= MAX_DEPTH) {
+    return existingProps
+  }
+
   const merged = typeof existingProps === 'object' ? { ...existingProps } : {}
 
   Object.entries(newProps).forEach(([key, value]) => {
@@ -68,11 +82,11 @@ function mergeProperties(existingProps: SchemaObject, newProps: SchemaObject): S
       if (value.type === 'array' && value.items?.allOf) {
         merged[key] = {
           ...value,
-          items: mergeAllOfSchemas(value.items.allOf),
+          items: mergeAllOfSchemas(value.items.allOf, depth + 1),
         }
       } else if (value.allOf) {
         // Handle direct allOf in property
-        merged[key] = mergeAllOfSchemas(value.allOf)
+        merged[key] = mergeAllOfSchemas(value.allOf, depth + 1)
       } else {
         merged[key] = value
       }
@@ -82,19 +96,19 @@ function mergeProperties(existingProps: SchemaObject, newProps: SchemaObject): S
     // Merge existing property with new value
     if (value.allOf) {
       // If the new value has allOf, merge it with the existing property
-      merged[key] = mergeAllOfSchemas([merged[key], ...value.allOf])
+      merged[key] = mergeAllOfSchemas([merged[key], ...value.allOf], depth + 1)
     } else if (value.type === 'array' && value.items) {
       // Handle array type properties
       merged[key] = {
         ...merged[key],
         type: 'array',
-        items: mergeArrayItems(merged[key].items || {}, value.items),
+        items: mergeArrayItems(merged[key].items || {}, value.items, depth + 1),
       }
     } else {
       // For regular objects, merge properties recursively first
       const mergedProperties =
         merged[key].properties || value.properties
-          ? mergeProperties(merged[key].properties || {}, value.properties || {})
+          ? mergeProperties(merged[key].properties || {}, value.properties || {}, depth + 1)
           : undefined
 
       merged[key] = {
@@ -115,11 +129,15 @@ function mergeProperties(existingProps: SchemaObject, newProps: SchemaObject): S
 /**
  * Merges array items schemas
  */
-function mergeArrayItems(existing: Record<string, any>, incoming: Record<string, any>): Record<string, any> {
+function mergeArrayItems(existing: Record<string, any>, incoming: Record<string, any>, depth = 0): Record<string, any> {
+  if (depth >= MAX_DEPTH) {
+    return existing
+  }
+
   // Handle allOf in either schema
   if (existing.allOf || incoming.allOf) {
     const allOfSchemas = [...(existing.allOf || [existing]), ...(incoming.allOf || [incoming])]
-    return mergeAllOfSchemas(allOfSchemas)
+    return mergeAllOfSchemas(allOfSchemas, depth + 1)
   }
 
   // Regular merge for non-allOf items
@@ -130,7 +148,7 @@ function mergeArrayItems(existing: Record<string, any>, incoming: Record<string,
 
   // Recursively merge properties
   if (merged.properties || incoming.properties) {
-    merged.properties = mergeProperties(merged.properties || {}, incoming.properties || {})
+    merged.properties = mergeProperties(merged.properties || {}, incoming.properties || {}, depth + 1)
   }
 
   return merged
@@ -139,7 +157,11 @@ function mergeArrayItems(existing: Record<string, any>, incoming: Record<string,
 /**
  * Merges non-property schema attributes
  */
-const mergeSchemaAttributes = (target: SchemaObject, source: SchemaObject): SchemaObject => {
+const mergeSchemaAttributes = (target: SchemaObject, source: SchemaObject, depth = 0): SchemaObject => {
+  if (depth >= MAX_DEPTH) {
+    return target
+  }
+
   const merged = typeof target === 'object' ? { ...target } : {}
 
   // Merge required fields
@@ -163,7 +185,7 @@ const mergeSchemaAttributes = (target: SchemaObject, source: SchemaObject): Sche
     if (options) {
       options.forEach((option: SchemaObject) => {
         if (option.properties) {
-          merged.properties = mergeProperties(merged.properties || {}, option.properties)
+          merged.properties = mergeProperties(merged.properties || {}, option.properties, depth + 1)
         }
       })
     }


### PR DESCRIPTION
**Problem**

currently when having an infinite all of ref usage, the maximum call stack size exceeded error is thrown.

**Solution**

this pr sets a max depth to the number of all of schema merge capacity to prevent the error and maintain the properties getting displayed and fixes #5628.

| before | after |
| -------|------|
| <img width="1177" alt="image" src="https://github.com/user-attachments/assets/3cd09dbe-a067-45b2-a301-41cce37555e8" /> | <img width="1177" alt="image" src="https://github.com/user-attachments/assets/0a2dc60d-b002-4b7a-b400-b958388b2949" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
