### PR TITLE
feat(hono): support for dynamic configuration

### DIFF
--- a/.changeset/brave-eagles-invent.md
+++ b/.changeset/brave-eagles-invent.md
@@ -1,0 +1,5 @@
+---
+'@scalar/hono-api-reference': patch
+---
+
+feat: support for dynamic configuration in hono middleware

--- a/integrations/hono/README.md
+++ b/integrations/hono/README.md
@@ -28,6 +28,14 @@ const app = new Hono()
 // Use the middleware to serve the Scalar API Reference at /scalar
 app.get('/scalar', Scalar({ url: '/doc' }))
 
+// Or with dynamic configuration
+app.get('/scalar', Scalar((c) => {
+  return {
+    url: '/doc',
+    proxyUrl: c.env.ENVIRONMENT === 'development' ? 'https://proxy.scalar.com' : undefined,
+  }
+}))
+
 export default app
 ```
 


### PR DESCRIPTION
This PR introduces a flexible middleware for `hono` that accepts dynamic configuration as either a synchronous or asynchronous function with hono context, which is useful in runtimes like [Cloudflare Workers](https://hono.dev/docs/getting-started/cloudflare-workers#bindings) where environment values can be accessed via `c.env`

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
