### PR TITLE
fix(ci): restore changeset

### DIFF
--- a/.changeset/strange-singers-shout.md
+++ b/.changeset/strange-singers-shout.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: bump for tailwind fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
           webpackStatsFile: ./packages/api-reference/dist/browser/webpack-stats.json
 
   npm-publish:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
+    if: github.ref == 'refs/heads/main'
     runs-on: beefcake
     timeout-minutes: 15
     # Avoid running this job in parallel:


### PR DESCRIPTION
**Problem**

I removed NPM publish from running on PR merge, but apparently that was creating the release PR.

**Solution**

With this PR we restore that

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
