### PR TITLE
feat(Scalar.AspNetCore): add support for code samples

### DIFF
--- a/.changeset/cold-camels-smell.md
+++ b/.changeset/cold-camels-smell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feat(Scalar.AspNetCore): add support for code samples

--- a/integrations/aspnetcore/src/Scalar.AspNetCore.Microsoft/Extension/OpenApiOptionsExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore.Microsoft/Extension/OpenApiOptionsExtensions.cs
@@ -13,9 +13,10 @@ public static class OpenApiOptionsExtensions
     /// <param name="options"><see cref="OpenApiOptions" />.</param>
     public static OpenApiOptions AddScalarTransformers(this OpenApiOptions options)
     {
-        options.AddOperationTransformer<StabilityOpenApiOperationTransformer>();
-        options.AddOperationTransformer<ExcludeFromApiReferenceOpenApiOperationTransformer>();
         options.AddDocumentTransformer<ExcludeFromApiReferenceOpenApiDocumentTransformer>();
+        options.AddOperationTransformer<ExcludeFromApiReferenceOpenApiOperationTransformer>();
+        options.AddOperationTransformer<StabilityOpenApiOperationTransformer>();
+        options.AddOperationTransformer<CodeSampleOpenApiOperationTransformer>();
 
         return options;
     }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore.Microsoft/Transformers/CodeSampleOpenApiOperationTransformer.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore.Microsoft/Transformers/CodeSampleOpenApiOperationTransformer.cs
@@ -9,30 +9,38 @@ internal sealed class CodeSampleOpenApiOperationTransformer : IOpenApiOperationT
 {
     public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
     {
-        // We use LastOrDefault because this allows a specific endpoint to override the attribute
-        var codeSampleAttribute = context.Description.ActionDescriptor.EndpointMetadata.OfType<CodeSampleAttribute>().LastOrDefault();
+        var codeSampleAttributes = context.Description.ActionDescriptor.EndpointMetadata.OfType<CodeSampleAttribute>().ToArray();
 
-        if (codeSampleAttribute is null) return Task.CompletedTask;
+        if (codeSampleAttributes.Length == 0)
+        {
+            return Task.CompletedTask;
+        }
 
         operation.Extensions ??= new Dictionary<string, IOpenApiExtension>();
-
-        var sample = new OpenApiObject
+        var samples = new OpenApiArray();
+        foreach (var codeSampleAttribute in codeSampleAttributes)
         {
-            ["source"] = new OpenApiString(codeSampleAttribute.Sample)
-        };
+            var sample = new OpenApiObject
+            {
+                ["source"] = new OpenApiString(codeSampleAttribute.Sample)
+            };
 
-        if (codeSampleAttribute.Language.HasValue)
-        {
-            sample["lang"] = new OpenApiString(codeSampleAttribute.Language.Value.ToStringFast(true));
+            if (codeSampleAttribute.Language.HasValue)
+            {
+                sample["lang"] = new OpenApiString(codeSampleAttribute.Language.Value.ToStringFast(true));
+            }
+
+            if (codeSampleAttribute.Label is not null)
+            {
+                sample["label"] = new OpenApiString(codeSampleAttribute.Label);
+            }
+
+            samples.Add(sample);
         }
 
-        if (codeSampleAttribute.Label is not null)
-        {
-            sample["label"] = new OpenApiString(codeSampleAttribute.Label);
-        }
+        operation.Extensions.TryAdd(CodeSamples, samples);
 
-        OpenApiArray samples = [sample];
-        operation.Extensions.Add(CodeSamples, samples);
+
         return Task.CompletedTask;
     }
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore.Microsoft/Transformers/CodeSampleOpenApiOperationTransformer.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore.Microsoft/Transformers/CodeSampleOpenApiOperationTransformer.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+
+namespace Scalar.AspNetCore;
+
+internal sealed class CodeSampleOpenApiOperationTransformer : IOpenApiOperationTransformer
+{
+    public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
+    {
+        // We use LastOrDefault because this allows a specific endpoint to override the attribute
+        var codeSampleAttribute = context.Description.ActionDescriptor.EndpointMetadata.OfType<CodeSampleAttribute>().LastOrDefault();
+
+        if (codeSampleAttribute is null) return Task.CompletedTask;
+
+        operation.Extensions ??= new Dictionary<string, IOpenApiExtension>();
+
+        var sample = new OpenApiObject
+        {
+            ["source"] = new OpenApiString(codeSampleAttribute.Sample)
+        };
+
+        if (codeSampleAttribute.Language.HasValue)
+        {
+            sample["lang"] = new OpenApiString(codeSampleAttribute.Language.Value.ToStringFast(true));
+        }
+
+        if (codeSampleAttribute.Label is not null)
+        {
+            sample["label"] = new OpenApiString(codeSampleAttribute.Label);
+        }
+
+        OpenApiArray samples = [sample];
+        operation.Extensions.Add(CodeSamples, samples);
+        return Task.CompletedTask;
+    }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Extensions/SwaggerGenOptionsExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Extensions/SwaggerGenOptionsExtensions.cs
@@ -18,6 +18,7 @@ public static class SwaggerGenOptionsExtensions
         options.DocumentFilter<ExcludeFromApiReferenceDocumentFilter>();
         options.OperationFilter<ExcludeFromApiReferenceOperationFilter>();
         options.OperationFilter<StabilityOpenApiOperationFilter>();
+        options.OperationFilter<CodeSampleDocumentFilter>();
         return options;
     }
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Filters/CodeSampleDocumentFilter.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Filters/CodeSampleDocumentFilter.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Scalar.AspNetCore.Swashbuckle.Filters;
+
+internal sealed class CodeSampleDocumentFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        // We use LastOrDefault because this allows a specific endpoint to override the attribute
+        var codeSampleAttribute = context.ApiDescription.ActionDescriptor.EndpointMetadata.OfType<CodeSampleAttribute>().LastOrDefault();
+
+        if (codeSampleAttribute is null) return;
+
+        operation.Extensions ??= new Dictionary<string, IOpenApiExtension>();
+
+        var sample = new OpenApiObject
+        {
+            ["source"] = new OpenApiString(codeSampleAttribute.Sample)
+        };
+
+        if (codeSampleAttribute.Language.HasValue)
+        {
+            sample["lang"] = new OpenApiString(codeSampleAttribute.Language.Value.ToStringFast(true));
+        }
+
+        if (codeSampleAttribute.Label is not null)
+        {
+            sample["label"] = new OpenApiString(codeSampleAttribute.Label);
+        }
+
+        OpenApiArray samples = [sample];
+        operation.Extensions.Add(CodeSamples, samples);
+    }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Filters/CodeSampleDocumentFilter.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Filters/CodeSampleDocumentFilter.cs
@@ -9,29 +9,35 @@ internal sealed class CodeSampleDocumentFilter : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
-        // We use LastOrDefault because this allows a specific endpoint to override the attribute
-        var codeSampleAttribute = context.ApiDescription.ActionDescriptor.EndpointMetadata.OfType<CodeSampleAttribute>().LastOrDefault();
+        var codeSampleAttributes = context.ApiDescription.ActionDescriptor.EndpointMetadata.OfType<CodeSampleAttribute>().ToArray();
 
-        if (codeSampleAttribute is null) return;
+        if (codeSampleAttributes.Length == 0)
+        {
+            return;
+        }
 
         operation.Extensions ??= new Dictionary<string, IOpenApiExtension>();
-
-        var sample = new OpenApiObject
+        var samples = new OpenApiArray();
+        foreach (var codeSampleAttribute in codeSampleAttributes)
         {
-            ["source"] = new OpenApiString(codeSampleAttribute.Sample)
-        };
+            var sample = new OpenApiObject
+            {
+                ["source"] = new OpenApiString(codeSampleAttribute.Sample)
+            };
 
-        if (codeSampleAttribute.Language.HasValue)
-        {
-            sample["lang"] = new OpenApiString(codeSampleAttribute.Language.Value.ToStringFast(true));
+            if (codeSampleAttribute.Language.HasValue)
+            {
+                sample["lang"] = new OpenApiString(codeSampleAttribute.Language.Value.ToStringFast(true));
+            }
+
+            if (codeSampleAttribute.Label is not null)
+            {
+                sample["label"] = new OpenApiString(codeSampleAttribute.Label);
+            }
+
+            samples.Add(sample);
         }
 
-        if (codeSampleAttribute.Label is not null)
-        {
-            sample["label"] = new OpenApiString(codeSampleAttribute.Label);
-        }
-
-        OpenApiArray samples = [sample];
-        operation.Extensions.Add(CodeSamples, samples);
+        operation.Extensions.TryAdd(CodeSamples, samples);
     }
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Attributes/CodeSampleAttribute.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Attributes/CodeSampleAttribute.cs
@@ -1,0 +1,46 @@
+﻿namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Attribute used to attach code samples to API endpoints for documentation purposes.
+/// Can be applied to classes, methods, or delegates to provide example code.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Delegate)]
+public sealed class CodeSampleAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodeSampleAttribute"/> class.
+    /// </summary>
+    /// <param name="sample">The code sample content.</param>
+    /// <param name="label">An optional label for the code sample.</param>
+    public CodeSampleAttribute(string sample, string? label = null)
+    {
+        Sample = sample;
+        Label = label;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodeSampleAttribute"/> class with a specific language target.
+    /// </summary>
+    /// <param name="sample">The code sample content.</param>
+    /// <param name="language">The language for the code sample.</param>
+    /// <param name="label">An optional label for the code sample.</param>
+    public CodeSampleAttribute(string sample, ScalarTarget language, string? label = null)
+    {
+        Sample = sample;
+        Language = language;
+        Label = label;
+    }
+
+    internal CodeSampleAttribute(string sample, ScalarTarget? language, string? label = null)
+    {
+        Sample = sample;
+        Language = language;
+        Label = label;
+    }
+
+    internal string Sample { get; set; }
+
+    internal ScalarTarget? Language { get; set; }
+
+    internal string? Label { get; set; }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Attributes/CodeSampleAttribute.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Attributes/CodeSampleAttribute.cs
@@ -4,7 +4,7 @@
 /// Attribute used to attach code samples to API endpoints for documentation purposes.
 /// Can be applied to classes, methods, or delegates to provide example code.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Delegate)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Delegate, AllowMultiple = true)]
 public sealed class CodeSampleAttribute : Attribute
 {
     /// <summary>

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/ExtensionKeys.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/ExtensionKeys.cs
@@ -9,4 +9,6 @@ internal static class ExtensionKeys
     internal const string ScalarIgnore = "x-scalar-ignore";
 
     internal const string ScalarStability = "x-scalar-stability";
+
+    internal const string CodeSamples = "x-codeSamples";
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/EndpointConventionBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/EndpointConventionBuilderExtensions.cs
@@ -39,6 +39,20 @@ public static class EndpointConventionBuilderExtensions
     /// <param name="builder">The endpoint convention builder.</param>
     public static TBuilder Deprecated<TBuilder>(this TBuilder builder) where TBuilder : IEndpointConventionBuilder => builder.WithStability(Stability.Deprecated);
 
+    /// <summary>
+    /// Adds a code sample to the API endpoint.
+    /// </summary>
+    /// <typeparam name="TBuilder">The type of <see cref="IEndpointConventionBuilder" />.</typeparam>
+    /// <param name="builder">The endpoint convention builder.</param>
+    /// <param name="codeSample">The code sample to add.</param>
+    /// <param name="language">The language of the code sample.</param>
+    /// <param name="label">A label for the code sample.</param>
+    public static TBuilder CodeSample<TBuilder>(this TBuilder builder, string codeSample, ScalarTarget? language = null, string? label = null) where TBuilder : IEndpointConventionBuilder
+    {
+        builder.WithMetadata(new CodeSampleAttribute(codeSample, language, label));
+        return builder;
+    }
+
     private static TBuilder WithStability<TBuilder>(this TBuilder builder, Stability stability) where TBuilder : IEndpointConventionBuilder
     {
         builder.WithMetadata(new StabilityAttribute(stability));

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Microsoft.Tests/CodeSampleTransformerTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Microsoft.Tests/CodeSampleTransformerTests.cs
@@ -72,6 +72,9 @@ public class CodeSampleTransformerTests(WebApplicationFactory<Program> factory) 
                                         },
                                         "x-codeSamples": [
                                           {
+                                            "source": "const foo = 0"
+                                          },
+                                          {
                                             "source": "const foo = 0",
                                             "lang": "csharp",
                                             "label": "my-code"

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Microsoft.Tests/CodeSampleTransformerTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Microsoft.Tests/CodeSampleTransformerTests.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Scalar.AspNetCore.Microsoft.Tests;
+
+public class CodeSampleTransformerTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
+{
+    [Fact]
+    public async Task CodeSampleTransformer_ShouldAddCodeSamples()
+    {
+        // Arrange
+        var localFactory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services => services.AddOpenApi(options => options.AddScalarTransformers()));
+            builder.Configure(options =>
+            {
+                options.UseRouting();
+                options.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapOpenApi();
+
+                    var group = endpoints.MapGroup("/foo").WithTags("foo").CodeSample("const foo = 0");
+                    group.MapGet("/default", Results.NoContent);
+                    group.MapGet("/custom", Results.NoContent).CodeSample("const foo = 0", ScalarTarget.CSharp, "my-code");
+                });
+            });
+        });
+
+        var client = localFactory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/openapi/v1.json", TestContext.Current.CancellationToken);
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        const string expected = """
+                                {
+                                  "openapi": *,
+                                  "info": {
+                                    "title": "Scalar.AspNetCore.Microsoft.Tests | v1",
+                                    "version": "1.0.0"
+                                  }*
+                                  "paths": {
+                                    "/foo/default": {
+                                      "get": {
+                                        "tags": [
+                                          "foo"
+                                        ],
+                                        "responses": {
+                                          "200": {
+                                            "description": "OK"
+                                          }
+                                        },
+                                        "x-codeSamples": [
+                                          {
+                                            "source": "const foo = 0"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "/foo/custom": {
+                                      "get": {
+                                        "tags": [
+                                          "foo"
+                                        ],
+                                        "responses": {
+                                          "200": {
+                                            "description": "OK"
+                                          }
+                                        },
+                                        "x-codeSamples": [
+                                          {
+                                            "source": "const foo = 0",
+                                            "lang": "csharp",
+                                            "label": "my-code"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },*
+                                  "tags": [
+                                    {
+                                      "name": "foo"
+                                    }
+                                  ]
+                                }
+                                """;
+        content.Should().Match(expected);
+    }
+}

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Swashbuckle.Tests/CodeSampleFilterTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Swashbuckle.Tests/CodeSampleFilterTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
@@ -6,10 +6,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Scalar.AspNetCore.Swashbuckle.Tests;
 
-public class ExcludeFromApiReferenceFilterTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
+public class CodeSampleFilterTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
 {
     [Fact]
-    public async Task ExcludeFromApiReferenceTransformer_ShouldAddIgnoreExtension()
+    public async Task CodeSampleFilter_ShouldAddCodeSamples()
     {
         // Arrange
         var localFactory = factory.WithWebHostBuilder(builder =>
@@ -22,12 +22,9 @@ public class ExcludeFromApiReferenceFilterTests(WebApplicationFactory<Program> f
                 {
                     endpoints.MapSwagger("/openapi/{documentName}.json");
 
-                    var group = endpoints.MapGroup("/foo").WithTags("foo");
-                    group.MapGet("/exclude", Results.NoContent).ExcludeFromApiReference();
-                    group.MapGet("/include", Results.NoContent);
-                    var excludeGroup = endpoints.MapGroup("/full-exclude").WithTags("exclude").ExcludeFromApiReference();
-                    excludeGroup.MapGet("/foo", Results.NoContent);
-                    excludeGroup.MapGet("/bar", Results.NoContent);
+                    var group = endpoints.MapGroup("/foo").WithTags("foo").CodeSample("const foo = 0");
+                    group.MapGet("/default", Results.NoContent);
+                    group.MapGet("/custom", Results.NoContent).CodeSample("const foo = 0", ScalarTarget.CSharp, "my-code");
                 });
             });
         });
@@ -46,33 +43,7 @@ public class ExcludeFromApiReferenceFilterTests(WebApplicationFactory<Program> f
                                     "version": "1.0"
                                   },
                                   "paths": {
-                                    "/full-exclude/foo": {
-                                      "get": {
-                                        "tags": [
-                                          "exclude"
-                                        ],
-                                        "responses": {
-                                          "200": {
-                                            "description": "OK"
-                                          }
-                                        },
-                                        "x-scalar-ignore": true
-                                      }
-                                    },
-                                    "/full-exclude/bar": {
-                                      "get": {
-                                        "tags": [
-                                          "exclude"
-                                        ],
-                                        "responses": {
-                                          "200": {
-                                            "description": "OK"
-                                          }
-                                        },
-                                        "x-scalar-ignore": true
-                                      }
-                                    },
-                                    "/foo/exclude": {
+                                    "/foo/default": {
                                       "get": {
                                         "tags": [
                                           "foo"
@@ -82,10 +53,14 @@ public class ExcludeFromApiReferenceFilterTests(WebApplicationFactory<Program> f
                                             "description": "OK"
                                           }
                                         },
-                                        "x-scalar-ignore": true
+                                        "x-codeSamples": [
+                                          {
+                                            "source": "const foo = 0"
+                                          }
+                                        ]
                                       }
                                     },
-                                    "/foo/include": {
+                                    "/foo/custom": {
                                       "get": {
                                         "tags": [
                                           "foo"
@@ -94,7 +69,14 @@ public class ExcludeFromApiReferenceFilterTests(WebApplicationFactory<Program> f
                                           "200": {
                                             "description": "OK"
                                           }
-                                        }
+                                        },
+                                        "x-codeSamples": [
+                                          {
+                                            "source": "const foo = 0",
+                                            "lang": "csharp",
+                                            "label": "my-code"
+                                          }
+                                        ]
                                       }
                                     }
                                   },

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Swashbuckle.Tests/CodeSampleFilterTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Swashbuckle.Tests/CodeSampleFilterTests.cs
@@ -72,6 +72,9 @@ public class CodeSampleFilterTests(WebApplicationFactory<Program> factory) : ICl
                                         },
                                         "x-codeSamples": [
                                           {
+                                            "source": "const foo = 0"
+                                          },
+                                          {
                                             "source": "const foo = 0",
                                             "lang": "csharp",
                                             "label": "my-code"


### PR DESCRIPTION
This PR adds a new `[CodeSample]` attribute and one extension `CodeSample()` method to the `Scalar.AspNetCore` package to support custom code samples. The OpenAPI generator extensions are also updated to make use of the new attribute and extension method.
I also updated the related documentation to be easier to follow.

Usage:
```csharp
// Extension methods
app.MapPost("/orders", CreateOrder)
    .CodeSample("fetch('/orders', { method: 'POST' })", ScalarTarget.JavaScript, "Create Order")
    .CodeSample("curl -X POST /orders", ScalarTarget.Shell, "Create Order with cURL")

// Attribute
[CodeSample("fetch('/products').then(r => r.json())", ScalarTarget.JavaScript)]
public IActionResult GetProducts() { }
```

What do you think about the name `CodeSample`?


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
