### PR TITLE
feat(api-reference): curl example style

### DIFF
--- a/.changeset/gentle-rules-sparkle.md
+++ b/.changeset/gentle-rules-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+feat: updates hljs curl language style

--- a/packages/code-highlight/src/css/code.css
+++ b/packages/code-highlight/src/css/code.css
@@ -165,20 +165,12 @@
   color: var(--scalar-color-2);
 }
 
-.hljs.language-curl .hljs-keyword {
-  color: var(--scalar-color-orange);
-}
-
 .hljs.language-curl .hljs-string {
+  color: var(--scalar-color-blue);
+}
+
+.hljs.language-curl .hljs-literal {
   color: var(--scalar-color-1);
-}
-
-.hljs.language-curl .hljs-literal {
-  color: var(--scalar-color-blue);
-}
-
-.hljs.language-curl .hljs-literal {
-  color: var(--scalar-color-blue);
 }
 
 /** Compromise here */


### PR DESCRIPTION
**Solution**

this pr is a proposal to update the curl language style used in reference example to increase consistency with response style.

| state | preview |
| -------|------|
| before | <img width="547" alt="image" src="https://github.com/user-attachments/assets/1fc93377-66c7-4df4-a971-5c363e40a505" /> |
| after | <img width="547" alt="image" src="https://github.com/user-attachments/assets/ad7d4e63-e6c8-413c-9890-af237a323896" /> | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
