### PR TITLE
docs: file not found

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -65,7 +65,7 @@
             },
             {
               "name": "HTML/CDN",
-              "path": "documentation/integrations/html.md",
+              "path": "documentation/integrations/html-js.md",
               "type": "page"
             },
             {


### PR DESCRIPTION
Looks like this file was renamed (by me).

Before: The preview didn’t work.
After: It works!!

`npx @scalar/cli project preview scalar.config.json`