### PR TITLE
chore(configuration): adds .output exclusion to workspace configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
   - projects/**/*
   - '!**/.next/**'
   - '!**/dist/**'
+  - '!**/.output/**'
 onlyBuiltDependencies:
   - '@biomejs/biome'
   - '@todesktop/cli'


### PR DESCRIPTION
**Problem**

currently on pnpm command run, he workspace has conflict between two @scalar-examples/nuxt-playground-prod packages.

**Solution**

this pr adds the exclusion of `!**/.output/**` to the pnpm workspace configuration in order to prevent having package.json files that can have duplicate names across different examples/integrations.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
