### PR TITLE
chore: add `default` to `api-reference-react` package.json export field

### DIFF
--- a/.changeset/curvy-onions-thank.md
+++ b/.changeset/curvy-onions-thank.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference-react': patch
+---
+
+Add default export

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -34,7 +34,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./style.css": "./dist/style.css"
   },


### PR DESCRIPTION
**Problem**

Currently, attempting to import newer versions of `api-reference-react` into commonJS projects fails with:

`Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /node_modules/@scalar/api-reference-react/package.json`

Previously this was addressed in https://github.com/scalar/scalar/pull/3405 for other packages by adding a `default` export.

**Solution**

With this PR a default export is added in a similar fashion for `api-reference-react`.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
