### PR TITLE
feat(proxy): custom dial context

### DIFF
--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -163,7 +163,14 @@ func NewProxyServer(bypassCidr bool) *ProxyServer {
 						}
 					}
 
-					chosen := ip.String() + ":" + port
+					// Format chosen with brackets if IPv6
+					var chosen string
+					if ip.To4() == nil {
+						chosen = fmt.Sprintf("[%s]:%s", ip.String(), port)
+					} else {
+						chosen = fmt.Sprintf("%s:%s", ip.String(), port)
+					}
+
 					return dialer.DialContext(ctx, network, chosen)
 				}
 
@@ -195,7 +202,13 @@ func NewProxyServer(bypassCidr bool) *ProxyServer {
 						ip = v4
 					}
 
-					chosen := ip.String() + ":" + port
+					// Format with brackets if IPv6
+					var chosen string
+					if ip.To4() == nil {
+						chosen = fmt.Sprintf("[%s]:%s", ip.String(), port)
+					} else {
+						chosen = fmt.Sprintf("%s:%s", ip.String(), port)
+					}
 
 					return dialer.DialContext(ctx, network, chosen)
 				}


### PR DESCRIPTION
- Adds custom dialer to fully prevent dns rebind
- Checks ipv6->v4 mapping against cidr denylist
- Deny 0.0.0.0

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
