### PR TITLE
fix(api-reference): updates allof inside anyof style

### DIFF
--- a/.changeset/weak-brooms-relax.md
+++ b/.changeset/weak-brooms-relax.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates schema composition and propertuy style

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -206,10 +206,10 @@ const shouldRenderSchema = computed(() => {
           class="composition-selector bg-b-1.5 hover:bg-b-2 flex w-full cursor-pointer items-center gap-1 rounded-t-lg border border-b-0 px-2 py-1.25 pr-3 text-left"
           type="button">
           <span class="text-c-2">{{ humanizeType(composition) }}</span>
-          <span class="composition-selector-label text-c-1 relative">
+          <span class="composition-selector-label text-c-1">
             {{ selectedOption?.label || 'Schema' }}
           </span>
-          <ScalarIconCaretDown class="z-1" />
+          <ScalarIconCaretDown />
         </button>
       </ScalarListbox>
       <div class="composition-panel">

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -457,13 +457,17 @@ const handleDiscriminatorChange = (type: string) => {
 .property:not(:last-of-type) {
   border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
 }
-.property-description + .children {
+
+.property-description + .children,
+.children + .property-rule {
   margin-top: 9px;
 }
+
 .children {
   display: flex;
   flex-direction: column;
 }
+
 .children .property--compact.property--level-1 {
   padding: 12px;
 }


### PR DESCRIPTION
**Problem**

currently using allof inside anyof cause some ui glitches.

**Solution**

this pr updates schema composition style and property margin to fix the above and fixes #5838

| before | after |
| -------|------|
| <img width="587" alt="image" src="https://github.com/user-attachments/assets/f46f91f7-6f0e-4a32-ae8f-7501f9563ff9" /> | <img width="587" alt="image" src="https://github.com/user-attachments/assets/a318c817-c1b0-4e6f-ab9a-efa9615354bd" /> |
| lack of margin + dropdown layer issue | margin + dropdown visibility now optimal |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
