### PR TITLE
feat(api-reference): specification download button

### DIFF
--- a/.changeset/curly-roses-flow.md
+++ b/.changeset/curly-roses-flow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: updates download link component

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -156,8 +156,8 @@ onMounted(() => {
   history.scrollRestoration = 'manual'
 
   // Enable the spec download event bus
-  downloadEventBus.on(({ filename }) => {
-    downloadDocument(props.rawSpec, filename)
+  downloadEventBus.on(({ filename, format }) => {
+    downloadDocument(props.rawSpec, filename, format)
   })
 
   // Find scalar Y offset to support users who have tried to add their own headers

--- a/packages/api-reference/src/components/Badge/Badge.vue
+++ b/packages/api-reference/src/components/Badge/Badge.vue
@@ -9,6 +9,7 @@
   color: var(--scalar-color-2);
   font-size: var(--scalar-micro);
   background: var(--scalar-background-2);
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
   padding: 2px 6px;
   border-radius: 12px;
   font-weight: var(--scalar-semibold);

--- a/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
+++ b/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
@@ -1,4 +1,7 @@
 <script lang="ts" setup>
+import { ScalarButton } from '@scalar/components'
+
+import Badge from '@/components/Badge/Badge.vue'
 import { useConfig } from '@/hooks/useConfig'
 import { downloadEventBus } from '@/libs/download'
 
@@ -9,53 +12,115 @@ const { filename } = defineProps<{
 const config = useConfig()
 
 // id is retrieved at the layout level
-const handleDownloadClick = () => {
-  downloadEventBus.emit({ id: '', filename })
+const handleDownloadClick = (format: 'json' | 'yaml') => {
+  downloadEventBus.emit({ id: '', filename, format })
 }
 </script>
 <template>
-  <div class="download">
-    <template v-if="!config?.hideDownloadButton">
-      <!-- Direct URL -->
-      <template v-if="config?.url">
-        <a
-          class="download-button"
-          download
-          :href="config?.url"
-          target="_blank">
-          Download OpenAPI Document
-        </a>
-      </template>
-      <!-- Generate download from document -->
-      <template v-else>
-        <button
-          class="download-button"
-          role="link"
-          type="button"
-          @click="handleDownloadClick">
-          Download OpenAPI Document
-        </button>
-      </template>
-    </template>
+  <div
+    v-if="!config?.hideDownloadButton"
+    class="download-container">
+    <ScalarButton
+      class="download-button"
+      @click.prevent="handleDownloadClick('json')"
+      variant="ghost">
+      <span> Download OpenAPI Document </span>
+      <Badge class="extension">json</Badge>
+    </ScalarButton>
+    <ScalarButton
+      class="download-button"
+      @click.prevent="handleDownloadClick('yaml')"
+      variant="ghost">
+      <span> Download OpenAPI Document </span>
+      <Badge class="extension">yaml</Badge>
+    </ScalarButton>
   </div>
 </template>
 
 <style scoped>
-.download {
-  margin-bottom: 24px;
+.download-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 4px 0 24px;
+  position: relative;
+  width: fit-content;
+}
+
+.download-container:hover::before {
+  content: '';
+  width: calc(100% + 76px);
+  height: 90px;
+  position: absolute;
+  top: -11px;
+  left: -12px;
+  border-radius: var(--scalar-radius-lg);
+  box-shadow: var(--scalar-shadow-2);
+  pointer-events: none;
+  background: var(--scalar-background-1);
 }
 
 .download-button {
-  color: var(--scalar-link-color, var(--scalar-color-accent));
-  font-weight: var(--scalar-link-font-weight, inherit);
-  text-decoration: var(--scalar-text-decoration) !important;
-  text-decoration-color: var(--scalar-text-decoration-color);
-  font-size: var(--scalar-paragraph);
+  color: var(--scalar-link-color);
   cursor: pointer;
+  display: flex;
+  gap: 4px;
+  height: fit-content;
+  padding: 0;
+  position: relative;
+  white-space: nowrap;
 }
-.download-button:hover {
-  color: var(--scalar-link-color-hover, var(--scalar-color-accent));
-  text-decoration: var(--scalar-text-decoration-hover) !important;
-  text-decoration-color: var(--scalar-text-decoration-color-hover);
+
+.download-button::before {
+  border-radius: var(--scalar-radius);
+  content: '';
+  height: calc(100% + 16px);
+  left: -9px;
+  position: absolute;
+  top: -8px;
+  width: calc(100% + 70px);
+}
+
+.download-button:hover::before {
+  background: var(--scalar-background-2);
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+}
+
+.download-button span {
+  align-items: center;
+  color: var(--scalar-link-color);
+  display: flex;
+  font-size: var(--scalar-font-size-2);
+  font-weight: var(--scalar-regular);
+  gap: 6px;
+  line-height: 1.625;
+  z-index: 1;
+}
+
+.download-button:hover span {
+  text-decoration: var(--scalar-text-decoration-hover);
+  text-underline-offset: 2px;
+}
+
+/* Second button displayed when hovering over the download container */
+.download-button:nth-of-type(2) {
+  display: none;
+  position: absolute;
+  top: 42px;
+}
+
+.download-container:hover .download-button:nth-of-type(2) {
+  display: flex;
+}
+
+.extension {
+  position: absolute;
+  left: calc(100% + 8px);
+  opacity: 0;
+  z-index: 1;
+}
+
+.download-container:hover .extension {
+  opacity: 1;
 }
 </style>

--- a/packages/api-reference/src/libs/download.ts
+++ b/packages/api-reference/src/libs/download.ts
@@ -1,14 +1,15 @@
 import { isJsonString } from '@scalar/oas-utils/helpers'
 import { type EventBusKey, useEventBus } from '@vueuse/core'
+import { isDefined } from '@scalar/oas-utils/helpers'
 
-const downloadEventBusKey: EventBusKey<{ id: string; filename?: string }> = Symbol('download')
+const downloadEventBusKey: EventBusKey<{ id: string; filename?: string; format?: 'json' | 'yaml' }> = Symbol('download')
 export const downloadEventBus = useEventBus(downloadEventBusKey)
 
 /**
  * Trigger the download of the OpenAPI document
  */
-export function downloadDocument(content: string, filename?: string) {
-  const isJson = isJsonString(content)
+export function downloadDocument(content: string, filename?: string, format?: 'json' | 'yaml') {
+  const isJson = format === 'json' || (!isDefined(format) && isJsonString(content))
 
   const blob = isJson
     ? new Blob([content], { type: 'application/json' })


### PR DESCRIPTION
**Problem**

currently it is not possible to access both specification document extension. (yaml | json) on download.

**Solution**

this pr updates the download component style and introduces both extension to be downloaded at ease.

| after |
|------|
| <img width="1463" alt="image" src="https://github.com/user-attachments/assets/28796724-1efc-48d1-b737-f80af3696a14" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
