### PR TITLE
feat(openapi-parser): introduce parseJson and parseYaml plugins for bundler

### DIFF
--- a/.changeset/three-crabs-care.md
+++ b/.changeset/three-crabs-care.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': minor
+---
+
+feat(openapi-parser): introduce parseJson and parseYaml plugins for bundler

--- a/packages/openapi-parser/README.md
+++ b/packages/openapi-parser/README.md
@@ -174,7 +174,8 @@ console.log(result)
 This plugins handles local files. Only works on node.js environment
 
 ```ts
-import { bundle, readFiles } from '@scalar/openapi-parser'
+import { bundle } from '@scalar/openapi-parser'
+import { readFiles } from '@scalar/openapi-parser/plugins-browser'
 
 const document = {
   openapi: '3.1.0',
@@ -205,6 +206,48 @@ const result = await bundle(
   {
     plugins: [
       readFiles(),
+    ],
+    treeShake: false
+  },
+)
+
+// Bundled document
+console.log(result)
+```
+
+##### parseJson
+
+You can pass raw json string as input
+```ts
+import { bundle } from '@scalar/openapi-parser'
+import { parseJson } from '@scalar/openapi-parser/plugins-browser'
+
+const result = await bundle(
+  '{ "openapi": "3.1.1" }',
+  {
+    plugins: [
+      parseJson(),
+    ],
+    treeShake: false
+  },
+)
+
+// Bundled document
+console.log(result)
+```
+
+##### parseYaml
+
+You can pass raw yaml string as input
+```ts
+import { bundle } from '@scalar/openapi-parser'
+import { parseYaml } from '@scalar/openapi-parser/plugins-browser'
+
+const result = await bundle(
+  'openapi: "3.1.1"\n',
+  {
+    plugins: [
+      parseYaml(),
     ],
     treeShake: false
   },

--- a/packages/openapi-parser/src/plugins-browser.ts
+++ b/packages/openapi-parser/src/plugins-browser.ts
@@ -1,1 +1,3 @@
 export { fetchUrls } from './utils/bundle/plugins/fetch-urls'
+export { parseJson } from './utils/bundle/plugins/parse-json'
+export { parseYaml } from './utils/bundle/plugins/parse-yaml'

--- a/packages/openapi-parser/src/plugins.ts
+++ b/packages/openapi-parser/src/plugins.ts
@@ -1,2 +1,4 @@
 export { fetchUrls } from './utils/bundle/plugins/fetch-urls'
 export { readFiles } from './utils/bundle/plugins/read-files'
+export { parseJson } from './utils/bundle/plugins/parse-json'
+export { parseYaml } from './utils/bundle/plugins/parse-yaml'

--- a/packages/openapi-parser/src/utils/bundle/bundle.test.ts
+++ b/packages/openapi-parser/src/utils/bundle/bundle.test.ts
@@ -15,9 +15,11 @@ import {
 import { fetchUrls } from './plugins/fetch-urls'
 import { readFiles } from './plugins/read-files'
 import { setTimeout } from 'node:timers/promises'
+import { parseJson } from '@/utils/bundle/plugins/parse-json'
+import { parseYaml } from '@/utils/bundle/plugins/parse-yaml'
 
 describe('bundle', () => {
-  describe('external urls', () => {
+  describe.skip('external urls', () => {
     let server: FastifyInstance
     const PORT = 7289
 
@@ -1192,7 +1194,7 @@ describe('bundle', () => {
     })
   })
 
-  describe('local files', () => {
+  describe.skip('local files', () => {
     it('resolves from local files', async () => {
       const chunk1 = { a: 'a', b: 'b' }
       const chunk1Path = randomUUID()
@@ -1345,9 +1347,43 @@ describe('bundle', () => {
       })
     })
   })
+
+  describe('json inputs', () => {
+    it('should process json inputs', async () => {
+      const result = await bundle('{ "openapi": "3.1", "info": { "title": "Simple API", "version": "1.0" } }', {
+        treeShake: false,
+        plugins: [parseJson()],
+      })
+
+      expect(result).toEqual({
+        openapi: '3.1',
+        info: {
+          title: 'Simple API',
+          version: '1.0',
+        },
+      })
+    })
+  })
+
+  describe('yaml inputs', () => {
+    it('should process yaml inputs', async () => {
+      const result = await bundle('openapi: "3.1"\ninfo:\n  title: Simple API\n  version: "1.0"\n', {
+        treeShake: false,
+        plugins: [parseYaml()],
+      })
+
+      expect(result).toEqual({
+        openapi: '3.1',
+        info: {
+          title: 'Simple API',
+          version: '1.0',
+        },
+      })
+    })
+  })
 })
 
-describe('isRemoteUrl', () => {
+describe.skip('isRemoteUrl', () => {
   it.each([
     ['https://example.com/schema.json', true],
     ['http://api.example.com/schemas/user.json', true],
@@ -1360,7 +1396,7 @@ describe('isRemoteUrl', () => {
   })
 })
 
-describe('isLocalRef', () => {
+describe.skip('isLocalRef', () => {
   it.each([
     ['#/components/schemas/User', true],
     ['https://example.com/schema.json', false],
@@ -1370,7 +1406,7 @@ describe('isLocalRef', () => {
   })
 })
 
-describe('getNestedValue', () => {
+describe.skip('getNestedValue', () => {
   it.each([
     [{ a: { b: { c: 'hello' } } }, ['a', 'b', 'c'], 'hello'],
     [{ a: { b: { c: 'hello' } } }, [], { a: { b: { c: 'hello' } } }],
@@ -1381,7 +1417,7 @@ describe('getNestedValue', () => {
   })
 })
 
-describe('prefixInternalRef', () => {
+describe.skip('prefixInternalRef', () => {
   it.each([
     ['#/hello', ['prefix'], '#/prefix/hello'],
     ['#/a/b/c', ['prefixA', 'prefixB'], '#/prefixA/prefixB/a/b/c'],
@@ -1394,7 +1430,7 @@ describe('prefixInternalRef', () => {
   })
 })
 
-describe('prefixInternalRefRecursive', () => {
+describe.skip('prefixInternalRefRecursive', () => {
   it.each([
     [
       { a: { $ref: '#/a/b' }, b: { $ref: '#' } },
@@ -1412,7 +1448,7 @@ describe('prefixInternalRefRecursive', () => {
   })
 })
 
-describe('setValueAtPath', () => {
+describe.skip('setValueAtPath', () => {
   it.each([
     [{}, '/a/b/c', { hello: 'hi' }, { a: { b: { c: { hello: 'hi' } } } }],
     [{ a: { b: 'b' } }, '/a/c', { hello: 'hi' }, { a: { b: 'b', c: { hello: 'hi' } } }],

--- a/packages/openapi-parser/src/utils/bundle/bundle.test.ts
+++ b/packages/openapi-parser/src/utils/bundle/bundle.test.ts
@@ -19,7 +19,7 @@ import { parseJson } from '@/utils/bundle/plugins/parse-json'
 import { parseYaml } from '@/utils/bundle/plugins/parse-yaml'
 
 describe('bundle', () => {
-  describe.skip('external urls', () => {
+  describe('external urls', () => {
     let server: FastifyInstance
     const PORT = 7289
 
@@ -1194,7 +1194,7 @@ describe('bundle', () => {
     })
   })
 
-  describe.skip('local files', () => {
+  describe('local files', () => {
     it('resolves from local files', async () => {
       const chunk1 = { a: 'a', b: 'b' }
       const chunk1Path = randomUUID()
@@ -1383,7 +1383,7 @@ describe('bundle', () => {
   })
 })
 
-describe.skip('isRemoteUrl', () => {
+describe('isRemoteUrl', () => {
   it.each([
     ['https://example.com/schema.json', true],
     ['http://api.example.com/schemas/user.json', true],
@@ -1396,7 +1396,7 @@ describe.skip('isRemoteUrl', () => {
   })
 })
 
-describe.skip('isLocalRef', () => {
+describe('isLocalRef', () => {
   it.each([
     ['#/components/schemas/User', true],
     ['https://example.com/schema.json', false],
@@ -1406,7 +1406,7 @@ describe.skip('isLocalRef', () => {
   })
 })
 
-describe.skip('getNestedValue', () => {
+describe('getNestedValue', () => {
   it.each([
     [{ a: { b: { c: 'hello' } } }, ['a', 'b', 'c'], 'hello'],
     [{ a: { b: { c: 'hello' } } }, [], { a: { b: { c: 'hello' } } }],
@@ -1417,7 +1417,7 @@ describe.skip('getNestedValue', () => {
   })
 })
 
-describe.skip('prefixInternalRef', () => {
+describe('prefixInternalRef', () => {
   it.each([
     ['#/hello', ['prefix'], '#/prefix/hello'],
     ['#/a/b/c', ['prefixA', 'prefixB'], '#/prefixA/prefixB/a/b/c'],
@@ -1430,7 +1430,7 @@ describe.skip('prefixInternalRef', () => {
   })
 })
 
-describe.skip('prefixInternalRefRecursive', () => {
+describe('prefixInternalRefRecursive', () => {
   it.each([
     [
       { a: { $ref: '#/a/b' }, b: { $ref: '#' } },
@@ -1448,7 +1448,7 @@ describe.skip('prefixInternalRefRecursive', () => {
   })
 })
 
-describe.skip('setValueAtPath', () => {
+describe('setValueAtPath', () => {
   it.each([
     [{}, '/a/b/c', { hello: 'hi' }, { a: { b: { c: { hello: 'hi' } } } }],
     [{ a: { b: 'b' } }, '/a/c', { hello: 'hi' }, { a: { b: 'b', c: { hello: 'hi' } } }],

--- a/packages/openapi-parser/src/utils/bundle/bundle.test.ts
+++ b/packages/openapi-parser/src/utils/bundle/bundle.test.ts
@@ -1351,6 +1351,8 @@ describe('isRemoteUrl', () => {
   it.each([
     ['https://example.com/schema.json', true],
     ['http://api.example.com/schemas/user.json', true],
+    ['file://some/path', false],
+    ['random-string', false],
     ['#/components/schemas/User', false],
     ['./local-schema.json', false],
   ])('detects remote urls', (a, b) => {

--- a/packages/openapi-parser/src/utils/bundle/bundle.ts
+++ b/packages/openapi-parser/src/utils/bundle/bundle.ts
@@ -16,8 +16,13 @@ import { isObject } from '@/utils/is-object'
  * isRemoteUrl('./local-schema.json') // false
  * ```
  */
-export function isRemoteUrl(value: string): boolean {
-  return value.startsWith('http://') || value.startsWith('https://')
+export function isRemoteUrl(value: string) {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/packages/openapi-parser/src/utils/bundle/bundle.ts
+++ b/packages/openapi-parser/src/utils/bundle/bundle.ts
@@ -453,9 +453,10 @@ type Config = {
  * If the input is an object, it will be modified in place by adding an x-ext
  * property to store resolved external references.
  *
- * @param input - The OpenAPI specification object or string to bundle. If a string is provided,
- *                it should be a URL or file path that points to an OpenAPI specification.
- *                The string will be resolved using the provided plugins before bundling.
+ * @param input - The OpenAPI specification to bundle. Can be either an object or string.
+ *                If a string is provided, it will be resolved using the provided plugins.
+ *                If no plugin can process the input, the onReferenceError hook will be invoked
+ *                and an error will be emitted to the console.
  * @param config - Configuration object containing plugins and options for bundling OpenAPI specifications
  * @returns A promise that resolves to the bundled specification with all references embedded
  * @example

--- a/packages/openapi-parser/src/utils/bundle/plugins/parse-json/index.test.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/parse-json/index.test.ts
@@ -1,0 +1,22 @@
+import { parseJson } from '@/utils/bundle/plugins/parse-json'
+import { describe, expect, it } from 'vitest'
+
+describe('parse-json', () => {
+  it.each([
+    ['{}', true],
+    ['{ "a": "b" }', true],
+    ['{ "a": 2 }', true],
+    ["{ 'a': 2 }", false],
+    ['{ some string', false],
+    ['{ ', false],
+  ])('should validate if strings are json valid format', (a, b) => {
+    expect(parseJson().validate(a)).toBe(b)
+  })
+
+  it('should parse json string', async () => {
+    expect(await parseJson().exec('{ "message": "Hello World" }')).toEqual({
+      ok: true,
+      data: { message: 'Hello World' },
+    })
+  })
+})

--- a/packages/openapi-parser/src/utils/bundle/plugins/parse-json/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/parse-json/index.ts
@@ -1,0 +1,19 @@
+import type { Plugin } from '@/utils/bundle/bundle'
+import { isJson } from '@/utils/is-json'
+
+/**
+ * Creates a plugin that parses JSON strings into JavaScript objects.
+ * @returns A plugin object with validate and exec functions
+ * @example
+ * ```ts
+ * const jsonPlugin = parseJson()
+ * const result = jsonPlugin.exec('{"name": "John", "age": 30}')
+ * // result = { name: 'John', age: 30 }
+ * ```
+ */
+export function parseJson(): Plugin {
+  return {
+    validate: (value) => isJson(value),
+    exec: (value) => JSON.parse(value),
+  }
+}

--- a/packages/openapi-parser/src/utils/bundle/plugins/parse-json/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/parse-json/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '@/utils/bundle/bundle'
+import type { Plugin, ResolveResult } from '@/utils/bundle/bundle'
 import { isJson } from '@/utils/is-json'
 
 /**
@@ -14,6 +14,17 @@ import { isJson } from '@/utils/is-json'
 export function parseJson(): Plugin {
   return {
     validate: (value) => isJson(value),
-    exec: (value) => JSON.parse(value),
+    exec: async (value): Promise<ResolveResult> => {
+      try {
+        return {
+          ok: true,
+          data: JSON.parse(value),
+        }
+      } catch {
+        return {
+          ok: false,
+        }
+      }
+    },
   }
 }

--- a/packages/openapi-parser/src/utils/bundle/plugins/parse-yaml/index.test.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/parse-yaml/index.test.ts
@@ -1,0 +1,24 @@
+import { parseYaml } from '@/utils/bundle/plugins/parse-yaml'
+import { describe, expect, it } from 'vitest'
+
+describe('parse-yaml', () => {
+  it.each([
+    ['hi: hello\n', true],
+    ['- some: 1\n', true],
+    ['valid: value\nhey: hi\n', true],
+    ["{ 'a': 2 }", false],
+    ['{ some string', false],
+    ['{ ', false],
+    ['{}', false],
+    ['{ "json": "" }', false],
+  ])('should validate if strings are yaml valid format', (a, b) => {
+    expect(parseYaml().validate(a)).toBe(b)
+  })
+
+  it('should parse yaml string', async () => {
+    expect(await parseYaml().exec('{ "message": "Hello World" }')).toEqual({
+      ok: true,
+      data: { message: 'Hello World' },
+    })
+  })
+})

--- a/packages/openapi-parser/src/utils/bundle/plugins/parse-yaml/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/parse-yaml/index.ts
@@ -1,0 +1,20 @@
+import type { Plugin } from '@/utils/bundle/bundle'
+import { isYaml } from '@/utils/is-yaml'
+import YAML from 'yaml'
+
+/**
+ * Creates a plugin that parses YAML strings into JavaScript objects.
+ * @returns A plugin object with validate and exec functions
+ * @example
+ * ```ts
+ * const yamlPlugin = parseYaml()
+ * const result = yamlPlugin.exec('name: John\nage: 30')
+ * // result = { name: 'John', age: 30 }
+ * ```
+ */
+export function parseYaml(): Plugin {
+  return {
+    validate: (value) => isYaml(value),
+    exec: (value) => YAML.parse(value),
+  }
+}

--- a/packages/openapi-parser/src/utils/bundle/plugins/parse-yaml/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/parse-yaml/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '@/utils/bundle/bundle'
+import type { Plugin, ResolveResult } from '@/utils/bundle/bundle'
 import { isYaml } from '@/utils/is-yaml'
 import YAML from 'yaml'
 
@@ -15,6 +15,17 @@ import YAML from 'yaml'
 export function parseYaml(): Plugin {
   return {
     validate: (value) => isYaml(value),
-    exec: (value) => YAML.parse(value),
+    exec: async (value): Promise<ResolveResult> => {
+      try {
+        return {
+          ok: true,
+          data: YAML.parse(value),
+        }
+      } catch {
+        return {
+          ok: false,
+        }
+      }
+    },
   }
 }

--- a/packages/openapi-parser/src/utils/bundle/plugins/read-files/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/read-files/index.ts
@@ -1,5 +1,7 @@
 import { normalize } from '@/utils/normalize'
 import { isRemoteUrl, type Plugin, type ResolveResult } from '@/utils/bundle/bundle'
+import { isYaml } from '@/utils/is-yaml'
+import { isJson } from '@/utils/is-json'
 
 /**
  * Reads and normalizes data from a local file
@@ -49,7 +51,9 @@ export async function readFile(path: string): Promise<ResolveResult> {
  */
 export function readFiles(): Plugin {
   return {
-    validate: (value) => !isRemoteUrl(value),
+    validate: (value) => {
+      return !isRemoteUrl(value) && !isYaml(value) && !isJson(value)
+    },
     exec: (value) => readFile(value),
   }
 }

--- a/packages/openapi-parser/src/utils/load/load.ts
+++ b/packages/openapi-parser/src/utils/load/load.ts
@@ -27,6 +27,12 @@ export type LoadOptions = {
 } & ThrowOnErrorOption
 
 /**
+ * @deprecated This function is deprecated and will be removed in a future version.
+ * Please use the new bundler utility instead:
+ * ```ts
+ * import { bundle } from "@scalar/openapi-parser"
+ * ```
+ *
  * Loads an OpenAPI document, including any external references.
  *
  * This function handles loading content from various sources, normalizes the content,


### PR DESCRIPTION
**Problem**

Currently, the bundler does not support raw YAML or JSON strings as input, which limits flexibility when consuming APIs from dynamic or in-memory sources.

**Solution**

This PR adds support for parsing both YAML and JSON strings as valid input to the bundler, allowing them to be processed just like file-based documents.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
