### PR TITLE
feat(api-reference): discriminator support

### DIFF
--- a/.changeset/eight-gorillas-learn.md
+++ b/.changeset/eight-gorillas-learn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: adds schema discriminator helper functions

--- a/.changeset/neat-lions-check.md
+++ b/.changeset/neat-lions-check.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: adds schema discriminator support

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -1,0 +1,53 @@
+<script lang="ts" setup>
+import { ScalarListbox, type ScalarListboxOption } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
+import { computed } from 'vue'
+
+import type {
+  DiscriminatorMapping,
+  DiscriminatorPropertyName,
+} from './helpers/schema-discriminator'
+
+const { discriminatorMapping, modelValue, discriminatorPropertyName } =
+  defineProps<{
+    discriminatorMapping: DiscriminatorMapping
+    modelValue: string
+    discriminatorPropertyName?: DiscriminatorPropertyName
+  }>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+}>()
+
+const listboxOptions = computed(() =>
+  Object.keys(discriminatorMapping).map((type) => ({
+    id: type,
+    label: type,
+  })),
+)
+
+const selectedOption = computed({
+  get: () =>
+    listboxOptions.value.find(
+      (opt: ScalarListboxOption) => opt.id === modelValue,
+    ),
+  set: (opt: ScalarListboxOption) => emit('update:modelValue', opt.id),
+})
+</script>
+
+<template>
+  <ScalarListbox
+    v-model="selectedOption"
+    :options="listboxOptions"
+    resize>
+    <button
+      class="bg-b-1.5 hover:bg-b-2 py-1.25 flex w-full items-center gap-1 border-b px-2"
+      type="button">
+      <span class="text-c-2">Discriminator</span>
+      <span class="composition-selector-label text-c-1 relative">
+        {{ discriminatorPropertyName }} {{ selectedOption?.label }}
+      </span>
+      <ScalarIconCaretDown />
+    </button>
+  </ScalarListbox>
+</template>

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -181,6 +181,11 @@ const modelName = computed(() => {
         name="name" />
       <template v-else>&sol;<slot name="name" />&sol;</template>
     </div>
+    <div
+      v-if="value?.isDiscriminator"
+      class="property-discriminator">
+      Discriminator
+    </div>
     <template v-if="value">
       <SchemaPropertyDetail v-if="value?.type">
         <ScreenReader>Type:</ScreenReader>
@@ -357,6 +362,12 @@ const modelName = computed(() => {
   font-size: var(--scalar-micro);
   color: var(--scalar-color-green);
 }
+
+.property-discriminator {
+  font-size: var(--scalar-micro);
+  color: var(--scalar-color-purple);
+}
+
 .property-detail {
   font-size: var(--scalar-micro);
   color: var(--scalar-color-2);

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-discriminator.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-discriminator.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
-import { getDiscriminatorPropertyName } from './schema-discriminator'
+import {
+  getDiscriminatorMapping,
+  getDiscriminatorPropertyName,
+  hasDiscriminator,
+  mergeDiscriminatorSchemas,
+} from './schema-discriminator'
 
 describe('schema-discriminator', () => {
   describe('getDiscriminatorPropertyName', () => {
@@ -17,6 +22,152 @@ describe('schema-discriminator', () => {
     it('returns undefined when no discriminator', () => {
       const schema: OpenAPIV3_1.SchemaObject = {}
       expect(getDiscriminatorPropertyName(schema)).toBeUndefined()
+    })
+  })
+
+  describe('getDiscriminatorMapping', () => {
+    it('returns mapping from discriminator', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {
+        discriminator: {
+          propertyName: 'type',
+          mapping: {
+            terrestrial: '#/components/schemas/TerrestrialPlanet',
+            gas_giant: '#/components/schemas/GasGiant',
+          },
+        },
+      }
+      expect(getDiscriminatorMapping(schema)).toEqual({
+        terrestrial: '#/components/schemas/TerrestrialPlanet',
+        gas_giant: '#/components/schemas/GasGiant',
+      })
+    })
+  })
+
+  describe('hasDiscriminator', () => {
+    it('returns true when schema has discriminator', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {
+        discriminator: {
+          propertyName: 'type',
+        },
+      }
+      expect(hasDiscriminator(schema)).toBe(true)
+    })
+
+    it('returns false when schema has no discriminator', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {}
+      expect(hasDiscriminator(schema)).toBe(false)
+    })
+  })
+
+  describe('mergeDiscriminatorSchemas', () => {
+    it('merges base schema with selected type schema', () => {
+      const baseSchema: OpenAPIV3_1.SchemaObject = {
+        type: 'object',
+        required: ['name', 'type'],
+        properties: {
+          name: { type: 'string' },
+          type: { type: 'string' },
+        },
+        discriminator: {
+          propertyName: 'type',
+          mapping: {
+            terrestrial: '#/components/schemas/TerrestrialPlanet',
+          },
+        },
+      }
+
+      const schemas: Record<string, OpenAPIV3_1.SchemaObject> = {
+        TerrestrialPlanet: {
+          type: 'object',
+          required: ['atmosphere'],
+          properties: {
+            atmosphere: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  compound: { type: 'string' },
+                  percentage: { type: 'number' },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const result = mergeDiscriminatorSchemas(baseSchema, 'terrestrial', schemas)
+      expect(result).toEqual({
+        type: 'object',
+        required: ['name', 'type', 'atmosphere'],
+        properties: {
+          name: { type: 'string' },
+          type: { type: 'string' },
+          atmosphere: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                compound: { type: 'string' },
+                percentage: { type: 'number' },
+              },
+            },
+          },
+        },
+      })
+    })
+
+    it('merges schema with allOf composition', () => {
+      const baseSchema: OpenAPIV3_1.SchemaObject = {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: { type: 'string' },
+        },
+        discriminator: {
+          propertyName: 'type',
+          mapping: {
+            gas_giant: '#/components/schemas/GasGiantWithAllOf',
+          },
+        },
+      }
+
+      const schemas: Record<string, OpenAPIV3_1.SchemaObject> = {
+        GasGiantWithAllOf: {
+          type: 'object',
+          allOf: [
+            {
+              type: 'object',
+              required: ['mass'],
+              properties: {
+                mass: { type: 'number', format: 'float' },
+              },
+            },
+            {
+              type: 'object',
+              required: ['satellites'],
+              properties: {
+                satellites: {
+                  type: 'array',
+                  items: { type: 'object' },
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      const result = mergeDiscriminatorSchemas(baseSchema, 'gas_giant', schemas)
+      expect(result).toEqual({
+        type: 'object',
+        properties: {
+          mass: { type: 'number', format: 'float' },
+          satellites: {
+            type: 'array',
+            items: { type: 'object' },
+          },
+        },
+        required: ['type', 'mass', 'satellites'],
+      })
     })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-discriminator.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-discriminator.ts
@@ -1,6 +1,89 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
+export type DiscriminatorMapping = NonNullable<OpenAPIV3_1.DiscriminatorObject['mapping']>
+
+export type DiscriminatorPropertyName = OpenAPIV3_1.DiscriminatorObject['propertyName']
+
+/** Get discriminator mapping from schema */
+export function getDiscriminatorMapping(schema: OpenAPIV3_1.SchemaObject): DiscriminatorMapping | undefined {
+  if (!schema.discriminator?.mapping) {
+    return undefined
+  }
+
+  return schema.discriminator.mapping
+}
+
 /** Get discriminator property name from schema */
-export function getDiscriminatorPropertyName(schema: OpenAPIV3_1.SchemaObject): string | undefined {
+export function getDiscriminatorPropertyName(schema: OpenAPIV3_1.SchemaObject): DiscriminatorPropertyName | undefined {
   return schema.discriminator?.propertyName
+}
+
+/** Check if schema has a discriminator */
+export function hasDiscriminator(schema: OpenAPIV3_1.SchemaObject): boolean {
+  return schema.discriminator !== undefined
+}
+
+/** Merge discriminator schemas */
+export function mergeDiscriminatorSchemas(
+  baseSchema: OpenAPIV3_1.SchemaObject,
+  selectedType: string,
+  schemas: Record<string, OpenAPIV3_1.SchemaObject>,
+): OpenAPIV3_1.SchemaObject | undefined {
+  if (!baseSchema.discriminator?.mapping || !selectedType) {
+    return undefined
+  }
+
+  const refPath = baseSchema.discriminator.mapping[selectedType]
+  if (!refPath) {
+    return undefined
+  }
+
+  // Extract schema name from ref path
+  const schemaName = refPath.split('/').pop()
+  if (!schemaName || !schemas[schemaName]) {
+    return undefined
+  }
+
+  const selectedSchema = schemas[schemaName]
+
+  // If the selected schema has allOf, merge all subschemas
+  if (selectedSchema.allOf) {
+    const mergedSchema: OpenAPIV3_1.SchemaObject = {
+      type: selectedSchema.type,
+      properties: {},
+      required: [],
+    }
+    const properties: Record<string, OpenAPIV3_1.SchemaObject | OpenAPIV3_1.ReferenceObject> = {}
+    const required = new Set<string>()
+
+    // First add base schema required fields
+    if (baseSchema.required) {
+      baseSchema.required.forEach((field: string) => required.add(field))
+    }
+
+    // Then process all allOf schemas
+    for (const subSchema of selectedSchema.allOf) {
+      if ('properties' in subSchema) {
+        Object.assign(properties, subSchema.properties)
+      }
+      if ('required' in subSchema && Array.isArray(subSchema.required)) {
+        subSchema.required.forEach((field: string) => required.add(field))
+      }
+    }
+
+    mergedSchema.properties = properties
+    mergedSchema.required = Array.from(required)
+
+    return mergedSchema
+  }
+
+  // If no allOf, merge with base schema
+  return {
+    type: selectedSchema.type || baseSchema.type,
+    properties: {
+      ...(baseSchema.properties || {}),
+      ...(selectedSchema.properties || {}),
+    },
+    required: [...(baseSchema.required || []), ...(selectedSchema.required || [])],
+  } as OpenAPIV3_1.SchemaObject
 }


### PR DESCRIPTION
**Problem**

currently in discriminator presence reference is not retrieving mapping nor resolving schemas in its ui.

**Solution**

this pr introduces schema discriminator in order to be able to select schema accordingly and fixes #795 .

| after |
|------|
| <img width="1464" alt="image" src="https://github.com/user-attachments/assets/b31d894d-f905-446f-9555-35b2f1d49f0c" /> |

**Test**
[Open API spec doc](https://sandbox.scalar.com/files/FRNqy/openapi.yaml)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
