### PR TITLE
refactor(api-reference): faster sidebar

### DIFF
--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -15,6 +15,8 @@ const props = defineProps<{
   configuration?: AnyApiReferenceConfiguration
 }>()
 
+console.log('API REFERENCE')
+
 const {
   availableDocuments,
   selectedConfiguration,

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -15,8 +15,6 @@ const props = defineProps<{
   configuration?: AnyApiReferenceConfiguration
 }>()
 
-console.log('API REFERENCE')
-
 const {
   availableDocuments,
   selectedConfiguration,

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -115,7 +115,6 @@ useResizeObserver(documentEl, (entries) => {
 // Check for Obtrusive Scrollbars
 const obtrusiveScrollbars = computed(hasObtrusiveScrollbars)
 
-console.log('CREATE SIDEBAR')
 const {
   breadcrumb,
   collapsedSidebarItems,
@@ -178,7 +177,8 @@ onBeforeMount(() => updateHash())
 
 // Disables intersection observer and scrolls to section once it has been opened
 const scrollToSection = async (id?: string) => {
-  isIntersectionEnabled.value = false
+  // TODO: Bring back
+  // isIntersectionEnabled.value = false
   updateHash()
 
   if (id) {
@@ -188,7 +188,8 @@ const scrollToSection = async (id?: string) => {
   }
 
   await sleep(100)
-  isIntersectionEnabled.value = true
+  // TODO: Bring back
+  // isIntersectionEnabled.value = true
 }
 
 const yPosition = ref(0)
@@ -344,7 +345,6 @@ const themeStyleTag = computed(
 )
 </script>
 <template>
-  FOOBAR: {{ rawSpec }}
   <div v-html="themeStyleTag" />
   <div
     ref="documentEl"

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -115,7 +115,7 @@ useResizeObserver(documentEl, (entries) => {
 // Check for Obtrusive Scrollbars
 const obtrusiveScrollbars = computed(hasObtrusiveScrollbars)
 
-console.log('CREAATE SIDEBAR')
+console.log('CREATE SIDEBAR')
 const {
   breadcrumb,
   collapsedSidebarItems,
@@ -126,6 +126,7 @@ const {
   // setParsedSpec,
   scrollToOperation,
 } = useSidebar({
+  // TODO: Use dereferenced document instead
   content: {
     openapi: '3.1.1',
     info: {
@@ -145,6 +146,9 @@ const {
     components: {},
     tags: [],
   },
+  // TODO: Add those
+  // tagSort: props.tagSort,
+  // operationSort: props.operationSort,
 })
 
 const {
@@ -250,6 +254,7 @@ onMounted(() =>
 )
 
 onUnmounted(() => downloadEventBus.reset())
+
 // Initialize the server state
 onServerPrefetch(() => {
   const ctx = useSSRContext<SSRState>()

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -7,8 +7,8 @@ import type { Spec } from '@scalar/types/legacy'
 import { computed } from 'vue'
 
 import { BaseUrl } from '@/features/BaseUrl'
+import { useSidebar } from '@/features/Sidebar'
 import { useConfig } from '@/hooks/useConfig'
-import { useSidebar } from '@/hooks/useSidebar'
 import { getModels, hasModels } from '@/libs/openapi'
 
 import { ClientLibraries } from './ClientLibraries'

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -5,9 +5,9 @@ import { computed, inject, onMounted, type Ref } from 'vue'
 
 import { SpecificationExtension } from '@/components/SpecificationExtension'
 import { OPENAPI_VERSION_SYMBOL } from '@/features/DownloadLink'
+import { DEFAULT_INTRODUCTION_SLUG } from '@/features/Sidebar'
 import { useConfig } from '@/hooks/useConfig'
 import { useNavState } from '@/hooks/useNavState'
-import { DEFAULT_INTRODUCTION_SLUG } from '@/hooks/useSidebar'
 
 import DownloadLink from '../../../features/DownloadLink/DownloadLink.vue'
 import { Badge } from '../../Badge'

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -3,8 +3,8 @@ import { ScalarErrorBoundary } from '@scalar/components'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { computed, useId } from 'vue'
 
+import { useSidebar } from '@/features/Sidebar'
 import { useNavState } from '@/hooks/useNavState'
-import { useSidebar } from '@/hooks/useSidebar'
 
 import {
   CompactSection,

--- a/packages/api-reference/src/components/Content/Tag/OperationsListItem.vue
+++ b/packages/api-reference/src/components/Content/Tag/OperationsListItem.vue
@@ -8,8 +8,8 @@ import { getPointer } from '@/blocks/helpers/getPointer'
 import { useBlockProps } from '@/blocks/hooks/useBlockProps'
 import { HttpMethod } from '@/components/HttpMethod'
 import { SectionHeaderTag } from '@/components/Section'
+import { useSidebar } from '@/hooks/old/useSidebar'
 import { useNavState } from '@/hooks/useNavState'
-import { useSidebar } from '@/hooks/useSidebar'
 import { isOperationDeprecated } from '@/libs/openapi'
 
 const { transformedOperation, tag, collection } = defineProps<{

--- a/packages/api-reference/src/components/Content/Tag/OperationsListItem.vue
+++ b/packages/api-reference/src/components/Content/Tag/OperationsListItem.vue
@@ -8,7 +8,7 @@ import { getPointer } from '@/blocks/helpers/getPointer'
 import { useBlockProps } from '@/blocks/hooks/useBlockProps'
 import { HttpMethod } from '@/components/HttpMethod'
 import { SectionHeaderTag } from '@/components/Section'
-import { useSidebar } from '@/hooks/old/useSidebar'
+import { useSidebar } from '@/features/Sidebar'
 import { useNavState } from '@/hooks/useNavState'
 import { isOperationDeprecated } from '@/libs/openapi'
 

--- a/packages/api-reference/src/components/Content/Tag/TagList.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagList.vue
@@ -7,8 +7,8 @@ import { computed } from 'vue'
 
 import { Lazy } from '@/components/Content/Lazy'
 import { Operation } from '@/features/Operation'
+import { useSidebar } from '@/features/Sidebar'
 import { useNavState } from '@/hooks/useNavState'
-import { useSidebar } from '@/hooks/useSidebar'
 
 import TagAccordion from './TagAccordion.vue'
 import TagSection from './TagSection.vue'

--- a/packages/api-reference/src/components/Content/Tag/TagSection.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagSection.vue
@@ -6,8 +6,8 @@ import { computed, nextTick, ref, useId } from 'vue'
 import Tag from '@/components/Content/Tag/Tag.vue'
 import { SectionContainer } from '@/components/Section'
 import ShowMoreButton from '@/components/ShowMoreButton.vue'
+import { useSidebar } from '@/features/Sidebar'
 import { useNavState } from '@/hooks/useNavState'
-import { useSidebar } from '@/hooks/useSidebar'
 
 const props = defineProps<{
   id?: string

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -28,6 +28,7 @@ defineEmits<{
 const slots = defineSlots<ReferenceLayoutSlots & DocumentSelectorSlot>()
 
 const { mediaQueries } = useBreakpoints()
+// TODO: Wait, we don’t have the sidebar yet.
 const { isSidebarOpen } = useSidebar()
 const isDevelopment = import.meta.env.MODE === 'development'
 

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -11,8 +11,8 @@ import { computed, watch } from 'vue'
 import ApiReferenceLayout from '@/components/ApiReferenceLayout.vue'
 import MobileHeader from '@/components/MobileHeader.vue'
 import { SearchButton } from '@/features/Search'
+import { useSidebar } from '@/features/Sidebar'
 import { useNavState } from '@/hooks/useNavState'
-import { useSidebar } from '@/hooks/useSidebar'
 import type {
   DocumentSelectorSlot,
   ReferenceLayoutProps,

--- a/packages/api-reference/src/components/Layouts/ModernLayout.vue
+++ b/packages/api-reference/src/components/Layouts/ModernLayout.vue
@@ -6,7 +6,7 @@ import {
 } from '@scalar/components'
 import { getObjectKeys } from '@scalar/oas-utils/helpers'
 import { useBreakpoints } from '@scalar/use-hooks/useBreakpoints'
-import { computed, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import ApiReferenceLayout from '@/components/ApiReferenceLayout.vue'
 import MobileHeader from '@/components/MobileHeader.vue'
@@ -29,7 +29,8 @@ const slots = defineSlots<ReferenceLayoutSlots & DocumentSelectorSlot>()
 
 const { mediaQueries } = useBreakpoints()
 // TODO: Wait, we don’t have the sidebar yet.
-const { isSidebarOpen } = useSidebar()
+// const { isSidebarOpen } = useSidebar()
+const isSidebarOpen = ref(true)
 const isDevelopment = import.meta.env.MODE === 'development'
 
 watch(mediaQueries.lg, (newValue, oldValue) => {

--- a/packages/api-reference/src/components/MobileHeader.vue
+++ b/packages/api-reference/src/components/MobileHeader.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ScalarIconButton } from '@scalar/components'
 
-import { useSidebar } from '@/hooks/useSidebar'
+import { useSidebar } from '@/features/Sidebar'
 
 defineProps<{
   open?: boolean

--- a/packages/api-reference/src/components/Section/Section.vue
+++ b/packages/api-reference/src/components/Section/Section.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import IntersectionObserver from '@/components/IntersectionObserver.vue'
+import { useSidebar } from '@/features/Sidebar'
 import { useNavState } from '@/hooks/useNavState'
-import { useSidebar } from '@/hooks/useSidebar'
 
 const props = defineProps<{
   id?: string

--- a/packages/api-reference/src/components/ShowMoreButton.vue
+++ b/packages/api-reference/src/components/ShowMoreButton.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components'
 
+import { useSidebar } from '@/features/Sidebar'
 import { useConfig } from '@/hooks/useConfig'
-import { useSidebar } from '@/hooks/useSidebar'
 
 const { id } = defineProps<{
   id: string

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -4,14 +4,14 @@ import { onMounted, onUnmounted, ref, watch } from 'vue'
 
 import SidebarElement from '@/components/Sidebar/SidebarElement.vue'
 import SidebarGroup from '@/components/Sidebar/SidebarGroup.vue'
+import { useSidebar, type SortOptions } from '@/features/Sidebar'
 import { sleep } from '@/helpers/sleep'
 import { useNavState } from '@/hooks/useNavState'
-import { useSidebar, type SorterOption } from '@/hooks/useSidebar'
 
 const props = defineProps<
   {
     parsedSpec: Spec
-  } & SorterOption
+  } & SortOptions
 >()
 
 const { hash, isIntersectionEnabled } = useNavState()
@@ -19,8 +19,8 @@ const { hash, isIntersectionEnabled } = useNavState()
 const { items, toggleCollapsedSidebarItem, collapsedSidebarItems } = useSidebar(
   {
     parsedSpec: props.parsedSpec,
-    tagsSorter: props.tagsSorter,
-    operationsSorter: props.operationsSorter,
+    tagSort: props.tagSort,
+    operationSort: props.operationSort,
   },
 )
 

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -8,21 +8,11 @@ import { useSidebar, type SortOptions } from '@/features/Sidebar'
 import { sleep } from '@/helpers/sleep'
 import { useNavState } from '@/hooks/useNavState'
 
-const props = defineProps<
-  {
-    parsedSpec: Spec
-  } & SortOptions
->()
-
 const { hash, isIntersectionEnabled } = useNavState()
 
-const { items, toggleCollapsedSidebarItem, collapsedSidebarItems } = useSidebar(
-  {
-    parsedSpec: props.parsedSpec,
-    tagSort: props.tagSort,
-    operationSort: props.operationSort,
-  },
-)
+// TODO: Use dereferenced document instead
+const { items, toggleCollapsedSidebarItem, collapsedSidebarItems } =
+  useSidebar()
 
 // This offset determines how far down the sidebar the items scroll
 const SCROLL_OFFSET = -160
@@ -107,9 +97,10 @@ onMounted(() => {
 <template>
   <div class="sidebar">
     <slot name="sidebar-start" />
+    <!-- TODO: Bring back the title here: -->
     <nav
       ref="scrollerEl"
-      :aria-label="`Table of contents for ${parsedSpec.info?.title}`"
+      :aria-label="`Table of contents for ${parsedSpec?.info?.title}`"
       class="sidebar-pages custom-scroll custom-scroll-self-contain-overflow">
       <SidebarGroup :level="0">
         <template

--- a/packages/api-reference/src/components/SingleApiReference.vue
+++ b/packages/api-reference/src/components/SingleApiReference.vue
@@ -12,6 +12,8 @@ const { configuration } = defineProps<{
   configuration: Partial<ApiReferenceConfiguration>
 }>()
 
+console.log('SINGLE API REFERENCE')
+
 // If content changes it is emitted to the parent component to be handed back in as a spec string
 defineEmits<{
   (e: 'updateContent', value: string): void

--- a/packages/api-reference/src/components/SingleApiReference.vue
+++ b/packages/api-reference/src/components/SingleApiReference.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { upgrade } from '@scalar/openapi-parser'
+import { createCollection } from '@scalar/store'
 import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { useSeoMeta } from '@unhead/vue'
@@ -31,6 +33,24 @@ if (configuration.metaData) {
   useSeoMeta(configuration.metaData)
 }
 
+const { parsedSpec, rawSpec } = useReactiveSpec({
+  proxyUrl: toRef(() => configuration.proxyUrl || ''),
+  specConfig: toRef(() => configuration || {}),
+})
+
+// New Store
+const collection = createCollection(rawSpec.value)
+
+// TODO: Woah, this should all be done in the store.
+watch(rawSpec, (rawSpec) => {
+  const { specification: content } = upgrade(rawSpec) as unknown as Record<
+    string,
+    unknown
+  >
+
+  collection.update(content as unknown as Record<string, unknown>)
+})
+
 // TODO: defineSlots
 
 const favicon = computed(() => configuration.favicon)
@@ -44,6 +64,10 @@ useFavicon(favicon)
     v-if="configuration?.customCss">
     {{ configuration.customCss }}
   </component>
+  <div style="color: white">
+    <h1>Hello from the new Store 👋 {{ collection.document.info?.title }}</h1>
+  </div>
+  <pre><code style="color: white">{{ collection.document.servers }}</code></pre>
   <Layouts
     :configuration="configuration"
     :isDark="isDarkMode"

--- a/packages/api-reference/src/components/SingleApiReference.vue
+++ b/packages/api-reference/src/components/SingleApiReference.vue
@@ -12,8 +12,6 @@ const { configuration } = defineProps<{
   configuration: Partial<ApiReferenceConfiguration>
 }>()
 
-console.log('SINGLE API REFERENCE')
-
 // If content changes it is emitted to the parent component to be handed back in as a spec string
 defineEmits<{
   (e: 'updateContent', value: string): void

--- a/packages/api-reference/src/components/SingleApiReference.vue
+++ b/packages/api-reference/src/components/SingleApiReference.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { upgrade } from '@scalar/openapi-parser'
-import { createCollection } from '@scalar/store'
 import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { useSeoMeta } from '@unhead/vue'
@@ -38,19 +37,6 @@ const { parsedSpec, rawSpec } = useReactiveSpec({
   specConfig: toRef(() => configuration || {}),
 })
 
-// New Store
-const collection = createCollection(rawSpec.value)
-
-// TODO: Woah, this should all be done in the store.
-watch(rawSpec, (rawSpec) => {
-  const { specification: content } = upgrade(rawSpec) as unknown as Record<
-    string,
-    unknown
-  >
-
-  collection.update(content as unknown as Record<string, unknown>)
-})
-
 // TODO: defineSlots
 
 const favicon = computed(() => configuration.favicon)
@@ -64,10 +50,6 @@ useFavicon(favicon)
     v-if="configuration?.customCss">
     {{ configuration.customCss }}
   </component>
-  <div style="color: white">
-    <h1>Hello from the new Store 👋 {{ collection.document.info?.title }}</h1>
-  </div>
-  <pre><code style="color: white">{{ collection.document.servers }}</code></pre>
   <Layouts
     :configuration="configuration"
     :isDark="isDarkMode"

--- a/packages/api-reference/src/features/Operation/Webhooks.vue
+++ b/packages/api-reference/src/features/Operation/Webhooks.vue
@@ -13,8 +13,8 @@ import {
   SectionHeaderTag,
 } from '@/components/Section'
 import ShowMoreButton from '@/components/ShowMoreButton.vue'
+import { useSidebar } from '@/features/Sidebar'
 import { useNavState } from '@/hooks/useNavState'
-import { useSidebar } from '@/hooks/useSidebar'
 
 import Webhook from './components/Webhook.vue'
 

--- a/packages/api-reference/src/features/Search/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/SearchModal.vue
@@ -19,8 +19,8 @@ import {
   type EntryType,
   type FuseData,
 } from '@/features/Search/useSearchIndex'
+import { useSidebar } from '@/features/Sidebar'
 import { scrollToId } from '@/helpers/scroll-to-id'
-import { useSidebar } from '@/hooks/useSidebar'
 
 const props = defineProps<{
   parsedSpec: Spec

--- a/packages/api-reference/src/features/Search/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.ts
@@ -3,9 +3,9 @@ import type { Spec, TransformedOperation } from '@scalar/types/legacy'
 import Fuse, { type FuseResult } from 'fuse.js'
 import { type Ref, computed, ref, watch } from 'vue'
 
+import { useSidebar } from '@/features/Sidebar'
 import { useNavState } from '@/hooks/useNavState'
 import { type ParamMap, useOperation } from '@/hooks/useOperation'
-import { useSidebar } from '@/hooks/useSidebar'
 import { getHeadingsFromMarkdown } from '@/libs/markdown'
 import { extractRequestBody, getModels } from '@/libs/openapi'
 

--- a/packages/api-reference/src/features/Sidebar/components/Sidebar.vue
+++ b/packages/api-reference/src/features/Sidebar/components/Sidebar.vue
@@ -1,0 +1,265 @@
+<script setup lang="ts">
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
+
+import { useSidebar, type SortOptions } from '@/features/Sidebar'
+import { sleep } from '@/helpers/sleep'
+import { useNavState } from '@/hooks/useNavState'
+
+import SidebarElement from './SidebarElement.vue'
+import SidebarGroup from './SidebarGroup.vue'
+
+const { content, tagSort, operationSort } = defineProps<
+  {
+    // TODO: Make sure to upgrade it to OpenAPIV3_1.Document
+    content: OpenAPIV3_1.Document
+  } & SortOptions
+>()
+
+const { hash, isIntersectionEnabled } = useNavState()
+
+const { items, toggleCollapsedSidebarItem, collapsedSidebarItems } = useSidebar(
+  {
+    content,
+    tagSort,
+    operationSort,
+  },
+)
+
+// This offset determines how far down the sidebar the items scroll
+const SCROLL_OFFSET = -160
+const scrollerEl = ref<HTMLElement | null>(null)
+const disableScroll = ref(true)
+
+// Watch for the active item changing so we can scroll the sidebar,
+// but not when we click, only on scroll.
+// Also disable scroll on expansion of sidebar tag
+watch(hash, (id) => {
+  if (
+    !isIntersectionEnabled.value ||
+    disableScroll.value ||
+    typeof window === 'undefined'
+  ) {
+    return
+  }
+  scrollSidebar(id)
+})
+
+const scrollSidebar = (id: string) => {
+  const el = document.getElementById(`sidebar-${id}`)
+  if (!el || !scrollerEl.value) {
+    return
+  }
+
+  let top = SCROLL_OFFSET
+
+  // Since the elements are mostly nested, we need to do some offset calculations
+  if (el.getAttribute('data-sidebar-type') === 'heading') {
+    top +=
+      el.offsetTop +
+      (el.getElementsByClassName('sidebar-heading')?.[0] as HTMLElement)
+        .offsetHeight
+  } else {
+    top +=
+      el.offsetTop +
+      (el.parentElement?.offsetTop ?? 0) +
+      (el.parentElement?.parentElement?.offsetTop ?? 0)
+  }
+  scrollerEl.value.scrollTo({ top, behavior: 'smooth' })
+}
+
+/** Adds an observer to watch for elements */
+const observeSidebarElement = (id: string) => {
+  if (!scrollerEl.value) {
+    return
+  }
+
+  const observer = new MutationObserver((mutations, obs) => {
+    const el = document.getElementById(`sidebar-${id}`)
+    if (el) {
+      scrollSidebar(id)
+      disableScroll.value = false
+      obs.disconnect() // Stop observing once we find the element
+    }
+  })
+
+  // Start observing the document with the configured parameters
+  observer.observe(scrollerEl.value, {
+    childList: true,
+    subtree: true,
+  })
+
+  return observer
+}
+
+onMounted(() => {
+  const observer = observeSidebarElement(hash.value)
+
+  // Enable scrolling after some time
+  if (!hash.value) {
+    setTimeout(() => (disableScroll.value = false), 300)
+  }
+
+  // Cleanup the observer when component is unmounted
+  onUnmounted(() => {
+    observer?.disconnect()
+  })
+})
+</script>
+<template>
+  <div class="sidebar">
+    <slot name="sidebar-start" />
+    <nav
+      ref="scrollerEl"
+      :aria-label="`Table of contents for ${content.info?.title}`"
+      class="sidebar-pages custom-scroll custom-scroll-self-contain-overflow">
+      <SidebarGroup :level="0">
+        <template
+          v-for="item in items.entries"
+          :key="item.id">
+          <template v-if="item.isGroup">
+            <li class="sidebar-group-title">
+              {{ item.displayTitle ?? item.title }}
+            </li>
+            <template
+              v-for="group in item.children"
+              :key="group.id">
+              <SidebarElement
+                :id="`sidebar-${group.id}`"
+                data-sidebar-type="heading"
+                :hasChildren="group.children && group.children.length > 0"
+                :isActive="hash === group.id"
+                :item="{
+                  id: group.id,
+                  title: group.displayTitle ?? group.title,
+                  select: group.select,
+                  httpVerb: group.httpVerb,
+                  deprecated: group.deprecated ?? false,
+                }"
+                :open="collapsedSidebarItems[group.id] ?? false"
+                @toggleOpen="
+                  async () => {
+                    disableScroll = true
+                    toggleCollapsedSidebarItem(group.id)
+                    await sleep(100)
+                    disableScroll = false
+                  }
+                ">
+                <template v-if="group.children && group.children?.length > 0">
+                  <SidebarGroup :level="1">
+                    <template
+                      v-for="child in group.children"
+                      :key="child.id">
+                      <SidebarElement
+                        v-if="item.show"
+                        :id="`sidebar-${child.id}`"
+                        :isActive="hash === child.id"
+                        :item="{
+                          id: child.id,
+                          title: child.displayTitle ?? child.title,
+                          select: child.select,
+                          httpVerb: child.httpVerb,
+                          deprecated: child.deprecated ?? false,
+                        }" />
+                    </template>
+                  </SidebarGroup>
+                </template>
+              </SidebarElement>
+            </template>
+          </template>
+          <template v-else>
+            <SidebarElement
+              v-if="item.show"
+              :id="`sidebar-${item.id}`"
+              data-sidebar-type="heading"
+              :hasChildren="item.children && item.children.length > 0"
+              :isActive="hash === item.id"
+              :item="{
+                id: item.id,
+                title: item.displayTitle ?? item.title,
+                select: item.select,
+                httpVerb: item.httpVerb,
+                deprecated: item.deprecated ?? false,
+              }"
+              :open="collapsedSidebarItems[item.id] ?? false"
+              @toggleOpen="
+                async () => {
+                  disableScroll = true
+                  toggleCollapsedSidebarItem(item.id)
+                  await sleep(100)
+                  disableScroll = false
+                }
+              ">
+              <template v-if="item.children && item.children?.length > 0">
+                <SidebarGroup :level="1">
+                  <template
+                    v-for="child in item.children"
+                    :key="child.id">
+                    <SidebarElement
+                      v-if="item.show"
+                      :id="`sidebar-${child.id}`"
+                      :isActive="hash === child.id"
+                      :item="{
+                        id: child.id,
+                        title: child.displayTitle ?? child.title,
+                        select: child.select,
+                        httpVerb: child.httpVerb,
+                        deprecated: child.deprecated ?? false,
+                      }" />
+                  </template>
+                </SidebarGroup>
+              </template>
+            </SidebarElement>
+          </template>
+        </template>
+      </SidebarGroup>
+    </nav>
+    <slot name="sidebar-end" />
+  </div>
+</template>
+
+<style scoped>
+.sidebar {
+  --scalar-sidebar-indent-base: 12px;
+  --scalar-sidebar-font-weight-active: var(--scalar-semibold);
+  --scalar-sidebar-font-weight: var(--scalar-semibold);
+}
+.sidebar {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  border-right: var(--scalar-border-width) solid
+    var(--scalar-sidebar-border-color, var(--scalar-border-color));
+  background: var(--scalar-sidebar-background-1, var(--scalar-background-1));
+  --scalar-sidebar-level: 0;
+}
+.sidebar-pages {
+  flex: 1;
+  padding: 9px 12px;
+}
+
+@media (max-width: 1000px) {
+  .sidebar {
+    min-height: 0;
+    border-right: none;
+  }
+  .sidebar-pages {
+    padding-top: 12px;
+  }
+}
+.sidebar-group-title {
+  color: var(--scalar-sidebar-color-1);
+  font-size: var(--scalar-mini);
+  padding: 12px 6px 6px;
+  font-weight: var(--scalar-semibold);
+  text-transform: uppercase;
+  word-break: break-word;
+  line-height: 1.385;
+}
+.sidebar-group-item + .sidebar-group-title {
+  border-top: var(--scalar-border-width) solid
+    var(--scalar-sidebar-border-color);
+  margin-top: 9px;
+}
+</style>

--- a/packages/api-reference/src/features/Sidebar/components/Sidebar.vue
+++ b/packages/api-reference/src/features/Sidebar/components/Sidebar.vue
@@ -12,19 +12,19 @@ import SidebarGroup from './SidebarGroup.vue'
 const { content, tagSort, operationSort } = defineProps<
   {
     // TODO: Make sure to upgrade it to OpenAPIV3_1.Document
-    content: OpenAPIV3_1.Document
+    // content: OpenAPIV3_1.Document
   } & SortOptions
 >()
 
 const { hash, isIntersectionEnabled } = useNavState()
 
-const { items, toggleCollapsedSidebarItem, collapsedSidebarItems } = useSidebar(
-  {
-    content,
-    tagSort,
-    operationSort,
-  },
-)
+const { items, toggleCollapsedSidebarItem, collapsedSidebarItems } =
+  useSidebar()
+// {
+//   content,
+//   tagSort,
+//   operationSort,
+// },
 
 // This offset determines how far down the sidebar the items scroll
 const SCROLL_OFFSET = -160
@@ -109,9 +109,10 @@ onMounted(() => {
 <template>
   <div class="sidebar">
     <slot name="sidebar-start" />
+    <!-- TODO: Bring back title -->
+    <!-- :aria-label="`Table of contents for ${content.info?.title}`" -->
     <nav
       ref="scrollerEl"
-      :aria-label="`Table of contents for ${content.info?.title}`"
       class="sidebar-pages custom-scroll custom-scroll-self-contain-overflow">
       <SidebarGroup :level="0">
         <template

--- a/packages/api-reference/src/features/Sidebar/components/SidebarElement.vue
+++ b/packages/api-reference/src/features/Sidebar/components/SidebarElement.vue
@@ -1,0 +1,345 @@
+<script setup lang="ts">
+import {
+  ScalarIcon,
+  ScalarSidebarGroupToggle,
+  type Icon,
+} from '@scalar/components'
+import { combineUrlAndPath } from '@scalar/oas-utils/helpers'
+
+import { scrollToId, sleep } from '@/helpers'
+import { useConfig } from '@/hooks/useConfig'
+
+import { useNavState } from '../../hooks'
+import SidebarHttpBadge from './SidebarHttpBadge.vue'
+
+const props = defineProps<{
+  id: string
+  item: {
+    id: string
+    title: string
+    select?: () => void
+    link?: string
+    icon?: {
+      src: string
+    }
+    httpVerb?: string
+    deprecated?: boolean
+  }
+  isActive?: boolean
+  hasChildren?: boolean
+  open?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'toggleOpen'): void
+}>()
+
+const { getFullHash, isIntersectionEnabled, replaceUrlState } = useNavState()
+
+const config = useConfig()
+
+// We disable intersection observer on click
+const handleClick = async () => {
+  // wait for a short delay before enabling intersection observer
+  isIntersectionEnabled.value = false
+
+  if (props.hasChildren) {
+    emit('toggleOpen')
+  }
+  props.item?.select?.()
+
+  // Re-enable intersection observer
+  await sleep(100)
+  isIntersectionEnabled.value = true
+}
+
+// Build relative URL and add hash
+const generateLink = () => {
+  if (config.value.pathRouting) {
+    return combineUrlAndPath(config.value.pathRouting.basePath, props.item.id)
+  }
+  if (typeof window !== 'undefined') {
+    const newUrl = new URL(window.location.href)
+    newUrl.hash = getFullHash(props.item.id)
+    return `${newUrl.pathname}${newUrl.search}${newUrl.hash}`
+  }
+  return `#${getFullHash(props.item.id)}`
+}
+
+// For path routing we want to handle the clicks
+const onAnchorClick = async (ev: Event) => {
+  config.value.onSidebarClick?.(props.item.id)
+
+  if (config.value.pathRouting) {
+    ev.preventDefault()
+
+    // Due to the prevent default
+    if (props.hasChildren) {
+      emit('toggleOpen')
+    }
+    props.item?.select?.()
+
+    // Make sure to open the section
+    emit('toggleOpen')
+
+    // Disable intersection observer before we scroll
+    isIntersectionEnabled.value = false
+
+    replaceUrlState(props.item.id)
+    scrollToId(props.item.id)
+
+    await sleep(100)
+    isIntersectionEnabled.value = true
+  }
+}
+</script>
+<template>
+  <li
+    :id="id"
+    class="sidebar-group-item">
+    <div
+      class="sidebar-heading"
+      :class="{
+        'sidebar-group-item__folder': hasChildren,
+        'active_page': isActive,
+        'deprecated': item.deprecated ?? false,
+      }"
+      @click="handleClick">
+      <!-- If children are detected then show the nesting icon -->
+      <!-- Use &hairsp; to vertically center scalar icon button to the first line of text in the sidebar heading link -->
+      <p
+        v-if="hasChildren && !config.defaultOpenAllTags"
+        class="sidebar-heading-chevron">
+        <button
+          :aria-expanded="open"
+          class="toggle-nested-icon"
+          type="button"
+          @click.stop="handleClick">
+          <ScalarSidebarGroupToggle :open="open">
+            <template #label>
+              {{ open ? 'Collapse' : 'Expand' }} {{ item.title }}
+            </template>
+          </ScalarSidebarGroupToggle>
+        </button>
+        &hairsp;
+      </p>
+      <a
+        class="sidebar-heading-link"
+        :href="generateLink()"
+        :tabindex="hasChildren ? -1 : 0"
+        @click="onAnchorClick">
+        <ScalarIcon
+          v-if="item?.icon?.src"
+          class="sidebar-icon"
+          :icon="item.icon.src as Icon" />
+        <p class="sidebar-heading-link-title">
+          {{ item.title }}
+        </p>
+        <p
+          v-if="item.httpVerb && !hasChildren"
+          class="sidebar-heading-link-method">
+          &hairsp;
+          <span class="sr-only">HTTP Method:&nbsp;</span>
+          <SidebarHttpBadge
+            :active="isActive"
+            :method="item.httpVerb" />
+        </p>
+      </a>
+    </div>
+    <slot v-if="open" />
+    <div
+      v-if="$slots['action-menu']"
+      class="action-menu">
+      <slot name="action-menu" />
+    </div>
+  </li>
+</template>
+<style scoped>
+.sidebar-heading {
+  display: flex;
+  gap: 6px;
+
+  color: var(--scalar-sidebar-color-2, var(--scalar-color-2));
+  font-size: var(--scalar-mini);
+  font-weight: var(--scalar-semibold);
+  word-break: break-word;
+  line-height: 1.385;
+  max-width: 100%;
+  position: relative;
+  cursor: pointer;
+  border-radius: var(--scalar-radius);
+  flex: 1;
+  padding-right: 9px;
+  user-select: none;
+}
+.sidebar-heading-link-method {
+  margin: 0;
+}
+.sidebar-heading.deprecated .sidebar-heading-link-title {
+  text-decoration: line-through;
+}
+.sidebar-heading-link-title {
+  margin: 0;
+}
+.sidebar-heading:hover {
+  background: var(
+    --scalar-sidebar-item-hover-background,
+    var(--scalar-background-2)
+  );
+}
+.sidebar-heading:hover .sidebar-heading-link-title {
+  color: var(--scalar-sidebar-item-hover-color);
+}
+
+.sidebar-heading-link:focus-visible {
+  outline: none;
+}
+
+.sidebar-heading:has(> .sidebar-heading-link:focus-visible) {
+  z-index: 1;
+  outline: 1px solid var(--scalar-color-accent);
+}
+
+.active_page.sidebar-heading:hover,
+.active_page.sidebar-heading {
+  color: var(--scalar-sidebar-color-active, var(--scalar-color-accent));
+
+  background: var(
+    --scalar-sidebar-item-active-background,
+    var(--scalar-background-accent)
+  );
+}
+.active_page.sidebar-heading p {
+  font-weight: var(--scalar-sidebar-font-weight-active, var(--scalar-semibold));
+}
+.active_page.sidebar-heading:hover .sidebar-heading-link-title {
+  color: var(--scalar-sidebar-color-active, var(--scalar-color-accent));
+}
+.sidebar-indent-nested .sidebar-indent-nested .sidebar-heading:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: calc((var(--scalar-sidebar-level) * 12px));
+  width: var(--scalar-border-width);
+  height: 100%;
+  background: var(--scalar-sidebar-indent-border);
+}
+.sidebar-indent-nested .sidebar-indent-nested .sidebar-heading:hover:before {
+  background: var(--scalar-sidebar-indent-border-hover);
+}
+.sidebar-indent-nested
+  .sidebar-indent-nested
+  .active_page.sidebar-heading:before {
+  background: var(--scalar-sidebar-indent-border-active);
+}
+
+.sidebar-heading-link {
+  text-decoration: none;
+  color: inherit;
+  padding-right: 12px;
+  padding: 6px 0;
+  display: flex;
+  flex: 1;
+  justify-content: space-between;
+  gap: 2px;
+}
+.sidebar-heading p {
+  height: fit-content;
+  display: flex;
+  align-items: center;
+  font-weight: var(--scalar-sidebar-font-weight, var(--scalar-semibold));
+}
+.sidebar-heading p:empty {
+  display: none;
+}
+/* Sidebar link icon */
+.link-icon {
+  position: relative;
+  left: 4px;
+}
+
+.sidebar-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 6px;
+  width: 13px;
+  height: 13px;
+}
+
+.sidebar-icon > svg {
+  width: 13px;
+  height: 13px;
+}
+
+.sidebar-group-item {
+  position: relative;
+}
+
+/* Folder/page collapse icon */
+/* awkward pixel value to deal with hairspace alignment across browser*/
+.sidebar-heading-chevron {
+  margin: 5px -5.5px 5px -9px;
+}
+.sidebar-heading-chevron .toggle-nested-icon:focus-visible {
+  outline: none;
+}
+.sidebar-heading:has(
+    .sidebar-heading-chevron .toggle-nested-icon:focus-visible
+  ) {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--scalar-color-accent);
+}
+.toggle-nested-icon {
+  color: var(--scalar-color-3);
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.active_page .toggle-nested-icon {
+  color: var(--scalar-sidebar-color-active, var(--scalar-color-accent));
+}
+
+.toggle-nested-icon:hover,
+.toggle-nested-icon:focus-visible {
+  color: currentColor;
+}
+
+.action-menu {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  display: flex;
+  gap: 6px;
+}
+/**
+* Some awkwardness to make the dropdown buttons hidden when not hovered
+* but still show when the panel is open and focused
+*/
+.action-menu :deep(.button-wrapper button) {
+  /* Hide the icons by default */
+  opacity: 0;
+  width: 20px;
+  height: 20px;
+  padding: 4px;
+}
+.action-menu:hover :deep(.button-wrapper button),
+.action-menu :deep(.button-wrapper button:hover),
+.sidebar-heading:hover ~ .action-menu :deep(.button-wrapper button),
+.action-menu :deep(.button-wrapper button[aria-expanded='true']) {
+  opacity: 1;
+}
+.sidebar-heading:has(~ .action-menu:hover) {
+  color: var(--scalar-sidebar-color-1, var(--scalar-color-1));
+  background: var(
+    --scalar-sidebar-item-hover-background,
+    var(--scalar-background-2)
+  );
+}
+.sidebar-group-item__folder {
+  color: var(--scalar-sidebar-color-1, var(--scalar-color-1));
+  text-transform: var(--scalar-tag-text-transform, initial);
+}
+</style>

--- a/packages/api-reference/src/features/Sidebar/components/SidebarElement.vue
+++ b/packages/api-reference/src/features/Sidebar/components/SidebarElement.vue
@@ -6,10 +6,11 @@ import {
 } from '@scalar/components'
 import { combineUrlAndPath } from '@scalar/oas-utils/helpers'
 
-import { scrollToId, sleep } from '@/helpers'
+import { scrollToId } from '@/helpers/scroll-to-id'
+import { sleep } from '@/helpers/sleep'
 import { useConfig } from '@/hooks/useConfig'
+import { useNavState } from '@/hooks/useNavState'
 
-import { useNavState } from '../../hooks'
 import SidebarHttpBadge from './SidebarHttpBadge.vue'
 
 const props = defineProps<{

--- a/packages/api-reference/src/features/Sidebar/components/SidebarGroup.vue
+++ b/packages/api-reference/src/features/Sidebar/components/SidebarGroup.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+defineProps<{
+  level: number
+}>()
+</script>
+
+<template>
+  <ul
+    class="sidebar-group sidebar-indent-nested"
+    :style="{ '--scalar-sidebar-level': level }">
+    <slot />
+  </ul>
+</template>
+
+<style scoped>
+.sidebar-group {
+  list-style: none;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+/* We indent each level of nesting further */
+.sidebar-indent-nested :deep(.sidebar-heading) {
+  /* prettier-ignore */
+  padding-left: calc((var(--scalar-sidebar-level) * var(--scalar-sidebar-indent-base)) + 12px) !important;
+}
+
+/* Collapse/expand icons must also be offset */
+.sidebar-indent-nested :deep(.sidebar-heading .toggle-nested-icon) {
+  /* prettier-ignore */
+  left: calc((var(--scalar-sidebar-level) * var(--scalar-sidebar-indent-base)) + 2px) !important;
+}
+
+/* Change font colors and weights for nested items */
+/* Needs :where to lower specificity */
+:where(.sidebar-indent-nested) :deep(.sidebar-heading) {
+  color: var(--scalar-sidebar-color-1, var(--scalar-color-1));
+}
+:where(.sidebar-indent-nested)
+  :deep(:where(.sidebar-indent-nested) .sidebar-heading) {
+  color: var(--scalar-sidebar-color-2, var(--scalar-color-2));
+}
+</style>

--- a/packages/api-reference/src/features/Sidebar/components/SidebarHttpBadge.test.ts
+++ b/packages/api-reference/src/features/Sidebar/components/SidebarHttpBadge.test.ts
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import SidebarHttpBadge from './SidebarHttpBadge.vue'
+
+describe('SidebarHttpBadge', () => {
+  it('adds the correct method class', () => {
+    const wrapper = mount(SidebarHttpBadge, {
+      props: {
+        method: 'GET',
+      },
+    })
+
+    expect(wrapper.classes()).toContain('sidebar-heading-type--get')
+  })
+
+  it('handles different HTTP methods', () => {
+    const methods = ['POST', 'PUT', 'DELETE', 'PATCH']
+
+    methods.forEach((method) => {
+      const wrapper = mount(SidebarHttpBadge, {
+        props: {
+          method,
+        },
+      })
+
+      expect(wrapper.classes()).toContain(`sidebar-heading-type--${method.toLowerCase()}`)
+    })
+  })
+
+  it('adds active class when active prop is true', () => {
+    const wrapper = mount(SidebarHttpBadge, {
+      props: {
+        method: 'GET',
+        active: true,
+      },
+    })
+
+    expect(wrapper.classes()).toContain('sidebar-heading-type-active')
+  })
+})

--- a/packages/api-reference/src/features/Sidebar/components/SidebarHttpBadge.vue
+++ b/packages/api-reference/src/features/Sidebar/components/SidebarHttpBadge.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { HttpMethod } from '@/components/HttpMethod'
+
+defineProps<{
+  method: string
+  active?: boolean
+}>()
+</script>
+
+<template>
+  <HttpMethod
+    :class="[
+      'sidebar-heading-type',
+      `sidebar-heading-type--${method.toLowerCase()}`,
+      { 'sidebar-heading-type-active': active },
+    ]"
+    :method="method"
+    property="--method-color"
+    short />
+</template>
+
+<style scoped>
+.sidebar-heading-type {
+  display: block;
+  min-width: 3.9em;
+  overflow: hidden;
+  line-height: 14px;
+  flex-shrink: 0;
+  color: white;
+  color: color-mix(
+    in srgb,
+    var(--method-color, var(--scalar-color-1)),
+    transparent 0%
+  );
+  text-transform: uppercase;
+  font-size: 10px;
+  font-weight: var(--scalar-bold);
+  text-align: right;
+  position: relative;
+  font-family: var(--scalar-font-code);
+  white-space: nowrap;
+  margin-left: 3px;
+}
+</style>

--- a/packages/api-reference/src/features/Sidebar/components/index.ts
+++ b/packages/api-reference/src/features/Sidebar/components/index.ts
@@ -1,0 +1,1 @@
+export { default as Sidebar } from './Sidebar.vue'

--- a/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.bench.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.bench.ts
@@ -1,0 +1,55 @@
+import { bench, describe, expect, vi } from 'vitest'
+import { computed, toValue } from 'vue'
+
+import { parse } from '@/helpers'
+import { useSidebar as useSidebarOld } from '@/hooks/old/useSidebar'
+import { apiReferenceConfigurationSchema } from '@scalar/types'
+import { createSidebar } from './create-sidebar'
+
+// Fetch the Stripe OpenAPI document once for all benchmarks
+const EXAMPLE_DOCUMENT = await fetch(
+  'https://raw.githubusercontent.com/stripe/openapi/refs/heads/master/openapi/spec3.json',
+).then((r) => r.json())
+
+const parsedSpec = await parse(EXAMPLE_DOCUMENT)
+
+// Mock the useConfig hook
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: vi.fn().mockReturnValue(computed(() => apiReferenceConfigurationSchema.parse({}))),
+}))
+
+// Mock vue's inject
+vi.mock('vue', () => {
+  const actual = require('vue')
+  return {
+    ...actual,
+    inject: vi.fn().mockReturnValue({
+      getTagId: vi.fn(),
+      getOperationId: vi.fn(),
+      getHeadingId: vi.fn(),
+      getModelId: vi.fn(),
+      getWebhookId: vi.fn(),
+      hash: { value: '' },
+      hashPrefix: { value: '' },
+      isIntersectionEnabled: { value: false },
+    }),
+  }
+})
+
+describe('createSidebar', async () => {
+  bench('old (stripe)', async () => {
+    const { items } = useSidebarOld({
+      parsedSpec,
+    })
+
+    expect(toValue(items)).toBeDefined()
+  })
+
+  bench('new (stripe)', async () => {
+    const { items } = createSidebar({
+      content: EXAMPLE_DOCUMENT,
+    })
+
+    expect(toValue(items)).toBeDefined()
+  })
+})

--- a/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.bench.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.bench.ts
@@ -1,7 +1,7 @@
 import { bench, describe, expect, vi } from 'vitest'
 import { computed, toValue } from 'vue'
 
-import { parse } from '@/helpers'
+import { parse } from '@/helpers/parse'
 import { useSidebar as useSidebarOld } from '@/hooks/old/useSidebar'
 import { apiReferenceConfigurationSchema } from '@scalar/types'
 import { createSidebar } from './create-sidebar'

--- a/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.test.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.test.ts
@@ -1,0 +1,1175 @@
+import type { SortOptions } from '@/features/Sidebar/types'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { describe, expect, it } from 'vitest'
+import { toValue } from 'vue'
+import { createSidebar } from './create-sidebar'
+
+/**
+ * Parse the given OpenAPI document and return the items for the sidebar.
+ */
+async function getItemsForDocument(content: Record<string, any>, options?: SortOptions) {
+  const { items } = createSidebar({
+    ...{
+      tagSort: undefined,
+      operationSort: undefined,
+      ...options,
+    },
+    content,
+  })
+
+  return toValue(items)
+}
+
+describe('createSidebar', async () => {
+  describe('instance', () => {
+    it('creates a new instance every time', async () => {
+      const content = {
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Hello World',
+            },
+          },
+        },
+      } as OpenAPIV3_1.Document
+
+      const sidebar1 = createSidebar({ content })
+      const sidebar2 = createSidebar({ content })
+
+      // Every call to createSidebar should return a new instance
+      expect(toValue(sidebar1.items)).not.toBe(toValue(sidebar2.items))
+      // But have the same values
+      expect(JSON.stringify(toValue(sidebar1.items))).toMatchObject(JSON.stringify(toValue(sidebar2.items)))
+    })
+  })
+
+  describe('empty content', () => {
+    it("doesn't return any entries for an empty specification", async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {},
+        }),
+      ).toStrictEqual({
+        titles: {},
+        entries: [],
+      })
+    })
+  })
+
+  describe('tags', () => {
+    it('has a tag', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Hello World',
+                tags: ['Foobar'],
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'Foobar',
+            children: [
+              {
+                title: 'Hello World',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('has multiple tags', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Hello World',
+                tags: ['Foobar', 'Barfoo'],
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'Foobar',
+            children: [
+              {
+                title: 'Hello World',
+              },
+            ],
+          },
+          {
+            title: 'Barfoo',
+            children: [
+              {
+                title: 'Hello World',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('shows operations without tags directly in the sidebar', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Get Hello',
+              },
+              post: {
+                summary: 'Post Hello',
+              },
+            },
+            '/world': {
+              get: {
+                summary: 'Get World',
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'Get Hello',
+          },
+          {
+            title: 'Post Hello',
+          },
+          {
+            title: 'Get World',
+          },
+        ],
+      })
+    })
+
+    it('filters out both internal and ignored tags', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: { title: 'Test', version: '1.0.0' },
+          tags: [
+            { name: 'Public' },
+            { name: 'Internal', 'x-internal': true },
+            { name: 'Ignored', 'x-scalar-ignore': true },
+            { name: 'Both', 'x-internal': true, 'x-scalar-ignore': true },
+          ],
+          paths: {
+            '/hello': {
+              get: {
+                tags: ['Public'],
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [{ title: 'Public' }],
+      })
+    })
+
+    it('sorts tags alphabetically', async () => {
+      expect(
+        await getItemsForDocument(
+          {
+            openapi: '3.1.0',
+            info: {
+              title: 'Hello World',
+              version: '1.0.0',
+            },
+            paths: {
+              '/hello': {
+                get: {
+                  summary: 'Hello World',
+                  tags: ['Foobar', 'Barfoo'],
+                },
+              },
+            },
+          },
+          {
+            tagSort: 'alpha',
+          },
+        ),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'Barfoo',
+            children: [
+              {
+                title: 'Hello World',
+              },
+            ],
+          },
+          {
+            title: 'Foobar',
+            children: [
+              {
+                title: 'Hello World',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('sorts tags with custom function', async () => {
+      expect(
+        await getItemsForDocument(
+          {
+            openapi: '3.1.0',
+            info: {
+              title: 'Hello World',
+              version: '1.0.0',
+            },
+            paths: {
+              '/hello': {
+                get: {
+                  summary: 'Hello World',
+                  tags: ['Foobar', 'Barfoo'],
+                },
+              },
+            },
+          },
+          {
+            tagSort: (a) => {
+              if (a.name === 'Foobar') {
+                return -1
+              }
+
+              return 1
+            },
+          },
+        ),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'Foobar',
+            children: [
+              {
+                title: 'Hello World',
+              },
+            ],
+          },
+          {
+            title: 'Barfoo',
+            children: [
+              {
+                title: 'Hello World',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('adds to existing tags', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          tags: [
+            {
+              name: 'Foobar',
+              description: 'Foobar',
+            },
+          ],
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Hello World',
+                tags: ['Foobar'],
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'Foobar',
+            children: [
+              {
+                title: 'Hello World',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('creates a default tag', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          tags: [
+            {
+              name: 'Foobar',
+              description: 'Foobar',
+            },
+          ],
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Get Hello World',
+                tags: ['foobar'],
+              },
+              post: {
+                summary: 'Post Hello World',
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'foobar',
+            children: [
+              {
+                title: 'Get Hello World',
+              },
+            ],
+          },
+          {
+            title: 'default',
+            children: [
+              {
+                title: 'Post Hello World',
+              },
+            ],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('tag groups', () => {
+    it('groups tags by x-tagGroups', async () => {
+      expect(
+        await getItemsForDocument({
+          'openapi': '3.1.0',
+          'info': {
+            title: 'Example',
+            version: '1.0',
+          },
+          'tags': [
+            {
+              name: 'planets',
+            },
+          ],
+          'x-tagGroups': [
+            {
+              name: 'galaxy',
+              tags: ['planets'],
+            },
+          ],
+          'paths': {
+            '/planets': {
+              get: {
+                summary: 'Get all planets',
+                tags: ['planets'],
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'galaxy',
+            children: [
+              {
+                title: 'planets',
+                children: [
+                  {
+                    title: 'Get all planets',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('groups tags by x-tagGroups and shows default webhook group', async () => {
+      expect(
+        await getItemsForDocument({
+          'openapi': '3.1.0',
+          'info': {
+            title: 'Example',
+            version: '1.0',
+          },
+          'tags': [
+            {
+              name: 'planets',
+            },
+          ],
+          'x-tagGroups': [
+            {
+              name: 'galaxy',
+              tags: ['planets'],
+            },
+          ],
+          'paths': {
+            '/planets': {
+              get: {
+                summary: 'Get all planets',
+                tags: ['planets'],
+              },
+            },
+          },
+          'webhooks': {
+            hello: {
+              post: {
+                tags: ['planets'],
+                summary: 'Hello Webhook',
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'galaxy',
+            children: [
+              {
+                title: 'planets',
+                children: [
+                  {
+                    title: 'Get all planets',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            title: 'Webhooks',
+            children: [
+              {
+                title: 'Hello Webhook',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it.todo('groups tags by x-tagGroups and adds the webhooks to the tag group', async () => {
+      expect(
+        await getItemsForDocument({
+          'openapi': '3.1.0',
+          'info': {
+            title: 'Example',
+            version: '1.0',
+          },
+          'tags': [
+            {
+              name: 'planets',
+            },
+          ],
+          'x-tagGroups': [
+            {
+              name: 'galaxy',
+              tags: ['planets', 'webhooks'],
+            },
+          ],
+          'paths': {
+            '/planets': {
+              get: {
+                summary: 'Get all planets',
+                tags: ['planets'],
+              },
+            },
+          },
+          'webhooks': {
+            hello: {
+              post: {
+                summary: 'Hello Webhook',
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'galaxy',
+            children: [
+              {
+                title: 'planets',
+                children: [
+                  {
+                    title: 'Get all planets',
+                  },
+                ],
+              },
+              {
+                title: 'Webhooks',
+                children: [
+                  {
+                    title: 'Hello Webhook',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it.todo('groups tags by x-tagGroups and keeps the webhook default entry', async () => {
+      expect(
+        await getItemsForDocument({
+          'openapi': '3.1.0',
+          'info': {
+            title: 'Example',
+            version: '1.0',
+          },
+          'tags': [
+            {
+              name: 'planets',
+            },
+          ],
+          'x-tagGroups': [
+            {
+              name: 'galaxy',
+              tags: ['planets'],
+            },
+          ],
+          'paths': {
+            '/planets': {
+              get: {
+                summary: 'Get all planets',
+                tags: ['planets'],
+              },
+            },
+          },
+          'webhooks': {
+            hello: {
+              post: {
+                summary: 'Hello Webhook',
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'galaxy',
+            children: [
+              {
+                title: 'planets',
+                children: [
+                  {
+                    title: 'Get all planets',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            title: 'Webhooks',
+            children: [
+              {
+                title: 'Hello Webhook',
+              },
+            ],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('description', () => {
+    it('adds heading to the sidebar', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+            description: '# Foobar',
+          },
+          paths: {},
+        }),
+      ).toMatchObject({
+        titles: {},
+        entries: [
+          {
+            id: 'description/foobar',
+            title: 'Foobar',
+            children: [],
+          },
+        ],
+      })
+    })
+
+    it('adds two levels of headings to the sidebar', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+            description: '# Foobar\n\n## Barfoo',
+          },
+          paths: {},
+        }),
+      ).toMatchObject({
+        titles: {},
+        entries: [
+          {
+            id: 'description/foobar',
+            title: 'Foobar',
+            children: [
+              {
+                id: 'description/barfoo',
+                title: 'Barfoo',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it("doesn't add third level of headings", async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+            description: '# Foobar\n\n## Barfoo\n\n### Foofoo',
+          },
+          paths: {},
+        }),
+      ).toMatchObject({
+        titles: {},
+        entries: [
+          {
+            id: 'description/foobar',
+            title: 'Foobar',
+            children: [
+              {
+                id: 'description/barfoo',
+                title: 'Barfoo',
+              },
+            ],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('operations', () => {
+    it('has a single entry for a single operation', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Hello World',
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [{ title: 'Hello World' }],
+      })
+    })
+
+    it('has two entries for a single operation and a webhook', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Hello World',
+              },
+            },
+          },
+          webhooks: {
+            hello: {
+              post: {
+                summary: 'Hello Webhook',
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          { title: 'Hello World' },
+          {
+            title: 'Webhooks',
+            children: [
+              {
+                title: 'Hello Webhook',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('hides operations with x-internal: true', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                'summary': 'Get',
+                'x-internal': false,
+              },
+              post: {
+                'summary': 'Post',
+                'x-internal': true,
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [{ title: 'Get' }],
+      })
+    })
+
+    it('sorts operations alphabetically with summary', async () => {
+      expect(
+        await getItemsForDocument(
+          {
+            openapi: '3.1.0',
+            info: {
+              title: 'Hello World',
+              version: '1.0.0',
+            },
+            paths: {
+              '/hello': {
+                get: {
+                  summary: 'Operation A',
+                  tags: ['Hello'],
+                },
+              },
+              '/world': {
+                get: {
+                  summary: 'Operation B',
+                  tags: ['Hello'],
+                },
+              },
+            },
+          },
+          {
+            operationSort: 'alpha',
+          },
+        ),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'Hello',
+            children: [
+              {
+                title: 'Operation A',
+              },
+              {
+                title: 'Operation B',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('sorts operations alphabetically with paths', async () => {
+      expect(
+        await getItemsForDocument(
+          {
+            openapi: '3.1.0',
+            info: {
+              title: 'Hello World',
+              version: '1.0.0',
+            },
+            paths: {
+              '/foo': {
+                get: {
+                  tags: ['Hello'],
+                },
+              },
+              '/bar': {
+                get: {
+                  tags: ['Hello'],
+                },
+              },
+            },
+          },
+          {
+            operationSort: 'alpha',
+          },
+        ),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'Hello',
+            children: [
+              {
+                title: '/bar',
+              },
+              {
+                title: '/foo',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('sorts operations by method', async () => {
+      expect(
+        await getItemsForDocument(
+          {
+            openapi: '3.1.0',
+            info: {
+              title: 'Hello World',
+              version: '1.0.0',
+            },
+            paths: {
+              '/hello': {
+                post: {
+                  summary: 'Operation A',
+                  tags: ['Example'],
+                },
+              },
+              '/world': {
+                get: {
+                  summary: 'Operation B',
+                  tags: ['Example'],
+                },
+              },
+            },
+          },
+          {
+            operationSort: 'method',
+          },
+        ),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'Example',
+            children: [
+              {
+                title: 'Operation B',
+              },
+              {
+                title: 'Operation A',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it.todo('sorts operations with custom function', async () => {
+      expect(
+        await getItemsForDocument(
+          {
+            openapi: '3.1.0',
+            info: {
+              title: 'Hello World',
+              version: '1.0.0',
+            },
+            paths: {
+              '/foo': {
+                post: {
+                  summary: 'Hello World',
+                  tags: ['Foobar'],
+                },
+              },
+              '/hello': {
+                delete: {
+                  summary: 'Also World',
+                  tags: ['Foobar'],
+                },
+              },
+              '/world': {
+                get: {
+                  summary: 'Also Hello World',
+                  tags: ['Foobar'],
+                },
+              },
+              '/bar': {
+                get: {
+                  summary: 'Bar',
+                  tags: ['Foobar'],
+                },
+              },
+            },
+          },
+          {
+            operationSort: (a, b) => {
+              const methodOrder = ['GET', 'POST', 'DELETE']
+              const methodComparison = methodOrder.indexOf(a.httpVerb) - methodOrder.indexOf(b.httpVerb)
+
+              if (methodComparison !== 0) {
+                return methodComparison
+              }
+
+              return a.path.localeCompare(b.path)
+            },
+          },
+        ),
+      ).toMatchObject({
+        entries: [
+          {
+            title: 'Foobar',
+            children: [
+              {
+                title: 'Bar',
+              },
+              {
+                title: 'Also Hello World',
+              },
+              {
+                title: 'Hello World',
+              },
+              {
+                title: 'Also World',
+              },
+            ],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('webhooks', () => {
+    it('shows webhooks', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {},
+          webhooks: {
+            hello: {
+              post: {
+                'summary': 'Webhook',
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [{ title: 'Webhooks', children: [{ title: 'Webhook' }] }],
+      })
+    })
+
+    it('hides webhooks with x-internal: true', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Operation',
+              },
+            },
+          },
+          webhooks: {
+            hello: {
+              post: {
+                'summary': 'Webhook',
+              },
+            },
+            goodbye: {
+              post: {
+                'summary': 'Secret Webhook',
+                'x-internal': true,
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [{ title: 'Operation' }, { title: 'Webhooks', children: [{ title: 'Webhook' }] }],
+      })
+    })
+
+    it('shows operations and webhooks', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Operation',
+              },
+            },
+          },
+          webhooks: {
+            hello: {
+              post: {
+                'summary': 'Webhook',
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [{ title: 'Operation' }, { title: 'Webhooks', children: [{ title: 'Webhook' }] }],
+      })
+    })
+  })
+
+  describe('schemas', () => {
+    it('shows schemas', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Get',
+              },
+            },
+          },
+          components: {
+            schemas: {
+              Planet: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          { title: 'Get' },
+          {
+            title: 'Models',
+            children: [
+              {
+                title: 'Planet',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('hides schemas with x-internal: true', async () => {
+      expect(
+        await getItemsForDocument({
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Get',
+              },
+            },
+          },
+          components: {
+            schemas: {
+              Planet: {
+                'type': 'object',
+                'x-internal': false,
+                'properties': {
+                  name: {
+                    type: 'string',
+                  },
+                },
+              },
+              User: {
+                'type': 'object',
+                'x-internal': true,
+                'properties': {
+                  name: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ).toMatchObject({
+        entries: [
+          { title: 'Get' },
+          {
+            title: 'Models',
+            children: [
+              {
+                title: 'Planet',
+              },
+            ],
+          },
+        ],
+      })
+    })
+  })
+})

--- a/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.ts
@@ -1,0 +1,387 @@
+import { getWebhooks } from '@/features/Sidebar/helpers/get-webhooks'
+import type { InputOption, OperationSortOption, SidebarEntry, SortOptions } from '@/features/Sidebar/types'
+import { getHeadingsFromMarkdown, getLowestHeadingLevel } from '@/helpers'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { Heading } from '@scalar/types/legacy'
+import { computed } from 'vue'
+import { getOperationsByTag } from './get-operations-by-tag'
+import { getSchemas } from './get-schemas'
+import { getTags } from './get-tags'
+
+/**
+ * Represents a tag group in the OpenAPI specification.
+ * Used to organize operations into logical groups.
+ */
+type TagGroup = {
+  name: string
+  tags: string[]
+}
+
+/**
+ * Extended OpenAPI document that includes custom tag groups.
+ */
+type ExtendedDocument = OpenAPIV3_1.Document & {
+  'x-tagGroups'?: TagGroup[]
+}
+
+/**
+ * Represents a tagged entry in the sidebar with its children.
+ */
+type TaggedEntry = {
+  id: string
+  title: string
+  displayTitle?: string
+  show: boolean
+  children: SidebarEntry[]
+}
+
+/**
+ * Represents a webhook entry in the sidebar.
+ */
+type WebhookEntry = {
+  id: string
+  title: string
+  httpVerb: string
+  show: boolean
+}
+
+/**
+ * Creates a sidebar entry for a single API operation.
+ * Each operation is uniquely identified by its tag, method, and path.
+ */
+function createOperationEntry(
+  titlesById: Record<string, string>,
+  tag: OpenAPIV3_1.TagObject,
+  item: { method: string; path: string; operation: OpenAPIV3_1.OperationObject },
+): SidebarEntry {
+  const id = `${tag.name}-${item.method}-${item.path}`
+  const title = item.operation.summary ?? item.path
+  titlesById[id] = title
+
+  return {
+    id,
+    title,
+    httpVerb: item.method,
+    show: true,
+    select: () => {
+      console.log(`Selected operation: ${id}`)
+    },
+  }
+}
+
+/**
+ * Creates sidebar entries for operations organized by tag groups.
+ * Tag groups provide a hierarchical organization of API operations.
+ */
+function createTagGroupEntries(
+  content: ExtendedDocument,
+  titlesById: Record<string, string>,
+  tags: OpenAPIV3_1.TagObject[],
+  operationSort?: OperationSortOption['sort'],
+): SidebarEntry[] {
+  if (!content['x-tagGroups']?.length) {
+    return []
+  }
+
+  const tagMap = new Map(tags.map((tag) => [tag.name, tag]))
+
+  return content['x-tagGroups'].map((group) => {
+    const children: SidebarEntry[] = []
+
+    // Process regular tags
+    const groupTags = group.tags
+      .filter((tagName) => tagName !== 'webhooks')
+      .map((tagName) => tagMap.get(tagName))
+      .filter((tag): tag is OpenAPIV3_1.TagObject => tag !== undefined)
+
+    const tagEntries = groupTags
+      .map((tag) => {
+        const operations = getOperationsByTag(content, tag, {
+          sort: operationSort,
+          filter: (operation) => !operation['x-internal'] && !operation['x-scalar-ignore'],
+        })
+
+        return {
+          id: tag.name ?? 'untitled-tag',
+          title: tag.name ?? 'Untitled Tag',
+          displayTitle: tag['x-displayName'] ?? tag.name ?? 'Untitled Tag',
+          show: true,
+          children: operations.map((item) => createOperationEntry(titlesById, tag, item)),
+        }
+      })
+      .filter((entry) => entry.children.length > 0)
+
+    children.push(...tagEntries)
+
+    // Add webhooks if present in the group
+    if (group.tags.includes('webhooks')) {
+      const webhookEntry = createWebhookEntries(content, titlesById)
+      if (webhookEntry) {
+        children.push(webhookEntry)
+      }
+    }
+
+    return {
+      id: `group-${group.name}`,
+      title: group.name,
+      show: true,
+      isGroup: true,
+      children,
+    }
+  })
+}
+
+/**
+ * Creates sidebar entries for operations organized by tags.
+ * If tag groups are present, they are used instead of flat tags.
+ */
+function createTaggedEntries(
+  content: ExtendedDocument,
+  titlesById: Record<string, string>,
+  tags: OpenAPIV3_1.TagObject[],
+  operationSort?: OperationSortOption['sort'],
+): SidebarEntry[] {
+  if (content['x-tagGroups']?.length) {
+    return createTagGroupEntries(content, titlesById, tags, operationSort)
+  }
+
+  return tags
+    .map((tag): TaggedEntry | null => {
+      const operations = getOperationsByTag(content, tag, {
+        sort: operationSort,
+        filter: (operation) => !operation['x-internal'] && !operation['x-scalar-ignore'],
+      })
+
+      if (!operations.length) {
+        return null
+      }
+
+      return {
+        id: tag.name ?? 'untitled-tag',
+        title: tag.name ?? 'Untitled Tag',
+        displayTitle: tag['x-displayName'] ?? tag.name ?? 'Untitled Tag',
+        show: true,
+        children: operations.map((item) => createOperationEntry(titlesById, tag, item)),
+      }
+    })
+    .filter((entry): entry is TaggedEntry => entry !== null)
+}
+
+/**
+ * Creates sidebar entries for operations that don't have tags.
+ * These operations are either grouped under a 'default' tag or shown individually.
+ */
+function createUntaggedEntries(
+  content: OpenAPIV3_1.Document,
+  titlesById: Record<string, string>,
+  hasTaggedOperations: boolean,
+  operationSort?: OperationSortOption['sort'],
+): SidebarEntry[] {
+  const untaggedOperations = getOperationsByTag(
+    content,
+    { name: 'default' },
+    {
+      sort: operationSort,
+      filter: (operation) => {
+        return !operation['x-internal'] && !operation['x-scalar-ignore'] && !operation.tags?.length
+      },
+    },
+  )
+
+  if (!untaggedOperations.length) {
+    return []
+  }
+
+  if (hasTaggedOperations) {
+    return [
+      {
+        id: 'default',
+        title: 'default',
+        show: true,
+        children: untaggedOperations.map((item) => createOperationEntry(titlesById, { name: 'default' }, item)),
+      },
+    ]
+  }
+
+  return untaggedOperations.map((item) => createOperationEntry(titlesById, { name: 'untagged' }, item))
+}
+
+/**
+ * Creates sidebar entries for webhooks.
+ * Webhooks are grouped under a single 'Webhooks' section.
+ */
+function createWebhookEntries(content: OpenAPIV3_1.Document, titlesById: Record<string, string>): SidebarEntry | null {
+  const webhooks = getWebhooks(content, {
+    filter: (webhook) => !webhook['x-internal'] && !webhook['x-scalar-ignore'],
+  })
+
+  if (Object.keys(webhooks).length === 0) {
+    return null
+  }
+
+  const webhookEntries = Object.entries(webhooks).flatMap(([name, webhook]) =>
+    Object.entries(webhook)
+      .map(([method, operation]): WebhookEntry | null => {
+        if (typeof operation !== 'object') {
+          return null
+        }
+
+        const id = `webhook-${name}-${method}`
+        titlesById[id] = name
+
+        return {
+          id,
+          title: operation.summary ?? name,
+          httpVerb: method,
+          show: true,
+        }
+      })
+      .filter((entry): entry is WebhookEntry => entry !== null),
+  )
+
+  return {
+    id: 'webhooks',
+    title: 'Webhooks',
+    show: true,
+    children: webhookEntries,
+  }
+}
+
+/**
+ * Creates sidebar entries for schema definitions.
+ * Schemas are grouped under a single 'Models' section.
+ */
+function createSchemaEntries(content: OpenAPIV3_1.Document, titlesById: Record<string, string>): SidebarEntry | null {
+  const schemas = getSchemas(content, {
+    filter: (schema) => !schema['x-internal'] && !schema['x-scalar-ignore'],
+  })
+
+  if (Object.keys(schemas).length === 0) {
+    return null
+  }
+
+  const schemaEntries = Object.entries(schemas).map(([name]) => {
+    const id = `schema-${name}`
+    titlesById[id] = name
+
+    return {
+      id,
+      title: name,
+      show: true,
+      select: () => {
+        console.log(`Selected schema: ${id}`)
+      },
+    }
+  })
+
+  return {
+    id: 'models',
+    title: 'Models',
+    show: true,
+    children: schemaEntries,
+  }
+}
+
+/**
+ * Creates sidebar entries from markdown headings in the OpenAPI description.
+ * Only includes the top two levels of headings for a clean hierarchy.
+ */
+function createHeadingEntries(
+  description: string | undefined,
+  getHeadingId: (heading: Heading) => string,
+): SidebarEntry[] {
+  if (!description?.trim()) {
+    return []
+  }
+
+  const headings = getHeadingsFromMarkdown(description)
+  const lowestLevel = getLowestHeadingLevel(headings)
+  const relevantHeadings = headings.filter(
+    (heading) => heading.depth === lowestLevel || heading.depth === lowestLevel + 1,
+  )
+
+  if (!relevantHeadings.length) {
+    return []
+  }
+
+  const entries: SidebarEntry[] = []
+  let currentParent: SidebarEntry | null = null
+
+  for (const heading of relevantHeadings) {
+    const entry: SidebarEntry = {
+      id: getHeadingId(heading),
+      title: heading.value,
+      show: true,
+    }
+
+    if (heading.depth === lowestLevel) {
+      entry.children = []
+      entries.push(entry)
+      currentParent = entry
+    } else if (currentParent) {
+      currentParent.children?.push(entry)
+    }
+  }
+
+  return entries
+}
+
+/**
+ * Creates a new instance of the sidebar with the given OpenAPI specification.
+ * Returns a computed property that generates the sidebar structure.
+ */
+export function createSidebar(options?: InputOption & SortOptions) {
+  const items = computed(() => {
+    if (!options?.content) {
+      return { entries: [], titles: {} }
+    }
+
+    const titlesById: Record<string, string> = {}
+    const content = options.content as OpenAPIV3_1.Document
+
+    // Get and filter tags
+    const tags = getTags(content, {
+      sort: options.tagSort,
+      filter: (tag) => !tag['x-internal'] && !tag['x-scalar-ignore'],
+    })
+
+    // Check for tagged operations
+    const hasTaggedOperations = tags.some(
+      (tag) =>
+        getOperationsByTag(content, tag, {
+          filter: (operation) => !operation['x-internal'] && !operation['x-scalar-ignore'],
+        }).length > 0,
+    )
+
+    // Build sidebar entries
+    const entries: SidebarEntry[] = [
+      // Add heading entries from description
+      ...createHeadingEntries(content.info?.description, (heading) => `description/${heading.slug}`),
+      // Add tagged operations
+      ...createTaggedEntries(content, titlesById, tags, options.operationSort),
+    ]
+
+    // Add untagged operations if no default tag exists
+    if (!tags.some((tag) => tag.name === 'default')) {
+      entries.push(...createUntaggedEntries(content, titlesById, hasTaggedOperations, options.operationSort))
+    }
+
+    // Add webhooks and schemas if they exist
+    const webhookEntry = createWebhookEntries(content, titlesById)
+    if (webhookEntry) {
+      entries.push(webhookEntry)
+    }
+
+    const schemaEntry = createSchemaEntries(content, titlesById)
+    if (schemaEntry) {
+      entries.push(schemaEntry)
+    }
+
+    return {
+      entries,
+      titles: titlesById,
+    }
+  })
+
+  return { items }
+}

--- a/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.ts
@@ -387,5 +387,19 @@ export function createSidebar(options?: InputOption & SortOptions) {
     items,
     // TODO: Implement this
     isSidebarOpen: ref(true),
+    // TODO: Implement this
+    hideModels: ref(false),
+    // TODO: Implement this
+    defaultOpenAllTags: ref(false),
+    // TODO: Implement this
+    breadcrumb: ref([]),
+    // TODO: Implement this
+    collapsedSidebarItems: ref({
+      'default': true,
+    }),
+    // TODO: Implement this
+    setCollapsedSidebarItem: () => {},
+    // TODO: Implement this
+    scrollToOperation: () => {},
   }
 }

--- a/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.ts
@@ -1,6 +1,6 @@
 import { getWebhooks } from '@/features/Sidebar/helpers/get-webhooks'
 import type { InputOption, OperationSortOption, SidebarEntry, SortOptions } from '@/features/Sidebar/types'
-import { getHeadingsFromMarkdown, getLowestHeadingLevel } from '@/helpers'
+import { getHeadingsFromMarkdown, getLowestHeadingLevel } from '@/libs/markdown'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Heading } from '@scalar/types/legacy'
 import { computed } from 'vue'

--- a/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/create-sidebar.ts
@@ -3,7 +3,7 @@ import type { InputOption, OperationSortOption, SidebarEntry, SortOptions } from
 import { getHeadingsFromMarkdown, getLowestHeadingLevel } from '@/libs/markdown'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Heading } from '@scalar/types/legacy'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { getOperationsByTag } from './get-operations-by-tag'
 import { getSchemas } from './get-schemas'
 import { getTags } from './get-tags'
@@ -383,5 +383,9 @@ export function createSidebar(options?: InputOption & SortOptions) {
     }
   })
 
-  return { items }
+  return {
+    items,
+    // TODO: Implement this
+    isSidebarOpen: ref(true),
+  }
 }

--- a/packages/api-reference/src/features/Sidebar/helpers/get-operations-by-tag.test.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/get-operations-by-tag.test.ts
@@ -1,0 +1,93 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { describe, expect, it } from 'vitest'
+import { getOperationsByTag } from './get-operations-by-tag'
+
+const EXAMPLE_DOCUMENT = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  tags: [
+    {
+      name: 'Hello',
+      description: 'Hello World',
+      operations: [],
+    },
+    {
+      name: 'World',
+      description: 'World Hello',
+      operations: [],
+    },
+  ],
+  paths: {
+    '/hello': {
+      get: {
+        summary: 'Hello World',
+        tags: ['Hello'],
+      },
+    },
+    '/world': {
+      post: {
+        summary: 'World Hello',
+        tags: ['World'],
+      },
+    },
+  },
+} as const
+
+describe('getOperationsByTag', () => {
+  it('returns operations for a specific tag', () => {
+    const operationsSorter = (a: OpenAPIV3_1.OperationObject, b: OpenAPIV3_1.OperationObject) =>
+      a.summary?.localeCompare(b.summary || b.path) ?? 0
+
+    const tag: OpenAPIV3_1.TagObject = {
+      name: 'Hello',
+      description: 'Hello World',
+      operations: [],
+    }
+
+    const operations = getOperationsByTag(EXAMPLE_DOCUMENT, tag, {
+      sort: operationsSorter,
+    })
+
+    expect(operations).toHaveLength(1)
+    expect(operations[0].path).toBe('/hello')
+    expect(operations[0].method).toBe('GET')
+  })
+
+  it('filters operations based on the filter function', () => {
+    const tag: OpenAPIV3_1.TagObject = {
+      name: 'Hello',
+      description: 'Hello World',
+      operations: [],
+    }
+
+    // Add a new path with a deprecated operation
+    const testDocument = {
+      ...EXAMPLE_DOCUMENT,
+      paths: {
+        ...EXAMPLE_DOCUMENT.paths,
+        '/hello-deprecated': {
+          get: {
+            summary: 'Deprecated Hello',
+            tags: ['Hello'],
+            deprecated: true,
+          },
+        },
+      },
+    } as OpenAPIV3_1.Document
+
+    // Test without filter - should get all operations
+    const allOperations = getOperationsByTag(testDocument, tag)
+    expect(allOperations).toHaveLength(2)
+
+    // Test with filter to exclude deprecated operations
+    const filteredOperations = getOperationsByTag(testDocument, tag, {
+      filter: (operation) => !operation.deprecated,
+    })
+    expect(filteredOperations).toHaveLength(1)
+    expect(filteredOperations[0].path).toBe('/hello')
+    expect(filteredOperations[0].method).toBe('GET')
+  })
+})

--- a/packages/api-reference/src/features/Sidebar/helpers/get-operations-by-tag.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/get-operations-by-tag.ts
@@ -1,0 +1,82 @@
+import type { OperationSortOption } from '@/features/Sidebar/types'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+/**
+ * Takes an OpenAPI Document and a tag, and returns an array of operations that have the tag.
+ */
+export function getOperationsByTag(
+  content: OpenAPIV3_1.Document,
+  tag: OpenAPIV3_1.TagObject,
+  { sort, filter }: OperationSortOption & { filter?: (operation: OpenAPIV3_1.OperationObject) => boolean } = {},
+) {
+  const operations: {
+    method: OpenAPIV3_1.HttpMethods
+    path: string
+    operation: OpenAPIV3_1.OperationObject
+  }[] = []
+
+  if (!content.paths) {
+    return operations
+  }
+
+  // Loop through all paths in the document
+  Object.entries(content.paths).forEach(([path, pathItem]) => {
+    if (!pathItem) {
+      return
+    }
+
+    // Loop through all HTTP methods in the path
+    Object.entries(pathItem).forEach(([method, operation]) => {
+      // Skip if not an operation
+      if (typeof operation === 'string') {
+        return
+      }
+
+      // Skip if the operation doesn't match the filter
+      if (filter && !filter(operation)) {
+        return
+      }
+
+      // For default tag, include operations without tags
+      // TODO: Make the 'default' tag configurable
+      if (tag.name === 'default') {
+        if (!operation?.tags) {
+          operations.push({
+            method: method.toUpperCase() as OpenAPIV3_1.HttpMethods,
+            path,
+            operation,
+          })
+        }
+        return
+      }
+
+      // For other tags, only include operations that have the tag
+      if (operation?.tags?.includes(tag.name)) {
+        operations.push({
+          method: method.toUpperCase() as OpenAPIV3_1.HttpMethods,
+          path,
+          operation,
+        })
+      }
+    })
+  })
+
+  // Sort operations by path
+  if (sort === 'alpha') {
+    return operations.sort((a, b) => a.path.localeCompare(b.path))
+  }
+
+  // Sort operations by method
+  if (sort === 'method') {
+    return operations.sort((a, b) => a.method.localeCompare(b.method))
+  }
+
+  // Sort operations by a custom function
+  if (typeof sort === 'function') {
+    // TODO: We need the path and method
+    // TODO: Do we need to make sure we’re backwards compatible with the old sort function?
+    return operations.sort((a, b) => sort(a.operation, b.operation))
+  }
+
+  return operations
+}

--- a/packages/api-reference/src/features/Sidebar/helpers/get-schemas.test.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/get-schemas.test.ts
@@ -1,0 +1,80 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { describe, expect, it } from 'vitest'
+import { getSchemas } from './get-schemas'
+
+describe('getSchemas', () => {
+  const EXAMPLE_DOCUMENT: OpenAPIV3_1.Document = {
+    openapi: '3.1.0',
+    info: {
+      title: 'Test API',
+      version: '1.0.0',
+    },
+    components: {
+      schemas: {
+        User: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+          },
+        },
+        Error: {
+          type: 'object',
+          properties: {
+            code: { type: 'integer' },
+            message: { type: 'string' },
+          },
+        },
+      },
+    },
+  }
+
+  it('returns all schemas from OpenAPI document', () => {
+    const result = getSchemas(EXAMPLE_DOCUMENT)
+    expect(result).toEqual(EXAMPLE_DOCUMENT.components?.schemas)
+    expect(Object.keys(result)).toHaveLength(2)
+    expect(result).toHaveProperty('User')
+    expect(result).toHaveProperty('Error')
+  })
+
+  it('returns empty object when no schemas exist', () => {
+    const WITHOUT_SCHEMAS: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {},
+    }
+    const result = getSchemas(WITHOUT_SCHEMAS)
+    expect(result).toEqual({})
+  })
+
+  it('returns empty object when content is undefined', () => {
+    const result = getSchemas(undefined)
+    expect(result).toEqual({})
+  })
+
+  it('filters schemas based on provided filter function', () => {
+    const filter = (schema: OpenAPIV3_1.SchemaObject) => schema.properties?.id !== undefined
+
+    const result = getSchemas(EXAMPLE_DOCUMENT, { filter })
+
+    expect(Object.keys(result)).toHaveLength(1)
+    expect(result).toHaveProperty('User')
+    expect(result).not.toHaveProperty('Error')
+  })
+
+  it('handles empty components object', () => {
+    const EMPTY_COMPONENTS: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {},
+    }
+    const result = getSchemas(EMPTY_COMPONENTS)
+    expect(result).toEqual({})
+  })
+})

--- a/packages/api-reference/src/features/Sidebar/helpers/get-schemas.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/get-schemas.ts
@@ -1,0 +1,32 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+/**
+ * Returns all schemas from the OpenAPI document.
+ */
+export function getSchemas(
+  content?: OpenAPIV3_1.Document,
+  {
+    filter,
+  }: {
+    filter?: (schema: OpenAPIV3_1.SchemaObject) => boolean
+  } = {},
+) {
+  if (!content) {
+    return {} as Record<string, OpenAPIV3_1.SchemaObject>
+  }
+
+  const schemas =
+    // OpenAPI 3.x
+    (
+      Object.keys(content?.components?.schemas ?? {}).length
+        ? content?.components?.schemas
+        : // Fallback
+          {}
+    ) as Record<string, OpenAPIV3_1.SchemaObject>
+
+  if (filter) {
+    return Object.fromEntries(Object.entries(schemas).filter(([_, schema]) => filter(schema)))
+  }
+
+  return schemas
+}

--- a/packages/api-reference/src/features/Sidebar/helpers/get-tags.test.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/get-tags.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest'
+import { getTags } from './get-tags'
+
+const EXAMPLE_DOCUMENT = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  tags: [
+    {
+      name: 'Hello',
+      description: 'Hello World',
+      operations: [],
+    },
+    {
+      name: 'World',
+      description: 'World Hello',
+      operations: [],
+    },
+  ],
+  paths: {
+    '/hello': {
+      get: {
+        summary: 'Hello World',
+        tags: ['Hello'],
+      },
+    },
+    '/world': {
+      post: {
+        summary: 'World Hello',
+        tags: ['World'],
+      },
+    },
+  },
+} as const
+
+describe('getTags', () => {
+  it('returns sorted tags when using a custom sorter', () => {
+    const tagsSorter = (a: ExtendedTagObject, b: ExtendedTagObject) => a.name?.localeCompare(b.name ?? '') ?? 0
+    const tags = getTags(EXAMPLE_DOCUMENT, { sort: tagsSorter })
+
+    expect(tags).toHaveLength(2)
+    expect(tags?.[0].name).toBe('Hello')
+    expect(tags?.[1].name).toBe('World')
+  })
+
+  it('returns empty array when no tags exist', () => {
+    const EMPTY_COLLECTION = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Empty API',
+        version: '1.0.0',
+      },
+      paths: {},
+    } as const
+
+    const tags = getTags(EMPTY_COLLECTION)
+    expect(tags).toHaveLength(0)
+  })
+
+  it('returns unsorted tags when no sort option is provided', () => {
+    const tags = getTags(EXAMPLE_DOCUMENT)
+    expect(tags).toHaveLength(2)
+    expect(tags).toEqual(EXAMPLE_DOCUMENT.tags)
+  })
+
+  it('sorts tags alphabetically when sort is alpha', () => {
+    const UNSORTED_COLLECTION = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Unsorted API',
+        version: '1.0.0',
+      },
+      tags: [
+        {
+          name: 'Zebra',
+          description: 'Zebra description',
+          operations: [],
+        },
+        {
+          name: 'Apple',
+          description: 'Apple description',
+          operations: [],
+        },
+      ],
+    } as const
+
+    const tags = getTags(UNSORTED_COLLECTION, { sort: 'alpha' })
+    expect(tags).toHaveLength(2)
+    expect(tags?.[0].name).toBe('Apple')
+    expect(tags?.[1].name).toBe('Zebra')
+  })
+
+  it('handles tags with missing names', () => {
+    const COLLECTION_WITH_MISSING_NAMES = {
+      openapi: '3.1.0',
+      info: {
+        title: 'API with Missing Names',
+        version: '1.0.0',
+      },
+      tags: [
+        {
+          name: 'Valid',
+          description: 'Valid tag',
+          operations: [],
+        },
+        {
+          description: 'Missing name tag',
+          operations: [],
+        },
+      ],
+    } as const
+
+    const tags = getTags(COLLECTION_WITH_MISSING_NAMES, { sort: 'alpha' })
+    expect(tags).toHaveLength(2)
+    expect(tags?.[0].name).toBe('Valid')
+    expect(tags?.[1].name).toBeUndefined()
+  })
+
+  it('filters out internal tags', () => {
+    const EXAMPLE_DOCUMENT_WITH_INTERNAL_TAG = {
+      openapi: '3.1.0',
+      info: { title: 'Test', version: '1.0.0' },
+      tags: [
+        { name: 'Public', operations: [] },
+        { name: 'Internal', 'x-internal': true, operations: [] },
+      ],
+    } as const
+
+    const tags = getTags(EXAMPLE_DOCUMENT_WITH_INTERNAL_TAG, { filter: (tag) => tag['x-internal'] !== true })
+    expect(tags).toHaveLength(1)
+    expect(tags[0].name).toBe('Public')
+  })
+
+  it('filters out ignored tags', () => {
+    const EXAMPLE_DOCUMENT_WITH_IGNORED_TAG = {
+      openapi: '3.1.0',
+      info: { title: 'Test', version: '1.0.0' },
+      tags: [
+        { name: 'Public', operations: [] },
+        { name: 'Ignored', 'x-scalar-ignore': true, operations: [] },
+      ],
+    } as const
+
+    const tags = getTags(EXAMPLE_DOCUMENT_WITH_IGNORED_TAG, { filter: (tag) => tag['x-scalar-ignore'] !== true })
+    expect(tags).toHaveLength(1)
+    expect(tags[0].name).toBe('Public')
+  })
+
+  it('uses x-displayName for sorting when available', () => {
+    const EXAMPLE_DOCUMENT_WITH_DISPLAY_NAME = {
+      openapi: '3.1.0',
+      info: { title: 'Test', version: '1.0.0' },
+      tags: [
+        { name: 'b', 'x-displayName': 'Zebra', operations: [] },
+        { name: 'a', 'x-displayName': 'Apple', operations: [] },
+      ],
+    } as const
+
+    const tags = getTags(EXAMPLE_DOCUMENT_WITH_DISPLAY_NAME, { sort: 'alpha' })
+    expect(tags).toHaveLength(2)
+    expect(tags[0].name).toBe('a')
+    expect(tags[1].name).toBe('b')
+  })
+
+  it('returns empty array when no tags are defined', () => {
+    const EXAMPLE_DOCUMENT_WITH_TAGS = {
+      openapi: '3.1.0',
+      info: { title: 'Test', version: '1.0.0' },
+      paths: {
+        '/test': {
+          get: {
+            tags: ['Tag1'],
+            operationId: 'test',
+          },
+        },
+      },
+    } as const
+
+    const tags = getTags(EXAMPLE_DOCUMENT_WITH_TAGS)
+    expect(tags).toHaveLength(1)
+    expect(tags[0].name).toBe('Tag1')
+  })
+
+  it('returns default tag for operations without tags', () => {
+    const EXAMPLE_DOCUMENT_WITH_TAGS = {
+      openapi: '3.1.0',
+      info: { title: 'Test', version: '1.0.0' },
+      paths: {
+        '/test': {
+          get: {
+            // No tags here
+            operationId: 'test1',
+          },
+          post: {
+            tags: ['Tag1'],
+            operationId: 'test2',
+          },
+        },
+      },
+    } as const
+
+    const tags = getTags(EXAMPLE_DOCUMENT_WITH_TAGS)
+    expect(tags).toHaveLength(2)
+    expect(tags[0].name).toBe('Tag1')
+    expect(tags[1].name).toBe('default')
+  })
+
+  it('filters tags based on the filter function', () => {
+    const EXAMPLE_DOCUMENT_WITH_TAGS = {
+      openapi: '3.1.0',
+      info: { title: 'Test', version: '1.0.0' },
+      tags: [
+        { name: 'Public', description: 'Public tag', operations: [] },
+        { name: 'Private', description: 'Private tag', operations: [] },
+        { name: 'Admin', description: 'Admin tag', operations: [] },
+      ],
+    } as const
+
+    // Test without filter - should get all tags
+    const allTags = getTags(EXAMPLE_DOCUMENT_WITH_TAGS)
+    expect(allTags).toHaveLength(3)
+
+    // Test with filter to only include tags with 'Public' in the name
+    const filteredTags = getTags(EXAMPLE_DOCUMENT_WITH_TAGS, {
+      filter: (tag) => tag.name?.includes('Public') ?? false,
+    })
+    expect(filteredTags).toHaveLength(1)
+    expect(filteredTags[0].name).toBe('Public')
+  })
+})

--- a/packages/api-reference/src/features/Sidebar/helpers/get-tags.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/get-tags.ts
@@ -1,0 +1,87 @@
+import type { TagSortOption } from '@/features/Sidebar/types'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+// TODO: The store should support those custom properties
+type ExtendedTagObject = OpenAPIV3_1.TagObject & {
+  'x-internal'?: boolean
+  'x-scalar-ignore'?: boolean
+  'x-displayName'?: string
+  operations?: any[]
+}
+
+/**
+ * Takes an OpenAPI Document and returns an array of tags.
+ */
+export function getTags(content: OpenAPIV3_1.Document, { sort, filter }: TagSortOption = {}): ExtendedTagObject[] {
+  // Start with top-level tags
+  let tags = (content.tags ?? []) as ExtendedTagObject[]
+
+  // Collect tags from paths if they exist
+  if (content.paths) {
+    const pathTags = new Set<string>()
+    let hasUntaggedOperations = false
+    let hasTaggedOperations = false
+
+    // Loop through all paths and operations to collect unique tags
+    Object.values(content.paths).forEach((pathItem) => {
+      if (!pathItem) {
+        return
+      }
+
+      Object.values(pathItem).forEach((operation) => {
+        if (typeof operation === 'object') {
+          if (operation?.tags?.length) {
+            operation.tags.forEach((tag: string) => pathTags.add(tag))
+            hasTaggedOperations = true
+          } else {
+            hasUntaggedOperations = true
+          }
+        }
+      })
+    })
+
+    // Add any tags from paths that aren't already in the top-level tags
+    pathTags.forEach((tagName) => {
+      if (!tags.some((t) => t.name === tagName)) {
+        tags.push({ name: tagName })
+      }
+    })
+
+    // Only add default tag if we have both tagged and untagged operations
+    if (hasTaggedOperations && hasUntaggedOperations && !tags.some((t) => t.name === 'default')) {
+      tags.push({ name: 'default' })
+    }
+  }
+
+  if (filter) {
+    tags = tags.filter(filter)
+  }
+
+  if (sort === 'alpha') {
+    return tags.sort((a, b) => {
+      // Handle undefined names by putting them at the end
+      if (!a.name && !b.name) {
+        return 0
+      }
+
+      if (!a.name) {
+        return 1
+      }
+
+      if (!b.name) {
+        return -1
+      }
+
+      const nameA = a['x-displayName'] ?? a.name
+      const nameB = b['x-displayName'] ?? b.name
+
+      return nameA.localeCompare(nameB)
+    })
+  }
+
+  if (typeof sort === 'function') {
+    return tags.sort(sort)
+  }
+
+  return tags
+}

--- a/packages/api-reference/src/features/Sidebar/helpers/get-webhooks.test.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/get-webhooks.test.ts
@@ -1,0 +1,129 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { describe, expect, it } from 'vitest'
+import { getWebhooks } from './get-webhooks'
+
+describe('getWebhooks', () => {
+  it('returns empty object when no content is provided', () => {
+    const result = getWebhooks()
+    expect(result).toEqual({})
+  })
+
+  it('returns empty object when content has no webhooks', () => {
+    const EXAMPLE_DOCUMENT = {} as OpenAPIV3_1.Document
+    const result = getWebhooks(EXAMPLE_DOCUMENT)
+    expect(result).toEqual({})
+  })
+
+  it('returns webhooks from OpenAPI 3.x document', () => {
+    const EXAMPLE_DOCUMENT = {
+      webhooks: {
+        'user.created': {
+          post: {
+            operationId: 'userCreated',
+            summary: 'User created webhook',
+          },
+        },
+        'user.updated': {
+          put: {
+            operationId: 'userUpdated',
+            summary: 'User updated webhook',
+          },
+        },
+      },
+    } as OpenAPIV3_1.Document
+
+    const result = getWebhooks(EXAMPLE_DOCUMENT)
+
+    expect(result).toEqual({
+      'user.created': {
+        post: {
+          operationId: 'userCreated',
+          summary: 'User created webhook',
+        },
+      },
+      'user.updated': {
+        put: {
+          operationId: 'userUpdated',
+          summary: 'User updated webhook',
+        },
+      },
+    })
+  })
+
+  it('filters webhooks based on provided filter function', () => {
+    const EXAMPLE_DOCUMENT = {
+      webhooks: {
+        'user.created': {
+          post: {
+            operationId: 'userCreated',
+            summary: 'User created webhook',
+            tags: ['user'],
+          },
+        },
+        'user.updated': {
+          put: {
+            operationId: 'userUpdated',
+            summary: 'User updated webhook',
+            tags: ['admin'],
+          },
+        },
+      },
+    } as OpenAPIV3_1.Document
+
+    const filter = (webhook: OpenAPIV3_1.PathItemObject) => {
+      const operation = webhook as OpenAPIV3_1.OperationObject
+      return operation.tags?.includes('user') ?? false
+    }
+
+    const result = getWebhooks(EXAMPLE_DOCUMENT, { filter })
+
+    expect(result).toEqual({
+      'user.created': {
+        post: {
+          operationId: 'userCreated',
+          summary: 'User created webhook',
+          tags: ['user'],
+        },
+      },
+    })
+  })
+
+  it('handles webhooks with multiple HTTP methods', () => {
+    const EXAMPLE_DOCUMENT = {
+      webhooks: {
+        'user.events': {
+          post: {
+            operationId: 'userCreated',
+            summary: 'User created webhook',
+          },
+          put: {
+            operationId: 'userUpdated',
+            summary: 'User updated webhook',
+          },
+          delete: {
+            operationId: 'userDeleted',
+            summary: 'User deleted webhook',
+          },
+        },
+      },
+    } as OpenAPIV3_1.Document
+
+    const result = getWebhooks(EXAMPLE_DOCUMENT)
+    expect(result).toEqual({
+      'user.events': {
+        post: {
+          operationId: 'userCreated',
+          summary: 'User created webhook',
+        },
+        put: {
+          operationId: 'userUpdated',
+          summary: 'User updated webhook',
+        },
+        delete: {
+          operationId: 'userDeleted',
+          summary: 'User deleted webhook',
+        },
+      },
+    })
+  })
+})

--- a/packages/api-reference/src/features/Sidebar/helpers/get-webhooks.ts
+++ b/packages/api-reference/src/features/Sidebar/helpers/get-webhooks.ts
@@ -1,0 +1,46 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+/**
+ * Returns all webhooks from the OpenAPI document.
+ * Each webhook can have HTTP methods (get, post, put, etc.) as keys.
+ */
+export function getWebhooks(
+  content?: OpenAPIV3_1.Document,
+  {
+    filter,
+  }: {
+    filter?: (webhook: OpenAPIV3_1.PathItemObject) => boolean
+  } = {},
+) {
+  if (!content) {
+    return {} as Record<string, Record<OpenAPIV3_1.HttpMethods, OpenAPIV3_1.OperationObject>>
+  }
+
+  const webhooks =
+    // OpenAPI 3.x
+    (
+      Object.keys(content?.webhooks ?? {}).length
+        ? content?.webhooks
+        : // Fallback
+          {}
+    ) as Record<string, Record<OpenAPIV3_1.HttpMethods, OpenAPIV3_1.OperationObject>>
+
+  if (filter) {
+    // Filter each webhook's operations based on the filter function
+    return Object.fromEntries(
+      Object.entries(webhooks)
+        .map(([name, webhook]) => {
+          const filteredOperations = Object.fromEntries(
+            Object.entries(webhook).filter(([_, operation]) => filter(operation as OpenAPIV3_1.PathItemObject)),
+          )
+          // Only include webhooks that have at least one matching operation
+          return Object.keys(filteredOperations).length > 0 ? [name, filteredOperations] : null
+        })
+        .filter(
+          (entry): entry is [string, Record<OpenAPIV3_1.HttpMethods, OpenAPIV3_1.OperationObject>] => entry !== null,
+        ),
+    )
+  }
+
+  return webhooks
+}

--- a/packages/api-reference/src/features/Sidebar/hooks/useSidebar.test.ts
+++ b/packages/api-reference/src/features/Sidebar/hooks/useSidebar.test.ts
@@ -1,0 +1,98 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, inject, provide } from 'vue'
+import { createSidebar } from '../helpers/create-sidebar'
+import { SIDEBAR_SYMBOL, useSidebar } from './useSidebar'
+
+const EXAMPLE_DOCUMENT = {
+  openapi: '3.1.1',
+  info: {
+    title: 'Example',
+    version: '1.0',
+  },
+  paths: {
+    '/hello': {
+      get: {
+        summary: 'Hello World',
+      },
+    },
+  },
+} as OpenAPIV3_1.Document
+
+// Mock Vue's provide and inject
+vi.mock('vue', async () => {
+  const actual = await vi.importActual('vue')
+  return {
+    ...actual,
+    provide: vi.fn(),
+    inject: vi.fn(),
+  }
+})
+
+// Mock the createSidebar function
+vi.mock('../helpers/create-sidebar', () => ({
+  createSidebar: vi.fn(),
+}))
+
+describe('useSidebar', () => {
+  // Reset mocks before each test
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('when called with a collection', () => {
+    it('creates and provides a new sidebar instance', () => {
+      // Arrange
+      const mockSidebar = {
+        items: computed(() => ({
+          entries: [],
+          titles: {},
+        })),
+      }
+      vi.mocked(createSidebar).mockReturnValue(mockSidebar)
+
+      // Act
+      const result = useSidebar(EXAMPLE_DOCUMENT, { tagSort: 'alpha', operationSort: 'alpha' })
+
+      // Assert
+      expect(createSidebar).toHaveBeenCalledWith({
+        content: EXAMPLE_DOCUMENT,
+        tagSort: 'alpha',
+        operationSort: 'alpha',
+      })
+      expect(provide).toHaveBeenCalledWith(SIDEBAR_SYMBOL, mockSidebar)
+      expect(result).toBe(mockSidebar)
+    })
+  })
+
+  describe('when called without a collection', () => {
+    it('injects an existing sidebar instance', () => {
+      // Arrange
+      const mockSidebar = {
+        items: computed(() => ({
+          entries: [],
+          titles: {},
+        })),
+      }
+      vi.mocked(inject).mockReturnValue(mockSidebar)
+
+      // Act
+      const result = useSidebar()
+
+      // Assert
+      expect(inject).toHaveBeenCalledWith(SIDEBAR_SYMBOL)
+      expect(result).toBe(mockSidebar)
+    })
+
+    it('throws an error when no sidebar instance is found', () => {
+      // Arrange
+      vi.mocked(inject).mockReturnValue(undefined)
+
+      // Act & Assert
+      expect(() => useSidebar()).toThrow(
+        'useSidebar() was called without a collection and no sidebar instance was found. ' +
+          'Make sure to call useSidebar(collection) in a parent component first.',
+      )
+    })
+  })
+})

--- a/packages/api-reference/src/features/Sidebar/hooks/useSidebar.ts
+++ b/packages/api-reference/src/features/Sidebar/hooks/useSidebar.ts
@@ -1,0 +1,45 @@
+import type { SortOptions } from '@/features/Sidebar/types'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { type InjectionKey, inject, provide } from 'vue'
+import { createSidebar } from '../helpers/create-sidebar'
+
+/**
+ * Injection key for the sidebar instance.
+ * This ensures type safety when injecting the sidebar.
+ */
+export const SIDEBAR_SYMBOL: InjectionKey<ReturnType<typeof createSidebar>> = Symbol('sidebar')
+
+/**
+ * Composable for managing the sidebar state.
+ *
+ * When called with a collection, it creates and provides a new sidebar instance.
+ * When called without parameters, it returns the injected sidebar instance.
+ */
+export function useSidebar(
+  content?: OpenAPIV3_1.Document,
+  sortOptions?: SortOptions,
+): ReturnType<typeof createSidebar> {
+  // If collection is provided, create and provide a new sidebar instance
+  if (content) {
+    const sidebar = createSidebar({
+      content,
+      ...sortOptions,
+    })
+
+    provide(SIDEBAR_SYMBOL, sidebar)
+
+    return sidebar
+  }
+
+  // Otherwise, try to inject the existing sidebar instance
+  const sidebar = inject(SIDEBAR_SYMBOL)
+
+  if (!sidebar) {
+    throw new Error(
+      'useSidebar() was called without a collection and no sidebar instance was found. ' +
+        'Make sure to call useSidebar(collection) in a parent component first.',
+    )
+  }
+
+  return sidebar
+}

--- a/packages/api-reference/src/features/Sidebar/hooks/useSidebar.ts
+++ b/packages/api-reference/src/features/Sidebar/hooks/useSidebar.ts
@@ -26,14 +26,12 @@ export function useSidebar(
       ...sortOptions,
     })
 
-    console.log('PROVIDE SIDEBAR')
     provide(SIDEBAR_SYMBOL, sidebar)
 
     return sidebar
   }
 
   // Otherwise, try to inject the existing sidebar instance
-  console.log('INJECT SIDEBAR')
   const sidebar = inject(SIDEBAR_SYMBOL)
 
   if (!sidebar) {

--- a/packages/api-reference/src/features/Sidebar/hooks/useSidebar.ts
+++ b/packages/api-reference/src/features/Sidebar/hooks/useSidebar.ts
@@ -20,31 +20,27 @@ export function useSidebar(
   sortOptions?: SortOptions,
 ): ReturnType<typeof createSidebar> {
   // If collection is provided, create and provide a new sidebar instance
-  console.log('USESIDEBAR')
   if (content) {
-    console.log('WITH CONTENT')
     const sidebar = createSidebar({
       content,
       ...sortOptions,
     })
 
+    console.log('PROVIDE SIDEBAR')
     provide(SIDEBAR_SYMBOL, sidebar)
 
     return sidebar
   }
 
-  console.log('WITHOUT CONTENT')
-
   // Otherwise, try to inject the existing sidebar instance
+  console.log('INJECT SIDEBAR')
   const sidebar = inject(SIDEBAR_SYMBOL)
 
   if (!sidebar) {
-    return null
-    // TODO: BRING BRACK
-    // throw new Error(
-    //   'useSidebar() was called without a collection and no sidebar instance was found. ' +
-    //     'Make sure to call useSidebar(collection) in a parent component first.',
-    // )
+    throw new Error(
+      'useSidebar() was called without a collection and no sidebar instance was found. ' +
+        'Make sure to call useSidebar(collection) in a parent component first.',
+    )
   }
 
   return sidebar

--- a/packages/api-reference/src/features/Sidebar/hooks/useSidebar.ts
+++ b/packages/api-reference/src/features/Sidebar/hooks/useSidebar.ts
@@ -20,7 +20,9 @@ export function useSidebar(
   sortOptions?: SortOptions,
 ): ReturnType<typeof createSidebar> {
   // If collection is provided, create and provide a new sidebar instance
+  console.log('USESIDEBAR')
   if (content) {
+    console.log('WITH CONTENT')
     const sidebar = createSidebar({
       content,
       ...sortOptions,
@@ -31,14 +33,18 @@ export function useSidebar(
     return sidebar
   }
 
+  console.log('WITHOUT CONTENT')
+
   // Otherwise, try to inject the existing sidebar instance
   const sidebar = inject(SIDEBAR_SYMBOL)
 
   if (!sidebar) {
-    throw new Error(
-      'useSidebar() was called without a collection and no sidebar instance was found. ' +
-        'Make sure to call useSidebar(collection) in a parent component first.',
-    )
+    return null
+    // TODO: BRING BRACK
+    // throw new Error(
+    //   'useSidebar() was called without a collection and no sidebar instance was found. ' +
+    //     'Make sure to call useSidebar(collection) in a parent component first.',
+    // )
   }
 
   return sidebar

--- a/packages/api-reference/src/features/Sidebar/index.ts
+++ b/packages/api-reference/src/features/Sidebar/index.ts
@@ -1,0 +1,4 @@
+export { createSidebar } from './helpers/create-sidebar'
+export { Sidebar } from './components'
+export { useSidebar } from './hooks/useSidebar'
+export type { SidebarEntry, SortOptions } from './types'

--- a/packages/api-reference/src/features/Sidebar/index.ts
+++ b/packages/api-reference/src/features/Sidebar/index.ts
@@ -1,4 +1,6 @@
 export { createSidebar } from './helpers/create-sidebar'
 export { Sidebar } from './components'
-export { useSidebar } from './hooks/useSidebar'
+export { useSidebar, SIDEBAR_SYMBOL } from './hooks/useSidebar'
 export type { SidebarEntry, SortOptions } from './types'
+
+export const DEFAULT_INTRODUCTION_SLUG = 'introduction'

--- a/packages/api-reference/src/features/Sidebar/types.ts
+++ b/packages/api-reference/src/features/Sidebar/types.ts
@@ -1,0 +1,39 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+export type SidebarEntry = {
+  id: string
+  title: string
+  displayTitle?: string
+  children?: SidebarEntry[]
+  select?: () => void
+  httpVerb?: string
+  show: boolean
+  deprecated?: boolean
+  isGroup?: boolean
+}
+
+export type InputOption = {
+  content: OpenAPIV3_1.Document
+}
+
+export type SortOptions = {
+  tagSort?: TagSortOption['sort']
+  operationSort?: OperationSortOption['sort']
+}
+
+export type OperationSortOption = {
+  sort?: 'alpha' | 'method' | ((a: OpenAPIV3_1.OperationObject, b: OpenAPIV3_1.OperationObject) => number)
+}
+
+export type TagSortOption = {
+  sort?: 'alpha' | ((a: ExtendedTagObject, b: ExtendedTagObject) => number)
+  filter?: (tag: ExtendedTagObject) => boolean
+}
+
+// TODO: The store should support those custom properties
+export type ExtendedTagObject = OpenAPIV3_1.TagObject & {
+  'x-internal'?: boolean
+  'x-scalar-ignore'?: boolean
+  'x-displayName'?: string
+  operations?: any[]
+}

--- a/packages/api-reference/src/hooks/old/useSidebar.test.ts
+++ b/packages/api-reference/src/hooks/old/useSidebar.test.ts
@@ -1,0 +1,1062 @@
+import { describe, expect, it, vi } from 'vitest'
+import { computed, toValue } from 'vue'
+
+import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { parse } from '../../helpers'
+import { type SorterOption, useSidebar } from './useSidebar'
+
+// Mock the useConfig hook
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: vi.fn().mockReturnValue(computed(() => apiReferenceConfigurationSchema.parse({}))),
+}))
+
+// Mock vue's inject
+vi.mock('vue', () => {
+  const actual = require('vue')
+  return {
+    ...actual,
+    inject: vi.fn().mockReturnValue({
+      getTagId: vi.fn(),
+      getOperationId: vi.fn(),
+      getHeadingId: vi.fn(),
+      getModelId: vi.fn(),
+      getWebhookId: vi.fn(),
+      hash: { value: '' },
+      hashPrefix: { value: '' },
+      isIntersectionEnabled: { value: false },
+    }),
+  }
+})
+/**
+ * Parse the given OpenAPI definition and return the items for the sidebar.
+ */
+async function getItemsForDocument(definition: Record<string, any>, options?: SorterOption) {
+  const parsedSpec = await parse(definition)
+
+  const { items } = useSidebar({
+    ...{
+      tagsSorter: undefined,
+      operationsSorter: undefined,
+      ...options,
+    },
+    parsedSpec,
+  })
+
+  return toValue(items)
+}
+
+describe('useSidebar', async () => {
+  it('doesn’t return any entries for an empty specification', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {},
+      }),
+    ).toStrictEqual({
+      titles: {},
+      entries: [],
+    })
+  })
+
+  it('has a single entry for a single operation', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Hello World',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [{ title: 'Hello World' }],
+    })
+  })
+
+  it('has two entries for a single operation and a webhook', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Hello World',
+            },
+          },
+        },
+        webhooks: {
+          hello: {
+            post: {
+              summary: 'Hello Webhook',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        { title: 'Hello World' },
+        {
+          title: 'Webhooks',
+          children: [
+            {
+              title: 'Hello Webhook',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('has a single entry for a single operation', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Hello World',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [{ title: 'Hello World' }],
+    })
+  })
+
+  it('has a tag', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Hello World',
+              tags: ['Foobar'],
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('has multiple tags', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Hello World',
+              tags: ['Foobar', 'Barfoo'],
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+        {
+          title: 'Barfoo',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('sorts tags alphabetically', async () => {
+    expect(
+      await getItemsForDocument(
+        {
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Hello World',
+                tags: ['Foobar', 'Barfoo'],
+              },
+            },
+          },
+        },
+        {
+          tagsSorter: 'alpha',
+        },
+      ),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Barfoo',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('sorts tags with custom function', async () => {
+    expect(
+      await getItemsForDocument(
+        {
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Hello World',
+                tags: ['Foobar', 'Barfoo'],
+              },
+            },
+          },
+        },
+        {
+          tagsSorter: (a) => {
+            if (a.name === 'Foobar') {
+              return -1
+            }
+
+            return 1
+          },
+        },
+      ),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+        {
+          title: 'Barfoo',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('adds to existing tags', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        tags: [
+          {
+            name: 'Foobar',
+            description: 'Foobar',
+          },
+        ],
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Hello World',
+              tags: ['Foobar'],
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('creates a default tag', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        tags: [
+          {
+            name: 'Foobar',
+            description: 'Foobar',
+          },
+        ],
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Get Hello World',
+              tags: ['foobar'],
+            },
+            post: {
+              summary: 'Post Hello World',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'foobar',
+          children: [
+            {
+              title: 'Get Hello World',
+            },
+          ],
+        },
+        {
+          title: 'default',
+          children: [
+            {
+              title: 'Post Hello World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('groups tags by x-tagGroups', async () => {
+    expect(
+      await getItemsForDocument({
+        'openapi': '3.1.0',
+        'info': {
+          title: 'Example',
+          version: '1.0',
+        },
+        'tags': [
+          {
+            name: 'planets',
+          },
+        ],
+        'x-tagGroups': [
+          {
+            name: 'galaxy',
+            tags: ['planets'],
+          },
+        ],
+        'paths': {
+          '/planets': {
+            get: {
+              summary: 'Get all planets',
+              tags: ['planets'],
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'galaxy',
+          children: [
+            {
+              title: 'planets',
+              children: [
+                {
+                  title: 'Get all planets',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('groups tags by x-tagGroups and shows default webhook group', async () => {
+    expect(
+      await getItemsForDocument({
+        'openapi': '3.1.0',
+        'info': {
+          title: 'Example',
+          version: '1.0',
+        },
+        'tags': [
+          {
+            name: 'planets',
+          },
+        ],
+        'x-tagGroups': [
+          {
+            name: 'galaxy',
+            tags: ['planets'],
+          },
+        ],
+        'paths': {
+          '/planets': {
+            get: {
+              summary: 'Get all planets',
+              tags: ['planets'],
+            },
+          },
+        },
+        'webhooks': {
+          hello: {
+            post: {
+              tags: ['planets'],
+              summary: 'Hello Webhook',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'galaxy',
+          children: [
+            {
+              title: 'planets',
+              children: [
+                {
+                  title: 'Get all planets',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          title: 'Webhooks',
+          children: [
+            {
+              title: 'Hello Webhook',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('groups tags by x-tagGroups and adds the webhooks to the tag group', async () => {
+    expect(
+      await getItemsForDocument({
+        'openapi': '3.1.0',
+        'info': {
+          title: 'Example',
+          version: '1.0',
+        },
+        'tags': [
+          {
+            name: 'planets',
+          },
+        ],
+        'x-tagGroups': [
+          {
+            name: 'galaxy',
+            tags: ['planets', 'webhooks'],
+          },
+        ],
+        'paths': {
+          '/planets': {
+            get: {
+              summary: 'Get all planets',
+              tags: ['planets'],
+            },
+          },
+        },
+        'webhooks': {
+          hello: {
+            post: {
+              summary: 'Hello Webhook',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'galaxy',
+          children: [
+            {
+              title: 'planets',
+              children: [
+                {
+                  title: 'Get all planets',
+                },
+              ],
+            },
+            {
+              title: 'Webhooks',
+              children: [
+                {
+                  title: 'Hello Webhook',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('groups tags by x-tagGroups and keeps the webhook default entry', async () => {
+    expect(
+      await getItemsForDocument({
+        'openapi': '3.1.0',
+        'info': {
+          title: 'Example',
+          version: '1.0',
+        },
+        'tags': [
+          {
+            name: 'planets',
+          },
+        ],
+        'x-tagGroups': [
+          {
+            name: 'galaxy',
+            tags: ['planets'],
+          },
+        ],
+        'paths': {
+          '/planets': {
+            get: {
+              summary: 'Get all planets',
+              tags: ['planets'],
+            },
+          },
+        },
+        'webhooks': {
+          hello: {
+            post: {
+              summary: 'Hello Webhook',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'galaxy',
+          children: [
+            {
+              title: 'planets',
+              children: [
+                {
+                  title: 'Get all planets',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          title: 'Webhooks',
+          children: [
+            {
+              title: 'Hello Webhook',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('hides operations with x-internal: true', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              'summary': 'Get',
+              'x-internal': false,
+            },
+            post: {
+              'summary': 'Post',
+              'x-internal': true,
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [{ title: 'Get' }],
+    })
+  })
+
+  it('hides webhooks with x-internal: true', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Get',
+            },
+          },
+        },
+        webhooks: {
+          hello: {
+            post: {
+              'summary': 'Hello Webhook',
+              'x-internal': true,
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [{ title: 'Get' }],
+    })
+  })
+
+  it('shows schemas', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Get',
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Planet: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        { title: 'Get' },
+        {
+          title: 'Models',
+          children: [
+            {
+              title: 'Planet',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('hides schemas with x-internal: true', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Get',
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Planet: {
+              'type': 'object',
+              'x-internal': false,
+              'properties': {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+            User: {
+              'type': 'object',
+              'x-internal': true,
+              'properties': {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      entries: [
+        { title: 'Get' },
+        {
+          title: 'Models',
+          children: [
+            {
+              title: 'Planet',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('adds heading to the sidebar', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+          description: '# Foobar',
+        },
+        paths: {},
+      }),
+    ).toMatchObject({
+      titles: {},
+      entries: [
+        {
+          id: 'description/foobar',
+          title: 'Foobar',
+          children: [],
+        },
+      ],
+    })
+  })
+
+  it('adds two levels of headings to the sidebar', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+          description: '# Foobar\n\n## Barfoo',
+        },
+        paths: {},
+      }),
+    ).toMatchObject({
+      titles: {},
+      entries: [
+        {
+          id: 'description/foobar',
+          title: 'Foobar',
+          children: [
+            {
+              id: 'description/barfoo',
+              title: 'Barfoo',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('doesn’t add third level of headings', async () => {
+    expect(
+      await getItemsForDocument({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+          description: '# Foobar\n\n## Barfoo\n\n### Foofoo',
+        },
+        paths: {},
+      }),
+    ).toMatchObject({
+      titles: {},
+      entries: [
+        {
+          id: 'description/foobar',
+          title: 'Foobar',
+          children: [
+            {
+              id: 'description/barfoo',
+              title: 'Barfoo',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('sorts operations alphabetically with summary', async () => {
+    expect(
+      await getItemsForDocument(
+        {
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              get: {
+                summary: 'Hello',
+                tags: ['Hello'],
+              },
+            },
+            '/world': {
+              get: {
+                summary: 'Also Hello',
+                tags: ['Hello'],
+              },
+            },
+          },
+        },
+        {
+          operationsSorter: 'alpha',
+        },
+      ),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Hello',
+          children: [
+            {
+              title: 'Also Hello',
+            },
+            {
+              title: 'Hello',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('sorts operations alphabetically with paths', async () => {
+    expect(
+      await getItemsForDocument(
+        {
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/foo': {
+              get: {
+                tags: ['Hello'],
+              },
+            },
+            '/bar': {
+              get: {
+                tags: ['Hello'],
+              },
+            },
+          },
+        },
+        {
+          operationsSorter: 'alpha',
+        },
+      ),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Hello',
+          children: [
+            {
+              title: '/bar',
+            },
+            {
+              title: '/foo',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('sorts operations by method', async () => {
+    expect(
+      await getItemsForDocument(
+        {
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/hello': {
+              post: {
+                summary: 'Also Hello',
+                tags: ['Hello'],
+              },
+            },
+            '/world': {
+              get: {
+                summary: 'Hello',
+                tags: ['Hello'],
+              },
+            },
+          },
+        },
+        {
+          operationsSorter: 'method',
+        },
+      ),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Hello',
+          children: [
+            {
+              title: 'Hello',
+            },
+            {
+              title: 'Also Hello',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('sorts operations with custom function', async () => {
+    expect(
+      await getItemsForDocument(
+        {
+          openapi: '3.1.0',
+          info: {
+            title: 'Hello World',
+            version: '1.0.0',
+          },
+          paths: {
+            '/foo': {
+              post: {
+                summary: 'Hello World',
+                tags: ['Foobar'],
+              },
+            },
+            '/hello': {
+              delete: {
+                summary: 'Also World',
+                tags: ['Foobar'],
+              },
+            },
+            '/world': {
+              get: {
+                summary: 'Also Hello World',
+                tags: ['Foobar'],
+              },
+            },
+            '/bar': {
+              get: {
+                summary: 'Bar',
+                tags: ['Foobar'],
+              },
+            },
+          },
+        },
+        {
+          operationsSorter: (a, b) => {
+            const methodOrder = ['GET', 'POST', 'DELETE']
+            const methodComparison = methodOrder.indexOf(a.httpVerb) - methodOrder.indexOf(b.httpVerb)
+
+            if (methodComparison !== 0) {
+              return methodComparison
+            }
+
+            return a.path.localeCompare(b.path)
+          },
+        },
+      ),
+    ).toMatchObject({
+      entries: [
+        {
+          title: 'Foobar',
+          children: [
+            {
+              title: 'Bar',
+            },
+            {
+              title: 'Also Hello World',
+            },
+            {
+              title: 'Hello World',
+            },
+            {
+              title: 'Also World',
+            },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/packages/api-reference/src/hooks/old/useSidebar.test.ts
+++ b/packages/api-reference/src/hooks/old/useSidebar.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { computed, toValue } from 'vue'
 
+import { parse } from '@/helpers/parse'
 import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
-import { parse } from '../../helpers'
 import { type SorterOption, useSidebar } from './useSidebar'
 
 // Mock the useConfig hook

--- a/packages/api-reference/src/hooks/old/useSidebar.ts
+++ b/packages/api-reference/src/hooks/old/useSidebar.ts
@@ -1,0 +1,440 @@
+import { isOperationDeprecated } from '@/libs/operation'
+import { ssrState } from '@scalar/oas-utils/helpers'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { Spec, Tag, TransformedOperation } from '@scalar/types/legacy'
+import { computed, reactive, ref, watch } from 'vue'
+import { lazyBus } from '../../components/Content/Lazy/lazyBus'
+import {
+  getHeadingsFromMarkdown,
+  getLowestHeadingLevel,
+  getModels,
+  hasModels,
+  hasWebhooks,
+  scrollToId,
+} from '../../helpers'
+import { useNavState } from '../useNavState'
+
+export type SidebarEntry = {
+  id: string
+  title: string
+  displayTitle?: string
+  children?: SidebarEntry[]
+  select?: () => void
+  httpVerb?: string
+  show: boolean
+  deprecated?: boolean
+  isGroup?: boolean
+}
+
+export const DEFAULT_INTRODUCTION_SLUG = 'introduction'
+
+/**
+ * This is a temp hack to get the navState outside of a setup function.
+ * Sidebar will eventually be replaced by the client one so we can remove this whole hook then.
+ */
+const navState = ref<ReturnType<typeof useNavState> | null>(null)
+
+// Track the parsed spec
+const parsedSpec = ref<Spec | undefined>(undefined)
+
+/** Keep track of the given options */
+const optionsRef = reactive<Partial<ParsedSpecOption & SorterOption>>({})
+
+/** Helper to overwrite the current OpenAPI document */
+function setParsedSpec(spec: Spec) {
+  // Sort tags alphabetically
+  if (optionsRef.tagsSorter === 'alpha') {
+    spec.tags = spec.tags?.sort((a, b) => a.name.localeCompare(b.name))
+  }
+  // Custom tags sorting
+  else if (typeof optionsRef.tagsSorter === 'function') {
+    spec.tags = spec.tags?.sort(optionsRef.tagsSorter)
+  }
+
+  // Sort function for operations by title
+  const sortByTitle = (a: TransformedOperation, b: TransformedOperation) => {
+    const titleA = a.name ?? a.path
+    const titleB = b.name ?? b.path
+
+    return titleA.localeCompare(titleB)
+  }
+  // Sort function for operations by method
+  const sortByMethod = (a: TransformedOperation, b: TransformedOperation) => a.httpVerb.localeCompare(b.httpVerb)
+
+  let operationSorterFunc: ((a: TransformedOperation, b: TransformedOperation) => number) | undefined
+
+  // Sort operations alphabetically
+  if (optionsRef.operationsSorter === 'alpha') {
+    operationSorterFunc = sortByTitle
+  }
+  // Sort operations by method
+  else if (optionsRef.operationsSorter === 'method') {
+    operationSorterFunc = sortByMethod
+  }
+  // Custom operations sorting
+  else if (typeof optionsRef.operationsSorter === 'function') {
+    operationSorterFunc = optionsRef.operationsSorter
+  }
+  // Apply sorting to operations if a sorter function exists
+  if (operationSorterFunc) {
+    spec.tags?.forEach((tag) => {
+      tag.operations = tag.operations?.sort(operationSorterFunc)
+    })
+  }
+
+  return (parsedSpec.value = spec)
+}
+
+const hideModels = ref(false)
+const defaultOpenAllTags = ref(false)
+
+// Track which sidebar items are collapsed
+type CollapsedSidebarItems = Record<string, boolean>
+
+const collapsedSidebarItems = reactive<CollapsedSidebarItems>(ssrState['useSidebarContent-collapsedSidebarItems'] ?? {})
+
+function toggleCollapsedSidebarItem(key: string) {
+  collapsedSidebarItems[key] = !collapsedSidebarItems[key]
+}
+
+function setCollapsedSidebarItem(key: string, value: boolean) {
+  collapsedSidebarItems[key] = value
+}
+
+// Track headings in the spec description
+const headings = ref<any[]>([])
+
+function updateHeadings(description: string) {
+  const newHeadings = getHeadingsFromMarkdown(description)
+  const lowestLevel = getLowestHeadingLevel(newHeadings)
+
+  return newHeadings.filter((heading) => {
+    return (
+      // highest level, eg. # Introduction
+      heading.depth === lowestLevel ||
+      // second highest level, eg. ## Authentication
+      heading.depth === lowestLevel + 1
+    )
+  })
+}
+
+// Create the list of sidebar items from the given spec
+const items = computed(() => {
+  if (!navState.value) {
+    return { entries: [], titles: {} }
+  }
+
+  const { getHeadingId, getModelId, getOperationId, getTagId, getWebhookId } = navState.value
+
+  // Check whether the API client is visible
+  const titlesById: Record<string, string> = {}
+
+  // Headings from the OpenAPI description field
+  const headingEntries: SidebarEntry[] = []
+  let currentHeading: SidebarEntry | null = null
+
+  headings.value.forEach((heading) => {
+    // If the heading is the lowest level, create a new heading entry.
+    if (heading.depth === getLowestHeadingLevel(headings.value)) {
+      currentHeading = {
+        id: getHeadingId(heading),
+        title: heading.value,
+        show: true,
+        children: [],
+      }
+
+      headingEntries.push(currentHeading)
+    }
+    // If the heading is the second lowest level, add it to the current heading entry.
+    else if (currentHeading) {
+      currentHeading.children?.push({
+        id: getHeadingId(heading),
+        title: heading.value,
+        show: true,
+      })
+    }
+  })
+
+  // Tags & Operations
+  const firstTag = parsedSpec.value?.tags?.[0]
+
+  // Check whether there is more than one default tag
+  const moreThanOneDefaultTag = (tags?: Tag[]) =>
+    tags?.length !== 1 || tags[0].name !== 'default' || tags[0].description !== ''
+
+  const operationEntries: SidebarEntry[] | undefined =
+    firstTag && moreThanOneDefaultTag(parsedSpec.value?.tags)
+      ? parsedSpec.value?.tags
+          // Filter out tags without operations
+          ?.filter((tag: Tag) => tag.operations?.length > 0)
+          .map((tag: Tag) => {
+            return {
+              id: getTagId(tag),
+              title: tag.name,
+              displayTitle: tag['x-displayName'] ?? tag.name,
+              show: true,
+              children: tag.operations?.map((operation: TransformedOperation) => {
+                const id = getOperationId(operation, tag)
+                const title = operation.name ?? operation.path
+                titlesById[id] = title
+
+                return {
+                  id,
+                  title,
+                  httpVerb: operation.httpVerb,
+                  // TODO: Workaround until we're using the store directly
+                  deprecated: operation.information
+                    ? isOperationDeprecated({
+                        deprecated: operation.information?.deprecated,
+                        'x-scalar-stability': operation.information?.['x-scalar-stability'],
+                      })
+                    : false,
+                  show: true,
+                  select: () => {},
+                }
+              }),
+            }
+          })
+      : firstTag?.operations?.map((operation) => {
+          const id = getOperationId(operation, firstTag)
+          const title = operation.name ?? operation.path
+          titlesById[id] = title
+
+          return {
+            id,
+            title,
+            httpVerb: operation.httpVerb,
+            // TODO: Workaround until we're using the store directly
+            deprecated: operation.information
+              ? isOperationDeprecated({
+                  deprecated: operation.information?.deprecated,
+                  'x-scalar-stability': operation.information?.['x-scalar-stability'],
+                })
+              : false,
+            show: true,
+            select: () => {},
+          }
+        })
+
+  // Models
+  let modelEntries: SidebarEntry[] =
+    hasModels(parsedSpec.value) && !hideModels.value
+      ? [
+          {
+            id: getModelId(),
+            title: 'Models',
+            show: true,
+            children: Object.keys(getModels(parsedSpec.value) ?? {}).map((name) => {
+              const id = getModelId({ name })
+              titlesById[id] = name
+
+              return {
+                id,
+                title: (getModels(parsedSpec.value)?.[name] as any).title ?? name,
+                show: true,
+              }
+            }),
+          },
+        ]
+      : []
+
+  // Webhooks
+  let webhookEntries: SidebarEntry[] = hasWebhooks(parsedSpec.value)
+    ? [
+        {
+          id: getWebhookId(),
+          title: 'Webhooks',
+          show: true,
+          children: Object.keys(parsedSpec.value?.webhooks ?? {}).flatMap((name) => {
+            const id = getWebhookId({ name })
+            titlesById[id] = name
+
+            return (Object.keys(parsedSpec.value?.webhooks?.[name] ?? {}) as OpenAPIV3_1.HttpMethods[]).map(
+              (httpVerb) => {
+                return {
+                  id: getWebhookId({ name, method: httpVerb }),
+                  title: parsedSpec.value?.webhooks?.[name][httpVerb]?.name,
+                  httpVerb: httpVerb as string,
+                  show: true,
+                }
+              },
+            )
+          }) as SidebarEntry[],
+        },
+      ]
+    : []
+
+  const groupOperations: SidebarEntry[] | undefined = parsedSpec.value?.['x-tagGroups']
+    ? parsedSpec.value?.['x-tagGroups']?.map((tagGroup) => {
+        const children: SidebarEntry[] = []
+        tagGroup.tags?.map((tagName: string) => {
+          if (tagName === 'models' && modelEntries.length > 0) {
+            // Add default models entry to the group
+            children.push(modelEntries[0])
+            // Don't show default models entry
+            modelEntries = []
+          } else if (tagName === 'webhooks' && webhookEntries.length > 0) {
+            // Add default webhooks entry to the group
+            children.push(webhookEntries[0])
+            // Don't show default webhooks entry
+            webhookEntries = []
+          } else {
+            const tag = operationEntries?.find((entry) => entry.title === tagName)
+
+            if (tag) {
+              children.push(tag)
+            }
+          }
+        })
+        const sidebarTagGroup = {
+          id: tagGroup.name,
+          title: tagGroup.name,
+          children,
+          show: true,
+          isGroup: true,
+        }
+        return sidebarTagGroup
+      })
+    : undefined
+
+  const entries = [
+    ...headingEntries,
+    ...(groupOperations ?? operationEntries ?? []),
+    ...webhookEntries,
+    ...modelEntries,
+  ]
+
+  if (defaultOpenAllTags.value) {
+    entries.forEach((entry) => {
+      setCollapsedSidebarItem(entry.id, true)
+      entry.show = true
+    })
+  }
+
+  return {
+    entries,
+    titles: titlesById,
+  }
+})
+
+/**
+ * Controls whether or not the sidebar is open on mobile-only.
+ * Desktop uses the standard showSidebar prop which supercedes this one.
+ */
+const isSidebarOpen = ref(false)
+
+const breadcrumb = computed(() => items.value?.titles?.[navState.value?.hash ?? ''] ?? '')
+
+export type ParsedSpecOption = {
+  parsedSpec: Spec
+}
+
+export type SorterOption = {
+  tagsSorter?: 'alpha' | ((a: Tag, b: Tag) => number)
+  operationsSorter?: 'alpha' | 'method' | ((a: TransformedOperation, b: TransformedOperation) => number)
+}
+
+/**
+ * Scroll to operation
+ *
+ * Similar to scrollToId BUT in the case of a section not being open,
+ * it uses the lazyBus to ensure the section is open before scrolling to it
+ *
+ */
+export const scrollToOperation = (operationId: string, focus?: boolean) => {
+  const sectionId = navState.value?.getSectionId(operationId)
+
+  if (sectionId && sectionId !== operationId) {
+    // We use the lazyBus to check when the target has loaded then scroll to it
+    if (!collapsedSidebarItems[sectionId]) {
+      const unsubscribe = lazyBus.on((ev) => {
+        if (ev.id === operationId) {
+          scrollToId(operationId, focus)
+          unsubscribe()
+        }
+      })
+      setCollapsedSidebarItem(sectionId, true)
+    } else {
+      scrollToId(operationId, focus)
+    }
+  }
+}
+
+/**
+ * Provides the sidebar state and methods to control it.
+ *
+ * @deprecated We want to use the new useSidebar from @/features/Content
+ */
+export function useSidebar(options?: ParsedSpecOption & SorterOption) {
+  Object.assign(optionsRef, options)
+
+  // Hack navState
+  const _navState = useNavState()
+  navState.value = _navState
+  const { hash, getSectionId, getTagId } = _navState
+
+  if (options?.parsedSpec) {
+    setParsedSpec(options.parsedSpec)
+
+    // Open the first tag section by default OR specific section from hash
+    watch(
+      () => parsedSpec.value?.tags?.length,
+      () => {
+        if (hash.value) {
+          const hashSectionId = getSectionId(hash.value)
+          if (hashSectionId) {
+            setCollapsedSidebarItem(hashSectionId, true)
+          }
+        } else {
+          const firstTag = parsedSpec.value?.tags?.[0]
+          if (firstTag) {
+            setCollapsedSidebarItem(getTagId(firstTag), true)
+          }
+        }
+      },
+    )
+
+    // Watch the spec description for headings
+    watch(
+      () => parsedSpec.value?.info?.description,
+      () => {
+        const description = parsedSpec.value?.info?.description?.trim()
+
+        if (!description) {
+          return (headings.value = [])
+        }
+
+        const newHeadings = updateHeadings(description)
+
+        // Add "Introduction" as the first heading
+        if (description && !description.startsWith('#')) {
+          const introductionHeading = {
+            depth: newHeadings[0]?.depth ?? 1,
+            value: 'Introduction',
+            slug: DEFAULT_INTRODUCTION_SLUG,
+          }
+
+          newHeadings.unshift(introductionHeading)
+        }
+
+        return (headings.value = newHeadings)
+      },
+      {
+        immediate: true,
+      },
+    )
+  }
+
+  return {
+    breadcrumb,
+    items,
+    isSidebarOpen,
+    collapsedSidebarItems,
+    toggleCollapsedSidebarItem,
+    setCollapsedSidebarItem,
+    hideModels,
+    setParsedSpec,
+    defaultOpenAllTags,
+    scrollToOperation,
+  }
+}

--- a/packages/api-reference/src/hooks/old/useSidebar.ts
+++ b/packages/api-reference/src/hooks/old/useSidebar.ts
@@ -1,17 +1,12 @@
-import { isOperationDeprecated } from '@/libs/operation'
+import { scrollToId } from '@/helpers/scroll-to-id'
+import { getHeadingsFromMarkdown, getLowestHeadingLevel } from '@/libs/markdown'
+import { isOperationDeprecated } from '@/libs/openapi'
+import { getModels, hasModels, hasWebhooks } from '@/libs/openapi'
 import { ssrState } from '@scalar/oas-utils/helpers'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Spec, Tag, TransformedOperation } from '@scalar/types/legacy'
 import { computed, reactive, ref, watch } from 'vue'
 import { lazyBus } from '../../components/Content/Lazy/lazyBus'
-import {
-  getHeadingsFromMarkdown,
-  getLowestHeadingLevel,
-  getModels,
-  hasModels,
-  hasWebhooks,
-  scrollToId,
-} from '../../helpers'
 import { useNavState } from '../useNavState'
 
 export type SidebarEntry = {

--- a/packages/api-reference/src/hooks/useSidebar.test.ts
+++ b/packages/api-reference/src/hooks/useSidebar.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { computed, toValue } from 'vue'
 
+import { type SortOptions, useSidebar } from '@/features/Sidebar'
 import { parse } from '@/helpers/parse'
-import { type SorterOption, useSidebar } from '@/hooks/useSidebar'
 import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
 
 // Mock the useConfig hook
@@ -30,7 +30,7 @@ vi.mock('vue', () => {
 /**
  * Parse the given OpenAPI definition and return the items for the sidebar.
  */
-async function getItemsForDocument(definition: Record<string, any>, options?: SorterOption) {
+async function getItemsForDocument(definition: Record<string, any>, options?: SortOptions) {
   const parsedSpec = await parse(definition)
 
   const { items } = useSidebar({

--- a/packages/api-reference/src/hooks/useSidebar.ts
+++ b/packages/api-reference/src/hooks/useSidebar.ts
@@ -367,6 +367,7 @@ export function useSidebar(options?: ParsedSpecOption & SorterOption) {
   const { hash, getSectionId, getTagId } = _navState
 
   if (options?.parsedSpec) {
+    console.trace('CREATE WITH PARSED SPEC')
     setParsedSpec(options.parsedSpec)
 
     // Open the first tag section by default OR specific section from hash

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -16,7 +16,7 @@ export { Layouts } from '@/components/Layouts'
 export { parse } from '@/helpers/parse'
 export { createEmptySpecification } from '@/libs/openapi'
 export { useNavState } from '@/hooks/useNavState'
-export { useSidebar } from '@/hooks/useSidebar'
+export { useSidebar } from '@/hooks/old/useSidebar'
 export { useHttpClientStore } from '@/stores/useHttpClientStore'
 export type {
   ApiReferenceConfiguration,

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -16,7 +16,7 @@ export { Layouts } from '@/components/Layouts'
 export { parse } from '@/helpers/parse'
 export { createEmptySpecification } from '@/libs/openapi'
 export { useNavState } from '@/hooks/useNavState'
-export { useSidebar } from '@/hooks/old/useSidebar'
+export { useSidebar } from '@/features/Sidebar'
 export { useHttpClientStore } from '@/stores/useHttpClientStore'
 export type {
   ApiReferenceConfiguration,


### PR DESCRIPTION
⚠️ Requires #5660, so we can feed it something else (`dereferencedDocument`) than the `parsedSpec`.

Say hello to a (partially) revamped sidebar:

* Moved all related files to `@/feature/Sidebar`
* Get rid of the deprecated `parsedSpec` data structure
* Added benchmarks to make it faster (currently 600×, but that’ll vary a bit until the PR is done)
* More tests!

What this PR isn’t changing:

* The API to consume it is mostly the same (`const { items } = useSidebar({ content: { … } })`) to make it easier to integrate
* I tried to not touch the components in this PR

**Tasks**

- [ ] decouple from useNavState (we don't want this inside useSidebar)
- [ ] add supporting for expanding/collapsing sidebar items
* [ ] `pnpm test features/Sidebar` should pass
* [ ] `pnpm vitest bench create-sidebar` should show the new sidebar is faster
- [ ] remove old sidebar code

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
