### PR TITLE
perf(nuxt): replace $fetch with useFetch in component script setup

### DIFF
--- a/.changeset/thin-flowers-fold.md
+++ b/.changeset/thin-flowers-fold.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nuxt': patch
+---
+
+perf: replace $fetch with useFetch in component setup

--- a/integrations/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/integrations/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { ModernLayout, parse } from '@scalar/api-reference'
 import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
-import { useHead, useRequestURL, useSeoMeta } from '#imports'
+import { useFetch, useHead, useRequestURL, useSeoMeta } from '#imports'
 import type { Configuration } from '~/src/types'
 import { reactive, ref, toRaw } from 'vue'
 
@@ -23,8 +23,9 @@ const document =
     : content
       ? toRaw(content)
       : url
-        ? await $fetch<string>(url)
-        : await $fetch<string>('/_openapi.json')
+        ? (await useFetch<string>(url, { responseType: 'text' })).data.value
+        : (await useFetch<string>('/_openapi.json', { responseType: 'text' }))
+            .data.value
 
 // Check for empty spec
 if (!document) {


### PR DESCRIPTION
**Problem**

Currently, the component uses `$fetch`, using this in the script setup causes it to fetch twice (server and client), using `useFetch` solve this problem by ensuring that if something is fetched on server, the data is forwarded to the client in the payload.

**Solution**

With this PR we benefit from SSR with `useFetch`

References:
https://nuxt.com/docs/api/composables/use-fetch
https://nuxt.com/docs/getting-started/data-fetching#the-need-for-usefetch-and-useasyncdata

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
