### PR TITLE
fix(api-reference): schema property heading display

### DIFF
--- a/.changeset/eight-humans-leave.md
+++ b/.changeset/eight-humans-leave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates schema property heading logic

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -163,7 +163,6 @@ describe('SchemaPropertyHeading', () => {
     const wrapper = mount(SchemaPropertyHeading, {
       props: {
         value: {
-          type: 'string',
           default: null,
         },
       },
@@ -173,11 +172,10 @@ describe('SchemaPropertyHeading', () => {
     expect(defaultValueElement.text()).toContain('null')
   })
 
-  it('renders default value: empty string', async () => {
+  it('renders default value: empty', async () => {
     const wrapper = mount(SchemaPropertyHeading, {
       props: {
         value: {
-          type: 'string',
           default: '',
         },
       },
@@ -199,5 +197,19 @@ describe('SchemaPropertyHeading', () => {
     })
     const detailsElement = wrapper.find('.property-heading')
     expect(detailsElement.text()).toContain('PrettyModel')
+  })
+
+  it('renders default value without type being present', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          enum: ['bar', 'foo'],
+          default: 'foo',
+        },
+      },
+    })
+    const defaultValueElement = wrapper.find('.property-heading')
+    expect(defaultValueElement.text()).toContain('default:')
+    expect(defaultValueElement.text()).toContain('"foo"')
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -114,12 +114,15 @@ const displayType = computed(() => {
   if (Array.isArray(value?.type)) {
     return value.type.join(' | ')
   }
+
   if (value?.title) {
     return value.title
   }
+
   if (value?.name) {
     return value.name
   }
+
   return value?.type ?? ''
 })
 </script>
@@ -134,8 +137,8 @@ const displayType = computed(() => {
         name="name" />
       <template v-else>&sol;<slot name="name" />&sol;</template>
     </div>
-    <template v-if="value?.type">
-      <SchemaPropertyDetail>
+    <template v-if="value">
+      <SchemaPropertyDetail v-if="value?.type">
         <ScreenReader>Type:</ScreenReader>
         <template v-if="value?.items?.type">
           {{ value.type }}
@@ -145,9 +148,9 @@ const displayType = computed(() => {
           {{ displayType }}
           {{ value?.nullable ? ' | nullable' : '' }}
         </template>
-        <template v-if="value.minItems || value.maxItems">
-          {{ value.minItems }}&hellip;{{ value.maxItems }}
-        </template>
+      </SchemaPropertyDetail>
+      <SchemaPropertyDetail v-if="value.minItems || value.maxItems">
+        {{ value.minItems }}&hellip;{{ value.maxItems }}
       </SchemaPropertyDetail>
       <SchemaPropertyDetail v-if="value.minLength">
         <template #prefix>min:</template>


### PR DESCRIPTION
**Problem**

currently schema property heading only display most of the information in type presence.

**Solution**

this pr updates the property heading display logic and fixes #5683.

| before | after |
| -------|------|
| <img width="579" alt="image" src="https://github.com/user-attachments/assets/d61319b2-e1e7-45b5-b1f2-98693c6a1ce1" /> | <img width="579" alt="image" src="https://github.com/user-attachments/assets/bf78dca4-3c9a-4792-9415-f97fcd5902c7" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
