### PR TITLE
feat(scalar_fastapi): add `hide_client_button` to configuration

### DIFF
--- a/integrations/fastapi/README.md
+++ b/integrations/fastapi/README.md
@@ -44,6 +44,7 @@ Currently available [configuration options](https://github.com/scalar/scalar/blo
 - `servers` (default `[]`)
 - `default_open_all_tags` (default `false`)
 - `authentication` (default `{}`)
+- `hide_client_button`(default `false`)
 
 ## Example
 

--- a/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
@@ -283,6 +283,15 @@ def get_scalar_api_reference(
             """
         ),
     ] = {},
+    hide_client_button: Annotated[
+        bool,
+        Doc(
+            """
+            Whether to show the client button from the reference sidebar and modal
+            Default is False which means the client button is shown.
+            """
+        ),
+    ] = False,
     integration: Annotated[
         str | None,
         Doc(
@@ -332,6 +341,7 @@ def get_scalar_api_reference(
         servers: {json.dumps(servers)},
         defaultOpenAllTags: {json.dumps(default_open_all_tags)},
         authentication: {json.dumps(authentication)},
+        hideClientButton: {json.dumps(hide_client_button)},
         _integration: {json.dumps(integration)},
       }}
 

--- a/integrations/fastapi/setup.py
+++ b/integrations/fastapi/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='scalar_fastapi',
-    version='1.1.0',
+    version='1.2.0',
     packages=find_packages(),
     install_requires=[
         # Add your package dependencies here


### PR DESCRIPTION
**Problem**

Currently, [`hideClientButton`](https://github.com/scalar/scalar/blob/main/documentation/configuration.md#hideclientbutton-boolean) configuration is not available in FastAPI configuration.

**Solution**

With this PR, `hide_client_button` is added as configuration parameter to `get_scalar_api_reference`.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
