### PR TITLE
fix(api-reference): header properties style

### DIFF
--- a/.changeset/empty-rivers-clean.md
+++ b/.changeset/empty-rivers-clean.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates header properties style

--- a/packages/api-reference/src/features/Operation/components/ParameterHeaders.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterHeaders.vue
@@ -59,11 +59,9 @@ function hasSchema(
 
   align-self: flex-start;
 }
-
 .headers-card.headers-card--open {
   align-self: initial;
 }
-
 .headers-card-title {
   padding: 6px 10px;
 
@@ -86,15 +84,6 @@ button.headers-card-title:hover {
 .headers-card-title-icon--open {
   transform: rotate(45deg);
 }
-.headers-properties-open > .headers-card-title {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
-}
-.headers-properties-open {
-  width: 100%;
-}
-
 .headers-properties {
   display: flex;
   flex-direction: column;
@@ -104,11 +93,18 @@ button.headers-card-title:hover {
   border-radius: 13.5px;
   width: fit-content;
 }
-
+.headers-properties-open > .headers-card-title {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
+}
+.headers-properties-open {
+  border-radius: var(--scalar-radius-lg);
+  width: 100%;
+}
 .headers-card .property:last-of-type {
   padding-bottom: 10px;
 }
-
 .headers-card-title > .headers-card-title-icon {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
**Problem**

currently header properties doesn't expand nor use consistent radius when open.

**Solution**

this pr updates header properties style to behave like parameter properties style.

| before | after |
| -------|------|
| <img width="564" alt="image" src="https://github.com/user-attachments/assets/1d2d88e8-c203-4131-ac1b-7903f123ee8a" /> | <img width="564" alt="image" src="https://github.com/user-attachments/assets/081ff15a-f767-4cef-9767-b31cf430eed6" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
