### PR TITLE
chore(Scalar.AspNetCore): remove obsolete license URL property

### DIFF
--- a/.changeset/old-boxes-heal.md
+++ b/.changeset/old-boxes-heal.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+chore(Scalar.AspNetCore): remove obsolete license URL property

--- a/integrations/aspnetcore/src/Directory.Build.props
+++ b/integrations/aspnetcore/src/Directory.Build.props
@@ -11,11 +11,10 @@
 
   <PropertyGroup>
     <Authors>Scalar</Authors>
-    <LicenseUrl>https://github.com/scalar/scalar/blob/main/LICENSE</LicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/scalar/scalar</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <PackageTags>Scalar;OpenAPI;Swagger</PackageTags>
+    <PackageTags>Scalar;OpenAPI;Swagger;API Reference</PackageTags>
     <PackageProjectUrl>https://scalar.com</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
This PR removes the deprecated license URL property. This is some preparation for the prefix reservation.

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
