### PR TITLE
fix(api-reference): fix markdown styles pt2

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -432,6 +432,11 @@ const shouldRenderArrayOfObjects = computed(() => hasComplexArrayItems.value)
   font-size: var(--scalar-mini);
   position: relative;
 }
+.property.property--level-0:has(
+    .property-rule .schema-properties.schema-properties-open > ul li.property
+  ) {
+  padding-top: 0;
+}
 /* increase z-index for example hovers */
 .property:hover {
   z-index: 1;

--- a/packages/api-reference/src/components/DocumentSelector/DocumentSelector.vue
+++ b/packages/api-reference/src/components/DocumentSelector/DocumentSelector.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
-import {
-  ScalarIcon,
-  ScalarListbox,
-  type ScalarListboxOption,
-} from '@scalar/components'
+import { ScalarListbox, type ScalarListboxOption } from '@scalar/components'
+import { ScalarIconCaretUpDown } from '@scalar/icons'
 import type { SpecConfiguration } from '@scalar/types/api-reference'
 import { computed } from 'vue'
 
@@ -44,20 +41,13 @@ const selectedOption = computed({
         <div
           class="group/dropdown-label hover:bg-b-2 text-c-2 flex w-full cursor-pointer items-center rounded border py-1.75 pr-1.5 pl-1.75"
           tabindex="0">
-          <ScalarIcon
-            class="mr-1.25 min-w-4"
-            icon="Versions"
-            size="sm"
-            thickness="2" />
+          <ScalarIconCaretUpDown
+            class="mr-1.5 h-3 w-3 text-current"
+            weight="bold" />
           <span
             class="text-c-1 overflow-hidden text-sm font-medium text-ellipsis">
             {{ selectedOption?.label || 'Select API' }}
           </span>
-          <ScalarIcon
-            class="group-hover/dropdown-label:text-c-1 mr-2 ml-auto"
-            icon="ChevronDown"
-            size="sm"
-            thickness="2" />
         </div>
       </ScalarListbox>
     </div>

--- a/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
+++ b/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
@@ -24,14 +24,14 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
 <template>
   <div
     v-if="!config?.hideDownloadButton"
-    class="download-container">
+    class="download-container group">
     <button
       type="button"
       class="download-button"
       @click.prevent="handleDownloadClick('json')"
       variant="ghost">
       <span> Download OpenAPI Document </span>
-      <Badge class="extension">json</Badge>
+      <Badge class="extension hidden group-hover:flex">json</Badge>
     </button>
     <button
       type="button"
@@ -39,7 +39,7 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
       @click.prevent="handleDownloadClick('yaml')"
       variant="ghost">
       <span> Download OpenAPI Document </span>
-      <Badge class="extension">yaml</Badge>
+      <Badge class="extension hidden group-hover:flex">yaml</Badge>
     </button>
   </div>
 </template>
@@ -51,7 +51,7 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin: 4px 0 24px;
+  margin: 0 0 24px;
   position: relative;
   width: fit-content;
   z-index: 0;
@@ -60,7 +60,7 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
 .download-container:has(:focus-visible)::before,
 .download-container:hover::before {
   content: '';
-  width: calc(100% + 76px);
+  width: calc(100% + 24px);
   height: 90px;
   position: absolute;
   top: -11px;
@@ -75,11 +75,13 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
   color: var(--scalar-link-color);
   cursor: pointer;
   display: flex;
+  align-items: center;
+  justify-content: center;
   gap: 4px;
   height: fit-content;
   padding: 0;
   position: relative;
-  white-space: nowrap;
+  white-space: nowrap !important;
 
   outline: none;
 }
@@ -91,7 +93,7 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
   left: -9px;
   position: absolute;
   top: -8px;
-  width: calc(100% + 70px);
+  width: calc(100% + 18px);
 }
 
 .download-button:hover::before {
@@ -106,19 +108,27 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
 }
 
 .download-button span {
+  --font-color: var(--scalar-link-color, var(--scalar-color-accent));
+  --font-visited: var(--scalar-link-color-visited, var(--scalar-color-2));
+
+  text-decoration: var(--scalar-text-decoration);
+  color: var(--font-color);
+  font-weight: var(--scalar-link-font-weight, var(--scalar-semibold));
+  text-underline-offset: 0.25rem;
+  text-decoration-thickness: 1px;
+  text-decoration-color: color-mix(in srgb, var(--font-color) 30%, transparent);
   align-items: center;
-  color: var(--scalar-link-color);
   display: flex;
-  font-size: var(--scalar-font-size-2);
-  font-weight: var(--scalar-regular);
   gap: 6px;
   line-height: 1.625;
   z-index: 1;
 }
 
 .download-button:hover span {
+  text-decoration-color: var(currentColor, var(--scalar-color-1));
+  color: var(--scalar-link-color-hover, var(--scalar-color-accent));
+  -webkit-text-decoration: var(--scalar-text-decoration-hover);
   text-decoration: var(--scalar-text-decoration-hover);
-  text-underline-offset: 2px;
 }
 
 /* Second button displayed when hovering over the download container */
@@ -135,12 +145,9 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
 }
 
 .extension {
-  left: calc(100% + 8px);
-  opacity: 0;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
   z-index: 1;
+  background: var(--scalar-link-color, var(--scalar-color-accent));
+  color: var(--scalar-background-1);
 }
 .download-container:has(:focus-visible) .extension,
 .download-container:hover .extension {

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -3,7 +3,7 @@
 .scalar-app {
   /* Base container and variables */
   .markdown {
-    --scalar-heading-spacing: 44px;
+    --scalar-refs-heading-spacing: 24px;
     --markdown-border: var(--scalar-border-width) solid var(--scalar-border-color);
     --markdown-spacing-sm: 12px;
     --markdown-spacing-md: 16px;
@@ -17,6 +17,10 @@
     margin-bottom: var(--markdown-spacing-md);
   }
 
+  /* margin gets doubled between heading + non heading elements if we don't do this*/
+  .markdown > *:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):last-child {
+    margin-bottom: 0;
+  }
   /* Headings (h1-h6) */
   .markdown h1 {
     --font-size: 1.5rem;
@@ -44,7 +48,7 @@
     display: block;
     font-size: var(--font-size);
     font-weight: var(--scalar-bold);
-    margin-top: var(--scalar-heading-spacing);
+    margin-top: var(--scalar-refs-heading-spacing);
     margin-bottom: var(--markdown-spacing-sm);
     scroll-margin-top: 1rem;
   }
@@ -298,18 +302,22 @@
 
   /* Links */
   .markdown a {
-    --font-color: var(--scalar-color-1);
-    --font-visited: var(--scalar-color-2);
+    --font-color: var(--scalar-link-color, var(--scalar-color-accent));
+    --font-visited: var(--scalar-link-color-visited, var(--scalar-color-2));
+    text-decoration: var(--scalar-text-decoration);
 
     color: var(--font-color);
-    font-weight: var(--scalar-semibold);
+    font-weight: var(--scalar-link-font-weight, var(--scalar-semibold));
     text-underline-offset: 0.25rem;
     text-decoration-thickness: 1px;
-    text-decoration-color: color-mix(in srgb, var(--font-color, var(--scalar-color-1)) 30%, transparent);
+    text-decoration-color: color-mix(in srgb, var(--font-color) 30%, transparent);
   }
 
   .markdown a:hover {
-    text-decoration-color: var(--scalar-color-1);
+    text-decoration-color: var(currentColor, var(--scalar-color-1));
+    color: var(--scalar-link-color-hover, var(--scalar-color-accent));
+    -webkit-text-decoration: var(--scalar-text-decoration-hover);
+    text-decoration: var(--scalar-text-decoration-hover);
   }
 
   .markdown a:visited {

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -1,4 +1,8 @@
 /* basic theme */
+:root {
+  --scalar-text-decoration: underline;
+  --scalar-text-decoration-hover: underline;
+}
 .light-mode {
   --scalar-background-1: #fff;
   --scalar-background-2: #f6f6f6;
@@ -9,7 +13,7 @@
   --scalar-color-2: #757575;
   --scalar-color-3: #8e8e8e;
 
-  --scalar-color-accent: #0099ff;
+  --scalar-color-accent: var(--scalar-color-1);
   --scalar-border-color: #dfdfdf;
 }
 .dark-mode {
@@ -21,7 +25,7 @@
   --scalar-color-2: #a4a4a4;
   --scalar-color-3: #797979;
 
-  --scalar-color-accent: #3ea6ff;
+  --scalar-color-accent: var(--scalar-color-1);
   --scalar-background-accent: #3ea6ff1f;
 
   --scalar-border-color: #2d2d2d;
@@ -92,7 +96,7 @@
 }
 @supports (color: color(display-p3 1 1 1)) {
   .light-mode {
-    --scalar-color-accent: color(display-p3 0.0 0.6 1.0 / 1.0);
+    --scalar-color-accent: var(--scalar-color-1);
     --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1.0);
     --scalar-color-red: color(display-p3 0.937255 0.0 0.023529 / 1.0);
     --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1.0);
@@ -101,7 +105,7 @@
     --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1.0);
   }
   .dark-mode {
-    --scalar-color-accent: color(display-p3 0.243137 0.65098 1.0 / 1.0);
+    --scalar-color-accent: var(--scalar-color-1);
     --scalar-color-green: color(display-p3 0.0 0.713725 0.282353 / 1.0);
     --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1.0);
     --scalar-color-yellow: color(display-p3 1.0 0.788235 0.05098 / 1.0);


### PR DESCRIPTION
updated markdown styles

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8223a4d5-c7f0-4bef-96e6-e239a2c0a543" />


note reduced header margin from figmas as we decided this was the play 

(bonus also changed document selector UI + download OpenAPI file badge styles)
