### PR TITLE
fix(integrations): some typos in the laravel doc

### DIFF
--- a/documentation/integrations/laravel-scribe.md
+++ b/documentation/integrations/laravel-scribe.md
@@ -93,7 +93,7 @@ Done! Are you ready to generate your (first?) OpenAPI file like this:
 php artisan scribe:generate
 ```
 
-If you’re curioius how it looks, take a peek at the file (`storage/app/scribe/openapi.yaml`). The YAML file should describe you’re API. If you’ve just set up a new Laravel project, it has probably one route (`/api/user`).
+If you’re curious how it looks, take a peek at the file (`storage/app/scribe/openapi.yaml`). The YAML file should describe your API. If you’ve just set up a new Laravel project, it has probably one route (`/api/user`).
 
 Time to look at your new API reference. Start the PHP server again (`php artisan serve`) and open the following URL in your browser:
 


### PR DESCRIPTION
**Problem**

Currently, the doc specifically related to the laravel integration with Scribe had some typos, "curious" is curioius and  the sentence "The YAML file should describe you’re API." 

**Solution**

With this PR I fixed these typos.

**Checklist**

I’ve gone through the following:

- [ x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
