### PR TITLE
feat(Scalar.AspNetCore): support AdditionalQueryParameters

### DIFF
--- a/.changeset/poor-trainers-shake.md
+++ b/.changeset/poor-trainers-shake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feat(Scalar.AspNetCore): support AdditionalQueryParameters

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -306,6 +306,25 @@ app.MapScalarApiReference(options => options
 );
 ```
 
+##### Additional Query Parameters
+
+All OAuth2 flows support additional query parameters that can be included in the OAuth request using the `AdditionalQueryParameters` property. This is useful for adding custom parameters required by your OAuth provider, such as `audience`, `resource`, or other provider-specific parameters:
+
+```csharp
+app.MapScalarApiReference(options => options
+    .AddAuthorizationCodeFlow("OAuth2", flow =>
+    {
+        flow.ClientId = "your-client-id";
+        flow.AdditionalQueryParameters = new Dictionary<string, string>
+        {
+            ["audience"] = "https://api.example.com",
+            ["resource"] = "https://graph.microsoft.com",
+            ["custom_param"] = "custom_value"
+        };
+    })
+);
+```
+
 ##### Multiple OAuth2 Flows
 
 You can configure multiple OAuth2 flows for a single security scheme:

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/OAuthFlow.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/Authentication/Flows/OAuthFlow.cs
@@ -27,4 +27,10 @@ public abstract class OAuthFlow
     /// Gets or sets the authentication token.
     /// </summary>
     public string? Token { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional query parameters that should be included in the OAuth request.
+    /// </summary>
+    [JsonPropertyName("x-scalar-security-query")]
+    public IDictionary<string, string>? AdditionalQueryParameters { get; set; } 
 }

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsExtensionsTests.cs
@@ -168,7 +168,11 @@ public class ScalarOptionsExtensionsTests
                 ClientSecret = "clientSecret",
                 RedirectUri = "https://auth.example.com/callback",
                 SelectedScopes = ["foo"],
-                Token = "token"
+                Token = "token",
+                AdditionalQueryParameters = new Dictionary<string, string>
+                {
+                    ["foo"] = "bar"
+                }
             };
         });
 
@@ -187,6 +191,7 @@ public class ScalarOptionsExtensionsTests
         oauth2Scheme.Flows!.AuthorizationCode!.RedirectUri.Should().Be("https://auth.example.com/callback");
         oauth2Scheme.Flows!.AuthorizationCode!.SelectedScopes.Should().Contain("foo");
         oauth2Scheme.Flows!.AuthorizationCode!.Token.Should().Be("token");
+        oauth2Scheme.Flows!.AuthorizationCode!.AdditionalQueryParameters.Should().ContainKey("foo").And.ContainValue("bar");
     }
 
     [Fact]


### PR DESCRIPTION
**Problem**

Currently, it is not possible to use the `x-scalar-security-query` extension in the `Scalar.AspNetCore` integration.

**Solution**

Now it is 😎 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
