### PR TITLE
fix(build-tooling): exclude test files from esbuild entry points

### DIFF
--- a/.changeset/calm-pens-sneeze.md
+++ b/.changeset/calm-pens-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+fix: exclude test files from esbuild entry points

--- a/packages/build-tooling/src/esbuild/build.ts
+++ b/packages/build-tooling/src/esbuild/build.ts
@@ -5,9 +5,13 @@ import chokidar from 'chokidar'
 import path from 'node:path'
 import as from 'ansis'
 import { runCommand } from './helpers'
+import { glob } from 'glob'
 
 function makeEntryPoints(allowJs?: boolean) {
-  const entryPoints = ['src/**/*.ts']
+  const entryPoints = glob.sync(['src/**/*.ts'], {
+    ignore: ['**/*.@(test|spec).@(ts|js)'],
+  })
+
   if (allowJs) {
     entryPoints.push('src/**/*.js')
   }

--- a/packages/build-tooling/src/esbuild/build.ts
+++ b/packages/build-tooling/src/esbuild/build.ts
@@ -8,14 +8,17 @@ import { runCommand } from './helpers'
 import { glob } from 'glob'
 
 function makeEntryPoints(allowJs?: boolean) {
-  const entryPoints = glob.sync(['src/**/*.ts'], {
-    ignore: ['**/*.@(test|spec).@(ts|js)'],
-  })
+  const entryPoints = ['src/**/*.ts']
 
   if (allowJs) {
     entryPoints.push('src/**/*.js')
   }
-  return entryPoints
+
+  const entryPointsWithoutTests = glob.sync(entryPoints, {
+    ignore: ['**/*.@(test|spec).@(ts|js)'],
+  })
+
+  return entryPointsWithoutTests
 }
 
 function nodeBuildOptions(


### PR DESCRIPTION
This PR updates the `entryPoints` configuration for the `esbuild` build process to ensure that test and spec files (`.test.ts`, `.spec.ts`, `.test.js`, `.spec.js`) are excluded from the final bundle.