### PR TITLE
fix(openapi-parser): Migrate serialization style

### DIFF
--- a/.changeset/fresh-buckets-refuse.md
+++ b/.changeset/fresh-buckets-refuse.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: collectionFormat is not migrated to new style and explode keywords

--- a/packages/openapi-parser/src/utils/upgrade-from-two-to-three.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-two-to-three.test.ts
@@ -634,4 +634,202 @@ describe('upgradeFromTwoToThree', () => {
       },
     })
   })
+
+  it('transform query parameter collectionFormat to new serialization keywords', () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      produces: ['application/json'],
+      paths: {
+        '/planets': {
+          get: {
+            description:
+              'Get all planets from the system that the user has access to.',
+            consumes: ['application/json'],
+            parameters: [
+              {
+                name: 'tags',
+                in: 'query',
+                type: 'array',
+                collectionFormat: 'pipes',
+                items: {
+                  type: 'string',
+                },
+              },
+              {
+                name: 'queryParam',
+                in: 'query',
+                type: 'array',
+                collectionFormat: 'multi',
+                items: {
+                  type: 'string',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'A list of planets.',
+                headers: {
+                  next: {
+                    description: 'link to next page',
+                    type: 'string',
+                    maxLength: 100,
+                  },
+                },
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/definitions/planet',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.paths['/planets'].get.parameters).toStrictEqual([
+      {
+        name: 'tags',
+        in: 'query',
+        style: 'pipeDelimited',
+        explode: false,
+        schema: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+      {
+        name: 'queryParam',
+        in: 'query',
+        style: 'form',
+        explode: true,
+        schema: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+    ])
+  })
+
+  it('transform path parameter collectionFormat to new serialization keywords', () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      produces: ['application/json'],
+      paths: {
+        '/planets/{id}': {
+          get: {
+            description:
+              'Get all planets from the system that the user has access to.',
+            consumes: ['application/json'],
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'A list of planets.',
+                headers: {
+                  next: {
+                    description: 'link to next page',
+                    type: 'string',
+                    maxLength: 100,
+                  },
+                },
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/definitions/planet',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.paths['/planets/{id}'].get.parameters).toStrictEqual([
+      {
+        name: 'id',
+        in: 'path',
+        style: 'simple',
+        explode: false,
+        schema: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+    ])
+  })
+
+  it('transform header parameter collectionFormat to new serialization keywords', () => {
+    const result = upgradeFromTwoToThree({
+      swagger: '2.0',
+      produces: ['application/json'],
+      paths: {
+        '/planets': {
+          get: {
+            description:
+              'Get all planets from the system that the user has access to.',
+            consumes: ['application/json'],
+            parameters: [
+              {
+                name: 'myHeader',
+                in: 'header',
+                type: 'array',
+                collectionFormat: 'pipes',
+                items: {
+                  type: 'string',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'A list of planets.',
+                headers: {
+                  next: {
+                    description: 'link to next page',
+                    type: 'string',
+                    maxLength: 100,
+                  },
+                },
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/definitions/planet',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.paths['/planets'].get.parameters).toStrictEqual([
+      {
+        name: 'myHeader',
+        in: 'header',
+        schema: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+    ])
+  })
 })

--- a/packages/openapi-parser/src/utils/upgrade-from-two-to-three.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-two-to-three.test.ts
@@ -642,8 +642,7 @@ describe('upgradeFromTwoToThree', () => {
       paths: {
         '/planets': {
           get: {
-            description:
-              'Get all planets from the system that the user has access to.',
+            description: 'Get all planets from the system that the user has access to.',
             consumes: ['application/json'],
             parameters: [
               {
@@ -723,8 +722,7 @@ describe('upgradeFromTwoToThree', () => {
       paths: {
         '/planets/{id}': {
           get: {
-            description:
-              'Get all planets from the system that the user has access to.',
+            description: 'Get all planets from the system that the user has access to.',
             consumes: ['application/json'],
             parameters: [
               {
@@ -782,8 +780,7 @@ describe('upgradeFromTwoToThree', () => {
       paths: {
         '/planets': {
           get: {
-            description:
-              'Get all planets from the system that the user has access to.',
+            description: 'Get all planets from the system that the user has access to.',
             consumes: ['application/json'],
             parameters: [
               {

--- a/packages/openapi-parser/src/utils/upgrade-from-two-to-three.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-two-to-three.ts
@@ -301,9 +301,7 @@ function transformItemsObject<T extends Record<PropertyKey, unknown>>(obj: T): O
   }, {} as OpenAPIV3.SchemaObject)
 }
 
-function transformParameterObject(
-  parameter: OpenAPIV2.ParameterObject,
-): OpenAPIV3.ParameterObject {
+function transformParameterObject(parameter: OpenAPIV2.ParameterObject): OpenAPIV3.ParameterObject {
   // it is important to call getParameterSerializationStyle first because transformItemsObject modifies properties on which getParameterSerializationStyle rely on
   const serializationStyle = getParameterSerializationStyle(parameter)
   const schema = transformItemsObject(parameter)
@@ -322,10 +320,7 @@ type CollectionFormat = 'csv' | 'ssv' | 'tsv' | 'pipes' | 'multi'
 
 type ParameterSerializationStyle = { style?: string; explode?: boolean }
 
-const querySerialization: Record<
-  CollectionFormat,
-  ParameterSerializationStyle
-> = {
+const querySerialization: Record<CollectionFormat, ParameterSerializationStyle> = {
   ssv: {
     style: 'spaceDelimited',
     explode: false,
@@ -345,17 +340,16 @@ const querySerialization: Record<
   tsv: {},
 }
 
-const pathAndHeaderSerialization: Record<CollectionFormat, ParameterSerializationStyle> =
-  {
-    ssv: {},
-    pipes: {},
-    multi: {},
-    csv: {
-      style: 'simple',
-      explode: false,
-    },
-    tsv: {},
-  }
+const pathAndHeaderSerialization: Record<CollectionFormat, ParameterSerializationStyle> = {
+  ssv: {},
+  pipes: {},
+  multi: {},
+  csv: {
+    style: 'simple',
+    explode: false,
+  },
+  tsv: {},
+}
 
 const serializationStyles = {
   header: pathAndHeaderSerialization,
@@ -363,16 +357,10 @@ const serializationStyles = {
   path: pathAndHeaderSerialization,
 } as const
 
-function getParameterSerializationStyle(
-  parameter: OpenAPIV2.ParameterObject,
-): ParameterSerializationStyle {
+function getParameterSerializationStyle(parameter: OpenAPIV2.ParameterObject): ParameterSerializationStyle {
   if (
     parameter.type !== 'array' ||
-    !(
-      parameter.in === 'query' ||
-      parameter.in === 'path' ||
-      parameter.in === 'header'
-    )
+    !(parameter.in === 'query' || parameter.in === 'path' || parameter.in === 'header')
   ) {
     return {}
   }


### PR DESCRIPTION
**Problem**

Currently, the `collectionFormat` keyword is just ignored.

**Solution**

With this PR the `collectionFormat` keyword is migrated to the two new keywords `style` and `explode`. If the old behavior described by `collectionFormat` cannot be described with the new keywords, it is simply removed and the default behavior for the respective parameter types is used.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
