### PR TITLE
feat(api-reference): save selected client in local storage

### DIFF
--- a/.changeset/lazy-roses-beg.md
+++ b/.changeset/lazy-roses-beg.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: save selected client on local storage

--- a/.changeset/lazy-roses-beg.md
+++ b/.changeset/lazy-roses-beg.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-chore: save selected client on local storage
+feat: save selected client on local storage

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -2,8 +2,9 @@
 import { TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/vue'
 import { useWorkspace } from '@scalar/api-client/store'
 import { ScalarCodeBlock, ScalarMarkdown } from '@scalar/components'
-import { computed, ref, toRaw, useId, watch } from 'vue'
+import { computed, onMounted, ref, toRaw, useId, watch } from 'vue'
 
+import { REFERENCE_LS_KEYS } from '@/helpers/local-storage'
 import { useHttpClientStore } from '@/stores/useHttpClientStore'
 
 import ClientSelector from './ClientSelector.vue'
@@ -49,6 +50,14 @@ function handleChange(i: number) {
   }
   setHttpClient(tab)
 }
+
+// Restore selected client from localStorage
+onMounted(() => {
+  const storedClient = localStorage.getItem(REFERENCE_LS_KEYS.SELECTED_CLIENT)
+  if (storedClient) {
+    setHttpClient(JSON.parse(storedClient))
+  }
+})
 
 const installationInstructions = computed(() => {
   // Get the current collection from the store

--- a/packages/api-reference/src/helpers/local-storage.ts
+++ b/packages/api-reference/src/helpers/local-storage.ts
@@ -1,0 +1,7 @@
+/**
+ * localStorage keys for all reference resources
+ * to ensure we do not have any conflicts
+ */
+export const REFERENCE_LS_KEYS = {
+  SELECTED_CLIENT: 'scalar-reference-selected-client',
+} as const

--- a/packages/api-reference/src/stores/useHttpClientStore.ts
+++ b/packages/api-reference/src/stores/useHttpClientStore.ts
@@ -1,3 +1,4 @@
+import { REFERENCE_LS_KEYS } from '@/helpers/local-storage'
 import { objectMerge } from '@scalar/oas-utils/helpers'
 import { snippetz } from '@scalar/snippetz'
 import type { HiddenClients } from '@scalar/types/legacy'
@@ -164,6 +165,9 @@ const setHttpClient = (newState: Partial<HttpClientState>) => {
     ...httpClient,
     ...newState,
   })
+
+  // Save to localStorage
+  localStorage.setItem(REFERENCE_LS_KEYS.SELECTED_CLIENT, JSON.stringify(httpClient))
 }
 
 /** Keep track of the available and the selected HTTP client(s) */


### PR DESCRIPTION
**Problem**

Currently, it goes back to curl on every referesh

**Solution**

With this PR it restores the one you had selected

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
