### PR TITLE
fix(api-reference): introduction component alignment

### DIFF
--- a/.changeset/fuzzy-scissors-yawn.md
+++ b/.changeset/fuzzy-scissors-yawn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: moves download link to section column in introduction component

--- a/.changeset/three-cherries-hammer.md
+++ b/.changeset/three-cherries-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: adds server selector x axis overflow for long content

--- a/packages/api-client/src/components/Server/ServerSelector.vue
+++ b/packages/api-client/src/components/Server/ServerSelector.vue
@@ -89,10 +89,10 @@ const serverUrlWithoutTrailingSlash = computed(() => {
     :target="target"
     :teleport="`#${target}`">
     <ScalarButton
-      class="gap-0.75 text-c-1 h-6.5 w-full justify-start whitespace-nowrap rounded-b-lg px-3 py-1.5 text-xs font-normal -outline-offset-1 lg:text-sm"
+      class="gap-0.75 text-c-1 h-6.5 w-full justify-start overflow-x-auto whitespace-nowrap rounded-b-lg px-3 py-1.5 text-xs font-normal -outline-offset-1 lg:text-sm"
       variant="ghost">
       <span class="sr-only">Server:</span>
-      {{ serverUrlWithoutTrailingSlash }}
+      <span class="overflow-x-auto">{{ serverUrlWithoutTrailingSlash }}</span>
       <ScalarIcon
         class="text-c-2"
         icon="ChevronDown"
@@ -103,6 +103,6 @@ const serverUrlWithoutTrailingSlash = computed(() => {
     v-else
     class="gap-0.75 text-c-1 h-6.5 flex w-full items-center whitespace-nowrap rounded-b-lg px-3 py-1.5 text-xs lg:text-sm">
     <span class="sr-only">Server:</span>
-    {{ serverUrlWithoutTrailingSlash }}
+    <span class="overflow-x-auto">{{ serverUrlWithoutTrailingSlash }}</span>
   </div>
 </template>

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -88,9 +88,9 @@ onMounted(() => config.value.onLoaded?.())
             {{ info.title }}
           </SectionHeaderTag>
         </SectionHeader>
-        <DownloadLink :filename="filenameFromTitle" />
         <SectionColumns>
           <SectionColumn>
+            <DownloadLink :filename="filenameFromTitle" />
             <Description :value="info.description" />
           </SectionColumn>
           <SectionColumn v-if="$slots.aside">


### PR DESCRIPTION
**Solution**

this pr updates the introduction card style to bring back previous alignment of selector with content + fix overflowing issue with long server content.

| before | after |
| -------|------|
| <img width="1464" alt="image" src="https://github.com/user-attachments/assets/7ce0155a-ddf2-4130-8ce4-55458ea2264a" /> | <img width="1464" alt="image" src="https://github.com/user-attachments/assets/94c8544a-4d93-4259-98dc-2bb0bf7d1be7" /> |
| server selector aligned with description | server selector aligned with title baseline |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
