### PR TITLE
feat(api-reference): show example payload for webhooks

### DIFF
--- a/packages/api-reference/src/features/Operation/Webhooks.vue
+++ b/packages/api-reference/src/features/Operation/Webhooks.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarCodeBlock, ScalarMarkdown } from '@scalar/components'
+import { getExampleFromSchema } from '@scalar/oas-utils/spec-getters'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Webhooks } from '@scalar/types/legacy'
 import { computed, useId } from 'vue'
@@ -8,6 +9,8 @@ import { Lazy } from '@/components/Content/Lazy'
 import {
   CompactSection,
   Section,
+  SectionColumn,
+  SectionColumns,
   SectionContainer,
   SectionHeader,
   SectionHeaderTag,
@@ -95,8 +98,25 @@ const webhooksFiltered = computed(() => {
                 :value="webhooks[name][httpVerb]?.description"
                 withImages />
 
-              <!-- Details -->
-              <Webhook :webhook="webhooks[name][httpVerb]" />
+              <SectionColumns>
+                <SectionColumn>
+                  <!-- Details -->
+                  <Webhook :webhook="webhooks[name][httpVerb]" />
+                </SectionColumn>
+                <SectionColumn>
+                  <div
+                    class="dark-mode bg-b-2 overflow-hidden rounded-lg text-sm">
+                    <ScalarCodeBlock
+                      :content="
+                        getExampleFromSchema(
+                          webhooks[name][httpVerb]?.information?.requestBody
+                            ?.content?.['application/json']?.schema,
+                        )
+                      "
+                      lang="json" />
+                  </div>
+                </SectionColumn>
+              </SectionColumns>
             </CompactSection>
           </Lazy>
         </template>
@@ -108,7 +128,12 @@ const webhooksFiltered = computed(() => {
     </Section>
   </SectionContainer>
 </template>
+
 <style scoped>
+.example-payload {
+  border-radius: var(--scalar-radius);
+}
+
 .webhooks-list {
   display: contents;
 }

--- a/packages/api-reference/src/features/Operation/components/Webhook.vue
+++ b/packages/api-reference/src/features/Operation/components/Webhook.vue
@@ -19,6 +19,7 @@ defineProps<{
     <OperationResponses :operation="webhook" />
   </template>
 </template>
+
 <style scoped>
 .webhook-request-body {
   margin-top: -18px;


### PR DESCRIPTION
**Tasks**

- [ ] select for the media types
- [ ] xml support
- [ ] a heading
- [ ] some love from @cameronrohani 

**Problem**

Currently, …

**Solution**

With this PR …

**Preview**

<img width="1177" alt="Screenshot 2025-05-15 at 22 58 21" src="https://github.com/user-attachments/assets/828b16fd-1219-4d87-8c02-e666630d4add" />

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
