### PR TITLE
fix(oas-utils): do not add content-type for multipart requests

### DIFF
--- a/.changeset/angry-icons-applaud.md
+++ b/.changeset/angry-icons-applaud.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+fix(oas-utils): do not add content-type for multipart requests

--- a/packages/api-client/src/views/Components/CodeSnippet/helpers/convert-to-har-request.ts
+++ b/packages/api-client/src/views/Components/CodeSnippet/helpers/convert-to-har-request.ts
@@ -71,7 +71,7 @@ export const convertToHarRequest = ({
   // Handle request body if present
   if (body) {
     try {
-      const contentType = headers.find((h) => h.key.toLowerCase() === 'content-type')?.value || 'application/json'
+      const contentType = headers.find((h) => h.key.toLowerCase() === 'content-type')?.value
 
       // For form-data, convert to object while handling File objects
       if (body.activeBody === 'formData' && body.formData) {
@@ -100,19 +100,19 @@ export const convertToHarRequest = ({
         // Handle urlencoded form data
         if (body.formData?.encoding === 'urlencoded') {
           harRequest.postData = {
-            mimeType: contentType,
+            mimeType: contentType || 'application/x-www-form-urlencoded',
             params,
           }
         } else {
           harRequest.postData = {
-            mimeType: contentType,
+            mimeType: contentType || 'multipart/form-data',
             params,
           }
         }
       } else if (body.activeBody === 'raw' && body.raw) {
         // For other content types (JSON, plain text, url-encoded)
         harRequest.postData = {
-          mimeType: contentType,
+          mimeType: contentType || 'application/json',
           text: body.raw?.value ?? '',
         }
       }

--- a/packages/oas-utils/src/entities/spec/request-example.test.ts
+++ b/packages/oas-utils/src/entities/spec/request-example.test.ts
@@ -601,10 +601,7 @@ describe('createExampleFromRequest', () => {
         },
       },
       parameters: {
-        headers: [
-          { key: 'Accept', value: '*/*', enabled: true },
-          { key: 'Content-Type', value: 'multipart/form-data', enabled: true },
-        ],
+        headers: [{ key: 'Accept', value: '*/*', enabled: true }],
         path: [],
         query: [],
         cookies: [],

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -502,8 +502,8 @@ export function createExampleFromRequest(request: Request, name: string, server?
       }
     }
 
-    // Add the content-type header if it doesn't exist
-    if (requestBody?.mimeType && !contentTypeHeader) {
+    // Add the content-type header if it doesn't exist and if it's not multipart request
+    if (requestBody?.mimeType && !contentTypeHeader && !requestBody.mimeType.startsWith('multipart/')) {
       parameters.headers.push({
         key: 'Content-Type',
         value: requestBody.mimeType,


### PR DESCRIPTION
**Problem**

Currently, when building code examples for multipart requests, `Content-Type: multipart/form-data` header is added to the request. It is wrong behavior, because the correct header should contain **required** parameter `boundary` as per https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1. Often this value is desired by the HTTP client libraries because boundary should not be contained inside any of the parts.

I found out that if one explicitly passes header without boundary, both Python (requests) and curl do not overwrite the header and thus send malformed requests.

**Solution**

With this PR, header is removed.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] (N/A) I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
