### PR TITLE
chore: update cloudbuild machine type

### DIFF
--- a/cloudbuild.json
+++ b/cloudbuild.json
@@ -65,5 +65,5 @@
       }
     ],
   "options":
-    { "machineType": "E2_STANDARD_8", "logging": "CLOUD_LOGGING_ONLY" }
+    { "machineType": "E2_HIGHCPU_8", "logging": "CLOUD_LOGGING_ONLY" }
 }


### PR DESCRIPTION
**Problem**

Cloudbuild doesn't support std 8gb, just bumping it

**Solution**

Bump machine type

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
