### PR TITLE
fix(api-client): authentication section display

### DIFF
--- a/.changeset/four-worms-explode.md
+++ b/.changeset/four-worms-explode.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates auth section display logic

--- a/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestSection.vue
@@ -87,7 +87,12 @@ const filterIds = computed(
 )
 
 // If security = [] or [{}] just hide it on readOnly mode
-const isAuthHidden = computed(() => layout === 'modal' && !operation.security)
+const isAuthHidden = computed(
+  () =>
+    layout === 'modal' &&
+    !operation.security &&
+    !Object.keys(securitySchemes ?? {}).length,
+)
 
 const selectedFilter = ref<Filter>('All')
 


### PR DESCRIPTION
**Problem**

recent changes in #5829 cut too deep in the logic and auth is not getting displayed in operation security presence at all in the modal.

**Solution**

this pr updates the auth hidden logic to maintain the previous introduced fix to hide the auth section while keep it displayed accordingly. fixes #5860 #5858

| state | preview |
| -------|------|
| before | <img width="722" alt="image" src="https://github.com/user-attachments/assets/219a3ef0-f644-42b4-baf2-5b90c5542aca" /> |
| after | <img width="722" alt="image" src="https://github.com/user-attachments/assets/d5e07e70-f851-4ff5-94e1-fa857d2d762f" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
