### PR TITLE
fix(api-reference): search button style

### DIFF
--- a/.changeset/brown-buttons-itch.md
+++ b/.changeset/brown-buttons-itch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates search button style

--- a/packages/api-reference/src/features/Search/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/SearchButton.vue
@@ -106,11 +106,11 @@ function handleClick() {
   );
   color: var(--scalar-sidebar-color-2, var(--scalar-color-2));
   border-radius: var(--scalar-radius);
-  border-width: var(--scalar-border-width);
-  border-color: var(
-    --scalar-sidebar-search-border-color,
-    var(--scalar-border-color)
-  );
+  box-shadow: inset 0 0 0 0.5px
+    var(
+      --scalar-sidebar-search-border-color,
+      var(--scalar-sidebar-border-color, var(--scalar-border-color))
+    );
   /* prettier-ignore */
   cursor: pointer;
   appearance: none;


### PR DESCRIPTION
**Solution**

this pr updates the search button style to match with guide search button usage by using box shadow vs border.

| before | after |
| -------|------|
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/f3a70d89-adb8-44a7-8622-efe73c75dbe7" /> | <img width="280" alt="image" src="https://github.com/user-attachments/assets/6c0c1d8e-ec67-49f4-aa63-32db58be3f3a" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
