### PR TITLE
fix(api-reference): schema property child model name in type

### DIFF
--- a/.changeset/breezy-worms-wait.md
+++ b/.changeset/breezy-worms-wait.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: adds missing schemas to schema property

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -269,7 +269,8 @@ const displayPropertyHeading = (
         :level="level + 1"
         :name="name"
         :noncollapsible="noncollapsible"
-        :value="optimizedValue" />
+        :value="optimizedValue"
+        :schemas="schemas" />
     </div>
     <!-- Array of objects -->
     <template


### PR DESCRIPTION
**Problem**

currently the model name is not showing up when used within schema property child.

**Solution**

this pr adds missing schemas to schema property, fixes #5377.

| before | after |
| -------|------|
| <img width="581" alt="image" src="https://github.com/user-attachments/assets/14af852f-9541-435d-a42f-3311c394720b" /> | <img width="581" alt="image" src="https://github.com/user-attachments/assets/fdb6361a-62aa-4b40-b217-113c7834ef71" /> |
| array is displayed instead of model name | model get displayed | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
