### PR TITLE
chore(Scalar.AspNetCore): use centralized package management

### DIFF
--- a/integrations/aspnetcore/.editorconfig
+++ b/integrations/aspnetcore/.editorconfig
@@ -36,7 +36,7 @@ resharper_wrap_object_and_collection_initializer_style = chop_always
 resharper_check_namespace_highlighting = none
 
 
-[*.{csproj,slnx}]
+[*.{csproj,slnx,props}]
 ij_xml_space_inside_empty_tag = true
 
 

--- a/integrations/aspnetcore/Scalar.AspNetCore.slnx
+++ b/integrations/aspnetcore/Scalar.AspNetCore.slnx
@@ -10,11 +10,12 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Scalar.AspNetCore.Microsoft.Tests/Scalar.AspNetCore.Microsoft.Tests.csproj" />
-    <Project Path="tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj" />
     <Project Path="tests/Scalar.AspNetCore.Swashbuckle.Tests/Scalar.AspNetCore.Swashbuckle.Tests.csproj" />
+    <Project Path="tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj" />
     <File Path="tests/.editorconfig" />
     <File Path="tests/xunit.runner.json" />
     <File Path="tests/Directory.Build.props" />
+    <File Path="tests/Directory.Packages.props" />
   </Folder>
   <Folder Name="/tests/apis/">
     <Project Path="tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj" />

--- a/integrations/aspnetcore/src/Directory.Build.props
+++ b/integrations/aspnetcore/src/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -29,12 +29,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="$(AssemblyName).Tests"/>
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2"/>
+    <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/integrations/aspnetcore/tests/Directory.Build.props
+++ b/integrations/aspnetcore/tests/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
@@ -8,6 +8,6 @@
 
   <!--Copy xunit.runner.json to all test projects-->
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-    <Content Include="../xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
+    <Content Include="../xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/integrations/aspnetcore/tests/Directory.Packages.props
+++ b/integrations/aspnetcore/tests/Directory.Packages.props
@@ -1,0 +1,21 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="AwesomeAssertions" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="xunit.v3" Version="2.0.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFrameWork) == 'net8.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.16" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFrameWork) == 'net9.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
+  </ItemGroup>
+</Project>

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Microsoft.Tests/Scalar.AspNetCore.Microsoft.Tests.csproj
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Microsoft.Tests/Scalar.AspNetCore.Microsoft.Tests.csproj
@@ -6,21 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="8.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.v3" Version="2.0.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFrameWork) == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFrameWork) == 'net10.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0-preview.3.25172.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Swashbuckle.Tests/Scalar.AspNetCore.Swashbuckle.Tests.csproj
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Swashbuckle.Tests/Scalar.AspNetCore.Swashbuckle.Tests.csproj
@@ -5,21 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="8.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.v3" Version="2.0.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFrameWork) == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.16" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFrameWork) == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -5,22 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="8.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit.v3" Version="2.0.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFrameWork) == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.16" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFrameWork) == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Another maintenance PR 🛠️
This PR enables the `ManagePackageVersionsCentrally` feature for the .NET test projects. This simplifies the package management.

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
