### PR TITLE
fix(api-reference): z-index of download button

### DIFF
--- a/.changeset/stupid-trees-know.md
+++ b/.changeset/stupid-trees-know.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: z-index of download button

--- a/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
+++ b/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
@@ -54,6 +54,7 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
   margin: 4px 0 24px;
   position: relative;
   width: fit-content;
+  z-index: 0;
 }
 
 .download-container:has(:focus-visible)::before,


### PR DESCRIPTION
**Problem**

Currently, the download button floats on top of our lazy loader

**Solution**

With this PR we set the z-index to 0 so that it stays underneath.

| before | after |
| -------|------|
| ![image](https://github.com/user-attachments/assets/93d233ca-7cc7-4ed1-8a65-cd367ec3eea1) | ![image](https://github.com/user-attachments/assets/43aec6d9-ad77-4c07-84b7-244af934458e)|


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
