### PR TITLE
feat(Scalar.AspNetCore): add benchmarks and improve ScalarOptions mapping

### DIFF
--- a/.changeset/nine-lions-worry.md
+++ b/.changeset/nine-lions-worry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feat(Scalar.AspNetCore): improve mapper performance

--- a/integrations/aspnetcore/Scalar.AspNetCore.slnx
+++ b/integrations/aspnetcore/Scalar.AspNetCore.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/playground/">
     <Project Path="playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj" />
+    <Project Path="playground\Scalar.AspNetCore.Benchmarks\Scalar.AspNetCore.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Scalar.AspNetCore.Microsoft/Scalar.AspNetCore.Microsoft.csproj" />

--- a/integrations/aspnetcore/Scalar.AspNetCore.slnx
+++ b/integrations/aspnetcore/Scalar.AspNetCore.slnx
@@ -1,7 +1,7 @@
 <Solution>
   <Folder Name="/playground/">
     <Project Path="playground/Scalar.AspNetCore.Playground/Scalar.AspNetCore.Playground.csproj" />
-    <Project Path="playground\Scalar.AspNetCore.Benchmarks\Scalar.AspNetCore.Benchmarks.csproj" />
+    <Project Path="playground/Scalar.AspNetCore.Benchmarks/Scalar.AspNetCore.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Scalar.AspNetCore.Microsoft/Scalar.AspNetCore.Microsoft.csproj" />

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Benchmarks/Program.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Benchmarks/Program.cs
@@ -1,0 +1,4 @@
+using BenchmarkDotNet.Running;
+using Scalar.AspNetCore.Benchmarks;
+
+BenchmarkRunner.Run<ScalarOptionsMapperBenchmarks>();

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Benchmarks/Scalar.AspNetCore.Benchmarks.csproj
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Benchmarks/Scalar.AspNetCore.Benchmarks.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Scalar.AspNetCore\Scalar.AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Benchmarks/ScalarOptionsMapperBenchmarks.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Benchmarks/ScalarOptionsMapperBenchmarks.cs
@@ -21,7 +21,7 @@ public class ScalarOptionsMapperBenchmarks
         };
     }
 
-    [Benchmark(Baseline = true)]
+    [Benchmark]
     public void MapSimpleOptions()
     {
         var configuration = _simpleOptions.ToScalarConfiguration();

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Benchmarks/ScalarOptionsMapperBenchmarks.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Benchmarks/ScalarOptionsMapperBenchmarks.cs
@@ -1,11 +1,12 @@
 ﻿using System.Text.Json;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 
 namespace Scalar.AspNetCore.Benchmarks;
 
 [MemoryDiagnoser]
-[ShortRunJob]
-[MarkdownExporterAttribute.GitHub]
+[SimpleJob(RuntimeMoniker.Net90)]
+[SimpleJob(RuntimeMoniker.Net80)]
 public class ScalarOptionsMapperBenchmarks
 {
     private ScalarOptions _simpleOptions = null!;
@@ -13,7 +14,11 @@ public class ScalarOptionsMapperBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        _simpleOptions = new ScalarOptions();
+        _simpleOptions = new ScalarOptions
+        {
+            EnabledClients = [ScalarClient.HttpClient, ScalarClient.RestSharp],
+            EnabledTargets = [ScalarTarget.CSharp]
+        };
     }
 
     [Benchmark(Baseline = true)]

--- a/integrations/aspnetcore/playground/Scalar.AspNetCore.Benchmarks/ScalarOptionsMapperBenchmarks.cs
+++ b/integrations/aspnetcore/playground/Scalar.AspNetCore.Benchmarks/ScalarOptionsMapperBenchmarks.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+
+namespace Scalar.AspNetCore.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+[MarkdownExporterAttribute.GitHub]
+public class ScalarOptionsMapperBenchmarks
+{
+    private ScalarOptions _simpleOptions = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _simpleOptions = new ScalarOptions();
+    }
+
+    [Benchmark(Baseline = true)]
+    public void MapSimpleOptions()
+    {
+        var configuration = _simpleOptions.ToScalarConfiguration();
+        JsonSerializer.Serialize(configuration, typeof(ScalarConfiguration), ScalarConfigurationSerializerContext.Default);
+    }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Microsoft" />
     <InternalsVisibleTo Include="$(AssemblyName).Swashbuckle" />
+    <InternalsVisibleTo Include="$(AssemblyName).Benchmarks" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds a benchmark project to the `Scalar.AspNetCore` integration. The goal is to enable easier benchmarking, testing, and optimization of existing methods.
I also improved the mapper by reducing allocations and execution time. The code is also now more readable, IMO.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
