### PR TITLE
fix(api-reference): schema property name mismatch

### DIFF
--- a/.changeset/bright-rocks-melt.md
+++ b/.changeset/bright-rocks-melt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates schema property heading logic

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -82,6 +82,7 @@ const models = computed(() => {
             <ScalarErrorBoundary>
               <Schema
                 :hideHeading="true"
+                :hideModelNames="true"
                 noncollapsible
                 :schemas="schemas"
                 :value="(schemas as any)[name]" />

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -32,9 +32,11 @@ const props = withDefaults(
     hideHeading?: boolean
     /** Show a special one way toggle for additional properties, also has a top border when open */
     additionalProperties?: boolean
+    /** Hide model names in type display */
+    hideModelNames?: boolean
     schemas?: Record<string, OpenAPIV3_1.SchemaObject> | unknown
   }>(),
-  { level: 0, noncollapsible: false },
+  { level: 0, noncollapsible: false, hideModelNames: false },
 )
 
 const selectedDiscriminatorType = ref<string>('')
@@ -230,7 +232,8 @@ watch(
                   ...resolvedSchema.properties[property],
                   parent: resolvedSchema,
                   isDiscriminator: property === discriminatorPropertyName,
-                }" />
+                }"
+                :hideModelNames="hideModelNames" />
             </template>
 
             <!-- Pattern properties -->
@@ -250,7 +253,8 @@ watch(
                   value.discriminator?.propertyName === property
                     ? value
                     : resolvedSchema.patternProperties[property]
-                " />
+                "
+                :hideModelNames="hideModelNames" />
             </template>
 
             <!-- Additional properties -->
@@ -277,7 +281,8 @@ watch(
                   ...(typeof resolvedSchema.additionalProperties === 'object'
                     ? resolvedSchema.additionalProperties
                     : {}),
-                }" />
+                }"
+                :hideModelNames="hideModelNames" />
               <SchemaProperty
                 v-else
                 additional
@@ -290,7 +295,8 @@ watch(
                   value.discriminator?.propertyName === name
                     ? value
                     : resolvedSchema.additionalProperties
-                " />
+                "
+                :hideModelNames="hideModelNames" />
             </template>
           </template>
 
@@ -306,7 +312,8 @@ watch(
                 value.discriminator?.propertyName === name
                   ? value
                   : resolvedSchema
-              " />
+              "
+              :hideModelNames="hideModelNames" />
           </template>
         </DisclosurePanel>
       </div>

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -34,6 +34,7 @@ const props = withDefaults(
     additional?: boolean
     pattern?: boolean
     withExamples?: boolean
+    hideModelNames?: boolean
     schemas?: Record<string, OpenAPIV3_1.SchemaObject> | unknown
     hideHeading?: boolean
   }>(),
@@ -42,6 +43,7 @@ const props = withDefaults(
     required: false,
     compact: false,
     withExamples: true,
+    hideModelNames: false,
   },
 )
 
@@ -169,7 +171,8 @@ const displayPropertyHeading = (
       :pattern="pattern"
       :required="required"
       :value="optimizedValue"
-      :schemas="schemas">
+      :schemas="schemas"
+      :hideModelNames="hideModelNames">
       <template
         v-if="name"
         #name>

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -294,4 +294,68 @@ describe('SchemaPropertyHeading', () => {
     expect(detailsElement.text()).toContain('Planet')
     expect(detailsElement.text()).not.toContain('object')
   })
+
+  it('matches array schema to component schema by type and items', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'array',
+          items: { type: 'string' },
+          deprecated: false,
+        },
+        schemas: {
+          Planet: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          Satellite: {
+            type: 'string',
+          },
+        },
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('array Planet[]')
+  })
+
+  it('doesn’t show model name when hideModelNames is true', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        hideModelNames: true,
+        schemas: {
+          Planet: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('array string[]')
+    expect(detailsElement.text()).not.toContain('Planet')
+  })
+
+  it('shows model name when hideModelNames is false', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        hideModelNames: false,
+        schemas: {
+          Planet: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('array Planet[]')
+  })
 })


### PR DESCRIPTION
**Problem**

current logic for schema property heading is subject to value mismatch in some case which cause wrong property name being displayed. 

**Solution**

this pr updates the schema property heading logic and introduce a `hideModelNames` prop to differentiate data displayed between parameter and model. fixes #5737 

| before | after |
| -------|------|
| <img width="1116" alt="image" src="https://github.com/user-attachments/assets/b273cdb8-4ce7-4e92-9581-440ca4e0ec75" /> | <img width="1116" alt="image" src="https://github.com/user-attachments/assets/c904e26a-4bef-4ac9-9b6d-7b930582eb7e" /> |
| wrong schema name in parameter + schema name is displayed within model | right schema in parameter + type in model | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
