### PR TITLE
fix(api-reference): schema property heading type

### DIFF
--- a/.changeset/lovely-onions-peel.md
+++ b/.changeset/lovely-onions-peel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates schema property heading type handling

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -236,7 +236,21 @@ describe('SchemaPropertyHeading', () => {
       },
     })
     const detailsElement = wrapper.find('.property-heading')
-    expect(detailsElement.text()).toContain('object BarModel[]')
+    expect(detailsElement.text()).toContain('object BarModel')
+    expect(detailsElement.text()).not.toContain('[]')
+  })
+
+  it('formats array type with model reference correctly', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'array',
+          items: { type: 'object', name: 'BarModel' },
+        },
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('array BarModel[]')
   })
 
   it('displays plain type when no model name is present', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -131,9 +131,9 @@ const displayType = computed(() => {
   return value?.type ?? ''
 })
 
-/** Format the type and model name with array suffix */
+/** Format the type and model name */
 const formatTypeWithModel = (type: string, modelName: string) => {
-  return `${type} ${modelName}[]`
+  return type === 'array' ? `${type} ${modelName}[]` : `${type} ${modelName}`
 }
 
 /** Gets the model name */
@@ -143,7 +143,7 @@ const modelName = computed(() => {
   }
 
   // Handle array types with item references
-  if (value.items?.type) {
+  if (value.type === 'array' && value.items?.type) {
     const itemModelName =
       getModelNameFromSchema(value.items) || value.items.type
     return formatTypeWithModel(value.type, itemModelName)


### PR DESCRIPTION
**Solution**

following up with #5713 type were both handled the same way, this pr updates the logic to add array suffix accordingly.

| before | after |
| -------|------|
| <img width="882" alt="image" src="https://github.com/user-attachments/assets/0727ae62-846b-42d8-99e4-f5afab371b71" /> | <img width="882" alt="image" src="https://github.com/user-attachments/assets/88badc91-350f-4afc-9f17-58858d143916" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
