### PR TITLE
fix(api-reference): description on properties

### DIFF
--- a/.changeset/light-spoons-warn.md
+++ b/.changeset/light-spoons-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates schema description handling


### PR DESCRIPTION
**Problem**

up to today description is not displayed in compact (within tag) schema in order to prevent duplication in allof usage. this however is not the most optimal approach as it prevents any description from being displayed.

**Solution**

this pr extracts the schema description display handling and update the logic in order to only hide level 0 description as it corresponds to allof schema merging. fixes #5739 #5768 #5495 #5338

| before | after |
| -------|------|
| <img width="1116" alt="image" src="https://github.com/user-attachments/assets/e38ad3af-141e-4d42-9ce5-520d62121aa6" /> | <img width="1116" alt="image" src="https://github.com/user-attachments/assets/2730e1c2-613c-494e-8b39-65696cc73acd" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
