### PR TITLE
ci(galaxy): deploy galaxy.scalar.com

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,69 @@
+{
+  'steps':
+    [
+      {
+        'name': 'gcr.io/cloud-builders/docker',
+        'id': 'build-base',
+        'args':
+          [
+            'build',
+            '-t',
+            'gcr.io/${_PROJECT_ID}/${_BASE_BUILDER}',
+            '-f',
+            './tooling/base-docker-builder/Dockerfile',
+            '.',
+          ],
+      },
+      {
+        'name': 'gcr.io/cloud-builders/docker',
+        'id': 'push-base',
+        'waitFor': ['build-base'],
+        'args': ['push', 'gcr.io/${_PROJECT_ID}/${_BASE_BUILDER}'],
+      },
+      {
+        'name': 'gcr.io/cloud-builders/docker',
+        'id': 'build-galaxy',
+        'waitFor': ['push-base'],
+        'args':
+          [
+            'buildx',
+            'build',
+            '--build-arg',
+            'BASE_IMAGE=gcr.io/${_PROJECT_ID}/${_BASE_BUILDER}',
+            '-t',
+            'gcr.io/${_PROJECT_ID}/${_SERVICE_GALAXY}',
+            '-f',
+            './packages/galaxy/Dockerfile',
+            '.',
+          ],
+      },
+      {
+        'name': 'gcr.io/cloud-builders/docker',
+        'id': 'push-galaxy',
+        'waitFor': ['build-galaxy'],
+        'args': ['push', 'gcr.io/${_PROJECT_ID}/${_SERVICE_GALAXY}'],
+      },
+      {
+        'name': 'gcr.io/google.com/cloudsdktool/cloud-sdk',
+        'id': 'deploy-galaxy',
+        'entrypoint': 'gcloud',
+        'waitFor': ['push-galaxy'],
+        'args':
+          [
+            'run',
+            'deploy',
+            '$_SERVICE_GALAXY',
+            '--image=gcr.io/${_PROJECT_ID}/${_SERVICE_GALAXY}',
+            '--region=$_REGION',
+            '--platform=managed',
+            '--allow-unauthenticated',
+            '--execution-environment=gen2',
+            '--cpu=$_CPU',
+            '--memory=$_MEMORY',
+            '--service-account=$_SERVICE_ACCOUNT',
+          ],
+      },
+    ],
+  'options':
+    { 'machineType': 'E2_STANDARD_2', 'logging': 'CLOUD_LOGGING_ONLY' },
+}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -65,5 +65,5 @@
       },
     ],
   'options':
-    { 'machineType': 'E2_STANDARD_2', 'logging': 'CLOUD_LOGGING_ONLY' },
+    { 'machineType': 'E2_STANDARD_8', 'logging': 'CLOUD_LOGGING_ONLY' },
 }

--- a/packages/galaxy/Dockerfile
+++ b/packages/galaxy/Dockerfile
@@ -1,0 +1,24 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS builder
+WORKDIR /app
+
+# Build the package with the BUILD_PLAYGROUND flag set
+RUN pnpm --filter @scalar-examples/galaxy build
+
+FROM node:20-bullseye-slim AS runner
+COPY --from=builder /usr/bin/dumb-init /usr/bin/dumb-init
+
+ENV NODE_ENV=production
+
+# Use default non-root user from the node image
+USER node
+WORKDIR /app
+RUN chown node:node /app
+
+# Copy root node modules and any utilized packages
+COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/integrations/hono /app/integrations/hono
+COPY --from=builder /app/packages /app/packages
+WORKDIR /app/packages/galaxy
+
+CMD ["dumb-init", "node", "playground/dist/index.js"]

--- a/tooling/base-docker-builder/.dockerignore
+++ b/tooling/base-docker-builder/.dockerignore
@@ -1,0 +1,52 @@
+.env
+**/.env
+**/coverage/**
+coverage
+
+.env.staging
+.env.production
+.sh
+
+# Exclude nested dockerfile to prevent cache break issues
+**/Dockerfile
+
+# compiled output
+dist
+tmp
+/out-tsc
+**/dist/**
+
+# dependencies
+node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+db.sqlite
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:20-slim AS base
+
+# process init system and install necessary certificates
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init git ca-certificates && update-ca-certificates
+
+# Set Node.js memory limit to 8GB
+ENV NODE_OPTIONS="--max-old-space-size=8192"
+
+RUN npm install pnpm@10.5.2 --global
+RUN pnpm config set store-dir ~/.pnpm-store
+
+WORKDIR /app
+
+# Copy and build all packages to share across example builds
+COPY pnpm-lock.yaml .
+COPY pnpm-workspace.yaml .
+COPY package.json .
+COPY tsconfig.json .
+COPY tsconfig.node.json .
+COPY tsconfig.strict.json .
+COPY turbo.json .
+COPY packages ./packages
+COPY integrations ./integrations
+RUN pnpm install
+RUN pnpm turbo \
+  run build \
+  --filter='./packages/*' \
+  --filter='./integrations/*' \
+  # … don’t build too many in parallel, we don’t want to hit a memory limit.
+  --concurrency=2


### PR DESCRIPTION
**Problem**

We previously got rid of cloud build steps for the mock server, but it's really not an ideal flow for galaxy since we want it to be as up-to-date as possible. 

**Solution**

Adds the cloud build config only for the mock server, and I'll setup everything else on GCP for this 👍 

Fixes #5691

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
