### PR TITLE
fix(api-reference): schema property heading model name

### DIFF
--- a/.changeset/giant-steaks-give.md
+++ b/.changeset/giant-steaks-give.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: adds schema name and model get function to schema name helper

--- a/.changeset/pretty-weeks-rule.md
+++ b/.changeset/pretty-weeks-rule.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates schema property heading

--- a/.changeset/red-mails-beam.md
+++ b/.changeset/red-mails-beam.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: enhances primitives support in schema model name

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
@@ -138,6 +138,15 @@ describe('schema-name', () => {
       const schema: OpenAPIV3_1.SchemaObject = { type: 'object' }
       expect(getSchemaNameFromSchemas(schema)).toBe(null)
     })
+
+    it('does not return schema name for simple primitive types', () => {
+      const schema: OpenAPIV3_1.SchemaObject = { type: 'string' }
+      const schemas = {
+        foo: { type: 'string' },
+        bar: { type: 'number' },
+      }
+      expect(getSchemaNameFromSchemas(schema, schemas)).toBe(null)
+    })
   })
 
   describe('getModelName', () => {

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
-import { getModelNameFromSchema, getCompositionDisplay } from './schema-name'
+import { getModelNameFromSchema, getCompositionDisplay, getSchemaNameFromSchemas, getModelName } from './schema-name'
 
 describe('schema-name', () => {
   describe('getModelNameFromSchema', () => {
@@ -68,6 +68,178 @@ describe('schema-name', () => {
     it('returns null for empty object', () => {
       const schema: OpenAPIV3_1.SchemaObject = {}
       expect(getModelNameFromSchema(schema)).toBe(null)
+    })
+  })
+
+  describe('getSchemaNameFromSchemas', () => {
+    it('finds schema name by matching object properties', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          username: { type: 'string' },
+          deletedAt: { type: 'string', format: 'date-time', nullable: true },
+        },
+      }
+      const schemas = {
+        UserRequest: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            username: { type: 'string' },
+            deletedAt: { type: 'string', format: 'date-time', nullable: true },
+          },
+        },
+        ProblemDetails: {
+          type: 'object',
+          properties: {
+            type: { type: 'string', format: 'uri' },
+            title: { type: 'string' },
+            status: { type: 'integer', format: 'int32' },
+          },
+        },
+      }
+      expect(getSchemaNameFromSchemas(schema, schemas)).toBe('UserRequest')
+    })
+
+    it('finds schema name by matching array types', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {
+        type: 'array',
+        items: { type: 'string' },
+      }
+      const schemas = {
+        StringArray: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        NumberArray: {
+          type: 'array',
+          items: { type: 'number' },
+        },
+      }
+      expect(getSchemaNameFromSchemas(schema, schemas)).toBe('StringArray')
+    })
+
+    it('returns null when no matching schema found', () => {
+      const schema: OpenAPIV3_1.SchemaObject = {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+      }
+      const schemas = {
+        User: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      }
+      expect(getSchemaNameFromSchemas(schema, schemas)).toBe(null)
+    })
+
+    it('returns null when schemas is undefined', () => {
+      const schema: OpenAPIV3_1.SchemaObject = { type: 'object' }
+      expect(getSchemaNameFromSchemas(schema)).toBe(null)
+    })
+  })
+
+  describe('getModelName', () => {
+    it('returns null when value has no type', () => {
+      const value = { properties: { name: { type: 'string' } } }
+      expect(getModelName(value)).toBe(null)
+    })
+
+    it('returns array type when hideModelNames is true', () => {
+      const value = {
+        type: 'array',
+        items: { type: 'string' },
+      }
+      expect(getModelName(value, {}, true)).toBe('array string[]')
+    })
+
+    it('returns null when hideModelNames is true and not array', () => {
+      const value = { type: 'object' }
+      expect(getModelName(value, {}, true)).toBe(null)
+    })
+
+    it('returns model name with title', () => {
+      const value = {
+        type: 'object',
+        title: 'Planet',
+      }
+      expect(getModelName(value)).toBe('Planet')
+    })
+
+    it('returns array model name with title', () => {
+      const value = {
+        type: 'array',
+        title: 'PlanetArray',
+      }
+      expect(getModelName(value)).toBe('array PlanetArray[]')
+    })
+
+    it('finds schema name from component schemas', () => {
+      const value = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          email: { type: 'string' },
+        },
+      }
+      const schemas = {
+        User: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            email: { type: 'string' },
+          },
+        },
+      }
+      expect(getModelName(value, schemas)).toBe('User')
+    })
+
+    it('handles array with item title', () => {
+      const value = {
+        type: 'array',
+        items: {
+          type: 'object',
+          title: 'Planet',
+        },
+      }
+      expect(getModelName(value)).toBe('array Planet[]')
+    })
+
+    it('handles array with item name', () => {
+      const value = {
+        type: 'array',
+        items: {
+          type: 'object',
+          name: 'Planet',
+        },
+      }
+      expect(getModelName(value)).toBe('array Planet[]')
+    })
+
+    it('handles array with basic item type', () => {
+      const value = {
+        type: 'array',
+        items: { type: 'string' },
+      }
+      expect(getModelName(value)).toBe('array string[]')
+    })
+
+    it('handles array with object items fallback', () => {
+      const value = {
+        type: 'array',
+        items: {},
+      }
+      expect(getModelName(value)).toBe('array object[]')
+    })
+
+    it('handles discriminator schema names', () => {
+      const value = {
+        type: 'array',
+        items: { type: 'object' },
+      }
+      const mockGetDiscriminatorSchemaName = () => 'DiscriminatorModel'
+      expect(getModelName(value, {}, false, mockGetDiscriminatorSchemaName)).toBe('array DiscriminatorModel[]')
     })
   })
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
@@ -86,8 +86,15 @@ export function getSchemaNameFromSchemas(schema: OpenAPIV3_1.SchemaObject, schem
         return schemaName
       }
 
+      // Only return schema name if it has model name
       if (schema.type !== 'array' && schema.type !== 'object') {
-        return schemaName
+        const hasAdditionalProperties = Object.keys(schemaValue).some(
+          (key) => key !== 'type' && !['title', 'description'].includes(key),
+        )
+
+        if (hasAdditionalProperties || hasName(schemaName)) {
+          return schemaName
+        }
       }
     }
   }

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
@@ -64,6 +64,115 @@ export function getModelNameFromSchema(schema: OpenAPIV3_1.SchemaObject, schemas
 }
 
 /**
+ * Find schema name by matching against component schemas
+ */
+export function getSchemaNameFromSchemas(schema: OpenAPIV3_1.SchemaObject, schemas?: Schemas): string | null {
+  if (!schema || !schemas || typeof schemas !== 'object') {
+    return null
+  }
+
+  for (const [schemaName, schemaValue] of Object.entries(schemas)) {
+    if (schemaValue.type === schema.type) {
+      if (schema.type === 'array' && schemaValue.items?.type === schema.items?.type) {
+        return schemaName
+      }
+
+      if (
+        schema.type === 'object' &&
+        schemaValue.properties &&
+        schema.properties &&
+        stringify(schemaValue.properties) === stringify(schema.properties)
+      ) {
+        return schemaName
+      }
+
+      if (schema.type !== 'array' && schema.type !== 'object') {
+        return schemaName
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Format the type and model name for display
+ */
+export function formatTypeWithModel(type: string, modelName: string): string {
+  return type === 'array' ? `${type} ${modelName}[]` : `${type} ${modelName}`
+}
+
+/**
+ * Get the model name for a schema property
+ * e.g. User | Admin | array of User | array of Admin
+ */
+export function getModelName(
+  value: Record<string, any>,
+  schemas?: Schemas,
+  hideModelNames = false,
+  getDiscriminatorSchemaName?: (schema: any, schemas?: Schemas) => string | null,
+): string | null {
+  if (!value?.type) {
+    return null
+  }
+
+  if (hideModelNames) {
+    if (value.type === 'array' && value.items?.type) {
+      return `array ${value.items.type}[]`
+    }
+    return null
+  }
+
+  // First check if the entire schema matches a component schema
+  const modelName = getModelNameFromSchema(value, schemas)
+  if (modelName && (value.title || value.name)) {
+    return value.type === 'array' ? `array ${modelName}[]` : modelName
+  }
+
+  const schemaName = getSchemaNameFromSchemas(value, schemas)
+  if (schemaName) {
+    return value.type === 'array' ? `array ${schemaName}[]` : schemaName
+  }
+
+  // Handle array types with item references only if no full schema match was found
+  if (value.type === 'array' && value.items) {
+    // Check if items reference a discriminator schema
+    if (getDiscriminatorSchemaName) {
+      const baseSchemaName = getDiscriminatorSchemaName(value.items, schemas)
+      if (baseSchemaName) {
+        return formatTypeWithModel(value.type, baseSchemaName)
+      }
+    }
+
+    // Handle title/name
+    if (value.items.title || value.items.name) {
+      return formatTypeWithModel(value.type, value.items.title || value.items.name)
+    }
+
+    const itemModelName = getModelNameFromSchema(value.items, schemas)
+    if (itemModelName && itemModelName !== value.items.type) {
+      return formatTypeWithModel(value.type, itemModelName)
+    }
+
+    if (value.items.type) {
+      return formatTypeWithModel(value.type, value.items.type)
+    }
+
+    return formatTypeWithModel(value.type, 'object')
+  }
+
+  if (modelName && modelName !== value.type) {
+    if (modelName.startsWith('Array of ')) {
+      const itemType = modelName.replace('Array of ', '')
+      return `array ${itemType}[]`
+    }
+    return modelName
+  }
+
+  return null
+}
+
+/**
  * Check if a schema has a name (title, name, or custom identifier)
  */
 export function hasName(name: string | null): boolean {


### PR DESCRIPTION
**Problem**

update made in #5783 removed some logic unnecessarily so and do not properly check for the right schema model + model name used instead of primitive type.

**Solution**

this pr refactors schema property heading component by using the previously added schema name helper + adds new functions to it. fixes #5895 #5903 #5907

`model name`
| state | preview |
| -------|------|
| before | <img width="570" alt="image" src="https://github.com/user-attachments/assets/128f8b33-0ed4-4a97-a809-1f73634a6164" /> | 
| after | <img width="570" alt="image" src="https://github.com/user-attachments/assets/5530e769-5de4-49ed-9e71-8076404817da" /> |

`primitives`
| state | preview |
| -------|------|
| before | <img width="570" alt="image" src="https://github.com/user-attachments/assets/9f29f913-2906-4b09-91c9-42ba873ee241" />| 
| after | <img width="570" alt="image" src="https://github.com/user-attachments/assets/5a4fd7df-2c20-49ea-8045-c6978f2f8777" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
