### PR TITLE
feat(proxy): harden cidr ranges

### DIFF
--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -213,30 +213,6 @@ describe('create-request-operation', () => {
     })
   })
 
-  // TODO: this doesn't actually hit the proxy due to 127.0.0.1
-  it('reaches the echo server *with* the proxy', async () => {
-    const [error, requestOperation] = createRequestOperation(
-      createRequestPayload({
-        serverPayload: { url: VOID_URL },
-        proxyUrl: PROXY_URL,
-      }),
-    )
-    if (error) {
-      throw error
-    }
-
-    const [requestError, result] = await requestOperation.sendRequest()
-
-    expect(requestError).toBe(null)
-    if (!result || !('data' in result.response)) {
-      throw new Error('No data')
-    }
-    expect(JSON.parse(result?.response.data as string)).toMatchObject({
-      method: 'GET',
-      path: '/',
-    })
-  })
-
   it('replaces variables in urls', async () => {
     const [error, requestOperation] = createRequestOperation(
       createRequestPayload({


### PR DESCRIPTION
We need to ensure that the proxy does not allow any traffic to private ip ranges (including GCP loopback and metadata cidr) on both initial request and any redirects. 

The proxy has been isolated, but to prevent some easy mistakes in the future, I'm just adding these for now. 

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
