### PR TITLE
fix(api-reference): introduction card auth style

### DIFF
--- a/.changeset/fuzzy-camels-buy.md
+++ b/.changeset/fuzzy-camels-buy.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: updates introduction card and auth style

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -66,7 +66,8 @@ watch(
   <form @submit.prevent>
     <div
       v-if="selectedSchemeOptions.length > 1"
-      class="box-content flex h-8 flex-wrap gap-x-2.5 overflow-hidden border border-b-0 px-3">
+      class="box-content flex h-8 flex-wrap gap-x-2.5 overflow-hidden border border-b-0 px-3"
+      :class="layout === 'client' && 'border-r-0'">
       <div
         v-for="(option, index) in selectedSchemeOptions"
         :key="option.id"
@@ -105,7 +106,10 @@ watch(
 
     <div
       v-else
-      class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border-t px-4 text-sm">
+      class="text-c-3 bg-b-1 flex min-h-16 items-center justify-center border-t px-4 text-sm"
+      :class="
+        layout === 'reference' && 'min-h-[calc(4rem+0.5px)] rounded-b-lg border'
+      ">
       No authentication selected
     </div>
 

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -199,11 +199,6 @@ const introCardsSlot = computed(() =>
   flex-direction: column;
   justify-content: start;
 }
-@container narrow-references-container (max-width: 900px) {
-  .introduction-card-item {
-    border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
-  }
-}
 .introduction-card-item:has(.description) :deep(.server-form-container) {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;


### PR DESCRIPTION
**Problem**

follow up of #5693 as there is some missing element and enhancement opportunities.

**Solution**

this pr updates the introduction card and auth component style.

`auth`
| before | after |
| -------|------|
| <img width="1463" alt="image" src="https://github.com/user-attachments/assets/882221a7-0619-4982-bf52-adfd45fac17e" /> | <img width="1463" alt="image" src="https://github.com/user-attachments/assets/113a8ddd-2388-4332-b85b-1e87cf6c2019" /> |
| missing empty state border | empty state border displayed | 

`responsive`
| before | after |
| -------|------|
| <img width="825" alt="image" src="https://github.com/user-attachments/assets/f6cb4322-81f7-4e2f-a302-34d9148a9d7a" /> | <img width="825" alt="image" src="https://github.com/user-attachments/assets/dcf09747-c72f-46e0-af3c-c890d7e6e87b" /> |
| second border on display | legacy style code removed | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
