### PR TITLE
fix(api-client): support unexploded array query parameters

### DIFF
--- a/.changeset/forty-toes-build.md
+++ b/.changeset/forty-toes-build.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+support unexploded serialization of array query params

--- a/packages/api-client/src/libs/send-request/create-fetch-query-params.test.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-query-params.test.ts
@@ -1,10 +1,10 @@
-import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import type { RequestExample, RequestPayload } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
 import { createFetchQueryParams } from './create-fetch-query-params'
 
 describe('createFetchQueryParams', () => {
-  it('creates query paramer from an example', () => {
+  it('serializes query paramer from an example', () => {
     const requestExample: Pick<RequestExample, 'parameters'> = {
       parameters: {
         headers: [],
@@ -23,7 +23,7 @@ describe('createFetchQueryParams', () => {
     expect(result.toString()).toEqual('page=1&limit=10&search=John')
   })
 
-  it('handles array parameters (same name multiple times)', () => {
+  it('serializes array parameters (same name multiple times)', () => {
     const requestExample: Pick<RequestExample, 'parameters'> = {
       parameters: {
         headers: [],
@@ -59,7 +59,7 @@ describe('createFetchQueryParams', () => {
     expect([...result.entries()]).toHaveLength(0)
   })
 
-  it('handles query parameters for array type value', () => {
+  it('serializes exploded query parameters for array type value', () => {
     const requestExample: Pick<RequestExample, 'parameters'> = {
       parameters: {
         headers: [],
@@ -72,5 +72,40 @@ describe('createFetchQueryParams', () => {
     const result = createFetchQueryParams(requestExample, {})
 
     expect(result.toString()).toEqual('key=one&key=two')
+  })
+
+  it('serializes unexploded query parameters for array type value', () => {
+    const requestExample: Pick<RequestExample, 'parameters'> = {
+      parameters: {
+        headers: [],
+        path: [],
+        cookies: [],
+        query: [{ key: 'key', value: 'one, two, three', enabled: true, type: 'array' }],
+      },
+    }
+
+    const request = {
+      type: 'request',
+      parameters: [
+        {
+          in: 'query',
+          name: 'key',
+          style: 'form',
+          explode: false,
+          required: false,
+          deprecated: false,
+          schema: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+      ],
+    } satisfies RequestPayload
+
+    const result = createFetchQueryParams(requestExample, {}, request)
+
+    expect(result.toString()).toEqual('key=one,two,three')
   })
 })

--- a/packages/api-client/src/libs/send-request/create-fetch-query-params.test.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-query-params.test.ts
@@ -106,6 +106,6 @@ describe('createFetchQueryParams', () => {
 
     const result = createFetchQueryParams(requestExample, {}, request)
 
-    expect(result.toString()).toEqual('key=one,two,three')
+    expect(result.toString()).toEqual('key=one%2Ctwo%2Cthree')
   })
 })

--- a/packages/api-client/src/libs/send-request/create-fetch-query-params.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-query-params.ts
@@ -1,16 +1,56 @@
 import { replaceTemplateVariables } from '@/libs/string-template'
-import type { RequestExample } from '@scalar/oas-utils/entities/spec'
+import type { RequestExample, RequestPayload } from '@scalar/oas-utils/entities/spec'
 
-/** Populate the query parameters from the example parameters */
-export function createFetchQueryParams(example: Pick<RequestExample, 'parameters'>, env: object) {
+/**
+ * Populate the query parameters from the example parameters. This is an incomplete implementation that currently
+ * only supports the following styles and options:
+ *
+ * - `form` style with `explode` set to true or false
+ *
+ * @see https://spec.openapis.org/oas/v3.1.1.html#style-values
+ */
+export function createFetchQueryParams(
+  example: Pick<RequestExample, 'parameters'>,
+  env: object,
+  // TODO: remove this when example.parameters contains query parameters schema
+  request?: RequestPayload,
+): URLSearchParams {
   const params = new URLSearchParams()
+
+  const parameterSchemaMap = (request?.parameters ?? []).reduce(
+    (acc, param) => {
+      if (param.in === 'query') {
+        acc[param.name] = param
+      }
+      return acc
+    },
+    {} as Record<string, NonNullable<RequestPayload['parameters']>[number]>,
+  )
+
   example.parameters.query.forEach((p) => {
-    if (p.enabled) {
-      const values =
-        p.type === 'array'
-          ? replaceTemplateVariables(p.value ?? '', env).split(',')
-          : [replaceTemplateVariables(p.value ?? '', env)]
-      values.forEach((value) => params.append(p.key, value.trim()))
+    if (!p.enabled) return
+
+    const schema = parameterSchemaMap[p.key]
+
+    switch (p.type) {
+      case 'array': {
+        const values = replaceTemplateVariables(p.value ?? '', env).split(/,\ ?/)
+        // NOTE: we explicitly check for `false` here because the property is optional and the default serialization behavior is exploded.
+        if (schema?.explode === false) {
+          const csv = values.join(',')
+          params.append(p.key, csv)
+        } else {
+          values.forEach((value) => {
+            params.append(p.key, value.trim())
+          })
+        }
+        break
+      }
+      default: {
+        const value = replaceTemplateVariables(p.value ?? '', env)
+        params.append(p.key, value.trim())
+        break
+      }
     }
   })
 

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -95,7 +95,7 @@ export const createRequestOperation = ({
       })
     })
 
-    const _urlParams = createFetchQueryParams(example, env)
+    const _urlParams = createFetchQueryParams(example, env, request)
     const _headers = createFetchHeaders(example, env)
     const { body } = createFetchBody(request.method, example, env)
     const { cookieParams: _cookieParams } = setRequestCookies({

--- a/packages/oas-utils/src/entities/spec/parameters.test.ts
+++ b/packages/oas-utils/src/entities/spec/parameters.test.ts
@@ -81,4 +81,15 @@ describe('oasParameterSchema', () => {
 
     expect(() => oasParameterSchema.parse(validParameter)).not.toThrow()
   })
+
+  it('should validate examples with the explode property', () => {
+    const validParameter = {
+      in: 'query',
+      name: 'galaxy',
+      examples: ['Milky Way', 'Andromeda'],
+      explode: true,
+    }
+
+    expect(() => oasParameterSchema.parse(validParameter)).not.toThrow()
+  })
 })

--- a/packages/oas-utils/src/entities/spec/parameters.ts
+++ b/packages/oas-utils/src/entities/spec/parameters.ts
@@ -41,6 +41,7 @@ export const oasParameterSchema = z.object({
   content: z.unknown().optional(),
   /** Defaulted according to @url https://spec.openapis.org/oas/v3.1.0#parameter-object */
   style: parameterStyleSchema.optional(),
+  explode: z.boolean().optional(),
   example: z.unknown().optional(),
   examples: z
     .union([


### PR DESCRIPTION
**Problem**

Per #4232, the API client only has rudimentary support for array query params and can only correctly handle `style: 'form'` and `explode: true`. Unexploded array params are quite common, and though it would eventually be nice to see [all styles](https://spec.openapis.org/oas/v3.1.1.html#style-values) supported in paths, headers, queries, and cookies, this seems like a good start.

**Solution**

This patch updates `createFetchQueryParams` to take in an additional optional`Request` object, and uses that to locate the schema corresponding to each param to be serialized. If the schema has the `explode` property set to `false` (the default is `true`) then the parameters are serialized as CSV. Otherwise, the existing behavior of serializing the same key multiple times is used.

There is some awkward type gymnastics due to some duplication of zod schemas, and [this unresolved TODO](https://github.com/scalar/scalar/blob/main/packages/oas-utils/src/entities/spec/request-examples.ts#L18-L24) about including the request schema in the request itself. If there's a preferred approach to my workaround, I'm happy to implement it.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
