### PR TITLE
fix: theme laserwave string quotes

### DIFF
--- a/documentation/themes.md
+++ b/documentation/themes.md
@@ -4,7 +4,7 @@ You don’t like the color scheme? We’ve prepared some themes for you:
 
 ```vue
 /* theme?: 'alternate' | 'default' | 'moon' | 'purple' | 'solarized' |
-'bluePlanet' | 'saturn' | 'kepler' | 'mars' | 'deepSpace' | laserwave | 'none' */
+'bluePlanet' | 'saturn' | 'kepler' | 'mars' | 'deepSpace' | 'laserwave' | 'none' */
 <ApiReference :configuration="{ theme: 'moon' }" />
 ```
 


### PR DESCRIPTION
**Problem**

Currently, the `laserwave` theme option in the documentation is missing single quotes, which makes it inconsistent with other theme options and could cause confusion for developers trying to use this theme.

**Solution**

With this PR, I've added the missing single quotes around `laserwave` in the theme options list to maintain consistency with other theme string values.

**Checklist**

I've gone through the following:

- [x] I've added an explanation *why* this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.


<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->