### PR TITLE
fix(api-reference): display array item const

### DIFF
--- a/.changeset/olive-rivers-dream.md
+++ b/.changeset/olive-rivers-dream.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: displays array item const in property

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -111,6 +111,26 @@ describe('SchemaPropertyHeading', () => {
     expect(constElement.exists()).toBe(false)
   })
 
+  it('renders const value in array items', async () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'array',
+          items: {
+            const: 'foo',
+          },
+        },
+      },
+    })
+
+    const typeElement = wrapper.find('.property-detail')
+    expect(typeElement.text()).toContain('array')
+
+    const constElement = wrapper.find('.property-const')
+    expect(constElement.text()).toContain('const:')
+    expect(constElement.text()).toContain('foo')
+  })
+
   it('renders pattern badge', async () => {
     const wrapper = mount(SchemaPropertyHeading, {
       props: {

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -7,6 +7,7 @@ import type {
   OpenAPIV3_1,
 } from '@scalar/openapi-types'
 import { stringify } from 'flatted'
+import { computed } from 'vue'
 
 import { discriminators } from '@/components/Content/Schema/helpers/optimizeValueForDisplay'
 import SchemaPropertyExamples from '@/components/Content/Schema/SchemaPropertyExamples.vue'
@@ -81,6 +82,28 @@ const getModelNameFromSchema = (schema: OpenAPI.Document): string | null => {
 
   return null
 }
+
+/** Get the const value from the schema */
+const constValue = computed(() => {
+  if (isDefined(value?.const)) {
+    return value?.const
+  }
+
+  if (value?.enum?.length === 1) {
+    return value.enum[0]
+  }
+
+  if (value?.items) {
+    if (isDefined(value.items.const)) {
+      return value.items.const
+    }
+
+    if (value.items.enum?.length === 1) {
+      return value.items.enum[0]
+    }
+  }
+  return null
+})
 </script>
 <template>
   <div class="property-heading">
@@ -93,33 +116,7 @@ const getModelNameFromSchema = (schema: OpenAPI.Document): string | null => {
         name="name" />
       <template v-else>&sol;<slot name="name" />&sol;</template>
     </div>
-    <div
-      v-if="additional"
-      class="property-additional">
-      <template v-if="value?.['x-additionalPropertiesName']">
-        {{ value['x-additionalPropertiesName'] }}
-      </template>
-      <template v-else>additional properties</template>
-    </div>
-    <div
-      v-if="pattern"
-      class="property-pattern">
-      <Badge>pattern</Badge>
-    </div>
-    <div
-      v-if="value?.deprecated"
-      class="property-deprecated">
-      <Badge>deprecated</Badge>
-    </div>
-    <div
-      v-if="isDefined(value?.const) || (value?.enum && value.enum.length === 1)"
-      class="property-const">
-      <SchemaPropertyDetail truncate>
-        <template #prefix>const:</template>
-        {{ value?.const ?? value?.enum?.[0] }}
-      </SchemaPropertyDetail>
-    </div>
-    <template v-else-if="value?.type">
+    <template v-if="value?.type">
       <SchemaPropertyDetail>
         <ScreenReader>Type:</ScreenReader>
         <template v-if="value?.items?.type">
@@ -184,6 +181,32 @@ const getModelNameFromSchema = (schema: OpenAPI.Document): string | null => {
         {{ flattenDefaultValue(value) }}
       </SchemaPropertyDetail>
     </template>
+    <div
+      v-if="additional"
+      class="property-additional">
+      <template v-if="value?.['x-additionalPropertiesName']">
+        {{ value['x-additionalPropertiesName'] }}
+      </template>
+      <template v-else>additional properties</template>
+    </div>
+    <div
+      v-if="pattern"
+      class="property-pattern">
+      <Badge>pattern</Badge>
+    </div>
+    <div
+      v-if="value?.deprecated"
+      class="property-deprecated">
+      <Badge>deprecated</Badge>
+    </div>
+    <div
+      v-if="isDefined(constValue)"
+      class="property-const">
+      <SchemaPropertyDetail truncate>
+        <template #prefix>const:</template>
+        {{ constValue }}
+      </SchemaPropertyDetail>
+    </div>
     <template v-else>
       <!-- Shows only when a discriminator is used (so value?.type is undefined) -->
       <SchemaPropertyDetail v-if="value?.nullable === true">

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -176,7 +176,7 @@ const shouldShowParameter = computed(() => {
 .parameter-item-trigger
   + .parameter-item-container
   :deep(.property--level-0 > .property-heading .property-detail-value) {
-  font-size: var(--scalar-font-size-3);
+  font-size: var(--scalar-micro);
 }
 .parameter-item-required-optional {
   color: var(--scalar-color-2);


### PR DESCRIPTION
**Problem**

currently setting a const within an array is not getting displayed in the api reference.

**Solution**

this pr updates the property heading support of const to get it displayed and fixes #5648.

| before | after |
| -------|------|
| <img width="589" alt="image" src="https://github.com/user-attachments/assets/03174e30-c48f-4a0b-be21-b5d8dd00b47d" /> | <img width="589" alt="image" src="https://github.com/user-attachments/assets/fb40ea99-daa3-4783-b28f-7e87eb4cded4" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
