### PR TITLE
feat(api-reference): group tagged models together with APIs

### DIFF
--- a/packages/api-reference/src/components/Content/Tag/TagList.vue
+++ b/packages/api-reference/src/components/Content/Tag/TagList.vue
@@ -6,6 +6,7 @@ import type { Spec, Tag as TagType } from '@scalar/types/legacy'
 import { computed } from 'vue'
 
 import { Lazy } from '@/components/Content/Lazy'
+import { Models } from '@/features/Models'
 import { Operation } from '@/features/Operation'
 import { useNavState } from '@/hooks/useNavState'
 import { useSidebar } from '@/hooks/useSidebar'
@@ -59,6 +60,11 @@ const isLazy = (index: number) =>
       :collection="collection"
       :spec="spec"
       :tag="tag">
+      <Models
+        v-if="layout === 'modern' && tag.components"
+        :tag="tag"
+        :schemas="schemas"
+        :components="tag.components" />
       <Lazy
         v-for="(operation, operationIndex) in tag.operations"
         :id="getOperationId(operation, tag)"

--- a/packages/api-reference/src/features/Models/Model.vue
+++ b/packages/api-reference/src/features/Models/Model.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { ScalarCodeBlock, ScalarErrorBoundary } from '@scalar/components'
+import type { Collection, Server } from '@scalar/oas-utils/entities/spec'
+import { getExampleFromSchema } from '@scalar/oas-utils/spec-getters'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { Spec, Tag as TagType } from '@scalar/types/legacy'
+import { computed, useId } from 'vue'
+
+import { Anchor } from '@/components/Anchor'
+import { Card, CardContent, CardHeader } from '@/components/Card'
+import { Lazy } from '@/components/Content/Lazy'
+import { Schema, SchemaHeading } from '@/components/Content/Schema'
+import {
+  CompactSection,
+  Section,
+  SectionColumn,
+  SectionColumns,
+  SectionContent,
+  SectionHeader,
+  SectionHeaderTag,
+} from '@/components/Section'
+
+const { component } = defineProps<{
+  id: string
+  schemas?:
+    | OpenAPIV2.DefinitionsObject
+    | Record<string, OpenAPIV3.SchemaObject>
+    | Record<string, OpenAPIV3_1.SchemaObject>
+    | unknown
+  component: any
+}>()
+
+const labelId = useId()
+const title = computed(() => component.title ?? component.name)
+</script>
+<template>
+  <Section
+    :id="id"
+    :aria-labelledby="labelId"
+    :label="title"
+    tabindex="-1">
+    <SectionContent>
+      <SectionHeader>
+        <Anchor :id="id ?? ''">
+          <SectionHeaderTag
+            :id="id"
+            :level="3">
+            {{ title }}
+          </SectionHeaderTag>
+        </Anchor>
+      </SectionHeader>
+      <SectionColumns>
+        <SectionColumn>
+          <Schema
+            :hideHeading="true"
+            noncollapsible
+            :schemas="schemas"
+            :value="component" />
+        </SectionColumn>
+        <SectionColumn>
+          <Card class="scalar-card-sticky">
+            <CardHeader>
+              {{ title }}
+            </CardHeader>
+            <div class="custom-scroll">
+              <CardContent muted>
+                <ScalarCodeBlock
+                  class="bg-b-2 -outline-offset-2"
+                  :content="
+                    getExampleFromSchema(component, {
+                      emptyString: 'string',
+                      mode: 'read',
+                    })
+                  "
+                  lang="json" />
+              </CardContent>
+            </div>
+          </Card>
+        </SectionColumn>
+      </SectionColumns>
+    </SectionContent>
+  </Section>
+</template>

--- a/packages/api-reference/src/features/Models/Models.vue
+++ b/packages/api-reference/src/features/Models/Models.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { ScalarErrorBoundary } from '@scalar/components'
+import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { Spec, TagComponent, Tag as TagType } from '@scalar/types/legacy'
+import { computed } from 'vue'
+
+import { Anchor } from '@/components/Anchor'
+import { Lazy } from '@/components/Content/Lazy'
+import { useNavState } from '@/hooks/useNavState'
+
+import Model from './Model.vue'
+
+const { components } = defineProps<{
+  tag: TagType
+  schemas:
+    | OpenAPIV2.DefinitionsObject
+    | Record<string, OpenAPIV3.SchemaObject>
+    | Record<string, OpenAPIV3_1.SchemaObject>
+    | unknown
+  components: TagComponent[]
+}>()
+
+const { getModelId } = useNavState()
+</script>
+<template>
+  <div class="models-list">
+    <Lazy
+      v-for="component of components ?? []"
+      :id="getModelId({ name: component.name }, tag)"
+      :key="component.name"
+      isLazy>
+      <ScalarErrorBoundary>
+        <Model
+          :id="getModelId({ name: component.name }, tag)"
+          :schemas="schemas"
+          :component="component.schema" />
+      </ScalarErrorBoundary>
+    </Lazy>
+  </div>
+</template>

--- a/packages/api-reference/src/features/Models/index.ts
+++ b/packages/api-reference/src/features/Models/index.ts
@@ -1,0 +1,1 @@
+export { default as Models } from './Models.vue'

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -174,6 +174,31 @@ const transformResult = (originalSchema: OpenAPI.Document): Spec => {
     // Delete all schemas where `shouldIgnoreEntity` returns true
     if (shouldIgnoreEntity(schema.components?.schemas?.[name])) {
       delete schema.components?.schemas?.[name]
+      return
+    }
+
+    if (Array.isArray(schema.components?.schemas[name]?.['x-tags'])) {
+      const component = schema.components?.schemas[name]
+
+      component['x-tags'].forEach((componentTag: string) => {
+        let tag = schema.tags?.find((tag: UnknownObject) => tag.name === componentTag)
+
+        if (!tag) {
+          tag = {
+            name: componentTag,
+            description: '',
+            components: [],
+          }
+
+          schema.tags?.push(tag)
+        }
+
+        if (!tag.components) {
+          tag.components = []
+        }
+
+        tag.components.push({ schema: component, name })
+      })
     }
   })
 

--- a/packages/api-reference/src/hooks/useNavState.ts
+++ b/packages/api-reference/src/hooks/useNavState.ts
@@ -121,7 +121,11 @@ export const useNavState = (_config?: Ref<ApiReferenceConfiguration>) => {
     return ''
   }
 
-  const getModelId = (model?: { name: string }) => {
+  const getModelId = (model?: { name: string }, parentTag?: Tag): string => {
+    if (parentTag) {
+      return `${getTagId(parentTag)}/${getModelId(model)}`
+    }
+
     if (!model?.name) {
       return 'models'
     }

--- a/packages/types/src/legacy/reference-config.ts
+++ b/packages/types/src/legacy/reference-config.ts
@@ -260,7 +260,13 @@ export type Tag = {
   'name': string
   'description': string
   'operations': TransformedOperation[]
+  'components'?: TagComponent[]
   'x-displayName'?: string
+}
+
+export type TagComponent = {
+  name: string
+  schema: OpenAPIV3.ComponentsObject | OpenAPIV3_1.ComponentsObject
 }
 
 export type TagGroup = {


### PR DESCRIPTION
**Problem**

Currently, if you tag a few APIs, they are neatly nested under the collapsible heading in the side nav. However, models, tagged or not, are always displayed under the Models heading at the bottom of the side nav.

Related issue: #5314

**Solution**

This PR introduces support for grouping models alongside APIs in the side navigation by using `x-tags` on component schemas. With this change, models can be displayed above the same collapsible tag sections as the related APIs.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.
