### PR TITLE
fix(workspace-store): remove readFiles plugin from the client store

### DIFF
--- a/.changeset/many-books-fix.md
+++ b/.changeset/many-books-fix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix(workspace-store): remove readFiles plugin from the client store

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -4,14 +4,12 @@ import { createMagicProxy } from './helpers/proxy'
 import { isObject } from '@/helpers/general'
 import { getValueByPath } from '@/helpers/json-path-utils'
 import { bundle } from '@scalar/openapi-parser'
-import { readFiles } from '@scalar/openapi-parser/utils/bundle/plugins/read-files'
 import { fetchUrls } from '@scalar/openapi-parser/utils/bundle/plugins/fetch-urls'
 
 type WorkspaceDocumentMetaInput = { meta?: WorkspaceDocumentMeta; name: string }
 type WorkspaceDocumentInput =
   | ({ document: Record<string, unknown> } & WorkspaceDocumentMetaInput)
   | ({ url: string } & WorkspaceDocumentMetaInput)
-  | ({ path: string } & WorkspaceDocumentMetaInput)
 
 /**
  * Resolves a workspace document from various input sources (URL, local file, or direct document object).
@@ -40,10 +38,6 @@ type WorkspaceDocumentInput =
 async function loadDocument(workspaceDocument: WorkspaceDocumentInput) {
   if ('url' in workspaceDocument) {
     return fetchUrls().exec(workspaceDocument.url)
-  }
-
-  if ('path' in workspaceDocument) {
-    return readFiles().exec(workspaceDocument.path)
   }
 
   return {

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -173,7 +173,7 @@ export function createWorkspaceStoreSync(workspaceProps?: {
       return bundle(target, {
         root: activeDocument,
         treeShake: false,
-        plugins: [fetchUrls(), readFiles()],
+        plugins: [fetchUrls()],
         urlMap: false,
         hooks: {
           onResolveStart: (node) => {


### PR DESCRIPTION
**Problem**

We were previously handling file reading logic directly within the client-side store. This approach is incompatible with Webpack builds, leading to bundling issues since fs and related Node APIs are not available in the browser environment.

**Solution**

This PR removes the readFile plugin from the client store to resolve the Webpack compatibility issues. Instead, we rely solely on the fetchUrls plugin for loading document content in environments where direct file system access isn't available.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
