### PR TITLE
fix(helpers): ensure .js extension is emitted for imports

### DIFF
--- a/.changeset/rotten-laws-shop.md
+++ b/.changeset/rotten-laws-shop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+fix(helpers): ensure .js extension is emitted for imports

--- a/packages/helpers/tsconfig.json
+++ b/packages/helpers/tsconfig.json
@@ -1,6 +1,5 @@
 {
-  "extends": "../../tsconfig.strict.json",
-  "include": ["src"],
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
**Problem**

The `@scalar/helpers` package currently emits import statements without file extensions in the output. This causes issues in environments like Webpack (when fullySpecified: true is enabled) or when using ESM in Node.js, where explicit file extensions are required.

**Solution**

This PR updates the build process to include .js file extensions in internal import paths, ensuring compatibility with ESM and bundlers that enforce fully specified imports.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
