### PR TITLE
fix(api-client): address bar bg

### DIFF
--- a/.changeset/famous-pears-jog.md
+++ b/.changeset/famous-pears-jog.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates address bar background style

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -134,7 +134,7 @@ function updateRequestMethod(method: RequestMethod) {
 
 function getBackgroundColor() {
   const { method } = operation
-  return REQUEST_METHODS[method].backgroundColor
+  return REQUEST_METHODS[method].colorVar
 }
 
 function handleExecuteRequest() {
@@ -173,8 +173,10 @@ function updateRequestPath(url: string) {
         class="pointer-events-none absolute top-0 left-0 block h-full w-full overflow-hidden rounded-lg border">
         <div
           class="absolute top-0 left-0 z-[1002] h-full w-full"
-          :class="getBackgroundColor()"
-          :style="{ transform: `translate3d(-${percentage}%,0,0)` }" />
+          :style="{
+            backgroundColor: `color-mix(in srgb, transparent 90%, ${getBackgroundColor()})`,
+            transform: `translate3d(-${percentage}%,0,0)`,
+          }" />
       </div>
       <div class="z-context-plus flex gap-1">
         <HttpMethod


### PR DESCRIPTION
**Problem**

recent changes in #5795 and #5833 changed the approach that was used to display the background loading state, as highlighted in #5904

**Solution**

this pr updates the address bar style to bring bar the background on load.

| state | preview |
| -------|------|
| before | <img width="700" alt="image" src="https://github.com/user-attachments/assets/66c27aeb-992d-47b5-b69b-c0114edc83b0" /> | 
| after | <img width="700" alt="image" src="https://github.com/user-attachments/assets/325c3477-403e-4b1e-9ffb-1444609a3856" /> |

we might be able to remove the `backgroundColor` from the helper after this cc @amritk?

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
