### PR TITLE
fix(api-reference): schema references name in property heading

### DIFF
--- a/.changeset/yellow-games-own.md
+++ b/.changeset/yellow-games-own.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: displays schema references name in property heading

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -236,7 +236,7 @@ describe('SchemaPropertyHeading', () => {
       },
     })
     const detailsElement = wrapper.find('.property-heading')
-    expect(detailsElement.text()).toContain('object BarModel')
+    expect(detailsElement.text()).toContain('BarModel')
     expect(detailsElement.text()).not.toContain('[]')
   })
 
@@ -264,5 +264,34 @@ describe('SchemaPropertyHeading', () => {
     const detailsElement = wrapper.find('.property-heading')
     expect(detailsElement.text()).toContain('string')
     expect(detailsElement.text()).not.toContain('[]')
+  })
+
+  it('displays model name for schema references a component schema', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            pages: { type: 'integer' },
+          },
+        },
+        schemas: {
+          Planet: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              pages: { type: 'integer' },
+            },
+          },
+        },
+      },
+      slots: {
+        name: 'Planet',
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('Planet')
+    expect(detailsElement.text()).not.toContain('object')
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -82,9 +82,21 @@ const getModelNameFromSchema = (schema: OpenAPI.Document): string | null => {
   }
 
   if (schemas && typeof schemas === 'object') {
+    // Handle direct schema match
     for (const [schemaName, schemaValue] of Object.entries(schemas)) {
       if (stringify(schemaValue) === stringify(schema)) {
         return schemaName
+      }
+    }
+
+    // Handle case where schema is a reference to a component schema
+    if (schema.type === 'object' && schema.properties) {
+      for (const [schemaName, schemaValue] of Object.entries(schemas)) {
+        if (
+          stringify(schemaValue.properties) === stringify(schema.properties)
+        ) {
+          return schemaName
+        }
       }
     }
   }
@@ -152,7 +164,7 @@ const modelName = computed(() => {
   // Handle direct object references
   const objectModelName = getModelNameFromSchema(value)
   if (objectModelName) {
-    return formatTypeWithModel(value.type, objectModelName)
+    return objectModelName
   }
 
   return null


### PR DESCRIPTION
**Problem**

currently schema references name does not get displayed in the property heading.

**Solution**

this pr update schema property heading component logic and fixes #5552.

| before | after |
| -------|------|
| <img width="575" alt="image" src="https://github.com/user-attachments/assets/a84c170c-89c3-438a-a39a-0b201a8f8cf6" /> | <img width="575" alt="image" src="https://github.com/user-attachments/assets/53830348-6f57-453b-975a-9f3497c91da5" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
