### PR TITLE
feat(code-highlight): markdown style

### DIFF
--- a/.changeset/brown-schools-fail.md
+++ b/.changeset/brown-schools-fail.md
@@ -1,0 +1,6 @@
+---
+'@scalar/code-highlight': patch
+'@scalar/api-reference': patch
+---
+
+feat: updates markdown overall style

--- a/packages/api-reference/src/components/Content/Introduction/Description.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Description.vue
@@ -105,12 +105,8 @@ const transformHeading = (node: Record<string, any>) => {
 <style scoped>
 .introduction-description-heading {
   scroll-margin-top: 64px;
-  margin-top: 1em;
-  margin-bottom: 0.5em;
 }
-.markdown + .markdown {
-  margin-top: 1em;
-}
+
 .introduction-description {
   display: flex;
   flex-direction: column;

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -1,58 +1,291 @@
 @import url("./code.css");
 
 .scalar-app {
+  /* Base container and variables */
   .markdown {
+    --scalar-heading-spacing: 44px;
+    --markdown-border: var(--scalar-border-width) solid var(--scalar-border-color);
+    --markdown-spacing-sm: 12px;
+    --markdown-spacing-md: 16px;
+    --markdown-line-height: 1.625;
+
     font-family: var(--scalar-font);
     word-break: break-word;
   }
 
-  /* Apply base padding for all block elements */
+  .markdown > * {
+    margin-bottom: var(--markdown-spacing-md);
+  }
+
+  /* Headings (h1-h6) */
+  .markdown h1 {
+    --font-size: 1.5rem;
+    --markdown-line-height: 32px;
+  }
+
+  .markdown h2,
+  .markdown h3 {
+    --font-size: 1.25rem;
+    --markdown-line-height: 1.3;
+  }
+
+  .markdown h4,
+  .markdown h5,
+  .markdown h6 {
+    --font-size: 1rem;
+  }
+
   .markdown h1,
   .markdown h2,
   .markdown h3,
   .markdown h4,
   .markdown h5,
-  .markdown h6,
-  .markdown p,
-  .markdown div,
-  .markdown img,
-  .markdown details,
-  .markdown summary,
-  .markdown ul,
-  .markdown ol,
-  .markdown table,
-  .markdown blockquote,
-  .markdown code {
-    margin: 12px 0;
+  .markdown h6 {
+    display: block;
+    font-size: var(--font-size);
+    font-weight: var(--scalar-bold);
+    margin-top: var(--scalar-heading-spacing);
+    margin-bottom: var(--markdown-spacing-sm);
+    scroll-margin-top: 1rem;
   }
 
+  /* Text formatting and paragraphs */
+  .markdown b,
+  .markdown strong {
+    font-weight: var(--scalar-bold);
+  }
+
+  .markdown p {
+    color: inherit;
+    line-height: var(--markdown-line-height);
+    display: block;
+  }
+
+  /* Images */
+  .markdown img {
+    overflow: hidden;
+    border-radius: var(--scalar-radius);
+    max-width: 100%;
+  }
+
+  /* Lists */
+  .markdown ul:not(.contains-task-list),
+  .markdown ol {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .markdown ul:not(.contains-task-list) {
+    list-style-position: inside;
+  }
+
+  .markdown ul {
+    list-style-type: disc;
+  }
+
+  .markdown li {
+    line-height: var(--markdown-line-height);
+    position: relative;
+  }
+
+  .markdown ul li {
+    padding-left: var(--markdown-spacing-md);
+  }
+
+  .markdown ol {
+    counter-reset: item;
+    padding-left: 37.5px;
+  }
+
+  .markdown ol li::before {
+    content: counter(item) "\002E";
+    counter-increment: item;
+    font: var(--scalar-font);
+    font-weight: var(--scalar-semibold);
+    position: absolute;
+    top: 0;
+    left: -24px;
+    line-height: var(--markdown-line-height);
+    margin-right: var(--markdown-spacing-sm);
+  }
+
+  .markdown ol li::before,
+  .markdown ol ol ol li::before,
+  .markdown ol ol ol ol ol ol li::before {
+    content: counter(item, decimal) "\002E";
+  }
+
+  .markdown ol ol li::before,
+  .markdown ol ol ol ol li::before,
+  .markdown ol ol ol ol ol ol ol li::before {
+    content: counter(item, lower-alpha) "\002E";
+  }
+
+  .markdown ol ol li::before,
+  .markdown ol ol ol ol ol li::before,
+  .markdown ol ol ol ol ol ol ol ol li::before {
+    content: counter(item, lower-roman) "\002E";
+  }
+
+  .markdown ul:first-of-type li:first-of-type {
+    margin-top: 0;
+  }
+
+  /* Tables */
+  .markdown table {
+    display: table;
+    table-layout: fixed;
+    overflow-x: auto;
+    position: relative;
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1em 0;
+    box-shadow: 0 0 0 var(--scalar-border-width) var(--scalar-border-color);
+    border-radius: var(--scalar-radius);
+  }
+
+  .markdown tbody,
+  .markdown thead {
+    vertical-align: middle;
+  }
+
+  .markdown tbody {
+    display: table-row-group;
+  }
+
+  .markdown thead {
+    display: table-header-group;
+  }
+
+  .markdown tr {
+    display: table-row;
+    border-color: inherit;
+    vertical-align: inherit;
+  }
+
+  .markdown td,
+  .markdown th {
+    display: table-cell;
+    vertical-align: top;
+    min-width: 1em;
+    padding: 8.5px 16px;
+    line-height: var(--markdown-line-height);
+    position: relative;
+    word-break: initial;
+    font-size: var(--scalar-small);
+    color: var(--scalar-color-1);
+    border-right: var(--markdown-border);
+    border-bottom: var(--markdown-border);
+  }
+
+  .markdown td > *,
+  .markdown th > * {
+    margin-bottom: 0;
+  }
+
+  .markdown th:empty {
+    display: none;
+  }
+
+  .markdown td:first-of-type,
+  .markdown th:first-of-type {
+    border-left: none;
+  }
+
+  .markdown td:last-of-type,
+  .markdown th:last-of-type {
+    border-right: none;
+  }
+
+  .markdown tr:last-of-type td {
+    border-bottom: none;
+  }
+
+  .markdown th {
+    font-weight: var(--scalar-bold);
+    text-align: left;
+    border-left-color: transparent;
+    background: var(--scalar-background-2);
+  }
+
+  .markdown th:first-of-type {
+    border-top-left-radius: var(--scalar-radius);
+  }
+
+  .markdown th:last-of-type {
+    border-top-right-radius: var(--scalar-radius);
+  }
+
+  .markdown tr > [align="left"] {
+    text-align: left;
+  }
+
+  .markdown tr > [align="right"] {
+    text-align: right;
+  }
+
+  .markdown tr > [align="center"] {
+    text-align: center;
+  }
+
+  /* Details */
   .markdown details {
-    margin: 12px 0;
+    border: var(--markdown-border);
+    border-radius: var(--scalar-radius);
     color: var(--scalar-color-1);
   }
+
+  .markdown details > :not(summary) {
+    margin: var(--markdown-spacing-md);
+    margin-bottom: 0;
+  }
+
+  .markdown details > p:has(> strong):not(:has(:not(strong))) {
+    margin-bottom: 8px;
+  }
+
+  .markdown details > p:has(> strong):not(:has(:not(strong))) + * {
+    margin-top: 0;
+  }
+
+  .markdown details > table {
+    width: calc(100% - calc(var(--markdown-spacing-md) * 2));
+  }
+
   .markdown summary {
-    display: block;
-    margin: 1em 0;
-    padding-left: 20px;
+    background-color: var(--scalar-background-2);
+    border-radius: var(--scalar-radius);
+    display: flex;
+    align-items: top;
+    height: 40px;
+    padding: 11px 0px 11px 40px;
     position: relative;
     font-weight: var(--scalar-semibold);
     cursor: pointer;
     user-select: none;
   }
 
+  .markdown details[open] {
+    padding-bottom: var(--markdown-spacing-md);
+  }
+
+  .markdown details[open] summary {
+    border-bottom: var(--markdown-border);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
   .markdown summary::after {
     display: block;
     content: "";
-
     position: absolute;
-    top: -1px;
-    left: -1px;
-
-    width: 20px;
-    height: 20px;
-
+    top: calc(var(--markdown-spacing-sm) + 1px);
+    left: 14px;
+    width: var(--markdown-spacing-md);
+    height: var(--markdown-spacing-md);
     background-color: var(--scalar-color-3);
-    mask-image: url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m9 18 6-6-6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+    mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 256 256"><path d="M184.49,136.49l-80,80a12,12,0,0,1-17-17L159,128,87.51,56.49a12,12,0,1,1,17-17l80,80A12,12,0,0,1,184.49,136.49Z"></path></svg>');
   }
 
   .markdown summary:hover::after {
@@ -63,115 +296,50 @@
     transform: rotate(90deg);
   }
 
-  .markdown img {
-    overflow: hidden;
-    border-radius: var(--scalar-radius);
-    max-width: 100%;
-  }
-  /* Don't add margin to the first block */
-  .markdown > :first-child {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-
-  .markdown h1 {
-    --font-size: 1.4em;
-  }
-
-  .markdown h2 {
-    --font-size: 1.25em;
-  }
-
-  .markdown h3 {
-    --font-size: 1.1em;
-  }
-
-  .markdown h4 {
-    --font-size: 1em;
-  }
-
-  .markdown h6 {
-    --font-size: 1em;
-  }
-  .markdown h1,
-  .markdown h2,
-  .markdown h3,
-  .markdown h4,
-  .markdown h5,
-  .markdown h6 {
-    font-size: var(--font-size);
-    margin: 18px 0 6px;
-    font-weight: var(--scalar-bold);
-    display: block;
-    line-height: 1.45;
-    scroll-margin-top: 1rem;
-  }
-  .markdown b,
-  .markdown strong {
-    font-weight: var(--scalar-bold);
-  }
-  .markdown p {
-    color: inherit;
-    font-weight: var(--font-weight, var(--scalar-regular));
-    line-height: 1.5;
-    margin-bottom: 0;
-    display: block;
-  }
-
-  .markdown ul,
-  .markdown ol {
-    padding-left: 24px;
-    line-height: 1.5;
-    margin: 12px 0;
-    display: block;
-  }
-
-  .markdown ul {
-    list-style: disc;
-  }
-
-  .markdown ol {
-    list-style: decimal;
-  }
-
-  .markdown ul.contains-task-list {
-    list-style: none;
-    padding-left: 0;
-  }
-
-  .markdown li {
-    margin: 6px 0;
-    display: list-item;
-  }
-  .markdown ul:first-of-type li:first-of-type {
-    margin-top: 0;
-  }
+  /* Links */
   .markdown a {
-    color: var(--scalar-link-color, var(--scalar-color-accent));
-    font-weight: var(--scalar-link-font-weight, inherit);
-    text-decoration: var(--scalar-text-decoration);
-    cursor: pointer;
+    --font-color: var(--scalar-color-1);
+    --font-visited: var(--scalar-color-2);
+
+    color: var(--font-color);
+    font-weight: var(--scalar-semibold);
+    text-underline-offset: 0.25rem;
+    text-decoration-thickness: 1px;
+    text-decoration-color: color-mix(in srgb, var(--font-color, var(--scalar-color-1)) 30%, transparent);
   }
+
   .markdown a:hover {
-    color: var(--scalar-link-color-hover, var(--scalar-color-accent));
-    text-decoration: var(--scalar-text-decoration-hover);
+    text-decoration-color: var(--scalar-color-1);
   }
+
+  .markdown a:visited {
+    color: var(--font-visited);
+  }
+
+  /* Text effects and formatting */
   .markdown em {
     font-style: italic;
   }
-  .markdown sup {
-    font-size: var(--scalar-micro);
-    vertical-align: super;
-    font-weight: 450;
-  }
+
+  .markdown sup,
   .markdown sub {
     font-size: var(--scalar-micro);
-    vertical-align: sub;
     font-weight: 450;
   }
+
+  .markdown sup {
+    vertical-align: super;
+  }
+
+  .markdown sub {
+    vertical-align: sub;
+  }
+
   .markdown del {
     text-decoration: line-through;
   }
+
+  /* Code blocks and inline code */
   .markdown code {
     font-family: var(--scalar-font-code);
     background-color: var(--scalar-background-2);
@@ -188,105 +356,79 @@
   .markdown pre code {
     display: block;
     white-space: pre;
-    padding: 12px;
+    padding: var(--markdown-spacing-sm);
     line-height: 1.5;
-    margin: 12px 0;
+    margin: var(--markdown-spacing-sm) 0;
     -webkit-overflow-scrolling: touch;
     overflow-x: auto;
     max-width: 100%;
     min-width: 100px;
   }
 
+  /* Horizontal rules */
   .markdown hr {
     border: none;
-    border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
+    border-bottom: var(--markdown-border);
   }
 
+  /* Blockquotes */
   .markdown blockquote {
-    border-left: 3px solid var(--scalar-border-color);
-    padding-left: 12px;
+    border-left: 1px solid var(--scalar-color-1);
+    padding-left: var(--markdown-spacing-md);
     margin: 0;
     display: block;
+    font-weight: var(--scalar-bold);
+    font-size: var(--scalar-heading-2);
   }
 
-  .markdown table {
-    display: block;
-    overflow-x: auto;
+  /* Markdown Checklist */
+  .markdown .contains-task-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    list-style: none;
+  }
+
+  .markdown .contains-task-list li {
+    align-items: center;
+    display: flex;
+    gap: 10.5px;
+    padding-left: 10.5px;
+  }
+
+  .markdown .contains-task-list input {
     position: relative;
-    border-collapse: collapse;
-    width: max-content;
-    max-width: 100%;
-    margin: 1em 0;
-    box-shadow: 0 0 0 var(--scalar-border-width) var(--scalar-border-color);
-    border-radius: var(--scalar-radius-lg);
-  }
-  .markdown tbody {
-    display: table-row-group;
-    vertical-align: middle;
-  }
-  .markdown thead {
-    display: table-header-group;
-    vertical-align: middle;
+    appearance: none;
+    -webkit-appearance: none;
+    display: flex;
+    width: var(--markdown-spacing-md);
+    height: var(--markdown-spacing-md);
+    align-content: center;
+    justify-content: center;
+    border: 1px solid var(--scalar-color-3);
+    border-radius: var(--scalar-radius);
   }
 
-  .markdown tr {
-    display: table-row;
-    border-color: inherit;
-    vertical-align: inherit;
-  }
-  .markdown td,
-  .markdown th {
-    display: table-cell;
-    vertical-align: inherit;
-    min-width: 1em;
-    padding: 6px 9px;
-    vertical-align: top;
-    line-height: 1.5;
-    position: relative;
-    word-break: initial;
-    font-size: var(--scalar-small);
-    color: var(--scalar-color-1);
-    font-weight: var(--font-weight, var(--scalar-regular));
-    border-right: var(--scalar-border-width) solid var(--scalar-border-color);
-    border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
+  .markdown .contains-task-list input:checked {
+    background-color: var(--scalar-color-1);
+    border-color: var(--scalar-color-1);
   }
 
-  .markdown td > *,
-  .markdown th > * {
-    margin-bottom: 0;
-  }
-  .markdown th:empty {
-    display: none;
-  }
-  .markdown td:first-of-type,
-  .markdown th:first-of-type {
-    border-left: none;
-  }
-
-  .markdown td:last-of-type,
-  .markdown th:last-of-type {
-    border-right: none;
+  .markdown .contains-task-list input[type="checkbox"]::before {
+    content: "";
+    position: absolute;
+    left: 5px;
+    top: 1px;
+    width: 5px;
+    height: 10px;
+    border: solid var(--scalar-background-1);
+    border-width: 0 1.5px 1.5px 0;
+    transform: rotate(45deg);
+    opacity: 0;
   }
 
-  .markdown tr:last-of-type td {
-    border-bottom: none;
-  }
-
-  .markdown th {
-    font-weight: var(--scalar-semibold) !important;
-    text-align: left;
-    border-left-color: transparent;
-    background: var(--scalar-background-2);
-  }
-
-  .markdown tr > [align="left"] {
-    text-align: left;
-  }
-  .markdown tr > [align="right"] {
-    text-align: right;
-  }
-  .markdown tr > [align="center"] {
-    text-align: center;
+  .markdown .contains-task-list input[type="checkbox"]:checked::before {
+    opacity: 1;
   }
 
   /* Markdown Alert */
@@ -294,11 +436,11 @@
     align-items: stretch;
     border-radius: var(--scalar-radius-lg);
     background-color: color-mix(in srgb, var(--scalar-background-2), transparent);
-    border: var(--scalar-border-width) solid var(--scalar-border-color);
+    border: var(--markdown-border);
     display: flex;
     font-size: var(--scalar-small);
-    gap: 12px;
-    padding: 12px;
+    gap: var(--markdown-spacing-sm);
+    padding: calc(var(--markdown-spacing-sm) - 0.5px);
     padding-left: 42px;
     position: relative;
   }
@@ -306,10 +448,10 @@
   .markdown .markdown-alert::before {
     content: "";
     position: absolute;
-    left: 12px;
-    top: 12px;
-    width: 20px;
-    height: 20px;
+    left: var(--markdown-spacing-sm);
+    top: calc(var(--markdown-spacing-sm) + 0.5px);
+    width: 16px;
+    height: 16px;
     background-color: currentColor;
     mask-repeat: no-repeat;
     mask-size: contain;
@@ -354,6 +496,6 @@
 
   .markdown .markdown-alert .markdown-alert-content {
     margin: 0;
-    line-height: 1.5;
+    line-height: 20px;
   }
 }


### PR DESCRIPTION
**Problem**

currently some markdown style in the reference are lacking style.

**Solution**

this pr updates the style use within markdown.

| before  / after |
| -------|
| <img width="1462" alt="image" src="https://github.com/user-attachments/assets/a84f13f1-e350-4899-8e9d-0741066b560f" /> |
| <img width="1462" alt="image" src="https://github.com/user-attachments/assets/f72a292e-a096-44ee-a89b-b2827fa78e7e" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
