### PR TITLE
fix(openapi-parser): Swagger upgrade fails for non-objects

### DIFF
--- a/.changeset/dirty-ants-own.md
+++ b/.changeset/dirty-ants-own.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: swagger upgrade fails if you pass something that is not an object

--- a/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
+++ b/packages/openapi-parser/src/utils/upgradeFromTwoToThree.ts
@@ -12,7 +12,12 @@ export function upgradeFromTwoToThree(originalSpecification: UnknownObject) {
   let specification = originalSpecification
 
   // Version
-  if (specification !== null && typeof specification.swagger === 'string' && specification.swagger?.startsWith('2.0')) {
+  if (
+    specification !== null &&
+    typeof specification === 'object' &&
+    typeof specification.swagger === 'string' &&
+    specification.swagger?.startsWith('2.0')
+  ) {
     specification.openapi = '3.0.4'
     delete specification.swagger
   } else {


### PR DESCRIPTION
Taken from #5529

**Problem**

If you pass something that isn’t an object to the Swagger upgrade utility, it’s failing (swagger of undefined).

**Solution**

This PR adds a check whether we deal with an object.

Same for the OpenAPI 3.0 -> 3.1 upgrade.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
