### PR TITLE
feat(nuxt): SSR-friendly color mode preference implementation

### DIFF
--- a/.changeset/lazy-roses-wave.md
+++ b/.changeset/lazy-roses-wave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nuxt': patch
+---
+
+feat(nuxt): ssr-friendly color mode preference implementation

--- a/integrations/nuxt/package.json
+++ b/integrations/nuxt/package.json
@@ -53,7 +53,8 @@
     "@nuxt/kit": "^3.12.3",
     "@scalar/api-client": "workspace:*",
     "@scalar/api-reference": "workspace:*",
-    "@scalar/types": "workspace:*"
+    "@scalar/types": "workspace:*",
+    "@scalar/use-hooks": "workspace:*"
   },
   "devDependencies": {
     "@nuxt/devtools": "^1.3.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,6 +888,9 @@ importers:
       '@scalar/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@scalar/use-hooks':
+        specifier: workspace:*
+        version: link:../../packages/use-hooks
     devDependencies:
       '@nuxt/devtools':
         specifier: ^1.3.9


### PR DESCRIPTION
**Problem**

Currently, the nuxt module does not save the user's color mode preference when using the toggle switch, it is tied to starting with the one defined in the config.

**Solution**

With this PR we'll add support for saving the user's color mode preference and handle their states.

I look forward to your feedback.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
