### PR TITLE
fix(CI): we should only npm publish on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,9 +265,9 @@ jobs:
           webpackStatsFile: ./packages/api-reference/dist/browser/webpack-stats.json
 
   npm-publish:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
     runs-on: beefcake
-    timeout-minutes: 10
+    timeout-minutes: 15
     # Avoid running this job in parallel:
     # `changesets/action` creates/updates the release branch, which shouldn’t happen in parallel.
     # npm publish also shouldn’t happen in parallel.


### PR DESCRIPTION
**Problem**

Currently, we run the build step on npm publish on every PR merge but we don't publish. We also can't use blackrock for this job.

**Solution**

With this PR we extend the time to 15 min and only do it on release

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
