### PR TITLE
fix(api-client): request section section filter auth

### DIFF
--- a/.changeset/pink-pants-end.md
+++ b/.changeset/pink-pants-end.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates request section auth hidden logic"

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -87,9 +87,7 @@ const filterIds = computed(
 )
 
 // If security = [] or [{}] just hide it on readOnly mode
-const isAuthHidden = computed(
-  () => layout === 'modal' && operation.security?.length === 0,
-)
+const isAuthHidden = computed(() => layout === 'modal' && !operation.security)
 
 const selectedFilter = ref<Filter>('All')
 

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -151,6 +151,16 @@ const requestSectionViews = pluginManager.getViewComponents('request.section')
 
 const updateOperationHandler = (key: keyof Operation, value: string) =>
   requestMutators.edit(operation.uid, key, value)
+
+// Sets to all when auth filter is hidden but was previously selected to prevent empty section
+watch(
+  () => isAuthHidden.value,
+  (authHidden) => {
+    if (authHidden && selectedFilter.value === 'Auth') {
+      selectedFilter.value = 'All'
+    }
+  },
+)
 </script>
 <template>
   <ViewLayoutSection :aria-label="`Request: ${operation.summary}`">

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -54,7 +54,7 @@ const requestSections = [
   'Headers',
   'Query',
   'Body',
-  'Scripts',
+  // 'Scripts',
 ] as const
 
 type Filter = 'All' | (typeof requestSections)[number]


### PR DESCRIPTION
**Problem**

currently auth section is displayed even in no security presence + scripts are present while not introduced yet.

**Solution**

this pr updates the request section filter auth display logic + comment out the scripts for the time being.

| before | after |
| -------|------|
| <img width="700" alt="image" src="https://github.com/user-attachments/assets/c3579f02-a096-4c6c-87dc-6261026a7166" /> | <img width="700" alt="image" src="https://github.com/user-attachments/assets/a9354d13-9b62-4bbd-95ec-a391a60dcb8c" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
