### PR TITLE
chore(use-codemirror): remove unused packages

### DIFF
--- a/.changeset/smooth-turtles-type.md
+++ b/.changeset/smooth-turtles-type.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-codemirror': patch
+---
+
+chore: remove unused dependencies

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -67,11 +67,9 @@
     "@codemirror/view": "^6.35.3",
     "@lezer/common": "^1.2.3",
     "@lezer/highlight": "^1.2.1",
-    "@lezer/lr": "^1.4.2",
     "@replit/codemirror-css-color-picker": "^6.3.0",
     "@scalar/components": "workspace:*",
     "codemirror": "^6.0.0",
-    "style-mod": "^4.1.2",
     "vue": "catalog:*"
   },
   "devDependencies": {

--- a/packages/use-codemirror/src/themes/createCodeMirrorTheme.ts
+++ b/packages/use-codemirror/src/themes/createCodeMirrorTheme.ts
@@ -8,7 +8,10 @@
 import { HighlightStyle, type TagStyle, syntaxHighlighting } from '@codemirror/language'
 import type { Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import type { StyleSpec } from 'style-mod'
+
+type StyleSpec = {
+  [propOrSelector: string]: string | number | StyleSpec | null
+}
 
 export type CreateThemeOptions = {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2254,9 +2254,6 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.1
         version: 1.2.1
-      '@lezer/lr':
-        specifier: ^1.4.2
-        version: 1.4.2
       '@replit/codemirror-css-color-picker':
         specifier: ^6.3.0
         version: 6.3.0(@codemirror/language@6.10.7)(@codemirror/state@6.5.0)(@codemirror/view@6.35.3)
@@ -2266,9 +2263,6 @@ importers:
       codemirror:
         specifier: ^6.0.0
         version: 6.0.1(@lezer/common@1.2.3)
-      style-mod:
-        specifier: ^4.1.2
-        version: 4.1.2
       vue:
         specifier: catalog:*
         version: 3.5.12(typescript@5.6.2)


### PR DESCRIPTION
**Problem**

I saw there is an unused dependency in @scalar/use-codemirror and a dependency that we just use for a super small type.

**Solution**

I removed them. :)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
