### PR TITLE
fix(api-reference): schema composition required property label

### DIFF
--- a/.changeset/curly-brooms-accept.md
+++ b/.changeset/curly-brooms-accept.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: passes required property to nested schema

--- a/.changeset/metal-vans-jump.md
+++ b/.changeset/metal-vans-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: extracts render schema computed function

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
@@ -193,4 +193,39 @@ describe('SchemaComposition', () => {
       expect(panel.text()).toContain('nullable')
     })
   })
+
+  it('passes required array to Schema component for schema composition', () => {
+    const wrapper = mount(SchemaComposition, {
+      props: {
+        composition: 'anyOf',
+        value: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                foo: { const: 'Foo' },
+              },
+              required: ['foo'],
+            },
+            {
+              type: 'object',
+              properties: {
+                bar: { const: 'Bar' },
+              },
+            },
+          ],
+        },
+        level: 0,
+      },
+    })
+
+    const schemaComponent = wrapper.findComponent({ name: 'Schema' })
+    expect(schemaComponent.props('value')).toEqual({
+      type: 'object',
+      properties: {
+        foo: { const: 'Foo' },
+      },
+      required: ['foo'],
+    })
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
@@ -192,6 +192,64 @@ describe('SchemaComposition', () => {
       const panel = wrapper.find('.composition-panel')
       expect(panel.text()).toContain('nullable')
     })
+
+    it('renders const schema in composition panel', async () => {
+      const wrapper = mount(SchemaComposition, {
+        props: {
+          composition: 'anyOf',
+          value: {
+            anyOf: [
+              {
+                type: 'object',
+                properties: { foo: { const: 'Foo' } },
+                required: ['foo'],
+              },
+              {
+                type: 'object',
+                properties: { bar: { const: 'Bar' } },
+              },
+              { const: 'Baz' },
+            ],
+          },
+          level: 0,
+        },
+      })
+
+      const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+      await listbox.vm.$emit('update:modelValue', { id: '2', label: 'Schema' })
+      await wrapper.vm.$nextTick()
+
+      const schemaComponent = wrapper.findComponent({ name: 'Schema' })
+      expect(schemaComponent.exists()).toBe(true)
+      expect(schemaComponent.props('value')).toEqual({ const: 'Baz' })
+    })
+
+    it('renders enum schema in composition panel', async () => {
+      const wrapper = mount(SchemaComposition, {
+        props: {
+          composition: 'oneOf',
+          value: {
+            oneOf: [
+              {
+                type: 'string',
+                enum: ['option1', 'option2', 'option3'],
+              },
+              {
+                type: 'number',
+              },
+            ],
+          },
+          level: 0,
+        },
+      })
+
+      const schemaComponent = wrapper.findComponent({ name: 'Schema' })
+      expect(schemaComponent.exists()).toBe(true)
+      expect(schemaComponent.props('value')).toEqual({
+        type: 'string',
+        enum: ['option1', 'option2', 'option3'],
+      })
+    })
   })
 
   it('passes required array to Schema component for schema composition', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -175,6 +175,26 @@ const compositionValue = computed(() => {
   const type = compositionType.value
   return compositionSchema.value?.[type]
 })
+
+/** Check if the composition schema should be rendered */
+const shouldRenderSchema = computed(() => {
+  const schema = compositionSchema.value
+  if (!schema) {
+    return false
+  }
+
+  return !!(
+    schema.properties ||
+    schema.type ||
+    schema.nullable ||
+    schema.const !== undefined ||
+    schema.enum ||
+    schema.allOf ||
+    schema.oneOf ||
+    schema.anyOf ||
+    schema.items
+  )
+})
 </script>
 
 <template>
@@ -220,11 +240,7 @@ const compositionValue = computed(() => {
           <ScalarMarkdown :value="compositionSchema.description" />
         </div>
         <Schema
-          v-if="
-            compositionSchema?.properties ||
-            compositionSchema?.type ||
-            compositionSchema?.nullable
-          "
+          v-if="shouldRenderSchema"
           :compact="compact"
           :level="level + 1"
           :hideHeading="hideHeading"

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -236,6 +236,7 @@ const compositionValue = computed(() => {
               ? {
                   type: 'object',
                   properties: compositionSchema.properties,
+                  required: compositionSchema.required,
                 }
               : compositionSchema
           " />


### PR DESCRIPTION
**Problem**

currently required property are not highlighted when in nested schema composition. 

**Solution**

this pr passes the missing required information to get the label to show up in property. fixes #5772 

`required label`
| before | after |
| -------|------|
| <img width="1116" alt="image" src="https://github.com/user-attachments/assets/ecf20146-423c-4181-a09e-92a3648305c1" /> | <img width="1116" alt="image" src="https://github.com/user-attachments/assets/e287525f-943e-4d9c-ad9d-7c34c0ef5932" /> |

`const enum`
| before | after |
| -------|------|
| <img width="1116" alt="image" src="https://github.com/user-attachments/assets/3d82b4a6-0fa3-4ee1-8149-e09f340ff255" /> | <img width="1116" alt="image" src="https://github.com/user-attachments/assets/8e3b9496-da64-414a-b9ac-c39a39960b6a" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
