### PR TITLE
fix(openapi-parser): use dynamic imports inside the plugin

### DIFF
--- a/.changeset/poor-bulldogs-sleep.md
+++ b/.changeset/poor-bulldogs-sleep.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix(openapi-parser): use dynamic imports inside the plugin

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -73,7 +73,6 @@
     "@scalar/types": "workspace:*",
     "@types/node": "catalog:*",
     "fastify": "catalog:*",
-    "get-port": "catalog:*",
     "json-to-ast": "^2.1.0",
     "just-diff": "^6.0.2",
     "tinybench": "^2.8.0",

--- a/packages/openapi-parser/src/utils/bundle/bundle.test.ts
+++ b/packages/openapi-parser/src/utils/bundle/bundle.test.ts
@@ -1082,98 +1082,96 @@ describe('bundle', () => {
       })
     })
 
-    describe('hooks', () => {
-      it('run success hook', async () => {
-        const url = `http://localhost:${PORT}`
+    it('run success hook', async () => {
+      const url = `http://localhost:${PORT}`
 
-        const chunk1 = {
-          description: 'Chunk 1',
-        }
+      const chunk1 = {
+        description: 'Chunk 1',
+      }
 
-        server.get('/chunk1', (_, reply) => {
-          reply.send(chunk1)
-        })
-
-        await server.listen({ port: PORT })
-
-        const input = {
-          a: {
-            $ref: `${url}/chunk1#`,
-          },
-        }
-
-        const resolveStart = vi.fn()
-        const resolveError = vi.fn()
-        const resolveSuccess = vi.fn()
-
-        const refA = input.a
-
-        await bundle(input, {
-          plugins: [fetchUrls()],
-          treeShake: false,
-          hooks: {
-            onResolveStart(value) {
-              resolveStart(value)
-            },
-            onResolveError(value) {
-              resolveError(value)
-            },
-            onResolveSuccess(value) {
-              resolveSuccess(value)
-            },
-          },
-        })
-
-        expect(resolveStart).toHaveBeenCalledOnce()
-        expect(resolveStart).toHaveBeenCalledWith(refA)
-        expect(resolveSuccess).toHaveBeenCalledOnce()
-        expect(resolveSuccess).toHaveBeenCalledWith(refA)
-        expect(resolveError).not.toHaveBeenCalledOnce()
+      server.get('/chunk1', (_, reply) => {
+        reply.send(chunk1)
       })
 
-      it('run success hook', async () => {
-        const url = `http://localhost:${PORT}`
+      await server.listen({ port: PORT })
 
-        server.get('/chunk1', (_, reply) => {
-          reply.code(404).send()
-        })
+      const input = {
+        a: {
+          $ref: `${url}/chunk1#`,
+        },
+      }
 
-        await server.listen({ port: PORT })
+      const resolveStart = vi.fn()
+      const resolveError = vi.fn()
+      const resolveSuccess = vi.fn()
 
-        const input = {
-          a: {
-            $ref: `${url}/chunk1#`,
+      const refA = input.a
+
+      await bundle(input, {
+        plugins: [fetchUrls()],
+        treeShake: false,
+        hooks: {
+          onResolveStart(value) {
+            resolveStart(value)
           },
-        }
-
-        const resolveStart = vi.fn()
-        const resolveError = vi.fn()
-        const resolveSuccess = vi.fn()
-
-        const refA = input.a
-
-        await bundle(input, {
-          plugins: [fetchUrls()],
-          treeShake: false,
-          hooks: {
-            onResolveStart(value) {
-              resolveStart(value)
-            },
-            onResolveError(value) {
-              resolveError(value)
-            },
-            onResolveSuccess(value) {
-              resolveSuccess(value)
-            },
+          onResolveError(value) {
+            resolveError(value)
           },
-        })
-
-        expect(resolveStart).toHaveBeenCalledOnce()
-        expect(resolveStart).toHaveBeenCalledWith(refA)
-        expect(resolveSuccess).not.toHaveBeenCalledOnce()
-        expect(resolveError).toHaveBeenCalledOnce()
-        expect(resolveError).toHaveBeenCalledWith(refA)
+          onResolveSuccess(value) {
+            resolveSuccess(value)
+          },
+        },
       })
+
+      expect(resolveStart).toHaveBeenCalledOnce()
+      expect(resolveStart).toHaveBeenCalledWith(refA)
+      expect(resolveSuccess).toHaveBeenCalledOnce()
+      expect(resolveSuccess).toHaveBeenCalledWith(refA)
+      expect(resolveError).not.toHaveBeenCalledOnce()
+    })
+
+    it('run success hook', async () => {
+      const url = `http://localhost:${PORT}`
+
+      server.get('/chunk1', (_, reply) => {
+        reply.code(404).send()
+      })
+
+      await server.listen({ port: PORT })
+
+      const input = {
+        a: {
+          $ref: `${url}/chunk1#`,
+        },
+      }
+
+      const resolveStart = vi.fn()
+      const resolveError = vi.fn()
+      const resolveSuccess = vi.fn()
+
+      const refA = input.a
+
+      await bundle(input, {
+        plugins: [fetchUrls()],
+        treeShake: false,
+        hooks: {
+          onResolveStart(value) {
+            resolveStart(value)
+          },
+          onResolveError(value) {
+            resolveError(value)
+          },
+          onResolveSuccess(value) {
+            resolveSuccess(value)
+          },
+        },
+      })
+
+      expect(resolveStart).toHaveBeenCalledOnce()
+      expect(resolveStart).toHaveBeenCalledWith(refA)
+      expect(resolveSuccess).not.toHaveBeenCalledOnce()
+      expect(resolveError).toHaveBeenCalledOnce()
+      expect(resolveError).toHaveBeenCalledWith(refA)
     })
   })
 

--- a/packages/openapi-parser/src/utils/bundle/bundle.test.ts
+++ b/packages/openapi-parser/src/utils/bundle/bundle.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
 import fastify, { type FastifyInstance } from 'fastify'
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   bundle,
   getHash,
@@ -14,22 +14,21 @@ import {
 } from './bundle'
 import { fetchUrls } from './plugins/fetch-urls'
 import { readFiles } from './plugins/read-files'
-import getPort from 'get-port'
 
 describe('bundle', () => {
   describe('external urls', () => {
     let server: FastifyInstance
+    const PORT = 7289
 
     beforeEach(() => {
       server = fastify({ logger: false })
     })
 
-    afterAll(async () => {
+    afterEach(async () => {
       await server.close()
     })
 
     it('bundles external urls', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       const external = {
@@ -74,7 +73,6 @@ describe('bundle', () => {
     })
 
     it('bundles external urls from resolved external piece', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
       const chunk2 = {
         hey: 'hey',
@@ -137,7 +135,6 @@ describe('bundle', () => {
     })
 
     it('should correctly handle only urls without a pointer', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       server.get('/', (_, reply) => {
@@ -173,7 +170,6 @@ describe('bundle', () => {
 
     it('caches results for same resource', async () => {
       const fn = vi.fn()
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       server.get('/', (_, reply) => {
@@ -217,7 +213,6 @@ describe('bundle', () => {
     })
 
     it('handles correctly external nested refs', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       server.get('/nested/another-file.json', (_, reply) => {
@@ -261,7 +256,6 @@ describe('bundle', () => {
     })
 
     it('does not merge paths when we use absolute urls', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       server.get('/top-level', (_, reply) => {
@@ -305,7 +299,6 @@ describe('bundle', () => {
     })
 
     it('bundles from a url input', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       server.get('/top-level', (_, reply) => {
@@ -351,7 +344,6 @@ describe('bundle', () => {
     })
 
     it('generated a map when we turn the urlMap on', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       server.get('/top-level', (_, reply) => {
@@ -405,7 +397,6 @@ describe('bundle', () => {
     })
 
     it('prefixes the refs only once', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       const chunk2 = {
@@ -489,7 +480,6 @@ describe('bundle', () => {
     })
 
     it('bundles array references', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       const chunk1 = {
@@ -532,7 +522,6 @@ describe('bundle', () => {
     })
 
     it('bundles subpart of the document', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       const chunk1 = {
@@ -621,7 +610,6 @@ describe('bundle', () => {
     })
 
     it('tree shakes the external documents correctly', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       const chunk1 = {
@@ -676,7 +664,6 @@ describe('bundle', () => {
     })
 
     it('tree shakes correctly when working with nested external refs', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       const chunk2 = {
@@ -760,7 +747,6 @@ describe('bundle', () => {
     })
 
     it('handles circular references when we treeshake', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       const chunk1 = {
@@ -816,7 +802,6 @@ describe('bundle', () => {
     })
 
     it('handles chunks', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       const chunk1 = {
@@ -910,7 +895,6 @@ describe('bundle', () => {
     })
 
     it('when bundle partial document we ensure all the dependencies references are resolved', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       const chunk1 = {
@@ -972,7 +956,6 @@ describe('bundle', () => {
     })
 
     it('should correctly handle nested chunk urls', async () => {
-      const PORT = await getPort()
       const url = `http://localhost:${PORT}`
 
       const chunk1 = {
@@ -1101,7 +1084,6 @@ describe('bundle', () => {
 
     describe('hooks', () => {
       it('run success hook', async () => {
-        const PORT = await getPort()
         const url = `http://localhost:${PORT}`
 
         const chunk1 = {
@@ -1150,7 +1132,6 @@ describe('bundle', () => {
       })
 
       it('run success hook', async () => {
-        const PORT = await getPort()
         const url = `http://localhost:${PORT}`
 
         server.get('/chunk1', (_, reply) => {

--- a/packages/openapi-parser/src/utils/bundle/plugins/fetch-urls.test.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/fetch-urls.test.ts
@@ -2,12 +2,12 @@ import { fastify, type FastifyInstance } from 'fastify'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchUrl } from './fetch-urls'
 import assert from 'node:assert'
-import getPort from 'get-port'
 
 describe('fetchUrl', () => {
   const noLimit = <T>(fn: () => Promise<T>) => fn()
 
   let server: FastifyInstance
+  const PORT = 7291
 
   beforeEach(() => {
     server = fastify({ logger: false })
@@ -18,7 +18,6 @@ describe('fetchUrl', () => {
   })
 
   it('reads json response', async () => {
-    const PORT = await getPort()
     const url = `http://localhost:${PORT}`
 
     const response = {
@@ -39,7 +38,6 @@ describe('fetchUrl', () => {
   })
 
   it('reads yaml response', async () => {
-    const PORT = await getPort()
     const url = `http://localhost:${PORT}`
 
     server.get('/', (_, reply) => {
@@ -56,7 +54,6 @@ describe('fetchUrl', () => {
   })
 
   it('returns error on non-200 response', async () => {
-    const PORT = await getPort()
     const url = `http://localhost:${PORT}`
 
     server.get('/', (_, reply) => {
@@ -71,7 +68,6 @@ describe('fetchUrl', () => {
   })
 
   it('send headers to the specified domain', async () => {
-    const PORT = await getPort()
     const url = `http://localhost:${PORT}`
     const fn = vi.fn()
 
@@ -103,7 +99,6 @@ describe('fetchUrl', () => {
   })
 
   it('does not send headers to other domains', async () => {
-    const PORT = await getPort()
     const url = `http://localhost:${PORT}`
     const fn = vi.fn()
 

--- a/packages/openapi-parser/src/utils/bundle/plugins/read-files.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/read-files.ts
@@ -1,8 +1,6 @@
 import { normalize } from '@/utils/normalize'
 import { isRemoteUrl, type Plugin, type ResolveResult } from '@/utils/bundle/bundle'
 
-const fs = typeof window === 'undefined' ? await import('node:fs/promises') : undefined
-
 /**
  * Reads and normalizes data from a local file
  * @param path - The file path to read from
@@ -18,6 +16,8 @@ const fs = typeof window === 'undefined' ? await import('node:fs/promises') : un
  * ```
  */
 export async function readFile(path: string): Promise<ResolveResult> {
+  const fs = typeof window === 'undefined' ? await import('node:fs/promises') : undefined
+
   if (fs === undefined) {
     throw 'Can not use readFiles plugin outside of a node environment'
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ catalogs:
     fastify:
       specifier: ^4.26.2
       version: 4.28.0
-    get-port:
-      specifier: 7.1.0
-      version: 7.1.0
     nanoid:
       specifier: ^5.1.5
       version: 5.1.5
@@ -1978,9 +1975,6 @@ importers:
       fastify:
         specifier: catalog:*
         version: 4.28.0
-      get-port:
-        specifier: catalog:*
-        version: 7.1.0
       json-to-ast:
         specifier: ^2.1.0
         version: 2.1.0
@@ -12106,10 +12100,6 @@ packages:
 
   get-port-please@3.1.2:
     resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
-
-  get-port@7.1.0:
-    resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
-    engines: {node: '>=16'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -32045,8 +32035,6 @@ snapshots:
   get-package-type@0.1.0: {}
 
   get-port-please@3.1.2: {}
-
-  get-port@7.1.0: {}
 
   get-proto@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,6 @@ catalogs:
     commander: 13.1.0
     express: ^5.1.0
     fastify: ^4.26.2
-    get-port: 7.1.0
     nanoid: ^5.1.5
     next: ^15.2.3
     postcss: ^8.4.38


### PR DESCRIPTION
**Problem**

Currently, we're performing dynamic imports at the top level, which causes issues with Vite, particularly due to top-level await not being supported in all contexts.


**Solution**

This PR moves the dynamic imports inside the plugin definition, ensuring they're executed only when needed.
We also stabilize test behavior by using static ports, ensuring consistent values for the same files across test runs.

**Checklist**

I’ve gone through the following:

- [X] I’ve added an explanation _why_ this change is needed.
- [X] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
