### PR TITLE
feat(openapi-parser): correctly set the base origin for string inputs for the bundler

### DIFF
--- a/.changeset/five-birds-fetch.md
+++ b/.changeset/five-birds-fetch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+feat(openapi-parser): correctly set the base origin for string inputs for the bundler

--- a/packages/openapi-parser/src/utils/bundle/bundle.test.ts
+++ b/packages/openapi-parser/src/utils/bundle/bundle.test.ts
@@ -1371,14 +1371,13 @@ describe('bundle', () => {
 
       await fs.writeFile(chunk1Path, JSON.stringify(chunk1))
 
-      const input = {
+      const input = JSON.stringify({
         a: {
           '$ref': `./${chunk1Path}#/a`,
         },
-      }
+      })
 
-      // We pass the input as json string and not as an object
-      const result = await bundle(JSON.stringify(input), { plugins: [readFiles(), parseJson()], treeShake: false })
+      const result = await bundle(input, { plugins: [readFiles(), parseJson()], treeShake: false })
 
       await fs.rm(chunk1Path)
 
@@ -1417,14 +1416,13 @@ describe('bundle', () => {
 
       await fs.writeFile(chunk1Path, YAML.stringify(chunk1))
 
-      const input = {
+      const input = YAML.stringify({
         a: {
           '$ref': `./${chunk1Path}#/a`,
         },
-      }
+      })
 
-      // We pass the input as json string and not as an object
-      const result = await bundle(YAML.stringify(input), { plugins: [parseYaml(), readFiles()], treeShake: false })
+      const result = await bundle(input, { plugins: [parseYaml(), readFiles()], treeShake: false })
 
       await fs.rm(chunk1Path)
 

--- a/packages/openapi-parser/src/utils/bundle/bundle.ts
+++ b/packages/openapi-parser/src/utils/bundle/bundle.ts
@@ -27,6 +27,20 @@ export function isRemoteUrl(value: string) {
   }
 }
 
+/**
+ * Checks if a string represents a file path by ensuring it's not a remote URL,
+ * YAML content, or JSON content.
+ *
+ * @param value - The string to check
+ * @returns true if the string appears to be a file path, false otherwise
+ * @example
+ * ```ts
+ * isFilePath('./schemas/user.json') // true
+ * isFilePath('https://example.com/schema.json') // false
+ * isFilePath('{"type": "object"}') // false
+ * isFilePath('type: object') // false
+ * ```
+ */
 export function isFilePath(value: string) {
   return !isRemoteUrl(value) && !isYaml(value) && !isJson(value)
 }

--- a/packages/openapi-parser/src/utils/bundle/plugins/fetch-urls/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/fetch-urls/index.ts
@@ -75,7 +75,7 @@ export function fetchUrls(config?: FetchConfig & Partial<{ limit: number | null 
   const limiter = config?.limit ? createLimiter(config.limit) : <T>(fn: () => Promise<T>) => fn()
 
   return {
-    validate: (value) => isRemoteUrl(value),
+    validate: isRemoteUrl,
     exec: (value) => fetchUrl(value, limiter, config),
   }
 }

--- a/packages/openapi-parser/src/utils/bundle/plugins/parse-json/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/parse-json/index.ts
@@ -13,7 +13,7 @@ import { isJson } from '@/utils/is-json'
  */
 export function parseJson(): Plugin {
   return {
-    validate: (value) => isJson(value),
+    validate: isJson,
     exec: async (value): Promise<ResolveResult> => {
       try {
         return {

--- a/packages/openapi-parser/src/utils/bundle/plugins/parse-yaml/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/parse-yaml/index.ts
@@ -14,7 +14,7 @@ import YAML from 'yaml'
  */
 export function parseYaml(): Plugin {
   return {
-    validate: (value) => isYaml(value),
+    validate: isYaml,
     exec: async (value): Promise<ResolveResult> => {
       try {
         return {

--- a/packages/openapi-parser/src/utils/bundle/plugins/read-files/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/read-files/index.ts
@@ -54,6 +54,6 @@ export function readFiles(): Plugin {
     validate: (value) => {
       return !isRemoteUrl(value) && !isYaml(value) && !isJson(value)
     },
-    exec: (value) => readFile(value),
+    exec: readFile,
   }
 }

--- a/packages/openapi-parser/src/utils/bundle/plugins/read-files/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/read-files/index.ts
@@ -1,7 +1,5 @@
 import { normalize } from '@/utils/normalize'
-import { isRemoteUrl, type Plugin, type ResolveResult } from '@/utils/bundle/bundle'
-import { isYaml } from '@/utils/is-yaml'
-import { isJson } from '@/utils/is-json'
+import { isFilePath, type Plugin, type ResolveResult } from '@/utils/bundle/bundle'
 
 /**
  * Reads and normalizes data from a local file
@@ -51,9 +49,7 @@ export async function readFile(path: string): Promise<ResolveResult> {
  */
 export function readFiles(): Plugin {
   return {
-    validate: (value) => {
-      return !isRemoteUrl(value) && !isYaml(value) && !isJson(value)
-    },
+    validate: isFilePath,
     exec: readFile,
   }
 }


### PR DESCRIPTION
**Problem**

The bundler previously assumed that only two plugins—`fetchUrls` and `readFiles`—would handle string inputs. This assumption limited extensibility and caused incorrect handling of other potential string-based inputs.

**Solution**

This PR removes the hardcoded assumption and makes the input handling more flexible. It now checks whether the input string is a URL or a file path before setting the base origin, allowing other plugins to process string inputs correctly without unintended side effects.



**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
