### PR TITLE
feat(Scalar.AspNetCore): add support for persistent authentication state

### DIFF
--- a/.changeset/eight-pianos-fly.md
+++ b/.changeset/eight-pianos-fly.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feat(Scalar.AspNetCore): add support for persistent authentication state

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -854,6 +854,9 @@ Whether to persist authentication credentials in local storage. This allows the 
 }
 ```
 
+> [!WARNING]
+> Persisting authentication information in the browser's local storage may present security risks in certain environments. Use this feature with caution based on your security requirements.
+
 ### withDefaultFonts?: boolean
 
 By default we're using Inter and JetBrains Mono, served from our fonts CDN at `https://fonts.scalar.com`. If you use a different font or just don't want to load web fonts, pass `withDefaultFonts: false` to the configuration.

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -347,7 +347,8 @@ app.MapScalarApiReference(options => options
     .AddHttpAuthentication("BearerAuth", auth =>
     {
         auth.Token = "ey...";
-    });
+    })
+    .WithPersistentAuthentication() // Persists authentication between page refreshes
 );
 ```
 
@@ -396,6 +397,23 @@ app.MapScalarApiReference(options => options
 
 > [!NOTE]
 > For more detailed information about authentication, including how to configure security schemes in your OpenAPI document, refer to the [authentication documentation](https://github.com/scalar/scalar/blob/main/integrations/aspnetcore/docs/authentication.md).
+
+#### Persisting Authentication
+
+By default, authentication information is not persisted when the page is refreshed. To enable persistence of authentication data in the browser's local storage, use the `WithPersistentAuthentication` method:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .AddPreferredSecuritySchemes("OAuth2", "ApiKey")
+    // Configure your authentication schemes here
+    .WithPersistentAuthentication() // Enable persistence (default is true)
+);
+```
+
+With this configuration, users won't need to re-enter their authentication credentials after refreshing the page.
+
+> [!WARNING]
+> Persisting authentication information in the browser's local storage may present security risks in certain environments. Use this feature with caution based on your security requirements.
 
 ### Custom HTTP Client
 

--- a/integrations/aspnetcore/docs/authentication.md
+++ b/integrations/aspnetcore/docs/authentication.md
@@ -92,11 +92,12 @@ app.MapScalarApiReference(options => options
     .AddHttpAuthentication("BearerAuth", auth =>
     {
         auth.Token = "ey...";
-    });
+    })
+    .WithPersistentAuthentication() // Optional: persists authentication between page refreshes
 );
 ```
 
-This configuration preselects the `Bearer` authentication scheme in the API Reference and pre-fills the token with a given value.
+This configuration preselects the `Bearer` authentication scheme in the API Reference and pre-fills the token with a given value. Additionally, with `WithPersistentAuthentication()`, the authentication state will be persisted in the browser's local storage and restored when the user returns to the page.
 
 ### HTTP Basic Authentication
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarConfiguration.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarConfiguration.cs
@@ -65,6 +65,8 @@ internal sealed class ScalarConfiguration
 
     [JsonPropertyName("baseServerURL")]
     public required string? BaseServerUrl { get; init; }
+
+    public required bool PersistAuth { get; set; }
 }
 
 [JsonSerializable(typeof(ScalarConfiguration))]

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -820,4 +820,15 @@ public static class ScalarOptionsExtensions
         options.JavaScriptConfiguration = javaScriptConfiguration;
         return options;
     }
+
+    /// <summary>
+    /// Sets whether authentication state should be persisted in local storage.
+    /// </summary>
+    /// <param name="options"><see cref="ScalarOptions" />.</param>
+    /// <param name="persistAuth">Whether to persist authentication between page refreshes.</param>
+    public static ScalarOptions WithPersistentAuthentication(this ScalarOptions options, bool persistAuth = true)
+    {
+        options.PersistentAuthentication = persistAuth;
+        return options;
+    }
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -61,7 +61,8 @@ internal static class ScalarOptionsMapper
             Integration = options.DotNetFlag ? "dotnet" : null,
             HideClientButton = options.HideClientButton,
             Sources = sources,
-            BaseServerUrl = options.BaseServerUrl
+            BaseServerUrl = options.BaseServerUrl,
+            PersistAuth = options.PersistentAuthentication
         };
     }
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -265,4 +265,13 @@ public sealed class ScalarOptions
     /// </remarks>
     [StringSyntax(StringSyntaxAttribute.Uri)]
     public string? JavaScriptConfiguration { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether authentication state should be persisted in local storage.
+    /// </summary>
+    /// <value>The default value is <c>false</c>.</value>
+    /// <remarks>
+    /// When set to <c>true</c>, the authentication state will be stored in the browser's local storage and restored when the user returns to the page.
+    /// </remarks>
+    public bool PersistentAuthentication { get; set; }
 }

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -61,7 +61,8 @@ public class ScalarOptionsExtensionsTests
             .AddDocuments(new ScalarDocument("v4"))
             .WithBaseServerUrl("https://example.com")
             .WithDynamicBaseServerUrl()
-            .WithJavaScriptConfiguration("/scalar/config.js");
+            .WithJavaScriptConfiguration("/scalar/config.js")
+            .WithPersistentAuthentication();
 
         // Assert
         options.Title.Should().Be("My title");
@@ -108,6 +109,7 @@ public class ScalarOptionsExtensionsTests
         options.BaseServerUrl.Should().Be("https://example.com");
         options.DynamicBaseServerUrl.Should().BeTrue();
         options.JavaScriptConfiguration.Should().Be("/scalar/config.js");
+        options.PersistentAuthentication.Should().BeTrue();
 
 #pragma warning restore CS0618 // Type or member is obsolete
     }

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -35,6 +35,7 @@ public class ScalarOptionsMapperTests
         configuration.Theme.Should().Be("purple");
         configuration.Integration.Should().Be("dotnet");
         configuration.Sources.Should().BeEmpty();
+        configuration.PersistAuth.Should().BeFalse();
     }
 
     [Fact]
@@ -74,7 +75,8 @@ public class ScalarOptionsMapperTests
             TagSorter = TagSorter.Alpha,
             OperationSorter = OperationSorter.Method,
             DotNetFlag = false,
-            HideClientButton = true
+            HideClientButton = true,
+            PersistentAuthentication = true
         };
         options.AddDocument("v2");
 
@@ -111,6 +113,7 @@ public class ScalarOptionsMapperTests
         configuration.Integration.Should().BeNull();
         configuration.HideClientButton.Should().BeTrue();
         configuration.Sources.Should().ContainSingle().Which.Url.Should().Be("openapi/v2.json");
+        configuration.PersistAuth.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
**Problem**

Currently, the option `persistAuth` is not part of the `Scalar.AspNetCore` integration.

**Solution**

Now it is 😎!

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
