### PR TITLE
fix(api-reference): schema composition name handling

### DIFF
--- a/.changeset/spicy-olives-build.md
+++ b/.changeset/spicy-olives-build.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: updates schema composition name handling

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import SchemaComposition from './SchemaComposition.vue'
 
 describe('SchemaComposition', () => {
-  describe('getModelNameFromSchema', () => {
+  describe('schema name display', () => {
     it('displays schema title when both title and name are present', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
@@ -249,6 +249,28 @@ describe('SchemaComposition', () => {
         type: 'string',
         enum: ['option1', 'option2', 'option3'],
       })
+    })
+
+    it('handles nested compositions with titles', () => {
+      const wrapper = mount(SchemaComposition, {
+        props: {
+          composition: 'oneOf',
+          value: {
+            oneOf: [
+              {
+                allOf: [
+                  { title: 'Planet', type: 'object' },
+                  { type: 'object', properties: { test: { type: 'string' } } },
+                ],
+              },
+            ],
+          },
+          level: 0,
+        },
+      })
+
+      const tab = wrapper.find('.composition-selector-label')
+      expect(tab.text()).toBe('Planet')
     })
   })
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+import { getModelNameFromSchema, getCompositionDisplay } from './schema-name'
+
+describe('schema-name', () => {
+  describe('getModelNameFromSchema', () => {
+    it('returns title when present', () => {
+      const schema: OpenAPIV3_1.SchemaObject = { title: 'Galaxy Planet', type: 'object' }
+      expect(getModelNameFromSchema(schema)).toBe('Galaxy Planet')
+    })
+
+    it('returns name when present', () => {
+      const schema = { name: 'Galaxy Planet', type: 'object' } as any
+      expect(getModelNameFromSchema(schema)).toBe('Galaxy Planet')
+    })
+
+    it('prefers title over name', () => {
+      const schema = { title: 'Galaxy Planet', name: 'Other Name', type: 'object' } as any
+      expect(getModelNameFromSchema(schema)).toBe('Galaxy Planet')
+    })
+
+    it('finds schema name from schemas dictionary', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+      }
+      const schemas = {
+        GalaxyPlanet: { type: 'object', properties: { id: { type: 'string' } } },
+        Satellite: { type: 'object', properties: { name: { type: 'string' } } },
+      }
+      expect(getModelNameFromSchema(schema, schemas)).toBe('GalaxyPlanet')
+    })
+
+    it('handles array types with items', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {
+        type: 'array',
+        items: { type: 'string' },
+      }
+      expect(getModelNameFromSchema(schema)).toBe('Array of string')
+    })
+
+    it('handles array types with any items', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {
+        type: 'array',
+        items: {},
+      }
+      expect(getModelNameFromSchema(schema)).toBe('Array of any')
+    })
+
+    it('returns type when no other name available', () => {
+      const schema: OpenAPIV3_1.SchemaObject = { type: 'string' }
+      expect(getModelNameFromSchema(schema)).toBe('string')
+    })
+
+    it('handles union types', () => {
+      const schema: OpenAPIV3_1.SchemaObject = { type: ['string', 'null'] }
+      expect(getModelNameFromSchema(schema)).toBe('string | null')
+    })
+
+    it('returns first object key as fallback', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {
+        properties: { name: { type: 'string' } },
+      }
+      expect(getModelNameFromSchema(schema)).toBe('properties')
+    })
+
+    it('returns null for empty object', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {}
+      expect(getModelNameFromSchema(schema)).toBe(null)
+    })
+  })
+
+  describe('selectSchemasForLabeling', () => {
+    it('uses original schemas when they have $ref', () => {
+      const originalSchemas: OpenAPIV3_1.ReferenceObject[] = [
+        { $ref: '#/components/schemas/Planet' },
+        { $ref: '#/components/schemas/Satellite' },
+      ]
+      const processedSchemas: OpenAPIV3_1.SchemaObject[] = [
+        { type: 'object', properties: { id: { type: 'string' } } },
+        { type: 'object', properties: { name: { type: 'string' } } },
+      ]
+
+      const result = getCompositionDisplay(originalSchemas, processedSchemas)
+      expect(result).toBe(originalSchemas)
+    })
+
+    it('uses original schemas when they have custom names', () => {
+      const originalSchemas: OpenAPIV3_1.SchemaObject[] = [
+        { title: 'UserProfile', type: 'object' },
+        { title: 'CustomerData', type: 'object' },
+      ]
+      const processedSchemas: OpenAPIV3_1.SchemaObject[] = [{ type: 'object' }, { type: 'object' }]
+
+      const result = getCompositionDisplay(originalSchemas, processedSchemas)
+      expect(result).toBe(originalSchemas)
+    })
+
+    it('uses processed schemas when they have custom names but original do not', () => {
+      const originalSchemas: OpenAPIV3_1.SchemaObject[] = [{ allOf: [{ title: 'Planet' }, { type: 'object' }] }]
+      const processedSchemas: OpenAPIV3_1.SchemaObject[] = [{ title: 'Planet', type: 'object' }]
+
+      const result = getCompositionDisplay(originalSchemas, processedSchemas)
+      expect(result).toBe(processedSchemas)
+    })
+
+    it('defaults to original schemas when neither have custom names', () => {
+      const originalSchemas: OpenAPIV3_1.SchemaObject[] = [{ type: 'object' }, { type: 'string' }]
+      const processedSchemas: OpenAPIV3_1.SchemaObject[] = [{ type: 'object' }, { type: 'string' }]
+
+      const result = getCompositionDisplay(originalSchemas, processedSchemas)
+      expect(result).toBe(originalSchemas)
+    })
+
+    it('uses schemas dictionary for name lookup', () => {
+      const originalSchemas: OpenAPIV3_1.SchemaObject[] = [{ type: 'object', properties: { id: { type: 'string' } } }]
+      const processedSchemas: OpenAPIV3_1.SchemaObject[] = [{ type: 'object' }]
+      const schemas = {
+        GalaxyPlanet: { type: 'object', properties: { id: { type: 'string' } } },
+      }
+
+      const result = getCompositionDisplay(originalSchemas, processedSchemas, schemas)
+      expect(result).toBe(originalSchemas)
+    })
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
@@ -1,0 +1,120 @@
+import { stringify } from 'flatted'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { Schemas } from '@/features/Operation/types/schemas'
+
+/**
+ * Extract schema name from various schema formats
+ * Handles $ref, title, name, type, and schema dictionary lookup
+ */
+export function getModelNameFromSchema(schema: OpenAPIV3_1.SchemaObject, schemas?: Schemas): string | null {
+  if (!schema) {
+    return null
+  }
+
+  // Direct title/name properties
+  if ('title' in schema && schema.title) {
+    return schema.title
+  }
+
+  if ('name' in schema && schema.name) {
+    return schema.name
+  }
+
+  // Schema dictionary lookup by comparing stringified objects
+  if (schemas && typeof schemas === 'object') {
+    for (const [schemaName, schemaValue] of Object.entries(schemas)) {
+      // To avoid circular references, stringify the schema and compare
+      if (stringify(schemaValue) === stringify(schema)) {
+        return schemaName
+      }
+    }
+  }
+
+  // Handle $ref schemas - extract name from reference path
+  // e.g. SchemaName for #/components/schemas/SchemaName
+  if ('$ref' in schema) {
+    const refPath = schema.$ref
+    const match = refPath.match(/\/([^\/]+)$/)
+    if (match) {
+      return match[1]
+    }
+  }
+
+  // Handle array types with items
+  if ('type' in schema && schema.type === 'array' && 'items' in schema && schema.items) {
+    const itemType = ('type' in schema.items && schema.items.type) || 'any'
+
+    return `Array of ${itemType}`
+  }
+
+  // Fallback to type
+  if ('type' in schema && schema.type) {
+    return Array.isArray(schema.type) ? schema.type.join(' | ') : schema.type
+  }
+
+  // Last resort: use first object key
+  if (typeof schema === 'object') {
+    const keys = Object.keys(schema)
+    if (keys.length > 0) {
+      return keys[0]
+    }
+  }
+
+  return null
+}
+
+/**
+ * Check if a schema has a name (title, name, or custom identifier)
+ */
+export function hasName(name: string | null): boolean {
+  if (!name) {
+    return false
+  }
+
+  // Exclude composition keywords
+  const compositionKeywords = ['anyOf', 'oneOf', 'allOf']
+  if (compositionKeywords.includes(name)) {
+    return false
+  }
+
+  // Consider has having a name if it:
+  // - Has capital letters (PascalCase, camelCase)
+  // - Contains spaces (like "User Profile")
+  // - Has numbers with letters (like "foo (1)")
+  return /[A-Z]/.test(name) || /\s/.test(name) || /\(\d+\)/.test(name)
+}
+
+/**
+ * Choose the schemas to display in composition panel
+ */
+export function getCompositionDisplay(
+  baseSchemas: OpenAPIV3_1.SchemaObject[],
+  compositionSchemas: OpenAPIV3_1.SchemaObject[],
+  schemas?: Schemas,
+): OpenAPIV3_1.SchemaObject[] {
+  // If base schemas have $ref, always use them to preserve $ref information
+  if (baseSchemas.some((schema) => '$ref' in schema)) {
+    return baseSchemas
+  }
+
+  // Check if base schemas have names
+  const baseNames = baseSchemas.map((schema) => getModelNameFromSchema(schema, schemas))
+  const baseHasName = baseNames.some((name) => hasName(name))
+
+  // If base schemas have names, use them
+  if (baseHasName) {
+    return baseSchemas
+  }
+
+  // Check if composition schemas have names
+  const compositionNames = compositionSchemas.map((schema) => getModelNameFromSchema(schema, schemas))
+  const compositionHasName = compositionNames.some((name) => hasName(name))
+
+  // If composition schemas have names but original don't, use composition
+  if (compositionHasName) {
+    return compositionSchemas
+  }
+
+  // Default to base schemas
+  return baseSchemas
+}


### PR DESCRIPTION
**Problem**

recent update in schema composition and discriminator support introduced lack of name and content retrieval.

**Solution**

this pr extracts a schema name helper to better handle use cases and update the schema composition accordingly. fixes #5806

**Tests**
https://sandbox.scalar.com/e/dtj9s

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
