### PR TITLE
fix(api-reference): reference header index

### DIFF
--- a/.changeset/twenty-planets-complain.md
+++ b/.changeset/twenty-planets-complain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: increases z index for references header

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -440,7 +440,7 @@ const themeStyleTag = computed(
   grid-area: header;
   position: sticky;
   top: var(--scalar-custom-header-height, 0px);
-  z-index: 10;
+  z-index: 1000;
 
   height: var(--scalar-header-height, 0px);
 }


### PR DESCRIPTION
**Problem**

currently in reference header presence, on scroll the sidebar is going above.

**Solution**

this pr increases reference header z index to stay on top.

| before | after |
| -------|------|
| <img width="329" alt="image" src="https://github.com/user-attachments/assets/62542090-3602-47ab-aba9-170220bd0c8d" /> | <img width="329" alt="image" src="https://github.com/user-attachments/assets/bf725a22-47ed-446f-a57f-d2456ee4471e" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
