### PR TITLE
feat(workspace-store): create a sync client store

### DIFF
--- a/.changeset/poor-crabs-lay.md
+++ b/.changeset/poor-crabs-lay.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': minor
+---
+
+feat(workspace-store): create a sync client store

--- a/packages/workspace-store/src/create-workspace-store.ts
+++ b/packages/workspace-store/src/create-workspace-store.ts
@@ -60,6 +60,7 @@ async function loadDocument(workspaceDocument: WorkspaceDocumentInput) {
  * @param workspaceProps.meta - Optional metadata for the workspace
  * @param workspaceProps.documents - Optional record of documents to initialize the workspace with
  * @returns An object containing methods and getters for managing the workspace
+ * @deprecated Use `createWorkspaceStore` instead.
  */
 export function createWorkspaceStoreSync(workspaceProps?: {
   meta?: WorkspaceMeta
@@ -221,6 +222,32 @@ export function createWorkspaceStoreSync(workspaceProps?: {
   }
 }
 
+/**
+ * Creates a reactive workspace store that manages documents and their metadata.
+ * The store provides functionality for accessing, updating, and resolving document references.
+ *
+ * @param workspaceProps - Configuration object for the workspace
+ * @param workspaceProps.meta - Optional metadata for the workspace
+ * @param workspaceProps.documents - Optional record of documents to initialize the workspace with
+ * @returns An object containing methods and getters for managing the workspace
+ * @example
+ * // Create a workspace store with metadata and documents
+ * const store = await createWorkspaceStore({
+ *   meta: {
+ *     name: 'My Workspace',
+ *     description: 'A workspace for my API'
+ *   },
+ *   documents: [
+ *     {
+ *       name: 'petstore',
+ *       document: {
+ *         openapi: '3.0.0',
+ *         info: { title: 'Petstore API' }
+ *       }
+ *     }
+ *   ]
+ * })
+ */
 export async function createWorkspaceStore(workspaceProps?: {
   meta?: WorkspaceMeta
   documents?: WorkspaceDocumentInput[]

--- a/packages/workspace-store/src/index.ts
+++ b/packages/workspace-store/src/index.ts
@@ -1,5 +1,5 @@
 export { createServerWorkspaceStore } from './create-server-workspace-store'
-export { createWorkspaceStore } from './create-workspace-store'
+export { createWorkspaceStore, createWorkspaceStoreSync } from './create-workspace-store'
 export {
   WorkspaceSchema,
   type Workspace,


### PR DESCRIPTION
**Problem**

Currently, on the `api-client` package we don't support top level awaits

**Solution**

With this PR we introduce a sync store so we can use it on the `api-client` package

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
