### PR TITLE
fix(api-client): override Electron default User-Agent header

### DIFF
--- a/.changeset/real-sloths-fold.md
+++ b/.changeset/real-sloths-fold.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'scalar-app': patch
+---
+
+fix: override Electron default User-Agent header

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -130,6 +130,12 @@ export const createRequestOperation = ({
     const cookieParams = [..._cookieParams, ...security.cookies]
     const urlParams = new URLSearchParams([..._urlParams, ...security.urlParams])
 
+    // If we are running in Electron, we need to add a custom header
+    // that’s then forwarded as a `User-Agent` header.
+    if (isElectron() && headers['user-agent']) {
+      headers['X-Scalar-User-Agent'] = headers['user-agent']
+    }
+
     // Combine the url with the path and server + query params
     url = mergeUrls(url, pathString, urlParams)
 
@@ -172,6 +178,9 @@ export const createRequestOperation = ({
       body: body ?? null,
       headers,
     })
+
+    console.log('Proxied request', proxiedRequest)
+    console.log('Proxied headers', headers)
 
     const sendRequest = async (): Promise<
       ErrorResponse<{

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -179,9 +179,6 @@ export const createRequestOperation = ({
       headers,
     })
 
-    console.log('Proxied request', proxiedRequest)
-    console.log('Proxied headers', headers)
-
     const sendRequest = async (): Promise<
       ErrorResponse<{
         response: ResponseInstance

--- a/projects/scalar-app/src/main/index.ts
+++ b/projects/scalar-app/src/main/index.ts
@@ -96,6 +96,13 @@ function createWindow(): void {
       delete requestHeaders['X-Scalar-Cookie']
     }
 
+    if (requestHeaders['X-Scalar-User-Agent']) {
+      // replace the `User-Agent` header with the `X-Scalar-User-Agent`
+      requestHeaders['User-Agent'] = requestHeaders['X-Scalar-User-Agent']
+
+      delete requestHeaders['X-Scalar-User-Agent']
+    }
+
     callback({ requestHeaders })
   })
 


### PR DESCRIPTION
**Problem**

Electron automatically sets a default `User-Agent` header on requests, so the user-defined `User-Agent` is not used.

**Solution**

With this PR
- A custom `User-Agent` is passed via an `X-Scalar-User-Agent` header when running in Electron.
- `onBeforeSendHeaders` is used to replace the default `User-Agent` header with the value from `X-Scalar-User-Agent`.

This ensures that the final `User-Agent` reflects the user-defined value rather than Electron’s default behavior.

I'm not sure if this is the best approach — open to suggestions or alternative ideas 🤔.
fixes #5515 

before:
![Screenshot 2568-06-01 at 10 23 42](https://github.com/user-attachments/assets/ba7d2758-203f-49d2-a10d-29cb4082d626)

after:
![Screenshot 2568-06-01 at 10 20 12](https://github.com/user-attachments/assets/5225f5b5-c3e7-420d-aa9b-efb9a3f19363)
  
**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
