### PR TITLE
fix(api-reference): schema composition style and value

### DIFF
--- a/.changeset/wise-pants-play.md
+++ b/.changeset/wise-pants-play.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates schema composition style and missing value

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
@@ -153,5 +153,44 @@ describe('SchemaComposition', () => {
       const typeLabel = wrapper.find('span')
       expect(typeLabel.text()).toBe('One of')
     })
+
+    it('renders primitive type in composition panel', () => {
+      const wrapper = mount(SchemaComposition, {
+        props: {
+          composition: 'oneOf',
+          value: {
+            oneOf: [{ type: 'boolean' }, { type: 'object', properties: { foo: { type: 'string' } } }],
+          },
+          level: 0,
+        },
+      })
+
+      expect(wrapper.text()).toContain('boolean')
+    })
+
+    it('renders nullable schema in composition panel', async () => {
+      const wrapper = mount(SchemaComposition, {
+        props: {
+          composition: 'anyOf',
+          value: {
+            anyOf: [
+              {
+                type: 'object',
+                properties: { foo: { type: 'string' } },
+              },
+              { nullable: true },
+            ],
+          },
+          level: 0,
+        },
+      })
+
+      const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+      await listbox.vm.$emit('update:modelValue', { id: '1', label: 'Schema' })
+      await wrapper.vm.$nextTick()
+
+      const panel = wrapper.find('.composition-panel')
+      expect(panel.text()).toContain('nullable')
+    })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -106,11 +106,12 @@ const getSchemaWithComposition = (schemas: any[]) => {
 }
 
 const schemaComposition = computed(() => {
-  const schemaComposition = getSchemaWithComposition(value[composition])
-
-  if (!schemaComposition) {
+  // If there's no nested composition, return the direct composition array
+  if (!getSchemaWithComposition(value[composition])) {
     return value[composition]
   }
+
+  const schemaComposition = getSchemaWithComposition(value[composition])
 
   // Get schema with nested composition
   const schemaNestedComposition =
@@ -223,17 +224,25 @@ const compositionValue = computed(() => {
           <ScalarMarkdown :value="compositionSchema.description" />
         </div>
         <Schema
-          v-if="compositionSchema?.properties"
+          v-if="
+            compositionSchema?.properties ||
+            compositionSchema?.type ||
+            compositionSchema?.nullable
+          "
           :compact="compact"
           :level="level + 1"
           :hideHeading="hideHeading"
           :name="name"
           :noncollapsible="true"
           :schemas="schemas"
-          :value="{
-            type: 'object',
-            properties: compositionSchema.properties,
-          }" />
+          :value="
+            compositionSchema?.properties
+              ? {
+                  type: 'object',
+                  properties: compositionSchema.properties,
+                }
+              : compositionSchema
+          " />
         <!-- Nested tabs -->
         <template v-if="compositionSchema?.oneOf || compositionSchema?.anyOf">
           <SchemaComposition

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -345,14 +345,24 @@ const displayPropertyHeading = (
 .property:hover {
   z-index: 1;
 }
+
 .property--compact.property--level-0,
 .property--compact.property--level-1 {
   padding: 8px 0;
+}
+.composition-panel .property.property.property.property--level-0 {
+  padding: 0px;
 }
 .property--compact.property--level-0
   .composition-panel
   .property--compact.property--level-1 {
   padding: 8px;
+}
+
+/*  if a property doesn't have a heading, remove the top padding */
+.property:has(> .property-rule:nth-of-type(1)):not(.property--compact) {
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 .property--deprecated {
   background: repeating-linear-gradient(
@@ -364,9 +374,11 @@ const displayPropertyHeading = (
   );
   background-size: 100%;
 }
+
 .property--deprecated > * {
   opacity: 0.75;
 }
+
 .property-description {
   margin-top: 6px;
   line-height: 1.4;
@@ -415,20 +427,6 @@ const displayPropertyHeading = (
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
-.property-rule :deep(.composition-panel .composition-selector) {
-  border-top: 0;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-.property-rule
-  :deep(
-    .composition-panel:has(.property-rule)
-      > .schema-card
-      .schema-properties.schema-properties-open
-  ) {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
 .property-enum-value {
   color: var(--scalar-color-3);
   line-height: 1.5;
@@ -472,6 +470,7 @@ const displayPropertyHeading = (
   margin-top: 8px;
   list-style: none;
 }
+
 .property-example {
   background: transparent;
   border: none;


### PR DESCRIPTION
**Problem**

following recent refactoring some style got lost and also some properties value fallback is not happening anymore.

**Solution**

this pr updates the schema composition style along displaying value in some cases.

| before | after |
| -------|------|
| <img width="1086" alt="image" src="https://github.com/user-attachments/assets/4a6bd3e6-9865-4e34-a9e1-c690a818b633" /> | <img width="1086" alt="image" src="https://github.com/user-attachments/assets/c8cb416d-9cfb-4d3f-b556-9bc014aa8d2a" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
