### PR TITLE
fix(api-reference): add tailwind plugin to standalone vite config

### DIFF
--- a/.changeset/cool-ants-thank.md
+++ b/.changeset/cool-ants-thank.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): add tailwind plugin to standalone vite config

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -7,6 +7,7 @@ import { defineConfig } from 'vitest/config'
 
 import licenseBannerTemplate from './license-banner-template.txt'
 import { name, version } from './package.json'
+import tailwindcss from '@tailwindcss/vite'
 
 function replaceVariables(template: string, variables: Record<string, string>) {
   return Object.entries(variables).reduce((content, [key, value]) => {
@@ -28,6 +29,7 @@ export default defineConfig({
   },
   plugins: [
     vue(),
+    tailwindcss(),
     cssInjectedByJsPlugin(),
     webpackStats(),
     banner({


### PR DESCRIPTION
🤦‍♀️ 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
