### PR TITLE
fix(api-reference): decreases single property schema level

### DIFF
--- a/.changeset/early-bananas-punch.md
+++ b/.changeset/early-bananas-punch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: decreases level on single property schema

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -378,7 +378,6 @@ button.schema-card-title:hover {
 
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   border-radius: var(--scalar-radius-lg);
-  overflow: hidden;
   width: fit-content;
 }
 .schema-properties-name {

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -307,7 +307,7 @@ watch(
             <SchemaProperty
               :compact="compact"
               :hideHeading="hideHeading"
-              :level="level + 1"
+              :level="level"
               :name="(resolvedSchema as OpenAPIV3_1.SchemaObject).name"
               :schemas="schemas"
               :value="


### PR DESCRIPTION
**Problem**

recent updates increased single property level but now hides first level object content in compact elements.

**Solution**

this pr removes the added level incrementation:

| before | after |
| -------|------|
| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/563bfc94-087f-4ff4-b4a8-238514e7d533" /> | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/911a0a6e-78d2-4017-8f20-c5d2a3e449b7" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
