### PR TITLE
fix(api-client): server variable form border

### DIFF
--- a/.changeset/smart-ghosts-study.md
+++ b/.changeset/smart-ghosts-study.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: adds server variable form border for api reference

--- a/packages/api-client/src/components/Server/ServerVariablesForm.vue
+++ b/packages/api-client/src/components/Server/ServerVariablesForm.vue
@@ -6,11 +6,17 @@ import type {
   ServerVariableValues,
 } from '@/components/Server/types'
 
-const props = defineProps<{
+const {
+  values,
+  variables,
+  layout = 'client',
+} = defineProps<{
   variables?: ServerVariables | undefined
   values?: ServerVariableValues
   /** The ID of the input controlled by the variables form */
   controls?: string
+  /** The layout of the server variables form */
+  layout?: 'client' | 'reference'
 }>()
 
 const emit = defineEmits<{
@@ -22,11 +28,7 @@ function setVariable(name: string, value: string) {
 }
 
 const getVariable = (name: string) => {
-  return (
-    props.values?.[name] ??
-    props.variables?.[name]?.default ??
-    ''
-  ).toString()
+  return (values?.[name] ?? variables?.[name]?.default ?? '').toString()
 }
 </script>
 <template>
@@ -34,7 +36,9 @@ const getVariable = (name: string) => {
     <template
       v-for="name in Object.keys(variables)"
       :key="name">
-      <label class="group/label flex w-full">
+      <label
+        class="group/label flex w-full"
+        :class="layout === 'reference' && 'border-x border-b'">
         <span
           class="mr-1.5 flex items-center py-1.5 pl-3 after:content-[':'] group-has-[input]/label:mr-0">
           {{ name }}

--- a/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
+++ b/packages/api-reference/src/features/BaseUrl/BaseUrl.vue
@@ -55,6 +55,7 @@ const updateServer = (newServer: string) => {
   </div>
   <ServerVariablesForm
     :variables="server?.variables"
+    layout="reference"
     @update:variable="updateServerVariable" />
   <!-- Description -->
   <ScalarMarkdown


### PR DESCRIPTION
**Problem**

currently on reference border are missing from the server variable form.

**Solution**

this pr sets the missing style for server variable form when using reference layout.

| before | after |
| -------|------|
| <img width="598" alt="image" src="https://github.com/user-attachments/assets/e1785fc5-2237-4f5c-8e6d-1bd0198c3708" /> | <img width="598" alt="image" src="https://github.com/user-attachments/assets/3a989a8d-5053-4952-9f69-30ba3524bba8" /> |
| form border are missing | form border gets displayed | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
