### PR TITLE
fix(api-reference): copy path without hash when pathRouting is enabled

### DIFF
--- a/.changeset/real-buckets-destroy.md
+++ b/.changeset/real-buckets-destroy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: copy correct path when pathRouting enabled

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -6,7 +6,7 @@ import { useNavState } from '@/hooks/useNavState'
 
 import ScreenReader from '../ScreenReader.vue'
 
-defineProps<{
+const { id } = defineProps<{
   id: string
 }>()
 
@@ -14,8 +14,10 @@ const labelId = useId()
 
 const { copyToClipboard } = useClipboard()
 const { getHashedUrl } = useNavState()
-const getUrlWithId = (id: string) => {
-  return getHashedUrl(id)
+
+/** Ensure we copy the hash OR path if pathRouting is enabled */
+const handleCopy = () => {
+  copyToClipboard(getHashedUrl(id))
 }
 </script>
 <template>
@@ -32,7 +34,7 @@ const getUrlWithId = (id: string) => {
         :aria-describedby="labelId"
         class="anchor-copy"
         type="button"
-        @click.stop="copyToClipboard(getUrlWithId(id))">
+        @click.stop="handleCopy">
         <span aria-hidden="true">#</span>
         <ScreenReader>Copy link</ScreenReader>
       </button>

--- a/packages/api-reference/src/hooks/useNavState.test.ts
+++ b/packages/api-reference/src/hooks/useNavState.test.ts
@@ -203,4 +203,51 @@ describe('useNavState', () => {
       expect(navState.getSectionId()).toBe('tag/test-tag')
     })
   })
+
+  describe('getHashedUrl', () => {
+    it('should generate URL with hash routing', () => {
+      const mockConfig = computed(() => apiReferenceConfigurationSchema.parse({}))
+      vi.mocked(useConfig).mockReturnValue(mockConfig)
+
+      vi.mocked(inject).mockReturnValue({
+        isIntersectionEnabled: ref(false),
+        hash: ref(''),
+        hashPrefix: ref('prefix-'),
+      })
+      navState = useNavState()
+
+      const result = navState.getHashedUrl('test-hash', 'https://example.com', '?param=value')
+      expect(result).toBe('https://example.com/?param=value#prefix-test-hash')
+    })
+
+    it('should generate URL with path routing', () => {
+      const mockConfig = computed(() => {
+        return apiReferenceConfigurationSchema.parse({
+          pathRouting: {
+            basePath: '/docs',
+          },
+        })
+      })
+      vi.mocked(useConfig).mockReturnValue(mockConfig)
+      navState = useNavState()
+
+      const result = navState.getHashedUrl('test-path', 'https://example.com', '?param=value')
+      expect(result).toBe('https://example.com/docs/test-path?param=value')
+    })
+
+    it('should preserve search params when using path routing', () => {
+      const mockConfig = computed(() => {
+        return apiReferenceConfigurationSchema.parse({
+          pathRouting: {
+            basePath: '/docs',
+          },
+        })
+      })
+      vi.mocked(useConfig).mockReturnValue(mockConfig)
+      navState = useNavState()
+
+      const result = navState.getHashedUrl('test-path', 'https://example.com', '?param1=value1&param2=value2')
+      expect(result).toBe('https://example.com/docs/test-path?param1=value1&param2=value2')
+    })
+  })
 })

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -90,7 +90,15 @@ export const useNavState = (_config?: Ref<ApiReferenceConfiguration>) => {
 
   const getHashedUrl = (replacementHash: string, url = window.location.href, search = window.location.search) => {
     const newUrl = new URL(url)
-    newUrl.hash = hashPrefix.value + replacementHash
+
+    // Path routing
+    if (config.value.pathRouting) {
+      newUrl.pathname = combineUrlAndPath(config.value.pathRouting.basePath, replacementHash)
+    }
+    // Hash routing
+    else {
+      newUrl.hash = hashPrefix.value + replacementHash
+    }
     newUrl.search = search
     return newUrl.toString()
   }


### PR DESCRIPTION
**Problem**

Currently, we combine the path and hash when we hit the copy button

**Solution**

With this PR we check for path routing then correctly copy the path or hash

closes #5638

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
