### PR TITLE
feat(themes): use .scalar-app as the base class for all tailwind styles

### DIFF
--- a/.changeset/serious-chairs-sell.md
+++ b/.changeset/serious-chairs-sell.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+feat(themes): use .scalar-app as the base class for all tailwind styles

--- a/packages/api-client/src/style.css
+++ b/packages/api-client/src/style.css
@@ -6,9 +6,7 @@
 @import "@scalar/components/style.css"; /* Component Library Styles */
 @import "@scalar/themes/tailwind.css"; /* Tailwind Theme + Config */
 
-.scalar-client {
-  line-height: 1.5;
-
+.scalar-app {
   @import "tailwindcss/utilities.css";
 }
 

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -101,7 +101,7 @@ const introCardsSlot = computed(() =>
             :class="{ 'introduction-card-row': layout === 'classic' }">
             <div
               v-if="activeCollection?.servers?.length"
-              class="scalar-reference-intro-server scalar-client introduction-card-item text-sm [--scalar-address-bar-height:0px]">
+              class="scalar-reference-intro-server scalar-client introduction-card-item text-sm leading-normal [--scalar-address-bar-height:0px]">
               <BaseUrl
                 :collection="activeCollection"
                 :server="activeServer" />
@@ -112,7 +112,7 @@ const introCardsSlot = computed(() =>
                 activeWorkspace &&
                 Object.keys(securitySchemes ?? {}).length
               "
-              class="scalar-reference-intro-auth scalar-client introduction-card-item">
+              class="scalar-reference-intro-auth scalar-client introduction-card-item leading-normal">
               <RequestAuth
                 :collection="activeCollection"
                 :envVariables="activeEnvVariables"

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -74,7 +74,7 @@ const shouldShowParameter = computed(() => {
         class="parameter-item-trigger flex"
         :class="{ 'parameter-item-trigger-open': open }">
         <ScalarIcon
-          class="parameter-item-icon"
+          class="parameter-item-icon size-4.5"
           :icon="open ? 'ChevronDown' : 'ChevronRight'"
           thickness="1.5" />
         <span class="parameter-item-name">
@@ -227,11 +227,9 @@ const shouldShowParameter = computed(() => {
 }
 .parameter-item-icon {
   color: var(--scalar-color-3);
-  height: 18px;
   left: -19px;
   position: absolute;
   top: 11px;
-  width: 18px;
 }
 .parameter-item-trigger:hover .parameter-item-icon,
 .parameter-item-trigger:focus-visible .parameter-item-icon {

--- a/packages/api-reference/src/style.css
+++ b/packages/api-reference/src/style.css
@@ -5,7 +5,7 @@
 @import "@scalar/themes/style.css"; /* Theme Base Styles and Reset */
 @import "@scalar/themes/tailwind.css"; /* Tailwind Theme + Config */
 
-.scalar-api-reference {
+.scalar-app {
   @import "tailwindcss/utilities.css";
 }
 

--- a/packages/components/src/style.css
+++ b/packages/components/src/style.css
@@ -5,7 +5,7 @@
 @import "@scalar/themes/style.css"; /* Theme Base Styles and Reset */
 @import "@scalar/themes/tailwind.css"; /* Tailwind Theme + Config */
 
-:where(.scalar-app) {
+.scalar-app {
   @import "tailwindcss/utilities.css";
 }
 


### PR DESCRIPTION
Switches the components, references and the client to all use the .scalar-app scoping class so the styles can be deduped.

Unfortunately the deduping only seems to happen in production environments so we still have some duplication when running the dev servers.
 
**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
