### PR TITLE
fix(api-reference): display multipleof heading

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -358,4 +358,18 @@ describe('SchemaPropertyHeading', () => {
     const detailsElement = wrapper.find('.property-heading')
     expect(detailsElement.text()).toContain('array Planet[]')
   })
+
+  it('renders multipleOf property', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: {
+          type: 'number',
+          multipleOf: 0.001,
+        },
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('multiple of:')
+    expect(detailsElement.text()).toContain('0.001')
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -249,6 +249,10 @@ const modelName = computed(() => {
         <template #prefix>max:</template>
         {{ value.maximum }}
       </SchemaPropertyDetail>
+      <SchemaPropertyDetail v-if="value.multipleOf !== undefined">
+        <template #prefix>multiple of:</template>
+        {{ value.multipleOf }}
+      </SchemaPropertyDetail>
       <SchemaPropertyDetail
         v-if="value.pattern"
         code

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
-import { isDefined } from '@scalar/oas-utils/helpers'
+import { isDefined } from '@scalar/helpers/array/is-defined'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import { stringify } from 'flatted'
 import { computed } from 'vue'
 
 import SchemaPropertyExamples from '@/components/Content/Schema/SchemaPropertyExamples.vue'
@@ -230,26 +229,26 @@ const modelName = computed(() => {
         {{ value.format }}
       </SchemaPropertyDetail>
       <SchemaPropertyDetail
-        v-if="value.minimum !== undefined && value.exclusiveMinimum">
+        v-if="isDefined(value.minimum) && value.exclusiveMinimum">
         <template #prefix>greater than:</template>
         {{ value.minimum }}
       </SchemaPropertyDetail>
       <SchemaPropertyDetail
-        v-if="value.minimum !== undefined && !value.exclusiveMinimum">
+        v-if="isDefined(value.minimum) && !value.exclusiveMinimum">
         <template #prefix>min:</template>
         {{ value.minimum }}
       </SchemaPropertyDetail>
       <SchemaPropertyDetail
-        v-if="value.maximum !== undefined && value.exclusiveMaximum">
+        v-if="isDefined(value.maximum) && value.exclusiveMaximum">
         <template #prefix>less than:</template>
         {{ value.maximum }}
       </SchemaPropertyDetail>
       <SchemaPropertyDetail
-        v-if="value.maximum !== undefined && !value.exclusiveMaximum">
+        v-if="isDefined(value.maximum) && !value.exclusiveMaximum">
         <template #prefix>max:</template>
         {{ value.maximum }}
       </SchemaPropertyDetail>
-      <SchemaPropertyDetail v-if="value.multipleOf !== undefined">
+      <SchemaPropertyDetail v-if="isDefined(value.multipleOf)">
         <template #prefix>multiple of:</template>
         {{ value.multipleOf }}
       </SchemaPropertyDetail>


### PR DESCRIPTION
**Problem**

currently `multipleOf` is not getting displayed in the property heading.

**Solution**

this pr displays `multipleOf` in schema property heading. fixes #5720 

| state | preview |
| -------|------|
| before | <img width="624" alt="image" src="https://github.com/user-attachments/assets/87b2619f-e11f-4cdd-a400-050dba71590e" /> |
| after | <img width="624" alt="image" src="https://github.com/user-attachments/assets/dc093cd7-323c-4567-b22a-4e01e09ca680" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
