### PR TITLE
Removed app router route group from url

### DIFF
--- a/packages/nextjs-openapi/src/openapi.ts
+++ b/packages/nextjs-openapi/src/openapi.ts
@@ -92,6 +92,7 @@ export const OpenAPI = (config: OpenAPIConfig = {}) => {
       const rawPath = fileName
         .replace(/^(?:src\/)?app|\/route\.ts$/g, '')
         .replace(/\[/g, '{')
+        .replace(/\/\(\w+\)/g, '')
         .replace(/]/g, '}')
       const path = rawPath.startsWith('/') ? rawPath : '/' + rawPath
 


### PR DESCRIPTION
**Problem**

Currently, when cleaning the urls of the api routes, doesn't clean out the nextjs route groups

**Solution**

With this PR, I've added a regex rule that matches and cleans it

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
