### PR TITLE
fix(api-reference): sets schema name property heading

### DIFF
--- a/.changeset/grumpy-meals-warn.md
+++ b/.changeset/grumpy-meals-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: asses schemas to children object in schema property

--- a/.changeset/many-scissors-relax.md
+++ b/.changeset/many-scissors-relax.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: adds model name function in schema property heading

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -287,7 +287,8 @@ const displayPropertyHeading = (
           :level="level + 1"
           :name="name"
           :noncollapsible="noncollapsible"
-          :value="optimizedValue.items" />
+          :value="optimizedValue.items"
+          :schemas="schemas" />
       </div>
     </template>
     <!-- Compositions -->

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -212,4 +212,43 @@ describe('SchemaPropertyHeading', () => {
     expect(defaultValueElement.text()).toContain('default:')
     expect(defaultValueElement.text()).toContain('"foo"')
   })
+
+  it('formats array type with model reference', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'array',
+          items: { type: 'object', name: 'FooModel' },
+        },
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('array FooModel[]')
+  })
+
+  it('formats object type with direct model reference', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'object',
+          name: 'BarModel',
+        },
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('object BarModel[]')
+  })
+
+  it('displays plain type when no model name is present', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'string',
+        },
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('string')
+    expect(detailsElement.text()).not.toContain('[]')
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -130,6 +130,33 @@ const displayType = computed(() => {
 
   return value?.type ?? ''
 })
+
+/** Format the type and model name with array suffix */
+const formatTypeWithModel = (type: string, modelName: string) => {
+  return `${type} ${modelName}[]`
+}
+
+/** Gets the model name */
+const modelName = computed(() => {
+  if (!value?.type) {
+    return null
+  }
+
+  // Handle array types with item references
+  if (value.items?.type) {
+    const itemModelName =
+      getModelNameFromSchema(value.items) || value.items.type
+    return formatTypeWithModel(value.type, itemModelName)
+  }
+
+  // Handle direct object references
+  const objectModelName = getModelNameFromSchema(value)
+  if (objectModelName) {
+    return formatTypeWithModel(value.type, objectModelName)
+  }
+
+  return null
+})
 </script>
 <template>
   <div class="property-heading">
@@ -145,9 +172,8 @@ const displayType = computed(() => {
     <template v-if="value">
       <SchemaPropertyDetail v-if="value?.type">
         <ScreenReader>Type:</ScreenReader>
-        <template v-if="value?.items?.type">
-          {{ value.type }}
-          {{ getModelNameFromSchema(value.items) || value.items.type }}[]
+        <template v-if="modelName">
+          {{ modelName }}
         </template>
         <template v-else>
           {{ displayType }}


### PR DESCRIPTION
**Problem**

currently schema name of type object are not retrieved in the reference property level.

**Solution**

this pr adds a schema name function to handle both array and object type schema name retrieval and fixes #5711 .

| before | after |
| -------|------|
| <img width="825" alt="image" src="https://github.com/user-attachments/assets/8370df6d-7bb0-4743-81a7-ab80ba339bfa" /> | <img width="825" alt="image" src="https://github.com/user-attachments/assets/71f6fd62-c6a8-4216-9d6d-21ff1a397536" /> |
| only type object displayed | type object and model schema name displayed |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
