### PR TITLE
chore(nextjs-api-reference): bump version

### DIFF
--- a/.changeset/olive-ravens-study.md
+++ b/.changeset/olive-ravens-study.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nextjs-api-reference': patch
+---
+
+chore: bump version

--- a/integrations/nextjs/package.json
+++ b/integrations/nextjs/package.json
@@ -18,7 +18,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "0.8.1",
+  "version": "0.8.2",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
**Problem**

Currently, our CI broke on next

**Solution**

With this PR we manually bump the package version, may need to do this for others as well

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
