### PR TITLE
chore: add python integration to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ And there’s an ever-growing list of plugins and integrations:
 - [Scalar for Laravel](https://github.com/scalar/laravel)
 - [Ts.ED](https://tsed.dev/tutorials/scalar.html)
 - [Vue.js](packages/api-reference/README.md)
+- [Python](https://github.com/iagobalmeida/scalar_doc)
 
 ### Built-in Support
 


### PR DESCRIPTION
**Problem**

Currently, there is no integration with python (only FastAPI).

**Solution**

I've created a open source lib that abstracts the Scalar HTML usage via OO Python that is able to generate custom styled Scalar Docs also trhough CLI (making it usefull for CI/CD also).

The lib also allows the user to configure the generation of the static HTML file with `.toml` settings or via `poetry.tool` settings.

**Checklist**

I’ve gone through the following:

- [X] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [X] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
